### PR TITLE
feat(ruby): add conduit mini rack prototype

### DIFF
--- a/code/packages/ruby/conduit/BUILD
+++ b/code/packages/ruby/conduit/BUILD
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake compile && bundle exec rake test

--- a/code/packages/ruby/conduit/BUILD_windows
+++ b/code/packages/ruby/conduit/BUILD_windows
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake compile && bundle exec rake test

--- a/code/packages/ruby/conduit/CHANGELOG.md
+++ b/code/packages/ruby/conduit/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add the first `Conduit` Rack-like Ruby package on top of the Rust HTTP runtime.

--- a/code/packages/ruby/conduit/Gemfile
+++ b/code/packages/ruby/conduit/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/conduit/README.md
+++ b/code/packages/ruby/conduit/README.md
@@ -1,0 +1,26 @@
+# Conduit
+
+`Conduit` is a tiny Rack-like Ruby layer backed by the Rust `embeddable-http-server`.
+
+It currently focuses on the smallest useful server shape:
+
+- a callable app contract
+- a small route DSL
+- path params like `/hello/:name`
+- a native server that owns TCP sockets and HTTP/1 request assembly
+
+## Example
+
+```ruby
+require "coding_adventures_conduit"
+
+app = CodingAdventures::Conduit.app do
+  get "/hello/:name" do |request|
+    "Hello #{request.params.fetch("name")}"
+  end
+end
+
+server = CodingAdventures::Conduit::Server.new(app, port: 9292)
+server.start
+sleep
+```

--- a/code/packages/ruby/conduit/Rakefile
+++ b/code/packages/ruby/conduit/Rakefile
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+require "rbconfig"
+require_relative "ext/conduit_native/build_config"
+
+DLEXT = RbConfig::CONFIG["DLEXT"]
+EXT_DIR = File.expand_path("ext/conduit_native", __dir__)
+LIB_DIR = File.expand_path("lib", __dir__)
+
+CARGO_LIB = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libconduit_native.dylib"
+            when /mingw|mswin|cygwin/
+              "conduit_native.dll"
+            else
+              "libconduit_native.so"
+            end
+
+TARGET = "conduit_native.#{DLEXT}"
+
+desc "Compile the Rust native extension"
+task :compile do
+  cd EXT_DIR do
+    sh(*ConduitNativeBuildConfig.cargo_build_command)
+  end
+
+  src = File.join(ConduitNativeBuildConfig.target_release_dir(EXT_DIR), CARGO_LIB)
+  dst = File.join(LIB_DIR, TARGET)
+  mkdir_p LIB_DIR
+  cp src, dst
+  puts "Installed #{TARGET} to lib/"
+end
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+task test: :compile
+
+desc "Remove build artifacts"
+task :clean do
+  cd EXT_DIR do
+    sh(*ConduitNativeBuildConfig.cargo_clean_command) if File.exist?("Cargo.toml")
+  end
+  rm_f Dir[File.join(LIB_DIR, "conduit_native.*")]
+end
+
+task default: :test

