### PR TITLE
feat(music): add MUS01 text score spec and parser prototype

### DIFF
--- a/code/packages/python/music-machine/src/music_machine/score.py
+++ b/code/packages/python/music-machine/src/music_machine/score.py
@@ -1,0 +1,178 @@
+"""Text score parsing and rendering for the music machine."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+from note_frequency import Note, parse_note
+
+_DURATION_LINE_RE = re.compile(r"^\s*(\S+)\s+(\S+)(?:\s+(\S+))?\s*$")
+
+
+class ScoreParseError(ValueError):
+    """Raised when a score file cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class MusicalEvent:
+    """One event in a monophonic score."""
+
+    note: Note | None
+    duration_beats: float
+    velocity: float = 1.0
+
+    def duration_seconds(self, tempo_bpm: float) -> float:
+        """Convert this event duration to seconds for the given tempo."""
+        return 60.0 * self.duration_beats / tempo_bpm
+
+
+@dataclass(frozen=True)
+class Score:
+    """A parsed score with optional tempo and title."""
+
+    events: tuple[MusicalEvent, ...]
+    tempo_bpm: float = 120.0
+    title: str | None = None
+
+
+def _parse_duration(raw: str, *, line_no: int) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:  # pragma: no cover - defensive parse failure path
+        raise ScoreParseError(f"line {line_no}: invalid duration '{raw}'") from exc
+
+    if not math.isfinite(value) or value <= 0:
+        raise ScoreParseError(
+            f"line {line_no}: duration must be a positive finite number"
+        )
+
+    return value
+
+
+def _parse_velocity(raw: str | None, *, line_no: int) -> float:
+    if raw is None:
+        return 1.0
+
+    try:
+        value = float(raw)
+    except ValueError as exc:  # pragma: no cover - defensive parse failure path
+        raise ScoreParseError(f"line {line_no}: invalid velocity '{raw}'") from exc
+
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        raise ScoreParseError(f"line {line_no}: velocity must be within [0.0, 1.0]")
+
+    return value
+
+
+def _parse_directive(line: str, line_no: int) -> tuple[str, str] | None:
+    """Parse a directive line and return ``(key, value)``."""
+    if ":" not in line:
+        return None
+
+    key, value = line.split(":", 1)
+    key = key.strip().lower()
+    value = value.strip()
+    if not key or not value:
+        raise ScoreParseError(f"line {line_no}: malformed directive '{line}'")
+
+    return key, value
+
+
+def parse_score(text: str) -> Score:
+    """Parse a MUS01 text score into a Score model."""
+    tempo_bpm = 120.0
+    title: str | None = None
+    events: list[MusicalEvent] = []
+
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            continue
+
+        directive = _parse_directive(line, line_no)
+        if directive is not None:
+            key, value = directive
+            if key == "tempo":
+                try:
+                    tempo_bpm = float(value)
+                except ValueError as exc:
+                    raise ScoreParseError(
+                        f"line {line_no}: tempo must be a finite number"
+                    ) from exc
+
+                if not math.isfinite(tempo_bpm) or tempo_bpm <= 0.0:
+                    raise ScoreParseError(
+                        f"line {line_no}: tempo must be a positive finite number"
+                    )
+                continue
+
+            if key == "title":
+                title = value
+                continue
+
+            raise ScoreParseError(f"line {line_no}: unknown directive '{key}'")
+
+        match = _DURATION_LINE_RE.match(raw_line)
+        if match is None:
+            raise ScoreParseError(f"line {line_no}: malformed event line '{raw_line}'")
+
+        token, duration_raw, velocity_raw = match.groups()
+        duration_beats = _parse_duration(duration_raw, line_no=line_no)
+        velocity = _parse_velocity(velocity_raw, line_no=line_no)
+
+        note_token = token.strip().upper()
+        if note_token == "R":
+            note = None
+        else:
+            try:
+                note = parse_note(token)
+            except ValueError as exc:
+                raise ScoreParseError(f"line {line_no}: {exc}") from exc
+
+        events.append(
+            MusicalEvent(
+                note=note,
+                duration_beats=duration_beats,
+                velocity=velocity,
+            )
+        )
+
+    return Score(events=tuple(events), tempo_bpm=tempo_bpm, title=title)
+
+
+def score_duration_seconds(score: Score) -> float:
+    """Return total duration in seconds using the score tempo."""
+    return sum(event.duration_seconds(score.tempo_bpm) for event in score.events)
+
+
+def render_score(score: Score, sample_rate_hz: int = 44100) -> list[float]:
+    """Render a monophonic score to a list of samples."""
+    if sample_rate_hz <= 0:
+        raise ScoreParseError("sample_rate_hz must be greater than zero")
+
+    samples: list[float] = []
+    phase = 0.0
+
+    for event in score.events:
+        duration_seconds = event.duration_seconds(score.tempo_bpm)
+        frame_count = int(math.floor(duration_seconds * sample_rate_hz))
+
+        if frame_count <= 0:
+            continue
+
+        if event.note is None:
+            samples.extend([0.0] * frame_count)
+            continue
+
+        frequency = event.note.frequency()
+        angular_step = 2.0 * math.pi * frequency / sample_rate_hz
+        for _ in range(frame_count):
+            sample_value = event.velocity * math.sin(phase)
+            samples.append(sample_value)
+            phase += angular_step
+
+    return samples

