### PR TITLE
feat(rust): expand lexer action vocabulary

### DIFF
--- a/code/packages/rust/state-machine-markup-deserializer/README.md
+++ b/code/packages/rust/state-machine-markup-deserializer/README.md
@@ -66,6 +66,11 @@ and now also accepts the current lexer profile used by `html-lexer`:
 Numbers, dotted keys, malformed inline tables, and unsupported fields are still
 rejected so the reader stays bounded and predictable at the trust boundary.
 
+For lexer-profile definitions, transition `actions` are intentionally left as
+portable strings. The executable Rust vocabulary for those actions lives in the
+`state-machine-tokenizer` crate so the read side and runtime side can evolve
+independently.
+
 ## Dependencies
 
 - state-machine

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -12,3 +12,6 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 - Added a statically linked HTML skeleton tokenizer definition and fixture
   coverage for text, tags, chunked input, EOF flushing, diagnostics, and
   arbitrary Unicode text through `$any`.
+- Expanded the portable lexer action vocabulary with comment, doctype,
+  attribute, temporary-buffer, self-closing, and return-state actions so
+  future HTML lexer definitions can stay declarative without host callbacks.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -15,21 +15,61 @@ HTML-specific machine constructors live in `coding-adventures-html-lexer`. This
 package stays generic: it interprets lexer actions for any statically linked
 machine that uses the portable action vocabulary below.
 
-## Current Scope
+## Lexer Action Vocabulary
 
-The first runtime supports the small fixed action vocabulary needed by the HTML
-skeleton:
+The runtime interprets a bounded portable action vocabulary. Definitions stay
+serializable because actions are simple strings, and unknown actions still fail
+closed at runtime.
+
+Text buffering:
 
 - `append_text(current)`
 - `append_text(literal)`
 - `append_text_replacement`
 - `flush_text`
 - `emit_current_as_text`
+
+Tag tokens:
+
 - `create_start_tag`
 - `create_end_tag`
 - `append_tag_name(current)`
 - `append_tag_name(current_lowercase)`
+- `start_attribute`
+- `append_attribute_name(current)`
+- `append_attribute_name(current_lowercase)`
+- `append_attribute_name(literal)`
+- `append_attribute_value(current)`
+- `append_attribute_value(literal)`
+- `commit_attribute`
+- `mark_self_closing`
 - `emit_current_token`
