### PR TITLE
spec(diagrams): add shared diagram IR pipeline

### DIFF
--- a/code/specs/DG00-diagram-ir.md
+++ b/code/specs/DG00-diagram-ir.md
@@ -1,0 +1,631 @@
+# DG00 — Diagram IR and Layout Pipeline
+
+## Overview
+
+This spec defines the repo's general architecture for **text diagrams that
+render through `PaintScene` / `PaintInstruction`**.
+
+The short answer to the design question is:
+
+- **Yes**, we should have source-specific diagram packages.
+- **No**, we should not carry source-specific layout packages all the way down.
+- **Yes**, the final compiled target should stay `PaintScene` / `PaintInstruction`.
+- **Yes**, we should extend paint instructions and native backends where the
+  current primitive set is too weak.
+
+The key separation is:
+
+```text
+diagram source syntax
+  -> source AST
+  -> shared semantic Diagram IR
+  -> family-specific layout
+  -> layouted diagram IR
+  -> diagram-to-paint
+  -> PaintScene / PaintInstruction
+  -> Canvas / SVG / Metal / Direct2D / ...
+```
+
+That lets Mermaid, DOT, PlantUML subsets, WaveDrom, and future text-diagram
+formats share the expensive parts:
+
+- routing
+- node sizing
+- lane/timeline placement
+- label placement
+- paint lowering
+- backend work
+
+instead of re-implementing them per syntax.
+
+---
+
+## Design Rule
+
+Organize the stack by **source language at the parse layer** and by **diagram
+family at the layout layer**.
+
+Good split:
+
+- `mermaid-parser`
+- `dot-parser`
+- `plantuml-sequence-parser`
+- `wavedrom-parser`
+- `diagram-ir`
+- `diagram-layout-graph`
+- `diagram-layout-sequence`
+- `diagram-layout-waveform`
+- `diagram-to-paint`
+
+Bad split:
+
+- `mermaid-layout`
+- `dot-layout`
+- `plantuml-layout`
+- `wavedrom-layout`
+
+all doing their own geometry, routing, markers, labels, and paint lowering.
+
+Mermaid flowcharts and DOT graphs are different syntaxes for mostly the same
+graph-layout problem. Mermaid sequence diagrams and PlantUML sequence diagrams
+are different syntaxes for mostly the same timeline-layout problem. We should
+share that middle layer on purpose.
+
+---
+
+## Layer Position
+
+### Standalone diagram rendering
+
+```text
+Mermaid / DOT / PlantUML / WaveDrom source
+  -> source-specific parser
+  -> source-specific AST
+  -> diagram frontend lowerer
+  -> DiagramDocument (DG00)
+  -> family layout package
+  -> LayoutedDiagram (DG00)
+  -> diagram-to-paint
+  -> PaintScene (P2D00)
+  -> paint-vm backend
+```
+
+### Embedded in GFM / documents
+
+```text
+GFM source
+  -> gfm-parser
+  -> TE04 FencedBlockNode
+  -> diagram block transform
+  -> DiagramDocument (DG00)
+  -> family layout package
+  -> LayoutedDiagram
+  -> document/layout integration
+  -> PaintScene
+```
+
+TE04 is the parser seam that preserves fenced blocks.
+DG00 is the rendering seam that turns claimed diagram blocks into native paint.
+
+---
+
+## Package Plan
+
+### 1. Source packages
+
+Each source language gets its own parser package and AST.
+
+Examples:
+
+- `mermaid-parser`
+- `dot-parser`
+- `plantuml-sequence-parser`
+- `wavedrom-parser`
+
+Responsibilities:
+
+- lexical and syntax parsing
+- source-level validation
+- preserving dialect-specific constructs
+- exposing source spans / diagnostics
+
+Non-responsibilities:
+
+- native rendering
+- graph routing
+- backend-specific paint logic
+
+### 2. `diagram-ir`
+
+This package defines the shared semantic diagram model.
+
+Responsibilities:
+
+- family-neutral document envelope
+- family-specific semantic node unions
+- shared style and metadata types
+- no absolute geometry
+
+### 3. Family layout packages
+
+These are the real workhorses.
+
+- `diagram-layout-graph`
+- `diagram-layout-sequence`
+- `diagram-layout-waveform`
+
+Responsibilities:
+
+- measure labels
+- choose node sizes
+- route edges/messages
+- place clusters, lanes, tracks, notes, and annotations
+- produce absolute diagram geometry
+
+### 4. `diagram-to-paint`
+
+This package lowers a layouted diagram into `PaintInstruction`.
+
+Responsibilities:
+
+- expand markers to paintable geometry
+- expand text blocks into glyph runs or backend-compatible text instructions
+- choose paint z-order
+- produce one `PaintScene` or nested scene fragment
+
+### 5. Document integration package
+
+We likely also need a thin integration package, for example:
+
+- `document-diagram-blocks`
+- or `document-ast-diagram-transform`
+
+Responsibilities:
+
+- claim TE04 `FencedBlockNode`s by `name`
+- dispatch to the right source parser
+- produce an embedded diagram block representation
+- preserve code-block fallback for unknown fences
+
+This package is an adapter. It is not the owner of diagram semantics.
+
+---
+
+## Semantic Diagram IR
+
+`diagram-ir` should define a common envelope plus family-specific payloads.
+
+### Common envelope
+
+```text
+DiagramDocument
+  id: string?
+  family: "graph" | "sequence" | "waveform"
+  title: string?
+  metadata: map<string, scalar>
+  theme: DiagramTheme?
+  body: GraphDiagram | SequenceDiagram | WaveformDiagram
+```
+
+### Shared helper concepts
+
+```text
+DiagramStyleRef
+  id: string?
+  classes: list<string>
+  inline: map<string, scalar>
+
+DiagramLabel
+  text: string
+  style: DiagramStyleRef?
+
+DiagramNote
+  id: string?
+  label: DiagramLabel
+  attachment: attachment target?
+  style: DiagramStyleRef?
+
+DiagramConstraint
+  kind: family-specific symbolic constraint
+```
+
+### Graph family
+
+```text
+GraphDiagram
+  direction: "lr" | "rl" | "tb" | "bt"?
+  nodes: list<GraphNode>
+  edges: list<GraphEdge>
+  clusters: list<GraphCluster>
+  lanes: list<GraphLane>
+  constraints: list<DiagramConstraint>
+
+GraphNode
+  id: string
+  shape: "rect" | "rounded_rect" | "ellipse" | "diamond" | "pill" | "path"
+  label: DiagramLabel?
+  ports: list<GraphPort>
+  style: DiagramStyleRef?
+  parent: cluster_id?
+
+GraphPort
+  id: string
+  side: "top" | "right" | "bottom" | "left" | "auto"
+  label: DiagramLabel?
+
+GraphEdge
+  id: string?
+  from: endpoint
+  to: endpoint
+  label: DiagramLabel?
+  kind: "directed" | "undirected"
+  style: DiagramStyleRef?
+
+GraphCluster
+  id: string
+  label: DiagramLabel?
+  children: list<node_or_cluster_id>
+  style: DiagramStyleRef?
+
+GraphLane
+  id: string
+  label: DiagramLabel?
+  children: list<node_or_cluster_id>
+  style: DiagramStyleRef?
+```
+
+### Sequence family
+
+```text
+SequenceDiagram
+  participants: list<Participant>
+  events: list<SequenceEvent>
+  groups: list<SequenceGroup>
+
+Participant
+  id: string
+  label: DiagramLabel
+  style: DiagramStyleRef?
+
+SequenceEvent
+  kind: "message" | "reply" | "activation" | "deactivation" | "note" | "divider"
+  ...
+```
+
+The exact event union can evolve, but the semantic IR must carry concepts such
+as participants, lifelines, messages, activation spans, notes, and grouping.
+
+### Waveform family
+
+```text
+WaveformDiagram
+  tracks: list<WaveTrack>
+  markers: list<WaveMarker>
+  spans: list<WaveSpan>
+
+WaveTrack
+  id: string
+  label: DiagramLabel
+  samples: waveform-specific payload
+  style: DiagramStyleRef?
+```
+
+The waveform IR should talk about tracks, logical transitions, cycles, spans,
+and annotations, not SVG paths.
+
+### What does NOT belong in semantic IR
+
+Do not put these in `diagram-ir`:
+
+- absolute `x` / `y`
+- bezier control points
+- paint colors already flattened to backend strings
+- glyph IDs
+- backend-specific line dash objects
+
+The semantic IR should still describe the diagram, not how Direct2D or Metal
+will rasterize it.
+
+---
+
+## Layouted Diagram IR
+
+After family layout runs, we need a geometry-bearing IR that is still slightly
+more semantic than raw `PaintInstruction`.
+
+```text
+LayoutedDiagram
+  width: float
+  height: float
+  items: list<LayoutedDiagramItem>
+```
+
+Recommended item types:
+
+```text
+LayoutedDiagramItem =
+  | NodeBox
+  | EdgeRoute
+  | LabelBox
+  | LaneBand
+  | NoteBox
+  | Decoration
+  | GroupBounds
+
+NodeBox
+  id: string
+  shape: node shape
+  x: float
+  y: float
+  width: float
+  height: float
+  style: resolved style
+
+EdgeRoute
+  id: string?
+  points: list<Point>
+  curve: optional bezier/arc detail
+  start_marker: Marker?
+  end_marker: Marker?
+  label_box: Rect?
+  style: resolved style
+
+LabelBox
+  text: string
+  x: float
+  y: float
+  width: float
+  height: float
+  align: "start" | "center" | "end"
+  style: resolved text style
+```
+
+This is the right layer for:
+
+- routed polylines
+- arrowhead attachment points
+- note box geometry
+- lane and cluster rectangles
+- final z-order
+
+This is **not** yet the right layer for:
+
+- glyph IDs
+- backend handles
+- COM objects
+- Metal buffers
+
+### Why not lower straight to `PaintInstruction` from layout?
+
+Because some layout results need one more normalization step:
+
+- markers become paths
+- dashed edges may expand to backend stroke state
+- text boxes become one or more glyph runs
+- graph edges and sequence arrows share paint lowering logic
+
+That shared logic belongs in `diagram-to-paint`, not duplicated across every
+layout package.
+
+---
+
+## `diagram-to-paint`
+
+`diagram-to-paint` consumes `LayoutedDiagram` and emits `PaintScene`.
+
+### Responsibilities
+
+- convert node shapes to `rect`, `ellipse`, or `path`
+- convert routed edges to `path`
+- expand arrowheads and other markers into `path`
+- convert label boxes to glyph runs or backend-compatible text
+- emit `group`, `layer`, and `clip` where they help preserve structure
+
+### Lowering guidelines
+
+- Prefer `PaintPath` over inventing graph-specific paint instructions.
+- Prefer expanding arrowheads into small `PaintPath` children instead of adding
+  a dedicated `PaintArrowhead` instruction.
+- Prefer path-based edges over `PaintLine` whenever joins, dashes, or markers
+  matter.
+- Keep ports, participants, tracks, and lanes in Diagram IR, not in Paint IR.
+
+### Result
+
+The paint layer stays generic:
+
+```text
+LayoutedDiagram
+  -> diagram-to-paint
+  -> PaintScene
+```
+
+not:
+
+```text
+LayoutedDiagram
+  -> MermaidPaintInstruction | WaveDromPaintInstruction | ...
+```
+
+---
+
+## What Needs To Change In PaintInstructions
+
+Most diagram concepts do **not** require new paint instructions. They require a
+better diagram middle layer.
+
+The current paint IR is already good at:
+
+- rectangles
+- rounded rectangles
+- ellipses
+- arbitrary paths
+- groups
+- layers
+- clips
+- glyph runs
+- images
+
+### Must-have paint additions
+
+The main missing primitive for serious diagram work is **dashed strokes**.
+
+Recommended addition on strokable instructions:
+
+```text
+stroke_dash: list<float>?
+stroke_dash_offset: float?
+```
+
+Applies to:
+
+- `PaintPath`
+- `PaintLine`
+- `PaintRect`
+- `PaintEllipse`
+
+This covers:
+
+- Mermaid dashed links
+- UML dependency edges
+- lane separators
+- waveform guide lines
+
+### Nice-to-have paint additions
+
+These are helpful but not required for phase 1:
+
+- `miter_limit` on stroked paths
+- optional polyline convenience instruction that lowers to `PaintPath`
+- path-based clip support for non-rectangular clipping
+
+### What should NOT be added to PaintInstructions
+
+Do not add paint instructions for:
+
+- ports
+- graph nodes
+- graph edges
+- participants
+- lifelines
+- wave tracks
+- arrowheads as a first-class instruction
+
+Those belong above paint.
+
+---
+
+## What Needs To Change In Layout IR
+
+For standalone diagram rendering, DG00 can bypass document layout entirely:
+
+```text
+DiagramDocument -> family layout -> LayoutedDiagram -> PaintScene
+```
+
+For embedded document rendering, UI02 still needs a way to host a native paint
+fragment in flow.
+
+Recommended follow-up:
+
+- add a `paint_fragment` or equivalent content kind to `layout-ir`
+- or add a formally specified embedded scene-fragment contract in `ext`
+
+That fragment needs at least:
+
+- intrinsic width
+- intrinsic height
+- a paint callback or scene-fragment payload
+
+Without that, diagrams embedded in markdown are forced to degrade into text or
+images too early.
+
+---
+
+## Backend Work
+
+Once the diagram pipeline targets `PaintInstruction`, backend work becomes much
+more predictable.
+
+### Direct2D
+
+Best first native backend.
+
+Needed for strong parity:
+
+- finish dash-pattern support
+- keep path and glyph-run support solid
+- verify marker-heavy path scenes
+
+### Metal
+
+Biggest native gap for general diagrams.
+
+Needed:
+
+- robust `PaintPath` fill and stroke
+- robust ellipse rendering
+- dash-pattern support
+- stable glyph-run rendering for labels
+
+Without path support, diagram lowering stays artificially constrained.
+
+### GDI
+
+Treat as degraded fallback.
+
+Acceptable v1 compromises:
+
+- solid-line fallback when dash support is missing
+- limited path fidelity
+- simplified text handling
+
+### Canvas / SVG
+
+These should remain the fastest debug and parity backends:
+
+- easy visual snapshot testing
+- easy inspection of generated geometry
+- fast iteration on diagram lowering
+
+---
+
+## Recommended Implementation Order
+
+1. Land `diagram-ir` with graph family first.
+2. Land `diagram-layout-graph`.
+3. Land `diagram-to-paint`.
+4. Add dashed stroke support to `paint-instructions` and first-class backends.
+5. Use Canvas and SVG as reference outputs.
+6. Bring Direct2D to native parity for the first subset.
+7. Add document embedding via TE04 fenced-block transform plus a UI02 paint fragment.
+8. Add sequence family.
+9. Add waveform family.
+
+This gets us real end-to-end value early without over-designing sequence and
+waveform semantics before the graph pipeline exists.
+
+---
+
+## Practical Conclusion
+
+The architecture we want is:
+
+```text
+source-specific parser packages
+  -> shared family-aware Diagram IR
+  -> shared family layout packages
+  -> shared diagram-to-paint compiler
+  -> PaintScene / PaintInstruction
+  -> backend-specific execution
+```
+
+That means:
+
+- new diagram syntaxes are mostly frontend work
+- new diagram families are mostly IR + layout work
+- backend growth is mostly paint parity work
+- `PaintInstruction` remains the universal rendering target
+
+This is the right scaling shape for Mermaid today and for other text-diagram
+languages later.

