### PR TITLE
feat(debug-sidecar): LANG13 + LANG14 — source-location pipeline and native debug info specs

### DIFF
--- a/code/packages/python/debug-sidecar/BUILD
+++ b/code/packages/python/debug-sidecar/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --cov=debug_sidecar --cov-report=term-missing

--- a/code/packages/python/debug-sidecar/CHANGELOG.md
+++ b/code/packages/python/debug-sidecar/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.1.0] - 2026-04-23
+
+### Added
+
+- `DebugSidecarWriter` — accumulates source-location data during compilation:
+  - `add_source_file(path, checksum)` — registers source files with deduplication
+  - `begin_function` / `end_function` — records instruction ranges per function
+  - `record(fn_name, instr_index, *, file_id, line, col)` — one entry per emitted IIR instruction
+  - `declare_variable(fn_name, *, reg_index, name, type_hint, live_start, live_end)` — variable live-range bindings
+  - `finish() → bytes` — serializes to JSON UTF-8 bytes (format is internal; swap to binary later without changing callers)
+
+- `DebugSidecarReader` — answers debug queries from a compiled sidecar:
+  - `lookup(fn_name, instr_index) → SourceLocation | None` — DWARF-style bisect lookup; returns location of the nearest preceding recorded instruction
+  - `find_instr(file, line) → int | None` — reverse lookup for setting breakpoints; returns the lowest matching instruction index across all functions
+  - `live_variables(fn_name, at_instr) → list[Variable]` — variable inspection for the Variables panel; sorted by register index
+  - `source_files()`, `function_names()`, `function_range()` — metadata accessors
+
+- `SourceLocation` — frozen hashable `(file, line, col)` triple; `str()` returns `"file:line:col"`
+
+- `Variable` — frozen dataclass with `reg_index`, `name`, `type_hint`, `live_start`, `live_end`; `is_live_at(instr_index)` helper
+
+- `__init__.py` re-exports all public types from the top-level package
+
+- Comprehensive test suite covering writer serialization, reader round-trips, `lookup()` with DWARF-style coverage semantics, `find_instr()` cross-function scans, `live_variables()` range filtering, and error handling for corrupt/wrong-version sidecars

--- a/code/packages/python/debug-sidecar/README.md
+++ b/code/packages/python/debug-sidecar/README.md
@@ -1,0 +1,127 @@
+# debug-sidecar
+
+Source-location companion for the IIR pipeline. Maps instruction indices to
+file/line/col for debuggers, insight tools, and native debug info emitters
+(DWARF, CodeView).
+
+## What it does
+
+The IIR (`interpreter-ir`) pipeline keeps `IIRInstr` lean — no source
+positions stored on hot-path objects. `debug-sidecar` is the *separate
+channel* that carries that information forward, analogous to:
+
+- DWARF sections alongside ELF `.text`
+- Source maps alongside minified JavaScript
+- PDB files alongside Windows PE executables
+
+A compiler calls `DebugSidecarWriter` once per emitted instruction to record
+the mapping. After compilation, `finish()` returns an opaque `bytes` object.
+Any downstream consumer — a debugger adapter, an insight tool, a DWARF
+emitter — loads those bytes into `DebugSidecarReader` and queries them.
+
+## Stack position
+
+```
+Source (.tetrad)
+    │
+    ▼
+Compiler  ──── DebugSidecarWriter ─── finish() ──► bytes
+    │                                                │
+    ▼                                                ▼
+IIRFunction / IIRInstr              DebugSidecarReader
+                                         │
+                            ┌────────────┼────────────┐
+                            ▼            ▼             ▼
+                        debugger    jit-profiling   native-debug-info
+                        adapter       insights       (DWARF/CodeView)
+```
+
+## Usage
+
+### Writing (compiler side)
+
+```python
+from debug_sidecar import DebugSidecarWriter
+
+writer = DebugSidecarWriter()
+file_id = writer.add_source_file("fibonacci.tetrad")
+
+writer.begin_function("fibonacci", start_instr=0, param_count=1)
+writer.declare_variable("fibonacci", reg_index=0, name="n",
+                        type_hint="any", live_start=0, live_end=12)
+
+for instr_index, (instr, node) in enumerate(zip(instructions, ast_nodes)):
+    writer.record("fibonacci", instr_index,
+                  file_id=file_id, line=node.line, col=node.col)
+
+writer.end_function("fibonacci", end_instr=12)
+sidecar: bytes = writer.finish()
+```
+
+### Reading (debugger / tool side)
+
+```python
+from debug_sidecar import DebugSidecarReader
+
+reader = DebugSidecarReader(sidecar_bytes)
+
+# Offset → source  (debugger paused at instruction 7)
+loc = reader.lookup("fibonacci", 7)
+if loc:
+    print(f"Stopped at {loc}")   # "fibonacci.tetrad:3:5"
+
+# Source → offset  (setting a breakpoint on line 10)
+idx = reader.find_instr("fibonacci.tetrad", 10)
+if idx is not None:
+    vm.set_breakpoint(idx, "fibonacci")
+
+# Variable inspection
+for var in reader.live_variables("fibonacci", 5):
+    print(f"  {var.name} (reg {var.reg_index}): {var.type_hint}")
+```
+
+## API reference
+
+### `DebugSidecarWriter`
+
+| Method | Description |
+|---|---|
+| `add_source_file(path, checksum=b"") → int` | Register a source file; returns file_id (idempotent) |
+| `begin_function(fn_name, *, start_instr, param_count)` | Mark start of a function's instruction range |
+| `end_function(fn_name, *, end_instr)` | Mark end of a function's instruction range |
+| `record(fn_name, instr_index, *, file_id, line, col)` | Map one instruction to its source location |
+| `declare_variable(fn_name, *, reg_index, name, type_hint, live_start, live_end)` | Register a named variable binding |
+| `finish() → bytes` | Serialize to opaque bytes |
+
+### `DebugSidecarReader`
+
+| Method | Description |
+|---|---|
+| `lookup(fn_name, instr_index) → SourceLocation \| None` | Offset → source (DWARF-style, nearest preceding record) |
+| `find_instr(file, line) → int \| None` | Source → first matching instruction index |
+| `live_variables(fn_name, at_instr) → list[Variable]` | Variables live at an instruction, sorted by reg_index |
+| `source_files() → list[str]` | All registered source file paths |
+| `function_names() → list[str]` | All functions with debug info |
+| `function_range(fn_name) → tuple[int, int] \| None` | (start_instr, end_instr) for a function |
+
+### `SourceLocation`
+
+Frozen dataclass: `file: str`, `line: int`, `col: int`. `str()` returns
+`"file:line:col"`.
+
+### `Variable`
+
+Frozen dataclass: `reg_index`, `name`, `type_hint`, `live_start`, `live_end`.
+`is_live_at(instr_index) → bool`.
+
+## Internal format
+
+The sidecar is JSON serialized to UTF-8 bytes. This is intentionally simple
+for the initial implementation — it lets the full pipeline work while the
+compact binary format described in spec `05d` is finalized. The `finish()` /
+`DebugSidecarReader` boundary is the only place that knows the format, so
+swapping to binary later is a single-file change.
+
+## Spec
+
+[`code/specs/LANG13-debug-sidecar.md`](../../../../specs/LANG13-debug-sidecar.md)

--- a/code/packages/python/debug-sidecar/pyproject.toml
+++ b/code/packages/python/debug-sidecar/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-debug-sidecar"
+version = "0.1.0"
+description = "Source-location companion for the IIR pipeline: maps instruction indices to file/line/col for debuggers, insight tools, and native debug info emitters."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "ruff",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/debug_sidecar"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"

--- a/code/packages/python/debug-sidecar/src/debug_sidecar/__init__.py
+++ b/code/packages/python/debug-sidecar/src/debug_sidecar/__init__.py
@@ -1,0 +1,18 @@
+"""debug-sidecar — source-location companion for the IIR pipeline.
+
+Public API::
+
+    from debug_sidecar import DebugSidecarWriter, DebugSidecarReader
+    from debug_sidecar import SourceLocation, Variable
+"""
+
+from debug_sidecar.reader import DebugSidecarReader
+from debug_sidecar.types import SourceLocation, Variable
+from debug_sidecar.writer import DebugSidecarWriter
+
+__all__ = [
+    "DebugSidecarWriter",
+    "DebugSidecarReader",
+    "SourceLocation",
+    "Variable",
+]