+
+Comments and doctypes:
+
+- `create_comment`
+- `append_comment(current)`
+- `append_comment(current_lowercase)`
+- `append_comment(literal)`
+- `create_doctype`
+- `append_doctype_name(current)`
+- `append_doctype_name(current_lowercase)`
+- `append_doctype_name(literal)`
+- `mark_force_quirks`
+
+Temporary buffers and controlled state changes:
+
+- `clear_temporary_buffer`
+- `append_temporary_buffer(current)`
+- `append_temporary_buffer(current_lowercase)`
+- `append_temporary_buffer(literal)`
+- `append_temporary_buffer_to_text`
+- `set_return_state(state)`
+- `switch_to(state)`
+- `switch_to_return_state`
+
+Diagnostics and stream control:
+
 - `emit(EOF)`
 - `parse_error(code)`
 

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -115,6 +115,19 @@ pub enum TokenizerError {
     MissingCurrentCodePoint { action: String },
     /// An action required a current token but none exists.
     MissingCurrentToken { action: String },
+    /// An action required a current attribute but none exists.
+    MissingCurrentAttribute { action: String },
+    /// An action required a stored return state but none exists.
+    MissingReturnState { action: String },
+    /// An action expected one current token kind but saw another.
+    InvalidCurrentToken {
+        /// Portable action that failed.
+        action: String,
+        /// Expected token kind.
+        expected: &'static str,
+        /// Actual token kind.
+        actual: &'static str,
+    },
     /// A transition loop exceeded the per-input step budget.
     StepLimitExceeded {
         /// Current state when the budget was exceeded.
@@ -139,6 +152,20 @@ impl fmt::Display for TokenizerError {
             Self::MissingCurrentToken { action } => {
                 write!(f, "action `{action}` requires a current token")
             }
+            Self::MissingCurrentAttribute { action } => {
+                write!(f, "action `{action}` requires a current attribute")
+            }
+            Self::MissingReturnState { action } => {
+                write!(f, "action `{action}` requires a stored return state")
+            }
+            Self::InvalidCurrentToken {
+                action,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "action `{action}` expected current token kind `{expected}`, found `{actual}`"
+            ),
             Self::StepLimitExceeded {
                 state,
                 position,
@@ -162,7 +189,10 @@ pub type Result<T> = std::result::Result<T, TokenizerError>;
 pub struct Tokenizer {
     machine: EffectfulStateMachine,
     text_buffer: String,
+    temporary_buffer: String,
     current_token: Option<CurrentToken>,
+    current_attribute: Option<Attribute>,
+    return_state: Option<String>,
     tokens: VecDeque<Token>,
     diagnostics: Vec<Diagnostic>,
     trace: Vec<TokenizerTraceEntry>,
@@ -177,7 +207,10 @@ impl Tokenizer {
         Self {
             machine,
             text_buffer: String::new(),
+            temporary_buffer: String::new(),
             current_token: None,
+            current_attribute: None,
+            return_state: None,
             tokens: VecDeque::new(),
             diagnostics: Vec::new(),
             trace: Vec::new(),
@@ -223,7 +256,7 @@ impl Tokenizer {
                 position: before,
                 from,
                 input: None,
-                to: step.to,
+                to: self.machine.current_state().to_string(),
                 actions: step.effects,
                 consume: step.consume,
             });
@@ -274,7 +307,10 @@ impl Tokenizer {
     pub fn reset(&mut self) {
         self.machine.reset();
         self.text_buffer.clear();
+        self.temporary_buffer.clear();
         self.current_token = None;
+        self.current_attribute = None;
+        self.return_state = None;
         self.tokens.clear();
         self.diagnostics.clear();
         self.trace.clear();
@@ -306,7 +342,7 @@ impl Tokenizer {
                 position: before,
                 from,
                 input: Some(ch),
-                to: step.to,
+                to: self.machine.current_state().to_string(),
                 actions: step.effects,
                 consume: step.consume,
             });
@@ -347,11 +383,26 @@ impl Tokenizer {
                         attributes: Vec::new(),
                         self_closing: false,
                     });
+                    self.current_attribute = None;
                 }
                 "create_end_tag" => {
                     self.current_token = Some(CurrentToken::EndTag {
                         name: String::new(),
                     });
+                    self.current_attribute = None;
+                }
+                "create_comment" => {
+                    self.current_token = Some(CurrentToken::Comment {
+                        data: String::new(),
+                    });
+                    self.current_attribute = None;
+                }
+                "create_doctype" => {
+                    self.current_token = Some(CurrentToken::Doctype {
+                        name: None,
+                        force_quirks: false,
+                    });
+                    self.current_attribute = None;
                 }
                 "append_tag_name(current)" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
@@ -365,13 +416,138 @@ impl Tokenizer {
                     })?;
                     self.append_tag_name(action, ch, true)?;
                 }
+                "start_attribute" => {
+                    self.current_attribute = Some(Attribute {
+                        name: String::new(),
+                        value: String::new(),
+                    });
+                }
+                "append_attribute_name(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_attribute_name(action, ch, false)?;
+                }
+                "append_attribute_name(current_lowercase)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_attribute_name(action, ch, true)?;
+                }
+                "append_attribute_value(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_attribute_value(action, ch)?;
+                }
+                "commit_attribute" => self.commit_attribute(action)?,
+                "mark_self_closing" => self.mark_self_closing(action)?,
+                "append_comment(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_comment(action, ch, false)?;
+                }
+                "append_comment(current_lowercase)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_comment(action, ch, true)?;
+                }
+                "append_doctype_name(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_doctype_name(action, ch, false)?;
+                }
+                "append_doctype_name(current_lowercase)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_doctype_name(action, ch, true)?;
+                }
+                "mark_force_quirks" => self.mark_force_quirks(action)?,
+                "clear_temporary_buffer" => self.temporary_buffer.clear(),
+                "append_temporary_buffer(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.temporary_buffer.push(ch);
+                }
+                "append_temporary_buffer(current_lowercase)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    push_lowercase(&mut self.temporary_buffer, ch);
+                }
+                "append_temporary_buffer_to_text" => {
+                    self.text_buffer.push_str(&self.temporary_buffer);
+                    self.temporary_buffer.clear();
+                }
+                "switch_to_return_state" => {
+                    let return_state = self.return_state.clone().ok_or_else(|| {
+                        TokenizerError::MissingReturnState {
+                            action: action.clone(),
+                        }
+                    })?;
+                    self.machine
+                        .set_current_state(return_state)
+                        .map_err(TokenizerError::Machine)?;
+                }
                 "emit_current_token" => self.emit_current_token(action)?,
                 "emit(EOF)" => self.tokens.push_back(Token::Eof),
