### PR TITLE
Add TypeScript pcm-audio package

### DIFF
--- a/code/packages/typescript/pcm-audio/BUILD
+++ b/code/packages/typescript/pcm-audio/BUILD
@@ -1,0 +1,3 @@
+npm install --silent
+npm run build --silent
+npm test --silent

--- a/code/packages/typescript/pcm-audio/BUILD_windows
+++ b/code/packages/typescript/pcm-audio/BUILD_windows
@@ -1,0 +1,3 @@
+npm install --silent
+npm run build --silent
+npm test --silent

--- a/code/packages/typescript/pcm-audio/CHANGELOG.md
+++ b/code/packages/typescript/pcm-audio/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the reusable TypeScript PCM encoding stage with:
+  - `PCMFormat` metadata validation
+  - `PCMBuffer` container with timing helpers
+  - `floatToPcm16`, `encodeSampleBuffer`, and `samplesToPcmBuffer`

--- a/code/packages/typescript/pcm-audio/README.md
+++ b/code/packages/typescript/pcm-audio/README.md
@@ -1,0 +1,28 @@
+# typescript/pcm-audio
+
+`pcm-audio` is the reusable digital encoding stage in `MUS01`.
+
+It converts normalized floating-point samples into signed 16-bit PCM integers for the
+next audio layer:
+
+```text
+floating samples -> PCMFormat -> PCMBuffer
+```
+
+The package is intentionally small and deterministic. It does not write files or
+talk to audio devices.
+
+## Usage
+
+```ts
+import { floatToPcm16, samplesToPcmBuffer } from "@coding-adventures/pcm-audio";
+
+const pcm = samplesToPcmBuffer([0.0, 1.0, -1.0, 2.0], { sampleRateHz: 4.0 });
+console.log(pcm.samples); // [0, 32767, -32768, 32767]
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/typescript/pcm-audio/package-lock.json
+++ b/code/packages/typescript/pcm-audio/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "@coding-adventures/pcm-audio",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/pcm-audio",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/code/packages/typescript/pcm-audio/package.json
+++ b/code/packages/typescript/pcm-audio/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@coding-adventures/pcm-audio",
+  "version": "0.1.0",
+  "description": "Reusable PCM encoding stage for virtual audio pipelines",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "node node_modules/typescript/bin/tsc",
+    "test": "node node_modules/typescript/bin/tsc -p tsconfig.test.json && node --test dist-test/tests/pcm-audio.test.js"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/code/packages/typescript/pcm-audio/required_capabilities.json
+++ b/code/packages/typescript/pcm-audio/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/pcm-audio",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/typescript/pcm-audio/src/index.ts
+++ b/code/packages/typescript/pcm-audio/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./pcm_audio.js";

--- a/code/packages/typescript/pcm-audio/src/pcm_audio.ts
+++ b/code/packages/typescript/pcm-audio/src/pcm_audio.ts
@@ -1,0 +1,243 @@
+export const DEFAULT_SAMPLE_RATE_HZ = 44_100.0;
+export const DEFAULT_BIT_DEPTH = 16;
+export const DEFAULT_CHANNEL_COUNT = 1;
+export const DEFAULT_FULL_SCALE_VOLTAGE = 1.0;
+export const PCM16_MIN = -32_768;
+export const PCM16_MAX = 32_767;
+
+export interface SampleBufferLike {
+  samples: Iterable<number>;
+  sampleRateHz: number;
+  startTimeSeconds?: number;
+}
+
+export interface PCMEncodingOptions {
+  sampleRateHz?: number;
+  startTimeSeconds?: number;
+  pcmFormat?: PCMFormat;
+}
+
+export class PCMFormat {
+  readonly sampleRateHz: number;
+  readonly channelCount: number;
+  readonly bitDepth: number;
+  readonly fullScaleVoltage: number;
+
+  constructor(
+    sampleRateHz: number = DEFAULT_SAMPLE_RATE_HZ,
+    channelCount: number = DEFAULT_CHANNEL_COUNT,
+    bitDepth: number = DEFAULT_BIT_DEPTH,
+    fullScaleVoltage: number = DEFAULT_FULL_SCALE_VOLTAGE,
+  ) {
+    this.sampleRateHz = positiveFloat("sampleRateHz", sampleRateHz);
+    this.channelCount = positiveInt("channelCount", channelCount);
+    if (this.channelCount !== DEFAULT_CHANNEL_COUNT) {
+      throw new RangeError("PCMFormat supports only mono audio in this V1 model");
+    }
+    this.bitDepth = positiveInt("bitDepth", bitDepth);
+    if (this.bitDepth !== DEFAULT_BIT_DEPTH) {
+      throw new RangeError("PCMFormat supports only 16-bit PCM in this V1 model");
+    }
+    this.fullScaleVoltage = positiveFloat("fullScaleVoltage", fullScaleVoltage);
+  }
+
+  get minimumInteger(): number {
+    return PCM16_MIN;
+  }
+
+  get maximumInteger(): number {
+    return PCM16_MAX;
+  }
+
+  get sampleWidthBytes(): number {
+    return this.bitDepth / 8;
+  }
+
+  integerSampleRate(): number {
+    return integerSampleRate(this.sampleRateHz);
+  }
+}
+
+export class PCMBuffer {
+  readonly samples: ReadonlyArray<number>;
+  readonly pcmFormat: PCMFormat;
+  readonly startTimeSeconds: number;
+  readonly clippedSampleCount: number;
+
+  constructor(
+    samples: Iterable<number>,
+    pcmFormat: PCMFormat,
+    startTimeSeconds = 0.0,
+    clippedSampleCount = 0,
+  ) {
+    this.samples = validateIntegerSamples(samples);
+    if (!(pcmFormat instanceof PCMFormat)) {
+      throw new TypeError("pcmFormat must be a PCMFormat");
+    }
+    this.pcmFormat = pcmFormat;
+    this.startTimeSeconds = finiteFloat("startTimeSeconds", startTimeSeconds);
+    this.clippedSampleCount = nonNegativeInt("clippedSampleCount", clippedSampleCount);
+  }
+
+  sampleCount(): number {
+    return this.samples.length;
+  }
+
+  samplePeriodSeconds(): number {
+    return 1.0 / this.pcmFormat.sampleRateHz;
+  }
+
+  durationSeconds(): number {
+    return this.sampleCount() / this.pcmFormat.sampleRateHz;
+  }
+
+  timeAt(index: number): number {
+    if (!Number.isInteger(index)) {
+      throw new TypeError(`index must be an integer, got ${String(index)}`);
+    }
+    if (index < 0 || index >= this.sampleCount()) {
+      throw new RangeError(
+        `index must be in [0, ${this.sampleCount()}), got ${String(index)}`,
+      );
+    }
+    return this.startTimeSeconds + index / this.pcmFormat.sampleRateHz;
+  }
+
+  toLittleEndianBytes(): Uint8Array {
+    const bytes = new Uint8Array(this.sampleCount() * 2);
+    const view = new DataView(bytes.buffer);
+    for (let i = 0; i < this.sampleCount(); i += 1) {
+      view.setInt16(i * 2, this.samples[i], true);
+    }
+    return bytes;
+  }
+}
+
+export function floatToPcm16(sample: number): [number, boolean] {
+  const value = finiteFloat("sample", sample);
+  const clipped = value < -1.0 || value > 1.0;
+  const bounded = clamp(value, -1.0, 1.0);
+  if (bounded >= 0.0) {
+    return [Math.round(bounded * PCM16_MAX), clipped];
+  }
+  return [Math.round(bounded * Math.abs(PCM16_MIN)), clipped];
+}
+
+export function encodeSampleBuffer(
+  sampleBuffer: SampleBufferLike,
+  pcmFormat?: PCMFormat,
+): PCMBuffer {
+  if (
+    sampleBuffer === null ||
+    typeof sampleBuffer !== "object" ||
+    !isIterable(sampleBuffer.samples)
+  ) {
+    throw new TypeError("sampleBuffer must be an object with iterable samples");
+  }
+  const activeFormat =
+    pcmFormat === undefined
+      ? new PCMFormat(sampleBuffer.sampleRateHz)
+      : pcmFormat;
+
+  const pcmSamples: number[] = [];
+  let clippedSampleCount = 0;
+
+  for (const sample of sampleBuffer.samples) {
+    const [encoded, clipped] = floatToPcm16(sample);
+    pcmSamples.push(encoded);
+    if (clipped) {
+      clippedSampleCount += 1;
+    }
+  }
+
+  return new PCMBuffer(
+    pcmSamples,
+    activeFormat,
+    finiteFloat("sampleBuffer.startTimeSeconds", sampleBuffer.startTimeSeconds ?? 0.0),
+    clippedSampleCount,
+  );
+}
+
+export function samplesToPcmBuffer(
+  samples: Iterable<number>,
+  options: PCMEncodingOptions,
+): PCMBuffer {
+  if (options === undefined || options === null || typeof options !== "object") {
+    throw new TypeError("options must be an object");
+  }
+
+  const pcmFormat = options.pcmFormat ?? new PCMFormat(options.sampleRateHz);
+
+  const sampleBuffer: SampleBufferLike = {
+    samples,
+    sampleRateHz: options.sampleRateHz ?? DEFAULT_SAMPLE_RATE_HZ,
+    startTimeSeconds: options.startTimeSeconds ?? 0.0,
+  };
+  return encodeSampleBuffer(sampleBuffer, pcmFormat);
+}
+
+function positiveFloat(name: string, value: number): number {
+  const converted = finiteFloat(name, value);
+  if (converted <= 0.0) {
+    throw new RangeError(`${name} must be > 0.0, got ${converted}`);
+  }
+  return converted;
+}
+
+function finiteFloat(name: string, value: number): number {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite real number, got ${String(value)}`);
+  }
+  return value;
+}
+
+function nonNegativeInt(name: string, value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new TypeError(`${name} must be an integer >= 0, got ${String(value)}`);
+  }
+  if (value < 0) {
+    throw new RangeError(`${name} must be >= 0, got ${value}`);
+  }
+  return value;
+}
+
+function positiveInt(name: string, value: number): number {
+  const converted = nonNegativeInt(name, value);
+  if (converted === 0) {
+    throw new RangeError(`${name} must be > 0, got ${converted}`);
+  }
+  return converted;
+}
+
+function integerSampleRate(sampleRateHz: number): number {
+  const rounded = Math.round(sampleRateHz);
+  if (Math.abs(sampleRateHz - rounded) > 1e-9) {
+    throw new RangeError(
+      "sampleRateHz must be integer-valued for WAV output, got " + sampleRateHz,
+    );
+  }
+  return rounded;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function validateIntegerSamples(samples: Iterable<number>): number[] {
+  const checked: number[] = [];
+  for (const sample of samples) {
+    if (!Number.isInteger(sample) || sample < PCM16_MIN || sample > PCM16_MAX) {
+      throw new RangeError(
+        `PCM samples must be signed 16-bit integers in [${PCM16_MIN}, ${PCM16_MAX}], got ${String(
+          sample,
+        )}`,
+      );
+    }
+    checked.push(sample);
+  }
+  return checked;
+}
+
+function isIterable(value: unknown): value is Iterable<number> {
+  return value != null && typeof value === "object" && Symbol.iterator in Object(value);
+}

--- a/code/packages/typescript/pcm-audio/tests/pcm-audio.test.ts
+++ b/code/packages/typescript/pcm-audio/tests/pcm-audio.test.ts
@@ -106,6 +106,5 @@ test("PCMBuffer rejects invalid metadata", () => {
 test("PCMBuffer validates index bounds for time lookup", () => {
   const pcm = new PCMBuffer([0], new PCMFormat(8.0));
   assert.throws(() => pcm.timeAt(1), /in \[0, 1\)/);
-  // @ts-expect-error deliberate negative test
   assert.throws(() => pcm.timeAt(0.5), /integer/);
 });

--- a/code/packages/typescript/pcm-audio/tests/pcm-audio.test.ts
+++ b/code/packages/typescript/pcm-audio/tests/pcm-audio.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_BIT_DEPTH,
+  DEFAULT_CHANNEL_COUNT,
+  DEFAULT_FULL_SCALE_VOLTAGE,
+  DEFAULT_SAMPLE_RATE_HZ,
+  PCM16_MAX,
+  PCM16_MIN,
+  PCMBuffer,
+  PCMFormat,
+  encodeSampleBuffer,
+  floatToPcm16,
+  SampleBufferLike,
+  samplesToPcmBuffer,
+} from "../src/index.js";
+
+test("versioned defaults are visible", () => {
+  assert.equal(DEFAULT_SAMPLE_RATE_HZ, 44_100.0);
+  assert.equal(DEFAULT_BIT_DEPTH, 16);
+  assert.equal(DEFAULT_CHANNEL_COUNT, 1);
+  assert.equal(DEFAULT_FULL_SCALE_VOLTAGE, 1.0);
+  assert.equal(PCM16_MIN, -32_768);
+  assert.equal(PCM16_MAX, 32_767);
+});
+
+test("PCMFormat validates V1 shape", () => {
+  const format = new PCMFormat(8.0, 1, 16, 2.0);
+  assert.equal(format.sampleRateHz, 8.0);
+  assert.equal(format.minimumInteger, PCM16_MIN);
+  assert.equal(format.maximumInteger, PCM16_MAX);
+  assert.equal(format.sampleWidthBytes, 2);
+  assert.equal(format.integerSampleRate(), 8);
+});
+
+test("PCMFormat rejects invalid shapes", () => {
+  assert.throws(() => new PCMFormat(0.0), /sampleRateHz/i);
+  assert.throws(() => new PCMFormat(8.0, 2), /mono/i);
+  assert.throws(() => new PCMFormat(8.0, 1, 24), /16-bit/i);
+  assert.throws(() => new PCMFormat(8.0, 1, 16, 0.0), /fullScaleVoltage/i);
+});
+
+test("PCMFormat rejects non-integer sample rates through integerSampleRate", () => {
+  assert.throws(() => new PCMFormat(44_100.5).integerSampleRate(), /integer-valued/i);
+});
+
+test("floatToPcm16 clips and reports clipping", () => {
+  assert.deepEqual(floatToPcm16(0.0), [0, false]);
+  assert.deepEqual(floatToPcm16(1.0), [32_767, false]);
+  assert.deepEqual(floatToPcm16(-1.0), [-32_768, false]);
+  assert.deepEqual(floatToPcm16(2.0), [32_767, true]);
+  assert.deepEqual(floatToPcm16(-2.0), [-32_768, true]);
+});
+
+test("floatToPcm16 rejects non-finite or non-number", () => {
+  assert.throws(() => floatToPcm16(Number.NaN), /finite real/);
+  assert.throws(() => floatToPcm16(Number.POSITIVE_INFINITY), /finite real/);
+  // @ts-expect-error deliberate negative test
+  assert.throws(() => floatToPcm16(undefined), /finite real/);
+});
+
+test("encodeSampleBuffer tracks clipping and timing", () => {
+  const sampleBuffer: SampleBufferLike = {
+    samples: [0.0, 1.0, -1.0, 2.0],
+    sampleRateHz: 4.0,
+    startTimeSeconds: 10.0,
+  };
+  const pcm = encodeSampleBuffer(sampleBuffer);
+  assert.deepEqual(Array.from(pcm.samples), [0, 32767, -32768, 32767]);
+  assert.equal(pcm.clippedSampleCount, 1);
+  assert.equal(pcm.sampleCount(), 4);
+  assert.equal(pcm.samplePeriodSeconds(), 0.25);
+  assert.equal(pcm.durationSeconds(), 1.0);
+  assert.equal(pcm.timeAt(2), 10.5);
+});
+
+test("samplesToPcmBuffer supports raw float sequences", () => {
+  const pcm = samplesToPcmBuffer([0.0, 0.5, -0.5], { sampleRateHz: 3.0 });
+  assert.deepEqual(Array.from(pcm.samples), [0, 16384, -16384]);
+  assert.equal(pcm.sampleCount(), 3);
+  assert.equal(pcm.durationSeconds(), 1.0);
+});
+
+test("PCMBuffer packs little-endian bytes", () => {
+  const pcm = new PCMBuffer([0, 32767, -32768], new PCMFormat(3.0));
+  assert.deepEqual(Array.from(pcm.toLittleEndianBytes()), [0, 0, 255, 127, 0, 128]);
+});
+
+test("PCMBuffer rejects invalid integer samples", () => {
+  assert.throws(
+    () => new PCMBuffer([32768], new PCMFormat(8.0)),
+    /signed 16-bit/i,
+  );
+});
+
+test("PCMBuffer rejects invalid metadata", () => {
+  assert.throws(() => new PCMBuffer([0], {} as PCMFormat), /PCMFormat/i);
+  assert.throws(() => new PCMBuffer([0], new PCMFormat(8.0), Number.NaN), /finite real/);
+  assert.throws(
+    () => new PCMBuffer([0], new PCMFormat(8.0), 0.0, -1),
+    /clippedSampleCount/i,
+  );
+});
+
+test("PCMBuffer validates index bounds for time lookup", () => {
+  const pcm = new PCMBuffer([0], new PCMFormat(8.0));
+  assert.throws(() => pcm.timeAt(1), /in \[0, 1\)/);
+  // @ts-expect-error deliberate negative test
+  assert.throws(() => pcm.timeAt(0.5), /integer/);
+});

--- a/code/packages/typescript/pcm-audio/tsconfig.json
+++ b/code/packages/typescript/pcm-audio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/code/packages/typescript/pcm-audio/tsconfig.test.json
+++ b/code/packages/typescript/pcm-audio/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["tests/**/*.ts"]
+}

--- a/code/packages/typescript/pcm-audio/tsconfig.test.json
+++ b/code/packages/typescript/pcm-audio/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "rootDir": ".",
+    "outDir": "dist-test"
   },
   "include": ["tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Added new TypeScript package `typescript/pcm-audio` with PCM format/buffer types and encoding helpers.
- Added deterministic conversion helpers and validations (`PCMFormat`, `PCMBuffer`, `floatToPcm16`, `encodeSampleBuffer`, `samplesToPcmBuffer`).
- Added Node-test suite, changelog, required capabilities file, and build scripts.
- Added package lockfile for CI compatibility.

## Testing
- Not executed in this run.