--- a/code/packages/python/debug-sidecar/src/debug_sidecar/reader.py
+++ b/code/packages/python/debug-sidecar/src/debug_sidecar/reader.py
@@ -1,0 +1,228 @@
+"""DebugSidecarReader — queries source-location data at runtime.
+
+The reader is the consumer side of the debug sidecar pipeline.  It loads the
+bytes produced by ``DebugSidecarWriter.finish()`` and answers three kinds of
+questions:
+
+1. **Offset → source** (debugger paused):
+   ``lookup(fn_name, instr_index)`` → ``SourceLocation | None``
+
+2. **Source → offset** (setting a breakpoint):
+   ``find_instr(file, line)`` → ``int | None``
+
+3. **Variable inspection** (Variables panel):
+   ``live_variables(fn_name, at_instr)`` → ``list[Variable]``
+
+Usage::
+
+    reader = DebugSidecarReader(sidecar_bytes)
+
+    # Where did instruction 7 in 'fibonacci' come from?
+    loc = reader.lookup("fibonacci", 7)
+    if loc:
+        print(f"Stopped at {loc}")   # "fibonacci.tetrad:3:5"
+
+    # Set a breakpoint on line 10 of fibonacci.tetrad
+    idx = reader.find_instr("fibonacci.tetrad", 10)
+    if idx is not None:
+        vm.set_breakpoint(idx, "fibonacci")
+
+    # What variables are live when the debugger pauses at instruction 5?
+    for var in reader.live_variables("fibonacci", 5):
+        print(f"  {var.name} (reg {var.reg_index}): {var.type_hint}")
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+
+from debug_sidecar.types import SourceLocation, Variable
+
+
+class DebugSidecarReader:
+    """Answers debug queries from a compiled sidecar.
+
+    Parameters
+    ----------
+    data:
+        Bytes returned by ``DebugSidecarWriter.finish()``.
+
+    Raises
+    ------
+    ValueError
+        If ``data`` is not a valid sidecar (wrong version or corrupt JSON).
+    """
+
+    def __init__(self, data: bytes) -> None:
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError(f"invalid sidecar data: {exc}") from exc
+
+        if payload.get("version") != 1:
+            raise ValueError(
+                f"unsupported sidecar version: {payload.get('version')!r}"
+            )
+
+        self._source_files: list[dict] = payload.get("source_files", [])
+        self._raw_line_table: dict[str, list[dict]] = payload.get("line_table", {})
+        self._functions: dict[str, dict] = payload.get("functions", {})
+        self._raw_variables: dict[str, list[dict]] = payload.get("variables", {})
+
+        # Pre-build sorted index: {fn_name: sorted list of instr_index values}
+        # Used for bisect lookups in lookup().
+        self._sorted_indices: dict[str, list[int]] = {
+            fn: [row["instr_index"] for row in rows]
+            for fn, rows in self._raw_line_table.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Source location lookup (offset → source)
+    # ------------------------------------------------------------------
+
+    def lookup(self, fn_name: str, instr_index: int) -> SourceLocation | None:
+        """Return the source location of instruction ``instr_index`` in ``fn_name``.
+
+        Uses the last row whose index is ≤ ``instr_index``, exactly as the
+        DWARF line-number lookup algorithm works.  This means a generated
+        instruction that maps to no explicit record still gets the location of
+        the nearest preceding recorded instruction.
+
+        Returns ``None`` if the function has no debug information or if
+        ``instr_index`` is before the first recorded instruction.
+
+        Parameters
+        ----------
+        fn_name:
+            Function name as registered with the writer.
+        instr_index:
+            0-based instruction index within the function body.
+
+        Returns
+        -------
+        SourceLocation | None
+        """
+        rows = self._raw_line_table.get(fn_name)
+        if not rows:
+            return None
+
+        indices = self._sorted_indices[fn_name]
+        # bisect_right gives the insertion point after any existing equal values.
+        pos = bisect.bisect_right(indices, instr_index) - 1
+        if pos < 0:
+            return None
+
+        row = rows[pos]
+        file_id = row["file_id"]
+        if file_id >= len(self._source_files):
+            return None
+
+        return SourceLocation(
+            file=self._source_files[file_id]["path"],
+            line=row["line"],
+            col=row["col"],
+        )
+
+    # ------------------------------------------------------------------
+    # Reverse lookup (source → offset)
+    # ------------------------------------------------------------------
+
+    def find_instr(self, file: str, line: int) -> int | None:
+        """Return the first instruction index that maps to ``(file, line)``.
+
+        Scans all functions for a row matching the given file and line number.
+        Returns the instruction index with the lowest index (first instruction
+        on that source line), or ``None`` if the line is not reachable.
+
+        Parameters
+        ----------
+        file:
+            Source file path (must match a path registered with the writer).
+        line:
+            1-based line number.
+
+        Returns
+        -------
+        int | None
+            First instruction index that originated at ``file:line``.
+        """
+        # Resolve file path to file_id
+        file_id = None
+        for i, sf in enumerate(self._source_files):
+            if sf["path"] == file:
+                file_id = i
+                break
+        if file_id is None:
+            return None
+
+        best: int | None = None
+        for rows in self._raw_line_table.values():
+            for row in rows:
+                if row["file_id"] == file_id and row["line"] == line:
+                    if best is None or row["instr_index"] < best:
+                        best = row["instr_index"]
+        return best
+
+    # ------------------------------------------------------------------
+    # Variable inspection
+    # ------------------------------------------------------------------
+
+    def live_variables(self, fn_name: str, at_instr: int) -> list[Variable]:
+        """Return all variables live at instruction ``at_instr`` in ``fn_name``.
+
+        A variable is live at ``at_instr`` when
+        ``live_start <= at_instr < live_end``.
+
+        Parameters
+        ----------
+        fn_name:
+            Function name.
+        at_instr:
+            0-based instruction index.
+
+        Returns
+        -------
+        list[Variable]
+            Variables alive at the given instruction, sorted by register index.
+        """
+        raw = self._raw_variables.get(fn_name, [])
+        result = [
+            Variable(
+                reg_index=v["reg_index"],
+                name=v["name"],
+                type_hint=v["type_hint"],
+                live_start=v["live_start"],
+                live_end=v["live_end"],
+            )
+            for v in raw
+            if v["live_start"] <= at_instr < v["live_end"]
+        ]
+        result.sort(key=lambda v: v.reg_index)
+        return result
+
+    # ------------------------------------------------------------------
+    # Metadata queries
+    # ------------------------------------------------------------------
+
+    def source_files(self) -> list[str]:
+        """Return the list of source file paths registered in this sidecar."""
+        return [sf["path"] for sf in self._source_files]
+
+    def function_names(self) -> list[str]:
+        """Return the list of function names that have debug information."""
+        return list(self._functions.keys())
+
+    def function_range(self, fn_name: str) -> tuple[int, int] | None:
+        """Return the (start_instr, end_instr) range for ``fn_name``.
+
+        Returns ``None`` if the function was not registered with the writer.
+        ``end_instr`` may be ``None`` if ``end_function()`` was never called.
+        """
+        fn = self._functions.get(fn_name)
+        if fn is None:
+            return None
+        end = fn.get("end_instr")
+        if end is None:
+            return None
+        return (fn["start_instr"], end)

--- a/code/packages/python/debug-sidecar/src/debug_sidecar/types.py
+++ b/code/packages/python/debug-sidecar/src/debug_sidecar/types.py
@@ -1,0 +1,69 @@
+"""Core data types for debug-sidecar.
+
+``SourceLocation``
+    A frozen, hashable (file, line, col) triple.  The reader returns these
+    in response to instruction-index queries.
+
+``Variable``
+    A register binding with a human name, type hint, and live range.  The
+    live range is expressed as [live_start, live_end) instruction indices so
+    the reader can answer "what variables are live at instruction N?".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    """Source position for one IIR instruction.
+
+    Parameters
+    ----------
+    file:
+        Source file path as registered with ``DebugSidecarWriter.add_source_file``.
+    line:
+        1-based line number.
+    col:
+        1-based column number.
+    """
+
+    file: str
+    line: int
+    col: int
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}:{self.col}"
+
+
+@dataclass(frozen=True)
+class Variable:
+    """A named register binding valid over a range of instruction indices.
+
+    Parameters
+    ----------
+    reg_index:
+        IIR register index (matches the register number in the VM's frame).
+    name:
+        Human-readable variable name from the source program.
+    type_hint:
+        Declared type string (``"any"``, ``"u8"``, ``"Int"``, …).  Empty
+        string if no type annotation was given.
+    live_start:
+        First instruction index at which this binding is valid (inclusive).
+    live_end:
+        One-past-last instruction index at which this binding is valid
+        (exclusive).  A binding is live at instruction N when
+        ``live_start <= N < live_end``.
+    """
+
+    reg_index: int
+    name: str
+    type_hint: str
+    live_start: int
+    live_end: int
+
+    def is_live_at(self, instr_index: int) -> bool:
+        """Return True if this variable is live at ``instr_index``."""
+        return self.live_start <= instr_index < self.live_end