+                _ if action.starts_with("set_return_state(") && action.ends_with(')') => {
+                    let state = action
+                        .trim_start_matches("set_return_state(")
+                        .trim_end_matches(')');
+                    if !self.machine.has_state(state) {
+                        return Err(TokenizerError::Machine(format!("Unknown state '{state}'")));
+                    }
+                    self.return_state = Some(state.to_string());
+                }
+                _ if action.starts_with("switch_to(") && action.ends_with(')') => {
+                    let state = action
+                        .trim_start_matches("switch_to(")
+                        .trim_end_matches(')');
+                    self.machine
+                        .set_current_state(state.to_string())
+                        .map_err(TokenizerError::Machine)?;
+                }
                 _ if action.starts_with("append_text(") && action.ends_with(')') => {
                     let literal = action
                         .trim_start_matches("append_text(")
                         .trim_end_matches(')');
                     self.text_buffer.push_str(literal);
+                }
+                _ if action.starts_with("append_attribute_name(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_attribute_name(")
+                        .trim_end_matches(')');
+                    self.attribute_mut(action)?.name.push_str(literal);
+                }
+                _ if action.starts_with("append_attribute_value(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_attribute_value(")
+                        .trim_end_matches(')');
+                    self.attribute_mut(action)?.value.push_str(literal);
+                }
+                _ if action.starts_with("append_comment(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_comment(")
+                        .trim_end_matches(')');
+                    self.comment_data_mut(action)?.push_str(literal);
+                }
+                _ if action.starts_with("append_doctype_name(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_doctype_name(")
+                        .trim_end_matches(')');
+                    self.doctype_name_mut(action)?.push_str(literal);
+                }
+                _ if action.starts_with("append_temporary_buffer(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_temporary_buffer(")
+                        .trim_end_matches(')');
+                    self.temporary_buffer.push_str(literal);
                 }
                 _ if action.starts_with("parse_error(") && action.ends_with(')') => {
                     let code = action
@@ -398,27 +574,111 @@ impl Tokenizer {
     }
 
     fn append_tag_name(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {
-        let current_token =
-            self.current_token
-                .as_mut()
-                .ok_or_else(|| TokenizerError::MissingCurrentToken {
-                    action: action.to_string(),
-                })?;
-        match current_token {
+        match self.current_token_mut(action)? {
             CurrentToken::StartTag { name, .. } | CurrentToken::EndTag { name } => {
                 if lowercase {
-                    for lowered in ch.to_lowercase() {
-                        name.push(lowered);
-                    }
+                    push_lowercase(name, ch);
                 } else {
                     name.push(ch);
                 }
                 Ok(())
             }
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "start-tag-or-end-tag",
+                actual: other.kind_name(),
+            }),
+        }
+    }
+
+    fn append_attribute_name(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {
+        let attribute = self.attribute_mut(action)?;
+        if lowercase {
+            push_lowercase(&mut attribute.name, ch);
+        } else {
+            attribute.name.push(ch);
+        }
+        Ok(())
+    }
+
+    fn append_attribute_value(&mut self, action: &str, ch: char) -> Result<()> {
+        self.attribute_mut(action)?.value.push(ch);
+        Ok(())
+    }
+
+    fn commit_attribute(&mut self, action: &str) -> Result<()> {
+        let attribute = self.current_attribute.take().ok_or_else(|| {
+            TokenizerError::MissingCurrentAttribute {
+                action: action.to_string(),
+            }
+        })?;
+        match self.current_token_mut(action)? {
+            CurrentToken::StartTag { attributes, .. } => {
+                attributes.push(attribute);
+                Ok(())
+            }
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "start-tag",
+                actual: other.kind_name(),
+            }),
+        }
+    }
+
+    fn mark_self_closing(&mut self, action: &str) -> Result<()> {
+        match self.current_token_mut(action)? {
+            CurrentToken::StartTag { self_closing, .. } => {
+                *self_closing = true;
+                Ok(())
+            }
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "start-tag",
+                actual: other.kind_name(),
+            }),
+        }
+    }
+
+    fn append_comment(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {
+        let data = self.comment_data_mut(action)?;
+        if lowercase {
+            push_lowercase(data, ch);
+        } else {
+            data.push(ch);
+        }
+        Ok(())
+    }
+
+    fn append_doctype_name(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {
+        let name = self.doctype_name_mut(action)?;
+        if lowercase {
+            push_lowercase(name, ch);
+        } else {
+            name.push(ch);
+        }
+        Ok(())
+    }
+
+    fn mark_force_quirks(&mut self, action: &str) -> Result<()> {
+        match self.current_token_mut(action)? {
+            CurrentToken::Doctype { force_quirks, .. } => {
+                *force_quirks = true;
+                Ok(())
+            }
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "doctype",
+                actual: other.kind_name(),
+            }),
         }
     }
 
     fn emit_current_token(&mut self, action: &str) -> Result<()> {
+        if matches!(self.current_token, Some(CurrentToken::StartTag { .. }))
+            && self.current_attribute.is_some()
+        {
+            self.commit_attribute("commit_attribute")?;
+        }
         let token =
             self.current_token
                 .take()
@@ -436,8 +696,50 @@ impl Tokenizer {
                 self_closing,
             }),
             CurrentToken::EndTag { name } => self.tokens.push_back(Token::EndTag { name }),
