### PR TITLE
feat(algol): add phase7b direct nonlocal block goto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added PL04 Phase 7a local switch declarations, switch selections, and
   conditional designational `goto` support through type-checking, IR lowering,
   and WASM execution, while keeping nonlocal frame unwinding guarded.
+- Added PL04 Phase 7b direct nonlocal block `goto` support with frame/heap
+  unwinding inside one lowered function, while keeping procedure-crossing
+  jumps and nonlocal designational forms guarded.
 
 ### Added — TypeScript Port + JavaScript/TypeScript Grammars (PR #14)
 - **31 TypeScript packages** — complete port of the computing stack to TypeScript

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this package will be documented in this file.
 - Lowered Phase 7a local conditional designational expressions and switch
   selections into local IR jumps, including one-based switch dispatch and
   runtime failure for out-of-range switch indexes.
+- Lowered Phase 7b direct nonlocal block `goto` statements by unwinding exited
+  block frames before jumping to the outer ALGOL label.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -40,20 +40,24 @@ read-only expression thunks still raise targeted `CompileError` diagnostics
 until Phase 5 grows full store-helper coverage. The supported integer by-name
 surface is covered by the WASM acceptance suite, while full ALGOL forms such as
 non-integer formals, whole-array by-name values, procedure-valued actuals,
-nonlocal gotos, nonlocal switch selections, and escaping thunk descriptors
-remain future work.
+procedure-crossing gotos, nonlocal switch selections, and escaping thunk
+descriptors remain future work.
 
-Direct local `goto` statements lower to ordinary IR `JUMP` instructions
-targeting generated ALGOL labels. The downstream WASM backend's unstructured
-control-flow lowering handles forward and backward jumps, while this package
-continues to reject nonlocal gotos before IR generation. Local conditional
-designational expressions now lower as condition-controlled branch points that
-only evaluate the selected target. Local switch selections evaluate their
-integer index once, compare against one-based switch entries, and lower the
-chosen designational entry into the same local jump path. An out-of-range
-switch index follows the existing runtime-failure path and returns `0`.
-Switch declaration entries that select another switch remain guarded before IR
-lowering so recursive switch descriptors cannot expand without bound.
+Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
+generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal
+block jumps unwind each exited block with the same heap-pointer, current-frame,
+and stack-pointer restoration used by normal block exits before transferring
+control to the outer label. The downstream WASM backend's unstructured
+control-flow lowering handles forward, backward, and nonlocal block jumps.
+Local conditional designational expressions now lower as condition-controlled
+branch points that only evaluate the selected target. Local switch selections
+evaluate their integer index once, compare against one-based switch entries,
+and lower the chosen designational entry into the same local jump path. An
+out-of-range switch index follows the existing runtime-failure path and returns
+`0`. Switch declaration entries that select another switch remain guarded
+before IR lowering so recursive switch descriptors cannot expand without
+bound. Procedure-crossing gotos and nonlocal switch/designational forms remain
+guarded before IR generation.
 
 This phase keeps ALGOL frame memory and its 32-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -695,6 +695,13 @@ class AlgolIrCompiler:
         resolved = self.gotos_by_designational.get(id(desig_expr))
         if resolved is None:
             raise CompileError("goto designational expression was not resolved")
+        simple = _first_direct_node(desig_expr, "simple_desig")
+        if (
+            not any(token.value == "if" for token in _direct_tokens(desig_expr))
+            and _direct_label_from_simple_designational(simple) is not None
+        ):
+            self._emit_resolved_goto(resolved, scope)
+            return
         self._compile_designational(desig_expr, scope)
 
     def _compile_designational(self, node: ASTNode, scope: _FrameScope) -> None:
@@ -745,6 +752,20 @@ class AlgolIrCompiler:
             self._compile_designational(nested, scope)
             return
         raise CompileError("unsupported designational expression")
