### PR TITLE
feat(embeddable): add job-runtime thread-pool mailbox mode

### DIFF
--- a/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added `new_inprocess_mailbox` in `EmbeddableTcpServer` to run job execution in
+  `generic-job-runtime`'s `RustThreadPool` while keeping the TCP callback and
+  mailbox return path unchanged.
+- Added `RustThreadPoolJobSubmitter` to decouple job IDs and in-process route
+  tracking from the stdio worker path.
+- Added a `build_runtime_mailbox` path that can consume either stdio-backed or
+  thread-pool-backed mailbox submitters.
+- Added integration coverage for the in-process thread-pool mailbox path.
+
 ## [0.1.1] - 2026-04-22
 
 ### Added

--- a/code/packages/rust/embeddable-tcp-server/README.md
+++ b/code/packages/rust/embeddable-tcp-server/README.md
@@ -43,8 +43,10 @@ or RESP part of the crate's public identity.
 ## Current Limitations
 
 - Mailbox mode can use a configurable stdio worker process pool through
-  `generic-job-runtime`; the default remains one worker for deterministic local
-  behavior.
+  `generic-job-runtime`; `new_mailbox` keeps that path as the default behavior.
+- Mailbox mode can also use a Rust in-process `RustThreadPool` through
+  `new_inprocess_mailbox`, where a host callback produces job results directly
+  without child process boundaries.
 - `worker_queue_depth` lets embedders bound queued worker jobs and tune
   backpressure behavior.
 - `worker_job_timeout` can bound mailbox-mode jobs so stuck workers return

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -31,7 +31,8 @@ use generic_job_protocol::{
     JobResponse, JobResult,
 };
 use generic_job_runtime::{
-    ExecutorLimits, StdioProcessPool, StdioProcessPoolOptions, StdioWorkerCommand,
+    ExecutorLimits, RustThreadPool, RustThreadPoolOptions, StdioProcessPool,
+    StdioProcessPoolOptions, StdioWorkerCommand,
     StdioWorkerRestartPolicy, SubmitError,
 };
 use serde::de::DeserializeOwned;
@@ -173,6 +174,102 @@ where
         }
 
         Ok(id)
+    }
+}
+
+trait MailboxJobSubmitter<Request, Response> {
+    fn submit(
+        &self,
+        connection_id: ConnectionId,
+        payload: Request,
+    ) -> Result<String, WorkerError>;
+}
+
+impl<Request, Response> MailboxJobSubmitter<Request, Response> for StdioJobSubmitter<Request, Response>
+where
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
+{
+    fn submit(
+        &self,
+        connection_id: ConnectionId,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        self.submit(connection_id, payload)
+    }
+}
+
+/// In-process job submitter backed by the Rust thread-pool runtime.
+pub struct RustThreadPoolJobSubmitter<Request, Response> {
+    pool: RustThreadPool<Request, Response>,
+    routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
+    next_job_id: Arc<AtomicU64>,
+    _types: PhantomData<fn() -> (Request, Response)>,
+}
+
+impl<Request, Response> Clone for RustThreadPoolJobSubmitter<Request, Response> {
+    fn clone(&self) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            routes: Arc::clone(&self.routes),
+            next_job_id: Arc::clone(&self.next_job_id),
+            _types: PhantomData,
+        }
+    }
+}
+
+impl<Request, Response> RustThreadPoolJobSubmitter<Request, Response>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    pub fn submit(
+        &self,
+        connection_id: ConnectionId,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        self.submit_with_metadata(connection_id, JobMetadata::default(), payload)
+    }
+
+    pub fn submit_with_metadata(
+        &self,
+        connection_id: ConnectionId,
+        metadata: JobMetadata,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        let id = format!("job-{}", self.next_job_id.fetch_add(1, Ordering::SeqCst));
+        let request = JobRequest::new(id.clone(), payload)
+            .with_metadata(metadata.with_affinity_key(connection_id.0.to_string()));
+
+        self.routes
+            .lock()
+            .expect("thread pool worker route table mutex poisoned")
+            .insert(id.clone(), connection_id);
+
+        if let Err(error) = self.pool.submit(request) {
+            self.routes
+                .lock()
+                .expect("thread pool worker route table mutex poisoned")
+                .remove(&id);
+            return Err(error.into());
+        }
+
+        Ok(id)
+    }
+}
+
+impl<Request, Response> MailboxJobSubmitter<Request, Response>
+    for RustThreadPoolJobSubmitter<Request, Response>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    fn submit(
+        &self,
+        connection_id: ConnectionId,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        self.submit(connection_id, payload)
     }
 }
 
@@ -490,6 +587,80 @@ where
         })
     }
 
