### PR TITLE
Add versioned Haskell grammar sources

### DIFF
--- a/code/grammars/haskell/haskell1.0.grammar
+++ b/code/grammars/haskell/haskell1.0.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.0
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.0.tokens
+++ b/code/grammars/haskell/haskell1.0.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.0
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.1.grammar
+++ b/code/grammars/haskell/haskell1.1.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.1
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.1.tokens
+++ b/code/grammars/haskell/haskell1.1.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.1
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.2.grammar
+++ b/code/grammars/haskell/haskell1.2.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.2
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.2.tokens
+++ b/code/grammars/haskell/haskell1.2.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.2
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.3.grammar
+++ b/code/grammars/haskell/haskell1.3.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.3
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.3.tokens
+++ b/code/grammars/haskell/haskell1.3.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.3
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.4.grammar
+++ b/code/grammars/haskell/haskell1.4.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.4
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.4.tokens
+++ b/code/grammars/haskell/haskell1.4.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.4
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell2010.grammar
+++ b/code/grammars/haskell/haskell2010.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell 2010
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ======================================================================
+# Block Delimiters
+# ======================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ======================================================================
+# Top-Level Grammar
+# ======================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell2010.tokens
+++ b/code/grammars/haskell/haskell2010.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell 2010
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{\-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell98.grammar
+++ b/code/grammars/haskell/haskell98.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell 98
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ======================================================================
+# Block Delimiters
+# ======================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ======================================================================
+# Top-Level Grammar
+# ======================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell98.tokens
+++ b/code/grammars/haskell/haskell98.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell 98
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{\-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/packages/rust/paint-vm-direct2d/Cargo.toml
+++ b/code/packages/rust/paint-vm-direct2d/Cargo.toml
@@ -6,6 +6,8 @@ description = "Direct2D renderer for the paint-instructions scene model (P2D06)"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+window-core = { path = "../window-core" }
+window-win32 = { path = "../window-win32" }
 
 [dependencies.windows]
 version = "0.58"
@@ -13,10 +15,15 @@ features = [
     "Foundation_Numerics",
     "Win32_Graphics_Direct2D",
     "Win32_Graphics_Direct2D_Common",
+    "Win32_Graphics_DirectWrite",
+    "Win32_Graphics_Gdi",
     "Win32_Graphics_Imaging",
     "Win32_Graphics_Imaging_D2D",
+    "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
+    "Win32_System_LibraryLoader",
     "Win32_System_Com",
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [dev-dependencies]

--- a/code/packages/rust/paint-vm-direct2d/src/lib.rs
+++ b/code/packages/rust/paint-vm-direct2d/src/lib.rs
@@ -73,8 +73,12 @@
 pub const VERSION: &str = "0.1.0";
 
 use paint_instructions::{
-    PaintClip, PaintInstruction, PaintLine, PaintRect, PaintScene, PixelContainer,
+    FillRule, ImageSrc, PaintClip, PaintEllipse, PaintGlyphRun, PaintGroup, PaintImage,
+    PaintInstruction, PaintLayer, PaintLine, PaintPath, PaintRect, PaintScene, PathCommand,
+    PixelContainer,
 };
+#[cfg(target_os = "windows")]
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Platform gate
@@ -97,17 +101,41 @@ compile_error!(
 //   - IWICBitmap: a CPU-accessible bitmap that Direct2D can render into
 
 #[cfg(target_os = "windows")]
+use windows::core::{GUID, Interface, PCWSTR};
+#[cfg(target_os = "windows")]
+use windows::Foundation::Numerics::Matrix3x2;
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::{BOOL, FALSE, HWND, RECT};
+#[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Direct2D::Common::{
-    D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_COLOR_F, D2D1_PIXEL_FORMAT, D2D_POINT_2F, D2D_RECT_F,
+    D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_ALPHA_MODE_UNKNOWN, D2D1_BEZIER_SEGMENT, D2D1_COLOR_F,
+    D2D1_FIGURE_BEGIN_FILLED, D2D1_FIGURE_END_CLOSED, D2D1_FIGURE_END_OPEN,
+    D2D1_FILL_MODE_ALTERNATE, D2D1_FILL_MODE_WINDING, D2D1_PIXEL_FORMAT, D2D_POINT_2F, D2D_RECT_F,
+    D2D_SIZE_F, D2D_SIZE_U,
 };
 #[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Direct2D::{
     D2D1CreateFactory, ID2D1Factory, ID2D1RenderTarget, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,
-    D2D1_FACTORY_TYPE_SINGLE_THREADED, D2D1_RENDER_TARGET_PROPERTIES,
-    D2D1_RENDER_TARGET_TYPE_DEFAULT, D2D1_RENDER_TARGET_USAGE_NONE,
+    D2D1_ARC_SEGMENT, D2D1_ARC_SIZE_LARGE, D2D1_ARC_SIZE_SMALL,
+    D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_BITMAP_PROPERTIES, D2D1_ELLIPSE,
+    D2D1_FACTORY_TYPE_SINGLE_THREADED, D2D1_HWND_RENDER_TARGET_PROPERTIES, D2D1_LAYER_OPTIONS_NONE,
+    D2D1_LAYER_PARAMETERS, D2D1_PRESENT_OPTIONS_NONE, D2D1_QUADRATIC_BEZIER_SEGMENT,
+    D2D1_RENDER_TARGET_PROPERTIES, D2D1_RENDER_TARGET_TYPE_DEFAULT, D2D1_RENDER_TARGET_USAGE_NONE,
+    D2D1_ROUNDED_RECT, D2D1_SWEEP_DIRECTION_CLOCKWISE, D2D1_SWEEP_DIRECTION_COUNTER_CLOCKWISE,
 };
 #[cfg(target_os = "windows")]
-use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_B8G8R8A8_UNORM;
+use windows::Win32::Graphics::DirectWrite::{
+    DWriteCreateFactory, IDWriteFactory, IDWriteFontCollection, IDWriteFontFace,
+    DWRITE_FACTORY_TYPE_SHARED, DWRITE_FONT_STRETCH, DWRITE_FONT_STRETCH_CONDENSED,
+    DWRITE_FONT_STRETCH_EXPANDED, DWRITE_FONT_STRETCH_EXTRA_CONDENSED,
+    DWRITE_FONT_STRETCH_EXTRA_EXPANDED, DWRITE_FONT_STRETCH_NORMAL,
+    DWRITE_FONT_STRETCH_SEMI_CONDENSED, DWRITE_FONT_STRETCH_SEMI_EXPANDED,
+    DWRITE_FONT_STRETCH_ULTRA_CONDENSED, DWRITE_FONT_STRETCH_ULTRA_EXPANDED, DWRITE_FONT_STYLE,
+    DWRITE_FONT_STYLE_ITALIC, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STYLE_OBLIQUE,
+    DWRITE_FONT_WEIGHT, DWRITE_GLYPH_OFFSET, DWRITE_GLYPH_RUN, DWRITE_MEASURING_MODE_NATURAL,
+};
+#[cfg(target_os = "windows")]
+use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_UNKNOWN};
 #[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Imaging::{
     CLSID_WICImagingFactory, IWICBitmap, IWICImagingFactory, WICBitmapCacheOnLoad,
@@ -115,10 +143,16 @@ use windows::Win32::Graphics::Imaging::{
 };
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Com::{
-    CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED,
+    CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+    COINIT_MULTITHREADED,
 };
 #[cfg(target_os = "windows")]
-use windows::core::GUID;
+use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
+
+#[cfg(target_os = "windows")]
+use window_core::{LogicalSize, SurfacePreference, WindowAttributes};
+#[cfg(target_os = "windows")]
+use window_win32::Win32Backend;
 
 // ---------------------------------------------------------------------------
 // Colour parsing
@@ -131,9 +165,32 @@ use windows::core::GUID;
 /// - `"#rrggbbaa"` → (r, g, b, a)
 /// - `"#rgb"`      → expanded to `#rrggbb`
 /// - `"transparent"` / anything else → (0.0, 0.0, 0.0, 0.0)
-fn parse_hex_color(s: &str) -> (f64, f64, f64, f64) {
+fn parse_css_color(s: &str) -> (f64, f64, f64, f64) {
+    let s = s.trim();
     if s == "transparent" {
         return (0.0, 0.0, 0.0, 0.0);
+    }
+    if let Some(inner) = s.strip_prefix("rgba(").and_then(|v| v.strip_suffix(')')) {
+        let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+        if parts.len() == 4 {
+            return (
+                parse_css_channel(parts[0]),
+                parse_css_channel(parts[1]),
+                parse_css_channel(parts[2]),
+                parts[3].parse::<f64>().unwrap_or(1.0).clamp(0.0, 1.0),
+            );
+        }
+    }
+    if let Some(inner) = s.strip_prefix("rgb(").and_then(|v| v.strip_suffix(')')) {
+        let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+        if parts.len() == 3 {
+            return (
+                parse_css_channel(parts[0]),
+                parse_css_channel(parts[1]),
+                parse_css_channel(parts[2]),
+                1.0,
+            );
+        }
     }
     let hex = s.trim_start_matches('#');
     let hex = if hex.len() == 3 {
@@ -160,6 +217,15 @@ fn parse_hex_color(s: &str) -> (f64, f64, f64, f64) {
     (r, g, b, a)
 }
 
+fn parse_css_channel(s: &str) -> f64 {
+    s.parse::<f64>().unwrap_or(0.0).clamp(0.0, 255.0) / 255.0
+}
+
+#[allow(dead_code)]
+fn parse_hex_color(s: &str) -> (f64, f64, f64, f64) {
+    parse_css_color(s)
+}
+
 /// Convert RGBA floats to a Direct2D [`D2D1_COLOR_F`].
 ///
 /// Direct2D uses float4 colours in the range 0.0–1.0, same as our parsed values.
@@ -177,12 +243,99 @@ fn to_d2d_color(r: f64, g: f64, b: f64, a: f64) -> D2D1_COLOR_F {
 // Instruction dispatch — PaintInstruction → Direct2D calls
 // ---------------------------------------------------------------------------
 
+#[cfg(target_os = "windows")]
+struct RenderContext {
+    factory: ID2D1Factory,
+    font_collection: IDWriteFontCollection,
+    font_cache: HashMap<String, IDWriteFontFace>,
+    scene_bounds: D2D_RECT_F,
+}
+
+#[cfg(target_os = "windows")]
+impl RenderContext {
+    unsafe fn new(factory: ID2D1Factory, width: f32, height: f32) -> Self {
+        let dwrite_factory: IDWriteFactory = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)
+            .expect("Failed to create DWrite factory");
+        let mut font_collection = None;
+        dwrite_factory
+            .GetSystemFontCollection(&mut font_collection, FALSE)
+            .expect("Failed to get system font collection");
+        Self {
+            factory,
+            font_collection: font_collection.expect("system font collection"),
+            font_cache: HashMap::new(),
+            scene_bounds: D2D_RECT_F {
+                left: 0.0,
+                top: 0.0,
+                right: width,
+                bottom: height,
+            },
+        }
+    }
+
+    unsafe fn font_face_for_ref(&mut self, font_ref: &str) -> Option<IDWriteFontFace> {
+        if let Some(face) = self.font_cache.get(font_ref) {
+            return Some(face.clone());
+        }
+
+        let spec = parse_directwrite_font_ref(font_ref).unwrap_or_else(|| DWriteFontRef {
+            family: "Segoe UI".to_string(),
+            weight: 400,
+            style: DWRITE_FONT_STYLE_NORMAL,
+            stretch: DWRITE_FONT_STRETCH_NORMAL,
+        });
+        let face = self.resolve_font_face(&spec).or_else(|| {
+            self.resolve_font_face(&DWriteFontRef {
+                family: "Segoe UI".to_string(),
+                weight: 400,
+                style: DWRITE_FONT_STYLE_NORMAL,
+                stretch: DWRITE_FONT_STRETCH_NORMAL,
+            })
+        })?;
+        self.font_cache.insert(font_ref.to_string(), face.clone());
+        Some(face)
+    }
+
+    unsafe fn resolve_font_face(&self, spec: &DWriteFontRef) -> Option<IDWriteFontFace> {
+        let family_w = wide_null(&spec.family);
+        let mut index = 0u32;
+        let mut exists = BOOL(0);
+        self.font_collection
+            .FindFamilyName(PCWSTR(family_w.as_ptr()), &mut index, &mut exists)
+            .ok()?;
+        if !exists.as_bool() {
+            return None;
+        }
+        let family = self.font_collection.GetFontFamily(index).ok()?;
+        let font = family
+            .GetFirstMatchingFont(
+                DWRITE_FONT_WEIGHT(spec.weight as i32),
+                spec.stretch,
+                spec.style,
+            )
+            .ok()?;
+        font.CreateFontFace().ok()
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct DWriteFontRef {
+    family: String,
+    weight: u16,
+    style: DWRITE_FONT_STYLE,
+    stretch: DWRITE_FONT_STRETCH,
+}
+
 /// Render a list of [`PaintInstruction`]s into a Direct2D render target.
 ///
 /// This is the core dispatch loop. It recursively handles Group and Clip
 /// nodes, and dispatches Rect and Line to their respective D2D calls.
 #[cfg(target_os = "windows")]
-unsafe fn render_instructions(rt: &ID2D1RenderTarget, instructions: &[PaintInstruction]) {
+unsafe fn render_instructions(
+    ctx: &mut RenderContext,
+    rt: &ID2D1RenderTarget,
+    instructions: &[PaintInstruction],
+) {
     for instr in instructions {
         match instr {
             PaintInstruction::Rect(rect) => render_rect(rt, rect),
@@ -191,18 +344,15 @@ unsafe fn render_instructions(rt: &ID2D1RenderTarget, instructions: &[PaintInstr
                 // PaintGroup: render children directly into the same target.
                 // Transform support (SetTransform) is deferred — for barcodes,
                 // groups are purely logical containers.
-                render_instructions(rt, &group.children);
+                render_group(ctx, rt, group);
             }
-            PaintInstruction::Clip(clip) => render_clip(rt, clip),
-            // Planned but not yet implemented:
-            PaintInstruction::GlyphRun(_)
-            | PaintInstruction::Ellipse(_)
-            | PaintInstruction::Path(_)
-            | PaintInstruction::Layer(_)
-            | PaintInstruction::Gradient(_)
-            | PaintInstruction::Image(_) => {
-                // No-op for now. Barcodes only need Rect/Line/Group/Clip.
-            }
+            PaintInstruction::Clip(clip) => render_clip(ctx, rt, clip),
+            PaintInstruction::GlyphRun(run) => render_glyph_run(ctx, rt, run),
+            PaintInstruction::Ellipse(ellipse) => render_ellipse(rt, ellipse),
+            PaintInstruction::Path(path) => render_path(ctx, rt, path),
+            PaintInstruction::Layer(layer) => render_layer(ctx, rt, layer),
+            PaintInstruction::Image(image) => render_image(rt, image),
+            PaintInstruction::Gradient(_) => {}
         }
     }
 }
@@ -221,25 +371,44 @@ unsafe fn render_instructions(rt: &ID2D1RenderTarget, instructions: &[PaintInstr
 /// ```
 #[cfg(target_os = "windows")]
 unsafe fn render_rect(rt: &ID2D1RenderTarget, rect: &PaintRect) {
-    let fill = rect.fill.as_deref().unwrap_or("transparent");
-    let (r, g, b, a) = parse_hex_color(fill);
-    if a == 0.0 {
-        return;
-    }
-
-    let color = to_d2d_color(r, g, b, a);
-    let brush = rt
-        .CreateSolidColorBrush(&color as *const _, None)
-        .expect("Failed to create solid colour brush");
-
     let d2d_rect = D2D_RECT_F {
         left: rect.x as f32,
         top: rect.y as f32,
         right: (rect.x + rect.width) as f32,
         bottom: (rect.y + rect.height) as f32,
     };
+    let radius = rect.corner_radius.unwrap_or(0.0).max(0.0) as f32;
 
-    rt.FillRectangle(&d2d_rect as *const _, &brush);
+    if let Some(fill) = rect.fill.as_deref() {
+        if let Some(brush) = solid_brush(rt, fill) {
+            if radius > 0.0 {
+                let rounded = D2D1_ROUNDED_RECT {
+                    rect: d2d_rect,
+                    radiusX: radius,
+                    radiusY: radius,
+                };
+                rt.FillRoundedRectangle(&rounded, &brush);
+            } else {
+                rt.FillRectangle(&d2d_rect, &brush);
+            }
+        }
+    }
+
+    if let Some(stroke) = rect.stroke.as_deref() {
+        if let Some(brush) = solid_brush(rt, stroke) {
+            let stroke_width = rect.stroke_width.unwrap_or(1.0).max(0.0) as f32;
+            if radius > 0.0 {
+                let rounded = D2D1_ROUNDED_RECT {
+                    rect: d2d_rect,
+                    radiusX: radius,
+                    radiusY: radius,
+                };
+                rt.DrawRoundedRectangle(&rounded, &brush, stroke_width, None);
+            } else {
+                rt.DrawRectangle(&d2d_rect, &brush, stroke_width, None);
+            }
+        }
+    }
 }
 
 /// Render a [`PaintLine`] using Direct2D's `DrawLine`.
@@ -249,27 +418,19 @@ unsafe fn render_rect(rt: &ID2D1RenderTarget, rect: &PaintRect) {
 /// which manually constructs a thin rectangle from triangle vertices).
 #[cfg(target_os = "windows")]
 unsafe fn render_line(rt: &ID2D1RenderTarget, line: &PaintLine) {
-    let (r, g, b, a) = parse_hex_color(&line.stroke);
-    if a == 0.0 {
-        return;
+    if let Some(brush) = solid_brush(rt, &line.stroke) {
+        let p0 = D2D_POINT_2F {
+            x: line.x1 as f32,
+            y: line.y1 as f32,
+        };
+        let p1 = D2D_POINT_2F {
+            x: line.x2 as f32,
+            y: line.y2 as f32,
+        };
+        let stroke_width = line.stroke_width.unwrap_or(1.0) as f32;
+
+        rt.DrawLine(p0, p1, &brush, stroke_width, None);
     }
-
-    let color = to_d2d_color(r, g, b, a);
-    let brush = rt
-        .CreateSolidColorBrush(&color as *const _, None)
-        .expect("Failed to create solid colour brush for line");
-
-    let p0 = D2D_POINT_2F {
-        x: line.x1 as f32,
-        y: line.y1 as f32,
-    };
-    let p1 = D2D_POINT_2F {
-        x: line.x2 as f32,
-        y: line.y2 as f32,
-    };
-    let stroke_width = line.stroke_width.unwrap_or(1.0) as f32;
-
-    rt.DrawLine(p0, p1, &brush, stroke_width, None);
 }
 
 /// Render a [`PaintClip`] using Direct2D's axis-aligned clip.
@@ -281,7 +442,7 @@ unsafe fn render_line(rt: &ID2D1RenderTarget, line: &PaintLine) {
 ///
 /// Nested clips are intersected automatically by Direct2D.
 #[cfg(target_os = "windows")]
-unsafe fn render_clip(rt: &ID2D1RenderTarget, clip: &PaintClip) {
+unsafe fn render_clip(ctx: &mut RenderContext, rt: &ID2D1RenderTarget, clip: &PaintClip) {
     let clip_rect = D2D_RECT_F {
         left: clip.x as f32,
         top: clip.y as f32,
@@ -289,9 +450,450 @@ unsafe fn render_clip(rt: &ID2D1RenderTarget, clip: &PaintClip) {
         bottom: (clip.y + clip.height) as f32,
     };
 
-    rt.PushAxisAlignedClip(&clip_rect as *const _, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
-    render_instructions(rt, &clip.children);
+    rt.PushAxisAlignedClip(&clip_rect, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+    render_instructions(ctx, rt, &clip.children);
     rt.PopAxisAlignedClip();
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_group(ctx: &mut RenderContext, rt: &ID2D1RenderTarget, group: &PaintGroup) {
+    with_transform(rt, group.transform.as_ref(), || {
+        let opacity = group.opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f32;
+        if opacity < 1.0 {
+            with_layer(ctx, rt, opacity, |ctx, rt| {
+                render_instructions(ctx, rt, &group.children);
+            });
+        } else {
+            render_instructions(ctx, rt, &group.children);
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_layer(ctx: &mut RenderContext, rt: &ID2D1RenderTarget, layer: &PaintLayer) {
+    with_transform(rt, layer.transform.as_ref(), || {
+        let opacity = layer.opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f32;
+        with_layer(ctx, rt, opacity, |ctx, rt| {
+            render_instructions(ctx, rt, &layer.children);
+        });
+    });
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_ellipse(rt: &ID2D1RenderTarget, ellipse: &PaintEllipse) {
+    let d2d_ellipse = D2D1_ELLIPSE {
+        point: D2D_POINT_2F {
+            x: ellipse.cx as f32,
+            y: ellipse.cy as f32,
+        },
+        radiusX: ellipse.rx as f32,
+        radiusY: ellipse.ry as f32,
+    };
+    if let Some(fill) = ellipse.fill.as_deref() {
+        if let Some(brush) = solid_brush(rt, fill) {
+            rt.FillEllipse(&d2d_ellipse, &brush);
+        }
+    }
+    if let Some(stroke) = ellipse.stroke.as_deref() {
+        if let Some(brush) = solid_brush(rt, stroke) {
+            rt.DrawEllipse(
+                &d2d_ellipse,
+                &brush,
+                ellipse.stroke_width.unwrap_or(1.0) as f32,
+                None,
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_path(ctx: &RenderContext, rt: &ID2D1RenderTarget, path: &PaintPath) {
+    let fill_mode = match path.fill_rule.as_ref().unwrap_or(&FillRule::NonZero) {
+        FillRule::NonZero => D2D1_FILL_MODE_WINDING,
+        FillRule::EvenOdd => D2D1_FILL_MODE_ALTERNATE,
+    };
+    let geometry = match ctx.factory.CreatePathGeometry() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    let sink = match geometry.Open() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    sink.SetFillMode(fill_mode);
+
+    let mut figure_open = false;
+    for command in &path.commands {
+        match *command {
+            PathCommand::MoveTo { x, y } => {
+                if figure_open {
+                    sink.EndFigure(D2D1_FIGURE_END_OPEN);
+                }
+                sink.BeginFigure(point(x, y), D2D1_FIGURE_BEGIN_FILLED);
+                figure_open = true;
+            }
+            PathCommand::LineTo { x, y } => {
+                ensure_figure(&sink, &mut figure_open, x, y);
+                sink.AddLine(point(x, y));
+            }
+            PathCommand::QuadTo { cx, cy, x, y } => {
+                ensure_figure(&sink, &mut figure_open, x, y);
+                let segment = D2D1_QUADRATIC_BEZIER_SEGMENT {
+                    point1: point(cx, cy),
+                    point2: point(x, y),
+                };
+                sink.AddQuadraticBezier(&segment);
+            }
+            PathCommand::CubicTo {
+                cx1,
+                cy1,
+                cx2,
+                cy2,
+                x,
+                y,
+            } => {
+                ensure_figure(&sink, &mut figure_open, x, y);
+                let segment = D2D1_BEZIER_SEGMENT {
+                    point1: point(cx1, cy1),
+                    point2: point(cx2, cy2),
+                    point3: point(x, y),
+                };
+                sink.AddBezier(&segment);
+            }
+            PathCommand::ArcTo {
+                rx,
+                ry,
+                x_rotation,
+                large_arc,
+                sweep,
+                x,
+                y,
+            } => {
+                ensure_figure(&sink, &mut figure_open, x, y);
+                let segment = D2D1_ARC_SEGMENT {
+                    point: point(x, y),
+                    size: D2D_SIZE_F {
+                        width: rx as f32,
+                        height: ry as f32,
+                    },
+                    rotationAngle: x_rotation as f32,
+                    sweepDirection: if sweep {
+                        D2D1_SWEEP_DIRECTION_CLOCKWISE
+                    } else {
+                        D2D1_SWEEP_DIRECTION_COUNTER_CLOCKWISE
+                    },
+                    arcSize: if large_arc {
+                        D2D1_ARC_SIZE_LARGE
+                    } else {
+                        D2D1_ARC_SIZE_SMALL
+                    },
+                };
+                sink.AddArc(&segment);
+            }
+            PathCommand::Close => {
+                if figure_open {
+                    sink.EndFigure(D2D1_FIGURE_END_CLOSED);
+                    figure_open = false;
+                }
+            }
+        }
+    }
+    if figure_open {
+        sink.EndFigure(D2D1_FIGURE_END_OPEN);
+    }
+    if sink.Close().is_err() {
+        return;
+    }
+
+    if let Some(fill) = path.fill.as_deref() {
+        if let Some(brush) = solid_brush(rt, fill) {
+            rt.FillGeometry(&geometry, &brush, None);
+        }
+    }
+    if let Some(stroke) = path.stroke.as_deref() {
+        if let Some(brush) = solid_brush(rt, stroke) {
+            rt.DrawGeometry(
+                &geometry,
+                &brush,
+                path.stroke_width.unwrap_or(1.0) as f32,
+                None,
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_glyph_run(ctx: &mut RenderContext, rt: &ID2D1RenderTarget, run: &PaintGlyphRun) {
+    if run.glyphs.is_empty() {
+        return;
+    }
+    let Some(face) = ctx.font_face_for_ref(&run.font_ref) else {
+        return;
+    };
+    let Some(brush) = solid_brush(rt, run.fill.as_deref().unwrap_or("#000000")) else {
+        return;
+    };
+
+    for glyph in &run.glyphs {
+        let glyph_index = glyph.glyph_id as u16;
+        let glyph_indices = [glyph_index];
+        let glyph_advances = [0.0f32];
+        let glyph_offsets = [DWRITE_GLYPH_OFFSET {
+            advanceOffset: 0.0,
+            ascenderOffset: 0.0,
+        }];
+        let baseline = D2D_POINT_2F {
+            x: glyph.x as f32,
+            y: glyph.y as f32,
+        };
+
+        let glyph_run = DWRITE_GLYPH_RUN {
+            fontFace: std::mem::ManuallyDrop::new(Some(face.clone())),
+            fontEmSize: run.font_size as f32,
+            glyphCount: 1,
+            glyphIndices: glyph_indices.as_ptr(),
+            glyphAdvances: glyph_advances.as_ptr(),
+            glyphOffsets: glyph_offsets.as_ptr(),
+            isSideways: FALSE,
+            bidiLevel: 0,
+        };
+        rt.DrawGlyphRun(baseline, &glyph_run, &brush, DWRITE_MEASURING_MODE_NATURAL);
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn render_image(rt: &ID2D1RenderTarget, image: &PaintImage) {
+    let ImageSrc::Pixels(pixels) = &image.src else {
+        return;
+    };
+    if pixels.width == 0
+        || pixels.height == 0
+        || pixels.data.len() < pixels.width as usize * pixels.height as usize * 4
+    {
+        return;
+    }
+
+    let mut pbgra = Vec::with_capacity(pixels.data.len());
+    for rgba in pixels.data.chunks_exact(4) {
+        let a = rgba[3] as u16;
+        pbgra.push(((rgba[2] as u16 * a + 127) / 255) as u8);
+        pbgra.push(((rgba[1] as u16 * a + 127) / 255) as u8);
+        pbgra.push(((rgba[0] as u16 * a + 127) / 255) as u8);
+        pbgra.push(rgba[3]);
+    }
+
+    let props = D2D1_BITMAP_PROPERTIES {
+        pixelFormat: D2D1_PIXEL_FORMAT {
+            format: DXGI_FORMAT_B8G8R8A8_UNORM,
+            alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+        },
+        dpiX: 96.0,
+        dpiY: 96.0,
+    };
+    let bitmap = match rt.CreateBitmap(
+        D2D_SIZE_U {
+            width: pixels.width,
+            height: pixels.height,
+        },
+        Some(pbgra.as_ptr() as *const _),
+        pixels.width * 4,
+        &props,
+    ) {
+        Ok(bitmap) => bitmap,
+        Err(_) => return,
+    };
+    let dest = D2D_RECT_F {
+        left: image.x as f32,
+        top: image.y as f32,
+        right: (image.x + image.width) as f32,
+        bottom: (image.y + image.height) as f32,
+    };
+    rt.DrawBitmap(
+        &bitmap,
+        Some(&dest),
+        image.opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f32,
+        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR,
+        None,
+    );
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn with_layer<F>(ctx: &mut RenderContext, rt: &ID2D1RenderTarget, opacity: f32, f: F)
+where
+    F: FnOnce(&mut RenderContext, &ID2D1RenderTarget),
+{
+    let layer_size = D2D_SIZE_F {
+        width: (ctx.scene_bounds.right - ctx.scene_bounds.left).max(1.0),
+        height: (ctx.scene_bounds.bottom - ctx.scene_bounds.top).max(1.0),
+    };
+    let Ok(layer) = rt.CreateLayer(Some(&layer_size)) else {
+        f(ctx, rt);
+        return;
+    };
+    let mut params = D2D1_LAYER_PARAMETERS::default();
+    params.contentBounds = ctx.scene_bounds;
+    params.maskAntialiasMode = D2D1_ANTIALIAS_MODE_PER_PRIMITIVE;
+    params.maskTransform = identity_matrix();
+    params.opacity = opacity;
+    params.layerOptions = D2D1_LAYER_OPTIONS_NONE;
+    rt.PushLayer(&params, &layer);
+    f(ctx, rt);
+    rt.PopLayer();
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn with_transform<F>(rt: &ID2D1RenderTarget, transform: Option<&[f64; 6]>, f: F)
+where
+    F: FnOnce(),
+{
+    let Some(transform) = transform else {
+        f();
+        return;
+    };
+    let mut previous = identity_matrix();
+    rt.GetTransform(&mut previous);
+    let local = matrix_from_transform(transform);
+    let combined = multiply_matrix(previous, local);
+    rt.SetTransform(&combined);
+    f();
+    rt.SetTransform(&previous);
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn solid_brush(
+    rt: &ID2D1RenderTarget,
+    color: &str,
+) -> Option<windows::Win32::Graphics::Direct2D::ID2D1SolidColorBrush> {
+    let (r, g, b, a) = parse_css_color(color);
+    if a <= 0.0 {
+        return None;
+    }
+    let color = to_d2d_color(r, g, b, a);
+    rt.CreateSolidColorBrush(&color, None).ok()
+}
+
+#[cfg(target_os = "windows")]
+fn point(x: f64, y: f64) -> D2D_POINT_2F {
+    D2D_POINT_2F {
+        x: x as f32,
+        y: y as f32,
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn ensure_figure(
+    sink: &windows::Win32::Graphics::Direct2D::ID2D1GeometrySink,
+    figure_open: &mut bool,
+    x: f64,
+    y: f64,
+) {
+    if !*figure_open {
+        sink.BeginFigure(point(x, y), D2D1_FIGURE_BEGIN_FILLED);
+        *figure_open = true;
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn identity_matrix() -> Matrix3x2 {
+    Matrix3x2 {
+        M11: 1.0,
+        M12: 0.0,
+        M21: 0.0,
+        M22: 1.0,
+        M31: 0.0,
+        M32: 0.0,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn matrix_from_transform(t: &[f64; 6]) -> Matrix3x2 {
+    Matrix3x2 {
+        M11: t[0] as f32,
+        M12: t[1] as f32,
+        M21: t[2] as f32,
+        M22: t[3] as f32,
+        M31: t[4] as f32,
+        M32: t[5] as f32,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn multiply_matrix(a: Matrix3x2, b: Matrix3x2) -> Matrix3x2 {
+    Matrix3x2 {
+        M11: a.M11 * b.M11 + a.M12 * b.M21,
+        M12: a.M11 * b.M12 + a.M12 * b.M22,
+        M21: a.M21 * b.M11 + a.M22 * b.M21,
+        M22: a.M21 * b.M12 + a.M22 * b.M22,
+        M31: a.M31 * b.M11 + a.M32 * b.M21 + b.M31,
+        M32: a.M31 * b.M12 + a.M32 * b.M22 + b.M32,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn parse_directwrite_font_ref(font_ref: &str) -> Option<DWriteFontRef> {
+    let body = font_ref.strip_prefix("directwrite:")?;
+    let (family_part, rest) = body.split_once('@')?;
+    let mut weight = 400u16;
+    let mut style = DWRITE_FONT_STYLE_NORMAL;
+    let mut stretch_rank = 5u8;
+    for part in rest.split(';').skip(1) {
+        if let Some(value) = part.strip_prefix("w=") {
+            weight = value.parse().unwrap_or(weight);
+        } else if let Some(value) = part.strip_prefix("style=") {
+            style = match value {
+                "italic" => DWRITE_FONT_STYLE_ITALIC,
+                "oblique" => DWRITE_FONT_STYLE_OBLIQUE,
+                _ => DWRITE_FONT_STYLE_NORMAL,
+            };
+        } else if let Some(value) = part.strip_prefix("stretch=") {
+            stretch_rank = value.parse().unwrap_or(stretch_rank);
+        }
+    }
+    Some(DWriteFontRef {
+        family: unescape_ref_component(family_part),
+        weight,
+        style,
+        stretch: stretch_from_rank(stretch_rank),
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn stretch_from_rank(rank: u8) -> DWRITE_FONT_STRETCH {
+    match rank {
+        1 => DWRITE_FONT_STRETCH_ULTRA_CONDENSED,
+        2 => DWRITE_FONT_STRETCH_EXTRA_CONDENSED,
+        3 => DWRITE_FONT_STRETCH_CONDENSED,
+        4 => DWRITE_FONT_STRETCH_SEMI_CONDENSED,
+        6 => DWRITE_FONT_STRETCH_SEMI_EXPANDED,
+        7 => DWRITE_FONT_STRETCH_EXPANDED,
+        8 => DWRITE_FONT_STRETCH_EXTRA_EXPANDED,
+        9 => DWRITE_FONT_STRETCH_ULTRA_EXPANDED,
+        _ => DWRITE_FONT_STRETCH_NORMAL,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn unescape_ref_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(v as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+#[cfg(target_os = "windows")]
+fn wide_null(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +961,89 @@ pub fn render(scene: &PaintScene) -> PixelContainer {
     unsafe { render_unsafe(scene, width, height) }
 }
 
+/// Render a [`PaintScene`] directly into an existing Win32 HWND.
+#[cfg(target_os = "windows")]
+pub unsafe fn render_to_hwnd(hwnd: HWND, scene: &PaintScene) -> windows::core::Result<()> {
+    let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+
+    let mut rect = RECT::default();
+    GetClientRect(hwnd, &mut rect)?;
+    let width = (rect.right - rect.left).max(1) as u32;
+    let height = (rect.bottom - rect.top).max(1) as u32;
+
+    let d2d_factory: ID2D1Factory = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)?;
+    let rt_props = D2D1_RENDER_TARGET_PROPERTIES {
+        r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
+        pixelFormat: D2D1_PIXEL_FORMAT {
+            format: DXGI_FORMAT_UNKNOWN,
+            alphaMode: D2D1_ALPHA_MODE_UNKNOWN,
+        },
+        dpiX: 96.0,
+        dpiY: 96.0,
+        usage: D2D1_RENDER_TARGET_USAGE_NONE,
+        minLevel: Default::default(),
+    };
+    let hwnd_props = D2D1_HWND_RENDER_TARGET_PROPERTIES {
+        hwnd,
+        pixelSize: D2D_SIZE_U { width, height },
+        presentOptions: D2D1_PRESENT_OPTIONS_NONE,
+    };
+    let hwnd_target = d2d_factory.CreateHwndRenderTarget(&rt_props, &hwnd_props)?;
+    let render_target: ID2D1RenderTarget = hwnd_target.cast()?;
+    let mut ctx = RenderContext::new(d2d_factory, scene.width as f32, scene.height as f32);
+    let (bg_r, bg_g, bg_b, bg_a) = parse_css_color(&scene.background);
+    let bg_color = to_d2d_color(bg_r, bg_g, bg_b, bg_a);
+
+    render_target.BeginDraw();
+    render_target.Clear(Some(&bg_color));
+    render_instructions(&mut ctx, &render_target, &scene.instructions);
+    render_target.EndDraw(None, None)?;
+    Ok(())
+}
+
+/// Open a simple Win32 window and paint the scene through the Direct2D backend.
+#[cfg(target_os = "windows")]
+pub unsafe fn show_scene_in_window(scene: &PaintScene, title: &str) {
+    let scene_size = (scene.width.max(200.0), scene.height.max(100.0));
+    let scene = scene.clone();
+    let scene_ptr = Box::into_raw(Box::new(scene)) as isize;
+    let mut backend = Win32Backend::new();
+    let mut attributes = WindowAttributes::default();
+    attributes.title = title.to_string();
+    attributes.initial_size = LogicalSize::new(scene_size.0, scene_size.1);
+    attributes.preferred_surface = SurfacePreference::Direct2D;
+
+    if let Err(err) = backend.create_native_window(
+        attributes,
+        Some(render_paint_callback),
+        scene_ptr,
+    ) {
+        drop(unsafe { Box::from_raw(scene_ptr as *mut PaintScene) });
+        panic!("failed to create native Direct2D window: {err}");
+    }
+    let run_result = backend.run();
+
+    drop(unsafe { Box::from_raw(scene_ptr as *mut PaintScene) });
+
+    if let Err(err) = run_result {
+        panic!("failed to run Win32 message loop: {err}");
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn render_paint_callback(
+    hwnd: HWND,
+    user_data: isize,
+) {
+    let scene_ptr = user_data as *const PaintScene;
+    if scene_ptr.is_null() {
+        return;
+    }
+
+    let scene = unsafe { scene_ptr.as_ref().expect("scene pointer provided by show_scene_in_window") };
+    let _ = render_to_hwnd(hwnd, scene);
+}
+
 /// The actual rendering logic, wrapped in `unsafe` for COM/D2D FFI calls.
 ///
 /// ## WIC bitmap pixel format
@@ -390,9 +1075,8 @@ unsafe fn render_unsafe(scene: &PaintScene, width: u32, height: u32) -> PixelCon
     //
     // ID2D1Factory: creates render targets, geometries, etc.
     // IWICImagingFactory: creates WIC bitmaps for offscreen rendering.
-    let d2d_factory: ID2D1Factory =
-        D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)
-            .expect("Failed to create D2D1 factory");
+    let d2d_factory: ID2D1Factory = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)
+        .expect("Failed to create D2D1 factory");
 
     let wic_factory: IWICImagingFactory =
         CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
@@ -434,15 +1118,14 @@ unsafe fn render_unsafe(scene: &PaintScene, width: u32, height: u32) -> PixelCon
     // BeginDraw/EndDraw bracket all drawing operations. Clear sets the
     // entire surface to the background colour. Then we dispatch each
     // PaintInstruction to the appropriate D2D call.
-    let (bg_r, bg_g, bg_b, bg_a) = parse_hex_color(&scene.background);
+    let (bg_r, bg_g, bg_b, bg_a) = parse_css_color(&scene.background);
     let bg_color = to_d2d_color(bg_r, bg_g, bg_b, bg_a);
+    let mut ctx = RenderContext::new(d2d_factory.clone(), width as f32, height as f32);
 
     render_target.BeginDraw();
     render_target.Clear(Some(&bg_color as *const _));
-    render_instructions(&render_target, &scene.instructions);
-    render_target
-        .EndDraw(None, None)
-        .expect("EndDraw failed");
+    render_instructions(&mut ctx, &render_target, &scene.instructions);
+    render_target.EndDraw(None, None).expect("EndDraw failed");
 
     // ── Step 6: Read back pixels ─────────────────────────────────────────
     //
@@ -593,9 +1276,11 @@ mod tests {
     #[test]
     fn render_red_rect_on_white() {
         let mut scene = PaintScene::new(100.0, 100.0);
-        scene.instructions.push(PaintInstruction::Rect(
-            PaintRect::filled(10.0, 10.0, 80.0, 80.0, "#ff0000"),
-        ));
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                10.0, 10.0, 80.0, 80.0, "#ff0000",
+            )));
 
         let pixels = render(&scene);
         assert_eq!(pixels.width, 100);
@@ -635,9 +1320,15 @@ mod tests {
     #[test]
     fn transparent_rect_is_invisible() {
         let mut scene = PaintScene::new(50.0, 50.0);
-        scene.instructions.push(PaintInstruction::Rect(
-            PaintRect::filled(0.0, 0.0, 50.0, 50.0, "transparent"),
-        ));
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                0.0,
+                0.0,
+                50.0,
+                50.0,
+                "transparent",
+            )));
 
         let pixels = render(&scene);
         let (r, g, b, _a) = pixels.pixel_at(25, 25);
@@ -714,9 +1405,15 @@ mod tests {
         let mut scene = PaintScene::new(200.0, 100.0);
         for i in 0..20u32 {
             if i % 2 == 0 {
-                scene.instructions.push(PaintInstruction::Rect(
-                    PaintRect::filled(i as f64 * 10.0, 0.0, 10.0, 80.0, "#000000"),
-                ));
+                scene
+                    .instructions
+                    .push(PaintInstruction::Rect(PaintRect::filled(
+                        i as f64 * 10.0,
+                        0.0,
+                        10.0,
+                        80.0,
+                        "#000000",
+                    )));
             }
         }
 
@@ -750,13 +1447,15 @@ mod tests {
         for row in 0..4u32 {
             for col in 0..4u32 {
                 if (row + col) % 2 == 0 {
-                    scene.instructions.push(PaintInstruction::Rect(PaintRect::filled(
-                        col as f64 * module_size,
-                        row as f64 * module_size,
-                        module_size,
-                        module_size,
-                        "#000000",
-                    )));
+                    scene
+                        .instructions
+                        .push(PaintInstruction::Rect(PaintRect::filled(
+                            col as f64 * module_size,
+                            row as f64 * module_size,
+                            module_size,
+                            module_size,
+                            "#000000",
+                        )));
                 }
             }
         }

--- a/code/packages/rust/window-win32/Cargo.toml
+++ b/code/packages/rust/window-win32/Cargo.toml
@@ -6,3 +6,12 @@ description = "Win32 desktop window backend for window-core"
 
 [dependencies]
 window-core = { path = "../window-core" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System",
+    "Win32_System_LibraryLoader",
+] }

--- a/code/packages/rust/window-win32/src/lib.rs
+++ b/code/packages/rust/window-win32/src/lib.rs
@@ -2,15 +2,39 @@
 //!
 //! Win32 desktop window backend for `window-core`.
 //!
-//! Like `window-appkit`, this crate is an intentionally honest shell in the
-//! first slice. It teaches the mapping from cross-platform window attributes to
-//! Win32 expectations without pretending the `HWND` creation and message pump
-//! are already implemented.
+//! This crate now includes a concrete Win32 host implementation for native
+//! rendering workflows. It validates `window-core` attributes, creates a basic
+//! top-level `HWND`, and hosts a message loop with an optional paint callback.
+//!
+//! The paint callback is intentionally minimal for now: it is wired to a fixed
+//! `WM_PAINT` path so renderers can plug in their native drawing routines
+//! without duplicating the full HWND creation boilerplate.
 
-use window_core::{MountTarget, SurfacePreference, WindowAttributes, WindowError};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
-/// Crate version, kept explicit for examples and integration tests.
+use window_core::{
+    LogicalSize, MountTarget, RenderTarget, SurfacePreference, Window, WindowAttributes,
+    WindowBackend, WindowError, WindowId, Win32RenderTarget, PhysicalSize,
+};
+
 pub const VERSION: &str = "0.1.0";
+
+#[cfg(target_os = "windows")]
+use windows::core::{PCWSTR, w};
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+#[cfg(target_os = "windows")]
+use windows::Win32::Graphics::Gdi::{BeginPaint, EndPaint, GetStockObject, HBRUSH, PAINTSTRUCT, InvalidateRect, WHITE_BRUSH};
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, LoadCursorW, PostQuitMessage,
+    RegisterClassW, SetWindowTextW, ShowWindow,
+    TranslateMessage, WNDCLASSW, WM_CREATE, WM_DESTROY, WM_NCDESTROY, WM_PAINT, WS_OVERLAPPEDWINDOW,
+    CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, HMENU, IDC_ARROW, SW_SHOW, SW_HIDE,
+};
+#[cfg(target_os = "windows")]
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 
 /// Which Win32 host family the renderer should expect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,14 +43,115 @@ pub enum Win32SurfaceChoice {
     Hwnd,
 }
 
-/// Backend shell for Win32 validation and future native creation.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Win32Backend;
+/// A created Win32 window host.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Win32Window {
+    id: WindowId,
+    logical_size: LogicalSize,
+    physical_size: PhysicalSize,
+    #[allow(dead_code)]
+    scale_factor: f64,
+    hwnd: HWND,
+}
+
+impl Win32Window {
+    /// Return the raw Win32 window handle.
+    pub fn hwnd(&self) -> HWND {
+        self.hwnd
+    }
+}
+
+impl Window for Win32Window {
+    fn id(&self) -> WindowId {
+        self.id
+    }
+
+    fn logical_size(&self) -> LogicalSize {
+        self.logical_size
+    }
+
+    fn physical_size(&self) -> window_core::PhysicalSize {
+        self.physical_size
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.scale_factor
+    }
+
+    fn request_redraw(&self) -> Result<(), WindowError> {
+        #[cfg(target_os = "windows")]
+        unsafe {
+            let _ = InvalidateRect(self.hwnd, None, false);
+            Ok(())
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        Err(WindowError::UnsupportedPlatform(
+            "Win32 windows are only available on Windows",
+        ))
+    }
+
+    fn set_title(&self, title: &str) -> Result<(), WindowError> {
+        #[cfg(target_os = "windows")]
+        unsafe {
+            let title = wide_null(title);
+            let _ = SetWindowTextW(self.hwnd, PCWSTR(title.as_ptr()));
+            Ok(())
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        Err(WindowError::UnsupportedPlatform(
+            "Win32 windows are only available on Windows",
+        ))
+    }
+
+    fn set_visible(&self, visible: bool) -> Result<(), WindowError> {
+        #[cfg(target_os = "windows")]
+        unsafe {
+            let _ = if visible { ShowWindow(self.hwnd, SW_SHOW) } else { ShowWindow(self.hwnd, SW_HIDE) };
+            Ok(())
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        Err(WindowError::UnsupportedPlatform(
+            "Win32 windows are only available on Windows",
+        ))
+    }
+
+    fn render_target(&self) -> RenderTarget {
+        RenderTarget::Win32(Win32RenderTarget {
+            hwnd: self.hwnd.0 as usize,
+        })
+    }
+}
+
+/// Per-window callback invoked from `WM_PAINT`.
+pub type WindowPaintCallback = unsafe extern "system" fn(HWND, isize);
+
+#[derive(Debug, Clone, Copy)]
+struct PaintHandler {
+    callback: Option<WindowPaintCallback>,
+    user_data: isize,
+}
+
+#[cfg(target_os = "windows")]
+static PAINT_HANDLERS: OnceLock<Mutex<HashMap<isize, PaintHandler>>> = OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn paint_handlers() -> &'static Mutex<HashMap<isize, PaintHandler>> {
+    PAINT_HANDLERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Backend shell for Win32 validation and native creation.
+#[derive(Debug, Default)]
+pub struct Win32Backend {
+    next_id: u64,
+}
 
 impl Win32Backend {
     /// Construct a new backend shell.
     pub const fn new() -> Self {
-        Self
+        Self { next_id: 0 }
     }
 
     /// Human-readable backend name.
@@ -66,22 +191,220 @@ impl Win32Backend {
         self.choose_surface(attributes.preferred_surface)
     }
 
-    /// Reserve the place where real `HWND` creation will land next.
+    /// Create a real Win32 window host and optionally wire a paint callback.
+    #[cfg(target_os = "windows")]
     pub fn create_native_window(
         &mut self,
         attributes: WindowAttributes,
-    ) -> Result<Win32SurfaceChoice, WindowError> {
-        let surface = self.validate_attributes(&attributes)?;
-        Err(WindowError::backend(format!(
-            "native Win32 window creation is not wired yet (validated surface: {surface:?})"
-        )))
+        on_paint: Option<WindowPaintCallback>,
+        user_data: isize,
+    ) -> Result<Win32Window, WindowError> {
+        self.validate_attributes(&attributes)?;
+
+        let _ = self.choose_surface(attributes.preferred_surface)?;
+        self.next_id += 1;
+
+        let id = WindowId(self.next_id);
+        let class_name = w!("CodingAdventuresWindowCoreWin32");
+        ensure_window_class(class_name)?;
+        let size = attributes.initial_size.to_physical(1.0)?;
+        let title = wide_null(&attributes.title);
+        let instance = unsafe { GetModuleHandleW(None).expect("GetModuleHandleW failed") };
+        let hwnd = unsafe {
+            CreateWindowExW(
+                windows::Win32::UI::WindowsAndMessaging::WINDOW_EX_STYLE::default(),
+                class_name,
+                PCWSTR(title.as_ptr()),
+                WS_OVERLAPPEDWINDOW,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                size.width.max(1) as i32,
+                size.height.max(1) as i32,
+                HWND::default(),
+                HMENU::default(),
+                instance,
+                None,
+            )
+        };
+        let hwnd = match hwnd {
+            Ok(hwnd) => hwnd,
+            Err(error) => {
+                return Err(WindowError::backend(format!(
+                    "failed to create a Win32 window: {error}"
+                )))
+            }
+        };
+
+        if hwnd.is_invalid() {
+            return Err(WindowError::backend(
+                "failed to create a Win32 window for the requested attributes",
+            ));
+        }
+
+        register_paint_handler(hwnd, on_paint, user_data);
+        if attributes.visible {
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_SHOW);
+            }
+        }
+
+        Ok(Win32Window {
+            id,
+            logical_size: attributes.initial_size,
+            physical_size: size,
+            scale_factor: 1.0,
+            hwnd,
+        })
+    }
+
+    /// Non-Windows compatibility: keep the contract explicit until wired for the host.
+    #[cfg(not(target_os = "windows"))]
+    pub fn create_native_window(
+        &mut self,
+        _attributes: WindowAttributes,
+        _on_paint: Option<WindowPaintCallback>,
+        _user_data: isize,
+    ) -> Result<Win32Window, WindowError> {
+        Err(WindowError::UnsupportedPlatform(
+            "Win32 windows are only available on Windows",
+        ))
+    }
+
+    /// Run a blocking native Win32 message loop. Returns once `WM_QUIT` is received.
+    #[cfg(target_os = "windows")]
+    pub fn run(&self) -> Result<(), WindowError> {
+        let mut msg = windows::Win32::UI::WindowsAndMessaging::MSG::default();
+        loop {
+            unsafe {
+                let has_message = GetMessageW(&mut msg, HWND::default(), 0, 0);
+                if !has_message.as_bool() {
+                    return Ok(());
+                }
+                let _ = TranslateMessage(&msg);
+                let _ = DispatchMessageW(&msg);
+            }
+        }
+    }
+
+    /// Non-Windows compatibility path for API completeness.
+    #[cfg(not(target_os = "windows"))]
+    pub fn run(&self) -> Result<(), WindowError> {
+        Err(WindowError::UnsupportedPlatform(
+            "Win32 message loops are only available on Windows",
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn ensure_window_class(class_name: PCWSTR) -> Result<(), WindowError> {
+    static REGISTERED: OnceLock<bool> = OnceLock::new();
+    if REGISTERED.get().is_some() {
+        return Ok(());
+    }
+    let h_instance = unsafe { GetModuleHandleW(None).expect("GetModuleHandleW failed") };
+    let wc = WNDCLASSW {
+        style: CS_HREDRAW | CS_VREDRAW,
+        lpfnWndProc: Some(win32_window_proc),
+        hInstance: h_instance.into(),
+        hCursor: unsafe { LoadCursorW(None, IDC_ARROW).unwrap_or_default() },
+        hbrBackground: unsafe { HBRUSH(GetStockObject(WHITE_BRUSH).0) },
+        lpszClassName: class_name,
+        ..Default::default()
+    };
+    let already_registered = unsafe { RegisterClassW(&wc) != 0 };
+    if !already_registered {
+        return Err(WindowError::backend("failed to register Win32 window class"));
+    }
+    let _ = REGISTERED.set(true);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn register_paint_handler(hwnd: HWND, callback: Option<WindowPaintCallback>, user_data: isize) {
+    let key = hwnd.0 as isize;
+    let mut handlers = paint_handlers().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(callback) = callback {
+        handlers.insert(
+            key,
+            PaintHandler {
+                callback: Some(callback),
+                user_data,
+            },
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn win32_window_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    _lparam: LPARAM,
+) -> LRESULT {
+    match msg {
+        WM_CREATE => LRESULT(0),
+        WM_PAINT => {
+            let mut ps = PAINTSTRUCT::default();
+            BeginPaint(hwnd, &mut ps);
+            invoke_paint_handler(hwnd);
+            let _ = EndPaint(hwnd, &ps);
+            LRESULT(0)
+        }
+        WM_DESTROY => {
+            unregister_paint_handler(hwnd);
+            PostQuitMessage(0);
+            LRESULT(0)
+        }
+        WM_NCDESTROY => {
+            unregister_paint_handler(hwnd);
+            DefWindowProcW(hwnd, msg, wparam, LPARAM(0))
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, _lparam),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn unregister_paint_handler(hwnd: HWND) {
+    let key = hwnd.0 as isize;
+    let mut handlers = paint_handlers().lock().unwrap_or_else(|e| e.into_inner());
+    handlers.remove(&key);
+}
+
+#[cfg(target_os = "windows")]
+fn invoke_paint_handler(hwnd: HWND) {
+    let key = hwnd.0 as isize;
+    let handlers = paint_handlers().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(handler) = handlers.get(&key) {
+        if let Some(callback) = handler.callback {
+            unsafe { callback(hwnd, handler.user_data) };
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn wide_null(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+impl WindowBackend for Win32Backend {
+    type Window = Win32Window;
+
+    fn backend_name(&self) -> &'static str {
+        self.backend_name()
+    }
+
+    fn create_window(&mut self, attributes: WindowAttributes) -> Result<Self::Window, WindowError> {
+        self.create_native_window(attributes, None, 0)
+    }
+
+    fn pump_events(&mut self) -> Result<Vec<window_core::WindowEvent>, WindowError> {
+        Ok(Vec::new())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use window_core::LogicalSize;
 
     #[test]
     fn default_direct2d_and_cairo_share_the_hwnd_host() {
@@ -129,19 +452,25 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
-    fn create_native_window_is_honest_about_being_a_shell() {
+    fn create_native_window_is_not_available_off_windows() {
         let mut backend = Win32Backend::new();
         let err = backend
-            .create_native_window(WindowAttributes {
-                initial_size: LogicalSize::new(640.0, 480.0),
-                preferred_surface: SurfacePreference::Direct2D,
-                ..WindowAttributes::default()
-            })
+            .create_native_window(
+                WindowAttributes {
+                    initial_size: LogicalSize::new(640.0, 480.0),
+                    preferred_surface: SurfacePreference::Direct2D,
+                    ..WindowAttributes::default()
+                },
+                None,
+                0,
+            )
             .unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("native Win32 window creation is not wired yet"));
+        assert_eq!(
+            err,
+            WindowError::UnsupportedPlatform("Win32 windows are only available on Windows")
+        );
     }
 }

--- a/code/programs/rust/markdown-reader/Cargo.toml
+++ b/code/programs/rust/markdown-reader/Cargo.toml
@@ -19,6 +19,9 @@ text-native = { path = "../../../packages/rust/text-native" }
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc-bridge = { path = "../../../packages/rust/objc-bridge" }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+paint-vm-direct2d = { path = "../../../packages/rust/paint-vm-direct2d" }
+
 [[bin]]
 name = "markdown-reader"
 path = "src/main.rs"

--- a/code/programs/rust/markdown-reader/src/main.rs
+++ b/code/programs/rust/markdown-reader/src/main.rs
@@ -118,35 +118,66 @@ fn main() {
 
     // Full pipeline: parse → layout → paint → pixels.
     let scene = render_markdown_to_scene(&markdown);
-    let pixels = paint_metal::render(&scene);
-    eprintln!(
-        "markdown-reader: rendered {}×{} pixels ({} paint instructions)",
-        pixels.width,
-        pixels.height,
-        scene.instructions.len()
-    );
 
-    if let Some(path) = png_out {
-        match paint_codec_png::write_png(&pixels, &path) {
-            Ok(()) => {
-                eprintln!("markdown-reader: wrote {}", path);
-                return;
-            }
-            Err(e) => {
-                eprintln!("markdown-reader: failed to write {}: {}", path, e);
-                std::process::exit(1);
+    #[cfg(target_os = "windows")]
+    {
+        let pixels = paint_vm_direct2d::render(&scene);
+        eprintln!(
+            "markdown-reader: rendered {}Ã—{} pixels ({} paint instructions) via Direct2D",
+            pixels.width,
+            pixels.height,
+            scene.instructions.len()
+        );
+        if let Some(path) = png_out {
+            match paint_codec_png::write_png(&pixels, &path) {
+                Ok(()) => {
+                    eprintln!("markdown-reader: wrote {}", path);
+                    return;
+                }
+                Err(e) => {
+                    eprintln!("markdown-reader: failed to write {}: {}", path, e);
+                    std::process::exit(1);
+                }
             }
         }
+        unsafe {
+            paint_vm_direct2d::show_scene_in_window(&scene, "Markdown Reader - Direct2D");
+        }
+        return;
     }
 
-    #[cfg(target_vendor = "apple")]
-    unsafe {
-        show_in_window(&pixels, "Markdown Reader");
-    }
-
-    #[cfg(not(target_vendor = "apple"))]
+    #[cfg(not(target_os = "windows"))]
     {
-        eprintln!("markdown-reader: use --png <path> on non-Apple targets.");
+        let pixels = paint_metal::render(&scene);
+        eprintln!(
+            "markdown-reader: rendered {}×{} pixels ({} paint instructions)",
+            pixels.width,
+            pixels.height,
+            scene.instructions.len()
+        );
+
+        if let Some(path) = png_out {
+            match paint_codec_png::write_png(&pixels, &path) {
+                Ok(()) => {
+                    eprintln!("markdown-reader: wrote {}", path);
+                    return;
+                }
+                Err(e) => {
+                    eprintln!("markdown-reader: failed to write {}: {}", path, e);
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            show_in_window(&pixels, "Markdown Reader");
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            eprintln!("markdown-reader: use --png <path> on non-Apple targets.");
+        }
     }
 }
 
@@ -189,6 +220,376 @@ fn render_markdown_to_scene(markdown: &str) -> PaintScene {
 }
 
 // ---------------------------------------------------------------------------
+// Windows Direct2D window display
+// ---------------------------------------------------------------------------
+//
+// This is the first Windows-native Markdown slice. It intentionally renders
+// Markdown text straight through Direct2D/DirectWrite so the Direct2D window
+// path is usable before the full TXT03b DirectWrite shaper and PaintGlyphRun
+// registry are in place.
+
+#[cfg(any())]
+static DIRECT2D_MARKDOWN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+#[cfg(any())]
+unsafe fn show_direct2d_markdown_window(markdown: &str, title: &str) {
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::Graphics::Gdi::{GetStockObject, HBRUSH, WHITE_BRUSH};
+    use windows::Win32::System::Com::{CoInitializeEx, COINIT_APARTMENTTHREADED};
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, LoadCursorW,
+        RegisterClassW, ShowWindow, TranslateMessage, UpdateWindow, CS_HREDRAW, CS_VREDRAW,
+        CW_USEDEFAULT, HMENU, IDC_ARROW, MSG, SW_SHOW, WINDOW_EX_STYLE, WM_DESTROY, WM_PAINT,
+        WNDCLASSW, WS_OVERLAPPEDWINDOW, WS_VISIBLE,
+    };
+
+    let _ = DIRECT2D_MARKDOWN.set(markdown.to_string());
+    let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+
+    let instance = GetModuleHandleW(None).expect("GetModuleHandleW failed");
+    let class_name = w!("CodingAdventuresMarkdownReaderDirect2D");
+
+    let wc = WNDCLASSW {
+        style: CS_HREDRAW | CS_VREDRAW,
+        lpfnWndProc: Some(direct2d_window_proc),
+        hInstance: instance.into(),
+        hCursor: LoadCursorW(None, IDC_ARROW).unwrap_or_default(),
+        hbrBackground: HBRUSH(GetStockObject(WHITE_BRUSH).0),
+        lpszClassName: class_name,
+        ..Default::default()
+    };
+    RegisterClassW(&wc);
+
+    let title_wide = wide_null(title);
+    let hwnd = CreateWindowExW(
+        WINDOW_EX_STYLE::default(),
+        class_name,
+        PCWSTR(title_wide.as_ptr()),
+        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        WINDOW_WIDTH as i32,
+        WINDOW_HEIGHT as i32,
+        HWND::default(),
+        HMENU::default(),
+        instance,
+        None,
+    );
+    assert!(!hwnd.is_invalid(), "CreateWindowExW failed");
+
+    ShowWindow(hwnd, SW_SHOW);
+    let _ = UpdateWindow(hwnd);
+
+    let mut msg = MSG::default();
+    while GetMessageW(&mut msg, HWND::default(), 0, 0).into() {
+        let _ = TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    unsafe extern "system" fn direct2d_window_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        match msg {
+            WM_PAINT => {
+                paint_direct2d_window(hwnd);
+                LRESULT(0)
+            }
+            WM_DESTROY => {
+                windows::Win32::UI::WindowsAndMessaging::PostQuitMessage(0);
+                LRESULT(0)
+            }
+            _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+        }
+    }
+}
+
+#[cfg(any())]
+unsafe fn paint_direct2d_window(hwnd: windows::Win32::Foundation::HWND) {
+    use windows::Win32::Foundation::RECT;
+    use windows::Win32::Graphics::Direct2D::Common::{
+        D2D1_ALPHA_MODE_UNKNOWN, D2D1_COLOR_F, D2D1_PIXEL_FORMAT, D2D_RECT_F, D2D_SIZE_U,
+    };
+    use windows::Win32::Graphics::Direct2D::{
+        D2D1CreateFactory, D2D1_DRAW_TEXT_OPTIONS_NONE, D2D1_FACTORY_TYPE_SINGLE_THREADED,
+        D2D1_HWND_RENDER_TARGET_PROPERTIES, D2D1_PRESENT_OPTIONS_NONE,
+        D2D1_RENDER_TARGET_PROPERTIES, D2D1_RENDER_TARGET_TYPE_DEFAULT,
+        D2D1_RENDER_TARGET_USAGE_NONE,
+    };
+    use windows::Win32::Graphics::DirectWrite::{
+        DWriteCreateFactory, IDWriteFactory, DWRITE_FACTORY_TYPE_SHARED,
+        DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT,
+        DWRITE_FONT_WEIGHT_BOLD, DWRITE_FONT_WEIGHT_NORMAL, DWRITE_MEASURING_MODE_NATURAL,
+    };
+    use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN;
+    use windows::Win32::Graphics::Gdi::{BeginPaint, EndPaint, GetClientRect, PAINTSTRUCT};
+
+    let mut ps = PAINTSTRUCT::default();
+    BeginPaint(hwnd, &mut ps);
+
+    let mut rc = RECT::default();
+    if GetClientRect(hwnd, &mut rc).is_ok() {
+        let width = (rc.right - rc.left).max(1) as u32;
+        let height = (rc.bottom - rc.top).max(1) as u32;
+
+        let d2d_factory =
+            D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None).expect("D2D factory");
+        let dwrite_factory: IDWriteFactory =
+            DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED).expect("DWrite factory");
+
+        let rt_props = D2D1_RENDER_TARGET_PROPERTIES {
+            r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_UNKNOWN,
+                alphaMode: D2D1_ALPHA_MODE_UNKNOWN,
+            },
+            dpiX: 96.0,
+            dpiY: 96.0,
+            usage: D2D1_RENDER_TARGET_USAGE_NONE,
+            minLevel: Default::default(),
+        };
+        let hwnd_props = D2D1_HWND_RENDER_TARGET_PROPERTIES {
+            hwnd,
+            pixelSize: D2D_SIZE_U { width, height },
+            presentOptions: D2D1_PRESENT_OPTIONS_NONE,
+        };
+        let target = d2d_factory
+            .CreateHwndRenderTarget(&rt_props, &hwnd_props)
+            .expect("D2D HWND render target");
+
+        target.BeginDraw();
+        target.Clear(Some(&D2D1_COLOR_F {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
+        }));
+
+        let text_brush = target
+            .CreateSolidColorBrush(
+                &D2D1_COLOR_F {
+                    r: 0.08,
+                    g: 0.09,
+                    b: 0.11,
+                    a: 1.0,
+                },
+                None,
+            )
+            .expect("D2D text brush");
+
+        let accent_brush = target
+            .CreateSolidColorBrush(
+                &D2D1_COLOR_F {
+                    r: 0.86,
+                    g: 0.90,
+                    b: 0.96,
+                    a: 1.0,
+                },
+                None,
+            )
+            .expect("D2D accent brush");
+
+        let mut y = 24.0_f32;
+        let content_width = (width as f32 - 48.0).max(120.0);
+        let markdown = DIRECT2D_MARKDOWN.get().map(String::as_str).unwrap_or("");
+        for line in markdown_blocks(markdown) {
+            let size = line.size;
+            let weight = if line.bold {
+                DWRITE_FONT_WEIGHT_BOLD
+            } else {
+                DWRITE_FONT_WEIGHT_NORMAL
+            };
+            let format = create_text_format(&dwrite_factory, size, weight);
+            let wide = wide_null(&line.text);
+            let left = 24.0 + line.indent;
+            let rect = D2D_RECT_F {
+                left,
+                top: y + line.margin_top,
+                right: left + content_width - line.indent,
+                bottom: y + line.margin_top + line.box_height,
+            };
+            if line.accent {
+                target.FillRectangle(
+                    &D2D_RECT_F {
+                        left: 18.0,
+                        top: rect.top - 4.0,
+                        right: rect.right + 6.0,
+                        bottom: rect.bottom,
+                    },
+                    &accent_brush,
+                );
+            }
+            target.DrawText(
+                &wide[..wide.len().saturating_sub(1)],
+                &format,
+                &rect,
+                &text_brush,
+                D2D1_DRAW_TEXT_OPTIONS_NONE,
+                DWRITE_MEASURING_MODE_NATURAL,
+            );
+            y = rect.bottom + line.margin_bottom;
+            if y > height as f32 {
+                break;
+            }
+        }
+
+        target.EndDraw(None, None).expect("D2D EndDraw");
+    }
+
+    EndPaint(hwnd, &ps);
+
+    unsafe fn create_text_format(
+        factory: &IDWriteFactory,
+        size: f32,
+        weight: DWRITE_FONT_WEIGHT,
+    ) -> windows::Win32::Graphics::DirectWrite::IDWriteTextFormat {
+        let family = wide_null("Segoe UI");
+        let locale = wide_null("en-us");
+        factory
+            .CreateTextFormat(
+                windows::core::PCWSTR(family.as_ptr()),
+                None,
+                weight,
+                DWRITE_FONT_STYLE_NORMAL,
+                DWRITE_FONT_STRETCH_NORMAL,
+                size,
+                windows::core::PCWSTR(locale.as_ptr()),
+            )
+            .expect("DWrite text format")
+    }
+}
+
+#[cfg(any())]
+#[derive(Debug)]
+struct MarkdownDrawLine {
+    text: String,
+    size: f32,
+    bold: bool,
+    indent: f32,
+    margin_top: f32,
+    margin_bottom: f32,
+    box_height: f32,
+    accent: bool,
+}
+
+#[cfg(any())]
+fn markdown_blocks(markdown: &str) -> Vec<MarkdownDrawLine> {
+    let mut out = Vec::new();
+    let mut in_code = false;
+    for raw in markdown.lines() {
+        let trimmed = raw.trim();
+        if trimmed.starts_with("```") {
+            in_code = !in_code;
+            continue;
+        }
+        if trimmed.is_empty() {
+            out.push(MarkdownDrawLine {
+                text: String::new(),
+                size: 12.0,
+                bold: false,
+                indent: 0.0,
+                margin_top: 0.0,
+                margin_bottom: 8.0,
+                box_height: 4.0,
+                accent: false,
+            });
+            continue;
+        }
+
+        let (text, size, bold, indent, margin_top, margin_bottom, accent) = if in_code {
+            (raw.to_string(), 14.0, false, 18.0, 4.0, 6.0, true)
+        } else if let Some(rest) = trimmed.strip_prefix("# ") {
+            (
+                strip_inline_markup(rest),
+                32.0,
+                true,
+                0.0,
+                10.0,
+                12.0,
+                false,
+            )
+        } else if let Some(rest) = trimmed.strip_prefix("## ") {
+            (strip_inline_markup(rest), 24.0, true, 0.0, 8.0, 10.0, false)
+        } else if let Some(rest) = trimmed.strip_prefix("### ") {
+            (strip_inline_markup(rest), 19.0, true, 0.0, 6.0, 8.0, false)
+        } else if let Some(rest) = trimmed.strip_prefix("> ") {
+            (strip_inline_markup(rest), 16.0, false, 18.0, 4.0, 8.0, true)
+        } else if let Some(rest) = trimmed.strip_prefix("- ") {
+            (
+                format!("• {}", strip_inline_markup(rest)),
+                16.0,
+                false,
+                20.0,
+                2.0,
+                6.0,
+                false,
+            )
+        } else if let Some(rest) = ordered_list_body(trimmed) {
+            (
+                format!("• {}", strip_inline_markup(rest)),
+                16.0,
+                false,
+                20.0,
+                2.0,
+                6.0,
+                false,
+            )
+        } else {
+            (
+                strip_inline_markup(trimmed),
+                16.0,
+                false,
+                0.0,
+                2.0,
+                8.0,
+                false,
+            )
+        };
+
+        out.push(MarkdownDrawLine {
+            text,
+            size,
+            bold,
+            indent,
+            margin_top,
+            margin_bottom,
+            box_height: (size * 1.55).max(24.0),
+            accent,
+        });
+    }
+    out
+}
+
+#[cfg(any())]
+fn ordered_list_body(line: &str) -> Option<&str> {
+    let dot = line.find('.')?;
+    if dot == 0 || !line[..dot].chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(line[dot + 1..].trim_start())
+}
+
+#[cfg(any())]
+fn strip_inline_markup(input: &str) -> String {
+    input
+        .replace("**", "")
+        .replace('*', "")
+        .replace('`', "")
+        .replace('[', "")
+        .replace("](", " (")
+        .replace(')', "")
+}
+
+#[cfg(any())]
+fn wide_null(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+// ---------------------------------------------------------------------------
 // macOS window display
 // ---------------------------------------------------------------------------
 //
@@ -203,8 +604,8 @@ fn render_markdown_to_scene(markdown: &str) -> PaintScene {
 #[cfg(target_vendor = "apple")]
 unsafe fn show_in_window(pixels: &paint_instructions::PixelContainer, title: &str) {
     use objc_bridge::{
-        class, msg, msg_send_class, nsstring, release, CFRelease, CGPoint, CGRect, CGSize, Id,
-        NIL, NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE,
+        class, msg, msg_send_class, nsstring, release, CFRelease, CGPoint, CGRect, CGSize, Id, NIL,
+        NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE,
         NS_WINDOW_STYLE_MASK_MINIATURIZABLE, NS_WINDOW_STYLE_MASK_RESIZABLE,
         NS_WINDOW_STYLE_MASK_TITLED,
     };
@@ -318,11 +719,7 @@ unsafe fn create_nsimage_from_pixels(
     };
 
     let image_class = class("NSImage");
-    let image: Id = msg!(
-        msg_send_class(image_class, "alloc"),
-        "initWithSize:",
-        size
-    );
+    let image: Id = msg!(msg_send_class(image_class, "alloc"), "initWithSize:", size);
     msg!(image, "addRepresentation:", rep);
     release(rep);
 


### PR DESCRIPTION
## Summary

This PR adds initial versioned Haskell grammar sources under `code/grammars/haskell` so the Ruby grammar-tools pipeline can begin accepting Haskell versions.

## What's included

- Added `.tokens` and `.grammar` files for:
  - `haskell1.0`, `haskell1.1`, `haskell1.2`, `haskell1.3`, `haskell1.4`
  - `haskell98`, `haskell2010`
- Uses `mode: layout` and `layout_keywords` (`let`, `where`, `do`, `of`) in token grammars.
- Parser grammars consume virtual layout tokens (`VIRTUAL_LBRACE`, `VIRTUAL_SEMICOLON`, `VIRTUAL_RBRACE`) and explicit braces.

## Notes

- This change is intentionally minimal to establish the versioned grammar foundation.
- Wrapper package generation/wiring for Ruby `haskell_lexer` / `haskell_parser` is still pending and can be added in a follow-up PR.