--- a/code/packages/python/debug-sidecar/src/debug_sidecar/writer.py
+++ b/code/packages/python/debug-sidecar/src/debug_sidecar/writer.py
@@ -1,0 +1,246 @@
+"""DebugSidecarWriter — accumulates source-location data during compilation.
+
+The compiler calls this once per emitted IIRInstr to record the mapping from
+instruction index to source location.  After compilation, ``finish()`` returns
+the sidecar as an opaque ``bytes`` object that the reader can load.
+
+Design notes
+------------
+The sidecar is stored as JSON serialised to UTF-8 bytes.  This is intentionally
+simpler than the binary format in spec ``05d`` — it lets us get the full pipeline
+working (compiler → sidecar → debugger / insight tools → DWARF emitter) before
+investing in the compact binary format.  The ``finish()`` / ``DebugSidecarReader``
+boundary is the only place that knows about the on-disk format, so swapping to
+binary later is a single-file change.
+
+The writer is append-only and not thread-safe.  Each compilation should use its
+own writer instance.
+
+Usage::
+
+    writer = DebugSidecarWriter()
+    file_id = writer.add_source_file("fibonacci.tetrad")
+
+    writer.begin_function("fibonacci", start_instr=0, param_count=1)
+    writer.declare_variable("fibonacci", reg_index=0, name="n",
+                            type_hint="any", live_start=0, live_end=12)
+
+    for instr_index, (instr, node) in enumerate(zip(instructions, ast_nodes)):
+        writer.record("fibonacci", instr_index,
+                      file_id=file_id, line=node.line, col=node.col)
+
+    writer.end_function("fibonacci", end_instr=12)
+    sidecar: bytes = writer.finish()
+"""
+
+from __future__ import annotations
+
+import json
+
+
+class DebugSidecarWriter:
+    """Accumulates debug sidecar data during a single compilation.
+
+    Parameters
+    ----------
+    None — create one instance per compilation unit (module / file).
+    """
+
+    def __init__(self) -> None:
+        # source_files: list of {"path": str, "checksum": str (hex)}
+        self._source_files: list[dict] = []
+        self._source_file_index: dict[str, int] = {}
+
+        # line_table: {fn_name: [{instr_index, file_id, line, col}]}
+        self._line_table: dict[str, list[dict]] = {}
+
+        # functions: {fn_name: {start_instr, end_instr, param_count}}
+        self._functions: dict[str, dict] = {}
+
+        # variables: {fn_name: [{reg_index, name, type_hint, live_start, live_end}]}
+        self._variables: dict[str, list[dict]] = {}
+
+    # ------------------------------------------------------------------
+    # Source files
+    # ------------------------------------------------------------------
+
+    def add_source_file(self, path: str, checksum: bytes = b"") -> int:
+        """Register a source file and return its file_id.
+
+        Calling this multiple times with the same ``path`` is safe —
+        subsequent calls return the same ``file_id`` without duplicating the
+        entry.
+
+        Parameters
+        ----------
+        path:
+            Source file path (absolute or relative to the build directory).
+        checksum:
+            Optional SHA-256 of the source file at compile time.  Used by
+            debug adapters to warn about stale binaries.  Pass ``b""`` to
+            omit.
+
+        Returns
+        -------
+        int
+            0-based file_id for use in ``record()``.
+        """
+        if path in self._source_file_index:
+            return self._source_file_index[path]
+        file_id = len(self._source_files)
+        self._source_files.append({
+            "path": path,
+            "checksum": checksum.hex(),
+        })
+        self._source_file_index[path] = file_id
+        return file_id
+
+    # ------------------------------------------------------------------
+    # Line table
+    # ------------------------------------------------------------------
+
+    def record(
+        self,
+        fn_name: str,
+        instr_index: int,
+        *,
+        file_id: int,
+        line: int,
+        col: int,
+    ) -> None:
+        """Record the source location of one emitted IIRInstr.
+
+        Must be called for every instruction emitted by the compiler.
+        Calling it out of order (by ``instr_index``) is allowed — the reader
+        sorts by index at load time.
+
+        Parameters
+        ----------
+        fn_name:
+            Name of the function this instruction belongs to.
+        instr_index:
+            0-based index of the instruction within the function body.
+        file_id:
+            File identifier returned by ``add_source_file()``.
+        line:
+            1-based source line number.
+        col:
+            1-based source column number.
+        """
+        if fn_name not in self._line_table:
+            self._line_table[fn_name] = []
+        self._line_table[fn_name].append({
+            "instr_index": instr_index,
+            "file_id": file_id,
+            "line": line,
+            "col": col,
+        })
+
+    # ------------------------------------------------------------------
+    # Execution units (functions)
+    # ------------------------------------------------------------------
+
+    def begin_function(
+        self,
+        fn_name: str,
+        *,
+        start_instr: int,
+        param_count: int,
+    ) -> None:
+        """Register the start of a function's instruction range.
+
+        Must be paired with ``end_function()``.
+
+        Parameters
+        ----------
+        fn_name:
+            Function name (must match the ``IIRFunction.name``).
+        start_instr:
+            Index of the first instruction in this function's body.
+        param_count:
+            Number of parameters (for display in call stack frames).
+        """
+        self._functions[fn_name] = {
+            "start_instr": start_instr,
+            "end_instr": None,
+            "param_count": param_count,
+        }
+
+    def end_function(self, fn_name: str, *, end_instr: int) -> None:
+        """Record the end of a function's instruction range.
+
+        Parameters
+        ----------
+        fn_name:
+            Function name (must match a prior ``begin_function`` call).
+        end_instr:
+            One-past-last instruction index (exclusive upper bound).
+        """
+        if fn_name in self._functions:
+            self._functions[fn_name]["end_instr"] = end_instr
+
+    # ------------------------------------------------------------------
+    # Variables
+    # ------------------------------------------------------------------
+
+    def declare_variable(
+        self,
+        fn_name: str,
+        *,
+        reg_index: int,
+        name: str,
+        type_hint: str = "",
+        live_start: int,
+        live_end: int,
+    ) -> None:
+        """Record a named variable binding for a register.
+
+        Parameters
+        ----------
+        fn_name:
+            Function containing this variable.
+        reg_index:
+            IIR register index.
+        name:
+            Human-readable variable name.
+        type_hint:
+            Declared type (``"any"``, ``"u8"``, …), or ``""`` for no
+            annotation.
+        live_start:
+            First instruction index at which this binding is valid.
+        live_end:
+            One-past-last instruction index (exclusive).
+        """
+        if fn_name not in self._variables:
+            self._variables[fn_name] = []
+        self._variables[fn_name].append({
+            "reg_index": reg_index,
+            "name": name,
+            "type_hint": type_hint,
+            "live_start": live_start,
+            "live_end": live_end,
+        })
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def finish(self) -> bytes:
+        """Serialise the accumulated debug data to bytes.
+
+        Returns
+        -------
+        bytes
+            Opaque sidecar bytes.  Pass to ``DebugSidecarReader`` to query.
+        """
+        payload = {
+            "version": 1,
+            "source_files": self._source_files,
+            "line_table": {
+                fn: sorted(rows, key=lambda r: r["instr_index"])
+                for fn, rows in self._line_table.items()
+            },
+            "functions": self._functions,
+            "variables": self._variables,
+        }
+        return json.dumps(payload, separators=(",", ":")).encode("utf-8")

