### PR TITLE
feat(algol): unwind procedure-crossing goto

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -52,7 +52,8 @@ _RUNTIME_HEAP_LIMIT_OFFSET = 16
 _RUNTIME_THUNK_HEAP_MARK_OFFSET = 20
 _RUNTIME_THUNK_FAILURE_OFFSET = 24
 _RUNTIME_THUNK_HELPER_DEPTH_OFFSET = 28
-_RUNTIME_STATE_BYTES = 32
+_RUNTIME_PENDING_GOTO_LABEL_OFFSET = 32
+_RUNTIME_STATE_BYTES = 36
 _STATIC_LINK_PARAM_REG = 2
 _THUNK_HEAP_MARK_PARAM_REG = 3
 _VALUE_PARAM_BASE_REG = 4
@@ -114,6 +115,7 @@ class _FrameScope:
     heap_mark_reg: int | None = None
     parent: _FrameScope | None = None
     goto_parent: _FrameScope | None = None
+    function_owner_procedure_id: int | None = None
     active_thunk_heap_mark_reg: int | None = None
     helper_failure: bool = False
 
@@ -229,6 +231,9 @@ class AlgolIrCompiler:
             label.statement_node_id: label
             for label in type_result.semantic.labels
         }
+        self.labels_by_id = {
+            label.label_id: label for label in type_result.semantic.labels
+        }
         self.labels_by_block_name = {
             (label.declaring_block_id, label.name): label
             for label in type_result.semantic.labels
@@ -342,6 +347,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_THUNK_HEAP_MARK_OFFSET, _ZERO_REG)
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
         self._store_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, _ZERO_REG)
+        self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)
 
         block = _first_node(type_result.ast, "block")
         if block is None:
@@ -386,6 +392,9 @@ class AlgolIrCompiler:
             heap_mark_reg=heap_mark_reg,
             parent=parent,
             goto_parent=parent,
+            function_owner_procedure_id=(
+                parent.function_owner_procedure_id if parent is not None else None
+            ),
             active_thunk_heap_mark_reg=(
                 parent.active_thunk_heap_mark_reg if parent is not None else None
             ),
@@ -704,16 +713,6 @@ class AlgolIrCompiler:
         desig_expr = _first_direct_node(node, "desig_expr")
         if desig_expr is None:
             raise CompileError("goto statement is missing a designational expression")
-        resolved = self.gotos_by_designational.get(id(desig_expr))
-        if resolved is None:
-            raise CompileError("goto designational expression was not resolved")
-        simple = _first_direct_node(desig_expr, "simple_desig")
-        if (
-            not any(token.value == "if" for token in _direct_tokens(desig_expr))
-            and _direct_label_from_simple_designational(simple) is not None
-        ):
-            self._emit_resolved_goto(resolved, scope)
-            return
         self._compile_designational(desig_expr, scope)
 
     def _compile_designational(self, node: ASTNode, scope: _FrameScope) -> None:
@@ -749,10 +748,10 @@ class AlgolIrCompiler:
     ) -> None:
         direct = _direct_label_from_simple_designational(node)
         if direct is not None:
-            label = self.labels_by_block_name.get((scope.block_id, direct.value))
+            label = self._resolve_label_in_scope_chain(direct.value, scope)
             if label is None:
                 raise CompileError(f"goto target {direct.value!r} was not resolved")
-            self._emit(IrOp.JUMP, IrLabel(label.ir_label))
+            self._emit_goto_label(label, scope)
             return
 
         if any(token.value == "[" for token in _direct_tokens(node)):
@@ -766,8 +765,40 @@ class AlgolIrCompiler:
         raise CompileError("unsupported designational expression")
 
     def _emit_resolved_goto(self, resolved: ResolvedGoto, scope: _FrameScope) -> None:
-        self._emit_unwind_to_block(scope, resolved.target_block_id)
-        self._emit(IrOp.JUMP, IrLabel(resolved.ir_label))
+        label = self.labels_by_id.get(resolved.label_id)
+        if label is None:
+            raise CompileError(
+                f"goto target {resolved.target_name!r} has no label descriptor"
+            )
+        self._emit_goto_label(label, scope)
+
+    def _resolve_label_in_scope_chain(
+        self,
+        name: str,
+        scope: _FrameScope,
+    ) -> LabelDescriptor | None:
+        current: _FrameScope | None = scope
+        while current is not None:
+            label = self.labels_by_block_name.get((current.block_id, name))
+            if label is not None:
+                return label
+            current = current.goto_parent
+        return None
+
+    def _emit_goto_label(
+        self,
+        label: LabelDescriptor,
+        scope: _FrameScope,
+    ) -> None:
+        target_block = self.semantic_blocks_by_id[label.declaring_block_id]
+        if (
+            not scope.helper_failure
+            and target_block.owner_procedure_id == scope.function_owner_procedure_id
+        ):
+            self._emit_unwind_to_block(scope, label.declaring_block_id)
+            self._emit(IrOp.JUMP, IrLabel(label.ir_label))
+            return
+        self._emit_pending_goto_return(scope, label.label_id)
 
     def _emit_unwind_to_block(self, scope: _FrameScope, target_block_id: int) -> None:
         current: _FrameScope | None = scope