+            CurrentToken::Comment { data } => self.tokens.push_back(Token::Comment(data)),
+            CurrentToken::Doctype { name, force_quirks } => {
+                self.tokens.push_back(Token::Doctype { name, force_quirks })
+            }
         }
         Ok(())
+    }
+
+    fn current_token_mut(&mut self, action: &str) -> Result<&mut CurrentToken> {
+        self.current_token
+            .as_mut()
+            .ok_or_else(|| TokenizerError::MissingCurrentToken {
+                action: action.to_string(),
+            })
+    }
+
+    fn attribute_mut(&mut self, action: &str) -> Result<&mut Attribute> {
+        self.current_attribute
+            .as_mut()
+            .ok_or_else(|| TokenizerError::MissingCurrentAttribute {
+                action: action.to_string(),
+            })
+    }
+
+    fn comment_data_mut(&mut self, action: &str) -> Result<&mut String> {
+        match self.current_token_mut(action)? {
+            CurrentToken::Comment { data } => Ok(data),
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "comment",
+                actual: other.kind_name(),
+            }),
+        }
+    }
+
+    fn doctype_name_mut(&mut self, action: &str) -> Result<&mut String> {
+        match self.current_token_mut(action)? {
+            CurrentToken::Doctype { name, .. } => Ok(name.get_or_insert_with(String::new)),
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "doctype",
+                actual: other.kind_name(),
+            }),
+        }
     }
 
     fn advance(&mut self, ch: char) {
@@ -462,4 +764,28 @@ enum CurrentToken {
     EndTag {
         name: String,
     },
+    Comment {
+        data: String,
+    },
+    Doctype {
+        name: Option<String>,
+        force_quirks: bool,
+    },
+}
+
+impl CurrentToken {
+    fn kind_name(&self) -> &'static str {
+        match self {
+            Self::StartTag { .. } => "start-tag",
+            Self::EndTag { .. } => "end-tag",
+            Self::Comment { .. } => "comment",
+            Self::Doctype { .. } => "doctype",
+        }
+    }
+}
+
+fn push_lowercase(target: &mut String, ch: char) {
+    for lowered in ch.to_lowercase() {
+        target.push(lowered);
+    }
 }

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use state_machine::{EffectfulMatcher, EffectfulStateMachine, EffectfulTransition};
-use state_machine_tokenizer::{Tokenizer, TokenizerError};
+use state_machine_tokenizer::{Attribute, Token, Tokenizer, TokenizerError};
 
 #[test]
 fn tokenizer_rejects_unknown_actions() {
@@ -47,6 +47,309 @@ fn tokenizer_bounds_non_consuming_transition_loops() {
         error,
         TokenizerError::StepLimitExceeded { limit: 3, .. }
     ));
