### PR TITLE
feat(algol): allow boolean frame variables

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -227,6 +227,21 @@ class TestAlgolIrCompiler:
         assert IrOp.CMP_GT in opcodes
         assert IrOp.AND in opcodes
 
+    def test_compiles_boolean_variable_storage_and_readback(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "boolean flag; "
+                "flag := true; "
+                "if flag then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert opcodes.count(IrOp.STORE_WORD) >= 2
+        assert opcodes.count(IrOp.LOAD_WORD) >= 2
+
     def test_compiles_greater_equal_via_less_than_inversion(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -501,7 +501,7 @@ class AlgolTypeChecker:
 
         type_node = _first_node(inner, "type")
         declared_type = _first_keyword_value(type_node) if type_node is not None else ""
-        if declared_type != INTEGER:
+        if declared_type not in {INTEGER, BOOLEAN}:
             self._error(
                 inner, f"{declared_type or 'unknown'} variables are not supported yet"
             )

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -230,6 +230,19 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "real variables are not supported" in result.diagnostics[0].message
 
+    def test_accepts_boolean_variable_declaration_and_assignment(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "boolean flag; "
+            "flag := true; "
+            "if flag then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.root_scope.children[0].symbols["flag"].type_name == "boolean"
+
     def test_reports_arithmetic_operand_that_is_not_integer(self) -> None:
         ast = parse_algol("begin integer result; result := true + 1 end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -66,6 +66,30 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
 
+    def test_boolean_variable_assignment_drives_condition(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "boolean flag; "
+            "flag := true; "
+            "if flag then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_boolean_variable_shadowing_uses_nearest_frame(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "boolean flag; "
+            "flag := false; "
+            "begin boolean flag; "
+            "flag := true; "
+            "if flag then result := 9 else result := 0 "
+            "end; "
+            "if flag then result := 1 else result := result "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_forward_goto_skips_statements_until_label(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- allow `boolean` scalar declarations in the ALGOL type checker while keeping the rest of the current Phase 8 surface narrow
- add focused checker, IR, and WASM tests covering boolean variable assignment, condition use, and nested-frame shadowing
- verify the existing frame-backed lowering path can already carry boolean values end to end without widening the runtime model yet

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') uv run --python 3.12 --with pytest --with pytest-cov python -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `ruff check code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`