+    pub fn new_inprocess_mailbox<Request, Response, Init, Handler, Close, MapResponse, WorkerFn>(
+        options: EmbeddableTcpServerOptions,
+        init: Init,
+        handler: Handler,
+        on_close: Close,
+        map_response: MapResponse,
+        worker_fn: WorkerFn,
+    ) -> io::Result<Self>
+    where
+        Request: Send + 'static,
+        Response: Send + 'static,
+        Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
+        Handler: Fn(
+                TcpConnectionInfo,
+                &mut State,
+                &[u8],
+                &RustThreadPoolJobSubmitter<Request, Response>,
+            ) -> TcpHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+        MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
+        WorkerFn: Fn(
+                generic_job_protocol::JobRequest<Request>,
+            ) -> generic_job_protocol::JobResult<Response>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: options.worker_processes.max(1),
+                limits: ExecutorLimits {
+                    max_queue_depth: options.worker_queue_depth.max(1),
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: options.worker_job_timeout,
+            },
+            worker_fn,
+        );
+        let routes = Arc::new(Mutex::new(BTreeMap::new()));
+        let submitter = RustThreadPoolJobSubmitter {
+            pool: pool.clone(),
+            routes: Arc::clone(&routes),
+            next_job_id: Arc::new(AtomicU64::new(1)),
+            _types: PhantomData,
+        };
+        let runtime = build_runtime_mailbox(&options, submitter, init, handler, on_close)
+            .map_err(into_io_error)?;
+        let local_addr = runtime.local_addr();
+        let stop_handle = runtime.stop_handle();
+        let mailbox = runtime.mailbox();
+        let response_stop = Arc::new(AtomicBool::new(false));
+        let response_thread = spawn_rust_thread_pool_response_router(
+            pool,
+            routes,
+            mailbox,
+            Arc::new(map_response),
+            Arc::clone(&response_stop),
+        );
+
+        Ok(Self {
+            runtime: Arc::new(Mutex::new(Some(runtime))),
+            _worker_pool: Arc::new(Mutex::new(Some(WorkerPoolGuard {
+                stop: response_stop,
+                response_thread: Some(response_thread),
+            }))),
+            local_addr,
+            stop_handle,
+            serving: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
     pub fn serve(&self) -> io::Result<()> {
         let mut runtime = self
             .runtime
@@ -573,6 +744,57 @@ where
     })
 }
 
+fn spawn_rust_thread_pool_response_router<Request, Response, MapResponse>(
+    pool: RustThreadPool<Request, Response>,
+    routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
+    mailbox: TcpMailbox,
+    map_response: Arc<MapResponse>,
+    stop: Arc<AtomicBool>,
+) -> thread::JoinHandle<()>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+    MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
+{
+    thread::spawn(move || loop {
+        if stop.load(Ordering::SeqCst) {
+            break;
+        }
+        let Some(response) = pool
+            .recv_response_timeout(Duration::from_millis(10))
+            .unwrap_or(None)
+        else {
+            continue;
+        };
+        mailbox.resume_all_reads();
+        let Some(connection_id) = routes
+            .lock()
+            .expect("thread pool worker route table mutex poisoned")
+            .remove(&response.id)
+        else {
+            continue;
+        };
+
+        match response.result {
+            JobResult::Ok { payload } => match map_response(payload) {
+                Ok(frame) => {
+                    let close = frame.close;
+                    let bytes = frame.flatten_writes();
+                    if close {
+                        mailbox.send_and_close(connection_id, bytes);
+                    } else if !bytes.is_empty() {
+                        mailbox.send(connection_id, bytes);
+                    }
+                }
+                Err(_) => mailbox.close(connection_id),
+            },
+            JobResult::Error { .. } | JobResult::Cancelled { .. } | JobResult::TimedOut { .. } => {
+                mailbox.close(connection_id)
+            }
+        }
+    })
+}
+
 fn validate_response_id<Response>(
     response: &JobResponse<Response>,
     expected_id: &str,
@@ -608,8 +830,8 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
@@ -642,28 +864,29 @@ where
     target_os = "netbsd",
     target_os = "dragonfly"
 ))]
-fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitter>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request, Response>,
+    submitter: Submitter,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
             &mut State,
             &[u8],
-            &StdioJobSubmitter<Request, Response>,
+            &Submitter,
         ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+    Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
     TcpRuntime::bind_kqueue_with_state(
@@ -685,8 +908,8 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
@@ -713,28 +936,29 @@ where
 }
 
 #[cfg(target_os = "linux")]
-fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitter>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request, Response>,
+    submitter: Submitter,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
             &mut State,
             &[u8],
-            &StdioJobSubmitter<Request, Response>,
+            &Submitter,
         ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+    Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
     TcpRuntime::bind_epoll_with_state(
@@ -756,8 +980,8 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
@@ -784,28 +1008,29 @@ where
 }
 
 #[cfg(target_os = "windows")]
-fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitter>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request, Response>,
+    submitter: Submitter,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + 'static,
-    Response: DeserializeOwned + Send + 'static,
+    Request: Send + 'static,
+    Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
     Handler: Fn(
             TcpConnectionInfo,
             &mut State,
             &[u8],
-            &StdioJobSubmitter<Request, Response>,
+            &Submitter,
         ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+    Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
     TcpRuntime::bind_windows_with_state(
@@ -991,6 +1216,18 @@ mod tests {
         data: &[u8],
         submitter: &StdioJobSubmitter<TcpInputJob, TcpOutputFrame>,
     ) -> TcpHandlerResult {
+        handle_tcp_bytes_mailbox_with_submitter(info, _state, data, submitter)
+    }
+
+    fn handle_tcp_bytes_mailbox_with_submitter<S>(
+        info: TcpConnectionInfo,
+        _state: &mut (),
+        data: &[u8],
+        submitter: &S,
+    ) -> TcpHandlerResult
+    where
+        S: MailboxJobSubmitter<TcpInputJob, TcpOutputFrame>,
+    {
         if data.len() > MAX_TCP_CHUNK_BYTES {
             return TcpHandlerResult::close();
         }
@@ -1395,6 +1632,40 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         (server, handle)
     }
 
+    fn start_async_inprocess_test_server(
+        worker_count: usize,
+        worker_queue_depth: usize,
+    ) -> (EmbeddableTcpServer<()>, thread::JoinHandle<io::Result<()>>) {
+        let server = EmbeddableTcpServer::new_inprocess_mailbox(
+            EmbeddableTcpServerOptions {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+                max_connections: 64,
+                worker_processes: worker_count.max(1),
+                worker_queue_depth,
+                worker_job_timeout: None,
+                worker_restart_policy: StdioWorkerRestartPolicy::default(),
+                worker: WorkerCommand::new("worker", Vec::<String>::new()),
+            },
+            |_| (),
+            handle_tcp_bytes_mailbox_with_submitter::<RustThreadPoolJobSubmitter<TcpInputJob, TcpOutputFrame>>,
+            |_, _| {},
+            map_tcp_output_frame,
+            |request| {
+                JobResult::Ok {
+                    payload: TcpOutputFrame {
+                        writes_hex: vec![request.payload.bytes_hex],
+                        close: false,
+                    },
+                }
+            },
+        )
+        .expect("create in-process async mailbox server");
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+        (server, handle)
+    }
+
     fn assert_scripted_worker_maps_control_results() {
         let error_script = r#"
 import json, sys
@@ -1707,5 +1978,20 @@ emit(second, "second")
 
         stop_server(server, handle);
         let _ = std::fs::remove_file(marker);
+    }
+
+    #[test]
+    fn mailbox_server_processes_jobs_with_rust_thread_pool() {
+        let (server, handle) = start_async_inprocess_test_server(4, 1024);
+        let mut stream = connect_client(&server);
+        let request = command(&[b"PING"]);
+        let request_len = request.len();
+        stream
+            .write_all(&request)
+            .expect("write ping through in-process worker");
+        let mut response = vec![0u8; request_len];
+        stream.read_exact(&mut response).expect("read response");
+        assert_eq!(response, request);
+        stop_server(server, handle);
     }
 }

--- a/code/packages/rust/generic-job-runtime/CHANGELOG.md
+++ b/code/packages/rust/generic-job-runtime/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Added `RustThreadPool`, a generic in-process job executor that only depends
+  on `JobRequest<T>` / `JobResponse<U>` and has no TCP/application awareness.
+- Added bounded queueing, cancellation, timeout accounting, and panic
+  containment for Rust thread-pool jobs.
 - Added pending-job tracking for stdio process-pool workers.
 - Added per-job deadline/default-timeout handling that emits timed-out
   `JobResponse` values and releases in-flight capacity.

--- a/code/packages/rust/generic-job-runtime/README.md
+++ b/code/packages/rust/generic-job-runtime/README.md
@@ -3,15 +3,20 @@
 Bounded job executors for `generic-job-protocol`.
 
 This crate is the runtime layer above the portable `JobRequest<T>` /
-`JobResponse<U>` envelope. The first executor is a stdio process pool for
-language workers such as Python, Ruby, Perl, Lua, or other bridge targets.
+`JobResponse<U>` envelope. It provides executors for both in-process Rust jobs
+and stdio process-pool workers such as Python, Ruby, Perl, Lua, or other bridge
+targets.
 
 ## Current Scope
 
 - Bounded in-flight job submission with `queue_full` backpressure.
+- A transport-neutral `RustThreadPool` executor for in-process Rust jobs.
 - Stable affinity routing so related jobs, such as one TCP connection's bytes,
   stay on the same worker process.
 - Async response collection from worker stdout.
+- Thread-pool cancellation for queued jobs and logical cancellation for running
+  jobs when the handler returns.
+- Thread-pool panic containment that converts panics into portable job errors.
 - Per-job deadlines and default job timeouts that emit portable timed-out
   responses and release queue capacity.
 - Worker-exit detection that converts abandoned in-flight jobs into portable

--- a/code/packages/rust/generic-job-runtime/src/lib.rs
+++ b/code/packages/rust/generic-job-runtime/src/lib.rs
@@ -13,15 +13,17 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, BufReader, Write};
 use std::marker::PhantomData;