--- a/code/specs/MD01-gfm-mermaid-paint-pipeline.md
+++ b/code/specs/MD01-gfm-mermaid-paint-pipeline.md
@@ -1,0 +1,443 @@
+# MD01 — GFM Mermaid Diagrams Through Paint VM
+
+## Overview
+
+This note answers a narrow architecture question:
+
+> Do we already have enough packages and abstractions to take a fenced
+> Mermaid diagram in GFM and render it through backend-native paint APIs
+> such as Metal and Direct2D via `PaintScene` / `PaintInstruction`?
+
+Short answer:
+
+- **Yes for the paint IR direction.** `PaintScene` is already expressive enough
+  for Mermaid-style diagrams.
+- **Not yet for the markdown/document seam.** The current GFM and document
+  pipeline still collapses fenced blocks too early.
+- **Not yet for full native backend parity.** Direct2D is already close enough
+  for a first real diagram backend; Metal and GDI still have important gaps.
+
+This analysis was done against `origin/main` at commit `6b0c65934`.
+
+---
+
+## What Already Exists
+
+### 1. GFM parsing already has the raw ingredients for a general fenced-block seam
+
+The repo already has first-party GFM packages in multiple languages, including:
+
+- `code/packages/typescript/gfm-parser`
+- `code/packages/typescript/gfm`
+- `code/packages/rust/gfm-parser`
+- `code/packages/rust/gfm`
+- `code/packages/csharp/gfm-parser`
+
+Today the parser already preserves the key signal we need for a fenced block:
+
+- fenced code blocks become `CodeBlockNode`
+- `CodeBlockNode.language` is populated from the fence info string
+
+So this source:
+
+````markdown
+```mermaid
+flowchart LR
+  A --> B
+```
+````
+
+already parses as "this is a code block whose language is `mermaid`".
+
+That means the line-level parser is **not** the primary blocker. The missing
+piece is a more general AST primitive that preserves fenced blocks before they
+are forced into code rendering.
+
+### 2. The paint IR is already expressive enough for diagram rendering
+
+The current TypeScript `paint-instructions` package already exposes the core
+shapes a Mermaid renderer wants:
+
+- `rect`
+- `ellipse`
+- `path`
+- `line`
+- `glyph_run`
+- `text`
+- `group`
+- `layer`
+- `clip`
+- `gradient`
+- `image`
+
+For Mermaid-class diagrams this is already a strong target IR:
+
+- nodes map to `rect`, `ellipse`, or `path`
+- connectors map to `line` or `path`
+- labels map to `glyph_run` or `text`
+- clusters/subgraphs map to `group`, `clip`, and optional `layer`
+
+This is exactly the right direction: parse Mermaid once, lower it into
+`PaintInstruction`, then let each backend do its own platform-native drawing.
+
+### 3. Several backends already exist
+
+Current backend picture:
+
+| Backend | Status for diagram work |
+| --- | --- |
+| TypeScript `paint-vm-canvas` | Strong |
+| TypeScript `paint-vm-svg` | Strong |
+| Rust `paint-vm-direct2d` | Strong first native target |
+| Rust `paint-metal` | Partial |
+| Rust `paint-vm-gdi` | Minimal fallback only |
+| Rust `paint-vm-ascii` | Debug-only / rect-only mindset |
+
+The important point is that the project is **not** missing the backend concept.
+It already has the right Paint VM shape.
+
+### 4. There is already end-to-end markdown rendering infrastructure
+
+The repo already has working text/document pipelines such as:
+
+- `code/programs/typescript/markdown-canvas-demo`
+- `code/programs/rust/markdown-reader`
+- `code/specs/MD00-commonmark-to-metal.md`
+
+So Mermaid support does not need to invent a brand-new rendering universe.
+It needs to plug into an existing markdown -> document -> layout -> paint flow.
+
+---
+
+## The Real Gaps
+
+## Gap 1 — Fenced blocks are collapsed too early
+
+Today the GFM parser stops at:
+
+```text
+GFM source
+  -> DocumentNode
+  -> CodeBlockNode { language: "mermaid", value: "..." }
+```
+
+That is correct for ordinary code rendering, but it is too eager for richer
+fenced-block features.
+
+The better seam is:
+
+```text
+FencedBlockNode(name="mermaid", info="mermaid", value="...")
+  -> Mermaid parser
+  -> Diagram AST / Diagram layout
+  -> PaintScene fragment
+```
+
+Without that primitive, the rest of the pipeline sees only "a code block" and
+renders the Mermaid source literally.
+
+## Gap 2 — `document-ast-to-layout` has no general fenced-block hook
+
+Right now `document-ast-to-layout` renders every `code_block` as preformatted
+monospace text. It has no generic "fenced block fallback plus optional
+specialized transform" contract.
+
+That means even though the parser recognizes fenced metadata, the layout layer
+does not yet have a first-class place to intercept and reinterpret it.
+
+## Gap 3 — Layout IR has no native "embedded paint fragment" leaf
+
+This is the most important abstraction gap.
+
+The current `layout-ir` leaf content kinds are effectively:
+
+- text
+- image
+
+That is enough for prose and pictures, but not for "a box in document flow that
+internally contains arbitrary vector paint instructions".
+
+For Mermaid we do **not** want to rasterize to an image too early, because the
+goal is native Paint VM rendering:
+
+```text
+Mermaid -> semantic diagram -> PaintInstructions -> Metal / Direct2D / ...
+```
+
+So the layout layer needs one of these:
+
+1. A new leaf kind such as `paint_fragment`
+2. A diagram container contract in `ext`
+3. A post-layout composition step that can splice a nested `PaintScene`
+
+Without one of those, Mermaid blocks can only be treated as text or as images.
+
+## Gap 4 — There is no Mermaid parser package yet
+
+The repo contains packages that **emit Mermaid text** from graph structures
+(`directed-graph` visualization helpers), but that is the opposite direction.
+
+We do **not** yet have:
+
+- `mermaid-parser`
+- `diagram-ast`
+- `diagram-layout`
+- `diagram-to-paint`
+
+Those are the missing semantic layers.
+
+## Gap 5 — Native backend support is uneven
+
+### Direct2D
+
+`paint-vm-direct2d` is already the best native candidate for a first Mermaid
+backend. It dispatches:
+
+- `rect`
+- `line`
+- `group`
+- `clip`
+- `glyph_run`
+- `ellipse`
+- `path`
+- `layer`
+- `image`
+
+`gradient` is still not implemented, but that is not a blocker for a first
+Mermaid subset.
+
+### Metal
+
+`paint-metal` is not ready for general Mermaid output yet.
+
+Current practical support is centered around:
+
+- `rect`
+- `line`
+- `group`
+- `clip`
+- glyph overlay for `glyph_run`
+
+Important Mermaid-relevant gaps still exist:
+
+- no real `path` rendering
+- no real `ellipse` rendering
+- no `layer`
+- no `image`
+- no `gradient`
+
+This matters because Mermaid nodes and connectors quickly need more than
+axis-aligned rectangles:
+
+- diamonds
+- rounded clusters
+- arrowheads
+- curved or orthogonal paths
+
+### GDI
+
+`paint-vm-gdi` is currently only a fallback for very simple scenes:
+
+- `rect`
+- `line`
+- `group`
+- `clip`
+
+That is not enough for a serious Mermaid implementation unless we accept a very
+degraded subset.
+
+## Gap 6 — Rust/native paint IR currently has `GlyphRun`, not `Text`
+
+TypeScript has both `PaintGlyphRun` and `PaintText`.
+Rust/native currently centers on `PaintGlyphRun`.
+
+That is fine for Direct2D and a mature native text stack, but it means the
+cross-language story is not yet perfectly aligned. For Mermaid labels this is
+not fatal, but it is worth preserving as a design constraint:
+
+- native backends should prefer shaped glyph runs
+- web/canvas can still use `PaintText`
+
+---
+
+## What This Means Architecturally
+
+## The paint abstraction is already the correct target
+
+We do **not** need a separate "Mermaid renderer abstraction".
+The existing target should stay:
+
+```text
+Mermaid source
+  -> Mermaid parser
+  -> DG00 Diagram IR
+  -> DG00 graph layout
+  -> PaintScene / PaintInstruction
+  -> Paint VM backend
+```
+
+That keeps Metal, Direct2D, SVG, Canvas, and any future backend on one shared
+scene model.
+
+## The GFM parser probably needs a general fenced-block primitive, not a rewrite
+
+For Mermaid and future fenced features, the parser is mostly doing the right
+thing already. The main parser-side improvement is:
+
+1. Preserve fenced blocks as a generic TE04 `FencedBlockNode`
+2. Keep both a fast dispatch key and the full fence info string
+3. Keep Mermaid parsing out of the core GFM syntax parser
+
+In other words:
+
+- the GFM parser should stay responsible for Markdown
+- a Mermaid package should be responsible for Mermaid
+- default consumers should still be able to render unknown fences like code blocks
+
+That separation is healthy.
+
+## The biggest missing seam is between document layout and paint
+
+If Mermaid must participate in markdown flow like a normal block element, we
+need a first-class way to say:
+
+> "This block occupies width X and height Y in layout, but when it paints, it
+> emits its own nested paint instructions instead of plain text/image content."
+
+That is the missing abstraction.
+
+---
+
+## Recommended Plan
+
+## Phase 1 — Add the general fenced-block primitive
+
+Adopt TE04 `FencedBlockNode` in the GFM layer:
+
+```text
+fenced_block
+  name
+  info
+  value
+```
+
+Default consumers should render unknown fenced blocks like code blocks.
+Specialized transforms can claim names such as `mermaid`.
+
+## Phase 2 — Introduce a native diagram block seam
+
+Add a layout/content concept for embedded native paint fragments:
+
+```text
+paint_fragment
+  intrinsic width / height
+  paint children or paint-scene fragment
+```
+
+This is still the cleanest way to keep Mermaid native all the way down once a
+fenced block has been claimed by a diagram transform.
+
+## Phase 3 — Add a Mermaid-specific transform package
+
+Introduce a package whose job is:
+
+```text
+DocumentNode
+  -> walk blocks
+  -> find FencedBlockNode(name="mermaid")
+  -> parse Mermaid source
+  -> lower into DG00 Diagram IR
+  -> replace with diagram-aware block representation
+```
+
+Possible package names:
+
+- `gfm-mermaid`
+- `document-ast-diagram-transform`
+- `mermaid-block-transform`
+
+This should be a transform package, not part of the core parser.
+
+## Phase 4 — Start with a focused Mermaid subset
+
+The first supported subset should be small and backend-friendly:
+
+- `flowchart`
+- basic `stateDiagram-v2`
+- straight connectors
+- rectangular / rounded / diamond nodes
+- text labels
+- subgraphs later
+
+Avoid starting with:
+
+- sequence diagrams
+- class diagrams
+- CSS-like Mermaid theming
+- animation
+- icon/image embedding
+
+The goal is to prove the pipeline, not to clone Mermaid.js in one step.
+
+## Phase 5 — Use Direct2D as the first native reference backend
+
+Direct2D is the best first native target because it already has working support
+for most of the scene primitives a Mermaid subset needs.
+
+Suggested backend order:
+
+1. SVG / Canvas for fast debug output
+2. Direct2D for the first native parity target
+3. Metal after `PaintPath` and ellipse support land
+4. GDI only as a degraded fallback
+
+## Phase 6 — Close the Metal gap
+
+If Metal is a must-have first-class target, the next missing backend work is
+clear:
+
+- implement `PaintPath`
+- implement `PaintEllipse`
+- keep `GlyphRun` path solid
+- optionally add `Layer` later
+
+Until then, Metal can render only a narrow subset of Mermaid output.
+
+---
+
+## Practical Conclusion
+
+We already have enough infrastructure to justify this direction.
+
+What we **have**:
+
+- a good GFM parser
+- a shared document AST
+- a shared paint IR
+- several paint backends
+- native markdown rendering pipelines
+
+What we **do not yet have**:
+
+- a general fenced-block primitive in the GFM AST
+- a Mermaid parser
+- a diagram AST/layout layer
+- a document-to-diagram transform seam built on fenced blocks
+- a layout leaf that can carry native paint fragments
+- full Metal parity for diagram primitives
+
+So the answer is:
+
+- **enough to begin**
+- **not enough to ship full Mermaid rendering yet**
+
+The next architectural move should not be "make GFM much more magical".
+It should be:
+
+1. add a general fenced-block primitive after GFM parse
+2. add a diagram-aware transform on top of that primitive
+3. add a native paint-fragment concept to the layout/paint bridge
+4. target Direct2D first, then close Metal path support
+
+That path preserves the repo's strongest design choice: one backend-neutral
+scene model, many native renderers.

