### PR TITLE
feat(riscv): preserve return addresses for calls

### DIFF
--- a/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- Add call-frame lowering for nested `CALL`/`RET` programs.
+- Emit a hidden call stack for compiler-generated RISC-V images that need one.
+
 ## 0.1.0
 
 - Initial `ir-to-riscv-compiler` package.

--- a/code/packages/go/ir-to-riscv-compiler/README.md
+++ b/code/packages/go/ir-to-riscv-compiler/README.md
@@ -33,3 +33,8 @@ sim.Run(result.Bytes)
 same image. `MachineCodeResult.Bytes` contains the assembled text section
 followed by any declared IR data bytes. `DataOffsets` and `LabelOffsets` are
 absolute byte offsets from the beginning of the loaded program.
+
+When a program uses `CALL`, the backend emits a small runtime prelude that
+initializes `sp` to a hidden call-frame stack appended after the IR data segment.
+Every called label saves `ra` on entry, and `RET` restores it before returning,
+so nested calls can safely return through multiple frames.

--- a/code/packages/go/ir-to-riscv-compiler/assembly.go
+++ b/code/packages/go/ir-to-riscv-compiler/assembly.go
@@ -10,12 +10,18 @@ import (
 func (c *IrToRiscVCompiler) emitAssembly(program *ir.IrProgram, plan *compilePlan) (string, error) {
 	var builder strings.Builder
 	builder.WriteString(".text\n")
+	if plan.usesCallFrames() {
+		for _, line := range emitStackSetupAssembly(plan.stackTop) {
+			builder.WriteString(line)
+			builder.WriteByte('\n')
+		}
+	}
 	if plan.entryTrampoline {
 		builder.WriteString(fmt.Sprintf("  j %s\n", program.EntryLabel))
 	}
 
 	for _, instruction := range program.Instructions {
-		lines, err := c.emitAssemblyInstruction(instruction)
+		lines, err := c.emitAssemblyInstruction(instruction, plan)
 		if err != nil {
 			return "", err
 		}
@@ -25,7 +31,7 @@ func (c *IrToRiscVCompiler) emitAssembly(program *ir.IrProgram, plan *compilePla
 		}
 	}
 
-	if len(program.Data) > 0 {
+	if len(program.Data) > 0 || plan.usesCallFrames() {
 		builder.WriteString("\n.data\n")
 		for _, decl := range program.Data {
 			builder.WriteString(fmt.Sprintf("%s:\n", decl.Label))
@@ -42,19 +48,27 @@ func (c *IrToRiscVCompiler) emitAssembly(program *ir.IrProgram, plan *compilePla
 			}
 			builder.WriteString(fmt.Sprintf("  .byte %s\n", strings.Join(values, ", ")))
 		}
+		if plan.usesCallFrames() {
+			builder.WriteString(fmt.Sprintf("%s:\n", callFrameStackLabel))
+			builder.WriteString(fmt.Sprintf("  .zero %d\n", callFrameStackSize))
+		}
 	}
 
 	return builder.String(), nil
 }
 
-func (c *IrToRiscVCompiler) emitAssemblyInstruction(instruction ir.IrInstruction) ([]string, error) {
+func (c *IrToRiscVCompiler) emitAssemblyInstruction(instruction ir.IrInstruction, plan *compilePlan) ([]string, error) {
 	switch instruction.Opcode {
 	case ir.OpLabel:
 		label, err := labelOperand(instruction, 0)
 		if err != nil {
 			return nil, err
 		}
-		return []string{fmt.Sprintf("%s:", label.Name)}, nil
+		lines := []string{fmt.Sprintf("%s:", label.Name)}
+		if plan.callTargets[label.Name] {
+			lines = append(lines, emitCallTargetPrologueAssembly()...)
+		}
+		return lines, nil
 	case ir.OpComment:
 		text := ""
 		if len(instruction.Operands) > 0 {
@@ -138,7 +152,10 @@ func (c *IrToRiscVCompiler) emitAssemblyInstruction(instruction ir.IrInstruction
 		}
 		return []string{fmt.Sprintf("  call %s", label.Name)}, nil
 	case ir.OpRet:
-		return []string{"  ret"}, nil
+		if !plan.usesCallFrames() {
+			return []string{"  ret"}, nil
+		}
+		return emitRetEpilogueAssembly(), nil
 	case ir.OpSyscall:
 		imm, err := immOperand(instruction, 0)
 		if err != nil {
@@ -246,6 +263,29 @@ func emitCmpEqNeAssembly(instruction ir.IrInstruction, equal bool) ([]string, er
 		fmt.Sprintf("  xor %s, %s, %s", regName(dst), regName(left), regName(right)),
 		fmt.Sprintf("  sltu %s, zero, %s", regName(dst), regName(dst)),
 	}, nil
+}
+
+func emitCallTargetPrologueAssembly() []string {
+	return []string{
+		"  addi sp, sp, -4",
+		"  sw ra, 0(sp)",
+	}
+}
+
+func emitStackSetupAssembly(stackTop int) []string {
+	upper, lower := splitUpperLower(stackTop)
+	return []string{
+		fmt.Sprintf("  lui sp, %d", upper),
+		fmt.Sprintf("  addi sp, sp, %d", lower),
+	}
+}
+
+func emitRetEpilogueAssembly() []string {
+	return []string{
+		"  lw ra, 0(sp)",
+		"  addi sp, sp, 4",
+		"  ret",
+	}
 }
 
 func threePhysicalRegs(instruction ir.IrInstruction) (int, int, int, error) {

--- a/code/packages/go/ir-to-riscv-compiler/compiler.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler.go
@@ -11,8 +11,12 @@ import (
 const (
 	x0              = 0
 	xRa             = 1
+	xSp             = 2
 	xSyscallNumber  = 17
 	xBackendScratch = 31
+
+	callFrameStackLabel = "__riscv_call_stack"
+	callFrameStackSize  = 1024
 )
 
 // MachineCodeResult is the output of lowering IR to a flat RISC-V image.
@@ -42,8 +46,14 @@ func (e LoweringError) Error() string {
 type compilePlan struct {
 	labelOffsets    map[string]int
 	dataOffsets     map[string]int
+	callTargets     map[string]bool
+	stackTop        int
 	textSize        int
 	entryTrampoline bool
+}
+
+func (p *compilePlan) usesCallFrames() bool {
+	return len(p.callTargets) > 0
 }
 
 // IrToRiscVCompiler lowers compiler IR to RV32I machine code.
@@ -64,6 +74,9 @@ func (c *IrToRiscVCompiler) Compile(program *ir.IrProgram) (*MachineCodeResult, 
 	}
 
 	words := make([]uint32, 0, plan.textSize/4)
+	if plan.usesCallFrames() {
+		words = append(words, emitLoadAddress(xSp, plan.stackTop)...)
+	}
 	if plan.entryTrampoline {
 		entryOffset := plan.labelOffsets[program.EntryLabel]
 		if err := validateJalOffset(entryOffset); err != nil {
@@ -87,6 +100,9 @@ func (c *IrToRiscVCompiler) Compile(program *ir.IrProgram) (*MachineCodeResult, 
 
 	image := riscv.Assemble(words)
 	image = append(image, dataBytes(program.Data)...)
+	if plan.usesCallFrames() {
+		image = append(image, make([]byte, callFrameStackSize)...)
+	}
 	assembly, err := c.emitAssembly(program, plan)
 	if err != nil {
 		return nil, err
@@ -103,8 +119,14 @@ func (c *IrToRiscVCompiler) Compile(program *ir.IrProgram) (*MachineCodeResult, 
 }
 
 func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
+	callTargets, err := collectCallTargets(program)
+	if err != nil {
+		return nil, err
+	}
+
 	labelOffsets := map[string]int{}
-	pc := 0
+	pc := stackSetupSize(callTargets) * 4
+	fallthroughOffset := pc
 	for _, instruction := range program.Instructions {
 		if instruction.Opcode == ir.OpLabel {
 			label, err := labelOperand(instruction, 0)
@@ -117,16 +139,25 @@ func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
 			labelOffsets[label.Name] = pc
 		}
 
-		size, err := c.instructionSize(instruction)
+		size, err := c.instructionSize(instruction, callTargets)
 		if err != nil {
 			return nil, err
+		}
+		if instruction.Opcode == ir.OpLabel {
+			label, err := labelOperand(instruction, 0)
+			if err != nil {
+				return nil, err
+			}
+			if callTargets[label.Name] {
+				size += callTargetPrologueSize()
+			}
 		}
 		pc += size * 4
 	}
 
 	entryTrampoline := false
 	if program.EntryLabel != "" {
-		if entryOffset, ok := labelOffsets[program.EntryLabel]; ok && entryOffset != 0 {
+		if entryOffset, ok := labelOffsets[program.EntryLabel]; ok && entryOffset != fallthroughOffset {
 			entryTrampoline = true
 			for name, offset := range labelOffsets {
 				labelOffsets[name] = offset + 4
@@ -147,16 +178,27 @@ func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
 		dataOffsets[decl.Label] = dataPC
 		dataPC += decl.Size
 	}
+	stackTop := 0
+	if len(callTargets) > 0 {
+		if _, exists := dataOffsets[callFrameStackLabel]; exists {
+			return nil, fmt.Errorf("duplicate data label %q", callFrameStackLabel)
+		}
+		dataOffsets[callFrameStackLabel] = dataPC
+		stackTop = dataPC + callFrameStackSize
+		dataPC += callFrameStackSize
+	}
 
 	return &compilePlan{
 		labelOffsets:    labelOffsets,
 		dataOffsets:     dataOffsets,
+		callTargets:     callTargets,
+		stackTop:        stackTop,
 		textSize:        pc,
 		entryTrampoline: entryTrampoline,
 	}, nil
 }
 
-func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction) (int, error) {
+func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction, callTargets map[string]bool) (int, error) {
 	switch instruction.Opcode {
 	case ir.OpLabel, ir.OpComment:
 		return 0, nil
@@ -186,8 +228,13 @@ func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction) (int, 
 			return 1, nil
 		}
 		return loadConstSize(imm.Value) + 1, nil
-	case ir.OpJump, ir.OpBranchZ, ir.OpBranchNz, ir.OpCall, ir.OpRet, ir.OpNop:
+	case ir.OpJump, ir.OpBranchZ, ir.OpBranchNz, ir.OpCall, ir.OpNop:
 		return 1, nil
+	case ir.OpRet:
+		if len(callTargets) == 0 {
+			return 1, nil
+		}
+		return retEpilogueSize(), nil
 	case ir.OpSyscall:
 		imm, err := immOperand(instruction, 0)
 		if err != nil {
@@ -203,7 +250,16 @@ func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction) (int, 
 
 func (c *IrToRiscVCompiler) emitInstruction(instruction ir.IrInstruction, pc int, plan *compilePlan) ([]uint32, error) {
 	switch instruction.Opcode {
-	case ir.OpLabel, ir.OpComment:
+	case ir.OpLabel:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		if plan.callTargets[label.Name] {
+			return emitCallTargetPrologue(), nil
+		}
+		return nil, nil
+	case ir.OpComment:
 		return nil, nil
 	case ir.OpLoadImm:
 		dst, err := physicalRegOperand(instruction, 0)
@@ -281,7 +337,10 @@ func (c *IrToRiscVCompiler) emitInstruction(instruction ir.IrInstruction, pc int
 		}
 		return []uint32{riscv.EncodeJal(xRa, offset)}, nil
 	case ir.OpRet:
-		return []uint32{riscv.EncodeJalr(x0, xRa, 0)}, nil
+		if !plan.usesCallFrames() {
+			return []uint32{riscv.EncodeJalr(x0, xRa, 0)}, nil
+		}
+		return emitRetEpilogue(), nil
 	case ir.OpSyscall:
 		imm, err := immOperand(instruction, 0)
 		if err != nil {
@@ -347,6 +406,51 @@ func (c *IrToRiscVCompiler) emitStore(instruction ir.IrInstruction, encode func(
 		riscv.EncodeAdd(xBackendScratch, base, offset),
 		encode(src, xBackendScratch, 0),
 	}, nil
+}
+
+func collectCallTargets(program *ir.IrProgram) (map[string]bool, error) {
+	targets := map[string]bool{}
+	for _, instruction := range program.Instructions {
+		if instruction.Opcode != ir.OpCall {
+			continue
+		}
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		targets[label.Name] = true
+	}
+	return targets, nil
+}
+
+func callTargetPrologueSize() int {
+	return 2
+}
+
+func stackSetupSize(callTargets map[string]bool) int {
+	if len(callTargets) == 0 {
+		return 0
+	}
+	return 2
+}
+
+func retEpilogueSize() int {
+	return 3
+}
+
+func emitCallTargetPrologue() []uint32 {
+	return []uint32{
+		riscv.EncodeAddi(xSp, xSp, -4),
+		riscv.EncodeSw(xRa, xSp, 0),
+	}
+}
+
+func emitRetEpilogue() []uint32 {
+	return []uint32{
+		riscv.EncodeLw(xRa, xSp, 0),
+		riscv.EncodeAddi(xSp, xSp, 4),
+		riscv.EncodeJalr(x0, xRa, 0),
+	}
 }
 
 func emitThreeReg(instruction ir.IrInstruction, encode func(rd, rs1, rs2 int) uint32) ([]uint32, error) {

--- a/code/packages/go/ir-to-riscv-compiler/compiler_test.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler_test.go
@@ -131,6 +131,49 @@ func TestCompileHonorsEntryLabelWithTrampoline(t *testing.T) {
 	}
 }
 
+func TestCompilePreservesReturnAddressAcrossNestedCalls(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpCall, ir.IrLabel{Name: "first"}),
+		instr(2, ir.OpHalt),
+		label("first"),
+		instr(3, ir.OpCall, ir.IrLabel{Name: "second"}),
+		instr(4, ir.OpRet),
+		label("second"),
+		instr(5, ir.OpLoadImm, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 42}),
+		instr(6, ir.OpRet),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(5); got != 42 {
+		t.Fatalf("expected nested call result in v0/x5 to be 42, got %d", got)
+	}
+	expectedStackTop := uint32(result.DataOffsets[callFrameStackLabel] + callFrameStackSize)
+	if got := sim.CPU.Registers.Read(2); got != expectedStackTop {
+		t.Fatalf("expected stack pointer to be restored to %d, got %d", expectedStackTop, got)
+	}
+	if !strings.Contains(result.Assembly, "sw ra, 0(sp)") ||
+		!strings.Contains(result.Assembly, "lw ra, 0(sp)") {
+		t.Fatalf("expected call frame save/restore in assembly, got:\n%s", result.Assembly)
+	}
+
+	assembled, err := riscvassembler.Assemble(result.Assembly)
+	if err != nil {
+		t.Fatalf("assemble emitted assembly failed: %v\n%s", err, result.Assembly)
+	}
+	if !bytes.Equal(assembled.Bytes, result.Bytes) {
+		t.Fatalf("expected emitted assembly to reassemble to compiler bytes")
+	}
+}
+
 func TestCompileRejectsUnknownLabel(t *testing.T) {
 	program := ir.NewIrProgram("_start")
 	program.Instructions = []ir.IrInstruction{

--- a/code/packages/go/nib-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/nib-riscv-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Add nested-call end-to-end coverage through the RISC-V backend call frames.
+
 ## 0.1.0
 
 - Add Nib to RISC-V assembly, assembler, and simulator orchestration.

--- a/code/packages/go/nib-riscv-compiler/README.md
+++ b/code/packages/go/nib-riscv-compiler/README.md
@@ -20,7 +20,9 @@ value from physical register `x6`, the RISC-V register currently used for Nib's
 
 ## Current scope
 
-This first path is intended for simple Nib programs whose `main` does not make
-nested function calls. The current starter calling convention uses `ra` directly,
-so a function that calls another function needs stack-frame support before it can
-return reliably.
+This path supports simple Nib programs and nested function calls that only need
+the current fixed-register ABI. Arguments are copied into virtual registers in
+order, and the return value is reported from virtual `v1`/physical `x6`.
+
+The remaining ABI gaps are local values that must survive across calls, recursion
+depth beyond the hidden backend stack, and richer argument/return conventions.

--- a/code/packages/go/nib-riscv-compiler/compiler_test.go
+++ b/code/packages/go/nib-riscv-compiler/compiler_test.go
@@ -57,6 +57,28 @@ func TestRunSourceExecutesNibOnRiscVSimulator(t *testing.T) {
 	}
 }
 
+func TestRunSourceExecutesNestedNibCallsOnRiscVSimulator(t *testing.T) {
+	source := strings.Join([]string{
+		"fn inner() -> u4 { return 7; }",
+		"fn middle() -> u4 { return inner(); }",
+		"fn main() -> u4 { return middle(); }",
+	}, " ")
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.ReturnValue != 7 {
+		t.Fatalf("expected nested call return value 7, got %d", run.ReturnValue)
+	}
+	if !strings.Contains(run.Package.Assembly, "sw ra, 0(sp)") ||
+		!strings.Contains(run.Package.Assembly, "lw ra, 0(sp)") {
+		t.Fatalf("expected call frame save/restore in assembly, got:\n%s", run.Package.Assembly)
+	}
+}
+
 func TestTypeErrorsReportStage(t *testing.T) {
 	_, err := CompileSource("fn main() { let flag: bool = 1; }")
 	if err == nil {

--- a/code/specs/RV01-riscv-compiler-roadmap.md
+++ b/code/specs/RV01-riscv-compiler-roadmap.md
@@ -21,21 +21,22 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 | Language | Current status | To run directly on RISC-V |
 |----------|----------------|---------------------------|
-| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator`. | Add stack-frame support so nested calls/recursion preserve `ra`; extend static variable reads if needed; add ABI tests for arguments/returns. |
+| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs and nested no-spill calls lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator`. | Extend static variable reads if needed; add ABI tests for arguments/returns and values that must survive across calls. |
 | Brainfuck | Go parser, `brainfuck-ir-compiler`, and `brainfuck-riscv-compiler` package exist. Programs lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator` with host byte I/O syscalls for `.` and `,`. | Add broader corpus tests, debug-mode bounds-check E2E tests, and richer host I/O controls if interactive execution is needed. |
 | Dartmouth BASIC | Go lexer/parser exist. Python has `dartmouth-basic-ir-compiler`, GE-225, WASM, and JVM-oriented pipelines. | Port or bridge the Python IR compiler to Go `compiler-ir`; add `MUL`/`DIV` to Go `compiler-ir` and the RISC-V backend or lower them to helper loops; implement PRINT syscalls/trap host output in the RISC-V VM. |
-| Oct | Python has lexer/parser/type-checker/IR compiler for the Intel 8008 pipeline. | Port or bridge Oct typed AST/IR into Go; add Go `compiler-ir` opcodes used by Oct but not yet present here (`OR`, `XOR`, `NOT`, and any target-specific syscall shapes); add RISC-V syscall host behavior for `in`, `out`, carry/parity/rotate intrinsics; add stack-frame support for nested calls. |
+| Oct | Python has lexer/parser/type-checker/IR compiler for the Intel 8008 pipeline. | Port or bridge Oct typed AST/IR into Go; add Go `compiler-ir` opcodes used by Oct but not yet present here (`OR`, `XOR`, `NOT`, and any target-specific syscall shapes); add RISC-V syscall host behavior for `in`, `out`, carry/parity/rotate intrinsics; add a real register allocator for values that survive across calls. |
 | Starlark | Go compiler targets the Starlark VM bytecode, not `compiler-ir`. | Add a Starlark-to-`compiler-ir` lowerer or a direct RISC-V backend for its bytecode. |
 | Mosaic | Go analyzer produces Mosaic-specific IR for UI/component emitters. | Add a Mosaic-to-`compiler-ir` lowering only if there is a meaningful native runtime target; otherwise it is not a natural RISC-V candidate. |
 | Parser-only languages | Many languages currently have lexers/parsers only. | Add semantic analysis plus a `compiler-ir` lowering before the common RISC-V backend can be reused. |
 
 ## Backend gaps
 
-- Calling convention: current IR-to-RISC-V uses a starter fixed register mapping
-  and raw `ra`. This works for a single `_start -> main` call but not for
-  functions that call other functions.
-- Stack and frames: needed for nested calls, recursion, spilled virtual
-  registers, and local storage beyond the fixed physical-register map.
+- Calling convention: current IR-to-RISC-V emits a hidden call stack and saves
+  `ra` for labels targeted by `CALL`, so nested returns work. It still uses a
+  starter fixed register mapping, so values live across calls can be clobbered.
+- Stack and frames: `ra` save/restore exists. Spilled virtual registers, local
+  storage beyond the fixed physical-register map, and deeper runtime ABI support
+  still need real frame layout work.
 - Syscalls: `riscv-simulator` now has an opt-in host syscall layer for simple
   byte I/O and exit when no trap handler is installed. Richer language runtimes
   still need a standard ABI for strings, numbers, files, and interactive input.
@@ -47,8 +48,8 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 ## Suggested sequence
 
-1. Add RISC-V stack-frame support for `CALL`/`RET`.
-2. Add broader Nib and Brainfuck E2E corpus tests.
+1. Add broader Nib and Brainfuck E2E corpus tests.
+2. Add register allocation or spill slots for values that survive calls.
 3. Port/bridge Dartmouth BASIC IR to Go and add `MUL`/`DIV`.
 4. Port/bridge Oct IR to Go and add the remaining bitwise/syscall ABI support.
 5. Standardize a richer RISC-V language runtime ABI for text and numeric I/O.


### PR DESCRIPTION
## Summary
- add call-frame lowering in `ir-to-riscv-compiler` for IR programs that use `CALL`
- emit a hidden backend stack plus stack-pointer prelude, save `ra` at called labels, and restore it in expanded `RET`
- add IR and Nib RISC-V nested-call coverage and update readiness docs/roadmap

## Tests
- `go test -c -o /tmp/ir-to-riscv-compiler.test` in `code/packages/go/ir-to-riscv-compiler`
- `go test -c -o /tmp/nib-riscv-compiler.test` in `code/packages/go/nib-riscv-compiler`
- `go test -c -o /tmp/riscv-simulator.test` in `code/packages/go/riscv-simulator`
- `go test -c -o /tmp/riscv-assembler.test` in `code/packages/go/riscv-assembler`

Note: local `go test` execution still hangs in this macOS session before producing runtime output, so I used compile checks locally and left runtime execution to CI.