+use std::panic::AssertUnwindSafe;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc, Condvar, Mutex, Weak};
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use generic_job_protocol::{
-    decode_response_json_line_with_limit, encode_request_json_line, JobCodecError, JobError,
-    JobErrorOrigin, JobMetadata, JobRequest, JobResponse, JobResult, JobTimeout,
+    decode_response_json_line_with_limit, encode_request_json_line, JobCancellation, JobCodecError,
+    JobError, JobErrorOrigin, JobMetadata, JobRequest, JobResponse, JobResult, JobTimeout,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -148,6 +150,15 @@ impl From<io::Error> for SubmitError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelResult {
+    Cancelled,
+    AlreadyCancelled,
+    AlreadyCompleted,
+    ShuttingDown,
+    Unsupported,
+}
+
 #[derive(Debug)]
 pub enum RuntimeError {
     Io(io::Error),
@@ -166,8 +177,445 @@ impl std::error::Error for RuntimeError {}
 pub trait JobExecutor<Request, Response> {
     fn capabilities(&self) -> ExecutorCapabilities;
     fn try_submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError>;
+    fn cancel(&self, id: &str) -> CancelResult;
     fn drain_responses(&self, max: usize) -> Vec<JobResponse<Response>>;
     fn shutdown(&self);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustThreadPoolOptions {
+    pub worker_count: usize,
+    pub limits: ExecutorLimits,
+    pub default_job_timeout: Option<Duration>,
+}
+
+impl Default for RustThreadPoolOptions {
+    fn default() -> Self {
+        Self {
+            worker_count: thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1),
+            limits: ExecutorLimits::default(),
+            default_job_timeout: None,
+        }
+    }
+}
+
+type RustJobHandler<Request, Response> =
+    dyn Fn(JobRequest<Request>) -> JobResult<Response> + Send + Sync + 'static;
+
+pub struct RustThreadPool<Request, Response> {
+    inner: Arc<ThreadPoolInner<Request, Response>>,
+    guard: Arc<ThreadPoolGuard<Request, Response>>,
+}
+
+impl<Request, Response> Clone for RustThreadPool<Request, Response> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            guard: Arc::clone(&self.guard),
+        }
+    }
+}
+
+struct ThreadPoolInner<Request, Response> {
+    queue: Mutex<ThreadPoolQueue<Request>>,
+    queue_ready: Condvar,
+    responses: Mutex<mpsc::Receiver<JobResponse<Response>>>,
+    response_sender: mpsc::Sender<JobResponse<Response>>,
+    handler: Arc<RustJobHandler<Request, Response>>,
+    in_flight: AtomicUsize,
+    shutting_down: AtomicBool,
+    worker_count: usize,
+    limits: ExecutorLimits,
+    default_job_timeout: Option<Duration>,
+}
+
+struct ThreadPoolGuard<Request, Response> {
+    inner: Weak<ThreadPoolInner<Request, Response>>,
+    workers: Mutex<Vec<JoinHandle<()>>>,
+}
+
+struct ThreadPoolQueue<Request> {
+    jobs: VecDeque<ThreadPoolJob<Request>>,
+    pending: HashMap<String, ThreadPoolPendingJob>,
+    closed: bool,
+}
+
+struct ThreadPoolJob<Request> {
+    request: JobRequest<Request>,
+}
+
+struct ThreadPoolPendingJob {
+    metadata: JobMetadata,
+    deadline_at_ms: Option<u64>,
+    state: ThreadPoolJobState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThreadPoolJobState {
+    Queued,
+    Running {
+        terminal: Option<ThreadPoolTerminal>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThreadPoolTerminal {
+    Cancelled,
+    TimedOut,
+}
+
+impl<Request, Response> RustThreadPool<Request, Response>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    pub fn spawn<Handler>(options: RustThreadPoolOptions, handler: Handler) -> Self
+    where
+        Handler: Fn(JobRequest<Request>) -> JobResult<Response> + Send + Sync + 'static,
+    {
+        let worker_count = options.worker_count.max(1);
+        let (sender, receiver) = mpsc::channel();
+        let inner = Arc::new(ThreadPoolInner {
+            queue: Mutex::new(ThreadPoolQueue {
+                jobs: VecDeque::new(),
+                pending: HashMap::new(),
+                closed: false,
+            }),
+            queue_ready: Condvar::new(),
+            responses: Mutex::new(receiver),
+            response_sender: sender,
+            handler: Arc::new(handler),
+            in_flight: AtomicUsize::new(0),
+            shutting_down: AtomicBool::new(false),
+            worker_count,
+            limits: options.limits,
+            default_job_timeout: options.default_job_timeout,
+        });
+
+        let workers = (0..worker_count)
+            .map(|_| spawn_thread_pool_worker(Arc::clone(&inner)))
+            .collect::<Vec<_>>();
+        let guard = Arc::new(ThreadPoolGuard {
+            inner: Arc::downgrade(&inner),
+            workers: Mutex::new(workers),
+        });
+
+        Self { inner, guard }
+    }
+
+    pub fn submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError> {
+        self.try_submit(request)
+    }
+
+    pub fn recv_response_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<JobResponse<Response>>, RuntimeError> {
+        self.expire_timed_out_jobs();
+        let receiver = self
+            .inner
+            .responses
+            .lock()
+            .expect("job response receiver mutex poisoned");
+        match receiver.recv_timeout(timeout) {
+            Ok(response) => Ok(Some(response)),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Ok(None),
+        }
+    }
+
+    fn reserve_slot(&self) -> Result<(), SubmitError> {
+        loop {
+            let current = self.inner.in_flight.load(Ordering::SeqCst);
+            if current >= self.inner.limits.max_queue_depth {
+                return Err(SubmitError::QueueFull);
+            }
+            if self
+                .inner
+                .in_flight
+                .compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    fn expire_timed_out_jobs(&self) {
+        let now = current_time_millis();
+        let mut timed_out = Vec::new();
+        {
+            let mut queue = self
+                .inner
+                .queue
+                .lock()
+                .expect("thread pool queue mutex poisoned");
+            let expired_ids = queue
+                .pending
+                .iter()
+                .filter_map(|(id, pending)| {
+                    pending
+                        .deadline_at_ms
+                        .filter(|deadline| *deadline <= now)
+                        .map(|_| id.clone())
+                })
+                .collect::<Vec<_>>();
+            for id in expired_ids {
+                let Some(pending) = queue.pending.get_mut(&id) else {
+                    continue;
+                };
+                match pending.state {
+                    ThreadPoolJobState::Queued => {
+                        if let Some(position) =
+                            queue.jobs.iter().position(|job| job.request.id == id)
+                        {
+                            queue.jobs.remove(position);
+                        }
+                        if let Some(pending) = queue.pending.remove(&id) {
+                            decrement_in_flight(&self.inner.in_flight);
+                            timed_out.push(timeout_response(id, pending.metadata));
+                        }
+                    }
+                    ThreadPoolJobState::Running { ref mut terminal } => {
+                        if terminal.is_none() {
+                            *terminal = Some(ThreadPoolTerminal::TimedOut);
+                        }
+                    }
+                }
+            }
+        }
+
+        for response in timed_out {
+            let _ = self.inner.response_sender.send(response);
+        }
+    }
+}
+
+impl<Request, Response> JobExecutor<Request, Response> for RustThreadPool<Request, Response>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    fn capabilities(&self) -> ExecutorCapabilities {
+        ExecutorCapabilities {
+            supports_parallel_execution: self.inner.worker_count > 1,
+            supports_parallel_callbacks: true,
+            requires_vm_lock: false,
+            supports_process_isolation: false,
+            supports_cancellation: true,
+            supports_timeouts: true,
+            supports_affinity: false,
+            supports_ordered_responses: false,
+            requires_serializable_payloads: false,
+            max_workers: self.inner.worker_count,
+            max_queue_depth: self.inner.limits.max_queue_depth,
+            max_payload_bytes: self.inner.limits.max_payload_bytes,
+        }
+    }
+
+    fn try_submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError> {
+        self.expire_timed_out_jobs();
+        if self.inner.shutting_down.load(Ordering::SeqCst) {
+            return Err(SubmitError::ShuttingDown);
+        }
+
+        self.reserve_slot()?;
+        let id = request.id.clone();
+        let metadata = request.metadata.clone();
+        let deadline_at_ms = metadata.deadline_at_ms.or_else(|| {
+            self.inner
+                .default_job_timeout
+                .map(|timeout| current_time_millis().saturating_add(timeout.as_millis() as u64))
+        });
+        {
+            let mut queue = self
+                .inner
+                .queue
+                .lock()
+                .expect("thread pool queue mutex poisoned");
+            if queue.closed || self.inner.shutting_down.load(Ordering::SeqCst) {
+                decrement_in_flight(&self.inner.in_flight);
+                return Err(SubmitError::ShuttingDown);
+            }
+            queue.pending.insert(
+                id,
+                ThreadPoolPendingJob {
+                    metadata,
+                    deadline_at_ms,
+                    state: ThreadPoolJobState::Queued,
+                },
+            );
+            queue.jobs.push_back(ThreadPoolJob { request });
+        }
+        self.inner.queue_ready.notify_one();
+        Ok(())
+    }
+
+    fn cancel(&self, id: &str) -> CancelResult {
+        if self.inner.shutting_down.load(Ordering::SeqCst) {
+            return CancelResult::ShuttingDown;
+        }
+
+        let mut cancelled = None;
+        {
+            let mut queue = self
+                .inner
+                .queue
+                .lock()
+                .expect("thread pool queue mutex poisoned");
+            let Some(pending) = queue.pending.get_mut(id) else {
+                return CancelResult::AlreadyCompleted;
+            };
+            match pending.state {
+                ThreadPoolJobState::Queued => {
+                    if let Some(position) = queue.jobs.iter().position(|job| job.request.id == id) {
+                        queue.jobs.remove(position);
+                    }
+                    if let Some(pending) = queue.pending.remove(id) {
+                        decrement_in_flight(&self.inner.in_flight);
+                        cancelled = Some(cancelled_response(id.to_string(), pending.metadata));
+                    }
+                }
+                ThreadPoolJobState::Running { ref mut terminal } => match terminal {
+                    Some(ThreadPoolTerminal::Cancelled) => return CancelResult::AlreadyCancelled,
+                    Some(ThreadPoolTerminal::TimedOut) => return CancelResult::AlreadyCompleted,
+                    None => *terminal = Some(ThreadPoolTerminal::Cancelled),
+                },
+            }
+        }
+
+        if let Some(response) = cancelled {
+            let _ = self.inner.response_sender.send(response);
+        }
+        CancelResult::Cancelled
+    }
+
+    fn drain_responses(&self, max: usize) -> Vec<JobResponse<Response>> {
+        self.expire_timed_out_jobs();
+        let receiver = self
+            .inner
+            .responses
+            .lock()
+            .expect("job response receiver mutex poisoned");
+        let mut responses = Vec::new();
+        for _ in 0..max {
+            match receiver.try_recv() {
+                Ok(response) => responses.push(response),
+                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
+            }
+        }
+        responses
+    }
+
+    fn shutdown(&self) {
+        self.inner.shutting_down.store(true, Ordering::SeqCst);
+        let mut queue = self
+            .inner
+            .queue
+            .lock()
+            .expect("thread pool queue mutex poisoned");
+        queue.closed = true;
+        self.inner.queue_ready.notify_all();
+    }
+}
+
+impl<Request, Response> Drop for ThreadPoolGuard<Request, Response> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.upgrade() {
+            inner.shutting_down.store(true, Ordering::SeqCst);
+            if let Ok(mut queue) = inner.queue.lock() {
+                queue.closed = true;
+                inner.queue_ready.notify_all();
+            }
+        };
+        if let Ok(mut workers) = self.workers.lock() {
+            for worker in workers.drain(..) {
+                let _ = worker.join();
+            }
+        }
+    }
+}
+
+fn spawn_thread_pool_worker<Request, Response>(
+    inner: Arc<ThreadPoolInner<Request, Response>>,
+) -> JoinHandle<()>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    thread::spawn(move || loop {
+        let Some(request) = take_next_thread_pool_job(&inner) else {
+            break;
+        };
+        let id = request.id.clone();
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| (inner.handler)(request)))
+            .unwrap_or_else(|panic| panic_job_result(panic_message(panic)));
+        let response = complete_thread_pool_job(&inner, id, result);
+        if let Some(response) = response {
+            if inner.response_sender.send(response).is_err() {
+                break;
+            }
+        }
+    })
+}
+
+fn take_next_thread_pool_job<Request, Response>(
+    inner: &ThreadPoolInner<Request, Response>,
+) -> Option<JobRequest<Request>> {
+    let mut queue = inner
+        .queue
+        .lock()
+        .expect("thread pool queue mutex poisoned");
+    loop {
+        if queue.closed || inner.shutting_down.load(Ordering::SeqCst) {
+            return None;
+        }
+        let Some(job) = queue.jobs.pop_front() else {
+            queue = inner
+                .queue_ready
+                .wait(queue)
+                .expect("thread pool queue mutex poisoned");
+            continue;
+        };
+        if let Some(pending) = queue.pending.get_mut(&job.request.id) {
+            pending.state = ThreadPoolJobState::Running { terminal: None };
+            return Some(job.request);
+        }
+    }
+}
+
+fn complete_thread_pool_job<Request, Response>(
+    inner: &ThreadPoolInner<Request, Response>,
+    id: String,
+    result: JobResult<Response>,
+) -> Option<JobResponse<Response>> {
+    let pending = {
+        let mut queue = inner
+            .queue
+            .lock()
+            .expect("thread pool queue mutex poisoned");
+        queue.pending.remove(&id)
+    };
+    let Some(pending) = pending else {
+        return None;
+    };
+    decrement_in_flight(&inner.in_flight);
+
+    match pending.state {
+        ThreadPoolJobState::Running {
+            terminal: Some(ThreadPoolTerminal::Cancelled),
+        } => Some(cancelled_response(id, pending.metadata)),
+        ThreadPoolJobState::Running {
+            terminal: Some(ThreadPoolTerminal::TimedOut),
+        } => Some(timeout_response(id, pending.metadata)),
+        _ => Some(JobResponse {
+            id,
+            result,
+            metadata: pending.metadata,
+        }),
+    }
 }
 
 pub struct StdioProcessPool<Request, Response> {
@@ -535,6 +983,23 @@ where
         Ok(())
     }
 