+}
+
+#[test]
+fn tokenizer_builds_start_tag_attributes_and_self_closing_markers() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&[
+                "data",
+                "tag_open",
+                "before_attr",
+                "attr_name",
+                "attr_value",
+                "before_close",
+                "done",
+            ]),
+            set(&["<", "A", " ", "H", "=", "X", "/", ">"]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("<".to_string()),
+                    "tag_open",
+                ),
+                EffectfulTransition::new(
+                    "tag_open",
+                    EffectfulMatcher::Event("A".to_string()),
+                    "before_attr",
+                )
+                .with_effects(&["create_start_tag", "append_tag_name(current_lowercase)"]),
+                EffectfulTransition::new(
+                    "before_attr",
+                    EffectfulMatcher::Event(" ".to_string()),
+                    "attr_name",
+                ),
+                EffectfulTransition::new(
+                    "attr_name",
+                    EffectfulMatcher::Event("H".to_string()),
+                    "attr_value",
+                )
+                .with_effects(&[
+                    "start_attribute",
+                    "append_attribute_name(current_lowercase)",
+                    "append_attribute_name(ref)",
+                ]),
+                EffectfulTransition::new(
+                    "attr_value",
+                    EffectfulMatcher::Event("=".to_string()),
+                    "attr_value",
+                ),
+                EffectfulTransition::new(
+                    "attr_value",
+                    EffectfulMatcher::Event("X".to_string()),
+                    "before_close",
+                )
+                .with_effects(&["append_attribute_value(current)"]),
+                EffectfulTransition::new(
+                    "before_close",
+                    EffectfulMatcher::Event("/".to_string()),
+                    "before_close",
+                )
+                .with_effects(&[
+                    "append_attribute_value(y)",
+                    "commit_attribute",
+                    "mark_self_closing",
+                ]),
+                EffectfulTransition::new(
+                    "before_close",
+                    EffectfulMatcher::Event(">".to_string()),
+                    "done",
+                )
+                .with_effects(&["emit_current_token"]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("<A H=X/>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::StartTag {
+            name: "a".to_string(),
+            attributes: vec![Attribute {
+                name: "href".to_string(),
+                value: "Xy".to_string(),
+            }],
+            self_closing: true,
+        }]
+    );
+}
+
+#[test]
+fn tokenizer_builds_comment_tokens_with_current_and_literal_actions() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "comment", "done"]),
+            set(&["!", "O", "k", ".", ";"]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("!".to_string()),
+                    "comment",
+                )
+                .with_effects(&["create_comment"]),
+                EffectfulTransition::new(
+                    "comment",
+                    EffectfulMatcher::Event("O".to_string()),
+                    "comment",
+                )
+                .with_effects(&["append_comment(current_lowercase)"]),
+                EffectfulTransition::new(
+                    "comment",
+                    EffectfulMatcher::Event("k".to_string()),
+                    "comment",
+                )
+                .with_effects(&["append_comment(current)"]),
+                EffectfulTransition::new(
+                    "comment",
+                    EffectfulMatcher::Event(".".to_string()),
+                    "comment",
+                )
+                .with_effects(&["append_comment(!)"]),
+                EffectfulTransition::new(
+                    "comment",
+                    EffectfulMatcher::Event(";".to_string()),
+                    "done",
+                )
+                .with_effects(&["emit_current_token"]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("!Ok.;").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Comment("ok!".to_string())]
+    );
+}
+
+#[test]
+fn tokenizer_builds_doctypes_and_marks_force_quirks() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "doctype", "done"]),
+            set(&["D", "H", "t", "!"]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("D".to_string()),
+                    "doctype",
+                )
+                .with_effects(&["create_doctype"]),
+                EffectfulTransition::new(
+                    "doctype",
+                    EffectfulMatcher::Event("H".to_string()),
+                    "doctype",
+                )
+                .with_effects(&["append_doctype_name(current_lowercase)"]),
+                EffectfulTransition::new(
+                    "doctype",
+                    EffectfulMatcher::Event("t".to_string()),
+                    "doctype",
+                )
+                .with_effects(&["append_doctype_name(current)"]),
+                EffectfulTransition::new(
+                    "doctype",
+                    EffectfulMatcher::Event("!".to_string()),
+                    "done",
+                )
+                .with_effects(&[
+                    "append_doctype_name(ml)",
+                    "mark_force_quirks",
+                    "emit_current_token",
+                ]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("DHt!").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Doctype {
+            name: Some("html".to_string()),
+            force_quirks: true,
+        }]
+    );
+}
+
+#[test]
+fn tokenizer_uses_temporary_buffer_actions() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "buffering", "done"]),
+            set(&["A", "a", ";"]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("A".to_string()),
+                    "buffering",
+                )
+                .with_effects(&[
+                    "clear_temporary_buffer",
+                    "append_temporary_buffer(current_lowercase)",
+                ]),
+                EffectfulTransition::new(
+                    "buffering",
+                    EffectfulMatcher::Event("a".to_string()),
+                    "buffering",
+                )
+                .with_effects(&["append_temporary_buffer(current)"]),
+                EffectfulTransition::new(
+                    "buffering",
+                    EffectfulMatcher::Event(";".to_string()),
+                    "done",
+                )
+                .with_effects(&[
+                    "append_temporary_buffer(!)",
+                    "append_temporary_buffer_to_text",
+                    "flush_text",
+                ]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("Aa;").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("aa!".to_string())]
+    );
+}
+
+#[test]
+fn tokenizer_supports_switch_to_with_reconsume() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "switched", "done"]),
+            set(&["x"]),
+            vec![
+                EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                    .with_effects(&["switch_to(switched)"])
+                    .consuming(false),
+                EffectfulTransition::new("switched", EffectfulMatcher::Any, "done")
+                    .with_effects(&["append_text(current)", "flush_text"]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("x").unwrap();
+
+    assert_eq!(tokenizer.drain_tokens(), vec![Token::Text("x".to_string())]);
+    assert_eq!(tokenizer.trace()[0].to, "switched");
+}
+
+#[test]
+fn tokenizer_supports_return_state_round_trips() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "entity", "done"]),
+            set(&["&", "x"]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("&".to_string()),
+                    "entity",
+                )
+                .with_effects(&["set_return_state(data)"]),
+                EffectfulTransition::new("entity", EffectfulMatcher::Any, "entity")
+                    .with_effects(&["append_text(current)", "switch_to_return_state"]),
+                EffectfulTransition::new("data", EffectfulMatcher::End, "done")
+                    .with_effects(&["flush_text", "emit(EOF)"])
+                    .consuming(false),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("&x").unwrap();
+    assert_eq!(tokenizer.current_state(), "data");
+
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("x".to_string()), Token::Eof]
+    );
 }
 
 fn set(values: &[&str]) -> HashSet<String> {

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to the `state-machine` crate will be documented in this file
 - Allowed `$any` transitions to accept runtime events outside the declared
   alphabet when the current state has an `Any` fallback, which lets tokenizer
   wrappers process arbitrary Unicode text without declaring every code point.
+- Added controlled runtime state hops for effectful transducers via
+  `EffectfulStateMachine::set_current_state`, which lets wrapper runtimes model
+  return-state flows without embedding host-language callbacks in definitions.
 
 ### Changed
 

--- a/code/packages/rust/state-machine/src/transducer.rs
+++ b/code/packages/rust/state-machine/src/transducer.rs
@@ -366,6 +366,25 @@ impl EffectfulStateMachine {
         &self.current
     }
 
+    /// Whether the machine declares the given state identifier.
+    pub fn has_state(&self, state: &str) -> bool {
+        self.states.contains(state)
+    }
+
+    /// Force the current state to one of the declared machine states.
+    ///
+    /// Wrapper runtimes use this for controlled state changes such as HTML
+    /// tokenizer return-state hops. Unknown targets are rejected so callers
+    /// still fail closed.
+    pub fn set_current_state(&mut self, state: impl Into<String>) -> Result<(), String> {
+        let state = state.into();
+        if !self.states.contains(&state) {
+            return Err(format!("Unknown state '{state}'"));
+        }
+        self.current = state;
+        Ok(())
+    }
+
     /// Whether the current state is final.
     pub fn is_final(&self) -> bool {
         self.final_states.contains(&self.current)

--- a/code/packages/rust/state-machine/tests/transducer_test.rs
+++ b/code/packages/rust/state-machine/tests/transducer_test.rs
@@ -267,3 +267,25 @@ fn any_transition_accepts_events_outside_declared_alphabet() {
 
     assert_eq!(step.effects, vec!["append_text(current)".to_string()]);
 }
+
+#[test]
+fn effectful_machine_allows_controlled_runtime_state_hops() {
+    let mut machine = EffectfulStateMachine::new(
+        set(&["data", "escaped"]),
+        set(&["x"]),
+        vec![EffectfulTransition::new(
+            "escaped",
+            EffectfulMatcher::Any,
+            "data",
+        )],
+        "data".to_string(),
+        HashSet::new(),
+    )
+    .unwrap();
+
+    machine.set_current_state("escaped").unwrap();
+    assert_eq!(machine.current_state(), "escaped");
+
+    let error = machine.set_current_state("missing").unwrap_err();
+    assert!(error.contains("Unknown state"));
+}


### PR DESCRIPTION
## Summary
- expand the Rust lexer runtime action vocabulary with attributes, comments, doctypes, temporary buffers, self-closing markers, and controlled state hops
- add a controlled `EffectfulStateMachine::set_current_state` primitive so tokenizer wrappers can model return-state flows without callbacks
- document the lexer action surface and add focused Rust tests for the new runtime actions

## Verification
- `cargo fmt -p state-machine -p state-machine-tokenizer -p state-machine-markup-deserializer`
- `cargo check -p state-machine -p state-machine-tokenizer -p state-machine-markup-deserializer`
- `cargo check -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer --no-run`
- `cargo test -p state-machine --test transducer_test --no-run`
- `cargo test -p coding-adventures-html-lexer --no-run`
- `git diff --check`

## Notes
- live `cargo test` execution in this environment still stalls after the Rust test binary starts, so I verified successful compilation of the affected test binaries with `--no-run`

Closes #1113