@@ -1212,15 +1243,16 @@ class AlgolIrCompiler:
             IrRegister(active_thunk_heap_mark),
             *(IrRegister(argument) for argument in call_arguments),
         )
-        if scope.helper_failure:
-            self._emit_helper_return_on_thunk_failure(scope)
-        result = self._fresh_reg()
-        self._copy_reg(dst=result, src=_RESULT_REG)
         if descriptor_heap_mark is not None:
             self._store_runtime_state(
                 _RUNTIME_HEAP_POINTER_OFFSET,
                 descriptor_heap_mark,
             )
+        if scope.helper_failure:
+            self._emit_helper_return_on_thunk_failure(scope)
+        self._emit_handle_pending_goto_after_call(scope)
+        result = self._fresh_reg()
+        self._copy_reg(dst=result, src=_RESULT_REG)
         return result
 
     def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
@@ -1440,6 +1472,7 @@ class AlgolIrCompiler:
                 heap_mark_reg=None,
                 parent=None,
                 goto_parent=None,
+                function_owner_procedure_id=None,
                 active_thunk_heap_mark_reg=active_thunk_heap_mark,
                 helper_failure=True,
             )
@@ -1509,6 +1542,7 @@ class AlgolIrCompiler:
                 heap_mark_reg=None,
                 parent=None,
                 goto_parent=None,
+                function_owner_procedure_id=None,
                 active_thunk_heap_mark_reg=active_thunk_heap_mark,
                 helper_failure=True,
             )
@@ -1562,6 +1596,7 @@ class AlgolIrCompiler:
                 heap_mark_reg=None,
                 parent=parent,
                 goto_parent=parent,
+                function_owner_procedure_id=procedure.procedure_id,
                 active_thunk_heap_mark_reg=None,
             )
             parent_block_id = parent_block.frame_layout.static_parent_id
@@ -1580,6 +1615,7 @@ class AlgolIrCompiler:
             heap_mark_reg=heap_mark_reg,
             parent=None,
             goto_parent=parent,
+            function_owner_procedure_id=procedure.procedure_id,
             active_thunk_heap_mark_reg=_THUNK_HEAP_MARK_PARAM_REG,
         )
         self._initialize_scalar_slots(scope)
@@ -1811,6 +1847,7 @@ class AlgolIrCompiler:
             IrRegister(active_thunk_heap_mark),
         )
         self._emit_propagate_thunk_failure(scope)
+        self._emit_handle_pending_goto_after_call(scope)
         self._copy_reg(dst=dst, src=_RESULT_REG)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(storage_label)
@@ -1911,6 +1948,7 @@ class AlgolIrCompiler:
                 IrRegister(value_reg),
             )
             self._emit_propagate_thunk_failure(scope)
+            self._emit_handle_pending_goto_after_call(scope)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(storage_label)
             self._emit(
@@ -2113,6 +2151,88 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(else_label)
         self._label(end_label)
+
+    def _emit_pending_goto_return(
+        self,
+        scope: _FrameScope,
+        label_id: int,
+    ) -> None:
+        self._store_runtime_state(
+            _RUNTIME_PENDING_GOTO_LABEL_OFFSET,
+            self._const_reg(label_id),
+        )
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        if not scope.helper_failure:
+            self._emit_unwind_for_return(scope)
+        if scope.helper_failure:
+            self._emit_leave_thunk_helper()
+        self._emit_restore_active_thunk_heap_mark(scope)
+        self._emit(IrOp.RET)
+
+    def _emit_handle_pending_goto_after_call(self, scope: _FrameScope) -> None:
+        pending_label = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, pending_label)
+        index = self.if_count
+        self.if_count += 1
+        no_pending_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        self._emit(IrOp.BRANCH_Z, IrRegister(pending_label), IrLabel(no_pending_label))
+        if scope.helper_failure:
+            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_leave_thunk_helper()
+            self._emit_restore_active_thunk_heap_mark(scope)
+            self._emit(IrOp.RET)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(no_pending_label)
+            self._label(end_label)
+            return
+
+        active_scopes = self._active_function_scopes(scope)
+        active_block_ids = {active_scope.block_id for active_scope in active_scopes}
+        for label in self.labels_by_id.values():
+            if label.declaring_block_id not in active_block_ids:
+                continue
+            next_label = f"if_{self.if_count}_else"
+            next_end_label = f"if_{self.if_count}_end"
+            self.if_count += 1
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(pending_label),
+                IrRegister(self._const_reg(label.label_id)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(next_label))
+            self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)
+            self._emit_unwind_to_block(scope, label.declaring_block_id)
+            self._emit(IrOp.JUMP, IrLabel(label.ir_label))
+            self._emit(IrOp.JUMP, IrLabel(next_end_label))
+            self._label(next_label)
+            self._label(next_end_label)
+
+        if scope.function_owner_procedure_id is not None:
+            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_unwind_for_return(scope)
+            self._emit_restore_active_thunk_heap_mark(scope)
+            self._emit(IrOp.RET)
+        else:
+            self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)
+            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit(IrOp.HALT)
+
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(no_pending_label)
+        self._label(end_label)
+
+    def _active_function_scopes(self, scope: _FrameScope) -> list[_FrameScope]:
+        active_scopes: list[_FrameScope] = []
+        current: _FrameScope | None = scope
+        while current is not None:
+            if current.function_owner_procedure_id != scope.function_owner_procedure_id:
+                break
+            active_scopes.append(current)
+            current = current.parent
+        return active_scopes
 
     def _emit_helper_runtime_failure_guard(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -121,6 +121,27 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.LOAD_WORD) >= 1
         assert opcodes.count(IrOp.STORE_WORD) >= 1
 