+
+    def _emit_resolved_goto(self, resolved: ResolvedGoto, scope: _FrameScope) -> None:
+        self._emit_unwind_to_block(scope, resolved.target_block_id)
+        self._emit(IrOp.JUMP, IrLabel(resolved.ir_label))
+
+    def _emit_unwind_to_block(self, scope: _FrameScope, target_block_id: int) -> None:
+        current: _FrameScope | None = scope
+        while current is not None and current.block_id != target_block_id:
+            self._emit_leave_frame(current)
+            current = current.parent
+        if current is None:
+            raise CompileError(
+                f"goto target block {target_block_id} is not active in this function"
+            )
 
     def _compile_switch_selection(self, node: ASTNode, scope: _FrameScope) -> None:
         selection = self.switch_selections.get(id(node))

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -95,6 +95,32 @@ class TestAlgolIrCompiler:
         assert len(algol_labels) == 1
         assert algol_labels[0] in jumps
 
+    def test_compiles_direct_nonlocal_block_goto_with_frame_unwind(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "begin integer inner; goto done; inner := 99 end; "
+                "done: result := 7 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        jumps = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.JUMP
+        ]
+
+        target = next(label for label in labels if label.startswith("algol_label_"))
+        assert target in jumps
+        assert opcodes.count(IrOp.LOAD_WORD) >= 1
+        assert opcodes.count(IrOp.STORE_WORD) >= 1
+
     def test_compiles_conditional_designational_goto(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this package will be documented in this file.
 - Added Phase 7a switch descriptors, local switch selection resolution, and
   conditional designational `goto` checking, with nonlocal switch selections
   and recursively selected switch entries still guarded for later phases.
+- Added Phase 7b direct nonlocal block `goto` resolution within one
+  procedure/function, while keeping procedure-crossing jumps and nonlocal
+  designational branches guarded.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -9,8 +9,9 @@ comparisons, boolean conditions, nested blocks, `if` statements,
 `for ... step ... until ... do` loops, integer value/by-name procedures, and
 descriptor metadata for integer arrays with integer bounds. Direct labels and
 direct local `goto` statements are accepted within one active ALGOL frame, as
-are local switch declarations, switch selections, and conditional
-designational `goto` forms.
+are direct nonlocal block `goto` statements that stay inside the same lowered
+function. Local switch declarations, switch selections, and conditional
+designational `goto` forms are also supported.
 
 The checker also builds the first ALGOL 60 full-runtime semantic model. Each
 source block receives a stable block id, lexical depth, static-parent id, and a
@@ -26,23 +27,25 @@ dimension metadata for lower/upper bound expressions, and resolved read/write
 accesses that preserve the static-link delta and subscript count needed by the
 IR and WASM lowering stages.
 Labels receive stable label descriptors and direct local `goto` statements
-resolve to those descriptors. Switch declarations receive stable descriptors
-whose entries point at checked local designational expressions, and switch
-selection use sites resolve to their chosen switch symbol. Nonlocal gotos and
-switch selections that cross an ALGOL frame boundary remain guarded with
-targeted diagnostics. Switch entries that recursively select another switch
-are also guarded until the later dispatch-lowering phase.
+resolve to those descriptors. Direct nonlocal block `goto` statements resolve
+to outer active blocks in the same procedure/function; jumps that cross a
+procedure boundary remain guarded. Switch declarations receive stable
+descriptors whose entries point at checked local designational expressions, and
+switch selection use sites resolve to their chosen switch symbol. Nonlocal
+switch selections and nonlocal conditional/switch designational branches remain
+guarded with targeted diagnostics. Switch entries that recursively select
+another switch are also guarded until the later dispatch-lowering phase.
 
 Unsupported ALGOL 60 features, including real/Boolean/string arrays, array
 parameters, procedure-valued parameters, nonlocal switches, and nonlocal
-`goto`, are reported as diagnostics instead of being silently accepted by the
-compiled pipeline. By-name parameters are accepted in the semantic model,
-while later lowering packages now implement the integer call-by-name subset.
-The checker keeps guarding the remaining full-ALGOL gaps, including
-non-assignable actuals passed to written by-name formals, non-integer by-name
-types, whole-array parameters, procedure-valued parameters, conditional
-designational expressions that cross frame boundaries, and nonlocal `goto`
-forms.
+procedure-crossing `goto`, are reported as diagnostics instead of being
+silently accepted by the compiled pipeline. By-name parameters are accepted in
+the semantic model, while later lowering packages now implement the integer
+call-by-name subset. The checker keeps guarding the remaining full-ALGOL gaps,
+including non-assignable actuals passed to written by-name formals,
+non-integer by-name types, whole-array parameters, procedure-valued parameters,
+conditional designational expressions that cross frame boundaries, and `goto`
+forms that escape a called procedure.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -107,6 +107,7 @@ class Scope:
     parent: Scope | None = None
     block_id: int = -1
     depth: int = -1
+    owner_procedure_id: int | None = None
     frame_layout: FrameLayout | None = None
     symbols: dict[str, Symbol] = field(default_factory=dict)
     children: list[Scope] = field(default_factory=list)
@@ -460,6 +461,11 @@ class AlgolTypeChecker:
             parent=parent,
             block_id=block_id,
             depth=depth,
+            owner_procedure_id=(
+                owner_procedure_id
+                if owner_procedure_id is not None
+                else parent.owner_procedure_id
+            ),
             frame_layout=frame_layout,
         )
         parent.children.append(scope)