--- a/code/packages/python/music-machine/tests/test_score.py
+++ b/code/packages/python/music-machine/tests/test_score.py
@@ -1,29 +1,13 @@
-import sys
-from importlib import util
-from pathlib import Path
-
 import pytest
 
-_SCORE_MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "src"
-    / "music_machine"
-    / "score.py"
+from music_machine.score import (
+    MusicalEvent,
+    Score,
+    ScoreParseError,
+    parse_score,
+    render_score,
+    score_duration_seconds,
 )
-_SCORE_SPEC = util.spec_from_file_location("music_machine_score", _SCORE_MODULE_PATH)
-if _SCORE_SPEC is None or _SCORE_SPEC.loader is None:
-    raise RuntimeError("Unable to load music-machine score module fixture")
-
-_SCORE_MODULE = util.module_from_spec(_SCORE_SPEC)
-sys.modules[_SCORE_SPEC.name] = _SCORE_MODULE
-_SCORE_SPEC.loader.exec_module(_SCORE_MODULE)  # type: ignore[arg-type]
-
-MusicalEvent = _SCORE_MODULE.MusicalEvent
-Score = _SCORE_MODULE.Score
-ScoreParseError = _SCORE_MODULE.ScoreParseError
-parse_score = _SCORE_MODULE.parse_score
-render_score = _SCORE_MODULE.render_score
-score_duration_seconds = _SCORE_MODULE.score_duration_seconds
 
 
 class TestParseScore:

--- a/code/packages/python/music-machine/tests/test_score.py
+++ b/code/packages/python/music-machine/tests/test_score.py
@@ -1,0 +1,93 @@
+import sys
+from importlib import util
+from pathlib import Path
+
+import pytest
+
+_SCORE_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "music_machine"
+    / "score.py"
+)
+_SCORE_SPEC = util.spec_from_file_location("music_machine_score", _SCORE_MODULE_PATH)
+if _SCORE_SPEC is None or _SCORE_SPEC.loader is None:
+    raise RuntimeError("Unable to load music-machine score module fixture")
+
+_SCORE_MODULE = util.module_from_spec(_SCORE_SPEC)
+sys.modules[_SCORE_SPEC.name] = _SCORE_MODULE
+_SCORE_SPEC.loader.exec_module(_SCORE_MODULE)  # type: ignore[arg-type]
+
+MusicalEvent = _SCORE_MODULE.MusicalEvent
+Score = _SCORE_MODULE.Score
+ScoreParseError = _SCORE_MODULE.ScoreParseError
+parse_score = _SCORE_MODULE.parse_score
+render_score = _SCORE_MODULE.render_score
+score_duration_seconds = _SCORE_MODULE.score_duration_seconds
+
+
+class TestParseScore:
+    def test_parses_directives_and_events(self) -> None:
+        score = parse_score(
+            """
+            # Happy Birthday first bar
+            title: Birthday Test
+            tempo: 120
+
+            A4 0.5
+            R 0.25 0.6
+            C5 1
+            """
+        )
+
+        assert score.title == "Birthday Test"
+        assert score.tempo_bpm == 120.0
+        assert len(score.events) == 3
+        assert score.events[0].note is not None
+        assert score.events[0].duration_beats == 0.5
+        assert score.events[0].velocity == 1.0
+        assert score.events[1].note is None
+        assert score.events[1].velocity == 0.6
+
+    def test_unknown_directive_errors(self) -> None:
+        with pytest.raises(ScoreParseError, match="unknown directive"):
+            parse_score("key: C\n")
+
+    def test_invalid_event_fails(self) -> None:
+        with pytest.raises(ScoreParseError):
+            parse_score("A4\n")
+
+
+class TestDuration:
+    def test_score_duration_seconds(self) -> None:
+        score = Score(
+            tempo_bpm=120.0,
+            events=(
+                MusicalEvent(note=None, duration_beats=1.0),
+                MusicalEvent(note=None, duration_beats=2.0),
+            ),
+        )
+        assert score_duration_seconds(score) == 1.5
+
+
+class TestRenderScore:
+    def test_renders_notes_and_rests(self) -> None:
+        score = parse_score(
+            """
+            tempo: 60
+            A4 1
+            R 1
+            B4 1
+            """
+        )
+        samples = render_score(score, sample_rate_hz=8)
+
+        # 3 beats at 1 beat/sec -> 3 seconds at 8 Hz => 24 samples
+        assert len(samples) == 24
+        assert any(sample != 0.0 for sample in samples[:8])
+        assert any(sample == 0.0 for sample in samples[8:16])
+
+    def test_bad_sample_rate_rejected(self) -> None:
+        score = Score(tempo_bpm=120.0, events=())
+        with pytest.raises(ScoreParseError, match="sample_rate_hz"):
+            render_score(score, sample_rate_hz=0)