--- a/code/specs/TE00-document-ast.md
+++ b/code/specs/TE00-document-ast.md
@@ -833,7 +833,7 @@ ones.
 | Spec  | Title                        | New node types                                                          |
 |-------|------------------------------|-------------------------------------------------------------------------|
 | TE00  | Document AST (this)          | 19 node types above                                                     |
-| TE04  | GFM Extensions               | `TableNode`, `TableRowNode`, `TableCellNode`, `StrikeNode`, `TaskItemNode` |
+| TE04  | GFM Extensions               | `TableNode`, `TableRowNode`, `TableCellNode`, `StrikeNode`, `TaskItemNode`, `FencedBlockNode` |
 | TE05  | ThunderEgg Dialect           | `WikiLinkNode`, `WikiEmbedNode`, `HighlightNode`, `MathInlineNode`, `MathBlockNode`, `FrontmatterNode`, `CalloutNode` |
 
 GFM node types (TE04):
@@ -844,6 +844,7 @@ interface TableRowNode  { readonly type: "table_row";      readonly isHeader: bo
 interface TableCellNode { readonly type: "table_cell";     readonly children: readonly InlineNode[] }
 interface StrikeNode    { readonly type: "strikethrough";  readonly children: readonly InlineNode[] }
 interface TaskItemNode  { readonly type: "task_item";      readonly checked: boolean; readonly children: readonly BlockNode[] }
+interface FencedBlockNode { readonly type: "fenced_block"; readonly name: string | null; readonly info: string | null; readonly value: string }
 ```
 
 ThunderEgg dialect node types (TE05):

--- a/code/specs/TE01-commonmark-parser.md
+++ b/code/specs/TE01-commonmark-parser.md
@@ -822,7 +822,7 @@ The AST defined in this spec is the stable foundation. Future specs extend it:
 | TE01  | CommonMark Parser (this)     | —         | All 20 node types above                             |
 | TE02  | Parsing Algorithm            | TE01      | None — specifies how to produce TE01 AST            |
 | TE03  | HTML Renderer                | TE01      | None — specifies toHtml(DocumentNode)               |
-| TE04  | GFM Extensions               | TE01–03   | TableNode, TableRowNode, TableCellNode, StrikeNode, TaskListItemNode |
+| TE04  | GFM Extensions               | TE01–03   | TableNode, TableRowNode, TableCellNode, StrikeNode, TaskListItemNode, FencedBlockNode |
 | TE05  | ThunderEgg Dialect           | TE01–04   | WikiLinkNode, WikiEmbedNode, HighlightNode, MathNode, FrontmatterNode, CalloutNode |
 
 GFM node types (TE04):
@@ -834,6 +834,7 @@ interface TableRowNode   { type: "table_row";  isHeader: boolean; children: read
 interface TableCellNode  { type: "table_cell"; children: readonly InlineNode[] }
 interface StrikeNode     { type: "strikethrough"; children: readonly InlineNode[] }
 interface TaskItemNode   { type: "task_item";  checked: boolean; children: readonly BlockNode[] }
+interface FencedBlockNode { type: "fenced_block"; name: string | null; info: string | null; value: string }
 ```
 
 ThunderEgg dialect node types (TE05):

--- a/code/specs/TE04-gfm-extensions.md
+++ b/code/specs/TE04-gfm-extensions.md
@@ -1,0 +1,345 @@
+# TE04 — GFM Extensions
+
+## Overview
+
+TE04 extends the CommonMark / Document AST stack with GitHub Flavored Markdown
+features that are not part of baseline CommonMark but are important in real
+documents and applications.
+
+The currently relevant GFM additions are:
+
+- strikethrough
+- task list items
+- pipe tables
+- a **general fenced block primitive**
+
+That last item is the important architectural addition in this spec.
+
+Historically, fenced blocks in the repo have been normalized immediately into
+`CodeBlockNode { language, value }`. That is fine for syntax-highlighted code,
+but it collapses several future uses into one rendering choice too early:
+
+- Mermaid
+- Graphviz / DOT
+- fenced admonitions
+- fenced chart DSLs
+- fenced UI/layout snippets
+- any future block whose payload is not "just code"
+
+TE04 therefore adds a GFM-specific node that preserves the generic fenced-block
+shape long enough for downstream transforms to decide what it means.
+
+---
+
+## New Node Types
+
+TE04 adds these GFM node types:
+
+```typescript
+interface TableNode {
+  readonly type: "table";
+  readonly align: readonly ("left" | "right" | "center" | null)[];
+  readonly children: readonly TableRowNode[];
+}
+
+interface TableRowNode {
+  readonly type: "table_row";
+  readonly isHeader: boolean;
+  readonly children: readonly TableCellNode[];
+}
+
+interface TableCellNode {
+  readonly type: "table_cell";
+  readonly children: readonly InlineNode[];
+}
+
+interface StrikethroughNode {
+  readonly type: "strikethrough";
+  readonly children: readonly InlineNode[];
+}
+
+interface TaskItemNode {
+  readonly type: "task_item";
+  readonly checked: boolean;
+  readonly children: readonly BlockNode[];
+}
+
+interface FencedBlockNode {
+  readonly type: "fenced_block";
+  readonly name: string | null;
+  readonly info: string | null;
+  readonly value: string;
+}
+```
+
+---
+
+## `FencedBlockNode`
+
+### Purpose
+
+`FencedBlockNode` is a **source-preserving GFM extension node**.
+
+It represents:
+
+- a fenced block opener/closer from Markdown
+- its normalized info string
+- its raw inner payload
+
+without prematurely deciding that the payload must be rendered as code.
+
+This is a GFM concern, not a core document concern, which is why it lives in
+TE04 rather than TE00.
+
+### Fields
+
+```typescript
+interface FencedBlockNode {
+  readonly type: "fenced_block";
+
+  // First whitespace-delimited token of the info string.
+  // Examples:
+  //   ```mermaid        -> "mermaid"
+  //   ```typescript     -> "typescript"
+  //   ```               -> null
+  readonly name: string | null;
+
+  // Entire normalized info string after the opening fence, or null if absent.
+  // Examples:
+  //   ```mermaid
+  //   -> "mermaid"
+  //
+  //   ```mermaid theme=dark
+  //   -> "mermaid theme=dark"
+  readonly info: string | null;
+
+  // Raw block payload, including the trailing newline when the block is non-empty.
+  readonly value: string;
+}
+```
+
+### Why both `name` and `info`?
+
+Because downstream consumers typically need two different views:
+
+- a cheap dispatch key, such as `"mermaid"` or `"typescript"`
+- the untouched remaining info payload for block-specific parsing
+
+`name` is the fast routing key.
+`info` is the source-preserving metadata string.
+
+### Why not just overload `CodeBlockNode.language`?
+
+Because `language` implies a rendering decision:
+
+> "This block is code, and the string is a syntax-highlighting hint."
+
+That is true for many fences, but not for all fences we want to support.
+
+`FencedBlockNode` preserves the more general truth:
+
+> "This is a fenced block. A later phase decides whether it is code,
+> a diagram, an admonition, a chart, or something else."
+
+---
+
+## Parsing Rules
+
+### Block recognition
+
+TE04 reuses the CommonMark fenced-block opening and closing rules:
+
+- backtick fences and tilde fences are both valid
+- opening fence indentation rules are unchanged
+- closing fence rules are unchanged
+- payload indentation stripping rules are unchanged
+
+This spec changes the **AST shape**, not the line-level parsing rules.
+
+### Mapping to `FencedBlockNode`
+
+For a fenced block:
+
+1. Parse the opening fence exactly as CommonMark already does.
+2. Extract the full normalized info string.
+3. Set `name` to the first whitespace-delimited token of that info string.
+4. Set `info` to the full normalized info string, or `null` if absent.
+5. Set `value` to the raw payload, preserving the current code-block newline rules.
+
+Examples:
+
+````markdown
+```mermaid
+flowchart LR
+  A --> B
+```
+````
+
+becomes:
+
+```typescript
+{
+  type: "fenced_block",
+  name: "mermaid",
+  info: "mermaid",
+  value: "flowchart LR\n  A --> B\n",
+}
+```
+
+````markdown
+```typescript linenos
+const x = 1;
+```
+````
+
+becomes:
+
+```typescript
+{
+  type: "fenced_block",
+  name: "typescript",
+  info: "typescript linenos",
+  value: "const x = 1;\n",
+}
+```
+
+````markdown
+```
+plain fenced text
+```
+````
+
+becomes:
+
+```typescript
+{
+  type: "fenced_block",
+  name: null,
+  info: null,
+  value: "plain fenced text\n",
+}
+```
+
+### Indented code blocks
+
+Indented code blocks are **not** `FencedBlockNode`.
+
+They remain `CodeBlockNode`, because they carry no GFM fence metadata and have
+no extension-dispatch role.
+
+That distinction is intentional:
+
+- `CodeBlockNode` = normalized literal/preformatted content
+- `FencedBlockNode` = source-level fenced construct awaiting interpretation
+
+---
+
+## Consumer Contract
+
+### Default rendering behavior
+
+Renderers and layout bridges that do not know any special fenced-block names
+should still behave sensibly.
+
+The default fallback for `FencedBlockNode` is:
+
+- render it visually like a code block
+- use `name` as a syntax-highlighting hint when applicable
+
+So a generic HTML renderer may treat:
+
+```typescript
+{ type: "fenced_block", name: "typescript", value: "const x = 1;\n" }
+```
+
+the same way it would have treated:
+
+```typescript
+{ type: "code_block", language: "typescript", value: "const x = 1;\n" }
+```
+
+This gives us a clean extension seam **without regressing default behavior**.
+
+### Specialized transforms
+
+A transform package may match on `FencedBlockNode.name` and replace the node
+with a richer representation.
+
+Examples:
+
+- `name === "mermaid"` -> parse diagram and replace with a diagram-aware block
+- `name === "admonition"` -> replace with callout/admonition structure
+- `name === "math"` -> replace with a math block node
+
+This is the main architectural value of the primitive.
+
+---
+
+## Relationship to TE00 `CodeBlockNode`
+
+TE00 `CodeBlockNode` remains correct and necessary.
+
+It is still the right normalized node for:
+
+- indented code blocks
+- non-Markdown frontends that directly produce literal preformatted blocks
+- post-transform fenced blocks that are still best rendered as code
+
+The relationship is:
+
+```text
+Markdown fenced block
+  -> FencedBlockNode        (TE04, source-preserving)
+  -> optional transform
+     -> CodeBlockNode       (if interpreted as ordinary code)
+     -> Diagram block       (future)
+     -> Other extension     (future)
+
+Indented code block / non-Markdown literal block
+  -> CodeBlockNode directly
+```
+
+---
+
+## Package Implications
+
+### `gfm-parser`
+
+`gfm-parser` should preserve fenced blocks as `FencedBlockNode` instead of
+eagerly collapsing them to `CodeBlockNode`.
+
+### `gfm`
+
+The convenience package may continue to provide code-block-like default output,
+but it should do that as a **consumer behavior**, not by removing the
+`FencedBlockNode` seam from the parsed AST.
+
+### `document-ast-to-html`
+
+Should provide a default fallback that renders unknown `fenced_block` nodes as
+`<pre><code>…</code></pre>`.
+
+### `document-ast-to-layout`
+
+Should provide a default fallback that renders unknown `fenced_block` nodes as
+monospace preformatted blocks, matching the current visual behavior of
+`code_block`.
+
+This keeps existing markdown rendering sane while making richer transforms
+possible.
+
+---
+
+## Acceptance Criteria
+
+TE04 is complete when:
+
+1. GFM parsers preserve fenced blocks as `FencedBlockNode`.
+2. `name` and full `info` are both preserved.
+3. Indented code blocks remain `CodeBlockNode`.
+4. HTML and layout consumers have a code-block fallback for unknown fenced blocks.
+5. A downstream transform can distinguish ordinary fenced code from
+   non-code fenced blocks without reparsing Markdown source.
+
+That gives the repo a general-purpose fence seam for Mermaid and for future
+fenced block features beyond diagrams.


### PR DESCRIPTION
## Summary
- add a shared DG00 diagram IR and layout pipeline that lowers text-diagram families into `PaintScene` / `PaintInstruction`
- add TE04 GFM fenced block extensions so Mermaid and future fenced block features have a general parser seam
- update the Mermaid paint-pipeline note and cross-reference the new fenced block primitive from the document/commonmark specs

## Details
This PR keeps parser packages source-specific while moving layout and paint lowering into shared family-oriented layers:

- source parser packages such as Mermaid, DOT, PlantUML subsets, and WaveDrom stay syntax-specific
- semantic diagram IR and family layout packages are shared across diagram families
- `diagram-to-paint` becomes the common lowering path into the existing Paint VM stack

It also calls out the concrete platform work still needed for strong diagram support:

- dashed stroke support in `PaintInstruction`
- a native paint-fragment seam for embedded diagrams in layout/document flow
- stronger Metal path/ellipse support, with Direct2D as the best first native parity target

## Testing
- not run (spec-only changes)