### PR TITLE
fix(music): keep later portable notes audible

### DIFF
--- a/code/packages/python/music-machine/src/music_machine/music_machine.py
+++ b/code/packages/python/music-machine/src/music_machine/music_machine.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import import_module
 from math import isfinite
 from numbers import Integral, Real
@@ -1129,8 +1129,18 @@ def render_portable_score_to_pcm(
                 instrument=instrument.profile_id,
                 sample_rate_hz=score.sample_rate_hz,
                 amplitude=note_amplitude,
-                start_time_seconds=start_seconds,
                 max_sample_count=max_sample_count,
+            )
+            rendered_note = replace(
+                rendered_note,
+                floating_samples=replace(
+                    rendered_note.floating_samples,
+                    start_time_seconds=start_seconds,
+                ),
+                pcm_buffer=replace(
+                    rendered_note.pcm_buffer,
+                    start_time_seconds=start_seconds,
+                ),
             )
             rendered_notes.append(rendered_note)
             clipped_sample_count += rendered_note.pcm_buffer.clipped_sample_count

--- a/code/packages/python/music-machine/tests/test_music_machine.py
+++ b/code/packages/python/music-machine/tests/test_music_machine.py
@@ -577,6 +577,26 @@ def test_render_portable_score_mixes_tracks_and_chords() -> None:
     assert any(rendered.pcm_buffer.samples[100:200])
 
 
+def test_render_portable_score_keeps_later_scheduled_notes_audible() -> None:
+    score = parse_portable_score(
+        """
+        format: music-machine-score/v2
+        ppq: 100
+        sample_rate: 2000
+        tempo 0 600
+        instrument lead kind=sine gain=0.5
+        track melody instrument=lead
+        event melody 0 100 note A4 velocity=0.8
+        event melody 300 100 note C5 velocity=0.8
+        """
+    )
+
+    rendered = render_portable_score_to_pcm(score)
+
+    assert any(rendered.pcm_buffer.samples[:200])
+    assert any(rendered.pcm_buffer.samples[600:800])
+
+
 def test_portable_score_supports_tempo_changes() -> None:
     score = parse_portable_score(
         """


### PR DESCRIPTION
## Summary

- Fix portable multi-track rendering so each note is sampled in note-local time before being mixed at its scheduled score position.
- Preserve the rendered note buffer metadata with the absolute score start time for inspection/debugging.
- Add a regression test that verifies later scheduled notes produce nonzero PCM samples instead of silence.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH='src:../note-frequency/src:../note-audio/src:../musical-instruments/src:../oscillator/src:../pcm-audio/src:../trig/src:../virtual-dac/src:../virtual-speaker/src:../wav-sink/src' python3.12 -m pytest tests/test_music_machine.py -q -o addopts=''`
- `python3.12 -m compileall -q src tests`
- `git diff --check`
- `ruff check src/music_machine/music_machine.py tests/test_music_machine.py`
- Render smoke confirmed both opening and later scheduled note windows contain nonzero samples with no clipping.

## Notes

This keeps the score scheduler responsible for placement in the mixed PCM timeline, while instrument rendering remains local to the note's own envelope and waveform.