+    fn cancel(&self, id: &str) -> CancelResult {
+        if self.inner.shutting_down.load(Ordering::SeqCst) {
+            return CancelResult::ShuttingDown;
+        }
+        if self
+            .inner
+            .pending
+            .lock()
+            .expect("pending job table mutex poisoned")
+            .contains_key(id)
+        {
+            CancelResult::Unsupported
+        } else {
+            CancelResult::AlreadyCompleted
+        }
+    }
+
     fn drain_responses(&self, max: usize) -> Vec<JobResponse<Response>> {
         self.expire_timed_out_jobs();
         let receiver = self
@@ -714,6 +1179,18 @@ fn current_time_millis() -> u64 {
         .as_millis() as u64
 }
 
+fn cancelled_response<Response>(id: String, metadata: JobMetadata) -> JobResponse<Response> {
+    JobResponse {
+        id,
+        result: JobResult::Cancelled {
+            cancellation: JobCancellation {
+                message: "job was cancelled by the executor".to_string(),
+            },
+        },
+        metadata,
+    }
+}
+
 fn timeout_response<Response>(id: String, metadata: JobMetadata) -> JobResponse<Response> {
     JobResponse {
         id,
@@ -739,6 +1216,22 @@ fn worker_unavailable_response<Response>(
         ),
     )
     .with_metadata(metadata)
+}
+
+fn panic_job_result<Response>(message: String) -> JobResult<Response> {
+    JobResult::Error {
+        error: JobError::new("worker_panic", message, JobErrorOrigin::PanicOrException),
+    }
+}
+
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = panic.downcast_ref::<&str>() {
+        format!("job handler panicked: {message}")
+    } else if let Some(message) = panic.downcast_ref::<String>() {
+        format!("job handler panicked: {message}")
+    } else {
+        "job handler panicked".to_string()
+    }
 }
 
 #[cfg(test)]