--- a/code/packages/python/debug-sidecar/tests/test_reader.py
+++ b/code/packages/python/debug-sidecar/tests/test_reader.py
@@ -1,0 +1,310 @@
+"""Tests for DebugSidecarReader — round-trip and query correctness."""
+
+import json
+
+import pytest
+
+from debug_sidecar.reader import DebugSidecarReader
+from debug_sidecar.types import SourceLocation, Variable
+from debug_sidecar.writer import DebugSidecarWriter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sidecar(**kwargs) -> bytes:
+    """Build a minimal valid sidecar from a raw payload dict."""
+    base = {"version": 1, "source_files": [], "line_table": {}, "functions": {}, "variables": {}}
+    base.update(kwargs)
+    return json.dumps(base).encode("utf-8")
+
+
+def _fibonacci_sidecar() -> bytes:
+    """A realistic fibonacci sidecar used across many tests."""
+    w = DebugSidecarWriter()
+    fid = w.add_source_file("fibonacci.tetrad")
+    w.begin_function("fibonacci", start_instr=0, param_count=1)
+    w.declare_variable("fibonacci", reg_index=0, name="n", type_hint="any",
+                       live_start=0, live_end=12)
+    w.declare_variable("fibonacci", reg_index=1, name="result", type_hint="any",
+                       live_start=4, live_end=12)
+    for idx, (line, col) in enumerate([
+        (1, 1),   # 0: load n
+        (2, 5),   # 1: cmp n < 2
+        (2, 5),   # 2: jmp_if
+        (3, 9),   # 3: ret n
+        (4, 5),   # 4: call fib(n-1)
+        (4, 5),   # 5: call fib(n-2)
+        (4, 5),   # 6: add
+        (5, 1),   # 7: ret result
+    ]):
+        w.record("fibonacci", idx, file_id=fid, line=line, col=col)
+    w.end_function("fibonacci", end_instr=8)
+    return w.finish()
+
+
+# ---------------------------------------------------------------------------
+# Initialization / error handling
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_valid_sidecar_loads(self):
+        data = _fibonacci_sidecar()
+        reader = DebugSidecarReader(data)
+        assert reader is not None
+
+    def test_invalid_utf8_raises_value_error(self):
+        with pytest.raises(ValueError, match="invalid sidecar"):
+            DebugSidecarReader(b"\xff\xfe not utf-8")
+
+    def test_invalid_json_raises_value_error(self):
+        with pytest.raises(ValueError, match="invalid sidecar"):
+            DebugSidecarReader(b"not json at all")
+
+    def test_wrong_version_raises_value_error(self):
+        data = _make_sidecar(version=42)
+        with pytest.raises(ValueError, match="unsupported sidecar version"):
+            DebugSidecarReader(data)
+
+    def test_missing_version_raises_value_error(self):
+        data = json.dumps({"source_files": [], "line_table": {}, "functions": {}, "variables": {}}).encode()
+        with pytest.raises(ValueError, match="unsupported sidecar version"):
+            DebugSidecarReader(data)
+
+    def test_version_none_raises_value_error(self):
+        data = _make_sidecar(version=None)
+        with pytest.raises(ValueError, match="unsupported sidecar version"):
+            DebugSidecarReader(data)
+
+
+# ---------------------------------------------------------------------------
+# lookup() — offset → source
+# ---------------------------------------------------------------------------
+
+class TestLookup:
+    def setup_method(self):
+        self.reader = DebugSidecarReader(_fibonacci_sidecar())
+
+    def test_exact_match(self):
+        loc = self.reader.lookup("fibonacci", 0)
+        assert loc == SourceLocation("fibonacci.tetrad", 1, 1)
+
+    def test_dwarf_style_coverage(self):
+        # Instructions 4, 5, 6 all map to line 4, col 5
+        for idx in (4, 5, 6):
+            loc = self.reader.lookup("fibonacci", idx)
+            assert loc is not None
+            assert loc.line == 4
+
+    def test_between_records_uses_preceding(self):
+        # No record at index 3 in this gap scenario; use the preceding
+        # Instruction 2 → line 2, instruction 3 → line 2 (same line, consecutive)
+        loc = self.reader.lookup("fibonacci", 3)
+        assert loc is not None
+        assert loc.line == 3  # record at idx 3 is line 3
+
+    def test_unknown_function_returns_none(self):
+        assert self.reader.lookup("no_such_fn", 0) is None
+
+    def test_before_first_record_returns_none(self):
+        # Create a sidecar whose first record is at index 5
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("f.tetrad")
+        w.begin_function("f", start_instr=5, param_count=0)
+        w.record("f", 5, file_id=fid, line=1, col=1)
+        reader = DebugSidecarReader(w.finish())
+        assert reader.lookup("f", 3) is None
+
+    def test_returns_source_location_type(self):
+        loc = self.reader.lookup("fibonacci", 0)
+        assert isinstance(loc, SourceLocation)
+
+    def test_instr_beyond_last_record_returns_last(self):
+        # Instruction 100 is past all records; should return last record's location
+        loc = self.reader.lookup("fibonacci", 100)
+        assert loc is not None
+        assert loc.line == 5  # last record is at line 5
+
+    def test_bad_file_id_returns_none(self):
+        data = _make_sidecar(
+            source_files=[{"path": "f.tetrad", "checksum": ""}],
+            line_table={"f": [{"instr_index": 0, "file_id": 99, "line": 1, "col": 1}]},
+        )
+        reader = DebugSidecarReader(data)
+        assert reader.lookup("f", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# find_instr() — source → offset
+# ---------------------------------------------------------------------------
+
+class TestFindInstr:
+    def setup_method(self):
+        self.reader = DebugSidecarReader(_fibonacci_sidecar())
+
+    def test_finds_first_instruction_on_line(self):
+        idx = self.reader.find_instr("fibonacci.tetrad", 1)
+        assert idx == 0  # instruction 0 is on line 1
+
+    def test_finds_lowest_index_for_multirow_line(self):
+        # Line 4 has instructions 4, 5, 6 — should return 4
+        idx = self.reader.find_instr("fibonacci.tetrad", 4)
+        assert idx == 4
+
+    def test_unknown_file_returns_none(self):
+        assert self.reader.find_instr("no_such_file.tetrad", 1) is None
+
+    def test_unknown_line_returns_none(self):
+        assert self.reader.find_instr("fibonacci.tetrad", 999) is None
+
+    def test_line_5_returns_correct_instruction(self):
+        idx = self.reader.find_instr("fibonacci.tetrad", 5)
+        assert idx == 7
+
+    def test_cross_function_scan(self):
+        """find_instr scans all functions; the first match across any function is returned."""
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("shared.tetrad")
+        w.begin_function("fn_a", start_instr=0, param_count=0)
+        w.record("fn_a", 3, file_id=fid, line=10, col=1)
+        w.begin_function("fn_b", start_instr=0, param_count=0)
+        w.record("fn_b", 1, file_id=fid, line=10, col=1)
+        reader = DebugSidecarReader(w.finish())
+        idx = reader.find_instr("shared.tetrad", 10)
+        # Both have line 10; lowest instr_index wins → 1
+        assert idx == 1
+
+
+# ---------------------------------------------------------------------------
+# live_variables()
+# ---------------------------------------------------------------------------
+
+class TestLiveVariables:
+    def setup_method(self):
+        self.reader = DebugSidecarReader(_fibonacci_sidecar())
+
+    def test_at_start_only_n_is_live(self):
+        vars_ = self.reader.live_variables("fibonacci", 0)
+        assert len(vars_) == 1
+        assert vars_[0].name == "n"
+
+    def test_at_instruction_4_both_live(self):
+        vars_ = self.reader.live_variables("fibonacci", 4)
+        names = {v.name for v in vars_}
+        assert names == {"n", "result"}
+
+    def test_sorted_by_reg_index(self):
+        vars_ = self.reader.live_variables("fibonacci", 4)
+        reg_indices = [v.reg_index for v in vars_]
+        assert reg_indices == sorted(reg_indices)
+
+    def test_at_live_end_not_included(self):
+        # Both n and result end at 12; at instruction 12 neither should appear
+        vars_ = self.reader.live_variables("fibonacci", 12)
+        assert vars_ == []
+
+    def test_unknown_function_returns_empty(self):
+        assert self.reader.live_variables("no_such_fn", 0) == []
+
+    def test_returns_variable_type(self):
+        vars_ = self.reader.live_variables("fibonacci", 0)
+        assert all(isinstance(v, Variable) for v in vars_)
+
+    def test_no_variables_registered(self):
+        w = DebugSidecarWriter()
+        w.begin_function("empty_fn", start_instr=0, param_count=0)
+        reader = DebugSidecarReader(w.finish())
+        assert reader.live_variables("empty_fn", 0) == []
+
+
+# ---------------------------------------------------------------------------
+# Metadata queries
+# ---------------------------------------------------------------------------
+
+class TestMetadata:
+    def setup_method(self):
+        self.reader = DebugSidecarReader(_fibonacci_sidecar())
+
+    def test_source_files(self):
+        assert self.reader.source_files() == ["fibonacci.tetrad"]
+
+    def test_function_names(self):
+        assert self.reader.function_names() == ["fibonacci"]
+
+    def test_function_range(self):
+        assert self.reader.function_range("fibonacci") == (0, 8)
+
+    def test_function_range_unknown_returns_none(self):
+        assert self.reader.function_range("no_such_fn") is None
+
+    def test_function_range_no_end_returns_none(self):
+        w = DebugSidecarWriter()
+        w.begin_function("f", start_instr=0, param_count=0)
+        # no end_function call
+        reader = DebugSidecarReader(w.finish())
+        assert reader.function_range("f") is None
+
+    def test_multiple_source_files(self):
+        w = DebugSidecarWriter()
+        w.add_source_file("a.tetrad")
+        w.add_source_file("b.tetrad")
+        reader = DebugSidecarReader(w.finish())
+        assert reader.source_files() == ["a.tetrad", "b.tetrad"]
+
+    def test_multiple_function_names(self):
+        w = DebugSidecarWriter()
+        w.begin_function("alpha", start_instr=0, param_count=0)
+        w.begin_function("beta", start_instr=10, param_count=0)
+        reader = DebugSidecarReader(w.finish())
+        assert set(reader.function_names()) == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip fidelity
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_checksum_preserved(self):
+        w = DebugSidecarWriter()
+        w.add_source_file("f.tetrad", checksum=b"\xca\xfe\xba\xbe")
+        data = w.finish()
+        # Just verify the reader loads it without error (checksum is internal)
+        reader = DebugSidecarReader(data)
+        assert reader.source_files() == ["f.tetrad"]
+
+    def test_empty_sidecar_round_trip(self):
+        w = DebugSidecarWriter()
+        data = w.finish()
+        reader = DebugSidecarReader(data)
+        assert reader.source_files() == []
+        assert reader.function_names() == []
+
+    def test_many_functions_round_trip(self):
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("prog.tetrad")
+        for i in range(20):
+            fn = f"fn_{i}"
+            w.begin_function(fn, start_instr=i * 10, param_count=i % 3)
+            w.record(fn, i * 10, file_id=fid, line=i + 1, col=1)
+            w.end_function(fn, end_instr=i * 10 + 10)
+        data = w.finish()
+        reader = DebugSidecarReader(data)
+        assert len(reader.function_names()) == 20
+        for i in range(20):
+            fn = f"fn_{i}"
+            loc = reader.lookup(fn, i * 10)
+            assert loc is not None
+            assert loc.line == i + 1
+
+    def test_large_instruction_indices(self):
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("big.tetrad")
+        w.begin_function("big", start_instr=0, param_count=0)
+        w.record("big", 10_000, file_id=fid, line=9999, col=1)
+        w.record("big", 20_000, file_id=fid, line=19999, col=1)
+        w.end_function("big", end_instr=20_001)
+        reader = DebugSidecarReader(w.finish())
+        loc = reader.lookup("big", 15_000)
+        assert loc is not None
+        assert loc.line == 9999  # between 10000 and 20000 → preceding record

--- a/code/packages/python/debug-sidecar/tests/test_types.py
+++ b/code/packages/python/debug-sidecar/tests/test_types.py
@@ -1,0 +1,69 @@
+"""Tests for debug_sidecar.types — SourceLocation and Variable."""
+
+import pytest
+
+from debug_sidecar.types import SourceLocation, Variable
+
+
+class TestSourceLocation:
+    def test_str_representation(self):
+        loc = SourceLocation(file="foo.tetrad", line=10, col=3)
+        assert str(loc) == "foo.tetrad:10:3"
+
+    def test_frozen(self):
+        loc = SourceLocation(file="foo.tetrad", line=1, col=1)
+        with pytest.raises(Exception):  # FrozenInstanceError
+            loc.line = 99  # type: ignore[misc]
+
+    def test_hashable(self):
+        loc1 = SourceLocation(file="a.tetrad", line=5, col=1)
+        loc2 = SourceLocation(file="a.tetrad", line=5, col=1)
+        assert loc1 == loc2
+        assert hash(loc1) == hash(loc2)
+
+    def test_different_locations_not_equal(self):
+        loc1 = SourceLocation(file="a.tetrad", line=1, col=1)
+        loc2 = SourceLocation(file="a.tetrad", line=2, col=1)
+        assert loc1 != loc2
+
+    def test_usable_in_set(self):
+        locs = {
+            SourceLocation("a.tetrad", 1, 1),
+            SourceLocation("a.tetrad", 1, 1),
+            SourceLocation("b.tetrad", 2, 3),
+        }
+        assert len(locs) == 2
+
+
+class TestVariable:
+    def test_is_live_at_start(self):
+        v = Variable(reg_index=0, name="x", type_hint="u8", live_start=3, live_end=10)
+        assert v.is_live_at(3)
+
+    def test_is_live_at_middle(self):
+        v = Variable(reg_index=0, name="x", type_hint="u8", live_start=3, live_end=10)
+        assert v.is_live_at(7)
+
+    def test_not_live_at_end(self):
+        # live_end is exclusive
+        v = Variable(reg_index=0, name="x", type_hint="u8", live_start=3, live_end=10)
+        assert not v.is_live_at(10)
+
+    def test_not_live_before_start(self):
+        v = Variable(reg_index=0, name="x", type_hint="u8", live_start=3, live_end=10)
+        assert not v.is_live_at(2)
+
+    def test_empty_type_hint(self):
+        v = Variable(reg_index=1, name="n", type_hint="", live_start=0, live_end=5)
+        assert v.type_hint == ""
+
+    def test_frozen(self):
+        v = Variable(reg_index=0, name="x", type_hint="any", live_start=0, live_end=5)
+        with pytest.raises(Exception):
+            v.name = "y"  # type: ignore[misc]
+
+    def test_single_instruction_range(self):
+        v = Variable(reg_index=0, name="tmp", type_hint="any", live_start=5, live_end=6)
+        assert v.is_live_at(5)
+        assert not v.is_live_at(6)
+        assert not v.is_live_at(4)

--- a/code/packages/python/debug-sidecar/tests/test_writer.py
+++ b/code/packages/python/debug-sidecar/tests/test_writer.py
@@ -1,0 +1,170 @@
+"""Tests for DebugSidecarWriter."""
+
+import json
+
+import pytest
+
+from debug_sidecar.writer import DebugSidecarWriter
+
+
+def _parse(data: bytes) -> dict:
+    return json.loads(data.decode("utf-8"))
+
+
+class TestAddSourceFile:
+    def test_returns_zero_for_first_file(self):
+        w = DebugSidecarWriter()
+        assert w.add_source_file("foo.tetrad") == 0
+
+    def test_returns_sequential_ids(self):
+        w = DebugSidecarWriter()
+        assert w.add_source_file("a.tetrad") == 0
+        assert w.add_source_file("b.tetrad") == 1
+        assert w.add_source_file("c.tetrad") == 2
+
+    def test_duplicate_path_returns_same_id(self):
+        w = DebugSidecarWriter()
+        id1 = w.add_source_file("foo.tetrad")
+        id2 = w.add_source_file("foo.tetrad")
+        assert id1 == id2 == 0
+
+    def test_checksum_stored_as_hex(self):
+        w = DebugSidecarWriter()
+        w.add_source_file("foo.tetrad", checksum=b"\xde\xad\xbe\xef")
+        payload = _parse(w.finish())
+        assert payload["source_files"][0]["checksum"] == "deadbeef"
+
+    def test_empty_checksum(self):
+        w = DebugSidecarWriter()
+        w.add_source_file("foo.tetrad")
+        payload = _parse(w.finish())
+        assert payload["source_files"][0]["checksum"] == ""
+
+    def test_path_preserved(self):
+        w = DebugSidecarWriter()
+        w.add_source_file("/abs/path/to/prog.tetrad")
+        payload = _parse(w.finish())
+        assert payload["source_files"][0]["path"] == "/abs/path/to/prog.tetrad"
+
+
+class TestRecord:
+    def test_record_creates_line_table_entry(self):
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("fib.tetrad")
+        w.begin_function("fib", start_instr=0, param_count=1)
+        w.record("fib", 0, file_id=fid, line=1, col=5)
+        payload = _parse(w.finish())
+        rows = payload["line_table"]["fib"]
+        assert len(rows) == 1
+        assert rows[0] == {"instr_index": 0, "file_id": 0, "line": 1, "col": 5}
+
+    def test_rows_sorted_by_instr_index(self):
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("f.tetrad")
+        w.begin_function("f", start_instr=0, param_count=0)
+        # Record out of order
+        w.record("f", 5, file_id=fid, line=6, col=1)
+        w.record("f", 2, file_id=fid, line=3, col=1)
+        w.record("f", 8, file_id=fid, line=9, col=1)
+        w.record("f", 0, file_id=fid, line=1, col=1)
+        payload = _parse(w.finish())
+        indices = [r["instr_index"] for r in payload["line_table"]["f"]]
+        assert indices == sorted(indices)
+
+    def test_multiple_functions(self):
+        w = DebugSidecarWriter()
+        fid = w.add_source_file("prog.tetrad")
+        w.begin_function("main", start_instr=0, param_count=0)
+        w.record("main", 0, file_id=fid, line=1, col=1)
+        w.begin_function("helper", start_instr=10, param_count=1)
+        w.record("helper", 0, file_id=fid, line=5, col=1)
+        payload = _parse(w.finish())
+        assert "main" in payload["line_table"]
+        assert "helper" in payload["line_table"]
+
+    def test_no_record_no_line_table(self):
+        w = DebugSidecarWriter()
+        payload = _parse(w.finish())
+        assert payload["line_table"] == {}
+
+
+class TestFunctions:
+    def test_begin_function_registers_start(self):
+        w = DebugSidecarWriter()
+        w.begin_function("fib", start_instr=0, param_count=1)
+        payload = _parse(w.finish())
+        fn = payload["functions"]["fib"]
+        assert fn["start_instr"] == 0
+        assert fn["param_count"] == 1
+        assert fn["end_instr"] is None
+
+    def test_end_function_sets_end(self):
+        w = DebugSidecarWriter()
+        w.begin_function("fib", start_instr=0, param_count=1)
+        w.end_function("fib", end_instr=12)
+        payload = _parse(w.finish())
+        assert payload["functions"]["fib"]["end_instr"] == 12
+
+    def test_end_function_no_begin_is_noop(self):
+        w = DebugSidecarWriter()
+        w.end_function("ghost", end_instr=5)
+        payload = _parse(w.finish())
+        assert "ghost" not in payload["functions"]
+
+
+class TestVariables:
+    def test_declare_variable_stored(self):
+        w = DebugSidecarWriter()
+        w.begin_function("fib", start_instr=0, param_count=1)
+        w.declare_variable("fib", reg_index=0, name="n", type_hint="u8",
+                           live_start=0, live_end=12)
+        payload = _parse(w.finish())
+        vars_ = payload["variables"]["fib"]
+        assert len(vars_) == 1
+        assert vars_[0] == {
+            "reg_index": 0, "name": "n", "type_hint": "u8",
+            "live_start": 0, "live_end": 12,
+        }
+
+    def test_multiple_variables(self):
+        w = DebugSidecarWriter()
+        w.begin_function("f", start_instr=0, param_count=2)
+        w.declare_variable("f", reg_index=0, name="a", type_hint="any",
+                           live_start=0, live_end=5)
+        w.declare_variable("f", reg_index=1, name="b", type_hint="any",
+                           live_start=0, live_end=5)
+        payload = _parse(w.finish())
+        assert len(payload["variables"]["f"]) == 2
+
+    def test_empty_type_hint_default(self):
+        w = DebugSidecarWriter()
+        w.begin_function("f", start_instr=0, param_count=1)
+        w.declare_variable("f", reg_index=0, name="x", live_start=0, live_end=3)
+        payload = _parse(w.finish())
+        assert payload["variables"]["f"][0]["type_hint"] == ""
+
+
+class TestFinish:
+    def test_version_is_one(self):
+        w = DebugSidecarWriter()
+        payload = _parse(w.finish())
+        assert payload["version"] == 1
+
+    def test_returns_bytes(self):
+        w = DebugSidecarWriter()
+        result = w.finish()
+        assert isinstance(result, bytes)
+
+    def test_valid_utf8_json(self):
+        w = DebugSidecarWriter()
+        data = w.finish()
+        parsed = json.loads(data.decode("utf-8"))
+        assert isinstance(parsed, dict)
+
+    def test_empty_writer_still_valid(self):
+        w = DebugSidecarWriter()
+        payload = _parse(w.finish())
+        assert payload["source_files"] == []
+        assert payload["line_table"] == {}
+        assert payload["functions"] == {}
+        assert payload["variables"] == {}

--- a/code/specs/LANG13-debug-sidecar.md
+++ b/code/specs/LANG13-debug-sidecar.md
@@ -1,0 +1,258 @@
+# LANG13 — debug-sidecar: Source-Location Companion for the IIR Pipeline
+
+## Overview
+
+Every IIR compiler knows two things about each instruction it emits: what the
+instruction does, and *where in the source file it came from*.  The first fact
+travels in `IIRInstr.op`.  The second has nowhere to go today — so debuggers
+can't map a paused VM back to a source line, insight tools can't say "line 3,
+column 5" instead of "instruction index 2", and stack traces show register
+numbers instead of variable names.
+
+`debug-sidecar` fixes this.  It is the Python implementation of the binary
+format specified in `05d-debug-sidecar-format.md`:
+
+- A **writer** (`DebugSidecarWriter`) that compilers call once per emitted
+  instruction to record `(instr_index, source_file, line, col)`.
+- A **reader** (`DebugSidecarReader`) that debuggers and insight tools call to
+  answer "given instruction index N in function F, what source location is that?"
+
+The sidecar is intentionally **separate from IIRInstr** — keeping debug noise
+off the hot execution path, exactly as DWARF is separate from ELF `.text` and
+JavaScript source maps are separate from minified `.js`.
+
+---
+
+## What travels alongside the IIRModule
+
+```
+Compiler output:
+  IIRModule          ← execution IR (IIRInstr, IIRFunction, …)
+  DebugSidecar       ← source mapping (bytes, written by DebugSidecarWriter)
+
+Consumer:
+  vm-core            ← executes IIRModule
+  debug-adapter      ← reads DebugSidecar to translate frame.ip → (file, line, col)
+  vm-type-suggestions ← optionally reads DebugSidecar to enrich output with source locations
+  jit-profiling-insights ← same
+```
+
+---
+
+## Public API
+
+### Writer
+
+```python
+from debug_sidecar import DebugSidecarWriter
+
+writer = DebugSidecarWriter()
+
+# Register the source file; returns a file_id
+file_id = writer.add_source_file("fibonacci.tetrad", checksum=b"\x00" * 32)
+
+# Called once per IIRInstr emitted by the compiler
+writer.record(
+    fn_name="fibonacci",
+    instr_index=0,
+    file_id=file_id,
+    line=3,
+    col=5,
+)
+
+# Register a function (execution unit)
+writer.begin_function(
+    fn_name="fibonacci",
+    start_instr=0,
+    param_count=1,
+)
+writer.end_function(fn_name="fibonacci", end_instr=12)
+
+# Register a variable (parameter or local)
+writer.declare_variable(
+    fn_name="fibonacci",
+    reg_index=0,
+    name="n",
+    type_hint="any",
+    live_start=0,
+    live_end=12,
+)
+
+# Serialise to bytes (store alongside IIRModule)
+sidecar_bytes: bytes = writer.finish()
+```
+
+### Reader
+
+```python
+from debug_sidecar import DebugSidecarReader
+
+reader = DebugSidecarReader(sidecar_bytes)
+
+# Offset → source location (used by debugger when VM pauses)
+loc = reader.lookup(fn_name="fibonacci", instr_index=2)
+# => SourceLocation(file="fibonacci.tetrad", line=3, col=5)
+
+# Source → instruction index (used to set breakpoints)
+instr_index = reader.find_instr(file="fibonacci.tetrad", line=3)
+# => 2
+
+# Variable names at a given point (used for variable inspection panel)
+vars = reader.live_variables(fn_name="fibonacci", at_instr=5)
+# => [Variable(reg=0, name="n", type_hint="any")]
+
+# All source files
+files = reader.source_files()
+# => ["fibonacci.tetrad"]
+```
+
+---
+
+## Data model
+
+### `SourceLocation`
+
+```python
+@dataclass(frozen=True)
+class SourceLocation:
+    file: str           # Source file path (from DebugSidecarWriter.add_source_file)
+    line: int           # 1-based line number
+    col: int            # 1-based column number
+```
+
+### `Variable`
+
+```python
+@dataclass(frozen=True)
+class Variable:
+    reg_index: int      # IIR register / slot index
+    name: str           # Human name from source ("n", "result", …)
+    type_hint: str      # Type annotation ("any", "u8", "Int", …)
+    live_start: int     # First instr_index where this binding is valid
+    live_end: int       # One-past-last instr_index
+```
+
+### `DebugSidecar` (internal, returned by `finish()` as bytes)
+
+The binary layout follows spec `05d` exactly:
+- Magic: `DBG\0` (4 bytes)
+- Version: `u16 = 1`
+- Section count + directory
+- Section 0x01: String table (deduplicated null-terminated strings)
+- Section 0x02: Source file table (path → SHA-256)
+- Section 0x03: Line number table (per-function delta-encoded rows)
+- Section 0x04: Execution unit table (function name, instr range, param count)
+- Section 0x05: Variable table (reg_index, name, type_hint, live range)
+
+For this implementation we use a **simplified in-memory format** — JSON
+serialised to bytes — so the focus stays on the API and the pipeline
+integration.  A follow-on PR can swap to the full binary format from spec `05d`
+without changing any callers (the `finish()` / `DebugSidecarReader` boundary
+encapsulates the format).
+
+---
+
+## Integration with compilers
+
+Every IIR compiler adds approximately 3 lines per emitted instruction:
+
+```python
+class FibonacciCompiler:
+    def compile(self, ast, source_path: str):
+        writer = DebugSidecarWriter()
+        file_id = writer.add_source_file(source_path)
+        writer.begin_function("fibonacci", start_instr=0, param_count=1)
+        writer.declare_variable("fibonacci", reg_index=0, name="n",
+                                type_hint="any", live_start=0, live_end=12)
+
+        instrs = []
+        for node in ast.body:
+            instr_index = len(instrs)
+            writer.record("fibonacci", instr_index,
+                          file_id=file_id, line=node.line, col=node.col)
+            instrs.append(self._compile_node(node))
+
+        writer.end_function("fibonacci", end_instr=len(instrs))
+        module = IIRModule(name="fibonacci", functions=[...])
+        sidecar = writer.finish()
+        return module, sidecar
+```
+
+---
+
+## Integration with insight tools
+
+`vm-type-suggestions` and `jit-profiling-insights` accept an optional sidecar
+to enrich their output with source locations:
+
+```python
+from debug_sidecar import DebugSidecarReader
+from vm_type_suggestions import suggest
+
+reader = DebugSidecarReader(sidecar_bytes)
+report = suggest(fn_list, program_name="fibonacci", sidecar=reader)
+
+# With sidecar:
+#   ✅ fibonacci — 1,048,576 calls
+#     'n' (arg 0) at fibonacci.tetrad:1:16: always u8
+#     → declare 'n: u8'
+
+# Without sidecar (current behaviour):
+#   ✅ fibonacci — 1,048,576 calls
+#     'n' (arg 0): always u8
+#     → declare 'n: u8'
+```
+
+---
+
+## Integration with LANG14 (native debug info)
+
+`DebugSidecarReader` is the input to the LANG14 converters that produce
+native debug info for AOT-compiled binaries:
+
+```python
+from debug_sidecar import DebugSidecarReader
+from native_debug_info import DwarfEmitter, CodeViewEmitter
+
+reader = DebugSidecarReader(sidecar_bytes)
+
+# Produce DWARF sections for ELF (Linux) or Mach-O (macOS)
+dwarf = DwarfEmitter(reader, load_address=0x400000)
+elf_with_dwarf = dwarf.embed_in_elf(elf_bytes, symbol_table)
+
+# Produce CodeView sections for PE (Windows)
+cv = CodeViewEmitter(reader, image_base=0x140000000)
+pe_with_cv = cv.embed_in_pe(pe_bytes, symbol_table)
+```
+
+---
+
+## Module layout
+
+```
+debug-sidecar/
+├── pyproject.toml
+├── BUILD
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── debug_sidecar/
+        ├── __init__.py
+        ├── types.py       # SourceLocation, Variable
+        ├── writer.py      # DebugSidecarWriter
+        └── reader.py      # DebugSidecarReader
+```
+
+---
+
+## Testing strategy
+
+- Writer → finish() → Reader round-trip for all section types.
+- `lookup(fn, instr_index)` returns correct source location.
+- `find_instr(file, line)` returns correct instruction index.
+- `live_variables(fn, at_instr)` returns only variables alive at that point.
+- Multiple functions in one sidecar.
+- Unknown instruction index returns `None` (not an exception).
+- Multiple source files in one sidecar.
+
+Target: **95%+ line coverage**.

--- a/code/specs/LANG14-native-debug-info.md
+++ b/code/specs/LANG14-native-debug-info.md
@@ -1,0 +1,346 @@
+# LANG14 — native-debug-info: DWARF, CodeView, and dSYM for AOT Binaries
+
+## Overview
+
+When `aot-core` compiles a program and `code-packager` wraps it in an ELF,
+Mach-O, or PE binary, the resulting file is opaque to native debuggers:
+`gdb`, `lldb`, and WinDbg can execute it but cannot set breakpoints by source
+line, cannot show variable names, and cannot print meaningful stack traces.
+
+`native-debug-info` closes this gap.  It reads a `DebugSidecar` (LANG13) and
+embeds the appropriate native debug format into the binary that `code-packager`
+already produced:
+
+| Binary format | Debug format | Debugger support |
+|---|---|---|
+| ELF64 (Linux) | DWARF 4 | `gdb`, `lldb`, `perf`, `addr2line`, `valgrind` |
+| Mach-O64 (macOS) | DWARF 4 in `__DWARF` segment | `lldb`, Xcode, Instruments |
+| PE32+ (Windows) | CodeView 4 in `.debug$S` section | WinDbg, Visual Studio, `dumpbin` |
+| WASM | DWARF 4 in custom sections | Chrome DevTools, `wasm-objdump` |
+
+The result: after `native-debug-info` runs, the binary is indistinguishable
+from one compiled by clang or rustc — `gdb` can set breakpoints, `lldb` shows
+local variable values, WinDbg prints function names.
+
+---
+
+## The full AOT debug pipeline
+
+```
+Source (.tetrad / .nib / …)
+        │
+        ▼
+Compiler  ──────────────────────────────► IIRModule + DebugSidecar
+        │
+        ▼
+aot-core.compile()  ───────────────────► CodeArtifact (native_bytes, symbol_table)
+        │
+        ▼
+code-packager.pack()  ─────────────────► raw ELF / Mach-O / PE bytes  (no debug info)
+        │
+        ▼
+native-debug-info.embed()  ────────────► ELF / Mach-O / PE with DWARF / CodeView
+        │
+   ┌────┴──────────────┐
+   ▼                   ▼
+ Linux binary       Windows binary
+ + DWARF            + CodeView
+   │
+ gdb / lldb       WinDbg / VS
+```
+
+---
+
+## DWARF for ELF (Linux) and Mach-O (macOS)
+
+DWARF is the dominant open debug format.  Linux ELF and macOS Mach-O both use
+it.  The difference is only in how it's packaged:
+
+- **ELF**: DWARF lives in named sections (`.debug_line`, `.debug_info`, etc.)
+  inside the ELF file itself.
+- **Mach-O**: DWARF lives in a `__DWARF` segment containing sections named
+  `__debug_line`, `__debug_info`, etc.  Apple's toolchain also produces a
+  separate `.dSYM` bundle (a directory), but embedding directly in the binary
+  is sufficient for `lldb` and Instruments.
+
+### DWARF sections we emit (DWARF 4, minimal subset)
+
+| Section | Content | Purpose |
+|---|---|---|
+| `.debug_abbrev` | Abbreviation table | Defines the structure of `.debug_info` entries |
+| `.debug_info` | Compilation unit + `DW_TAG_subprogram` entries | Function names, file/line ranges |
+| `.debug_line` | Line number program | Maps code address → (file, line, col) |
+| `.debug_str` | String table | Deduplicated strings referenced by other sections |
+
+This subset is sufficient for:
+- Setting breakpoints by source line (`gdb break file.c:42`)
+- Showing source in stack traces
+- Printing function names in `addr2line` and `perf report`
+
+**Not in scope for this implementation** (future PRs):
+- `DW_TAG_variable` / `DW_TAG_formal_parameter` (variable values)
+- `DW_TAG_base_type` (type descriptions)
+- `DW_AT_location` expressions (register/memory locations of variables)
+
+### `.debug_line` — Line Number Program
+
+DWARF 4 line number programs use a stack machine with opcodes to compactly
+encode the (address, file, line, col) mapping.  We use the simplest possible
+encoding: `DW_LNS_advance_pc` + `DW_LNS_advance_line` + `DW_LNS_copy` for
+every row.
+
+```
+Header:
+  unit_length      u32     (length of this section minus 4)
+  version          u16     (= 4 for DWARF 4)
+  header_length    u32     (length of header after this field)
+  minimum_instruction_length  u8  (= 1 for byte-addressed ISAs)
+  maximum_ops_per_instruction u8  (= 1)
+  default_is_stmt  u8      (= 1)
+  line_base        i8      (= -5)
+  line_range       u8      (= 14)
+  opcode_base      u8      (= 13, standard opcodes 1–12 + our first special)
+  standard_opcode_lengths  bytes[12]
+  include_directories  (null-terminated list, ending with empty string)
+  file_names  (null-terminated triplets: name, dir_index, mtime, size)
+  (empty string terminates file name list)
+
+Body (line number program opcodes):
+  DW_LNS_set_file    (0x04) + ULEB128 file_index
+  DW_LNS_advance_pc  (0x02) + ULEB128 address_delta
+  DW_LNS_advance_line (0x03) + SLEB128 line_delta
+  DW_LNS_copy        (0x01)    — emit one row
+  DW_LNE_end_sequence (0x00 0x01 0x01)  — end marker
+```
+
+### `.debug_info` — Compilation Unit
+
+```
+Compilation unit header:
+  unit_length    u32
+  version        u16  (= 4)
+  debug_abbrev_offset  u32  (= 0, our abbrev table starts at offset 0)
+  address_size   u8   (= 8 for 64-bit targets)
+
+Compilation unit DIE (DW_TAG_compile_unit, abbrev 1):
+  DW_AT_producer   DW_FORM_strp  → "coding-adventures aot-core"
+  DW_AT_language   DW_FORM_data2 → DW_LANG_C99 (0x0001, generic placeholder)
+  DW_AT_name       DW_FORM_strp  → source file name
+  DW_AT_comp_dir   DW_FORM_strp  → ""
+  DW_AT_low_pc     DW_FORM_addr  → load_address
+  DW_AT_high_pc    DW_FORM_data8 → code_size
+
+For each function (DW_TAG_subprogram, abbrev 2):
+  DW_AT_name       DW_FORM_strp  → function name
+  DW_AT_decl_file  DW_FORM_data1 → file index (1-based)
+  DW_AT_decl_line  DW_FORM_data4 → first source line
+  DW_AT_low_pc     DW_FORM_addr  → function start address
+  DW_AT_high_pc    DW_FORM_data8 → function byte length
+  DW_AT_external   DW_FORM_flag_present
+
+DW_TAG_null (0x00) — end of children
+DW_TAG_null (0x00) — end of compile unit children
+```
+
+### `.debug_abbrev` — Abbreviation Table
+
+```
+Abbrev 1: DW_TAG_compile_unit, DW_CHILDREN_yes
+  DW_AT_producer  DW_FORM_strp
+  DW_AT_language  DW_FORM_data2
+  DW_AT_name      DW_FORM_strp
+  DW_AT_comp_dir  DW_FORM_strp
+  DW_AT_low_pc    DW_FORM_addr
+  DW_AT_high_pc   DW_FORM_data8
+  0, 0  (terminator)
+
+Abbrev 2: DW_TAG_subprogram, DW_CHILDREN_no
+  DW_AT_name      DW_FORM_strp
+  DW_AT_decl_file DW_FORM_data1
+  DW_AT_decl_line DW_FORM_data4
+  DW_AT_low_pc    DW_FORM_addr
+  DW_AT_high_pc   DW_FORM_data8
+  DW_AT_external  DW_FORM_flag_present
+  0, 0  (terminator)
+
+0  (end of abbreviation table)
+```
+
+---
+
+## CodeView for PE (Windows)
+
+Windows uses **CodeView 4** embedded in the PE binary as a `.debug$S` section.
+WinDbg and Visual Studio read this without a separate `.pdb` file.
+
+### `.debug$S` section structure
+
+```
+Signature:  u32 = 4  (CodeView 4)
+
+Symbol subsection (DEBUG_S_SYMBOLS = 0xF1):
+  subsection_type  u32  (= 0xF1)
+  subsection_size  u32
+  per symbol:
+    record_length  u16
+    record_type    u16
+    payload        bytes[record_length - 2]
+
+Line number subsection (DEBUG_S_LINES = 0xF2):
+  subsection_type  u32  (= 0xF2)
+  subsection_size  u32
+  offset_of_contrib  u32   (RVA of code section)
+  section_index      u16   (section number, 1-based)
+  flags              u16   (= 0)
+  code_size          u32
+  per file block:
+    file_checksum_offset  u32
+    num_lines             u32
+    block_size            u32
+    per line:
+      offset  u32   (byte offset from start of function)
+      line_start  u32  (packed: bits 0–23 = line, bits 24–30 = col delta, bit 31 = is_statement)
+```
+
+### Symbol records we emit
+
+**`S_GPROC32` (0x1110)** — global procedure:
+```
+  parent        u32  (= 0)
+  end           u32  (offset to S_END)
+  next          u32  (= 0)
+  proc_len      u32  (byte length of function)
+  dbg_start     u32  (= 0)
+  dbg_end       u32  (= proc_len)
+  type_index    u32  (= 0, no type info)
+  offset        u32  (RVA of function start)
+  segment       u16  (section index)
+  flags         u8   (= 0)
+  name          null-terminated string
+```
+
+**`S_END` (0x0006)** — closes `S_GPROC32`.
+
+### `.debug$T` section
+
+A minimal type section with just one entry: `LF_PROCEDURE` with no arguments
+and return type `T_VOID`.  Without it some tools complain; with it they're
+satisfied enough to show function names.
+
+---
+
+## Public API
+
+```python
+from native_debug_info import DwarfEmitter, CodeViewEmitter
+from debug_sidecar import DebugSidecarReader
+
+reader = DebugSidecarReader(sidecar_bytes)
+
+# For Linux ELF or macOS Mach-O — same DWARF, different embedding
+emitter = DwarfEmitter(
+    reader=reader,
+    load_address=0x400000,       # must match the packager's load_address
+    symbol_table={"main": 0},    # function name → byte offset in code
+    code_size=len(native_bytes),
+)
+dwarf_sections = emitter.build()
+# => {".debug_abbrev": bytes, ".debug_info": bytes,
+#     ".debug_line": bytes, ".debug_str": bytes}
+
+# Embed into ELF
+elf_with_debug = emitter.embed_in_elf(elf_bytes)
+
+# Embed into Mach-O (same DWARF, __DWARF segment)
+macho_with_debug = emitter.embed_in_macho(macho_bytes)
+
+# For Windows PE — CodeView in .debug$S
+cv_emitter = CodeViewEmitter(
+    reader=reader,
+    image_base=0x140000000,
+    symbol_table={"main": 0},
+    code_rva=0x1000,             # RVA of .text section
+)
+pe_with_debug = cv_emitter.embed_in_pe(pe_bytes)
+```
+
+### `CodeArtifact` integration
+
+`native-debug-info` also provides a one-call convenience that reads the target
+from a `CodeArtifact` and dispatches to the right emitter:
+
+```python
+from native_debug_info import embed_debug_info
+from code_packager import PackagerRegistry
+
+registry = PackagerRegistry.default()
+packed_bytes = registry.pack(artifact)
+
+# Enrich with debug info if a sidecar is available
+if sidecar_bytes:
+    packed_bytes = embed_debug_info(packed_bytes, artifact, sidecar_bytes)
+```
+
+---
+
+## ULEB128 and SLEB128 encoding helpers
+
+DWARF uses LEB128 (Little-Endian Base-128) variable-length integers throughout.
+The package provides these as internal helpers:
+
+```python
+def encode_uleb128(value: int) -> bytes: ...
+def encode_sleb128(value: int) -> bytes: ...
+```
+
+---
+
+## Module layout
+
+```
+native-debug-info/
+├── pyproject.toml
+├── BUILD
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── native_debug_info/
+        ├── __init__.py
+        ├── dwarf.py        # DwarfEmitter — builds .debug_* sections
+        ├── codeview.py     # CodeViewEmitter — builds .debug$S / .debug$T
+        ├── embed.py        # embed_debug_info() — dispatches by target
+        └── leb128.py       # ULEB128 / SLEB128 encoding
+```
+
+---
+
+## Relationship to code-packager (LANG10)
+
+`code-packager` stays format-agnostic — it knows nothing about DWARF or
+CodeView.  `native-debug-info` is a post-processor that takes the packager's
+output and enriches it.  This follows the same layered design:
+
+```
+code-packager   →  bare ELF / Mach-O / PE  (no debug info)
+native-debug-info  →  same binary + DWARF / CodeView sections
+```
+
+The `code-packager` does not change.  The `CodeArtifact` does not need a
+`sidecar` field.  Debug info is opt-in and applied as a separate pass.
+
+---
+
+## Testing strategy
+
+- Unit tests for ULEB128 / SLEB128 encoding (all ranges, negative values).
+- Unit tests for each DWARF section builder in isolation.
+- Round-trip test: build DWARF sections from a known `DebugSidecarReader`,
+  parse the resulting bytes with a minimal DWARF parser, verify the line table
+  maps correctly.
+- Unit tests for CodeView `.debug$S` builder — verify symbol record headers.
+- Integration test: `DwarfEmitter.embed_in_elf()` on a known ELF; check magic,
+  section count increase, section names present.
+- Integration test: `CodeViewEmitter.embed_in_pe()` on a known PE; check
+  `.debug$S` section presence.
+
+Target: **95%+ line coverage**.


### PR DESCRIPTION
## Summary

- **LANG13 `debug-sidecar`** — implements the source-location sidecar pipeline that carries `(fn, instr_index) → (file, line, col)` mappings from the compiler to debuggers and insight tools. Keeps `IIRInstr` lean (no source positions on the hot path), analogous to DWARF sections alongside ELF `.text`.
- **LANG14 `native-debug-info`** — specification for DWARF 4 (ELF/Mach-O) and CodeView 4 (PE/Windows) emission from a compiled sidecar, enabling breakpoints and stepping in GDB/LLDB/WinDbg. Implementation is a follow-on PR.
- 70 tests, 100% passing, no runtime dependencies.

### debug-sidecar API

| Side | Class | Key methods |
|---|---|---|
| Writer (compiler) | `DebugSidecarWriter` | `add_source_file`, `begin/end_function`, `record`, `declare_variable`, `finish() → bytes` |
| Reader (debugger/tools) | `DebugSidecarReader` | `lookup(fn, instr) → SourceLocation`, `find_instr(file, line) → int`, `live_variables(fn, instr) → list[Variable]` |

`lookup()` uses `bisect_right` for O(log n) DWARF-style lookup — the nearest preceding record covers any generated instruction that has no explicit mapping.

### native-debug-info spec highlights

- **DWARF 4**: `.debug_abbrev` + `.debug_info` (DW_TAG_compile_unit + DW_TAG_subprogram DIEs) + `.debug_line` (stack-machine line number program) + `.debug_str`. Sufficient for breakpoints, source stack traces, and `addr2line`.
- **CodeView 4**: `.debug$S` with `DEBUG_S_SYMBOLS` (S_GPROC32 records) + `DEBUG_S_LINES`; `.debug$T` minimal type section.
- Both formats are post-processing passes on `code-packager` output — `code-packager` itself stays unchanged.

## Test plan

- [x] 70 unit tests passing (writer serialization, reader round-trips, DWARF-style lookup semantics, cross-function `find_instr`, live variable range filtering, error handling for corrupt/wrong-version sidecars)
- [x] Security review passed (pure in-memory JSON, no network/filesystem/subprocess)
- [ ] CI BUILD runs pytest with coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)