### PR TITLE
feat(rust): add html lexer profile deserializers

### DIFF
--- a/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this package will be documented in this file.
   DFA, NFA, and PDA machines from parsed `StateMachineDefinition` values.
 - Added phase 1 transducer validation for `$any`, `$end`, transition actions,
   and `consume = false` EOF transitions.
+- Added lexer-profile TOML lowering for `profile = "lexer/v1"` root fields,
+  `[[tokens]]`, `[[inputs]]`, `[[registers]]`, `[[guards]]`, `[[fixtures]]`,
+  inline matcher tables, and multiline string arrays.
+- Added lexer-profile validation for duplicate token/register/input/guard
+  identifiers, matcher references, done-state rules, and portable action/token
+  references.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/rust/state-machine-markup-deserializer/README.md
+++ b/code/packages/rust/state-machine-markup-deserializer/README.md
@@ -49,22 +49,22 @@ let definition = from_states_toml(source).unwrap();
 assert_eq!(definition.name, "turnstile");
 ```
 
-## Phase 1 Profile
+## Supported Profiles
 
-The first reader intentionally accepts a strict subset:
+The reader still supports the generic phase-1 DFA/NFA/PDA/transducer surface,
+and now also accepts the current lexer profile used by `html-lexer`:
 
-- root string fields: `format`, `name`, `kind`, `initial`, `initial_stack`
-- root string arrays: `alphabet`, `stack_alphabet`
-- repeated `[[states]]` tables with boolean marker fields
-- repeated `[[transitions]]` tables with `from`, `on`, `to`, `stack_pop`, and
-  `stack_push`
-- transducer transition fields `actions` and `consume`, with `$any` and `$end`
-  reserved for any-input and EOF matchers
+- root metadata such as `format`, `name`, `kind`, `initial`, `version`,
+  `profile`, `runtime_min`, `done`, and `includes`
+- repeated `[[states]]` and `[[transitions]]` tables
+- transducer transition fields `actions`, `consume`, `guard`, and `matcher`
+- lexer-profile sections `[[tokens]]`, `[[inputs]]`, `[[registers]]`,
+  `[[guards]]`, and `[[fixtures]]`
+- inline matcher tables such as `matcher = { literal = "<" }`
+- multiline string arrays for actions, fixtures, and includes
 
-Unsupported tables, duplicate keys, dotted keys, numbers, inline tables,
-includes, and malformed strings are rejected. That keeps the first
-implementation small enough to port while still exercising the same validation
-rules future language ports need.
+Numbers, dotted keys, malformed inline tables, and unsupported fields are still
+rejected so the reader stays bounded and predictable at the trust boundary.
 
 ## Dependencies
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -800,11 +800,16 @@ fn validate_pda_transition(
 }
 
 fn validate_transducer_transition(transition: &TransitionDefinition) -> Result<()> {
-    let event = transition.on.as_ref().ok_or_else(|| {
-        StateMachineMarkupError::MissingTransducerMatcher {
-            from: transition.from.clone(),
+    let is_eof = match (&transition.on, &transition.matcher) {
+        (Some(event), _) => event == END_INPUT,
+        (None, Some(MatcherDefinition::Eof)) => true,
+        (None, Some(_)) => false,
+        (None, None) => {
+            return Err(StateMachineMarkupError::MissingTransducerMatcher {
+                from: transition.from.clone(),
+            })
         }
-    })?;
+    };
     if transition.to.len() != 1 {
         return Err(StateMachineMarkupError::InvalidTransducerTargetCount {
             from: transition.from.clone(),
@@ -815,7 +820,7 @@ fn validate_transducer_transition(transition: &TransitionDefinition) -> Result<(
             from: transition.from.clone(),
         });
     }
-    if event == END_INPUT && transition.consume {
+    if is_eof && transition.consume {
         return Err(StateMachineMarkupError::ConsumingEndTransition {
             from: transition.from.clone(),
         });

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -14,8 +14,9 @@ use std::error::Error;
 use std::fmt;
 
 use state_machine::{
-    MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition, ANY_INPUT,
-    END_INPUT,
+    FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition,
+    RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition,
+    TransitionDefinition, ANY_INPUT, END_INPUT,
 };
 
 /// The current State Machine Markup document version.
@@ -76,10 +77,24 @@ pub enum StateMachineMarkupError {
     InvalidFormat { found: String },
     /// The `kind` field is unknown.
     UnknownKind { kind: String },
+    /// The `profile` field is unknown.
+    UnknownProfile { profile: String },
     /// The machine kind exists but the first reader does not support it yet.
     UnsupportedKind { kind: String },
+    /// A profile is incompatible with the selected machine kind.
+    ProfileKindMismatch { profile: String, kind: String },
     /// A state identifier appears more than once.
     DuplicateState { id: String },
+    /// A token identifier appears more than once.
+    DuplicateToken { id: String },
+    /// A token field appears more than once.
+    DuplicateTokenField { token: String, field: String },
+    /// An input class identifier appears more than once.
+    DuplicateInput { id: String },
+    /// A register identifier appears more than once.
+    DuplicateRegister { id: String },
+    /// A guard identifier appears more than once.
+    DuplicateGuard { id: String },
     /// A required identifier is empty.
     EmptyIdentifier { field: String },
     /// An identifier references a state that was never declared.
@@ -88,6 +103,14 @@ pub enum StateMachineMarkupError {
     UnknownAlphabetSymbol { symbol: String },
     /// A stack symbol is not listed in the stack alphabet.
     UnknownStackSymbol { field: String, symbol: String },
+    /// A lexer matcher references an input class that was never declared.
+    UnknownInputClass { id: String },
+    /// A lexer transition references a guard that was never declared.
+    UnknownGuard { id: String },
+    /// An action references a token that was never declared.
+    UnknownToken { id: String },
+    /// A portable action name is outside the current vocabulary.
+    UnknownAction { action: String },
     /// A set-like array contains the same item more than once.
     DuplicateArrayValue { field: String, value: String },
     /// DFA/NFA/PDA documents need exactly one initial state.
@@ -116,10 +139,16 @@ pub enum StateMachineMarkupError {
     MissingStackPop { from: String, on: String },
     /// Transducer transitions must use an explicit matcher event.
     MissingTransducerMatcher { from: String },
+    /// One transition declared both `on` and `matcher`.
+    ConflictingTransitionMatchers { from: String },
     /// Transducer transitions must have exactly one target.
     InvalidTransducerTargetCount { from: String },
     /// EOF transitions cannot consume input.
     ConsumingEndTransition { from: String },
+    /// A lexer matcher object is malformed.
+    InvalidMatcher { context: String, message: String },
+    /// The declared lexer done state must be final.
+    DoneStateNotFinal { state: String },
 }
 
 impl fmt::Display for StateMachineMarkupError {
@@ -177,13 +206,29 @@ impl fmt::Display for StateMachineMarkupError {
                 write!(f, "unsupported State Machine Markup format `{found}`")
             }
             Self::UnknownKind { kind } => write!(f, "unknown machine kind `{kind}`"),
+            Self::UnknownProfile { profile } => write!(f, "unknown machine profile `{profile}`"),
             Self::UnsupportedKind { kind } => {
                 write!(
                     f,
                     "machine kind `{kind}` is not supported by the phase 1 reader"
                 )
             }
+            Self::ProfileKindMismatch { profile, kind } => write!(
+                f,
+                "profile `{profile}` is incompatible with machine kind `{kind}`"
+            ),
             Self::DuplicateState { id } => write!(f, "state `{id}` is declared more than once"),
+            Self::DuplicateToken { id } => write!(f, "token `{id}` is declared more than once"),
+            Self::DuplicateTokenField { token, field } => {
+                write!(f, "token `{token}` repeats field `{field}`")
+            }
+            Self::DuplicateInput { id } => {
+                write!(f, "input class `{id}` is declared more than once")
+            }
+            Self::DuplicateRegister { id } => {
+                write!(f, "register `{id}` is declared more than once")
+            }
+            Self::DuplicateGuard { id } => write!(f, "guard `{id}` is declared more than once"),
             Self::EmptyIdentifier { field } => write!(f, "`{field}` must not be empty"),
             Self::UnknownState { field, state } => {
                 write!(f, "`{field}` references unknown state `{state}`")
@@ -196,6 +241,14 @@ impl fmt::Display for StateMachineMarkupError {
                     f,
                     "`{field}` uses stack symbol `{symbol}` outside the stack alphabet"
                 )
+            }
+            Self::UnknownInputClass { id } => {
+                write!(f, "matcher references unknown input class `{id}`")
+            }
+            Self::UnknownGuard { id } => write!(f, "transition references unknown guard `{id}`"),
+            Self::UnknownToken { id } => write!(f, "action references unknown token `{id}`"),
+            Self::UnknownAction { action } => {
+                write!(f, "unknown lexer action `{action}`")
             }
             Self::DuplicateArrayValue { field, value } => {
                 write!(f, "`{field}` repeats value `{value}`")
@@ -239,12 +292,22 @@ impl fmt::Display for StateMachineMarkupError {
                 f,
                 "transducer transition from `{from}` must use `{END_INPUT}` for EOF, not null"
             ),
+            Self::ConflictingTransitionMatchers { from } => write!(
+                f,
+                "transition from `{from}` must not declare both `on` and `matcher`"
+            ),
             Self::InvalidTransducerTargetCount { from } => write!(
                 f,
                 "transducer transition from `{from}` must have exactly one target"
             ),
             Self::ConsumingEndTransition { from } => {
                 write!(f, "EOF transition from `{from}` must not consume input")
+            }
+            Self::InvalidMatcher { context, message } => {
+                write!(f, "{context} has invalid matcher: {message}")
+            }
+            Self::DoneStateNotFinal { state } => {
+                write!(f, "done state `{state}` must be marked final")
             }
         }
     }
@@ -264,6 +327,23 @@ pub fn from_states_toml(source: &str) -> Result<StateMachineDefinition> {
 
 /// Validate a typed definition using the phase 1 DFA, NFA, PDA, and transducer rules.
 pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
+    match definition.profile.as_deref() {
+        None => {}
+        Some("lexer/v1") => {
+            if definition.kind != MachineKind::Transducer {
+                return Err(StateMachineMarkupError::ProfileKindMismatch {
+                    profile: "lexer/v1".to_string(),
+                    kind: definition.kind.as_str().to_string(),
+                });
+            }
+        }
+        Some(profile) => {
+            return Err(StateMachineMarkupError::UnknownProfile {
+                profile: profile.to_string(),
+            })
+        }
+    }
+
     match definition.kind {
         MachineKind::Dfa | MachineKind::Nfa | MachineKind::Pda | MachineKind::Transducer => {}
         _ => {
@@ -379,10 +459,15 @@ pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
                 });
             }
         }
+        if transition.on.is_some() && transition.matcher.is_some() {
+            return Err(StateMachineMarkupError::ConflictingTransitionMatchers {
+                from: transition.from.clone(),
+            });
+        }
         if let Some(event) = &transition.on {
             let transducer_builtin = matches!(definition.kind, MachineKind::Transducer)
                 && (event == ANY_INPUT || event == END_INPUT);
-            if !transducer_builtin && !alphabet.contains(event) {
+            if !transducer_builtin && transition.matcher.is_none() && !alphabet.contains(event) {
                 return Err(StateMachineMarkupError::UnknownAlphabetSymbol {
                     symbol: event.clone(),
                 });
@@ -405,7 +490,229 @@ pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
         }
     }
 
+    if definition.profile.as_deref() == Some("lexer/v1") {
+        validate_lexer_profile(definition, &state_ids)?;
+    }
+
     Ok(())
+}
+
+fn validate_lexer_profile(
+    definition: &StateMachineDefinition,
+    state_ids: &HashSet<String>,
+) -> Result<()> {
+    let mut token_names = HashSet::new();
+    for token in &definition.tokens {
+        if token.name.is_empty() {
+            return Err(StateMachineMarkupError::EmptyIdentifier {
+                field: "tokens.name".to_string(),
+            });
+        }
+        if !token_names.insert(token.name.clone()) {
+            return Err(StateMachineMarkupError::DuplicateToken {
+                id: token.name.clone(),
+            });
+        }
+        let mut field_names = HashSet::new();
+        for field in &token.fields {
+            if field.is_empty() {
+                return Err(StateMachineMarkupError::EmptyIdentifier {
+                    field: "tokens.fields".to_string(),
+                });
+            }
+            if !field_names.insert(field.clone()) {
+                return Err(StateMachineMarkupError::DuplicateTokenField {
+                    token: token.name.clone(),
+                    field: field.clone(),
+                });
+            }
+        }
+    }
+
+    let mut input_ids = HashSet::new();
+    for input in &definition.inputs {
+        if input.id.is_empty() {
+            return Err(StateMachineMarkupError::EmptyIdentifier {
+                field: "inputs.id".to_string(),
+            });
+        }
+        if !input_ids.insert(input.id.clone()) {
+            return Err(StateMachineMarkupError::DuplicateInput {
+                id: input.id.clone(),
+            });
+        }
+    }
+
+    let mut register_ids = HashSet::new();
+    for register in &definition.registers {
+        if register.id.is_empty() {
+            return Err(StateMachineMarkupError::EmptyIdentifier {
+                field: "registers.id".to_string(),
+            });
+        }
+        if register.type_name.is_empty() {
+            return Err(StateMachineMarkupError::EmptyIdentifier {
+                field: "registers.type".to_string(),
+            });
+        }
+        if !register_ids.insert(register.id.clone()) {
+            return Err(StateMachineMarkupError::DuplicateRegister {
+                id: register.id.clone(),
+            });
+        }
+    }
+
+    let mut guard_ids = HashSet::new();
+    for guard in &definition.guards {
+        if guard.id.is_empty() {
+            return Err(StateMachineMarkupError::EmptyIdentifier {
+                field: "guards.id".to_string(),
+            });
+        }
+        if !guard_ids.insert(guard.id.clone()) {
+            return Err(StateMachineMarkupError::DuplicateGuard {
+                id: guard.id.clone(),
+            });
+        }
+    }
+
+    if let Some(done) = &definition.done {
+        if !state_ids.contains(done) {
+            return Err(StateMachineMarkupError::UnknownState {
+                field: "done".to_string(),
+                state: done.clone(),
+            });
+        }
+        let is_final = definition
+            .states
+            .iter()
+            .find(|state| &state.id == done)
+            .map(|state| state.final_state)
+            .unwrap_or(false);
+        if !is_final {
+            return Err(StateMachineMarkupError::DoneStateNotFinal {
+                state: done.clone(),
+            });
+        }
+    }
+
+    for input in &definition.inputs {
+        validate_matcher(&input.matcher, &input_ids, &format!("inputs.{}", input.id))?;
+    }
+    for transition in &definition.transitions {
+        if let Some(matcher) = &transition.matcher {
+            validate_matcher(
+                matcher,
+                &input_ids,
+                &format!("transitions.from={}", transition.from),
+            )?;
+        }
+        if let Some(guard) = &transition.guard {
+            if !guard_ids.contains(guard) {
+                return Err(StateMachineMarkupError::UnknownGuard { id: guard.clone() });
+            }
+        }
+        for action in &transition.actions {
+            validate_action(action, &token_names)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_matcher(
+    matcher: &MatcherDefinition,
+    input_ids: &HashSet<String>,
+    context: &str,
+) -> Result<()> {
+    match matcher {
+        MatcherDefinition::Literal(value) => {
+            if value.is_empty() {
+                return Err(StateMachineMarkupError::InvalidMatcher {
+                    context: context.to_string(),
+                    message: "literal matcher must not be empty".to_string(),
+                });
+            }
+        }
+        MatcherDefinition::Eof | MatcherDefinition::Anything => {}
+        MatcherDefinition::Class(id) => {
+            if !input_ids.contains(id) {
+                return Err(StateMachineMarkupError::UnknownInputClass { id: id.clone() });
+            }
+        }
+        MatcherDefinition::OneOf(value) => {
+            if value.is_empty() {
+                return Err(StateMachineMarkupError::InvalidMatcher {
+                    context: context.to_string(),
+                    message: "`one_of` must not be empty".to_string(),
+                });
+            }
+        }
+        MatcherDefinition::Range { start, end } => {
+            if start.is_empty() || end.is_empty() {
+                return Err(StateMachineMarkupError::InvalidMatcher {
+                    context: context.to_string(),
+                    message: "`range` requires two non-empty bounds".to_string(),
+                });
+            }
+        }
+        MatcherDefinition::AnyOfClasses(ids) => {
+            if ids.is_empty() {
+                return Err(StateMachineMarkupError::InvalidMatcher {
+                    context: context.to_string(),
+                    message: "`any_of_classes` must not be empty".to_string(),
+                });
+            }
+            for id in ids {
+                if !input_ids.contains(id) {
+                    return Err(StateMachineMarkupError::UnknownInputClass { id: id.clone() });
+                }
+            }
+        }
+        MatcherDefinition::Lookahead(inner) => validate_matcher(inner, input_ids, context)?,
+    }
+    Ok(())
+}
+
+fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
+    match action {
+        "flush_text"
+        | "emit_current_as_text"
+        | "append_text_replacement"
+        | "create_start_tag"
+        | "create_end_tag"
+        | "emit_current_token" => return Ok(()),
+        _ => {}
+    }
+
+    if action.starts_with("append_text(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if matches!(
+        action,
+        "append_tag_name(current)" | "append_tag_name(current_lowercase)"
+    ) {
+        return Ok(());
+    }
+    if action.starts_with("parse_error(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("emit(") && action.ends_with(')') {
+        let token = action
+            .trim_start_matches("emit(")
+            .trim_end_matches(')')
+            .trim();
+        if token_names.contains(token) {
+            return Ok(());
+        }
+        return Err(StateMachineMarkupError::UnknownToken {
+            id: token.to_string(),
+        });
+    }
+
+    Err(StateMachineMarkupError::UnknownAction {
+        action: action.to_string(),
+    })
 }
 
 fn validate_dfa_transition(
@@ -539,6 +846,11 @@ struct RawDocument {
     root: HashMap<String, Value>,
     states: Vec<HashMap<String, Value>>,
     transitions: Vec<HashMap<String, Value>>,
+    tokens: Vec<HashMap<String, Value>>,
+    inputs: Vec<HashMap<String, Value>>,
+    registers: Vec<HashMap<String, Value>>,
+    guards: Vec<HashMap<String, Value>>,
+    fixtures: Vec<HashMap<String, Value>>,
 }
 
 impl RawDocument {
@@ -551,11 +863,57 @@ impl RawDocument {
         let kind = parse_kind(&required_string(&self.root, "kind", "root")?)?;
 
         let mut definition = StateMachineDefinition::new(name, kind);
+        definition.version = optional_string(&self.root, "version", "root")?;
+        definition.profile = optional_string(&self.root, "profile", "root")?;
         definition.initial = optional_string(&self.root, "initial", "root")?;
+        definition.done = optional_string(&self.root, "done", "root")?;
         definition.alphabet = optional_array(&self.root, "alphabet", "root")?.unwrap_or_default();
         definition.stack_alphabet =
             optional_array(&self.root, "stack_alphabet", "root")?.unwrap_or_default();
         definition.initial_stack = optional_string(&self.root, "initial_stack", "root")?;
+        definition.runtime_min = optional_string(&self.root, "runtime_min", "root")?;
+        definition.includes = optional_array(&self.root, "includes", "root")?.unwrap_or_default();
+
+        for (index, token) in self.tokens.iter().enumerate() {
+            let table = format!("tokens[{index}]");
+            definition.tokens.push(TokenDefinition {
+                name: required_string(token, "name", &table)?,
+                fields: optional_array(token, "fields", &table)?.unwrap_or_default(),
+            });
+        }
+
+        for (index, input) in self.inputs.iter().enumerate() {
+            let table = format!("inputs[{index}]");
+            let matcher = required_matcher(input, "matcher", &table)?;
+            definition.inputs.push(InputDefinition {
+                id: required_string(input, "id", &table)?,
+                matcher,
+            });
+        }
+
+        for (index, register) in self.registers.iter().enumerate() {
+            let table = format!("registers[{index}]");
+            definition.registers.push(RegisterDefinition {
+                id: required_string(register, "id", &table)?,
+                type_name: required_string(register, "type", &table)?,
+            });
+        }
+
+        for (index, guard) in self.guards.iter().enumerate() {
+            let table = format!("guards[{index}]");
+            definition.guards.push(GuardDefinition {
+                id: required_string(guard, "id", &table)?,
+            });
+        }
+
+        for (index, fixture) in self.fixtures.iter().enumerate() {
+            let table = format!("fixtures[{index}]");
+            definition.fixtures.push(FixtureDefinition {
+                name: required_string(fixture, "name", &table)?,
+                input: required_string(fixture, "input", &table)?,
+                tokens: optional_array(fixture, "tokens", &table)?.unwrap_or_default(),
+            });
+        }
 
         for (index, state) in self.states.iter().enumerate() {
             let table = format!("states[{index}]");
@@ -570,8 +928,10 @@ impl RawDocument {
 
         for (index, transition) in self.transitions.iter().enumerate() {
             let table = format!("transitions[{index}]");
+            let matcher = optional_matcher(transition, "matcher", &table)?;
             let on = optional_string(transition, "on", &table)?
-                .and_then(|event| (event != "epsilon").then_some(event));
+                .and_then(|event| (event != "epsilon").then_some(event))
+                .or_else(|| matcher.as_ref().map(lower_matcher_event));
             let to = match transition.get("to") {
                 Some(Value::String(target)) => vec![target.clone()],
                 Some(Value::Array(targets)) => targets.clone(),
@@ -592,7 +952,9 @@ impl RawDocument {
             definition.transitions.push(TransitionDefinition {
                 from: required_string(transition, "from", &table)?,
                 on,
+                matcher,
                 to,
+                guard: optional_string(transition, "guard", &table)?,
                 stack_pop: optional_string(transition, "stack_pop", &table)?,
                 stack_push: optional_array(transition, "stack_push", &table)?.unwrap_or_default(),
                 actions: optional_array(transition, "actions", &table)?.unwrap_or_default(),
@@ -609,6 +971,7 @@ enum Value {
     String(String),
     Bool(bool),
     Array(Vec<String>),
+    Table(HashMap<String, Value>),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -616,6 +979,11 @@ enum Section {
     Root,
     State(usize),
     Transition(usize),
+    Token(usize),
+    Input(usize),
+    Register(usize),
+    Guard(usize),
+    Fixture(usize),
 }
 
 fn parse_document(source: &str) -> Result<RawDocument> {
@@ -628,9 +996,12 @@ fn parse_document(source: &str) -> Result<RawDocument> {
 
     let mut document = RawDocument::default();
     let mut section = Section::Root;
+    let lines: Vec<&str> = source.lines().collect();
+    let mut line_index = 0;
 
-    for (zero_based_line, raw_line) in source.lines().enumerate() {
-        let line_number = zero_based_line + 1;
+    while line_index < lines.len() {
+        let line_number = line_index + 1;
+        let raw_line = lines[line_index];
         let raw_line = raw_line.trim_end_matches('\r');
         if raw_line.len() > MAX_LINE_BYTES {
             return Err(StateMachineMarkupError::LineTooLong {
@@ -643,6 +1014,7 @@ fn parse_document(source: &str) -> Result<RawDocument> {
         let without_comment = strip_comment(raw_line);
         let line = without_comment.trim();
         if line.is_empty() {
+            line_index += 1;
             continue;
         }
 
@@ -662,6 +1034,26 @@ fn parse_document(source: &str) -> Result<RawDocument> {
                     document.states.push(HashMap::new());
                     section = Section::State(document.states.len() - 1);
                 }
+                "tokens" => {
+                    document.tokens.push(HashMap::new());
+                    section = Section::Token(document.tokens.len() - 1);
+                }
+                "inputs" => {
+                    document.inputs.push(HashMap::new());
+                    section = Section::Input(document.inputs.len() - 1);
+                }
+                "registers" => {
+                    document.registers.push(HashMap::new());
+                    section = Section::Register(document.registers.len() - 1);
+                }
+                "guards" => {
+                    document.guards.push(HashMap::new());
+                    section = Section::Guard(document.guards.len() - 1);
+                }
+                "fixtures" => {
+                    document.fixtures.push(HashMap::new());
+                    section = Section::Fixture(document.fixtures.len() - 1);
+                }
                 "transitions" => {
                     if document.transitions.len() >= MAX_TRANSITIONS {
                         return Err(StateMachineMarkupError::TooManyTransitions {
@@ -679,6 +1071,7 @@ fn parse_document(source: &str) -> Result<RawDocument> {
                     })
                 }
             }
+            line_index += 1;
             continue;
         }
 
@@ -689,8 +1082,10 @@ fn parse_document(source: &str) -> Result<RawDocument> {
             });
         }
 
+        let (statement, consumed_until) = collect_statement(&lines, line_index)?;
         let (key, value_source) =
-            line.split_once('=')
+            statement
+                .split_once('=')
                 .ok_or_else(|| StateMachineMarkupError::Parse {
                     line: line_number,
                     column: 1,
@@ -735,6 +1130,7 @@ fn parse_document(source: &str) -> Result<RawDocument> {
                 line: line_number,
             });
         }
+        line_index = consumed_until + 1;
     }
 
     Ok(document)
@@ -745,6 +1141,11 @@ fn fields_for_section(document: &mut RawDocument, section: Section) -> &mut Hash
         Section::Root => &mut document.root,
         Section::State(index) => &mut document.states[index],
         Section::Transition(index) => &mut document.transitions[index],
+        Section::Token(index) => &mut document.tokens[index],
+        Section::Input(index) => &mut document.inputs[index],
+        Section::Register(index) => &mut document.registers[index],
+        Section::Guard(index) => &mut document.guards[index],
+        Section::Fixture(index) => &mut document.fixtures[index],
     }
 }
 
@@ -753,6 +1154,11 @@ fn section_name(section: Section) -> String {
         Section::Root => "root".to_string(),
         Section::State(index) => format!("states[{index}]"),
         Section::Transition(index) => format!("transitions[{index}]"),
+        Section::Token(index) => format!("tokens[{index}]"),
+        Section::Input(index) => format!("inputs[{index}]"),
+        Section::Register(index) => format!("registers[{index}]"),
+        Section::Guard(index) => format!("guards[{index}]"),
+        Section::Fixture(index) => format!("fixtures[{index}]"),
     }
 }
 
@@ -763,46 +1169,148 @@ fn field_allowed(section: Section, field: &str) -> bool {
             "format"
                 | "name"
                 | "kind"
+                | "version"
+                | "profile"
                 | "initial"
+                | "done"
                 | "alphabet"
                 | "stack_alphabet"
                 | "initial_stack"
+                | "runtime_min"
+                | "includes"
         ),
         Section::State(_) => matches!(
             field,
             "id" | "initial" | "accepting" | "final" | "external_entry"
         ),
+        Section::Token(_) => matches!(field, "name" | "fields"),
+        Section::Input(_) => matches!(field, "id" | "matcher"),
+        Section::Register(_) => matches!(field, "id" | "type"),
+        Section::Guard(_) => matches!(field, "id"),
+        Section::Fixture(_) => matches!(field, "name" | "input" | "tokens"),
         Section::Transition(_) => {
             matches!(
                 field,
-                "from" | "on" | "to" | "stack_pop" | "stack_push" | "actions" | "consume"
+                "from"
+                    | "on"
+                    | "matcher"
+                    | "to"
+                    | "guard"
+                    | "stack_pop"
+                    | "stack_push"
+                    | "actions"
+                    | "consume"
             )
         }
     }
 }
 
-fn parse_value(source: &str, line: usize) -> Result<Value> {
-    if source.starts_with('"') {
-        let (value, rest) = parse_quoted_string(source, line)?;
-        require_empty(rest, line)?;
-        return Ok(Value::String(value));
+fn collect_statement(lines: &[&str], start_index: usize) -> Result<(String, usize)> {
+    let mut statement = strip_comment(lines[start_index].trim_end_matches('\r'))
+        .trim()
+        .to_string();
+    let mut current = start_index;
+
+    while !value_is_closed(&statement) {
+        current += 1;
+        if current >= lines.len() {
+            return parse_error(start_index + 1, 1, "value is not closed");
+        }
+        let raw_line = lines[current].trim_end_matches('\r');
+        if raw_line.len() > MAX_LINE_BYTES {
+            return Err(StateMachineMarkupError::LineTooLong {
+                line: current + 1,
+                len: raw_line.len(),
+                max: MAX_LINE_BYTES,
+            });
+        }
+        let stripped = strip_comment(raw_line).trim();
+        statement.push('\n');
+        statement.push_str(stripped);
     }
-    if source.starts_with('[') {
-        return Ok(Value::Array(parse_array(source, line)?));
-    }
-    match source {
-        "true" => Ok(Value::Bool(true)),
-        "false" => Ok(Value::Bool(false)),
-        "" => parse_error(line, 1, "missing value"),
-        _ => parse_error(
-            line,
-            1,
-            "expected a basic string, boolean, or string array value",
-        ),
-    }
+
+    Ok((statement, current))
 }
 
-fn parse_array(source: &str, line: usize) -> Result<Vec<String>> {
+fn value_is_closed(statement: &str) -> bool {
+    let Some((_, value)) = statement.split_once('=') else {
+        return true;
+    };
+
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+
+    for ch in value.trim().chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    !in_string && bracket_depth == 0 && brace_depth == 0
+}
+
+fn parse_value(source: &str, line: usize) -> Result<Value> {
+    let (value, rest) = parse_value_prefix(source, line)?;
+    require_empty(rest, line)?;
+    Ok(value)
+}
+
+fn parse_value_prefix(source: &str, line: usize) -> Result<(Value, &str)> {
+    let source = source.trim_start();
+    if source.starts_with('"') {
+        let (value, rest) = parse_quoted_string(source, line)?;
+        return Ok((Value::String(value), rest));
+    }
+    if source.starts_with('[') {
+        let (values, rest) = parse_array_prefix(source, line)?;
+        return Ok((Value::Array(values), rest));
+    }
+    if source.starts_with('{') {
+        let (table, rest) = parse_inline_table_prefix(source, line)?;
+        return Ok((Value::Table(table), rest));
+    }
+    if let Some(rest) = source.strip_prefix("true") {
+        if rest.chars().next().is_none_or(is_value_boundary) {
+            return Ok((Value::Bool(true), rest));
+        }
+    }
+    if let Some(rest) = source.strip_prefix("false") {
+        if rest.chars().next().is_none_or(is_value_boundary) {
+            return Ok((Value::Bool(false), rest));
+        }
+    }
+    if source.is_empty() {
+        return parse_error(line, 1, "missing value");
+    }
+    parse_error(
+        line,
+        1,
+        "expected a basic string, boolean, string array, or inline table value",
+    )
+}
+
+fn is_value_boundary(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, ',' | '}' | ']')
+}
+
+fn parse_array_prefix(source: &str, line: usize) -> Result<(Vec<String>, &str)> {
     let mut rest = source
         .strip_prefix('[')
         .ok_or_else(|| StateMachineMarkupError::Parse {
@@ -815,8 +1323,7 @@ fn parse_array(source: &str, line: usize) -> Result<Vec<String>> {
     loop {
         rest = rest.trim_start();
         if let Some(after_end) = rest.strip_prefix(']') {
-            require_empty(after_end, line)?;
-            return Ok(values);
+            return Ok((values, after_end));
         }
         if values.len() >= MAX_ARRAY_ITEMS {
             return Err(StateMachineMarkupError::TooManyArrayItems {
@@ -836,10 +1343,64 @@ fn parse_array(source: &str, line: usize) -> Result<Vec<String>> {
             continue;
         }
         if let Some(after_end) = rest.strip_prefix(']') {
-            require_empty(after_end, line)?;
-            return Ok(values);
+            return Ok((values, after_end));
         }
         return parse_error(line, 1, "expected `,` or `]` after array item");
+    }
+}
+
+fn parse_inline_table_prefix(source: &str, line: usize) -> Result<(HashMap<String, Value>, &str)> {
+    let mut rest = source
+        .strip_prefix('{')
+        .ok_or_else(|| StateMachineMarkupError::Parse {
+            line,
+            column: 1,
+            message: "inline table must start with `{`".to_string(),
+        })?;
+    let mut fields = HashMap::new();
+
+    loop {
+        rest = rest.trim_start();
+        if let Some(after_end) = rest.strip_prefix('}') {
+            return Ok((fields, after_end));
+        }
+
+        let Some((key_source, after_key)) = rest.split_once('=') else {
+            return parse_error(line, 1, "inline table entry must be `key = value`");
+        };
+        let key = key_source.trim();
+        if key.is_empty() {
+            return parse_error(line, 1, "inline table key must not be empty");
+        }
+        if !key
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        {
+            return parse_error(
+                line,
+                1,
+                "inline table keys may contain only ASCII letters, digits, and underscores",
+            );
+        }
+
+        let (value, after_value) = parse_value_prefix(after_key.trim_start(), line)?;
+        if fields.insert(key.to_string(), value).is_some() {
+            return Err(StateMachineMarkupError::DuplicateKey {
+                table: "inline_table".to_string(),
+                field: key.to_string(),
+                line,
+            });
+        }
+
+        rest = after_value.trim_start();
+        if let Some(after_comma) = rest.strip_prefix(',') {
+            rest = after_comma;
+            continue;
+        }
+        if let Some(after_end) = rest.strip_prefix('}') {
+            return Ok((fields, after_end));
+        }
+        return parse_error(line, 1, "expected `,` or `}` after inline table entry");
     }
 }
 
@@ -995,6 +1556,90 @@ fn optional_array(
             expected: "a string array".to_string(),
         }),
         None => Ok(None),
+    }
+}
+
+fn required_matcher(
+    fields: &HashMap<String, Value>,
+    field: &str,
+    table: &str,
+) -> Result<MatcherDefinition> {
+    optional_matcher(fields, field, table)?.ok_or_else(|| StateMachineMarkupError::MissingField {
+        table: table.to_string(),
+        field: field.to_string(),
+    })
+}
+
+fn optional_matcher(
+    fields: &HashMap<String, Value>,
+    field: &str,
+    table: &str,
+) -> Result<Option<MatcherDefinition>> {
+    match fields.get(field) {
+        Some(Value::Table(value)) => Ok(Some(parse_matcher_table(value, table)?)),
+        Some(_) => Err(StateMachineMarkupError::InvalidField {
+            table: table.to_string(),
+            field: field.to_string(),
+            expected: "an inline table".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+fn parse_matcher_table(
+    fields: &HashMap<String, Value>,
+    context: &str,
+) -> Result<MatcherDefinition> {
+    if fields.len() != 1 {
+        return Err(StateMachineMarkupError::InvalidMatcher {
+            context: context.to_string(),
+            message: "matcher tables must contain exactly one key".to_string(),
+        });
+    }
+    let (kind, value) = fields.iter().next().expect("checked len == 1");
+    match (kind.as_str(), value) {
+        ("literal", Value::String(value)) => Ok(MatcherDefinition::Literal(value.clone())),
+        ("eof", Value::Bool(true)) => Ok(MatcherDefinition::Eof),
+        ("anything", Value::Bool(true)) => Ok(MatcherDefinition::Anything),
+        ("class", Value::String(value)) => Ok(MatcherDefinition::Class(value.clone())),
+        ("one_of", Value::String(value)) => Ok(MatcherDefinition::OneOf(value.clone())),
+        ("range", Value::Array(values)) if values.len() == 2 => Ok(MatcherDefinition::Range {
+            start: values[0].clone(),
+            end: values[1].clone(),
+        }),
+        ("any_of_classes", Value::Array(values)) => {
+            Ok(MatcherDefinition::AnyOfClasses(values.clone()))
+        }
+        ("lookahead", Value::Table(value)) => Ok(MatcherDefinition::Lookahead(Box::new(
+            parse_matcher_table(value, context)?,
+        ))),
+        ("eof", Value::Bool(false)) | ("anything", Value::Bool(false)) => {
+            Err(StateMachineMarkupError::InvalidMatcher {
+                context: context.to_string(),
+                message: format!("`{kind}` must be true when present"),
+            })
+        }
+        _ => Err(StateMachineMarkupError::InvalidMatcher {
+            context: context.to_string(),
+            message: format!("unsupported matcher entry `{kind}`"),
+        }),
+    }
+}
+
+fn lower_matcher_event(matcher: &MatcherDefinition) -> String {
+    match matcher {
+        MatcherDefinition::Literal(value) => value.clone(),
+        MatcherDefinition::Eof => END_INPUT.to_string(),
+        MatcherDefinition::Anything => ANY_INPUT.to_string(),
+        MatcherDefinition::Class(id) => format!("$class:{id}"),
+        MatcherDefinition::OneOf(value) => format!("$one_of:{value}"),
+        MatcherDefinition::Range { start, end } => format!("$range:{start}..{end}"),
+        MatcherDefinition::AnyOfClasses(ids) => {
+            format!("$any_of_classes:{}", ids.join(","))
+        }
+        MatcherDefinition::Lookahead(inner) => {
+            format!("$lookahead:{}", lower_matcher_event(inner))
+        }
     }
 }
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -930,8 +930,7 @@ impl RawDocument {
             let table = format!("transitions[{index}]");
             let matcher = optional_matcher(transition, "matcher", &table)?;
             let on = optional_string(transition, "on", &table)?
-                .and_then(|event| (event != "epsilon").then_some(event))
-                .or_else(|| matcher.as_ref().map(lower_matcher_event));
+                .and_then(|event| (event != "epsilon").then_some(event));
             let to = match transition.get("to") {
                 Some(Value::String(target)) => vec![target.clone()],
                 Some(Value::Array(targets)) => targets.clone(),
@@ -1623,23 +1622,6 @@ fn parse_matcher_table(
             context: context.to_string(),
             message: format!("unsupported matcher entry `{kind}`"),
         }),
-    }
-}
-
-fn lower_matcher_event(matcher: &MatcherDefinition) -> String {
-    match matcher {
-        MatcherDefinition::Literal(value) => value.clone(),
-        MatcherDefinition::Eof => END_INPUT.to_string(),
-        MatcherDefinition::Anything => ANY_INPUT.to_string(),
-        MatcherDefinition::Class(id) => format!("$class:{id}"),
-        MatcherDefinition::OneOf(value) => format!("$one_of:{value}"),
-        MatcherDefinition::Range { start, end } => format!("$range:{start}..{end}"),
-        MatcherDefinition::AnyOfClasses(ids) => {
-            format!("$any_of_classes:{}", ids.join(","))
-        }
-        MatcherDefinition::Lookahead(inner) => {
-            format!("$lookahead:{}", lower_matcher_event(inner))
-        }
     }
 }
 

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use state_machine::{
     MachineKind, MatcherDefinition, PDATransition, PushdownAutomaton, StateDefinition,
-    StateMachineDefinition, TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
+    StateMachineDefinition, TransitionDefinition, DFA, EPSILON, NFA,
 };
 use state_machine_markup_deserializer::{
     from_states_toml, validate_definition, StateMachineMarkupError, STATE_MACHINE_MARKUP_FORMAT,
@@ -94,7 +94,7 @@ fn lexer_profile_html_skeleton_toml_parses_into_typed_definition() {
 
     let first = &definition.transitions[0];
     assert_eq!(first.from, "data");
-    assert_eq!(first.on.as_deref(), Some("<"));
+    assert_eq!(first.on, None);
     assert_eq!(
         first.matcher,
         Some(MatcherDefinition::Literal("<".to_string()))
@@ -103,9 +103,9 @@ fn lexer_profile_html_skeleton_toml_parses_into_typed_definition() {
     let eof = definition
         .transitions
         .iter()
-        .find(|transition| transition.on.as_deref() == Some(END_INPUT))
+        .find(|transition| transition.matcher == Some(MatcherDefinition::Eof))
         .unwrap();
-    assert_eq!(eof.matcher, Some(MatcherDefinition::Eof));
+    assert_eq!(eof.on, None);
     assert!(!eof.consume);
 }
 
@@ -399,7 +399,7 @@ format = "state-machine/v1"
 name = "guarded"
 kind = "dfa"
 
-[[guards]]
+[[modes]]
 id = "never"
 "#;
     assert!(matches!(

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use state_machine::{
-    MachineKind, PDATransition, PushdownAutomaton, StateDefinition, StateMachineDefinition,
-    TransitionDefinition, DFA, EPSILON, NFA,
+    MachineKind, MatcherDefinition, PDATransition, PushdownAutomaton, StateDefinition,
+    StateMachineDefinition, TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
 };
 use state_machine_markup_deserializer::{
     from_states_toml, validate_definition, StateMachineMarkupError, STATE_MACHINE_MARKUP_FORMAT,
@@ -31,6 +31,9 @@ initial = true
     )
 }
 
+const HTML_SKELETON_LEXER_TOML: &str =
+    include_str!("../../html-lexer/html-skeleton.lexer.states.toml");
+
 #[test]
 fn dfa_serializer_output_round_trips_through_deserializer() {
     let dfa = DFA::new(
@@ -58,6 +61,87 @@ fn dfa_serializer_output_round_trips_through_deserializer() {
 
     assert_eq!(parsed.to_states_toml(), toml);
     assert!(imported.accepts(&["coin"]));
+}
+
+#[test]
+fn lexer_profile_html_skeleton_toml_parses_into_typed_definition() {
+    let definition = from_states_toml(HTML_SKELETON_LEXER_TOML).unwrap();
+
+    assert_eq!(definition.profile.as_deref(), Some("lexer/v1"));
+    assert_eq!(definition.version.as_deref(), Some("0.1.0"));
+    assert_eq!(
+        definition.runtime_min.as_deref(),
+        Some("state-machine-tokenizer/0.1")
+    );
+    assert_eq!(definition.done.as_deref(), Some("done"));
+    assert_eq!(
+        definition
+            .tokens
+            .iter()
+            .map(|token| token.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Text", "StartTag", "EndTag", "EOF"]
+    );
+    assert_eq!(
+        definition
+            .registers
+            .iter()
+            .map(|register| (register.id.as_str(), register.type_name.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("text_buffer", "string"), ("current_token", "token?")]
+    );
+    assert_eq!(definition.fixtures.len(), 2);
+
+    let first = &definition.transitions[0];
+    assert_eq!(first.from, "data");
+    assert_eq!(first.on.as_deref(), Some("<"));
+    assert_eq!(
+        first.matcher,
+        Some(MatcherDefinition::Literal("<".to_string()))
+    );
+
+    let eof = definition
+        .transitions
+        .iter()
+        .find(|transition| transition.on.as_deref() == Some(END_INPUT))
+        .unwrap();
+    assert_eq!(eof.matcher, Some(MatcherDefinition::Eof));
+    assert!(!eof.consume);
+}
+
+#[test]
+fn lexer_profile_rejects_unknown_input_classes_and_tokens() {
+    let source = r#"
+format = "state-machine/v1"
+profile = "lexer/v1"
+name = "bad-lexer"
+kind = "transducer"
+initial = "data"
+
+[[tokens]]
+name = "Text"
+
+[[states]]
+id = "data"
+initial = true
+
+[[states]]
+id = "done"
+final = true
+
+[[transitions]]
+from = "data"
+matcher = { class = "missing" }
+to = "done"
+actions = ["emit(EOF)"]
+"#;
+
+    assert_eq!(
+        from_states_toml(source).unwrap_err(),
+        StateMachineMarkupError::UnknownInputClass {
+            id: "missing".to_string()
+        }
+    );
 }
 
 #[test]

--- a/code/packages/rust/state-machine-markup-json-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-json-deserializer/CHANGELOG.md
@@ -12,3 +12,10 @@ All notable changes to this package will be documented in this file.
   literal event, stack-effect, malformed JSON, and limit-enforcement behavior.
 - Added transition `actions` and `consume` field parsing for transducer
   definitions.
+
+## [Unreleased]
+
+### Added
+
+- Added lexer-profile JSON lowering for root profile metadata, token/input/
+  register/guard/fixture arrays, inline matcher objects, and transition guards.

--- a/code/packages/rust/state-machine-markup-json-deserializer/README.md
+++ b/code/packages/rust/state-machine-markup-json-deserializer/README.md
@@ -16,8 +16,10 @@ JSON files in production. This reader exists for build tools, tests, and source
 compiler pipelines that need to validate canonical snapshots before generating
 static code.
 
-The reader also accepts transducer transition `actions` and `consume` flags,
-then delegates semantic checks to the shared markup validator.
+The reader accepts transducer transition `actions` and `consume` flags, and now
+also lowers lexer-profile metadata such as token/register/input declarations,
+typed matcher objects, fixtures, and transition guards before delegating
+semantic checks to the shared markup validator.
 
 ## Usage
 
@@ -48,11 +50,12 @@ assert!(machine.accepts(&["coin"]));
 
 ## Security Profile
 
-The parser accepts only the phase 1 State Machine Markup JSON profile: objects,
-arrays, strings, booleans, and `null` for transition epsilon. It rejects numbers,
-unknown fields, duplicate object keys, excessive nesting, oversized sources, and
-oversized arrays before returning a typed definition. For transducers, EOF is
-represented by the explicit `$end` matcher rather than JSON `null`.
+The parser accepts only the current bounded State Machine Markup JSON profile:
+objects, arrays, strings, booleans, and `null` for generic transition epsilon.
+It rejects numbers, unknown fields, duplicate object keys, excessive nesting,
+oversized sources, and oversized arrays before returning a typed definition.
+Lexer-profile matchers travel as small JSON objects such as
+`{"literal":"<"}` or `{"eof":true}`.
 
 ## Dependencies
 

--- a/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
@@ -12,7 +12,11 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
-use state_machine::{MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition};
+use state_machine::{
+    FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition,
+    RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition,
+    TransitionDefinition,
+};
 pub use state_machine_markup_deserializer::STATE_MACHINE_MARKUP_FORMAT;
 use state_machine_markup_deserializer::{validate_definition, StateMachineMarkupError};
 
@@ -145,10 +149,20 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
             "format",
             "name",
             "kind",
+            "version",
+            "profile",
             "initial",
+            "done",
             "alphabet",
             "stack_alphabet",
             "initial_stack",
+            "runtime_min",
+            "includes",
+            "tokens",
+            "inputs",
+            "registers",
+            "guards",
+            "fixtures",
             "states",
             "transitions",
         ],
@@ -162,11 +176,71 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
     let name = required_string(&root, "name", "root")?;
     let kind = parse_kind(&required_string(&root, "kind", "root")?)?;
     let mut definition = StateMachineDefinition::new(name, kind);
+    definition.version = optional_string(&root, "version", "root")?;
+    definition.profile = optional_string(&root, "profile", "root")?;
     definition.initial = optional_string(&root, "initial", "root")?;
+    definition.done = optional_string(&root, "done", "root")?;
     definition.alphabet = optional_string_array(&root, "alphabet", "root")?.unwrap_or_default();
     definition.stack_alphabet =
         optional_string_array(&root, "stack_alphabet", "root")?.unwrap_or_default();
     definition.initial_stack = optional_string(&root, "initial_stack", "root")?;
+    definition.runtime_min = optional_string(&root, "runtime_min", "root")?;
+    definition.includes = optional_string_array(&root, "includes", "root")?.unwrap_or_default();
+
+    let tokens = optional_array(&mut root, "tokens", "root")?.unwrap_or_default();
+    for (index, token) in tokens.into_iter().enumerate() {
+        let object = format!("tokens[{index}]");
+        let token = object_fields(token, &object)?;
+        ensure_allowed_fields(&token, &object, &["name", "fields"])?;
+        definition.tokens.push(TokenDefinition {
+            name: required_string(&token, "name", &object)?,
+            fields: optional_string_array(&token, "fields", &object)?.unwrap_or_default(),
+        });
+    }
+
+    let inputs = optional_array(&mut root, "inputs", "root")?.unwrap_or_default();
+    for (index, input) in inputs.into_iter().enumerate() {
+        let object = format!("inputs[{index}]");
+        let input = object_fields(input, &object)?;
+        ensure_allowed_fields(&input, &object, &["id", "matcher"])?;
+        definition.inputs.push(InputDefinition {
+            id: required_string(&input, "id", &object)?,
+            matcher: required_matcher(&input, "matcher", &object)?,
+        });
+    }
+
+    let registers = optional_array(&mut root, "registers", "root")?.unwrap_or_default();
+    for (index, register) in registers.into_iter().enumerate() {
+        let object = format!("registers[{index}]");
+        let register = object_fields(register, &object)?;
+        ensure_allowed_fields(&register, &object, &["id", "type"])?;
+        definition.registers.push(RegisterDefinition {
+            id: required_string(&register, "id", &object)?,
+            type_name: required_string(&register, "type", &object)?,
+        });
+    }
+
+    let guards = optional_array(&mut root, "guards", "root")?.unwrap_or_default();
+    for (index, guard) in guards.into_iter().enumerate() {
+        let object = format!("guards[{index}]");
+        let guard = object_fields(guard, &object)?;
+        ensure_allowed_fields(&guard, &object, &["id"])?;
+        definition.guards.push(GuardDefinition {
+            id: required_string(&guard, "id", &object)?,
+        });
+    }
+
+    let fixtures = optional_array(&mut root, "fixtures", "root")?.unwrap_or_default();
+    for (index, fixture) in fixtures.into_iter().enumerate() {
+        let object = format!("fixtures[{index}]");
+        let fixture = object_fields(fixture, &object)?;
+        ensure_allowed_fields(&fixture, &object, &["name", "input", "tokens"])?;
+        definition.fixtures.push(FixtureDefinition {
+            name: required_string(&fixture, "name", &object)?,
+            input: required_string(&fixture, "input", &object)?,
+            tokens: optional_string_array(&fixture, "tokens", &object)?.unwrap_or_default(),
+        });
+    }
 
     let states = required_array(&mut root, "states", "root")?;
     if states.len() > MAX_STATES {
@@ -208,17 +282,24 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
             &[
                 "from",
                 "on",
+                "matcher",
                 "to",
+                "guard",
                 "stack_pop",
                 "stack_push",
                 "actions",
                 "consume",
             ],
         )?;
+        let matcher = optional_matcher(&transition, "matcher", &object)?;
+        let on = optional_event(&transition, "on", &object)?
+            .or_else(|| matcher.as_ref().map(lower_matcher_event));
         definition.transitions.push(TransitionDefinition {
             from: required_string(&transition, "from", &object)?,
-            on: required_event(&transition, "on", &object)?,
+            on,
+            matcher,
             to: required_targets(&transition, "to", &object)?,
+            guard: optional_string(&transition, "guard", &object)?,
             stack_pop: optional_string(&transition, "stack_pop", &object)?,
             stack_push: optional_string_array(&transition, "stack_push", &object)?
                 .unwrap_or_default(),
@@ -266,6 +347,94 @@ fn ensure_allowed_fields(
         }
     }
     Ok(())
+}
+
+fn required_matcher(
+    fields: &HashMap<String, JsonValue>,
+    field: &str,
+    object: &str,
+) -> Result<MatcherDefinition> {
+    optional_matcher(fields, field, object)?.ok_or_else(|| {
+        StateMachineMarkupJsonError::MissingField {
+            object: object.to_string(),
+            field: field.to_string(),
+        }
+    })
+}
+
+fn optional_matcher(
+    fields: &HashMap<String, JsonValue>,
+    field: &str,
+    object: &str,
+) -> Result<Option<MatcherDefinition>> {
+    match fields.get(field) {
+        Some(JsonValue::Object(value)) => Ok(Some(parse_matcher_object(value, object)?)),
+        Some(_) => Err(StateMachineMarkupJsonError::InvalidField {
+            object: object.to_string(),
+            field: field.to_string(),
+            expected: "an object".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+fn parse_matcher_object(
+    fields: &Vec<(String, JsonValue)>,
+    object: &str,
+) -> Result<MatcherDefinition> {
+    if fields.len() != 1 {
+        return Err(StateMachineMarkupJsonError::Validation(
+            StateMachineMarkupError::InvalidMatcher {
+                context: object.to_string(),
+                message: "matcher objects must contain exactly one key".to_string(),
+            },
+        ));
+    }
+    let (kind, value) = &fields[0];
+    match (kind.as_str(), value) {
+        ("literal", JsonValue::String(value)) => Ok(MatcherDefinition::Literal(value.clone())),
+        ("eof", JsonValue::Bool(true)) => Ok(MatcherDefinition::Eof),
+        ("anything", JsonValue::Bool(true)) => Ok(MatcherDefinition::Anything),
+        ("class", JsonValue::String(value)) => Ok(MatcherDefinition::Class(value.clone())),
+        ("one_of", JsonValue::String(value)) => Ok(MatcherDefinition::OneOf(value.clone())),
+        ("range", JsonValue::Array(values)) if values.len() == 2 => Ok(MatcherDefinition::Range {
+            start: required_string_from_value(&values[0], object, "range[0]")?,
+            end: required_string_from_value(&values[1], object, "range[1]")?,
+        }),
+        ("any_of_classes", JsonValue::Array(values)) => Ok(MatcherDefinition::AnyOfClasses(
+            values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    required_string_from_value(value, object, &format!("any_of_classes[{index}]"))
+                })
+                .collect::<Result<Vec<_>>>()?,
+        )),
+        ("lookahead", JsonValue::Object(value)) => Ok(MatcherDefinition::Lookahead(Box::new(
+            parse_matcher_object(value, object)?,
+        ))),
+        _ => Err(StateMachineMarkupJsonError::Validation(
+            StateMachineMarkupError::InvalidMatcher {
+                context: object.to_string(),
+                message: format!("unsupported matcher entry `{kind}`"),
+            },
+        )),
+    }
+}
+
+fn lower_matcher_event(matcher: &MatcherDefinition) -> String {
+    match matcher {
+        MatcherDefinition::Literal(value) => value.clone(),
+        MatcherDefinition::Eof => "$end".to_string(),
+        MatcherDefinition::Anything => "$any".to_string(),
+        MatcherDefinition::Class(id) => format!("$class:{id}"),
+        MatcherDefinition::OneOf(value) => format!("$one_of:{value}"),
+        MatcherDefinition::Range { start, end } => format!("$range:{start}..{end}"),
+        MatcherDefinition::AnyOfClasses(ids) => format!("$any_of_classes:{}", ids.join(",")),
+        MatcherDefinition::Lookahead(inner) => {
+            format!("$lookahead:{}", lower_matcher_event(inner))
+        }
+    }
 }
 
 fn required_string(
@@ -338,6 +507,22 @@ fn required_array(
     }
 }
 
+fn optional_array(
+    fields: &mut HashMap<String, JsonValue>,
+    field: &str,
+    object: &str,
+) -> Result<Option<Vec<JsonValue>>> {
+    match fields.remove(field) {
+        Some(JsonValue::Array(values)) => Ok(Some(values)),
+        Some(_) => Err(StateMachineMarkupJsonError::InvalidField {
+            object: object.to_string(),
+            field: field.to_string(),
+            expected: "an array".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
 fn optional_string_array(
     fields: &HashMap<String, JsonValue>,
     field: &str,
@@ -376,7 +561,7 @@ fn optional_string_array(
     }
 }
 
-fn required_event(
+fn optional_event(
     fields: &HashMap<String, JsonValue>,
     field: &str,
     object: &str,
@@ -389,10 +574,7 @@ fn required_event(
             field: field.to_string(),
             expected: "a string or null".to_string(),
         }),
-        None => Err(StateMachineMarkupJsonError::MissingField {
-            object: object.to_string(),
-            field: field.to_string(),
-        }),
+        None => Ok(None),
     }
 }
 
@@ -434,6 +616,17 @@ fn required_targets(
         None => Err(StateMachineMarkupJsonError::MissingField {
             object: object.to_string(),
             field: field.to_string(),
+        }),
+    }
+}
+
+fn required_string_from_value(value: &JsonValue, object: &str, field: &str) -> Result<String> {
+    match value {
+        JsonValue::String(value) => Ok(value.clone()),
+        _ => Err(StateMachineMarkupJsonError::InvalidField {
+            object: object.to_string(),
+            field: field.to_string(),
+            expected: "a string".to_string(),
         }),
     }
 }

--- a/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
@@ -292,8 +292,7 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
             ],
         )?;
         let matcher = optional_matcher(&transition, "matcher", &object)?;
-        let on = optional_event(&transition, "on", &object)?
-            .or_else(|| matcher.as_ref().map(lower_matcher_event));
+        let on = optional_event(&transition, "on", &object)?;
         definition.transitions.push(TransitionDefinition {
             from: required_string(&transition, "from", &object)?,
             on,
@@ -419,21 +418,6 @@ fn parse_matcher_object(
                 message: format!("unsupported matcher entry `{kind}`"),
             },
         )),
-    }
-}
-
-fn lower_matcher_event(matcher: &MatcherDefinition) -> String {
-    match matcher {
-        MatcherDefinition::Literal(value) => value.clone(),
-        MatcherDefinition::Eof => "$end".to_string(),
-        MatcherDefinition::Anything => "$any".to_string(),
-        MatcherDefinition::Class(id) => format!("$class:{id}"),
-        MatcherDefinition::OneOf(value) => format!("$one_of:{value}"),
-        MatcherDefinition::Range { start, end } => format!("$range:{start}..{end}"),
-        MatcherDefinition::AnyOfClasses(ids) => format!("$any_of_classes:{}", ids.join(",")),
-        MatcherDefinition::Lookahead(inner) => {
-            format!("$lookahead:{}", lower_matcher_event(inner))
-        }
     }
 }
 

--- a/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use state_machine::{
-    MachineKind, PDATransition, PushdownAutomaton, StateDefinition, StateMachineDefinition,
-    TransitionDefinition, DFA, EPSILON, NFA,
+    MachineKind, MatcherDefinition, PDATransition, PushdownAutomaton, StateDefinition,
+    StateMachineDefinition, TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
 };
 use state_machine_markup_deserializer::StateMachineMarkupError;
 use state_machine_markup_json_deserializer::{
@@ -36,6 +36,58 @@ fn compact_root(states: &str, transitions: &str) -> String {
     format!(
         r#"{{"format":"state-machine/v1","name":"many","kind":"dfa","initial":"q0","alphabet":["a"],"states":[{states}],"transitions":[{transitions}]}}"#
     )
+}
+
+#[test]
+fn json_deserializer_parses_lexer_profile_matchers_and_sections() {
+    let source = r#"{
+  "format": "state-machine/v1",
+  "profile": "lexer/v1",
+  "name": "html-skeleton-lexer",
+  "kind": "transducer",
+  "version": "0.1.0",
+  "runtime_min": "state-machine-tokenizer/0.1",
+  "initial": "data",
+  "done": "done",
+  "includes": [],
+  "tokens": [
+    {"name": "Text", "fields": ["data"]},
+    {"name": "EOF", "fields": []}
+  ],
+  "registers": [
+    {"id": "text_buffer", "type": "string"}
+  ],
+  "inputs": [
+    {"id": "ascii_alpha", "matcher": {"one_of": "abc"}}
+  ],
+  "states": [
+    {"id": "data", "initial": true},
+    {"id": "done", "final": true}
+  ],
+  "transitions": [
+    {"from": "data", "matcher": {"literal": "<"}, "to": "data", "actions": ["append_text(<)"]},
+    {"from": "data", "matcher": {"eof": true}, "to": "done", "actions": ["emit(EOF)"], "consume": false}
+  ],
+  "fixtures": [
+    {"name": "plain", "input": "", "tokens": ["EOF"]}
+  ]
+}"#;
+
+    let definition = from_states_json(source).unwrap();
+
+    assert_eq!(definition.profile.as_deref(), Some("lexer/v1"));
+    assert_eq!(definition.tokens.len(), 2);
+    assert_eq!(definition.inputs.len(), 1);
+    assert_eq!(definition.fixtures.len(), 1);
+    assert_eq!(
+        definition.transitions[0].matcher,
+        Some(MatcherDefinition::Literal("<".to_string()))
+    );
+    assert_eq!(definition.transitions[1].on.as_deref(), Some(END_INPUT));
+    assert_eq!(
+        definition.transitions[1].matcher,
+        Some(MatcherDefinition::Eof)
+    );
 }
 
 #[test]
@@ -585,7 +637,9 @@ fn manual_definition_serializes_then_deserializes_flags() {
     definition.transitions = vec![TransitionDefinition {
         from: "q0".to_string(),
         on: Some("a".to_string()),
+        matcher: None,
         to: vec!["q0".to_string()],
+        guard: None,
         stack_pop: Some("$".to_string()),
         stack_push: vec!["$".to_string()],
         actions: Vec::new(),

--- a/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
@@ -470,7 +470,7 @@ fn json_deserializer_rejects_type_errors_and_missing_fields() {
 }"#
         )
         .unwrap_err(),
-        StateMachineMarkupJsonError::MissingField { .. }
+        StateMachineMarkupJsonError::Validation(_)
     ));
     assert!(matches!(
         from_states_json(

--- a/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use state_machine::{
     MachineKind, MatcherDefinition, PDATransition, PushdownAutomaton, StateDefinition,
-    StateMachineDefinition, TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
+    StateMachineDefinition, TransitionDefinition, DFA, EPSILON, NFA,
 };
 use state_machine_markup_deserializer::StateMachineMarkupError;
 use state_machine_markup_json_deserializer::{
@@ -83,7 +83,7 @@ fn json_deserializer_parses_lexer_profile_matchers_and_sections() {
         definition.transitions[0].matcher,
         Some(MatcherDefinition::Literal("<".to_string()))
     );
-    assert_eq!(definition.transitions[1].on.as_deref(), Some(END_INPUT));
+    assert_eq!(definition.transitions[1].on, None);
     assert_eq!(
         definition.transitions[1].matcher,
         Some(MatcherDefinition::Eof)

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -204,7 +204,9 @@ fn json_serializer_canonicalizes_set_like_arrays() {
     definition.transitions = vec![TransitionDefinition {
         from: "q0".to_string(),
         on: Some("a".to_string()),
+        matcher: None,
         to: vec!["q2".to_string(), "q1".to_string()],
+        guard: None,
         stack_pop: Some("base".to_string()),
         stack_push: vec!["top".to_string(), "base".to_string()],
         actions: Vec::new(),

--- a/code/packages/rust/state-machine-source-compiler/src/lib.rs
+++ b/code/packages/rust/state-machine-source-compiler/src/lib.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
 
-use state_machine::{MachineKind, StateMachineDefinition, TransitionDefinition};
+use state_machine::{MachineKind, MatcherDefinition, StateMachineDefinition, TransitionDefinition};
 use state_machine_markup_deserializer::{validate_definition, StateMachineMarkupError};
 
 /// Errors that can occur before source text is emitted.
@@ -102,16 +102,16 @@ pub fn to_rust_source(definition: &StateMachineDefinition) -> Result<String> {
     source.push_str("use state_machine::{");
     source.push_str(match definition.kind {
         MachineKind::Dfa => {
-            "DFA, MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition"
+            "DFA, MachineKind, MatcherDefinition, StateDefinition, StateMachineDefinition, TransitionDefinition"
         }
         MachineKind::Nfa => {
-            "MachineKind, NFA, StateDefinition, StateMachineDefinition, TransitionDefinition"
+            "MachineKind, MatcherDefinition, NFA, StateDefinition, StateMachineDefinition, TransitionDefinition"
         }
         MachineKind::Pda => {
-            "MachineKind, PushdownAutomaton, StateDefinition, StateMachineDefinition, TransitionDefinition"
+            "MachineKind, MatcherDefinition, PushdownAutomaton, StateDefinition, StateMachineDefinition, TransitionDefinition"
         }
         MachineKind::Transducer => {
-            "EffectfulStateMachine, MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition"
+            "EffectfulStateMachine, MachineKind, MatcherDefinition, StateDefinition, StateMachineDefinition, TransitionDefinition"
         }
         _ => unreachable!("unsupported kinds are rejected before source emission"),
     });
@@ -276,8 +276,14 @@ fn emit_transitions(source: &mut String, definition: &StateMachineDefinition) {
         source.push_str("            on: ");
         source.push_str(&rust_option_string(&transition.on));
         source.push_str(",\n");
+        source.push_str("            matcher: ");
+        source.push_str(&rust_option_matcher(&transition.matcher, 12));
+        source.push_str(",\n");
         source.push_str("            to: ");
         source.push_str(&rust_string_vec(&transition.to, 12));
+        source.push_str(",\n");
+        source.push_str("            guard: ");
+        source.push_str(&rust_option_string(&transition.guard));
         source.push_str(",\n");
         source.push_str("            stack_pop: ");
         source.push_str(&rust_option_string(&transition.stack_pop));
@@ -299,10 +305,14 @@ fn emit_transitions(source: &mut String, definition: &StateMachineDefinition) {
 fn sorted_transitions(definition: &StateMachineDefinition) -> Vec<TransitionDefinition> {
     let mut transitions = definition.transitions.clone();
     transitions.sort_by(|left, right| {
+        let left_matcher = left.matcher.as_ref().map(matcher_sort_key);
+        let right_matcher = right.matcher.as_ref().map(matcher_sort_key);
         (
             &left.from,
             &left.on,
+            &left_matcher,
             &left.to,
+            &left.guard,
             &left.stack_pop,
             &left.stack_push,
             &left.actions,
@@ -311,7 +321,9 @@ fn sorted_transitions(definition: &StateMachineDefinition) -> Vec<TransitionDefi
             .cmp(&(
                 &right.from,
                 &right.on,
+                &right_matcher,
                 &right.to,
+                &right.guard,
                 &right.stack_pop,
                 &right.stack_push,
                 &right.actions,
@@ -319,6 +331,23 @@ fn sorted_transitions(definition: &StateMachineDefinition) -> Vec<TransitionDefi
             ))
     });
     transitions
+}
+
+fn matcher_sort_key(value: &MatcherDefinition) -> String {
+    match value {
+        MatcherDefinition::Literal(value) => format!("literal:{value}"),
+        MatcherDefinition::Eof => "eof".to_string(),
+        MatcherDefinition::Anything => "anything".to_string(),
+        MatcherDefinition::Class(value) => format!("class:{value}"),
+        MatcherDefinition::OneOf(value) => format!("one_of:{value}"),
+        MatcherDefinition::Range { start, end } => format!("range:{start}..{end}"),
+        MatcherDefinition::AnyOfClasses(values) => {
+            format!("any_of_classes:{}", values.join(","))
+        }
+        MatcherDefinition::Lookahead(inner) => {
+            format!("lookahead:{}", matcher_sort_key(inner))
+        }
+    }
 }
 
 fn machine_kind_variant(definition: &StateMachineDefinition) -> &'static str {
@@ -362,6 +391,42 @@ fn rust_option_string(value: &Option<String>) -> String {
     match value {
         Some(value) => format!("Some({})", rust_to_string_expr(value)),
         None => "None".to_string(),
+    }
+}
+
+fn rust_option_matcher(value: &Option<MatcherDefinition>, indent: usize) -> String {
+    match value {
+        Some(value) => format!("Some({})", rust_matcher_expr(value, indent)),
+        None => "None".to_string(),
+    }
+}
+
+fn rust_matcher_expr(value: &MatcherDefinition, indent: usize) -> String {
+    match value {
+        MatcherDefinition::Literal(value) => {
+            format!("MatcherDefinition::Literal({})", rust_to_string_expr(value))
+        }
+        MatcherDefinition::Eof => "MatcherDefinition::Eof".to_string(),
+        MatcherDefinition::Anything => "MatcherDefinition::Anything".to_string(),
+        MatcherDefinition::Class(value) => {
+            format!("MatcherDefinition::Class({})", rust_to_string_expr(value))
+        }
+        MatcherDefinition::OneOf(value) => {
+            format!("MatcherDefinition::OneOf({})", rust_to_string_expr(value))
+        }
+        MatcherDefinition::Range { start, end } => format!(
+            "MatcherDefinition::Range {{ start: {}, end: {} }}",
+            rust_to_string_expr(start),
+            rust_to_string_expr(end)
+        ),
+        MatcherDefinition::AnyOfClasses(values) => format!(
+            "MatcherDefinition::AnyOfClasses({})",
+            rust_string_vec(values, indent)
+        ),
+        MatcherDefinition::Lookahead(inner) => format!(
+            "MatcherDefinition::Lookahead(Box::new({}))",
+            rust_matcher_expr(inner, indent)
+        ),
     }
 }
 

--- a/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
+++ b/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
@@ -125,7 +125,9 @@ fn transducer_definition_emits_effect_tables_and_constructor() {
     definition.transitions = vec![TransitionDefinition {
         from: "data".to_string(),
         on: Some(END_INPUT.to_string()),
+        matcher: None,
         to: vec!["done".to_string()],
+        guard: None,
         stack_pop: None,
         stack_push: Vec::new(),
         actions: vec!["flush_text".to_string(), "emit(EOF)".to_string()],

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -33,6 +33,10 @@ All notable changes to the `state-machine` crate will be documented in this file
   writers now belong in sibling serializer libraries.
 - Extended `TransitionDefinition` with `actions` and `consume` fields so the
   shared typed definition layer can represent tokenizer/transducer effects.
+- Extended the typed definition layer with profile metadata, lexer token/input/
+  register/fixture declarations, typed matcher objects, and optional transition
+  guards so build-time lexer tooling can lower `.lexer.states.toml` documents
+  without embedding host-language code.
 
 ## [0.1.0] - 2026-03-20
 

--- a/code/packages/rust/state-machine/src/definitions.rs
+++ b/code/packages/rust/state-machine/src/definitions.rs
@@ -49,6 +49,82 @@ impl MachineKind {
     }
 }
 
+/// Named token shape declared by a lexer-profile definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenDefinition {
+    /// Stable token identifier.
+    pub name: String,
+    /// Named fields carried by this token.
+    pub fields: Vec<String>,
+}
+
+impl TokenDefinition {
+    /// Create a token declaration with no fields.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            fields: Vec::new(),
+        }
+    }
+}
+
+/// Typed matcher object used by lexer-profile definitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatcherDefinition {
+    /// Match one literal event or code point.
+    Literal(String),
+    /// Match end-of-input.
+    Eof,
+    /// Match any non-EOF input.
+    Anything,
+    /// Match one named input class.
+    Class(String),
+    /// Match any character from a one-of set.
+    OneOf(String),
+    /// Match any character in the inclusive range.
+    Range { start: String, end: String },
+    /// Match any member of the listed named classes.
+    AnyOfClasses(Vec<String>),
+    /// Match only if the nested matcher succeeds without consuming input.
+    Lookahead(Box<MatcherDefinition>),
+}
+
+/// Named reusable input matcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputDefinition {
+    /// Stable input class identifier.
+    pub id: String,
+    /// Matcher definition lowered from the authoring surface.
+    pub matcher: MatcherDefinition,
+}
+
+/// Named runtime storage slot declared by a lexer-profile definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisterDefinition {
+    /// Stable register identifier.
+    pub id: String,
+    /// Portable register type name.
+    pub type_name: String,
+}
+
+/// Named guard declaration used by transitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuardDefinition {
+    /// Stable guard identifier.
+    pub id: String,
+}
+
+/// Build-time fixture embedded in a lexer-profile definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FixtureDefinition {
+    /// Stable fixture identifier.
+    pub name: String,
+    /// Input text to feed into the lexer.
+    pub input: String,
+    /// Expected token summaries.
+    pub tokens: Vec<String>,
+}
+
 /// A state entry in the typed definition layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StateDefinition {
@@ -84,8 +160,12 @@ pub struct TransitionDefinition {
     pub from: String,
     /// Input event. `None` represents epsilon in the in-memory model.
     pub on: Option<String>,
+    /// Typed matcher lowered from profile-specific authoring formats.
+    pub matcher: Option<MatcherDefinition>,
     /// Target states. DFA/PDA transitions use one target; NFA may use many.
     pub to: Vec<String>,
+    /// Optional named guard call.
+    pub guard: Option<String>,
     /// PDA stack symbol that must be read/popped.
     pub stack_pop: Option<String>,
     /// PDA stack symbols to push, ordered deepest-to-topmost.
@@ -110,7 +190,9 @@ impl TransitionDefinition {
         Self {
             from: from.into(),
             on,
+            matcher: None,
             to,
+            guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: Vec::new(),
@@ -124,16 +206,36 @@ impl TransitionDefinition {
 pub struct StateMachineDefinition {
     /// Human-readable machine name.
     pub name: String,
+    /// Optional authoring artifact version.
+    pub version: Option<String>,
+    /// Optional profile identifier layered on top of the base format.
+    pub profile: Option<String>,
     /// Machine family.
     pub kind: MachineKind,
+    /// Minimum runtime capability string needed by this definition.
+    pub runtime_min: Option<String>,
     /// Input alphabet.
     pub alphabet: Vec<String>,
     /// Stack alphabet for PDA definitions.
     pub stack_alphabet: Vec<String>,
     /// Initial state.
     pub initial: Option<String>,
+    /// Terminal EOF state for lexer-profile documents.
+    pub done: Option<String>,
     /// Initial stack marker for PDA definitions.
     pub initial_stack: Option<String>,
+    /// Build-time include paths.
+    pub includes: Vec<String>,
+    /// Token declarations for lexer-profile documents.
+    pub tokens: Vec<TokenDefinition>,
+    /// Named input classes for lexer-profile documents.
+    pub inputs: Vec<InputDefinition>,
+    /// Register declarations for lexer-profile documents.
+    pub registers: Vec<RegisterDefinition>,
+    /// Guard declarations shared by transitions.
+    pub guards: Vec<GuardDefinition>,
+    /// Inline fixtures for build-time smoke tests.
+    pub fixtures: Vec<FixtureDefinition>,
     /// State declarations.
     pub states: Vec<StateDefinition>,
     /// Transition declarations.
@@ -145,11 +247,21 @@ impl StateMachineDefinition {
     pub fn new(name: impl Into<String>, kind: MachineKind) -> Self {
         Self {
             name: name.into(),
+            version: None,
+            profile: None,
             kind,
+            runtime_min: None,
             alphabet: Vec::new(),
             stack_alphabet: Vec::new(),
             initial: None,
+            done: None,
             initial_stack: None,
+            includes: Vec::new(),
+            tokens: Vec::new(),
+            inputs: Vec::new(),
+            registers: Vec::new(),
+            guards: Vec::new(),
+            fixtures: Vec::new(),
             states: Vec::new(),
             transitions: Vec::new(),
         }

--- a/code/packages/rust/state-machine/src/lib.rs
+++ b/code/packages/rust/state-machine/src/lib.rs
@@ -39,7 +39,11 @@ pub mod pda;
 pub mod transducer;
 pub mod types;
 
-pub use definitions::{MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition};
+pub use definitions::{
+    FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition,
+    RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition,
+    TransitionDefinition,
+};
 pub use dfa::DFA;
 pub use minimize::minimize;
 pub use modal::{ModalStateMachine, ModeTransitionRecord};

--- a/code/packages/rust/state-machine/src/transducer.rs
+++ b/code/packages/rust/state-machine/src/transducer.rs
@@ -9,7 +9,7 @@
 use std::collections::HashSet;
 
 use crate::definitions::{
-    MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition,
+    MachineKind, MatcherDefinition, StateDefinition, StateMachineDefinition, TransitionDefinition,
 };
 
 /// Serialized transition event used for "match any non-EOF input".
@@ -272,16 +272,27 @@ impl EffectfulStateMachine {
                     transition.from
                 ));
             }
-            let matcher = match transition.on.as_deref() {
-                Some(ANY_INPUT) => EffectfulMatcher::Any,
-                Some(END_INPUT) => EffectfulMatcher::End,
-                Some(event) => EffectfulMatcher::Event(event.to_string()),
-                None => {
+            let matcher = match transition.matcher.as_ref() {
+                Some(MatcherDefinition::Literal(event)) => EffectfulMatcher::Event(event.clone()),
+                Some(MatcherDefinition::Anything) => EffectfulMatcher::Any,
+                Some(MatcherDefinition::Eof) => EffectfulMatcher::End,
+                Some(other) => {
                     return Err(format!(
-                        "Transducer transition from '{}' must use `$end` for EOF, not null",
-                        transition.from
+                        "Transducer matcher {:?} is not executable by EffectfulStateMachine yet",
+                        other
                     ))
                 }
+                None => match transition.on.as_deref() {
+                    Some(ANY_INPUT) => EffectfulMatcher::Any,
+                    Some(END_INPUT) => EffectfulMatcher::End,
+                    Some(event) => EffectfulMatcher::Event(event.to_string()),
+                    None => {
+                        return Err(format!(
+                            "Transducer transition from '{}' must use `$end` for EOF, not null",
+                            transition.from
+                        ))
+                    }
+                },
             };
             transitions.push(EffectfulTransition {
                 source: transition.from.clone(),
@@ -317,6 +328,11 @@ impl EffectfulStateMachine {
                     Some(transition.matcher.as_definition_event()),
                     vec![transition.target.clone()],
                 );
+                entry.matcher = Some(match &transition.matcher {
+                    EffectfulMatcher::Event(event) => MatcherDefinition::Literal(event.clone()),
+                    EffectfulMatcher::Any => MatcherDefinition::Anything,
+                    EffectfulMatcher::End => MatcherDefinition::Eof,
+                });
                 entry.actions = transition.effects.clone();
                 entry.consume = transition.consume;
                 entry

--- a/code/packages/rust/state-machine/tests/transducer_test.rs
+++ b/code/packages/rust/state-machine/tests/transducer_test.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use state_machine::{
-    EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulTransition, ANY_INPUT,
+    EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulTransition,
+    MatcherDefinition, StateDefinition, StateMachineDefinition, TransitionDefinition, ANY_INPUT,
     END_INPUT,
 };
 
@@ -158,6 +159,74 @@ fn effectful_machine_round_trips_through_definition_layer() {
         .any(|transition| transition.on.as_deref() == Some(END_INPUT) && !transition.consume));
     assert_eq!(imported.current_state(), "data");
     assert_eq!(imported.transitions().len(), machine.transitions().len());
+}
+
+#[test]
+fn effectful_machine_imports_typed_matcher_definitions() {
+    let mut definition = StateMachineDefinition::new(
+        "typed-html-skeleton",
+        state_machine::MachineKind::Transducer,
+    );
+    definition.alphabet = vec!["<".to_string(), "x".to_string()];
+    definition.initial = Some("data".to_string());
+    definition.states = vec![
+        StateDefinition {
+            initial: true,
+            ..StateDefinition::new("data")
+        },
+        StateDefinition::new("tag_open"),
+        StateDefinition {
+            final_state: true,
+            ..StateDefinition::new("done")
+        },
+    ];
+    definition.transitions = vec![
+        TransitionDefinition {
+            from: "data".to_string(),
+            to: vec!["tag_open".to_string()],
+            on: None,
+            consume: true,
+            actions: vec!["flush_text".to_string()],
+            matcher: Some(MatcherDefinition::Literal("<".to_string())),
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+        },
+        TransitionDefinition {
+            from: "data".to_string(),
+            to: vec!["done".to_string()],
+            on: None,
+            consume: false,
+            actions: vec!["emit(EOF)".to_string()],
+            matcher: Some(MatcherDefinition::Eof),
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+        },
+        TransitionDefinition {
+            from: "tag_open".to_string(),
+            to: vec!["tag_open".to_string()],
+            on: None,
+            consume: true,
+            actions: vec!["append_text(current)".to_string()],
+            matcher: Some(MatcherDefinition::Anything),
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+        },
+    ];
+
+    let mut machine = EffectfulStateMachine::from_definition(&definition).unwrap();
+
+    let open = machine.process(EffectfulInput::event("<")).unwrap();
+    assert!(open.consume);
+    assert_eq!(open.effects, vec!["flush_text".to_string()]);
+    assert_eq!(machine.current_state(), "tag_open");
+
+    let any = machine.process(EffectfulInput::event("x")).unwrap();
+    assert!(any.consume);
+    assert_eq!(any.effects, vec!["append_text(current)".to_string()]);
+    assert_eq!(machine.current_state(), "tag_open");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend the shared Rust state-machine definition layer with lexer-profile metadata, matcher objects, guards, registers, tokens, inputs, and fixtures
- teach the TOML and JSON deserializers to parse `profile = "lexer/v1"`, lower matcher objects into typed definitions, and validate lexer-specific sections and actions
- cover the new lowering path with HTML skeleton fixtures plus a direct transducer import test for typed matcher definitions

Closes #1111.

## Verification
- `cargo fmt -p state-machine -p state-machine-markup-deserializer -p state-machine-markup-json-deserializer -p state-machine-source-compiler`
- `cargo check -p state-machine -p state-machine-markup-deserializer -p state-machine-markup-json-deserializer -p state-machine-markup-serializer -p state-machine-markup-json-serializer -p state-machine-source-compiler -p coding-adventures-html-lexer`
- `cargo test -p state-machine --no-run`
- `cargo test -p state-machine-markup-deserializer --no-run`
- `cargo test -p state-machine-markup-json-deserializer --no-run`
- `cargo test -p state-machine-source-compiler --no-run`
- `git diff --check`

## Notes
- Local execution of freshly built Rust test binaries is still hanging in this environment before harness startup, so I verified successful compilation with `--no-run` rather than waiting on `cargo test` execution.