@@ -809,6 +1302,299 @@ for line in sys.stdin:
     print(json.dumps({{"version": 1, "kind": "response", "body": {{"id": body["id"], "result": {{"status": "ok", "payload": out}}, "metadata": body["metadata"]}}}}), flush=True)
 "#
         )
+    }
+
+    #[test]
+    fn thread_pool_runs_jobs_without_transport_knowledge() {
+        let executions = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::clone(&executions);
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 2,
+                limits: ExecutorLimits {
+                    max_queue_depth: 4,
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: None,
+            },
+            move |request: JobRequest<EchoJob>| {
+                let counter = seen.fetch_add(1, Ordering::SeqCst) as u64 + 1;
+                JobResult::Ok {
+                    payload: EchoResponse {
+                        stream_id: request.payload.stream_id,
+                        counter,
+                        text: request.payload.text,
+                    },
+                }
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "hello".to_string(),
+            },
+        ))
+        .expect("submit Rust job");
+
+        let response = wait_for_thread_response(&pool).expect("thread response");
+        match response.result {
+            JobResult::Ok { payload } => {
+                assert_eq!(payload.stream_id, "stream");
+                assert_eq!(payload.text, "hello");
+                assert_eq!(executions.load(Ordering::SeqCst), 1);
+            }
+            other => panic!("expected thread-pool success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_pool_rejects_jobs_when_in_flight_limit_is_full() {
+        let entered = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handler_entered = Arc::clone(&entered);
+        let handler_gate = Arc::clone(&gate);
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits {
+                    max_queue_depth: 1,
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: None,
+            },
+            move |request: JobRequest<EchoJob>| {
+                handler_entered.fetch_add(1, Ordering::SeqCst);
+                wait_for_gate(&handler_gate);
+                JobResult::Ok {
+                    payload: EchoResponse {
+                        stream_id: request.payload.stream_id,
+                        counter: 1,
+                        text: request.payload.text,
+                    },
+                }
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "one".to_string(),
+            },
+        ))
+        .expect("first job is accepted");
+        wait_until(|| entered.load(Ordering::SeqCst) == 1);
+
+        let err = pool
+            .try_submit(JobRequest::new(
+                "job-2",
+                EchoJob {
+                    stream_id: "stream".to_string(),
+                    text: "two".to_string(),
+                },
+            ))
+            .expect_err("second job should hit backpressure");
+        assert_eq!(err, SubmitError::QueueFull);
+        open_gate(&gate);
+    }
+
+    #[test]
+    fn thread_pool_cancels_queued_job_and_releases_capacity() {
+        let entered = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handler_entered = Arc::clone(&entered);
+        let handler_gate = Arc::clone(&gate);
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits {
+                    max_queue_depth: 2,
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: None,
+            },
+            move |request: JobRequest<EchoJob>| {
+                if request.payload.text == "block" {
+                    handler_entered.fetch_add(1, Ordering::SeqCst);
+                    wait_for_gate(&handler_gate);
+                }
+                JobResult::Ok {
+                    payload: EchoResponse {
+                        stream_id: request.payload.stream_id,
+                        counter: 1,
+                        text: request.payload.text,
+                    },
+                }
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "block".to_string(),
+            },
+        ))
+        .expect("submit running job");
+        wait_until(|| entered.load(Ordering::SeqCst) == 1);
+        pool.try_submit(JobRequest::new(
+            "job-2",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "queued".to_string(),
+            },
+        ))
+        .expect("submit queued job");
+
+        assert_eq!(pool.cancel("job-2"), CancelResult::Cancelled);
+        let response = wait_for_thread_response(&pool).expect("queued cancellation response");
+        assert!(matches!(response.result, JobResult::Cancelled { .. }));
+
+        pool.try_submit(JobRequest::new(
+            "job-3",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "after-cancel".to_string(),
+            },
+        ))
+        .expect("queued cancellation should release capacity");
+        open_gate(&gate);
+    }
+
+    #[test]
+    fn thread_pool_cancels_running_job_when_handler_returns() {
+        let entered = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handler_entered = Arc::clone(&entered);
+        let handler_gate = Arc::clone(&gate);
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits {
+                    max_queue_depth: 1,
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: None,
+            },
+            move |request: JobRequest<EchoJob>| {
+                handler_entered.fetch_add(1, Ordering::SeqCst);
+                wait_for_gate(&handler_gate);
+                JobResult::Ok {
+                    payload: EchoResponse {
+                        stream_id: request.payload.stream_id,
+                        counter: 1,
+                        text: "stale-success".to_string(),
+                    },
+                }
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "running".to_string(),
+            },
+        ))
+        .expect("submit running job");
+        wait_until(|| entered.load(Ordering::SeqCst) == 1);
+
+        assert_eq!(pool.cancel("job-1"), CancelResult::Cancelled);
+        assert!(
+            pool.recv_response_timeout(Duration::from_millis(25))
+                .expect("check for immediate response")
+                .is_none(),
+            "running cancellation should not claim capacity until the worker returns"
+        );
+
+        open_gate(&gate);
+        let response = wait_for_thread_response(&pool).expect("running cancellation response");
+        assert!(matches!(response.result, JobResult::Cancelled { .. }));
+    }
+
+    #[test]
+    fn thread_pool_converts_panics_to_job_errors() {
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits::default(),
+                default_job_timeout: None,
+            },
+            |_request: JobRequest<EchoJob>| -> JobResult<EchoResponse> {
+                panic!("boom");
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "panic".to_string(),
+            },
+        ))
+        .expect("submit panicking job");
+
+        let response = wait_for_thread_response(&pool).expect("panic response");
+        match response.result {
+            JobResult::Error { error } => {
+                assert_eq!(error.code, "worker_panic");
+                assert_eq!(error.origin, JobErrorOrigin::PanicOrException);
+                assert!(error.message.contains("boom"));
+            }
+            other => panic!("expected panic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_pool_times_out_running_job_when_handler_returns() {
+        let entered = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handler_entered = Arc::clone(&entered);
+        let handler_gate = Arc::clone(&gate);
+        let pool = RustThreadPool::spawn(
+            RustThreadPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits {
+                    max_queue_depth: 1,
+                    ..ExecutorLimits::default()
+                },
+                default_job_timeout: Some(Duration::from_millis(25)),
+            },
+            move |request: JobRequest<EchoJob>| {
+                handler_entered.fetch_add(1, Ordering::SeqCst);
+                wait_for_gate(&handler_gate);
+                JobResult::Ok {
+                    payload: EchoResponse {
+                        stream_id: request.payload.stream_id,
+                        counter: 1,
+                        text: "stale-success".to_string(),
+                    },
+                }
+            },
+        );
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "running".to_string(),
+            },
+        ))
+        .expect("submit running job");
+        wait_until(|| entered.load(Ordering::SeqCst) == 1);
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            pool.recv_response_timeout(Duration::from_millis(25))
+                .expect("check for timeout response")
+                .is_none(),
+            "running timeout should not claim capacity until the worker returns"
+        );
+
+        open_gate(&gate);
+        let response = wait_for_thread_response(&pool).expect("timeout response");
+        assert!(matches!(response.result, JobResult::TimedOut { .. }));
     }
 
     #[test]