+    def test_compiles_procedure_crossing_goto_with_pending_transfer(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure escape; begin goto done end; "
+                "escape; "
+                "done: result := 7 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.CALL in opcodes
+        assert opcodes.count(IrOp.RET) >= 2
+        assert any(label.startswith("algol_label_") for label in labels)
+
     def test_compiles_conditional_designational_goto(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -282,7 +303,7 @@ class TestAlgolIrCompiler:
                 )
         )
 
-        with pytest.raises(CompileError, match="frame bytes plus 32 runtime bytes"):
+        with pytest.raises(CompileError, match="frame bytes plus 36 runtime bytes"):
             compile_algol(typed)
 
     def test_compiles_integer_array_descriptor_and_element_accesses(self) -> None:

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1039,13 +1039,6 @@ class AlgolTypeChecker:
         if symbol.kind != LABEL:
             self._error(target_token, f"{target_token.value!r} is not a label")
             return
-        if scope.owner_procedure_id != declaring_scope.owner_procedure_id:
-            self._error(
-                target_token,
-                f"goto to label {target_token.value!r} crosses a procedure "
-                "boundary, which requires Phase 7c procedure unwinding",
-            )
-            return
         if lexical_depth_delta != 0 and not allow_nonlocal_label:
             self._error(
                 target_token,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -110,7 +110,7 @@ class TestAlgolTypeChecker:
         assert result.semantic.gotos[0].target_name == "done"
         assert result.semantic.gotos[0].lexical_depth_delta == 1
 
-    def test_rejects_procedure_crossing_goto_for_now(self) -> None:
+    def test_accepts_procedure_crossing_goto(self) -> None:
         ast = parse_algol(
             "begin integer result; "
             "procedure escape; begin goto done end; "
@@ -120,8 +120,9 @@ class TestAlgolTypeChecker:
         )
         result = check_algol(ast)
 
-        assert not result.ok
-        assert "crosses a procedure boundary" in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.gotos[0].target_name == "done"
 
     def test_rejects_conditional_nonlocal_designational_goto_for_now(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -131,18 +131,34 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [6]
 
-    def test_procedure_crossing_goto_reports_type_check_error(self) -> None:
-        with pytest.raises(AlgolWasmError) as raised:
-            compile_source(
-                "begin integer result; "
-                "procedure escape; "
-                "begin goto outerdone; result := 9 end; "
-                "escape; "
-                "result := 0; "
-                "outerdone: result := 7 "
-                "end"
-            )
-        assert raised.value.stage == "type-check"
+    def test_procedure_crossing_goto_unwinds_back_to_caller_label(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape; "
+            "begin goto outerdone; result := 9 end; "
+            "escape; "
+            "result := 0; "
+            "outerdone: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_procedure_crossing_goto_propagates_through_intermediate_procedure(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure outer; "
+            "begin "
+            "procedure inner; begin goto done end; "
+            "inner; "
+            "result := 3; "
+            "done: result := 8 "
+            "end; "
+            "outer "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
     def test_conditional_designational_goto_selects_branch(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- add a pending-goto runtime path so procedure-crossing `goto` can unwind through calls instead of emitting invalid cross-function jumps
- consume pending gotos at call sites when the target label is active in the current function, otherwise propagate them upward
- re-enable procedure-crossing goto in the type checker and cover the new control-flow behavior in IR and WASM tests

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') uv run --python 3.12 --with pytest --with pytest-cov python -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `ruff check code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`