### PR TITLE
feat(tcp): add sharded runtime and embeddable http primitive

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -348,6 +348,7 @@ members = [
     "state-machine-source-compiler",
     "state-machine-tokenizer",
     "embeddable-tcp-server",
+    "embeddable-http-server",
     "generic-job-protocol",
     "generic-job-runtime",
 ]

--- a/code/packages/rust/embeddable-http-server/BUILD
+++ b/code/packages/rust/embeddable-http-server/BUILD
@@ -1,0 +1,1 @@
+cargo test -p embeddable-http-server -- --nocapture

--- a/code/packages/rust/embeddable-http-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-http-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the initial HTTP/1 embeddable server primitive.

--- a/code/packages/rust/embeddable-http-server/Cargo.toml
+++ b/code/packages/rust/embeddable-http-server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "embeddable-http-server"
+version = "0.1.0"
+edition = "2021"
+description = "Embeddable HTTP/1 server primitive built on tcp-runtime"
+license = "MIT"
+
+[dependencies]
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }
+tcp-runtime = { path = "../tcp-runtime" }
+transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/embeddable-http-server/README.md
+++ b/code/packages/rust/embeddable-http-server/README.md
@@ -1,0 +1,8 @@
+# embeddable-http-server
+
+Embeddable HTTP/1 server primitive built on `tcp-runtime`.
+
+This crate owns HTTP/1 request framing and response serialization while leaving
+application work behind a handler callback. The eventual language bridges can
+wrap this crate and map requests into Rack-style or WSGI-style application
+objects without having to reimplement the socket runtime.

