### PR TITLE
test(riscv): broaden Nib and Brainfuck E2E coverage

### DIFF
--- a/code/packages/go/brainfuck-ir-compiler/compiler.go
+++ b/code/packages/go/brainfuck-ir-compiler/compiler.go
@@ -361,10 +361,11 @@ func (c *compiler) compileCommand(node *parser.ASTNode) error {
 // current cell by the given delta (+1 or -1).
 //
 // The sequence is:
-//   LOAD_BYTE  v2, v0, v1        ← load current cell
-//   ADD_IMM    v2, v2, delta      ← increment/decrement
-//   AND_IMM    v2, v2, 255        ← mask to byte (if enabled)
-//   STORE_BYTE v2, v0, v1        ← store back
+//
+//	LOAD_BYTE  v2, v0, v1        ← load current cell
+//	ADD_IMM    v2, v2, delta      ← increment/decrement
+//	AND_IMM    v2, v2, 255        ← mask to byte (if enabled)
+//	STORE_BYTE v2, v0, v1        ← store back
 func (c *compiler) emitCellMutation(delta int) []int {
 	var ids []int
 
@@ -409,19 +410,26 @@ func (c *compiler) emitCellMutation(delta int) []int {
 // to the __trap_oob label (which calls exit(1)).
 //
 // RIGHT (>):
-//   CMP_GT  v3, v1, v5        ← is ptr >= tape_size?
+//   ADD_IMM v3, v1, 1         ← predicted ptr after increment
+//   CMP_GT  v3, v3, v5        ← is predicted ptr > max?
 //   BRANCH_NZ v3, __trap_oob  ← if so, trap
 //
 // LEFT (<):
-//   CMP_LT  v3, v1, v6        ← is ptr < 0?
+//   ADD_IMM v3, v1, -1        ← predicted ptr after decrement
+//   CMP_LT  v3, v3, v6        ← is predicted ptr < 0?
 //   BRANCH_NZ v3, __trap_oob  ← if so, trap
 // ──────────────────────────────────────────────────────────────────────────────
 
 func (c *compiler) emitBoundsCheckRight() []int {
 	var ids []int
-	id := c.emit(ir.OpCmpGt,
+	id := c.emit(ir.OpAddImm,
 		ir.IrRegister{Index: regTemp2},
 		ir.IrRegister{Index: regTapePtr},
+		ir.IrImmediate{Value: 1})
+	ids = append(ids, id)
+	id = c.emit(ir.OpCmpGt,
+		ir.IrRegister{Index: regTemp2},
+		ir.IrRegister{Index: regTemp2},
 		ir.IrRegister{Index: regMaxPtr})
 	ids = append(ids, id)
 	id = c.emit(ir.OpBranchNz,
@@ -433,13 +441,18 @@ func (c *compiler) emitBoundsCheckRight() []int {
 
 func (c *compiler) emitBoundsCheckLeft() []int {
 	var ids []int
-	id := c.emit(ir.OpCmpLt,
+	id := c.emit(ir.OpAddImm,
+		ir.IrRegister{Index: regTemp2},
 		ir.IrRegister{Index: regTapePtr},
-		ir.IrRegister{Index: regTapePtr},
+		ir.IrImmediate{Value: -1})
+	ids = append(ids, id)
+	id = c.emit(ir.OpCmpLt,
+		ir.IrRegister{Index: regTemp2},
+		ir.IrRegister{Index: regTemp2},
 		ir.IrRegister{Index: regZero})
 	ids = append(ids, id)
 	id = c.emit(ir.OpBranchNz,
-		ir.IrRegister{Index: regTapePtr},
+		ir.IrRegister{Index: regTemp2},
 		ir.IrLabel{Name: "__trap_oob"})
 	ids = append(ids, id)
 	return ids

--- a/code/packages/go/brainfuck-riscv-compiler/compiler_test.go
+++ b/code/packages/go/brainfuck-riscv-compiler/compiler_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	brainfuckircompiler "github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck-ir-compiler"
 )
 
 func TestCompileSourceReturnsAssemblyAndBytes(t *testing.T) {
@@ -70,6 +72,83 @@ func TestRunSourceWithInputEchoesByte(t *testing.T) {
 	}
 	if got := run.OutputString(); got != "Z" {
 		t.Fatalf("expected output %q, got %q", "Z", got)
+	}
+}
+
+func TestRunSourceExecutesLoopHeavyBrainfuckProgramOnRiscVSimulator(t *testing.T) {
+	run, err := RunSource("++++++++[>++++++++<-]>+.")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if !run.HostExited {
+		t.Fatal("expected host exit syscall")
+	}
+	if got := run.OutputString(); got != "A" {
+		t.Fatalf("expected output %q, got %q", "A", got)
+	}
+}
+
+func TestRunSourceWithInputEchoesUntilZeroSentinel(t *testing.T) {
+	run, err := RunSourceWithInput(",[.,]", []byte{'O', 'K', 0})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if !run.HostExited {
+		t.Fatal("expected host exit syscall")
+	}
+	if got := run.OutputString(); got != "OK" {
+		t.Fatalf("expected output %q, got %q", "OK", got)
+	}
+}
+
+func TestRunSourceDebugBoundsCheckExitsOnRightOverflow(t *testing.T) {
+	config := brainfuckircompiler.DebugConfig()
+	config.TapeSize = 1
+	run, err := NewBrainfuckRiscVCompiler(&BrainfuckRiscVCompilerOptions{BuildConfig: &config}).RunSource(">")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if !run.HostExited {
+		t.Fatal("expected host exit syscall")
+	}
+	if run.ExitCode != 1 {
+		t.Fatalf("expected bounds trap exit code 1, got %d", run.ExitCode)
+	}
+	if len(run.Output) != 0 {
+		t.Fatalf("expected no output before bounds trap, got %v", run.Output)
+	}
+	if !strings.Contains(run.Package.Assembly, "__trap_oob:") {
+		t.Fatalf("expected debug assembly to contain trap label, got:\n%s", run.Package.Assembly)
+	}
+}
+
+func TestRunSourceDebugBoundsCheckExitsOnLeftUnderflow(t *testing.T) {
+	config := brainfuckircompiler.DebugConfig()
+	config.TapeSize = 4
+	run, err := NewBrainfuckRiscVCompiler(&BrainfuckRiscVCompilerOptions{BuildConfig: &config}).RunSource("<")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if !run.HostExited {
+		t.Fatal("expected host exit syscall")
+	}
+	if run.ExitCode != 1 {
+		t.Fatalf("expected bounds trap exit code 1, got %d", run.ExitCode)
+	}
+	if len(run.Output) != 0 {
+		t.Fatalf("expected no output before bounds trap, got %v", run.Output)
 	}
 }
 

--- a/code/packages/go/nib-ir-compiler/compiler.go
+++ b/code/packages/go/nib-ir-compiler/compiler.go
@@ -21,13 +21,14 @@ type CompileResult struct {
 }
 
 type Compiler struct {
-	config      BuildConfig
-	typedAST    *nibtypechecker.TypedAST
-	idGen       *ir.IDGenerator
-	program     *ir.IrProgram
-	loopCount   int
-	ifCount     int
-	constValues map[string]int
+	config        BuildConfig
+	typedAST      *nibtypechecker.TypedAST
+	idGen         *ir.IDGenerator
+	program       *ir.IrProgram
+	loopCount     int
+	ifCount       int
+	registerFloor int
+	constValues   map[string]int
 }
 
 func CompileNib(typedAST *nibtypechecker.TypedAST, config BuildConfig) CompileResult {
@@ -171,8 +172,10 @@ func (c *Compiler) compileFunction(node *parser.ASTNode) {
 			nextRegister++
 		}
 	}
+	c.registerFloor = nextRegister
 	c.compileBlock(blockNode, registers, nextRegister)
 	c.emit(ir.OpRet)
+	c.registerFloor = 0
 }
 
 func (c *Compiler) localRegisterBase() int {
@@ -191,8 +194,23 @@ func (c *Compiler) firstLocalRegister(paramCount int) int {
 	return base
 }
 
+func (c *Compiler) nextAvailableRegister(nextRegister int) int {
+	if nextRegister < c.registerFloor {
+		return c.registerFloor
+	}
+	return nextRegister
+}
+
+func (c *Compiler) claimRegisterBlock(nextRegister int, count int) int {
+	base := c.nextAvailableRegister(nextRegister)
+	if count > 0 && base+count > c.registerFloor {
+		c.registerFloor = base + count
+	}
+	return base
+}
+
 func (c *Compiler) compileBlock(block *parser.ASTNode, registers map[string]int, nextRegister int) int {
-	current := nextRegister
+	current := c.nextAvailableRegister(nextRegister)
 	for _, child := range childNodes(block) {
 		if child.RuleName == "stmt" && len(child.Children) > 0 {
 			if inner, ok := child.Children[0].(*parser.ASTNode); ok {
@@ -244,7 +262,7 @@ func (c *Compiler) compileLet(node *parser.ASTNode, registers map[string]int, ne
 	if name == "" || expression == nil {
 		return nextRegister
 	}
-	destination := nextRegister
+	destination := c.claimRegisterBlock(nextRegister, 1)
 	registers[name] = destination
 	resultRegister := c.compileExpr(expression, registers)
 	if resultRegister != destination {
@@ -255,7 +273,7 @@ func (c *Compiler) compileLet(node *parser.ASTNode, registers map[string]int, ne
 			c.emitComment("let " + name + ": " + string(nibType))
 		}
 	}
-	return nextRegister + 1
+	return destination + 1
 }
 
 func (c *Compiler) compileAssign(node *parser.ASTNode, registers map[string]int) {
@@ -310,8 +328,9 @@ func (c *Compiler) compileFor(node *parser.ASTNode, registers map[string]int, ne
 	if loopVar == "" || len(exprs) < 2 || blockNode == nil {
 		return nextRegister
 	}
-	loopRegister := nextRegister
-	limitRegister := nextRegister + 1
+	baseRegister := c.claimRegisterBlock(nextRegister, 2)
+	loopRegister := baseRegister
+	limitRegister := baseRegister + 1
 	startLabel := "loop_" + strconv.Itoa(c.loopCount) + "_start"
 	endLabel := "loop_" + strconv.Itoa(c.loopCount) + "_end"
 	c.loopCount++
@@ -331,11 +350,11 @@ func (c *Compiler) compileFor(node *parser.ASTNode, registers map[string]int, ne
 	c.emit(ir.OpBranchZ, ir.IrRegister{Index: regScratch}, ir.IrLabel{Name: endLabel})
 
 	nested := copyRegisters(registers)
-	c.compileBlock(blockNode, nested, nextRegister+2)
+	c.compileBlock(blockNode, nested, baseRegister+2)
 	c.emit(ir.OpAddImm, ir.IrRegister{Index: loopRegister}, ir.IrRegister{Index: loopRegister}, ir.IrImmediate{Value: 1})
 	c.emit(ir.OpJump, ir.IrLabel{Name: startLabel})
 	c.emitLabel(endLabel)
-	return nextRegister + 2
+	return baseRegister + 2
 }
 
 func (c *Compiler) compileIf(node *parser.ASTNode, registers map[string]int, nextRegister int) {
@@ -440,11 +459,19 @@ func (c *Compiler) compileCallExpr(node *parser.ASTNode, registers map[string]in
 	if functionName == "" {
 		return regScratch
 	}
+	stagedArgBase := c.claimRegisterBlock(regArgBase+len(args), len(args))
 	for index, arg := range args {
 		valueRegister := c.compileExpr(arg, registers)
-		destination := regArgBase + index
+		destination := stagedArgBase + index
 		if valueRegister != destination {
 			c.emit(ir.OpAddImm, ir.IrRegister{Index: destination}, ir.IrRegister{Index: valueRegister}, ir.IrImmediate{Value: 0})
+		}
+	}
+	for index := range args {
+		source := stagedArgBase + index
+		destination := regArgBase + index
+		if source != destination {
+			c.emit(ir.OpAddImm, ir.IrRegister{Index: destination}, ir.IrRegister{Index: source}, ir.IrImmediate{Value: 0})
 		}
 	}
 	c.emit(ir.OpCall, ir.IrLabel{Name: "_fn_" + functionName})

--- a/code/packages/go/nib-ir-compiler/compiler.go
+++ b/code/packages/go/nib-ir-compiler/compiler.go
@@ -158,7 +158,7 @@ func (c *Compiler) compileFunction(node *parser.ASTNode) {
 	registers := map[string]int{}
 	nextRegister := regArgBase
 	if c.config.CopyParametersToLocals {
-		nextRegister = c.localRegisterBase()
+		nextRegister = c.firstLocalRegister(len(params))
 		for index, param := range params {
 			argRegister := regArgBase + index
 			registers[param[0]] = nextRegister
@@ -180,6 +180,15 @@ func (c *Compiler) localRegisterBase() int {
 		return c.config.LocalRegisterBase
 	}
 	return defaultLocalRegisterBase
+}
+
+func (c *Compiler) firstLocalRegister(paramCount int) int {
+	base := c.localRegisterBase()
+	argLimit := regArgBase + paramCount
+	if base < argLimit {
+		return argLimit
+	}
+	return base
 }
 
 func (c *Compiler) compileBlock(block *parser.ASTNode, registers map[string]int, nextRegister int) int {

--- a/code/packages/go/nib-ir-compiler/compiler_test.go
+++ b/code/packages/go/nib-ir-compiler/compiler_test.go
@@ -1,8 +1,10 @@
 package nibircompiler
 
 import (
+	"strings"
 	"testing"
 
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
 	nibtypechecker "github.com/adhithyan15/coding-adventures/code/packages/go/nib-type-checker"
 )
 
@@ -20,5 +22,57 @@ func TestCompileSourceProducesIR(t *testing.T) {
 func TestParseLiteralRejectsOverflow(t *testing.T) {
 	if parsed, ok := parseLiteral("70000", "INT_LIT"); ok {
 		t.Fatalf("expected overflow to be rejected, got %d", parsed)
+	}
+}
+
+func TestCallSafeConfigCopiesParametersPastLiveArgumentRegisters(t *testing.T) {
+	typed := nibtypechecker.CheckSource(strings.Join([]string{
+		"fn sum7(a: u4, b: u4, c: u4, d: u4, e: u4, f: u4, g: u4) -> u4 {",
+		"  return a;",
+		"}",
+	}, " "))
+	if !typed.OK {
+		t.Fatalf("type check failed: %#v", typed.Errors)
+	}
+
+	result := CompileNib(typed.TypedAST, CallSafeConfig())
+	instructions := result.Program.Instructions
+	labelIndex := -1
+	for index, instruction := range instructions {
+		if instruction.Opcode != ir.OpLabel {
+			continue
+		}
+		label, ok := instruction.Operands[0].(ir.IrLabel)
+		if ok && label.Name == "_fn_sum7" {
+			labelIndex = index
+			break
+		}
+	}
+	if labelIndex < 0 {
+		t.Fatal("expected _fn_sum7 label in IR")
+	}
+
+	expectedCopies := [][2]int{
+		{9, 2},
+		{10, 3},
+		{11, 4},
+		{12, 5},
+		{13, 6},
+		{14, 7},
+		{15, 8},
+	}
+	for index, want := range expectedCopies {
+		instruction := instructions[labelIndex+1+index]
+		if instruction.Opcode != ir.OpAddImm {
+			t.Fatalf("expected parameter copy %d to be ADD_IMM, got %s", index, instruction.Opcode)
+		}
+		dst, ok := instruction.Operands[0].(ir.IrRegister)
+		if !ok || dst.Index != want[0] {
+			t.Fatalf("expected parameter copy %d to target v%d, got %#v", index, want[0], instruction.Operands[0])
+		}
+		src, ok := instruction.Operands[1].(ir.IrRegister)
+		if !ok || src.Index != want[1] {
+			t.Fatalf("expected parameter copy %d to read v%d, got %#v", index, want[1], instruction.Operands[1])
+		}
 	}
 }

--- a/code/packages/go/nib-ir-compiler/compiler_test.go
+++ b/code/packages/go/nib-ir-compiler/compiler_test.go
@@ -76,3 +76,62 @@ func TestCallSafeConfigCopiesParametersPastLiveArgumentRegisters(t *testing.T) {
 		}
 	}
 }
+
+func TestCallSafeConfigStagesNestedCallArgumentsOutsideLiveArgumentRegisters(t *testing.T) {
+	typed := nibtypechecker.CheckSource(strings.Join([]string{
+		"fn inc(value: u4) -> u4 { return value +% 1; }",
+		"fn sum7(a: u4, b: u4, c: u4, d: u4, e: u4, f: u4, g: u4) -> u4 {",
+		"  return a + b + c + d + e + f + g;",
+		"}",
+		"fn main() -> u4 {",
+		"  return sum7(inc(0), inc(1), inc(2), inc(3), inc(4), inc(5), inc(6));",
+		"}",
+	}, " "))
+	if !typed.OK {
+		t.Fatalf("type check failed: %#v", typed.Errors)
+	}
+
+	result := CompileNib(typed.TypedAST, CallSafeConfig())
+	instructions := result.Program.Instructions
+	callIndex := -1
+	for index, instruction := range instructions {
+		if instruction.Opcode != ir.OpCall {
+			continue
+		}
+		label, ok := instruction.Operands[0].(ir.IrLabel)
+		if ok && label.Name == "_fn_sum7" {
+			callIndex = index
+			break
+		}
+	}
+	if callIndex < 0 {
+		t.Fatal("expected call to _fn_sum7 in IR")
+	}
+
+	expectedCopies := [][2]int{
+		{2, 9},
+		{3, 10},
+		{4, 11},
+		{5, 12},
+		{6, 13},
+		{7, 14},
+		{8, 15},
+	}
+	if callIndex < len(expectedCopies) {
+		t.Fatalf("expected at least %d instructions before _fn_sum7 call, got %d", len(expectedCopies), callIndex)
+	}
+	for index, want := range expectedCopies {
+		instruction := instructions[callIndex-len(expectedCopies)+index]
+		if instruction.Opcode != ir.OpAddImm {
+			t.Fatalf("expected staged argument copy %d to be ADD_IMM, got %s", index, instruction.Opcode)
+		}
+		dst, ok := instruction.Operands[0].(ir.IrRegister)
+		if !ok || dst.Index != want[0] {
+			t.Fatalf("expected staged argument copy %d to target v%d, got %#v", index, want[0], instruction.Operands[0])
+		}
+		src, ok := instruction.Operands[1].(ir.IrRegister)
+		if !ok || src.Index != want[1] {
+			t.Fatalf("expected staged argument copy %d to read v%d, got %#v", index, want[1], instruction.Operands[1])
+		}
+	}
+}

--- a/code/packages/go/nib-riscv-compiler/compiler_test.go
+++ b/code/packages/go/nib-riscv-compiler/compiler_test.go
@@ -141,6 +141,64 @@ func TestRunSourceHandlesNibLocalsBeyondStarterRegisterMap(t *testing.T) {
 	}
 }
 
+func TestRunSourcePreservesEarlierNibArgumentsAcrossNestedCalls(t *testing.T) {
+	source := strings.Join([]string{
+		"fn inc(value: u8) -> u8 { return value +% 1; }",
+		"fn sum7(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8) -> u8 {",
+		"  return a + b + c + d + e + f + g;",
+		"}",
+		"fn main() -> u8 {",
+		"  return sum7(inc(0), inc(1), inc(2), inc(3), inc(4), inc(5), inc(6));",
+		"}",
+	}, " ")
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.ReturnValue != 28 {
+		t.Fatalf("expected nested-argument call result 28, got %d", run.ReturnValue)
+	}
+}
+
+func TestRunSourcePreservesSpilledNibLocalsAcrossCalls(t *testing.T) {
+	source := strings.Join([]string{
+		"fn bump(value: u8) -> u8 { return value +% 1; }",
+		"fn main() -> u8 {",
+		"  let a: u8 = 1;",
+		"  let b: u8 = 1;",
+		"  let c: u8 = 1;",
+		"  let d: u8 = 1;",
+		"  let e: u8 = 1;",
+		"  let f: u8 = 1;",
+		"  let g: u8 = 1;",
+		"  let h: u8 = 1;",
+		"  let i: u8 = 1;",
+		"  let j: u8 = 1;",
+		"  let k: u8 = 1;",
+		"  let l: u8 = 1;",
+		"  let m: u8 = 1;",
+		"  let called: u8 = bump(2);",
+		"  return a + b + c + d + e + f + g + h + i + j + k + l + m + called;",
+		"}",
+	}, " ")
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.ReturnValue != 16 {
+		t.Fatalf("expected spilled locals plus call result to be 16, got %d", run.ReturnValue)
+	}
+	if !strings.Contains(run.Package.Assembly, "addi sp, sp, -") {
+		t.Fatalf("expected spill-heavy function frame in assembly, got:\n%s", run.Package.Assembly)
+	}
+}
+
 func TestTypeErrorsReportStage(t *testing.T) {
 	_, err := CompileSource("fn main() { let flag: bool = 1; }")
 	if err == nil {

--- a/code/packages/go/nib-riscv-compiler/compiler_test.go
+++ b/code/packages/go/nib-riscv-compiler/compiler_test.go
@@ -143,11 +143,11 @@ func TestRunSourceHandlesNibLocalsBeyondStarterRegisterMap(t *testing.T) {
 
 func TestRunSourcePreservesEarlierNibArgumentsAcrossNestedCalls(t *testing.T) {
 	source := strings.Join([]string{
-		"fn inc(value: u8) -> u8 { return value +% 1; }",
-		"fn sum7(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8) -> u8 {",
+		"fn inc(value: u4) -> u4 { return value +% 1; }",
+		"fn sum7(a: u4, b: u4, c: u4, d: u4, e: u4, f: u4, g: u4) -> u4 {",
 		"  return a + b + c + d + e + f + g;",
 		"}",
-		"fn main() -> u8 {",
+		"fn main() -> u4 {",
 		"  return sum7(inc(0), inc(1), inc(2), inc(3), inc(4), inc(5), inc(6));",
 		"}",
 	}, " ")
@@ -165,22 +165,22 @@ func TestRunSourcePreservesEarlierNibArgumentsAcrossNestedCalls(t *testing.T) {
 
 func TestRunSourcePreservesSpilledNibLocalsAcrossCalls(t *testing.T) {
 	source := strings.Join([]string{
-		"fn bump(value: u8) -> u8 { return value +% 1; }",
-		"fn main() -> u8 {",
-		"  let a: u8 = 1;",
-		"  let b: u8 = 1;",
-		"  let c: u8 = 1;",
-		"  let d: u8 = 1;",
-		"  let e: u8 = 1;",
-		"  let f: u8 = 1;",
-		"  let g: u8 = 1;",
-		"  let h: u8 = 1;",
-		"  let i: u8 = 1;",
-		"  let j: u8 = 1;",
-		"  let k: u8 = 1;",
-		"  let l: u8 = 1;",
-		"  let m: u8 = 1;",
-		"  let called: u8 = bump(2);",
+		"fn bump(value: u4) -> u4 { return value +% 1; }",
+		"fn main() -> u4 {",
+		"  let a: u4 = 1;",
+		"  let b: u4 = 1;",
+		"  let c: u4 = 1;",
+		"  let d: u4 = 1;",
+		"  let e: u4 = 1;",
+		"  let f: u4 = 1;",
+		"  let g: u4 = 1;",
+		"  let h: u4 = 1;",
+		"  let i: u4 = 1;",
+		"  let j: u4 = 1;",
+		"  let k: u4 = 1;",
+		"  let l: u4 = 1;",
+		"  let m: u4 = 1;",
+		"  let called: u4 = bump(2);",
 		"  return a + b + c + d + e + f + g + h + i + j + k + l + m + called;",
 		"}",
 	}, " ")


### PR DESCRIPTION
## Summary
- add broader RISC-V end-to-end coverage for Nib calls, nested argument evaluation, and spill-heavy locals
- add broader Brainfuck RISC-V runtime coverage for loop-heavy execution, streamed input/output, and debug bounds-trap behavior
- fix Brainfuck debug bounds checks so they validate the predicted tape pointer instead of clobbering the live pointer register

## Verification
- `go test -c` in `code/packages/go/brainfuck-ir-compiler`
- `go test -c` in `code/packages/go/brainfuck-riscv-compiler`
- `go test -c` in `code/packages/go/nib-riscv-compiler`
- Local runtime execution of Go test binaries still hangs in this desktop environment, so CI is expected to provide the runtime signal for the new E2E tests.