### PR TITLE
ci: disable setup-go cache lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+          cache: false
 
       - name: Determine diff base
         id: diff-base
@@ -211,6 +212,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+          cache: false
 
       - name: Set up Python
         if: needs.detect.outputs.needs_python == 'true'


### PR DESCRIPTION
## Summary
- disable `actions/setup-go` cache lookup in the CI detect and build jobs
- isolates the workflow-only change from ALGOL PR #1120 so that ALGOL CI stays scoped to code/test changes

## Validation
- `git diff --check`
- reviewed the workflow diff: only adds `cache: false` under existing `actions/setup-go@v5` steps

## Security review
- no new workflow commands, permissions, network calls, or secret usage
- change only disables automatic setup-go cache behavior; it does not broaden CI capabilities