--- a/code/packages/rust/embeddable-http-server/src/lib.rs
+++ b/code/packages/rust/embeddable-http-server/src/lib.rs
@@ -1,0 +1,538 @@
+//! Embeddable HTTP/1 server primitive built on `tcp-runtime`.
+//!
+//! The TCP runtime owns sockets and native readiness. This crate owns HTTP/1
+//! request framing and response serialization, then hands complete requests to
+//! an application callback. Language bridges can later expose the callback as a
+//! Rack-like entry point without making the lower TCP runtime HTTP-aware.
+
+use std::fmt;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+
+use http1::{parse_request_head, Http1ParseError};
+use http_core::{BodyKind, Header, RequestHead};
+use tcp_runtime::{
+    PlatformError, TcpConnectionInfo, TcpHandlerResult, TcpRuntime, TcpRuntimeOptions,
+};
+
+pub const VERSION: &str = "0.1.0";
+
+const DEFAULT_MAX_REQUEST_HEAD_BYTES: usize = 16 * 1024;
+const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct HttpServerOptions {
+    pub tcp: TcpRuntimeOptions,
+    pub max_request_head_bytes: usize,
+    pub max_request_body_bytes: usize,
+}
+
+impl Default for HttpServerOptions {
+    fn default() -> Self {
+        Self {
+            tcp: TcpRuntimeOptions::default(),
+            max_request_head_bytes: DEFAULT_MAX_REQUEST_HEAD_BYTES,
+            max_request_body_bytes: DEFAULT_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpRequest {
+    pub connection: TcpConnectionInfo,
+    pub head: RequestHead,
+    pub body: Vec<u8>,
+}
+
+impl HttpRequest {
+    pub fn method(&self) -> &str {
+        &self.head.method
+    }
+
+    pub fn target(&self) -> &str {
+        &self.head.target
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.head.header(name)
+    }
+
+    pub fn wants_connection_close(&self) -> bool {
+        self.header("Connection")
+            .map(|value| {
+                value
+                    .split(',')
+                    .any(|part| part.trim().eq_ignore_ascii_case("close"))
+            })
+            .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub reason: String,
+    pub headers: Vec<Header>,
+    pub body: Vec<u8>,
+    pub close: bool,
+}
+
+impl HttpResponse {
+    pub fn new(status: u16, body: impl AsRef<[u8]>) -> Self {
+        Self {
+            status,
+            reason: default_reason(status).to_string(),
+            headers: Vec::new(),
+            body: body.as_ref().to_vec(),
+            close: false,
+        }
+    }
+
+    pub fn ok(body: impl AsRef<[u8]>) -> Self {
+        Self::new(200, body)
+    }
+
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push(Header {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    pub fn close(mut self) -> Self {
+        self.close = true;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpServerError {
+    Parse(Http1ParseError),
+    RequestHeadTooLarge,
+    RequestBodyTooLarge,
+    UnsupportedChunkedRequestBody,
+    UnsupportedUntilEofRequestBody,
+}
+
+impl fmt::Display for HttpServerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(error) => write!(f, "{error}"),
+            Self::RequestHeadTooLarge => f.write_str("HTTP request head is too large"),
+            Self::RequestBodyTooLarge => f.write_str("HTTP request body is too large"),
+            Self::UnsupportedChunkedRequestBody => {
+                f.write_str("chunked HTTP request bodies are not supported yet")
+            }
+            Self::UnsupportedUntilEofRequestBody => {
+                f.write_str("EOF-delimited HTTP request bodies are not supported")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HttpServerError {}
+
+impl From<Http1ParseError> for HttpServerError {
+    fn from(value: Http1ParseError) -> Self {
+        Self::Parse(value)
+    }
+}
+
+pub type HttpHandler = Arc<dyn Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static>;
+
+#[derive(Debug, Clone)]
+pub struct HttpConnectionState {
+    buffer: Vec<u8>,
+    limits: HttpServerLimits,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HttpServerLimits {
+    max_request_head_bytes: usize,
+    max_request_body_bytes: usize,
+}
+
+impl HttpConnectionState {
+    pub fn new(options: &HttpServerOptions) -> Self {
+        Self {
+            buffer: Vec::new(),
+            limits: HttpServerLimits {
+                max_request_head_bytes: options.max_request_head_bytes.max(1),
+                max_request_body_bytes: options.max_request_body_bytes,
+            },
+        }
+    }
+
+    pub fn receive(
+        &mut self,
+        connection: TcpConnectionInfo,
+        bytes: &[u8],
+        handler: &HttpHandler,
+    ) -> TcpHandlerResult {
+        self.buffer.extend_from_slice(bytes);
+        let mut output = Vec::new();
+        let mut close = false;
+
+        loop {
+            match self.pop_request(connection) {
+                Ok(Some(request)) => {
+                    let request_close = request.wants_connection_close();
+                    let mut response = handler(request);
+                    response.close = response.close || request_close;
+                    close = close || response.close;
+                    output.extend(serialize_response(&response));
+                    if close {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    let response = error_response(error);
+                    output.extend(serialize_response(&response));
+                    close = true;
+                    break;
+                }
+            }
+        }
+
+        if close {
+            TcpHandlerResult::write_and_close(output)
+        } else if output.is_empty() {
+            TcpHandlerResult::default()
+        } else {
+            TcpHandlerResult::write(output)
+        }
+    }
+
+    fn pop_request(
+        &mut self,
+        connection: TcpConnectionInfo,
+    ) -> Result<Option<HttpRequest>, HttpServerError> {
+        if self.buffer.len() > self.limits.max_request_head_bytes
+            && !contains_head_terminator(&self.buffer)
+        {
+            return Err(HttpServerError::RequestHeadTooLarge);
+        }
+
+        let parsed = match parse_request_head(&self.buffer) {
+            Ok(parsed) => parsed,
+            Err(Http1ParseError::IncompleteHead) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+
+        if parsed.body_offset > self.limits.max_request_head_bytes {
+            return Err(HttpServerError::RequestHeadTooLarge);
+        }
+
+        let body_len = match parsed.body_kind {
+            BodyKind::None => 0,
+            BodyKind::ContentLength(length) => length,
+            BodyKind::Chunked => return Err(HttpServerError::UnsupportedChunkedRequestBody),
+            BodyKind::UntilEof => return Err(HttpServerError::UnsupportedUntilEofRequestBody),
+        };
+        if body_len > self.limits.max_request_body_bytes {
+            return Err(HttpServerError::RequestBodyTooLarge);
+        }
+
+        let required = parsed.body_offset + body_len;
+        if self.buffer.len() < required {
+            return Ok(None);
+        }
+
+        let body = self.buffer[parsed.body_offset..required].to_vec();
+        self.buffer.drain(..required);
+        Ok(Some(HttpRequest {
+            connection,
+            head: parsed.head,
+            body,
+        }))
+    }
+}
+
+pub struct HttpServer<P> {
+    runtime: TcpRuntime<P, HttpConnectionState>,
+}
+
+impl<P> HttpServer<P>
+where
+    P: transport_platform::TransportPlatform,
+{
+    pub fn local_addr(&self) -> SocketAddr {
+        self.runtime.local_addr()
+    }
+
+    pub fn stop_handle(&self) -> tcp_runtime::StopHandle {
+        self.runtime.stop_handle()
+    }
+
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        self.runtime.serve()
+    }
+}
+
+impl<P> HttpServer<P>
+where
+    P: transport_platform::TransportPlatform,
+{
+    pub fn bind<F>(
+        platform: P,
+        address: tcp_runtime::BindAddress,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        let handler: HttpHandler = Arc::new(handler);
+        let state_options = options.clone();
+        let runtime = TcpRuntime::bind_with_state(
+            platform,
+            address,
+            options.tcp,
+            move |_| HttpConnectionState::new(&state_options),
+            move |info, state, bytes| state.receive(info, bytes, &handler),
+            |_, _| {},
+        )?;
+        Ok(Self { runtime })
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl HttpServer<transport_platform::bsd::KqueueTransportPlatform> {
+    pub fn bind_kqueue<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::bsd::KqueueTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            handler,
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl HttpServer<transport_platform::linux::EpollTransportPlatform> {
+    pub fn bind_epoll<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::linux::EpollTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            handler,
+        )
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl HttpServer<transport_platform::windows::WindowsTransportPlatform> {
+    pub fn bind_windows<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::windows::WindowsTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            handler,
+        )
+    }
+}
+
+fn serialize_response(response: &HttpResponse) -> Vec<u8> {
+    let mut output = Vec::new();
+    let reason = if response.reason.is_empty() {
+        default_reason(response.status)
+    } else {
+        &response.reason
+    };
+    output.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", response.status, reason).as_bytes());
+
+    let has_content_length = response
+        .headers
+        .iter()
+        .any(|header| header.name.eq_ignore_ascii_case("Content-Length"));
+    let has_connection = response
+        .headers
+        .iter()
+        .any(|header| header.name.eq_ignore_ascii_case("Connection"));
+
+    for header in &response.headers {
+        output.extend_from_slice(header.name.as_bytes());
+        output.extend_from_slice(b": ");
+        output.extend_from_slice(header.value.as_bytes());
+        output.extend_from_slice(b"\r\n");
+    }
+    if !has_content_length {
+        output.extend_from_slice(format!("Content-Length: {}\r\n", response.body.len()).as_bytes());
+    }
+    if response.close && !has_connection {
+        output.extend_from_slice(b"Connection: close\r\n");
+    }
+
+    output.extend_from_slice(b"\r\n");
+    output.extend_from_slice(&response.body);
+    output
+}
+
+fn error_response(error: HttpServerError) -> HttpResponse {
+    let (status, message) = match error {
+        HttpServerError::RequestHeadTooLarge | HttpServerError::RequestBodyTooLarge => {
+            (413, "Payload Too Large")
+        }
+        HttpServerError::UnsupportedChunkedRequestBody
+        | HttpServerError::UnsupportedUntilEofRequestBody => (501, "Not Implemented"),
+        HttpServerError::Parse(_) => (400, "Bad Request"),
+    };
+    HttpResponse::new(status, message.as_bytes().to_vec())
+        .with_header("Content-Type", "text/plain")
+        .close()
+}
+
+fn contains_head_terminator(bytes: &[u8]) -> bool {
+    bytes.windows(4).any(|window| window == b"\r\n\r\n")
+        || bytes.windows(2).any(|window| window == b"\n\n")
+}
+
+fn default_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        400 => "Bad Request",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        _ => "OK",
+    }
+}
+
+fn resolve_first_socket_addr<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr, PlatformError> {
+    addr.to_socket_addrs()
+        .map_err(PlatformError::from)?
+        .next()
+        .ok_or_else(|| PlatformError::Io("no socket addresses resolved".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn connection() -> TcpConnectionInfo {
+        TcpConnectionInfo {
+            id: tcp_runtime::ConnectionId(7),
+            peer_addr: SocketAddr::from(([127, 0, 0, 1], 43_210)),
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 80)),
+        }
+    }
+
+    #[test]
+    fn serializes_simple_http_response() {
+        let response = HttpResponse::ok("hello").with_header("Content-Type", "text/plain");
+        let bytes = serialize_response(&response);
+        let text = String::from_utf8(bytes).expect("response utf8");
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Length: 5\r\n"));
+        assert!(text.ends_with("\r\n\r\nhello"));
+    }
+
+    #[test]
+    fn buffers_fragmented_request_until_complete() {
+        let mut state = HttpConnectionState::new(&HttpServerOptions::default());
+        let handler: HttpHandler = Arc::new(|request| {
+            assert_eq!(request.method(), "POST");
+            assert_eq!(request.target(), "/submit");
+            assert_eq!(request.body, b"hello");
+            HttpResponse::ok("done")
+        });
+
+        let first = state.receive(
+            connection(),
+            b"POST /submit HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhe",
+            &handler,
+        );
+        assert!(first.write.is_empty());
+        assert!(!first.close);
+
+        let second = state.receive(connection(), b"llo", &handler);
+        let text = String::from_utf8(second.write).expect("response utf8");
+        assert!(text.contains("Content-Length: 4\r\n"));
+        assert!(text.ends_with("\r\n\r\ndone"));
+    }
+
+    #[test]
+    fn handles_pipelined_requests_in_one_tcp_read() {
+        let mut state = HttpConnectionState::new(&HttpServerOptions::default());
+        let handler: HttpHandler =
+            Arc::new(|request| HttpResponse::ok(format!("seen {}", request.target())));
+
+        let result = state.receive(
+            connection(),
+            b"GET /one HTTP/1.1\r\n\r\nGET /two HTTP/1.1\r\n\r\n",
+            &handler,
+        );
+        let text = String::from_utf8(result.write).expect("response utf8");
+        assert!(text.contains("seen /one"));
+        assert!(text.contains("seen /two"));
+        assert!(!result.close);
+    }
+
+    #[test]
+    fn parse_errors_close_connection_with_bad_request() {
+        let mut state = HttpConnectionState::new(&HttpServerOptions::default());
+        let handler: HttpHandler = Arc::new(|_| HttpResponse::ok("never"));
+
+        let result = state.receive(connection(), b"bad\r\n\r\n", &handler);
+        let text = String::from_utf8(result.write).expect("response utf8");
+        assert!(text.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(result.close);
+    }
+
+    #[test]
+    fn chunked_requests_are_rejected_until_supported() {
+        let mut state = HttpConnectionState::new(&HttpServerOptions::default());
+        let handler: HttpHandler = Arc::new(|_| HttpResponse::ok("never"));
+
+        let result = state.receive(
+            connection(),
+            b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
+            &handler,
+        );
+        let text = String::from_utf8(result.write).expect("response utf8");
+        assert!(text.starts_with("HTTP/1.1 501 Not Implemented\r\n"));
+        assert!(result.close);
+    }
+}

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -32,12 +32,14 @@ use generic_job_protocol::{
 };
 use generic_job_runtime::{
     ExecutorLimits, RustThreadPool, RustThreadPoolOptions, StdioProcessPool,
-    StdioProcessPoolOptions, StdioWorkerCommand,
-    StdioWorkerRestartPolicy, SubmitError,
+    StdioProcessPoolOptions, StdioWorkerCommand, StdioWorkerRestartPolicy, SubmitError,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tcp_runtime::{ConnectionId, PlatformError, StopHandle, TcpHandlerResult, TcpMailbox};
+use tcp_runtime::{
+    ConnectionId, PlatformError, ShardedStopHandle, ShardedTcpRuntime, StopHandle,
+    TcpHandlerResult, TcpMailbox,
+};
 use tcp_runtime::{TcpConnectionInfo, TcpRuntime, TcpRuntimeOptions};
 
 #[cfg(any(
@@ -49,11 +51,29 @@ use tcp_runtime::{TcpConnectionInfo, TcpRuntime, TcpRuntimeOptions};
 ))]
 type PlatformTcpRuntime<S> = TcpRuntime<transport_platform::bsd::KqueueTransportPlatform, S>;
 
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+type PlatformShardedTcpRuntime<S> =
+    ShardedTcpRuntime<transport_platform::bsd::KqueueTransportPlatform, S>;
+
 #[cfg(target_os = "linux")]
 type PlatformTcpRuntime<S> = TcpRuntime<transport_platform::linux::EpollTransportPlatform, S>;
 
+#[cfg(target_os = "linux")]
+type PlatformShardedTcpRuntime<S> =
+    ShardedTcpRuntime<transport_platform::linux::EpollTransportPlatform, S>;
+
 #[cfg(target_os = "windows")]
 type PlatformTcpRuntime<S> = TcpRuntime<transport_platform::windows::WindowsTransportPlatform, S>;
+
+#[cfg(target_os = "windows")]
+type PlatformShardedTcpRuntime<S> =
+    ShardedTcpRuntime<transport_platform::windows::WindowsTransportPlatform, S>;
 
 /// Command used to start an embedded language/application worker process.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,6 +97,7 @@ pub struct EmbeddableTcpServerOptions {
     pub host: String,
     pub port: u16,
     pub max_connections: usize,
+    pub event_loop_threads: usize,
     pub worker_processes: usize,
     pub worker_queue_depth: usize,
     pub worker_job_timeout: Option<Duration>,
@@ -99,6 +120,7 @@ impl Default for EmbeddableTcpServerOptions {
             host: "127.0.0.1".to_string(),
             port: 0,
             max_connections: TcpRuntimeOptions::default().max_connections,
+            event_loop_threads: 1,
             worker_processes: 1,
             worker_queue_depth: ExecutorLimits::default().max_queue_depth,
             worker_job_timeout: None,
@@ -178,23 +200,16 @@ where
 }
 
 trait MailboxJobSubmitter<Request, Response> {
-    fn submit(
-        &self,
-        connection_id: ConnectionId,
-        payload: Request,
-    ) -> Result<String, WorkerError>;
+    fn submit(&self, connection_id: ConnectionId, payload: Request) -> Result<String, WorkerError>;
 }
 
-impl<Request, Response> MailboxJobSubmitter<Request, Response> for StdioJobSubmitter<Request, Response>
+impl<Request, Response> MailboxJobSubmitter<Request, Response>
+    for StdioJobSubmitter<Request, Response>
 where
     Request: Serialize + Send + 'static,
     Response: DeserializeOwned + Send + 'static,
 {
-    fn submit(
-        &self,
-        connection_id: ConnectionId,
-        payload: Request,
-    ) -> Result<String, WorkerError> {
+    fn submit(&self, connection_id: ConnectionId, payload: Request) -> Result<String, WorkerError> {
         self.submit(connection_id, payload)
     }
 }
@@ -264,11 +279,7 @@ where
     Request: Send + 'static,
     Response: Send + 'static,
 {
-    fn submit(
-        &self,
-        connection_id: ConnectionId,
-        payload: Request,
-    ) -> Result<String, WorkerError> {
+    fn submit(&self, connection_id: ConnectionId, payload: Request) -> Result<String, WorkerError> {
         self.submit(connection_id, payload)
     }
 }
@@ -327,6 +338,59 @@ impl Drop for WorkerPoolGuard {
         self.stop.store(true, Ordering::SeqCst);
         if let Some(thread) = self.response_thread.take() {
             let _ = thread.join();
+        }
+    }
+}
+
+enum RuntimeInstance<State> {
+    Single(PlatformTcpRuntime<State>),
+    Sharded(PlatformShardedTcpRuntime<State>),
+}
+
+impl<State> RuntimeInstance<State>
+where
+    State: Send + 'static,
+{
+    fn local_addr(&self) -> SocketAddr {
+        match self {
+            Self::Single(runtime) => runtime.local_addr(),
+            Self::Sharded(runtime) => runtime.local_addr(),
+        }
+    }
+
+    fn mailbox(&self) -> TcpMailbox {
+        match self {
+            Self::Single(runtime) => runtime.mailbox(),
+            Self::Sharded(runtime) => runtime.mailbox(),
+        }
+    }
+
+    fn stop_handle(&self) -> RuntimeStopHandle {
+        match self {
+            Self::Single(runtime) => RuntimeStopHandle::Single(runtime.stop_handle()),
+            Self::Sharded(runtime) => RuntimeStopHandle::Sharded(runtime.stop_handle()),
+        }
+    }
+
+    fn serve(&mut self) -> Result<(), PlatformError> {
+        match self {
+            Self::Single(runtime) => runtime.serve(),
+            Self::Sharded(runtime) => runtime.serve(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum RuntimeStopHandle {
+    Single(StopHandle),
+    Sharded(ShardedStopHandle),
+}
+
+impl RuntimeStopHandle {
+    fn stop(&self) {
+        match self {
+            Self::Single(stop) => stop.stop(),
+            Self::Sharded(stop) => stop.stop(),
         }
     }
 }
@@ -475,10 +539,10 @@ impl From<SubmitError> for WorkerError {
 /// TCP server that embeds a generic job worker behind the Rust TCP runtime.
 #[derive(Clone)]
 pub struct EmbeddableTcpServer<State> {
-    runtime: Arc<Mutex<Option<PlatformTcpRuntime<State>>>>,
+    runtime: Arc<Mutex<Option<RuntimeInstance<State>>>>,
     _worker_pool: Arc<Mutex<Option<WorkerPoolGuard>>>,
     local_addr: SocketAddr,
-    stop_handle: StopHandle,
+    stop_handle: RuntimeStopHandle,
     serving: Arc<AtomicBool>,
 }
 
@@ -845,7 +909,7 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
@@ -863,16 +927,34 @@ where
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_kqueue_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| {
-            let mut worker = worker.lock().expect("embedded worker mutex poisoned");
-            handler(info, state, bytes, &mut worker)
-        },
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_kqueue_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_kqueue_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 #[cfg(any(
@@ -888,18 +970,13 @@ fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitt
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
     Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(
-            TcpConnectionInfo,
-            &mut State,
-            &[u8],
-            &Submitter,
-        ) -> TcpHandlerResult
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &Submitter) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -907,13 +984,28 @@ where
     Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_kqueue_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| handler(info, state, bytes, &submitter),
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_kqueue_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_kqueue_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -923,7 +1015,7 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
@@ -941,16 +1033,34 @@ where
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_epoll_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| {
-            let mut worker = worker.lock().expect("embedded worker mutex poisoned");
-            handler(info, state, bytes, &mut worker)
-        },
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_epoll_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_epoll_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -960,18 +1070,13 @@ fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitt
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
     Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(
-            TcpConnectionInfo,
-            &mut State,
-            &[u8],
-            &Submitter,
-        ) -> TcpHandlerResult
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &Submitter) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -979,13 +1084,28 @@ where
     Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_epoll_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| handler(info, state, bytes, &submitter),
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_epoll_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_epoll_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -995,7 +1115,7 @@ fn build_runtime<State, Request, Response, Init, Handler, Close>(
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
@@ -1013,16 +1133,34 @@ where
     Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_windows_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| {
-            let mut worker = worker.lock().expect("embedded worker mutex poisoned");
-            handler(info, state, bytes, &mut worker)
-        },
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_windows_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_windows_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| {
+                let mut worker = worker.lock().expect("embedded worker mutex poisoned");
+                handler(info, state, bytes, &mut worker)
+            },
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -1032,18 +1170,13 @@ fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close, Submitt
     init: Init,
     handler: Handler,
     on_close: Close,
-) -> Result<PlatformTcpRuntime<State>, PlatformError>
+) -> Result<RuntimeInstance<State>, PlatformError>
 where
     State: Send + 'static,
     Request: Send + 'static,
     Response: Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(
-            TcpConnectionInfo,
-            &mut State,
-            &[u8],
-            &Submitter,
-        ) -> TcpHandlerResult
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &Submitter) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -1051,13 +1184,28 @@ where
     Submitter: MailboxJobSubmitter<Request, Response> + Send + Sync + 'static,
 {
     let host = options.host.clone();
-    TcpRuntime::bind_windows_with_state(
-        (host.as_str(), options.port),
-        runtime_options(options),
-        init,
-        move |info, state, bytes| handler(info, state, bytes, &submitter),
-        on_close,
-    )
+    let runtime_options = runtime_options(options);
+    let worker_count = options.event_loop_threads.max(1);
+    if worker_count > 1 {
+        TcpRuntime::bind_windows_sharded_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            worker_count,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Sharded)
+    } else {
+        TcpRuntime::bind_windows_with_state(
+            (host.as_str(), options.port),
+            runtime_options,
+            init,
+            move |info, state, bytes| handler(info, state, bytes, &submitter),
+            on_close,
+        )
+        .map(RuntimeInstance::Single)
+    }
 }
 
 fn into_io_error(error: PlatformError) -> io::Error {
@@ -1374,6 +1522,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 host: "127.0.0.1".to_string(),
                 port: 0,
                 max_connections: 64,
+                event_loop_threads: 1,
                 worker_processes: 1,
                 worker_queue_depth: ExecutorLimits::default().max_queue_depth,
                 worker_job_timeout: None,
@@ -1633,6 +1782,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 host: "127.0.0.1".to_string(),
                 port: 0,
                 max_connections: 64,
+                event_loop_threads: 1,
                 worker_processes: 1,
                 worker_queue_depth,
                 worker_job_timeout: None,
@@ -1659,6 +1809,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 host: "127.0.0.1".to_string(),
                 port: 0,
                 max_connections: 64,
+                event_loop_threads: 1,
                 worker_processes: worker_count.max(1),
                 worker_queue_depth,
                 worker_job_timeout: None,
@@ -1666,16 +1817,16 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 worker: WorkerCommand::new("worker", Vec::<String>::new()),
             },
             |_| (),
-            handle_tcp_bytes_mailbox_with_submitter::<RustThreadPoolJobSubmitter<TcpInputJob, TcpOutputFrame>>,
+            handle_tcp_bytes_mailbox_with_submitter::<
+                RustThreadPoolJobSubmitter<TcpInputJob, TcpOutputFrame>,
+            >,
             |_, _| {},
             map_tcp_output_frame,
-            |request| {
-                JobResult::Ok {
-                    payload: TcpOutputFrame {
-                        writes_hex: vec![request.payload.bytes_hex],
-                        close: false,
-                    },
-                }
+            |request| JobResult::Ok {
+                payload: TcpOutputFrame {
+                    writes_hex: vec![request.payload.bytes_hex],
+                    close: false,
+                },
             },
         )
         .expect("create in-process async mailbox server");
@@ -1768,6 +1919,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         assert_eq!(options.host, "127.0.0.1");
         assert_eq!(options.port, 0);
         assert_eq!(options.worker, worker);
+        assert_eq!(options.event_loop_threads, 1);
         assert_eq!(options.worker_processes, 1);
         assert_eq!(
             options.worker_queue_depth,
@@ -2010,6 +2162,54 @@ emit(second, "second")
         let mut response = vec![0u8; request_len];
         stream.read_exact(&mut response).expect("read response");
         assert_eq!(response, request);
+        stop_server(server, handle);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn mailbox_server_can_use_multiple_event_loop_threads() {
+        let server = EmbeddableTcpServer::new_inprocess_mailbox(
+            EmbeddableTcpServerOptions {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+                max_connections: 64,
+                event_loop_threads: 2,
+                worker_processes: 4,
+                worker_queue_depth: 1024,
+                worker_job_timeout: None,
+                worker_restart_policy: StdioWorkerRestartPolicy::default(),
+                worker: WorkerCommand::new("worker", Vec::<String>::new()),
+            },
+            |_| (),
+            handle_tcp_bytes_mailbox_with_submitter::<
+                RustThreadPoolJobSubmitter<TcpInputJob, TcpOutputFrame>,
+            >,
+            |_, _| {},
+            map_tcp_output_frame,
+            |request| JobResult::Ok {
+                payload: TcpOutputFrame {
+                    writes_hex: vec![request.payload.bytes_hex],
+                    close: false,
+                },
+            },
+        )
+        .expect("create sharded in-process async mailbox server");
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+
+        let mut clients = (0..8).map(|_| connect_client(&server)).collect::<Vec<_>>();
+        for (index, client) in clients.iter_mut().enumerate() {
+            client
+                .write_all(format!("client-{index}").as_bytes())
+                .expect("write client payload");
+        }
+        for (index, client) in clients.iter_mut().enumerate() {
+            let expected = format!("client-{index}").into_bytes();
+            let mut response = vec![0u8; expected.len()];
+            client.read_exact(&mut response).expect("read response");
+            assert_eq!(response, expected);
+        }
+
         stop_server(server, handle);
     }
 }

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use transport_platform::{
@@ -70,10 +70,12 @@ impl StreamHandlerResult {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct StreamReactorOptions {
     pub listener: ListenerOptions,
     pub stream: StreamOptions,
+    /// Shared counter used by sharded reactors to allocate unique connection IDs.
+    pub connection_id_seed: Option<Arc<AtomicU64>>,
     pub read_buffer_size: usize,
     pub max_connections: usize,
     pub max_pending_write_bytes: usize,
@@ -85,6 +87,7 @@ impl Default for StreamReactorOptions {
         Self {
             listener: ListenerOptions::default(),
             stream: StreamOptions::default(),
+            connection_id_seed: None,
             read_buffer_size: DEFAULT_READ_BUFFER_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             max_pending_write_bytes: DEFAULT_MAX_PENDING_WRITE_BYTES,
@@ -92,6 +95,20 @@ impl Default for StreamReactorOptions {
         }
     }
 }
+
+impl PartialEq for StreamReactorOptions {
+    fn eq(&self, other: &Self) -> bool {
+        self.listener == other.listener
+            && self.stream == other.stream
+            && self.connection_id_seed.is_some() == other.connection_id_seed.is_some()
+            && self.read_buffer_size == other.read_buffer_size
+            && self.max_connections == other.max_connections
+            && self.max_pending_write_bytes == other.max_pending_write_bytes
+            && self.poll_timeout == other.poll_timeout
+    }
+}
+
+impl Eq for StreamReactorOptions {}
 
 #[derive(Clone)]
 pub struct StopHandle(Arc<AtomicBool>);
@@ -211,6 +228,7 @@ pub struct StreamReactor<P, S = ()> {
     max_pending_write_bytes: usize,
     poll_timeout: Duration,
     stream_options: StreamOptions,
+    connection_id_seed: Option<Arc<AtomicU64>>,
     state_init: StateInit<S>,
     handler: StatefulHandler<S>,
     on_close: CloseHandler<S>,
@@ -279,6 +297,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             max_pending_write_bytes: options.max_pending_write_bytes.max(1),
             poll_timeout: options.poll_timeout,
             stream_options: options.stream,
+            connection_id_seed: options.connection_id_seed,
             state_init: Arc::new(init),
             handler: Arc::new(handler),
             on_close: Arc::new(on_close),
@@ -360,8 +379,13 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                     self.platform
                         .set_stream_interest(accepted.stream, StreamInterest::readable())?;
 
-                    let connection_id = ConnectionId(self.next_connection_id);
-                    self.next_connection_id += 1;
+                    let connection_id = if let Some(seed) = &self.connection_id_seed {
+                        ConnectionId(seed.fetch_add(1, Ordering::SeqCst))
+                    } else {
+                        let id = ConnectionId(self.next_connection_id);
+                        self.next_connection_id += 1;
+                        id
+                    };
                     self.connection_index.insert(connection_id, accepted.stream);
                     self.connections.insert(
                         accepted.stream,

--- a/code/packages/rust/tcp-runtime/src/lib.rs
+++ b/code/packages/rust/tcp-runtime/src/lib.rs
@@ -8,7 +8,9 @@
 //! convenience constructors.
 
 use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, OnceLock};
+use std::thread;
 use std::time::Duration;
 
 pub use stream_reactor::{ConnectionId, StopHandle};
@@ -74,10 +76,12 @@ impl TcpHandlerResult {
 /// `TcpRuntimeOptions` is the TCP policy surface that callers configure.
 /// Listener options feed binding defaults, stream options shape accepted socket
 /// policy, and the remaining knobs forward into the generic stream runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct TcpRuntimeOptions {
     pub listener: ListenerOptions,
     pub stream: StreamOptions,
+    /// Optional shared seed used by sharded runtimes for unique connection IDs.
+    pub connection_id_seed: Option<Arc<AtomicU64>>,
     pub read_buffer_size: usize,
     pub max_connections: usize,
     pub max_pending_write_bytes: usize,
@@ -90,6 +94,7 @@ impl Default for TcpRuntimeOptions {
         Self {
             listener: defaults.listener,
             stream: defaults.stream,
+            connection_id_seed: None,
             read_buffer_size: defaults.read_buffer_size,
             max_connections: defaults.max_connections,
             max_pending_write_bytes: defaults.max_pending_write_bytes,
@@ -98,11 +103,26 @@ impl Default for TcpRuntimeOptions {
     }
 }
 
+impl PartialEq for TcpRuntimeOptions {
+    fn eq(&self, other: &Self) -> bool {
+        self.listener == other.listener
+            && self.stream == other.stream
+            && self.connection_id_seed.is_some() == other.connection_id_seed.is_some()
+            && self.read_buffer_size == other.read_buffer_size
+            && self.max_connections == other.max_connections
+            && self.max_pending_write_bytes == other.max_pending_write_bytes
+            && self.poll_timeout == other.poll_timeout
+    }
+}
+
+impl Eq for TcpRuntimeOptions {}
+
 impl From<TcpRuntimeOptions> for StreamReactorOptions {
     fn from(value: TcpRuntimeOptions) -> Self {
         Self {
             listener: value.listener,
             stream: value.stream,
+            connection_id_seed: value.connection_id_seed,
             read_buffer_size: value.read_buffer_size,
             max_connections: value.max_connections,
             max_pending_write_bytes: value.max_pending_write_bytes,
@@ -116,40 +136,146 @@ pub struct TcpRuntime<P, S = ()> {
     local_addr: SocketAddr,
 }
 
+pub struct ShardedTcpRuntime<P, S = ()> {
+    local_addr: SocketAddr,
+    worker_count: usize,
+    mailbox: TcpMailbox,
+    stop_handles: Vec<StopHandle>,
+    runtimes: Vec<TcpRuntime<P, S>>,
+}
+
+#[derive(Clone)]
+pub struct ShardedStopHandle {
+    stop_handles: Arc<[StopHandle]>,
+}
+
+impl ShardedStopHandle {
+    pub fn stop(&self) {
+        for stop in self.stop_handles.iter() {
+            stop.stop();
+        }
+    }
+}
+
+impl<P, S> ShardedTcpRuntime<P, S> {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn worker_count(&self) -> usize {
+        self.worker_count
+    }
+
+    pub fn mailbox(&self) -> TcpMailbox {
+        self.mailbox.clone()
+    }
+
+    pub fn stop_handle(&self) -> ShardedStopHandle {
+        ShardedStopHandle {
+            stop_handles: Arc::from(self.stop_handles.clone().into_boxed_slice()),
+        }
+    }
+
+    pub fn stop(&self) {
+        for stop in &self.stop_handles {
+            stop.stop();
+        }
+    }
+}
+
+impl<P, S> ShardedTcpRuntime<P, S>
+where
+    P: TransportPlatform + Send + 'static,
+    S: Send + 'static,
+{
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        let runtimes = std::mem::take(&mut self.runtimes);
+        let mut workers = Vec::with_capacity(runtimes.len());
+        for mut runtime in runtimes {
+            workers.push(thread::spawn(move || runtime.serve()));
+        }
+
+        let mut first_error = None;
+        for worker in workers {
+            let result = match worker.join() {
+                Ok(result) => result,
+                Err(_) => Err(PlatformError::ProviderFault(
+                    "TCP runtime worker panicked".to_string(),
+                )),
+            };
+            if first_error.is_none() {
+                first_error = result.err();
+            }
+        }
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<P, S> Drop for ShardedTcpRuntime<P, S> {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 #[derive(Clone)]
 pub struct TcpMailbox {
-    inner: StreamMailbox,
+    inners: Arc<[StreamMailbox]>,
 }
 
 impl TcpMailbox {
     pub fn send(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
-        self.inner.send(connection_id, bytes);
+        let bytes = bytes.into();
+        for inner in self.inners.iter() {
+            inner.send(connection_id, bytes.clone());
+        }
     }
 
     pub fn send_and_close(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
-        self.inner.send_and_close(connection_id, bytes);
+        let bytes = bytes.into();
+        for inner in self.inners.iter() {
+            inner.send_and_close(connection_id, bytes.clone());
+        }
     }
 
     pub fn close(&self, connection_id: ConnectionId) {
-        self.inner.close(connection_id);
+        for inner in self.inners.iter() {
+            inner.close(connection_id);
+        }
     }
 
     pub fn pause_reads(&self, connection_id: ConnectionId) {
-        self.inner.pause_reads(connection_id);
+        for inner in self.inners.iter() {
+            inner.pause_reads(connection_id);
+        }
     }
 
     pub fn resume_reads(&self, connection_id: ConnectionId) {
-        self.inner.resume_reads(connection_id);
+        for inner in self.inners.iter() {
+            inner.resume_reads(connection_id);
+        }
     }
 
     pub fn resume_all_reads(&self) {
-        self.inner.resume_all_reads();
+        for inner in self.inners.iter() {
+            inner.resume_all_reads();
+        }
+    }
+
+    fn from_mailboxes(mailboxes: Vec<StreamMailbox>) -> Self {
+        Self {
+            inners: Arc::from(mailboxes.into_boxed_slice()),
+        }
     }
 }
 
 impl From<StreamMailbox> for TcpMailbox {
     fn from(value: StreamMailbox) -> Self {
-        Self { inner: value }
+        Self::from_mailboxes(vec![value])
     }
 }
 
@@ -280,6 +406,87 @@ impl<P: TransportPlatform, S: Send + 'static> TcpRuntime<P, S> {
     }
 }
 
+fn bind_sharded_runtime_with_state<P, S, I, F, C>(
+    address: SocketAddr,
+    mut options: TcpRuntimeOptions,
+    worker_count: usize,
+    init: I,
+    handler: F,
+    on_close: C,
+    new_platform: impl Fn() -> Result<P, PlatformError>,
+) -> Result<ShardedTcpRuntime<P, S>, PlatformError>
+where
+    P: TransportPlatform + 'static,
+    S: Send + 'static,
+    I: Fn(TcpConnectionInfo) -> S + Send + Sync + 'static,
+    F: Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    C: Fn(TcpConnectionInfo, S) + Send + Sync + 'static,
+{
+    let worker_count = worker_count.max(1);
+    if worker_count > 1 {
+        options.listener.reuse_port = true;
+    }
+
+    let shared_connection_id = if worker_count > 1 {
+        Some(Arc::new(AtomicU64::new(1)))
+    } else {
+        None
+    };
+
+    let init: Arc<dyn Fn(TcpConnectionInfo) -> S + Send + Sync> = Arc::new(init);
+    let handler: Arc<dyn Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync> =
+        Arc::new(handler);
+    let on_close: Arc<dyn Fn(TcpConnectionInfo, S) + Send + Sync> = Arc::new(on_close);
+
+    let mut bind_address = address;
+    let mut runtimes = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let mut worker_options = options.clone();
+        if let Some(seed) = &shared_connection_id {
+            worker_options.connection_id_seed = Some(Arc::clone(seed));
+        }
+
+        let init = Arc::clone(&init);
+        let handler = Arc::clone(&handler);
+        let on_close = Arc::clone(&on_close);
+        let runtime = TcpRuntime::bind_with_state(
+            new_platform()?,
+            BindAddress::Ip(bind_address),
+            worker_options,
+            move |info| init(info),
+            move |info, state, bytes| handler(info, state, bytes),
+            move |info, state| on_close(info, state),
+        )?;
+
+        bind_address = runtime.local_addr();
+        runtimes.push(runtime);
+    }
+
+    let local_addr = runtimes
+        .first()
+        .map(TcpRuntime::local_addr)
+        .ok_or(PlatformError::InvalidResource)?;
+    let stop_handles = runtimes
+        .iter()
+        .map(TcpRuntime::stop_handle)
+        .collect::<Vec<_>>();
+    let mailbox = TcpMailbox::from_mailboxes(
+        runtimes
+            .iter()
+            .map(|runtime| runtime.reactor.mailbox())
+            .collect(),
+    );
+    let worker_count = runtimes.len();
+
+    Ok(ShardedTcpRuntime {
+        local_addr,
+        worker_count,
+        mailbox,
+        stop_handles,
+        runtimes,
+    })
+}
+
 #[cfg(any(
     target_os = "macos",
     target_os = "freebsd",
@@ -300,6 +507,26 @@ impl TcpRuntime<transport_platform::bsd::KqueueTransportPlatform, ()> {
         let address = resolve_first_socket_addr(addr)?;
         let platform = transport_platform::bsd::KqueueTransportPlatform::new()?;
         Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+
+    pub fn bind_kqueue_sharded<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        handler: F,
+    ) -> Result<ShardedTcpRuntime<transport_platform::bsd::KqueueTransportPlatform>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        Self::bind_kqueue_sharded_with_state(
+            addr,
+            options,
+            worker_count,
+            |_| (),
+            move |info, _, bytes| handler(info, bytes),
+            |_, _| {},
+        )
     }
 }
 
@@ -335,6 +562,31 @@ impl<S: Send + 'static> TcpRuntime<transport_platform::bsd::KqueueTransportPlatf
             on_close,
         )
     }
+
+    pub fn bind_kqueue_sharded_with_state<A, I, F, C>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<ShardedTcpRuntime<transport_platform::bsd::KqueueTransportPlatform, S>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        I: Fn(TcpConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+        C: Fn(TcpConnectionInfo, S) + Send + Sync + 'static,
+    {
+        bind_sharded_runtime_with_state(
+            resolve_first_socket_addr(addr)?,
+            options,
+            worker_count,
+            init,
+            handler,
+            on_close,
+            transport_platform::bsd::KqueueTransportPlatform::new,
+        )
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -351,6 +603,26 @@ impl TcpRuntime<transport_platform::linux::EpollTransportPlatform, ()> {
         let address = resolve_first_socket_addr(addr)?;
         let platform = transport_platform::linux::EpollTransportPlatform::new()?;
         Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+
+    pub fn bind_epoll_sharded<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        handler: F,
+    ) -> Result<ShardedTcpRuntime<transport_platform::linux::EpollTransportPlatform>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        Self::bind_epoll_sharded_with_state(
+            addr,
+            options,
+            worker_count,
+            |_| (),
+            move |info, _, bytes| handler(info, bytes),
+            |_, _| {},
+        )
     }
 }
 
@@ -380,6 +652,34 @@ impl<S: Send + 'static> TcpRuntime<transport_platform::linux::EpollTransportPlat
             on_close,
         )
     }
+
+    pub fn bind_epoll_sharded_with_state<A, I, F, C>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<
+        ShardedTcpRuntime<transport_platform::linux::EpollTransportPlatform, S>,
+        PlatformError,
+    >
+    where
+        A: ToSocketAddrs,
+        I: Fn(TcpConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+        C: Fn(TcpConnectionInfo, S) + Send + Sync + 'static,
+    {
+        bind_sharded_runtime_with_state(
+            resolve_first_socket_addr(addr)?,
+            options,
+            worker_count,
+            init,
+            handler,
+            on_close,
+            transport_platform::linux::EpollTransportPlatform::new,
+        )
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -396,6 +696,29 @@ impl TcpRuntime<transport_platform::windows::WindowsTransportPlatform, ()> {
         let address = resolve_first_socket_addr(addr)?;
         let platform = transport_platform::windows::WindowsTransportPlatform::new()?;
         Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+
+    pub fn bind_windows_sharded<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        handler: F,
+    ) -> Result<
+        ShardedTcpRuntime<transport_platform::windows::WindowsTransportPlatform>,
+        PlatformError,
+    >
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        Self::bind_windows_sharded_with_state(
+            addr,
+            options,
+            worker_count,
+            |_| (),
+            move |info, _, bytes| handler(info, bytes),
+            |_, _| {},
+        )
     }
 }
 
@@ -423,6 +746,34 @@ impl<S: Send + 'static> TcpRuntime<transport_platform::windows::WindowsTransport
             init,
             handler,
             on_close,
+        )
+    }
+
+    pub fn bind_windows_sharded_with_state<A, I, F, C>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        worker_count: usize,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<
+        ShardedTcpRuntime<transport_platform::windows::WindowsTransportPlatform, S>,
+        PlatformError,
+    >
+    where
+        A: ToSocketAddrs,
+        I: Fn(TcpConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+        C: Fn(TcpConnectionInfo, S) + Send + Sync + 'static,
+    {
+        bind_sharded_runtime_with_state(
+            resolve_first_socket_addr(addr)?,
+            options,
+            worker_count,
+            init,
+            handler,
+            on_close,
+            transport_platform::windows::WindowsTransportPlatform::new,
         )
     }
 }
@@ -490,6 +841,68 @@ mod tests {
             assert_eq!(echoed, format!("client-{i}-payload").into_bytes());
         }
 
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn sharded_runtime_serves_clients_across_multiple_reactors() {
+        let seen_ids = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let seen_in_handler = Arc::clone(&seen_ids);
+        let mut runtime = TcpRuntime::bind_kqueue_sharded(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            3,
+            move |info, bytes| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen ids mutex poisoned")
+                    .push(info.id);
+                TcpHandlerResult::write(bytes.to_vec())
+            },
+        )
+        .expect("bind sharded runtime");
+        let addr = runtime.local_addr();
+        assert_eq!(runtime.worker_count(), 3);
+
+        let stop = runtime.stop_handle();
+        let mailbox = runtime.mailbox();
+        let server = thread::spawn(move || runtime.serve());
+
+        let client_count = 24usize;
+        let barrier = Arc::new(Barrier::new(client_count));
+        let mut clients = Vec::new();
+
+        for i in 0..client_count {
+            let barrier = Arc::clone(&barrier);
+            clients.push(thread::spawn(move || -> Result<Vec<u8>, String> {
+                barrier.wait();
+                let mut stream = TcpStream::connect(addr).map_err(|e| e.to_string())?;
+                let payload = format!("sharded-{i}").into_bytes();
+                stream.write_all(&payload).map_err(|e| e.to_string())?;
+                stream
+                    .shutdown(Shutdown::Write)
+                    .map_err(|e| e.to_string())?;
+                let mut echoed = Vec::new();
+                stream.read_to_end(&mut echoed).map_err(|e| e.to_string())?;
+                Ok(echoed)
+            }));
+        }
+
+        for (i, client) in clients.into_iter().enumerate() {
+            let echoed = client.join().expect("client thread").expect("client io");
+            assert_eq!(echoed, format!("sharded-{i}").into_bytes());
+        }
+
+        let ids = seen_ids.lock().expect("seen ids mutex poisoned").clone();
+        let mut unique = ids.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(ids.len(), client_count);
+        assert_eq!(unique.len(), client_count);
+
+        mailbox.resume_all_reads();
         stop.stop();
         let result = server.join().expect("server thread");
         assert!(result.is_ok(), "server should exit cleanly: {result:?}");


### PR DESCRIPTION
## Summary
- add sharded `tcp-runtime` support with shared connection IDs and mailbox fanout so embedders can opt into multiple event-loop threads
- thread `event_loop_threads` through `embeddable-tcp-server` and add coverage for multi-reactor mailbox serving
- add a new `embeddable-http-server` crate that assembles HTTP/1 requests on top of `tcp-runtime` and serializes responses for higher-level language bridges

## Testing
- `cargo fmt --check -p stream-reactor -p tcp-runtime -p embeddable-tcp-server -p embeddable-http-server`
- `cargo metadata --no-deps --format-version 1 --offline`
