### PR TITLE
feat(algol): support boolean procedures

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -379,6 +379,27 @@ class TestAlgolIrCompiler:
         assert any(label.startswith("_fn_algol_") for label in labels)
         assert result.procedure_signatures[calls[0].operands[0].name] == 3
 
+    def test_compiles_boolean_value_procedure_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "boolean procedure negate(x); value x; boolean x; "
+                "begin negate := not x end; "
+                "if negate(false) then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert calls[0].operands[0].name.startswith("_fn_algol_")
+        assert result.procedure_signatures[calls[0].operands[0].name] == 3
+        assert IrOp.AND_IMM in opcodes
+
     def test_compiles_recursive_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -432,6 +453,29 @@ class TestAlgolIrCompiler:
         assert len(calls[0].operands) == 4
         assert result.procedure_signatures[calls[0].operands[0].name] == 3
         assert IrOp.ADD_IMM in opcodes
+        assert opcodes.count(IrOp.LOAD_WORD) >= 4
+        assert opcodes.count(IrOp.STORE_WORD) >= 8
+
+    def test_compiles_boolean_by_name_parameter_as_storage_pointer(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "boolean flag; "
+                "procedure settrue(x); boolean x; begin x := true end; "
+                "flag := false; settrue(flag); "
+                "if flag then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert len(calls[0].operands) == 4
+        assert result.procedure_signatures[calls[0].operands[0].name] == 3
         assert opcodes.count(IrOp.LOAD_WORD) >= 4
         assert opcodes.count(IrOp.STORE_WORD) >= 8
 

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -675,7 +675,7 @@ class AlgolTypeChecker:
             return
 
         return_type = _procedure_return_type(node)
-        if return_type is not None and return_type != INTEGER:
+        if return_type is not None and return_type not in {INTEGER, BOOLEAN}:
             self._error(
                 name_token,
                 f"{return_type} procedure results are not supported yet",
@@ -697,16 +697,18 @@ class AlgolTypeChecker:
         )
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
-            if mode == NAME and spec_types.get(formal.value) != INTEGER:
+            parameter_type = spec_types.get(formal.value)
+            if mode == NAME and parameter_type not in {INTEGER, BOOLEAN}:
                 self._error(
                     formal,
                     f"by-name parameter {formal.value!r} must have an integer "
-                    "specifier",
+                    "or boolean specifier",
                 )
-            elif mode == VALUE and spec_types.get(formal.value) != INTEGER:
+            elif mode == VALUE and parameter_type not in {INTEGER, BOOLEAN}:
                 self._error(
                     formal,
-                    f"value parameter {formal.value!r} must have an integer specifier",
+                    f"value parameter {formal.value!r} must have an integer or "
+                    "boolean specifier",
                 )
 
         procedure_id = self._next_procedure_id
@@ -762,9 +764,14 @@ class AlgolTypeChecker:
 
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
+            parameter_type = spec_types.get(formal.value)
             param_symbol = Symbol(
                 name=formal.value,
-                type_name=INTEGER,
+                type_name=(
+                    parameter_type
+                    if parameter_type in {INTEGER, BOOLEAN}
+                    else INTEGER
+                ),
                 line=formal.line,
                 column=formal.column,
                 symbol_id=self._next_symbol_id,
@@ -787,7 +794,7 @@ class AlgolTypeChecker:
                 parameters.append(
                     ProcedureParameter(
                         name=formal.value,
-                        type_name=INTEGER,
+                        type_name=param_symbol.type_name,
                         mode=mode,
                         symbol_id=param_symbol.symbol_id,
                         slot_offset=param_symbol.slot_offset,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -421,6 +421,42 @@ class TestAlgolTypeChecker:
         assert call.role == "statement"
         assert call.return_type is None
 
+    def test_accepts_boolean_value_procedure_signature_and_call(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "boolean procedure negate(x); value x; boolean x; "
+            "begin negate := not x end; "
+            "if negate(false) then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        descriptor = result.semantic.procedures[0]
+        assert descriptor.return_type == "boolean"
+        assert descriptor.parameters[0].type_name == "boolean"
+        call = result.semantic.procedure_calls[0]
+        assert call.return_type == "boolean"
+
+    def test_accepts_boolean_by_name_parameter_writeback(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "boolean flag; "
+            "procedure settrue(x); boolean x; begin x := true end; "
+            "flag := false; settrue(flag); "
+            "if flag then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.type_name == "boolean"
+        assert parameter.mode == "name"
+        assert parameter.may_write
+
     def test_accepts_integer_array_descriptor_and_accesses(self) -> None:
         ast = parse_algol(
             "begin integer result, lo, hi; "
@@ -737,6 +773,22 @@ class TestAlgolTypeChecker:
 
         assert not result.ok
         assert "by-name parameter 'x' expects integer" in result.diagnostics[0].message
+
+    def test_rejects_wrong_type_for_boolean_value_parameter(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "boolean procedure negate(x); value x; boolean x; "
+            "begin negate := not x end; "
+            "if negate(1) then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "parameter 'x' expects boolean, got integer"
+            in result.diagnostics[0].message
+        )
 
     def test_rejects_procedure_argument_count_mismatch(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -258,6 +258,16 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
+    def test_boolean_value_procedure_returns_boolean_result(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "boolean procedure negate(x); value x; boolean x; "
+            "begin negate := not x end; "
+            "if negate(false) then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_void_procedure_statement_writes_outer_frame(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -286,6 +296,16 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
+    def test_boolean_by_name_parameter_assignment_writes_back(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "procedure settrue(x); boolean x; begin x := true end; "
+            "flag := false; settrue(flag); "
+            "if flag then result := 1 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
 
     def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- allow ALGOL procedures to declare boolean value and by-name parameters plus boolean return slots
- keep the lowering path narrow by reusing the existing frame-backed call/return machinery, which already transports scalar 0/1 values correctly
- add focused checker, IR, and WASM tests for boolean procedure calls, boolean return values, and by-name boolean writeback

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') python -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 3 -type d -name src | tr '\n' ':') uv run --python 3.12 --with pytest --with pytest-cov python -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `ruff check code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`