### PR TITLE
feat(ruby): enrich conduit request helpers

### DIFF
--- a/code/packages/ruby/conduit/ext/conduit_native/src/lib.rs
+++ b/code/packages/ruby/conduit/ext/conduit_native/src/lib.rs
@@ -276,6 +276,13 @@ fn build_env(request: &HttpRequest) -> VALUE {
     let (path, query) = split_target(request.target());
     set_hash_str(&env, "PATH_INFO", path);
     set_hash_str(&env, "QUERY_STRING", query);
+    ruby_bridge::hash_aset(
+        env,
+        ruby_bridge::str_to_rb("conduit.query_params"),
+        build_query_params_hash(query),
+    );
+    let headers_hash = build_headers_hash(&request.head.headers);
+    ruby_bridge::hash_aset(env, ruby_bridge::str_to_rb("conduit.headers"), headers_hash);
     set_hash_str(
         &env,
         "SERVER_PROTOCOL",
@@ -306,6 +313,20 @@ fn build_env(request: &HttpRequest) -> VALUE {
         ruby_bridge::str_to_rb("SERVER_PORT"),
         ruby_bridge::usize_to_rb(request.connection.local_addr.port() as usize),
     );
+    if let Some(content_length) = request.head.content_length() {
+        ruby_bridge::hash_aset(
+            env,
+            ruby_bridge::str_to_rb("conduit.content_length"),
+            ruby_bridge::usize_to_rb(content_length),
+        );
+    }
+    if let Some((content_type, _charset)) = request.head.content_type() {
+        ruby_bridge::hash_aset(
+            env,
+            ruby_bridge::str_to_rb("conduit.content_type"),
+            ruby_bridge::str_to_rb(&content_type),
+        );
+    }
 
     for header in &request.head.headers {
         let key = header_env_key(&header.name);
@@ -327,6 +348,87 @@ fn split_target(target: &str) -> (&str, &str) {
     match target.split_once('?') {
         Some((path, query)) => (path, query),
         None => (target, ""),
+    }
+}
+
+fn build_headers_hash(headers: &[Header]) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    for header in headers {
+        ruby_bridge::hash_aset(
+            hash,
+            ruby_bridge::str_to_rb(&header.name.to_ascii_lowercase()),
+            ruby_bridge::str_to_rb(&header.value),
+        );
+    }
+    hash
+}
+
+fn build_query_params_hash(query: &str) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    if query.is_empty() {
+        return hash;
+    }
+
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (raw_key, raw_value) = match pair.split_once('=') {
+            Some((key, value)) => (key, value),
+            None => (pair, ""),
+        };
+
+        let key = percent_decode_component(raw_key);
+        if key.is_empty() {
+            continue;
+        }
+        let value = percent_decode_component(raw_value);
+        ruby_bridge::hash_aset(
+            hash,
+            ruby_bridge::str_to_rb(&key),
+            ruby_bridge::str_to_rb(&value),
+        );
+    }
+
+    hash
+}
+
+fn percent_decode_component(input: &str) -> String {
+    let mut output = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'+' => {
+                output.push(b' ');
+                index += 1;
+            }
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(high), Some(low)) =
+                    (hex_nibble(bytes[index + 1]), hex_nibble(bytes[index + 2]))
+                {
+                    output.push(high << 4 | low);
+                    index += 3;
+                } else {
+                    output.push(b'%');
+                    index += 1;
+                }
+            }
+            byte => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
     }
 }
 

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/request.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/request.rb
@@ -3,11 +3,13 @@
 module CodingAdventures
   module Conduit
     class Request
-      attr_reader :env, :params
+      attr_reader :env, :params, :query_params, :headers
 
-      def initialize(env, params: {})
+      def initialize(env, params: {}, query_params: {}, headers: {})
         @env = env
         @params = params
+        @query_params = query_params
+        @headers = headers
       end
 
       def method
@@ -24,6 +26,21 @@ module CodingAdventures
 
       def body
         env.fetch("rack.input", "")
+      end
+
+      def header(name)
+        headers[name.to_s.downcase]
+      end
+
+      def content_length
+        value = env["conduit.content_length"]
+        return nil if value.nil?
+
+        Integer(value)
+      end
+
+      def content_type
+        env["conduit.content_type"]
       end
 
       def [](key)

--- a/code/packages/ruby/conduit/lib/coding_adventures/conduit/router.rb
+++ b/code/packages/ruby/conduit/lib/coding_adventures/conduit/router.rb
@@ -14,12 +14,19 @@ module CodingAdventures
       def call(env)
         method = env.fetch("REQUEST_METHOD")
         path = env.fetch("PATH_INFO")
+        query_params = env.fetch("conduit.query_params", {})
+        headers = env.fetch("conduit.headers", {})
 
         @routes.each do |route|
           params = route.match?(method, path)
           next if params.nil?
 
-          request = Request.new(env, params: params)
+          request = Request.new(
+            env,
+            params: params,
+            query_params: query_params,
+            headers: headers
+          )
           return normalize_result(invoke_route(route.block, request))
         end
 

--- a/code/packages/ruby/conduit/test/conduit_test.rb
+++ b/code/packages/ruby/conduit/test/conduit_test.rb
@@ -28,6 +28,34 @@ class TestConduitRouter < Minitest::Test
     assert_equal "text/plain", headers["content-type"]
     assert_equal ["Hello Adhithya"], body
   end
+
+  def test_request_exposes_preparsed_query_and_header_helpers
+    seen = nil
+    app = CodingAdventures::Conduit.app do
+      get "/hello/:name" do |request|
+        seen = request
+        "Hello #{request.params.fetch("name")}"
+      end
+    end
+
+    app.call(
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/hello/Adhithya",
+      "QUERY_STRING" => "lang=rust",
+      "rack.input" => "hello",
+      "conduit.query_params" => { "lang" => "rust", "empty" => "" },
+      "conduit.headers" => { "content-type" => "text/plain", "x-name" => "Adhithya" },
+      "conduit.content_length" => 5,
+      "conduit.content_type" => "text/plain"
+    )
+
+    refute_nil seen
+    assert_equal({ "lang" => "rust", "empty" => "" }, seen.query_params)
+    assert_equal "Adhithya", seen.header("X-Name")
+    assert_equal 5, seen.content_length
+    assert_equal "text/plain", seen.content_type
+    assert_equal "hello", seen.body
+  end
 end
 
 class TestConduitServer < Minitest::Test


### PR DESCRIPTION
## Summary
- move more HTTP request shaping into the Rust `conduit_native` layer
- expose pre-parsed query params, normalized headers, and content helpers through `Conduit::Request`
- add Ruby coverage for the richer request helper surface

## Verification
- `cargo fmt --manifest-path code/packages/ruby/conduit/ext/conduit_native/Cargo.toml`
- `ruby -c code/packages/ruby/conduit/lib/coding_adventures/conduit/request.rb`
- `ruby -c code/packages/ruby/conduit/lib/coding_adventures/conduit/router.rb`
- `ruby -c code/packages/ruby/conduit/test/conduit_test.rb`
- pure Ruby sanity check covering `query_params`, `header`, `content_length`, and `content_type`

## Note
- true native end-to-end verification is still deferred because local Cargo helper binaries remain blocked on this machine by the previously investigated macOS signing/execution issue