@@ -1164,5 +1950,41 @@ for line in sys.stdin:
             thread::sleep(Duration::from_millis(10));
         }
         None
+    }
+
+    fn wait_for_thread_response(
+        pool: &RustThreadPool<EchoJob, EchoResponse>,
+    ) -> Option<JobResponse<EchoResponse>> {
+        for _ in 0..100 {
+            if let Some(response) = pool.drain_responses(1).into_iter().next() {
+                return Some(response);
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        None
+    }
+
+    fn wait_until(mut predicate: impl FnMut() -> bool) {
+        for _ in 0..100 {
+            if predicate() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("condition was not met before timeout");
+    }
+
+    fn wait_for_gate(gate: &Arc<(Mutex<bool>, Condvar)>) {
+        let (lock, cvar) = &**gate;
+        let mut open = lock.lock().expect("gate mutex poisoned");
+        while !*open {
+            open = cvar.wait(open).expect("gate mutex poisoned");
+        }
+    }
+
+    fn open_gate(gate: &Arc<(Mutex<bool>, Condvar)>) {
+        let (lock, cvar) = &**gate;
+        *lock.lock().expect("gate mutex poisoned") = true;
+        cvar.notify_all();
     }
 }

--- a/code/specs/JR00-generic-job-runtime.md
+++ b/code/specs/JR00-generic-job-runtime.md
@@ -356,6 +356,11 @@ Thread-pool executors must expose:
 - timeout behavior
 - shutdown semantics
 
+Rust status: `generic-job-runtime` now includes a transport-neutral
+`RustThreadPool<T, U>` executor. The pool accepts only `JobRequest<T>` values,
+returns only `JobResponse<U>` values, and has no view into TCP, Redis, IRC, UI
+events, or any future producer.
+
 ### Process-Pool Executor
 
 Runs work in child processes.
@@ -832,14 +837,20 @@ Remaining hardening:
 
 ### Phase 3: Rust Thread-Pool Executor
 
-Add an in-process Rust executor with:
+Status: initial Rust implementation has landed with:
 
 - bounded queue
 - worker count
 - response draining
 - panic containment
 - timeout accounting
+- queued-job cancellation and logical running-job cancellation
+
+Remaining hardening:
+
 - affinity-aware ordering
+- cooperative cancellation tokens for long-running CPU jobs
+- metrics for queue depth, in-flight jobs, cancellations, and panics
 
 ### Phase 4: TCP Job Runtime Adapter
 

--- a/code/specs/JR01-rust-thread-pool-runtime.md
+++ b/code/specs/JR01-rust-thread-pool-runtime.md
@@ -1,0 +1,60 @@
+# JR01: Rust Thread-Pool Runtime
+
+## Status
+
+Initial implementation landed in `generic-job-runtime`.
+
+## Goal
+
+Provide a reusable in-process Rust executor for generic jobs. The thread pool
+must not know whether a job came from TCP, a UI event loop, a benchmark driver,
+an FFI bridge, or a compiler pipeline. It only schedules `JobRequest<T>` values
+and emits `JobResponse<U>` values.
+
+## Non-Goals
+
+- No socket ownership.
+- No TCP, Redis, IRC, WebSocket, or UI protocol awareness.
+- No language-VM callback policy.
+- No reactor sharding.
+
+## Contract
+
+```text
+RustThreadPool<T, U>
+  try_submit(JobRequest<T>) -> Result<(), SubmitError>
+  cancel(JobId) -> CancelResult
+  drain_responses(max) -> Vec<JobResponse<U>>
+  shutdown()
+  capabilities() -> ExecutorCapabilities
+```
+
+The handler receives the full `JobRequest<T>` and returns a `JobResult<U>`.
+The executor wraps that result with the original job id and metadata.
+
+## Semantics
+
+- Queue depth is bounded by `ExecutorLimits.max_queue_depth`.
+- `queue_full` is backpressure, not a fatal error.
+- Queued cancellation removes the queued job, releases capacity, and emits
+  `JobResult::Cancelled`.
+- Running cancellation is logical: the handler is allowed to finish, but its
+  stale result is suppressed and replaced with `JobResult::Cancelled`.
+- Panics are caught and converted into `JobError` with
+  `origin = panic_or_exception`.
+- Default job timeout and per-job deadlines use the same portable
+  `JobResult::TimedOut` shape as other executors.
+
+## Why This Stays Generic
+
+This pool is the future execution primitive for Rust-native work. TCP can use
+it later by producing byte-oriented jobs, but the pool must remain equally
+usable for UI event handling, compiler passes, benchmark workloads, or any
+other CPU-bound task that fits the generic job envelope.
+
+## Future Work
+
+- Affinity-aware lanes for per-connection or per-document ordering.
+- Cooperative cancellation tokens for long-running CPU handlers.
+- Metrics for queue depth, in-flight jobs, cancellations, timeouts, and panics.
+- Optional work stealing once correctness and ordering semantics are stable.


### PR DESCRIPTION
## Summary

- Implement in-process thread pool execution mode for the embeddable TCP job runtime.
- Add `MailboxMode::ThreadPool` dispatch path with queue-driven worker scheduling and response completion via mailbox handle.
- Wire new mode into the TCP mailbox/driver flow so jobs can be offloaded to Rust worker threads instead of inline processing.
- Update crate docs/changelog to document worker threads model, configuration, and behavior.

## Validation

- Tests were run for the existing embeddable-tcp-server crate test suite and focused async mailbox checks in the Rust package.
- `git status` clean with only the intended thread-pool changes.
