### PR TITLE
Add versioned Haskell .grammar and .tokens files

### DIFF
--- a/code/grammars/haskell/haskell1.0.grammar
+++ b/code/grammars/haskell/haskell1.0.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.0
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.0.tokens
+++ b/code/grammars/haskell/haskell1.0.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.0
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.1.grammar
+++ b/code/grammars/haskell/haskell1.1.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.1
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.1.tokens
+++ b/code/grammars/haskell/haskell1.1.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.1
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.2.grammar
+++ b/code/grammars/haskell/haskell1.2.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.2
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.2.tokens
+++ b/code/grammars/haskell/haskell1.2.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.2
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.3.grammar
+++ b/code/grammars/haskell/haskell1.3.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.3
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.3.tokens
+++ b/code/grammars/haskell/haskell1.3.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.3
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell1.4.grammar
+++ b/code/grammars/haskell/haskell1.4.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell haskell1.4
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ============================================================================
+# Block Delimiters
+# ============================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ============================================================================
+# Top-Level Grammar
+# ============================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell1.4.tokens
+++ b/code/grammars/haskell/haskell1.4.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell haskell1.4
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell2010.grammar
+++ b/code/grammars/haskell/haskell2010.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell 2010
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ======================================================================
+# Block Delimiters
+# ======================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ======================================================================
+# Top-Level Grammar
+# ======================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell2010.tokens
+++ b/code/grammars/haskell/haskell2010.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell 2010
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{\-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where

--- a/code/grammars/haskell/haskell98.grammar
+++ b/code/grammars/haskell/haskell98.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for Haskell 98
+# @version 1
+#
+# Minimal versioned grammar used to validate that layout-aware token streams
+# can be parsed through the Ruby grammar parser stack.
+
+# ======================================================================
+# Block Delimiters
+# ======================================================================
+# Virtual layout tokens are emitted as VIRTUAL_* in layout mode. Allow both
+# explicit braces and implicit layout braces in the same grammar.
+layout_open = VIRTUAL_LBRACE | LBRACE | "{";
+layout_close = VIRTUAL_RBRACE | RBRACE | "}";
+layout_sep = VIRTUAL_SEMICOLON | SEMICOLON | NEWLINE;
+
+# ======================================================================
+# Top-Level Grammar
+# ======================================================================
+file = { declaration [ layout_sep ] };
+declaration = module_decl | let_decl | do_decl | expr_decl;
+
+module_decl = "module" module_name "where" layout_open module_body layout_close;
+module_name = NAME { DOT NAME };
+module_body = { declaration [ layout_sep ] };
+
+let_decl = "let" layout_open let_bindings layout_close "in" expr_decl;
+let_bindings = { binding [ layout_sep ] };
+binding = NAME EQUALS expr_decl;
+
+do_decl = "do" layout_open { expr_decl [ layout_sep ] } layout_close;
+
+expr_decl = lambda_expr | app_expr | NAME | INTEGER | FLOAT | STRING | CHARACTER;
+
+lambda_expr = LAMBDA { NAME } RARROW expr_decl;
+app_expr = atom_expr { atom_expr };
+atom_expr = NAME
+          | INTEGER
+          | FLOAT
+          | STRING
+          | CHARACTER
+          | LPAREN expr_decl RPAREN
+          | LPAREN expr_list RPAREN
+          | LBRACKET [ expr_list ] RBRACKET;
+
+expr_list = expr_decl { COMMA expr_decl };

--- a/code/grammars/haskell/haskell98.tokens
+++ b/code/grammars/haskell/haskell98.tokens
@@ -1,0 +1,91 @@
+# Token definitions for Haskell 98
+# @version 1
+#
+# Minimal versioned Haskell lexical specification used by the Ruby
+# layout-mode lexer prototype.
+
+# ============================================================================
+# Lexer Mode
+# ============================================================================
+mode: layout
+
+layout_keywords:
+  let
+  where
+  do
+  of
+
+# ============================================================================
+# Skip Patterns
+# ============================================================================
+skip:
+  LINE_COMMENT = /--[^\n]*/
+  BLOCK_COMMENT = /\{\-[\s\S]*?\-\}/
+  WHITESPACE = /[ \t\r]+/
+
+# ============================================================================
+# Literals
+# ============================================================================
+FLOAT = /[0-9]+\.[0-9]+/
+INTEGER = /[0-9]+/
+CHARACTER = /'(?:[^'\\]|\\.)'/
+STRING = /"(?:[^"\\]|\\.)*"/
+
+# ============================================================================
+# Operators and Punctuation
+# ============================================================================
+LAMBDA = "\\"
+RARROW = "->"
+LARROW = "<-"
+DARROW = "=>"
+DOUBLE_COLON = "::"
+DOUBLE_DOT = ".."
+EQUALS = "="
+EQ = "=="
+PLUS = "+"
+MINUS = "-"
+STAR = "*"
+SLASH = "/"
+PIPE = "|"
+AMPERSAND = "&"
+CARET = "^"
+TILDE = "~"
+BANG = "!"
+LESSTHAN = "<"
+GREATERTHAN = ">"
+COLON = ":"
+COMMA = ","
+SEMICOLON = ";"
+DOT = "."
+LPAREN = "("
+RPAREN = ")"
+LBRACKET = "["
+RBRACKET = "]"
+LBRACE = "{"
+RBRACE = "}"
+
+# ============================================================================
+# Identifiers
+# ============================================================================
+NAME = /[A-Za-z_][A-Za-z0-9_']*/
+
+keywords:
+  as
+  case
+  class
+  data
+  do
+  else
+  foreign
+  if
+  import
+  in
+  infix
+  infixl
+  infixr
+  let
+  module
+  of
+  then
+  type
+  where


### PR DESCRIPTION
## Summary

- add versioned Haskell grammar/token files for supported language versions (1.0, 1.1, 1.2, 1.3, 1.4, 98, 2010)
- this restores the intended Haskell grammar/versioned infrastructure work without unrelated changes from previous branch history

## Notes
- This branch is a clean replay of commit `d37e2dbc0` against `origin/main`.
- PR scope should now be limited to `code/grammars/haskell/*` files only.