--- a/code/packages/ruby/conduit/coding_adventures_conduit.gemspec
+++ b/code/packages/ruby/conduit/coding_adventures_conduit.gemspec
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/conduit/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_conduit"
+  spec.version       = CodingAdventures::Conduit::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "A tiny Rack-like Ruby layer backed by the Rust HTTP runtime"
+  spec.description   = "Conduit provides a small Ruby app and router API on top of the Rust embeddable HTTP server."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.6.0"
+
+  spec.files         = Dir[
+    "lib/**/*.rb",
+    "ext/**/*.{rb,rs,toml}",
+    "README.md",
+    "CHANGELOG.md"
+  ]
+  spec.require_paths = ["lib"]
+  spec.extensions    = ["ext/conduit_native/extconf.rb"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/conduit/examples/hello_name.rb
+++ b/code/packages/ruby/conduit/examples/hello_name.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "coding_adventures_conduit"
+
+app = CodingAdventures::Conduit.app do
+  get "/hello/:name" do |request|
+    "Hello #{request.params.fetch("name")}"
+  end
+end
+
+server = CodingAdventures::Conduit::Server.new(app, host: "127.0.0.1", port: 9292)
+server.start
+
+puts "Conduit listening at http://127.0.0.1:9292/hello/Adhithya"
+puts "Press Ctrl+C to stop."
+
+trap("INT") do
+  server.close
+  exit(0)
+end
+
+sleep

--- a/code/packages/ruby/conduit/ext/conduit_native/Cargo.toml
+++ b/code/packages/ruby/conduit/ext/conduit_native/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "conduit_native"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+embeddable-http-server = { path = "../../../../rust/embeddable-http-server" }
+http-core = { path = "../../../../rust/http-core" }
+ruby-bridge = { path = "../../../../rust/ruby-bridge" }
+transport-platform = { path = "../../../../rust/transport-platform" }
+
+[build-dependencies]

--- a/code/packages/ruby/conduit/ext/conduit_native/build.rs
+++ b/code/packages/ruby/conduit/ext/conduit_native/build.rs
@@ -1,0 +1,146 @@
+use std::path::PathBuf;
+
+fn main() {
+    match std::env::var("CARGO_CFG_TARGET_OS")
+        .unwrap_or_default()
+        .as_str()
+    {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => link_ruby_on_windows(),
+        _ => {}
+    }
+}
+
+fn link_ruby_on_windows() {
+    let Some(ruby) = find_ruby() else {
+        return;
+    };
+    let (Some(bin_dir), Some(lib_dir), Some(so_name)) = (
+        get_ruby_config(&ruby, "bindir"),
+        get_ruby_config(&ruby, "libdir"),
+        get_ruby_config(&ruby, "RUBY_SO_NAME"),
+    ) else {
+        return;
+    };
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    println!("cargo:rustc-link-search=native={lib_dir}");
+    println!("cargo:rustc-link-search=native={bin_dir}");
+
+    if target_env == "msvc" {
+        if generate_msvc_lib(&format!("{so_name}.dll"), &so_name, &out_dir) {
+            println!("cargo:rustc-link-search=native={out_dir}");
+            println!("cargo:rustc-link-lib={so_name}");
+        } else {
+            println!("cargo:rustc-link-lib=dylib={so_name}");
+        }
+        println!("cargo:rustc-cdylib-link-arg=/FORCE:UNRESOLVED");
+    } else if let Some(import_library) = get_ruby_config(&ruby, "LIBRUBY") {
+        let import_library = PathBuf::from(lib_dir).join(import_library);
+        println!("cargo:rustc-cdylib-link-arg={}", import_library.display());
+    } else {
+        println!("cargo:rustc-link-lib=dylib={so_name}");
+    }
+}
+
+fn generate_msvc_lib(dll_name: &str, so_name: &str, out_dir: &str) -> bool {
+    let symbols: &[(&str, bool)] = &[
+        ("rb_define_module", false),
+        ("rb_define_module_under", false),
+        ("rb_define_class_under", false),
+        ("rb_define_method", false),
+        ("rb_define_singleton_method", false),
+        ("rb_define_module_function", false),
+        ("rb_define_alloc_func", false),
+        ("rb_path2class", false),
+        ("rb_utf8_str_new", false),
+        ("rb_string_value_cstr", false),
+        ("rb_ary_new", false),
+        ("rb_ary_push", false),
+        ("rb_ary_entry", false),
+        ("rb_intern", false),
+        ("rb_funcallv", false),
+        ("rb_num2long", false),
+        ("rb_int2inum", false),
+        ("rb_float_new", false),
+        ("rb_num2dbl", false),
+        ("rb_hash_new", false),
+        ("rb_hash_aset", false),
+        ("rb_data_object_wrap", false),
+        ("rb_check_typeddata", false),
+        ("rb_raise", false),
+        ("rb_str_strlen", false),
+        ("rb_thread_call_without_gvl", false),
+        ("rb_thread_call_with_gvl", false),
+        ("rb_protect", false),
+        ("rb_errinfo", false),
+        ("rb_set_errinfo", false),
+        ("rb_cObject", true),
+        ("rb_eStandardError", true),
+        ("rb_eArgError", true),
+        ("rb_eRuntimeError", true),
+    ];
+
+    let def_path = PathBuf::from(out_dir).join(format!("{so_name}.def"));
+    let mut def_content = format!("LIBRARY {dll_name}\nEXPORTS\n");
+    for (sym, is_data) in symbols {
+        if *is_data {
+            def_content.push_str(&format!("    {sym} DATA\n"));
+        } else {
+            def_content.push_str(&format!("    {sym}\n"));
+        }
+    }
+    if std::fs::write(&def_path, def_content).is_err() {
+        return false;
+    }
+
+    let lib_path = PathBuf::from(out_dir).join(format!("{so_name}.lib"));
+    for program in ["lib.exe", "lib"] {
+        let result = std::process::Command::new(program)
+            .args([
+                &format!("/def:{}", def_path.display()),
+                &format!("/out:{}", lib_path.display()),
+                "/machine:x64",
+                "/nologo",
+            ])
+            .output();
+        if matches!(result, Ok(output) if output.status.success() && lib_path.exists()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn get_ruby_config(ruby: &str, key: &str) -> Option<String> {
+    let script = format!("require 'rbconfig'; print RbConfig::CONFIG['{key}']");
+    let output = std::process::Command::new(ruby)
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn find_ruby() -> Option<String> {
+    for finder in ["where", "which"] {
+        if let Ok(output) = std::process::Command::new(finder).arg("ruby").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}

--- a/code/packages/ruby/conduit/ext/conduit_native/build_config.rb
+++ b/code/packages/ruby/conduit/ext/conduit_native/build_config.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module ConduitNativeBuildConfig
+  module_function
+
+  def cargo_build_command
+    cargo_runner + ["build", "--release"] + rust_target_args
+  end
+
+  def cargo_clean_command
+    cargo_runner + ["clean"]
+  end
+
+  def cargo_make_command
+    (cargo_runner + ["build", "--release"] + rust_target_args).join(" ")
+  end
+
+  def target_release_dir(ext_dir)
+    target = rust_target
+    return File.join(ext_dir, "target", "release") if target.nil?
+
+    File.join(ext_dir, "target", target, "release")
+  end
+
+  def rust_target_args
+    target = rust_target
+    target.nil? ? [] : ["--target", target]
+  end
+
+  def rust_target
+    return ENV["CONDUIT_NATIVE_RUST_TARGET"] unless ENV["CONDUIT_NATIVE_RUST_TARGET"].to_s.empty?
+
+    case host_os
+    when /mingw|cygwin/
+      case host_cpu
+      when /x64|x86_64/ then "x86_64-pc-windows-gnu"
+      when /i\d86|x86/ then "i686-pc-windows-gnu"
+      end
+    when /mswin|msvc/
+      case host_cpu
+      when /x64|x86_64/ then "x86_64-pc-windows-msvc"
+      when /i\d86|x86/ then "i686-pc-windows-msvc"
+      end
+    end
+  end
+
+  def cargo_runner
+    if ruby_mingw? && ridk_available?
+      ["ridk", "exec", "cargo"]
+    else
+      ["cargo"]
+    end
+  end
+
+  def ruby_mingw?
+    host_os.match?(/mingw|cygwin/)
+  end
+
+  def host_os
+    RbConfig::CONFIG["host_os"].to_s
+  end
+
+  def host_cpu
+    RbConfig::CONFIG["host_cpu"].to_s
+  end
+
+  def ridk_available?
+    @ridk_available = system("ridk", "version", out: File::NULL, err: File::NULL) if @ridk_available.nil?
+    @ridk_available
+  end
+end

--- a/code/packages/ruby/conduit/ext/conduit_native/extconf.rb
+++ b/code/packages/ruby/conduit/ext/conduit_native/extconf.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+require_relative "build_config"
+
+dlext = RbConfig::CONFIG["DLEXT"]
+cargo_lib = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libconduit_native.dylib"
+            when /mingw|mswin|cygwin/
+              "conduit_native.dll"
+            else
+              "libconduit_native.so"
+            end
+
+target = "conduit_native.#{dlext}"
+lib_dir = File.expand_path("../../lib", __dir__)
+target_dir = ConduitNativeBuildConfig.target_release_dir(File.expand_path(__dir__))
+cargo_command = ConduitNativeBuildConfig.cargo_make_command
+
+File.write("Makefile", <<~MAKEFILE)
+  CARGO_DIR = #{File.expand_path(__dir__)}
+  TARGET_DIR = #{target_dir}
+  CARGO = #{cargo_command}
+  CARGO_LIB = $(TARGET_DIR)/#{cargo_lib}
+  INSTALL_DIR = #{lib_dir}
+  TARGET = $(INSTALL_DIR)/#{target}
+
+  all: $(TARGET)
+
+  $(TARGET): $(CARGO_LIB)
+  \t@mkdir -p $(INSTALL_DIR)
+  \tcp $(CARGO_LIB) $(TARGET)
+
+  $(CARGO_LIB): src/lib.rs Cargo.toml
+  \tcd $(CARGO_DIR) && $(CARGO)
+
+  clean:
+  \tcd $(CARGO_DIR) && #{ConduitNativeBuildConfig.cargo_clean_command.join(" ")}
+  \trm -f $(TARGET)
+
+  install: $(TARGET)
+
+  .PHONY: all clean install
+MAKEFILE
+
+puts "Makefile generated; will build via `cargo build --release`"

--- a/code/packages/ruby/conduit/ext/conduit_native/src/lib.rs
+++ b/code/packages/ruby/conduit/ext/conduit_native/src/lib.rs
@@ -1,0 +1,519 @@
+use std::ffi::{c_char, c_int, c_long, c_void, CString};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use embeddable_http_server::{HttpRequest, HttpResponse, HttpServer, HttpServerOptions};
+use http_core::Header;
+use ruby_bridge::{ID, VALUE};
+
+extern "C" {
+    fn rb_num2long(val: VALUE) -> c_long;
+    fn rb_thread_call_without_gvl(
+        func: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+        data1: *mut c_void,
+        ubf: Option<unsafe extern "C" fn(*mut c_void)>,
+        data2: *mut c_void,
+    ) -> *mut c_void;
+    fn rb_thread_call_with_gvl(
+        func: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+        data1: *mut c_void,
+    ) -> *mut c_void;
+    fn rb_protect(
+        func: unsafe extern "C" fn(VALUE) -> VALUE,
+        data: VALUE,
+        state: *mut c_int,
+    ) -> VALUE;
+    fn rb_errinfo() -> VALUE;
+    fn rb_set_errinfo(error: VALUE);
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+type PlatformHttpServer = HttpServer<transport_platform::bsd::KqueueTransportPlatform>;
+
+#[cfg(target_os = "linux")]
+type PlatformHttpServer = HttpServer<transport_platform::linux::EpollTransportPlatform>;
+
+#[cfg(target_os = "windows")]
+type PlatformHttpServer = HttpServer<transport_platform::windows::WindowsTransportPlatform>;
+
+struct RubyConduitServer {
+    server: Option<PlatformHttpServer>,
+    owner: VALUE,
+    running: Arc<AtomicBool>,
+}
+
+struct ServeCall {
+    server: *mut RubyConduitServer,
+    ok: bool,
+    error: Option<String>,
+}
+
+struct RubyDispatch {
+    owner: VALUE,
+    request: HttpRequest,
+    response: Option<Result<HttpResponse, String>>,
+}
+
+struct ProtectedDispatch {
+    owner: VALUE,
+    env: VALUE,
+    result: VALUE,
+}
+
+static mut NATIVE_SERVER_CLASS: VALUE = 0;
+static mut SERVER_ERROR: VALUE = 0;
+
+unsafe extern "C" fn server_alloc(klass: VALUE) -> VALUE {
+    ruby_bridge::wrap_data(
+        klass,
+        RubyConduitServer {
+            server: None,
+            owner: ruby_bridge::QNIL,
+            running: Arc::new(AtomicBool::new(false)),
+        },
+    )
+}
+
+extern "C" fn server_initialize(
+    self_val: VALUE,
+    host_val: VALUE,
+    port_val: VALUE,
+    max_connections_val: VALUE,
+) -> VALUE {
+    let host = string_from_rb(host_val, "host must be a String");
+    let port = u16_from_rb(port_val, "port must be between 0 and 65535");
+    let max_connections =
+        usize_from_rb(max_connections_val, "max_connections must be non-negative");
+
+    let mut options = HttpServerOptions::default();
+    options.tcp.max_connections = max_connections;
+
+    let owner = self_val;
+    let running = {
+        let slot = unsafe { ruby_bridge::unwrap_data_mut::<RubyConduitServer>(self_val) };
+        slot.owner = owner;
+        Arc::clone(&slot.running)
+    };
+
+    let server = match bind_server(&host, port, options, move |request| {
+        dispatch_http_request(owner, request)
+    }) {
+        Ok(server) => server,
+        Err(error) => raise_server_error(&format!("failed to start Conduit HTTP runtime: {error}")),
+    };
+
+    let slot = unsafe { ruby_bridge::unwrap_data_mut::<RubyConduitServer>(self_val) };
+    slot.server = Some(server);
+    slot.running = running;
+    self_val
+}
+
+extern "C" fn server_serve(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data_mut::<RubyConduitServer>(self_val) };
+    if slot.server.is_none() {
+        raise_server_error("server is closed");
+    }
+    let mut call = ServeCall {
+        server: slot as *mut RubyConduitServer,
+        ok: false,
+        error: None,
+    };
+
+    unsafe {
+        rb_thread_call_without_gvl(
+            serve_without_gvl,
+            &mut call as *mut ServeCall as *mut c_void,
+            None,
+            ptr::null_mut(),
+        );
+    }
+
+    if call.ok {
+        ruby_bridge::QNIL
+    } else {
+        let message = call
+            .error
+            .unwrap_or_else(|| "Conduit HTTP runtime failed".to_string());
+        raise_server_error(&message)
+    }
+}
+
+extern "C" fn server_stop(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data::<RubyConduitServer>(self_val) };
+    match slot.server.as_ref() {
+        Some(server) => server.stop_handle().stop(),
+        None => raise_server_error("server is closed"),
+    }
+    ruby_bridge::QNIL
+}
+
+extern "C" fn server_dispose(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data_mut::<RubyConduitServer>(self_val) };
+    if slot.running.load(Ordering::SeqCst) {
+        raise_server_error("cannot dispose a running server; stop and wait first");
+    }
+    slot.server.take();
+    slot.owner = ruby_bridge::QNIL;
+    ruby_bridge::QNIL
+}
+
+extern "C" fn server_running(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data::<RubyConduitServer>(self_val) };
+    ruby_bridge::bool_to_rb(slot.running.load(Ordering::SeqCst))
+}
+
+extern "C" fn server_local_host(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data::<RubyConduitServer>(self_val) };
+    let server = slot
+        .server
+        .as_ref()
+        .unwrap_or_else(|| raise_server_error("server is closed"));
+    ruby_bridge::str_to_rb(&server.local_addr().ip().to_string())
+}
+
+extern "C" fn server_local_port(self_val: VALUE) -> VALUE {
+    let slot = unsafe { ruby_bridge::unwrap_data::<RubyConduitServer>(self_val) };
+    let server = slot
+        .server
+        .as_ref()
+        .unwrap_or_else(|| raise_server_error("server is closed"));
+    ruby_bridge::usize_to_rb(server.local_addr().port() as usize)
+}
+
+unsafe extern "C" fn serve_without_gvl(data: *mut c_void) -> *mut c_void {
+    let call = &mut *(data as *mut ServeCall);
+    let slot = &mut *call.server;
+    let Some(server) = slot.server.as_mut() else {
+        call.ok = false;
+        call.error = Some("server is closed".to_string());
+        return ptr::null_mut();
+    };
+
+    slot.running.store(true, Ordering::SeqCst);
+    let result = server.serve();
+    slot.running.store(false, Ordering::SeqCst);
+    match result {
+        Ok(()) => {
+            call.ok = true;
+        }
+        Err(error) => {
+            call.ok = false;
+            call.error = Some(format!("Conduit HTTP runtime failed: {error}"));
+        }
+    }
+    ptr::null_mut()
+}
+
+fn dispatch_http_request(owner: VALUE, request: HttpRequest) -> HttpResponse {
+    let mut dispatch = RubyDispatch {
+        owner,
+        request,
+        response: None,
+    };
+
+    unsafe {
+        rb_thread_call_with_gvl(
+            dispatch_with_gvl,
+            &mut dispatch as *mut RubyDispatch as *mut c_void,
+        );
+    }
+
+    match dispatch
+        .response
+        .take()
+        .unwrap_or_else(|| Err("Conduit dispatch did not return a response".to_string()))
+    {
+        Ok(response) => response,
+        Err(message) => HttpResponse::new(500, message).with_header("Content-Type", "text/plain"),
+    }
+}
+
+unsafe extern "C" fn dispatch_with_gvl(data: *mut c_void) -> *mut c_void {
+    let dispatch = &mut *(data as *mut RubyDispatch);
+    let env = build_env(&dispatch.request);
+    let mut protected = ProtectedDispatch {
+        owner: dispatch.owner,
+        env,
+        result: ruby_bridge::QNIL,
+    };
+    let mut state = 0;
+    let result = rb_protect(
+        protected_dispatch,
+        &mut protected as *mut ProtectedDispatch as VALUE,
+        &mut state,
+    );
+
+    if state != 0 {
+        let error = rb_errinfo();
+        rb_set_errinfo(ruby_bridge::QNIL);
+        let _ = error;
+        dispatch.response = Some(Err("Conduit app raised an exception".to_string()));
+        return ptr::null_mut();
+    }
+
+    protected.result = result;
+    dispatch.response = Some(parse_response(result));
+    ptr::null_mut()
+}
+
+unsafe extern "C" fn protected_dispatch(data: VALUE) -> VALUE {
+    let protected = &mut *(data as *mut ProtectedDispatch);
+    let mid = intern("dispatch_request");
+    let args = [protected.env];
+    ruby_bridge::rb_funcallv(protected.owner, mid, 1, args.as_ptr())
+}
+
+fn build_env(request: &HttpRequest) -> VALUE {
+    let env = ruby_bridge::hash_new();
+    set_hash_str(&env, "REQUEST_METHOD", request.method());
+    let (path, query) = split_target(request.target());
+    set_hash_str(&env, "PATH_INFO", path);
+    set_hash_str(&env, "QUERY_STRING", query);
+    set_hash_str(
+        &env,
+        "SERVER_PROTOCOL",
+        &format!(
+            "HTTP/{}.{}",
+            request.head.version.major, request.head.version.minor
+        ),
+    );
+    set_hash_str(&env, "rack.url_scheme", "http");
+    set_hash_str(&env, "rack.input", &String::from_utf8_lossy(&request.body));
+    set_hash_str(
+        &env,
+        "REMOTE_ADDR",
+        &request.connection.peer_addr.ip().to_string(),
+    );
+    ruby_bridge::hash_aset(
+        env,
+        ruby_bridge::str_to_rb("REMOTE_PORT"),
+        ruby_bridge::usize_to_rb(request.connection.peer_addr.port() as usize),
+    );
+    set_hash_str(
+        &env,
+        "SERVER_NAME",
+        &request.connection.local_addr.ip().to_string(),
+    );
+    ruby_bridge::hash_aset(
+        env,
+        ruby_bridge::str_to_rb("SERVER_PORT"),
+        ruby_bridge::usize_to_rb(request.connection.local_addr.port() as usize),
+    );
+
+    for header in &request.head.headers {
+        let key = header_env_key(&header.name);
+        set_hash_str(&env, &key, &header.value);
+    }
+
+    env
+}
+
+fn set_hash_str(hash: &VALUE, key: &str, value: &str) {
+    ruby_bridge::hash_aset(
+        *hash,
+        ruby_bridge::str_to_rb(key),
+        ruby_bridge::str_to_rb(value),
+    );
+}
+
+fn split_target(target: &str) -> (&str, &str) {
+    match target.split_once('?') {
+        Some((path, query)) => (path, query),
+        None => (target, ""),
+    }
+}
+
+fn header_env_key(name: &str) -> String {
+    let normalized = name.replace('-', "_").to_ascii_uppercase();
+    match normalized.as_str() {
+        "CONTENT_TYPE" | "CONTENT_LENGTH" => normalized,
+        _ => format!("HTTP_{normalized}"),
+    }
+}
+
+fn parse_response(value: VALUE) -> Result<HttpResponse, String> {
+    if ruby_bridge::array_len(value) != 3 {
+        return Err("Conduit app must return [status, headers, body]".to_string());
+    }
+
+    let status = u16_from_rb_result(
+        ruby_bridge::array_entry(value, 0),
+        "response status must be between 0 and 65535",
+    )?;
+    let headers = parse_header_pairs(ruby_bridge::array_entry(value, 1))?;
+    let body = parse_body_chunks(ruby_bridge::array_entry(value, 2))?;
+
+    Ok(HttpResponse {
+        status,
+        reason: String::new(),
+        headers,
+        body,
+        close: false,
+    })
+}
+
+fn parse_header_pairs(value: VALUE) -> Result<Vec<Header>, String> {
+    let mut headers = Vec::new();
+    let len = ruby_bridge::array_len(value);
+    for index in 0..len {
+        let pair = ruby_bridge::array_entry(value, index);
+        if ruby_bridge::array_len(pair) != 2 {
+            return Err("response headers must be [name, value] pairs".to_string());
+        }
+        let name = string_from_rb_result(
+            ruby_bridge::array_entry(pair, 0),
+            "response header name must be a String",
+        )?;
+        let value = string_from_rb_result(
+            ruby_bridge::array_entry(pair, 1),
+            "response header value must be a String",
+        )?;
+        headers.push(Header { name, value });
+    }
+    Ok(headers)
+}
+
+fn parse_body_chunks(value: VALUE) -> Result<Vec<u8>, String> {
+    let mut body = Vec::new();
+    let len = ruby_bridge::array_len(value);
+    for index in 0..len {
+        let chunk = string_from_rb_result(
+            ruby_bridge::array_entry(value, index),
+            "response body chunks must be Strings",
+        )?;
+        body.extend_from_slice(chunk.as_bytes());
+    }
+    Ok(body)
+}
+
+fn string_from_rb(value: VALUE, message: &str) -> String {
+    match ruby_bridge::str_from_rb(value) {
+        Some(value) => value,
+        None => raise_arg_error(message),
+    }
+}
+
+fn string_from_rb_result(value: VALUE, message: &str) -> Result<String, String> {
+    ruby_bridge::str_from_rb(value).ok_or_else(|| message.to_string())
+}
+
+fn usize_from_rb(value: VALUE, message: &str) -> usize {
+    let number = unsafe { rb_num2long(value) };
+    if number < 0 {
+        raise_arg_error(message);
+    }
+    number as usize
+}
+
+fn u16_from_rb(value: VALUE, message: &str) -> u16 {
+    let number = usize_from_rb(value, message);
+    if number > u16::MAX as usize {
+        raise_arg_error(message);
+    }
+    number as u16
+}
+
+fn u16_from_rb_result(value: VALUE, message: &str) -> Result<u16, String> {
+    let number = unsafe { rb_num2long(value) };
+    if number < 0 || number > u16::MAX as c_long {
+        return Err(message.to_string());
+    }
+    Ok(number as u16)
+}
+
+fn raise_arg_error(message: &str) -> ! {
+    ruby_bridge::raise_error(ruby_bridge::path2class("ArgumentError"), message)
+}
+
+fn raise_server_error(message: &str) -> ! {
+    ruby_bridge::raise_error(unsafe { SERVER_ERROR }, message)
+}
+
+fn intern(name: &str) -> ID {
+    let c_name = CString::new(name).expect("method name must not contain NUL");
+    unsafe { ruby_bridge::rb_intern(c_name.as_ptr() as *const c_char) }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn bind_server(
+    host: &str,
+    port: u16,
+    options: HttpServerOptions,
+    handler: impl Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+) -> Result<PlatformHttpServer, transport_platform::PlatformError> {
+    PlatformHttpServer::bind_kqueue((host, port), options, handler)
+}
+
+#[cfg(target_os = "linux")]
+fn bind_server(
+    host: &str,
+    port: u16,
+    options: HttpServerOptions,
+    handler: impl Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+) -> Result<PlatformHttpServer, transport_platform::PlatformError> {
+    PlatformHttpServer::bind_epoll((host, port), options, handler)
+}
+
+#[cfg(target_os = "windows")]
+fn bind_server(
+    host: &str,
+    port: u16,
+    options: HttpServerOptions,
+    handler: impl Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+) -> Result<PlatformHttpServer, transport_platform::PlatformError> {
+    PlatformHttpServer::bind_windows((host, port), options, handler)
+}
+
+#[no_mangle]
+pub extern "C" fn Init_conduit_native() {
+    let coding_adventures = ruby_bridge::define_module("CodingAdventures");
+    let conduit = ruby_bridge::define_module_under(coding_adventures, "Conduit");
+
+    let error_class = ruby_bridge::define_class_under(
+        conduit,
+        "ServerError",
+        ruby_bridge::standard_error_class(),
+    );
+    unsafe { SERVER_ERROR = error_class };
+
+    let server_class =
+        ruby_bridge::define_class_under(conduit, "NativeServer", ruby_bridge::object_class());
+    unsafe { NATIVE_SERVER_CLASS = server_class };
+
+    ruby_bridge::define_alloc_func(server_class, server_alloc);
+    ruby_bridge::define_method_raw(
+        server_class,
+        "initialize",
+        server_initialize as *const c_void,
+        3,
+    );
+    ruby_bridge::define_method_raw(server_class, "serve", server_serve as *const c_void, 0);
+    ruby_bridge::define_method_raw(server_class, "stop", server_stop as *const c_void, 0);
+    ruby_bridge::define_method_raw(server_class, "dispose", server_dispose as *const c_void, 0);
+    ruby_bridge::define_method_raw(server_class, "running?", server_running as *const c_void, 0);
+    ruby_bridge::define_method_raw(
+        server_class,
+        "local_host",
+        server_local_host as *const c_void,
+        0,
+    );
+    ruby_bridge::define_method_raw(
+        server_class,
+        "local_port",
+        server_local_port as *const c_void,
+        0,
+    );
+}

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/application.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/application.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    class Application
+      def self.build(&block)
+        new(&block)
+      end
+
+      def initialize(&block)
+        @router = Router.new
+        instance_eval(&block) if block
+      end
+
+      def get(pattern, &block)
+        @router.add("GET", pattern, &block)
+      end
+
+      def call(env)
+        @router.call(env)
+      end
+    end
+
+    def self.app(&block)
+      Application.build(&block)
+    end
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/request.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/request.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    class Request
+      attr_reader :env, :params
+
+      def initialize(env, params: {})
+        @env = env
+        @params = params
+      end
+
+      def method
+        env.fetch("REQUEST_METHOD")
+      end
+
+      def path
+        env.fetch("PATH_INFO")
+      end
+
+      def query_string
+        env.fetch("QUERY_STRING", "")
+      end
+
+      def body
+        env.fetch("rack.input", "")
+      end
+
+      def [](key)
+        env[key]
+      end
+    end
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/route.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/route.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    class Route
+      attr_reader :method, :pattern, :block
+
+      def initialize(method, pattern, &block)
+        @method = method
+        @pattern = pattern
+        @block = block
+        @segments = split_segments(pattern)
+      end
+
+      def match?(request_method, path)
+        return nil unless request_method == method
+
+        path_segments = split_segments(path)
+        return nil unless path_segments.length == @segments.length
+
+        params = {}
+        @segments.zip(path_segments).each do |expected, actual|
+          if expected.start_with?(":")
+            params[expected[1..]] = actual
+          elsif expected != actual
+            return nil
+          end
+        end
+        params
+      end
+
+      private
+
+      def split_segments(path)
+        return [] if path == "/"
+
+        path.split("/").reject(&:empty?)
+      end
+    end
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/router.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/router.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    class Router
+      def initialize
+        @routes = []
+      end
+
+      def add(method, pattern, &block)
+        @routes << Route.new(method, pattern, &block)
+      end
+
+      def call(env)
+        method = env.fetch("REQUEST_METHOD")
+        path = env.fetch("PATH_INFO")
+
+        @routes.each do |route|
+          params = route.match?(method, path)
+          next if params.nil?
+
+          request = Request.new(env, params: params)
+          return normalize_result(invoke_route(route.block, request))
+        end
+
+        not_found
+      end
+
+      private
+
+      def invoke_route(block, request)
+        case block.arity
+        when 0
+          request.instance_exec(&block)
+        else
+          block.call(request)
+        end
+      end
+
+      def normalize_result(result)
+        case result
+        when Array
+          result
+        when String
+          [200, { "content-type" => "text/plain" }, [result]]
+        else
+          [200, { "content-type" => "text/plain" }, [result.to_s]]
+        end
+      end
+
+      def not_found
+        [404, { "content-type" => "text/plain" }, ["Not Found"]]
+      end
+    end
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/server.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/server.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    class NativeServer
+      def attach_app(app)
+        @app = app
+        self
+      end
+
+      def dispatch_request(env)
+        raise ServerError, "no app attached" unless @app
+
+        status, headers, body = @app.call(env)
+        [
+          Integer(status),
+          normalize_headers(headers),
+          normalize_body(body)
+        ]
+      end
+
+      private
+
+      def normalize_headers(headers)
+        return [] if headers.nil?
+
+        headers.to_h.map do |key, value|
+          [String(key), String(value)]
+        end
+      end
+
+      def normalize_body(body)
+        return [] if body.nil?
+        return [body] if body.is_a?(String)
+
+        if body.respond_to?(:each)
+          chunks = []
+          body.each { |chunk| chunks << String(chunk) }
+          body.close if body.respond_to?(:close)
+          chunks
+        else
+          [String(body)]
+        end
+      end
+    end
+
+    class Server
+      DEFAULT_HOST = "127.0.0.1"
+      DEFAULT_MAX_CONNECTIONS = 1024
+
+      attr_reader :host
+
+      def initialize(app, host: DEFAULT_HOST, port: 0, max_connections: DEFAULT_MAX_CONNECTIONS)
+        @app = app
+        @native = NativeServer.new(host, Integer(port), Integer(max_connections))
+        @native.attach_app(app)
+        @host = @native.local_host
+        @thread = nil
+        @closed = false
+      end
+
+      def port
+        ensure_open
+        @native.local_port
+      end
+
+      def local_addr
+        "#{host}:#{port}"
+      end
+
+      def running?
+        !@closed && @native.running?
+      end
+
+      def serve
+        ensure_open
+        @native.serve
+      end
+
+      def start
+        ensure_open
+        raise ServerError, "server thread is already running" if @thread&.alive?
+
+        @thread = Thread.new { @native.serve }
+        wait_until_running
+        @thread
+      end
+
+      def stop
+        return if @closed
+
+        @native.stop
+      end
+
+      def wait(timeout = nil)
+        @thread&.join(timeout)
+      end
+
+      def close
+        return if @closed
+
+        stop
+        wait(5)
+        @native.dispose
+        @closed = true
+      end
+
+      private
+
+      def ensure_open
+        raise ServerError, "server is closed" if @closed
+      end
+
+      def wait_until_running
+        100.times do
+          return if running?
+          raise ServerError, "server thread exited before listening" unless @thread.alive?
+
+          sleep 0.01
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/version.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Conduit
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/conduit/lib/coding_adventures_conduit.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures_conduit.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/conduit/version"
+require_relative "coding_adventures/conduit/request"
+require_relative "coding_adventures/conduit/route"
+require_relative "coding_adventures/conduit/router"
+require_relative "coding_adventures/conduit/application"
+
+require "conduit_native"
+
+require_relative "coding_adventures/conduit/server"

--- a/code/packages/ruby/conduit/required_capabilities.json
+++ b/code/packages/ruby/conduit/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/conduit",
+  "capabilities": [
+    {
+      "category": "network",
+      "action": "listen",
+      "target": "127.0.0.1:*",
+      "justification": "Conduit starts a local HTTP listener backed by the Rust TCP and HTTP runtime."
+    }
+  ],
+  "justification": "The Conduit gem embeds the Rust HTTP runtime so Ruby apps can serve local HTTP traffic."
+}

--- a/code/packages/ruby/conduit/test/conduit_test.rb
+++ b/code/packages/ruby/conduit/test/conduit_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestConduitRouter < Minitest::Test
+  def test_route_matches_named_params
+    route = CodingAdventures::Conduit::Route.new("GET", "/hello/:name") { "ok" }
+    assert_equal({ "name" => "Adhithya" }, route.match?("GET", "/hello/Adhithya"))
+    assert_nil route.match?("POST", "/hello/Adhithya")
+    assert_nil route.match?("GET", "/hello")
+  end
+
+  def test_application_normalizes_string_response
+    app = CodingAdventures::Conduit.app do
+      get "/hello/:name" do |request|
+        "Hello #{request.params.fetch("name")}"
+      end
+    end
+
+    status, headers, body = app.call(
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/hello/Adhithya",
+      "QUERY_STRING" => "",
+      "rack.input" => ""
+    )
+
+    assert_equal 200, status
+    assert_equal "text/plain", headers["content-type"]
+    assert_equal ["Hello Adhithya"], body
+  end
+end
+
+class TestConduitServer < Minitest::Test
+  def with_server(app)
+    server = CodingAdventures::Conduit::Server.new(app, port: 0)
+    thread = server.start
+    yield server
+  ensure
+    server&.stop
+    thread&.join(5)
+    server&.close
+  end
+
+  def test_native_server_handles_hello_route_end_to_end
+    app = CodingAdventures::Conduit.app do
+      get "/hello/:name" do |request|
+        "Hello #{request.params.fetch("name")}"
+      end
+    end
+
+    with_server(app) do |server|
+      uri = URI("http://#{server.host}:#{server.port}/hello/Adhithya")
+      response = Net::HTTP.get_response(uri)
+
+      assert_equal "200", response.code
+      assert_equal "Hello Adhithya", response.body
+      assert_equal "text/plain", response["content-type"]
+    end
+  end
+
+  def test_native_server_returns_not_found_for_missing_route
+    app = CodingAdventures::Conduit.app do
+      get "/hello/:name" do |request|
+        "Hello #{request.params.fetch("name")}"
+      end
+    end
+
+    with_server(app) do |server|
+      uri = URI("http://#{server.host}:#{server.port}/missing")
+      response = Net::HTTP.get_response(uri)
+
+      assert_equal "404", response.code
+      assert_equal "Not Found", response.body
+    end
+  end
+end

--- a/code/packages/ruby/conduit/test/test_helper.rb
+++ b/code/packages/ruby/conduit/test/test_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "net/http"
+require "socket"
+
+require "coding_adventures_conduit"


### PR DESCRIPTION
## Summary
- add a new `coding_adventures_conduit` Ruby package with a tiny Rack-like app/router API
- add a native `conduit_native` extension that maps the Rust embeddable HTTP server into a Ruby `app.call(env)` flow
- add example and tests for `/hello/:name` plus basic route matching and response normalization

## Verification
- `ruby -c code/packages/ruby/conduit/lib/coding_adventures/conduit/server.rb`
- `ruby -c code/packages/ruby/conduit/test/conduit_test.rb`
- pure Ruby router sanity check for `/hello/Adhithya` returned `200`, `text/plain`, and `Hello Adhithya`

## Known issue
- local native builds are currently blocked on this machine by a macOS execution/signing problem outside the repo
- Cargo helper binaries and even tiny local Rust/C executables are being rejected by `amfid` before `main`, so I could not complete the true end-to-end native run locally from this environment