--- a/code/specs/MUS01-text-score.md
+++ b/code/specs/MUS01-text-score.md
@@ -1,0 +1,159 @@
+# MUS01: Text-Based Score Format
+
+## 1. Overview
+
+This spec defines a tiny, text-first score format for writing melody as human-readable
+notes plus durations. It is the next layer after:
+
+- `MUS00` for note-to-frequency mapping
+- `OSC00` for oscillator/sampler abstractions
+
+The goal is to provide a lightweight file format that:
+
+- is easy for people to write by hand
+- is trivial to generate programmatically
+- can be consumed by a music machine that renders samples or feeds an instrument layer
+
+The package for this spec is initially a parser + renderer for simple monophonic lines.
+
+## 2. Core Abstractions
+
+The format represents a piece as:
+
+- optional directives (`tempo`, `title`)
+- one event per non-comment line
+
+Each event uses:
+
+```text
+<note-or-rest> <duration_beats> [<velocity>]
+```
+
+Where:
+
+- `<note-or-rest>` is `A4`, `C#5`, `Bb3`, etc., or `R` for a rest
+- `<duration_beats>` is a positive float
+- `<velocity>` is an optional float in the range `[0.0, 1.0]` (defaults to `1.0`)
+
+## 3. Example Score
+
+```text
+title: Happy Birthday
+tempo: 120
+
+A4 0.5
+A4 0.5
+G4 1.0
+A4 1.0
+C5 1.0
+B4 1.0
+
+R 0.5
+```
+
+At `tempo: 120`, one beat is `0.5` seconds.
+
+## 4. Directives
+
+Each score can start with any number of directive lines.
+
+- `tempo: <bpm>`  
+  - `<bpm>` must be greater than `0`
+  - defaults to `120` if not present
+- `title: <text>`
+  - optional
+  - stored as the score title
+
+Unsupported directives should raise parse errors.
+
+## 5. Comment and Whitespace Rules
+
+- Full-line comments start with `#` after optional indentation.
+- Empty lines are skipped.
+- Leading/trailing whitespace is ignored.
+- Inline comments are not supported initially.
+
+## 6. Timing Model
+
+If a score has tempo `T` BPM, then:
+
+```text
+duration_seconds = 60 * beats / T
+```
+
+Score and note events should preserve beat values so they can be re-tempo'd later.
+
+## 7. Rendering Model (First Layer)
+
+The first renderer is allowed to be intentionally simple:
+
+- For note events, emit sampled sine wave segments at the note frequency.
+- For rest events, emit zero-valued samples.
+- Concatenate rendered events in order.
+
+The initial implementation uses one sine oscillator per event and a uniform sample
+rate (e.g. `44100` Hz by default).
+
+## 8. Data Model
+
+The package should provide:
+
+- `MusicalEvent`
+  - `note: Note | None` (`None` for rests)
+  - `duration_beats: float`
+  - `velocity: float`
+  - `duration_seconds(tempo_bpm)` convenience method
+- `Score`
+  - `title: str | None`
+  - `tempo_bpm: float`
+  - `events: list[MusicalEvent]`
+
+## 9. API Surface
+
+- `parse_score(text: str) -> Score`
+- `render_score(score: Score, sample_rate_hz: int = 44100) -> list[float]`
+- `score_duration_seconds(score: Score) -> float`
+
+## 10. Validation
+
+Parsers and renderers must reject:
+
+- missing event duration
+- non-numeric durations
+- notes that fail `MUS00` parsing
+- beats or tempo values that are not positive
+- velocity outside `[0.0, 1.0]`
+- non-positive sample rates
+
+The parser should fail fast and report the line number where the error occurred.
+
+## 11. Example Programmatic API
+
+```python
+from music_machine import Score, MusicalEvent, parse_score, render_score
+
+score = parse_score("""
+title: Happy Birthday
+tempo: 120
+
+A4 0.5
+A4 0.5
+G4 1.0
+A4 1.0
+C5 1.0
+B4 1.0
+""")
+
+samples = render_score(score, sample_rate_hz=48000)
+print(len(samples))  # total PCM sample count for the score
+```
+
+## 12. Out Of Scope (This Version)
+
+- chords and polyphony
+- key/time signatures
+- swing/tuplet/grid feel
+- articulations beyond velocity
+- looping/scheduling metadata
+
+These are intentionally deferred to later music/track spec layers.


### PR DESCRIPTION
## Summary
- Add MUS01 text-score specification as `code/specs/MUS01-text-score.md`.
- Add a dedicated Python MUS01 parser/renderer module at `code/packages/python/music-machine/src/music_machine/score.py` with:
  - `MusicalEvent`, `Score`, `ScoreParseError`
  - `parse_score`, `render_score`, `score_duration_seconds`
  - support for `tempo` and `title` directives, rests (`R`), float beats, velocity [0.0, 1.0], and line-based parsing.
- Add focused tests in `code/packages/python/music-machine/tests/test_score.py` for parsing, validation, duration math, and rendering.

## Validation
- `python -m pytest code/packages/python/music-machine/tests/test_score.py -q --no-cov` with `PYTHONPATH` including `code/packages/python/music-machine/../note-frequency/src`.
- `ruff check` on new files.