@@ -471,7 +477,7 @@ class AlgolTypeChecker:
                 scope=scope,
                 frame_layout=frame_layout,
                 ast_node_id=id(ast_node) if ast_node is not None else None,
-                owner_procedure_id=owner_procedure_id,
+                owner_procedure_id=scope.owner_procedure_id,
             )
         )
         return scope
@@ -644,7 +650,12 @@ class AlgolTypeChecker:
             self._error(node, "switch declaration requires at least one entry")
             return
         for entry in entries:
-            self._check_designational(entry, scope, allow_switch_selection=False)
+            self._check_designational(
+                entry,
+                scope,
+                allow_nonlocal_label=False,
+                allow_switch_selection=False,
+            )
         self.semantic_switches.append(
             SwitchDescriptor(
                 switch_id=switch_id,
@@ -908,6 +919,7 @@ class AlgolTypeChecker:
         node: ASTNode,
         scope: Scope,
         *,
+        allow_nonlocal_label: bool = True,
         allow_switch_selection: bool = True,
     ) -> ResolvedGoto | None:
         if any(token.value == "if" for token in _direct_tokens(node)):
@@ -923,12 +935,14 @@ class AlgolTypeChecker:
                 self._check_simple_designational(
                     then_desig,
                     scope,
+                    allow_nonlocal_label=False,
                     allow_switch_selection=allow_switch_selection,
                 )
             if else_desig is not None:
                 self._check_designational(
                     else_desig,
                     scope,
+                    allow_nonlocal_label=False,
                     allow_switch_selection=allow_switch_selection,
                 )
             return ResolvedGoto(
@@ -952,6 +966,7 @@ class AlgolTypeChecker:
             simple,
             scope,
             outer_node=node,
+            allow_nonlocal_label=allow_nonlocal_label,
             allow_switch_selection=allow_switch_selection,
         )
 
@@ -961,6 +976,7 @@ class AlgolTypeChecker:
         scope: Scope,
         *,
         outer_node: ASTNode | None = None,
+        allow_nonlocal_label: bool = True,
         allow_switch_selection: bool = True,
     ) -> ResolvedGoto | None:
         target_token = _direct_label_from_simple_designational(node)
@@ -969,6 +985,7 @@ class AlgolTypeChecker:
                 target_token,
                 scope,
                 outer_node=outer_node or node,
+                allow_nonlocal_label=allow_nonlocal_label,
             )
 
         if any(token.value == "[" for token in _direct_tokens(node)):
@@ -998,6 +1015,7 @@ class AlgolTypeChecker:
             return self._check_designational(
                 nested,
                 scope,
+                allow_nonlocal_label=allow_nonlocal_label,
                 allow_switch_selection=allow_switch_selection,
             )
 
@@ -1010,6 +1028,7 @@ class AlgolTypeChecker:
         scope: Scope,
         *,
         outer_node: ASTNode,
