### PR TITLE
feat(riscv): preserve caller values across calls

### DIFF
--- a/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Preserve mapped caller virtual registers around `CALL`.
+- Document `v0` and `v1` as volatile starter-ABI registers.
+
 ## 0.2.0
 
 - Add call-frame lowering for nested `CALL`/`RET` programs.

--- a/code/packages/go/ir-to-riscv-compiler/README.md
+++ b/code/packages/go/ir-to-riscv-compiler/README.md
@@ -37,4 +37,6 @@ absolute byte offsets from the beginning of the loaded program.
 When a program uses `CALL`, the backend emits a small runtime prelude that
 initializes `sp` to a hidden call-frame stack appended after the IR data segment.
 Every called label saves `ra` on entry, and `RET` restores it before returning,
-so nested calls can safely return through multiple frames.
+so nested calls can safely return through multiple frames. The backend also
+saves and restores mapped virtual registers around each `CALL`, treating `v0`
+and `v1` as volatile starter-ABI registers.

--- a/code/packages/go/ir-to-riscv-compiler/assembly.go
+++ b/code/packages/go/ir-to-riscv-compiler/assembly.go
@@ -150,7 +150,7 @@ func (c *IrToRiscVCompiler) emitAssemblyInstruction(instruction ir.IrInstruction
 		if err != nil {
 			return nil, err
 		}
-		return []string{fmt.Sprintf("  call %s", label.Name)}, nil
+		return emitCallWithCallerSavesAssembly(label.Name, plan.callerSavedRegs), nil
 	case ir.OpRet:
 		if !plan.usesCallFrames() {
 			return []string{"  ret"}, nil
@@ -270,6 +270,36 @@ func emitCallTargetPrologueAssembly() []string {
 		"  addi sp, sp, -4",
 		"  sw ra, 0(sp)",
 	}
+}
+
+func emitCallWithCallerSavesAssembly(label string, regs []callerSavedRegister) []string {
+	lines := emitCallerSavePrologueAssembly(regs)
+	lines = append(lines, fmt.Sprintf("  call %s", label))
+	lines = append(lines, emitCallerSaveEpilogueAssembly(regs)...)
+	return lines
+}
+
+func emitCallerSavePrologueAssembly(regs []callerSavedRegister) []string {
+	if len(regs) == 0 {
+		return nil
+	}
+	lines := []string{fmt.Sprintf("  addi sp, sp, -%d", callerSaveFrameBytes(regs))}
+	for index, register := range regs {
+		lines = append(lines, fmt.Sprintf("  sw %s, %d(sp)", regName(register.physical), index*4))
+	}
+	return lines
+}
+
+func emitCallerSaveEpilogueAssembly(regs []callerSavedRegister) []string {
+	if len(regs) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(regs)+1)
+	for index, register := range regs {
+		lines = append(lines, fmt.Sprintf("  lw %s, %d(sp)", regName(register.physical), index*4))
+	}
+	lines = append(lines, fmt.Sprintf("  addi sp, sp, %d", callerSaveFrameBytes(regs)))
+	return lines
 }
 
 func emitStackSetupAssembly(stackTop int) []string {

--- a/code/packages/go/ir-to-riscv-compiler/compiler.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler.go
@@ -2,6 +2,7 @@ package irtoriscvcompiler
 
 import (
 	"fmt"
+	"sort"
 
 	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
 	sm "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map"
@@ -47,6 +48,7 @@ type compilePlan struct {
 	labelOffsets    map[string]int
 	dataOffsets     map[string]int
 	callTargets     map[string]bool
+	callerSavedRegs []callerSavedRegister
 	stackTop        int
 	textSize        int
 	entryTrampoline bool
@@ -54,6 +56,11 @@ type compilePlan struct {
 
 func (p *compilePlan) usesCallFrames() bool {
 	return len(p.callTargets) > 0
+}
+
+type callerSavedRegister struct {
+	virtual  int
+	physical int
 }
 
 // IrToRiscVCompiler lowers compiler IR to RV32I machine code.
@@ -123,6 +130,10 @@ func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	callerSavedRegs := []callerSavedRegister{}
+	if len(callTargets) > 0 {
+		callerSavedRegs = collectCallerSavedRegisters(program)
+	}
 
 	labelOffsets := map[string]int{}
 	pc := stackSetupSize(callTargets) * 4
@@ -139,7 +150,7 @@ func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
 			labelOffsets[label.Name] = pc
 		}
 
-		size, err := c.instructionSize(instruction, callTargets)
+		size, err := c.instructionSize(instruction, callTargets, callerSavedRegs)
 		if err != nil {
 			return nil, err
 		}
@@ -192,13 +203,14 @@ func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
 		labelOffsets:    labelOffsets,
 		dataOffsets:     dataOffsets,
 		callTargets:     callTargets,
+		callerSavedRegs: callerSavedRegs,
 		stackTop:        stackTop,
 		textSize:        pc,
 		entryTrampoline: entryTrampoline,
 	}, nil
 }
 
-func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction, callTargets map[string]bool) (int, error) {
+func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction, callTargets map[string]bool, callerSavedRegs []callerSavedRegister) (int, error) {
 	switch instruction.Opcode {
 	case ir.OpLabel, ir.OpComment:
 		return 0, nil
@@ -228,8 +240,10 @@ func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction, callTa
 			return 1, nil
 		}
 		return loadConstSize(imm.Value) + 1, nil
-	case ir.OpJump, ir.OpBranchZ, ir.OpBranchNz, ir.OpCall, ir.OpNop:
+	case ir.OpJump, ir.OpBranchZ, ir.OpBranchNz, ir.OpNop:
 		return 1, nil
+	case ir.OpCall:
+		return callInstructionSize(callerSavedRegs), nil
 	case ir.OpRet:
 		if len(callTargets) == 0 {
 			return 1, nil
@@ -331,11 +345,12 @@ func (c *IrToRiscVCompiler) emitInstruction(instruction ir.IrInstruction, pc int
 		if err != nil {
 			return nil, err
 		}
-		offset, err := jalOffset(instruction, label, pc, plan)
+		jalPC := pc + callerSavePrologueSize(plan.callerSavedRegs)*4
+		offset, err := jalOffset(instruction, label, jalPC, plan)
 		if err != nil {
 			return nil, err
 		}
-		return []uint32{riscv.EncodeJal(xRa, offset)}, nil
+		return emitCallWithCallerSaves(offset, plan.callerSavedRegs), nil
 	case ir.OpRet:
 		if !plan.usesCallFrames() {
 			return []uint32{riscv.EncodeJalr(x0, xRa, 0)}, nil
@@ -423,6 +438,39 @@ func collectCallTargets(program *ir.IrProgram) (map[string]bool, error) {
 	return targets, nil
 }
 
+func collectCallerSavedRegisters(program *ir.IrProgram) []callerSavedRegister {
+	seen := map[int]bool{}
+	for _, instruction := range program.Instructions {
+		for _, operand := range instruction.Operands {
+			register, ok := operand.(ir.IrRegister)
+			if !ok || isVolatileVirtualRegister(register.Index) {
+				continue
+			}
+			physical, ok := physicalRegister(register.Index)
+			if !ok || physical == xRa || physical == xSp || physical == xBackendScratch {
+				continue
+			}
+			seen[register.Index] = true
+		}
+	}
+	virtuals := make([]int, 0, len(seen))
+	for virtual := range seen {
+		virtuals = append(virtuals, virtual)
+	}
+	sort.Ints(virtuals)
+
+	registers := make([]callerSavedRegister, 0, len(virtuals))
+	for _, virtual := range virtuals {
+		physical, _ := physicalRegister(virtual)
+		registers = append(registers, callerSavedRegister{virtual: virtual, physical: physical})
+	}
+	return registers
+}
+
+func isVolatileVirtualRegister(index int) bool {
+	return index == 0 || index == 1
+}
+
 func callTargetPrologueSize() int {
 	return 2
 }
@@ -438,11 +486,64 @@ func retEpilogueSize() int {
 	return 3
 }
 
+func callInstructionSize(regs []callerSavedRegister) int {
+	return callerSavePrologueSize(regs) + 1 + callerSaveEpilogueSize(regs)
+}
+
+func callerSavePrologueSize(regs []callerSavedRegister) int {
+	if len(regs) == 0 {
+		return 0
+	}
+	return 1 + len(regs)
+}
+
+func callerSaveEpilogueSize(regs []callerSavedRegister) int {
+	if len(regs) == 0 {
+		return 0
+	}
+	return len(regs) + 1
+}
+
+func callerSaveFrameBytes(regs []callerSavedRegister) int {
+	return len(regs) * 4
+}
+
 func emitCallTargetPrologue() []uint32 {
 	return []uint32{
 		riscv.EncodeAddi(xSp, xSp, -4),
 		riscv.EncodeSw(xRa, xSp, 0),
 	}
+}
+
+func emitCallWithCallerSaves(offset int, regs []callerSavedRegister) []uint32 {
+	words := emitCallerSavePrologue(regs)
+	words = append(words, riscv.EncodeJal(xRa, offset))
+	words = append(words, emitCallerSaveEpilogue(regs)...)
+	return words
+}
+
+func emitCallerSavePrologue(regs []callerSavedRegister) []uint32 {
+	if len(regs) == 0 {
+		return nil
+	}
+	frameBytes := callerSaveFrameBytes(regs)
+	words := []uint32{riscv.EncodeAddi(xSp, xSp, -frameBytes)}
+	for index, register := range regs {
+		words = append(words, riscv.EncodeSw(register.physical, xSp, index*4))
+	}
+	return words
+}
+
+func emitCallerSaveEpilogue(regs []callerSavedRegister) []uint32 {
+	if len(regs) == 0 {
+		return nil
+	}
+	words := make([]uint32, 0, len(regs)+1)
+	for index, register := range regs {
+		words = append(words, riscv.EncodeLw(register.physical, xSp, index*4))
+	}
+	words = append(words, riscv.EncodeAddi(xSp, xSp, callerSaveFrameBytes(regs)))
+	return words
 }
 
 func emitRetEpilogue() []uint32 {

--- a/code/packages/go/ir-to-riscv-compiler/compiler_test.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler_test.go
@@ -174,6 +174,53 @@ func TestCompilePreservesReturnAddressAcrossNestedCalls(t *testing.T) {
 	}
 }
 
+func TestCompilePreservesCallerRegistersAroundCalls(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpCall, ir.IrLabel{Name: "caller"}),
+		instr(2, ir.OpHalt),
+		label("caller"),
+		instr(3, ir.OpLoadImm, ir.IrRegister{Index: 8}, ir.IrImmediate{Value: 5}),
+		instr(4, ir.OpLoadImm, ir.IrRegister{Index: 9}, ir.IrImmediate{Value: 9}),
+		instr(5, ir.OpCall, ir.IrLabel{Name: "clobber"}),
+		instr(6, ir.OpAdd, ir.IrRegister{Index: 1}, ir.IrRegister{Index: 8}, ir.IrRegister{Index: 9}),
+		instr(7, ir.OpRet),
+		label("clobber"),
+		instr(8, ir.OpLoadImm, ir.IrRegister{Index: 8}, ir.IrImmediate{Value: 100}),
+		instr(9, ir.OpLoadImm, ir.IrRegister{Index: 9}, ir.IrImmediate{Value: 200}),
+		instr(10, ir.OpRet),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(6); got != 14 {
+		t.Fatalf("expected caller return register v1/x6 to preserve 5+9 across call, got %d", got)
+	}
+	expectedStackTop := uint32(result.DataOffsets[callFrameStackLabel] + callFrameStackSize)
+	if got := sim.CPU.Registers.Read(2); got != expectedStackTop {
+		t.Fatalf("expected stack pointer to be restored to %d, got %d", expectedStackTop, got)
+	}
+	if !strings.Contains(result.Assembly, "sw x12, 0(sp)") ||
+		!strings.Contains(result.Assembly, "lw x12, 0(sp)") {
+		t.Fatalf("expected caller-save spill/reload in assembly, got:\n%s", result.Assembly)
+	}
+
+	assembled, err := riscvassembler.Assemble(result.Assembly)
+	if err != nil {
+		t.Fatalf("assemble emitted assembly failed: %v\n%s", err, result.Assembly)
+	}
+	if !bytes.Equal(assembled.Bytes, result.Bytes) {
+		t.Fatalf("expected emitted assembly to reassemble to compiler bytes")
+	}
+}
+
 func TestCompileRejectsUnknownLabel(t *testing.T) {
 	program := ir.NewIrProgram("_start")
 	program.Instructions = []ir.IrInstruction{

--- a/code/packages/go/nib-ir-compiler/CHANGELOG.md
+++ b/code/packages/go/nib-ir-compiler/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 
 - Added Go port of the Nib IR compiler.
+- Add `CallSafeConfig` to reserve argument registers separately from local
+  temporaries for RISC-V call-safe IR.

--- a/code/packages/go/nib-ir-compiler/README.md
+++ b/code/packages/go/nib-ir-compiler/README.md
@@ -1,3 +1,8 @@
 # nib-ir-compiler
 
 Go compiler stage that lowers typed Nib ASTs into the shared IR.
+
+`CallSafeConfig` stages arguments through virtual registers `v2+`, copies
+function parameters into local virtual registers on entry, and returns through
+virtual register `v1`. `ReleaseConfig` keeps the compact legacy register layout
+used by the Intel 4004 path.

--- a/code/packages/go/nib-ir-compiler/build_config.go
+++ b/code/packages/go/nib-ir-compiler/build_config.go
@@ -1,7 +1,9 @@
 package nibircompiler
 
 type BuildConfig struct {
-	InsertDebugComments bool
+	InsertDebugComments    bool
+	CopyParametersToLocals bool
+	LocalRegisterBase      int
 }
 
 func DebugConfig() BuildConfig {
@@ -10,4 +12,11 @@ func DebugConfig() BuildConfig {
 
 func ReleaseConfig() BuildConfig {
 	return BuildConfig{InsertDebugComments: false}
+}
+
+func CallSafeConfig() BuildConfig {
+	return BuildConfig{
+		CopyParametersToLocals: true,
+		LocalRegisterBase:      defaultLocalRegisterBase,
+	}
 }

--- a/code/packages/go/nib-ir-compiler/compiler.go
+++ b/code/packages/go/nib-ir-compiler/compiler.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	regZero    = 0
-	regScratch = 1
-	regVarBase = 2
+	regZero                  = 0
+	regScratch               = 1
+	regArgBase               = 2
+	defaultLocalRegisterBase = 8
 )
 
 type CompileResult struct {
@@ -155,13 +156,30 @@ func (c *Compiler) compileFunction(node *parser.ASTNode) {
 	c.emitComment("function: " + functionName)
 	c.emitLabel("_fn_" + functionName)
 	registers := map[string]int{}
-	nextRegister := regVarBase
-	for _, param := range params {
-		registers[param[0]] = nextRegister
-		nextRegister++
+	nextRegister := regArgBase
+	if c.config.CopyParametersToLocals {
+		nextRegister = c.localRegisterBase()
+		for index, param := range params {
+			argRegister := regArgBase + index
+			registers[param[0]] = nextRegister
+			c.emit(ir.OpAddImm, ir.IrRegister{Index: nextRegister}, ir.IrRegister{Index: argRegister}, ir.IrImmediate{Value: 0})
+			nextRegister++
+		}
+	} else {
+		for _, param := range params {
+			registers[param[0]] = nextRegister
+			nextRegister++
+		}
 	}
 	c.compileBlock(blockNode, registers, nextRegister)
 	c.emit(ir.OpRet)
+}
+
+func (c *Compiler) localRegisterBase() int {
+	if c.config.LocalRegisterBase > 0 {
+		return c.config.LocalRegisterBase
+	}
+	return defaultLocalRegisterBase
 }
 
 func (c *Compiler) compileBlock(block *parser.ASTNode, registers map[string]int, nextRegister int) int {
@@ -415,7 +433,7 @@ func (c *Compiler) compileCallExpr(node *parser.ASTNode, registers map[string]in
 	}
 	for index, arg := range args {
 		valueRegister := c.compileExpr(arg, registers)
-		destination := regVarBase + index
+		destination := regArgBase + index
 		if valueRegister != destination {
 			c.emit(ir.OpAddImm, ir.IrRegister{Index: destination}, ir.IrRegister{Index: valueRegister}, ir.IrImmediate{Value: 0})
 		}

--- a/code/packages/go/nib-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/nib-riscv-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Preserve Nib caller locals across RISC-V function calls.
+- Add end-to-end coverage for argument calls that leave caller locals live.
+
 ## 0.2.0
 
 - Add nested-call end-to-end coverage through the RISC-V backend call frames.

--- a/code/packages/go/nib-riscv-compiler/README.md
+++ b/code/packages/go/nib-riscv-compiler/README.md
@@ -20,9 +20,11 @@ value from physical register `x6`, the RISC-V register currently used for Nib's
 
 ## Current scope
 
-This path supports simple Nib programs and nested function calls that only need
-the current fixed-register ABI. Arguments are copied into virtual registers in
-order, and the return value is reported from virtual `v1`/physical `x6`.
+This path supports simple Nib programs and nested function calls with caller
+locals preserved across calls. Arguments are staged through virtual registers in
+order, function parameters are copied into local virtual registers on entry, and
+the return value is reported from virtual `v1`/physical `x6`.
 
-The remaining ABI gaps are local values that must survive across calls, recursion
-depth beyond the hidden backend stack, and richer argument/return conventions.
+The remaining ABI gaps are recursion depth beyond the hidden backend stack,
+values that outgrow the starter physical-register map, and richer
+argument/return conventions.

--- a/code/packages/go/nib-riscv-compiler/compiler.go
+++ b/code/packages/go/nib-riscv-compiler/compiler.go
@@ -113,7 +113,7 @@ func (c *NibRiscVCompiler) CompileSource(source string) (*PackageResult, error) 
 		return nil, wrapStage("type-check", errors.New(strings.Join(messages, "\n")))
 	}
 
-	config := nibircompiler.ReleaseConfig()
+	config := nibircompiler.CallSafeConfig()
 	if c.buildConfig != nil {
 		config = *c.buildConfig
 	}

--- a/code/packages/go/nib-riscv-compiler/compiler_test.go
+++ b/code/packages/go/nib-riscv-compiler/compiler_test.go
@@ -79,6 +79,34 @@ func TestRunSourceExecutesNestedNibCallsOnRiscVSimulator(t *testing.T) {
 	}
 }
 
+func TestRunSourcePreservesCallerLocalsAcrossNibCalls(t *testing.T) {
+	source := strings.Join([]string{
+		"fn add_one(value: u4) -> u4 {",
+		"  let scratch: u4 = value +% 1;",
+		"  return scratch;",
+		"}",
+		"fn main() -> u4 {",
+		"  let kept: u4 = 5;",
+		"  let called: u4 = add_one(6);",
+		"  return kept + called;",
+		"}",
+	}, " ")
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.ReturnValue != 12 {
+		t.Fatalf("expected caller local plus call result to be 12, got %d", run.ReturnValue)
+	}
+	if !strings.Contains(run.Package.Assembly, "sw x12, ") ||
+		!strings.Contains(run.Package.Assembly, "lw x12, ") {
+		t.Fatalf("expected caller-save spill/reload in assembly, got:\n%s", run.Package.Assembly)
+	}
+}
+
 func TestTypeErrorsReportStage(t *testing.T) {
 	_, err := CompileSource("fn main() { let flag: bool = 1; }")
 	if err == nil {

--- a/code/specs/RV01-riscv-compiler-roadmap.md
+++ b/code/specs/RV01-riscv-compiler-roadmap.md
@@ -21,7 +21,7 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 | Language | Current status | To run directly on RISC-V |
 |----------|----------------|---------------------------|
-| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs and nested no-spill calls lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator`. | Extend static variable reads if needed; add ABI tests for arguments/returns and values that must survive across calls. |
+| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs, nested calls, argument calls, and caller locals that survive calls lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator`. | Extend static variable reads if needed; add broader ABI tests for multi-argument returns and values that outgrow the starter register map. |
 | Brainfuck | Go parser, `brainfuck-ir-compiler`, and `brainfuck-riscv-compiler` package exist. Programs lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator` with host byte I/O syscalls for `.` and `,`. | Add broader corpus tests, debug-mode bounds-check E2E tests, and richer host I/O controls if interactive execution is needed. |
 | Dartmouth BASIC | Go lexer/parser exist. Python has `dartmouth-basic-ir-compiler`, GE-225, WASM, and JVM-oriented pipelines. | Port or bridge the Python IR compiler to Go `compiler-ir`; add `MUL`/`DIV` to Go `compiler-ir` and the RISC-V backend or lower them to helper loops; implement PRINT syscalls/trap host output in the RISC-V VM. |
 | Oct | Python has lexer/parser/type-checker/IR compiler for the Intel 8008 pipeline. | Port or bridge Oct typed AST/IR into Go; add Go `compiler-ir` opcodes used by Oct but not yet present here (`OR`, `XOR`, `NOT`, and any target-specific syscall shapes); add RISC-V syscall host behavior for `in`, `out`, carry/parity/rotate intrinsics; add a real register allocator for values that survive across calls. |
@@ -31,9 +31,11 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 ## Backend gaps
 
-- Calling convention: current IR-to-RISC-V emits a hidden call stack and saves
-  `ra` for labels targeted by `CALL`, so nested returns work. It still uses a
-  starter fixed register mapping, so values live across calls can be clobbered.
+- Calling convention: current IR-to-RISC-V emits a hidden call stack, saves
+  `ra` for labels targeted by `CALL`, and preserves mapped caller virtual
+  registers around calls while treating `v0` and `v1` as volatile starter-ABI
+  registers. It still uses a starter fixed register mapping, so programs that
+  outgrow that map need spill-slot allocation.
 - Stack and frames: `ra` save/restore exists. Spilled virtual registers, local
   storage beyond the fixed physical-register map, and deeper runtime ABI support
   still need real frame layout work.
@@ -49,7 +51,8 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 ## Suggested sequence
 
 1. Add broader Nib and Brainfuck E2E corpus tests.
-2. Add register allocation or spill slots for values that survive calls.
+2. Add register allocation or spill slots for virtual registers beyond the
+   starter physical-register map.
 3. Port/bridge Dartmouth BASIC IR to Go and add `MUL`/`DIV`.
 4. Port/bridge Oct IR to Go and add the remaining bitwise/syscall ABI support.
 5. Standardize a richer RISC-V language runtime ABI for text and numeric I/O.


### PR DESCRIPTION
## Summary
- preserve mapped caller virtual registers around IR `CALL`, with `v0`/`v1` left volatile for the starter ABI
- add a Nib `CallSafeConfig` that copies parameters out of argument registers for the RISC-V path while keeping the legacy compact layout for the Intel 4004 path
- add IR and Nib RISC-V coverage for locals that survive calls, and update the RISC-V readiness roadmap

## Tests
- `go test -c -o /tmp/ir-to-riscv-compiler.test` in `code/packages/go/ir-to-riscv-compiler`
- `go test -c -o /tmp/nib-ir-compiler.test` in `code/packages/go/nib-ir-compiler`
- `go test -c -o /tmp/nib-riscv-compiler.test` in `code/packages/go/nib-riscv-compiler`
- `go test -c -o /tmp/nib-compiler.test` in `code/packages/go/nib-compiler`
- `go test -c -o /tmp/brainfuck-riscv-compiler.test` in `code/packages/go/brainfuck-riscv-compiler`
- `go test -c -o /tmp/riscv-simulator.test` in `code/packages/go/riscv-simulator`
- `go test -c -o /tmp/riscv-assembler.test` in `code/packages/go/riscv-assembler`
- `git diff --check`

Note: local runtime `go test`/test-binary execution still hangs in this macOS session before producing test output, matching the previous PR behavior. CI should provide the runtime signal.