+        allow_nonlocal_label: bool,
     ) -> ResolvedGoto | None:
         resolved = scope.resolve_with_scope(target_token.value)
         if resolved is None:
@@ -1020,11 +1039,18 @@ class AlgolTypeChecker:
         if symbol.kind != LABEL:
             self._error(target_token, f"{target_token.value!r} is not a label")
             return
-        if lexical_depth_delta != 0:
+        if scope.owner_procedure_id != declaring_scope.owner_procedure_id:
             self._error(
                 target_token,
-                f"nonlocal goto to label {target_token.value!r} requires Phase 7 "
-                "frame unwinding",
+                f"goto to label {target_token.value!r} crosses a procedure "
+                "boundary, which requires Phase 7c procedure unwinding",
+            )
+            return
+        if lexical_depth_delta != 0 and not allow_nonlocal_label:
+            self._error(
+                target_token,
+                f"nonlocal designational label {target_token.value!r} requires "
+                "a direct Phase 7b goto",
             )
             return
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -96,7 +96,7 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "label 'missing' is not declared" in result.diagnostics[0].message
 
-    def test_rejects_nonlocal_goto_for_now(self) -> None:
+    def test_accepts_direct_nonlocal_block_goto(self) -> None:
         ast = parse_algol(
             "begin integer result; "
             "begin integer inner; goto done end; "
@@ -105,8 +105,35 @@ class TestAlgolTypeChecker:
         )
         result = check_algol(ast)
 
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.gotos[0].target_name == "done"
+        assert result.semantic.gotos[0].lexical_depth_delta == 1
+
+    def test_rejects_procedure_crossing_goto_for_now(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure escape; begin goto done end; "
+            "escape; "
+            "done: result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
         assert not result.ok
-        assert "nonlocal goto to label 'done'" in result.diagnostics[0].message
+        assert "crosses a procedure boundary" in result.diagnostics[0].message
+
+    def test_rejects_conditional_nonlocal_designational_goto_for_now(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "begin integer inner; goto if true then done else done end; "
+            "done: result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "nonlocal designational label 'done'" in result.diagnostics[0].message
 
     def test_accepts_conditional_designational_goto(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this package will be documented in this file.
   jumps, and terminal labels.
 - Executed Phase 7a local switch selections and conditional designational
   `goto` forms through the WASM path, including conditional switch entries.
+- Executed Phase 7b direct nonlocal block `goto` statements through the WASM
+  path with frame restoration before later block entry.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -39,13 +39,14 @@ available. The integer by-name acceptance tests cover the supported scalar,
 array, expression, nested-procedure, and Jensen's-device surface.
 Direct labels and direct local `goto` statements now execute through the
 unstructured IR-to-WASM lowering path, including forward jumps, backward jumps,
-and terminal labels on empty statements. Local switch declarations, switch
-selections, and conditional designational `goto` forms execute through that
-same path, including conditional switch entries. Switch entries that select
-another switch remain guarded to avoid recursive descriptor expansion.
-Nonlocal gotos, nonlocal switch selections, procedure-valued parameters,
-whole-array by-name values, and non-integer by-name formals remain later
-phases.
+terminal labels on empty statements, and direct nonlocal jumps from inner
+blocks to outer active labels. Nonlocal block jumps restore exited frames
+before entering later blocks. Local switch declarations, switch selections, and
+conditional designational `goto` forms execute through that same path,
+including conditional switch entries. Switch entries that select another switch
+remain guarded to avoid recursive descriptor expansion. Procedure-crossing
+gotos, nonlocal switch selections, procedure-valued parameters, whole-array
+by-name values, and non-integer by-name formals remain later phases.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -101,6 +101,36 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
+    def test_direct_nonlocal_block_goto_exits_inner_frame(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "begin integer inner; goto done; inner := 99 end; "
+            "result := 0; "
+            "done: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_nonlocal_block_goto_restores_frame_for_later_block(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "begin integer inner; goto done; inner := 99 end; "
+            "done: begin integer later; later := 8; result := later end "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_direct_nonlocal_block_goto_inside_procedure(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape; "
+            "begin begin integer inner; goto done; inner := 99 end; "
+            "done: result := 6 end; "
+            "escape "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [6]
+
     def test_conditional_designational_goto_selects_branch(self) -> None:
         result = compile_source(
             "begin integer result; "

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -957,8 +957,7 @@ The completed Phase 6 implementation uses the repository's unstructured IR
 control-flow path. It accepts direct labels and direct `goto` targets within the
 same active ALGOL frame, including forward jumps, backward jumps, and terminal
 labels on empty statements. Phase 7a extends that local path to conditional
-designational expressions and switch selections. It continues to reject
-nonlocal jumps until Phase 7b has frame unwinding.
+designational expressions and switch selections.
 
 ### Nonlocal Goto
 
@@ -972,8 +971,12 @@ Lowering must:
 4. restore display entries if displays are used
 5. transfer control to the target label
 
-Initial implementation should reject nonlocal `goto` until frame cleanup and
-dispatch are both implemented.
+The completed Phase 7b-1 implementation accepts direct nonlocal block gotos
+that stay inside one lowered function. It unwinds each exited block by
+restoring the block's heap mark, dynamic current frame, and stack pointer, then
+jumps to the target label. Procedure-crossing gotos, nonlocal conditional
+designational branches, and nonlocal switch selections remain guarded until
+the runtime has procedure escape propagation.
 
 ### Dispatch Loop Lowering
 
@@ -1354,30 +1357,34 @@ Acceptance:
 - forward and backward local gotos work
 - labels on empty statements work
 - invalid label references are rejected
-- nonlocal gotos and conditional/switch designational expressions are rejected
-  with targeted diagnostics
+- unsupported nonlocal and conditional/switch designational forms are rejected
+  with targeted diagnostics until their later phases land
 
 ### Phase 7: Nonlocal Goto and Switches
 
 Goal: Support designational expressions across block boundaries.
 
 Status: Phase 7a is complete for local switch declarations, local switch
-selections, and local conditional designational `goto` forms. Phase 7b remains
-for nonlocal `goto` and frame unwinding.
+selections, and local conditional designational `goto` forms. Phase 7b-1 is
+complete for direct nonlocal block `goto` statements inside one lowered
+function. Procedure-crossing `goto`, nonlocal conditional designational
+branches, and nonlocal switch selections remain future Phase 7 work.
 
 Deliverables:
 
 - switch descriptors (complete for local switches)
 - direct-label switch entries (complete for local switches)
 - conditional designational expressions (complete for local jumps)
-- nonlocal target analysis
-- frame unwinding
+- nonlocal target analysis (complete for direct block gotos)
+- frame unwinding (complete for direct block gotos)
+- procedure escape propagation
 
 Acceptance:
 
 - direct local switch selection works
 - conditional designational expression jumps to the chosen local label
-- nonlocal goto exits nested frames correctly
+- direct nonlocal block goto exits nested frames correctly
+- procedure-crossing goto exits called procedures correctly
 
 ### Phase 8: Rich Scalar Types
 


### PR DESCRIPTION
## Summary

- Adds type-checking support for direct nonlocal block `goto` inside one lowered function/procedure body with strict guards for unsupported forms.
- Lowers nonlocal block `goto` in IR by unwinding `_FrameScope` chain via existing `leave_frame` restoration before jumping to the target block.
- Extends WASM semantics tests to confirm frame unwinding and register restoration around nonlocal block jumps.
- Updates PL04 spec notes/changelogs for phase 7b-1 completion status.

## Testing notes

- Focused checks already passed in prior pass:
  - ruff on checker/ir/wasm sources and tests
  - checker and ir compiler tests
  - wasm compiler tests (pending CI re-run in this PR)

## Security review notes

- No new external I/O, shell, network, serialization, or unsafe loading paths were introduced.
- New guardrails ensure previously unsupported forms remain rejected (procedure-crossing, nonlocal conditional/switch-like designational forms).
- `goto` now only lowers through existing frame-restore paths, minimizing blast radius of control-flow changes.
