### PR TITLE
feat(ir): add f64 wasm lowering foundation

### DIFF
--- a/code/packages/python/compiler-ir/src/compiler_ir/__init__.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/__init__.py
@@ -46,6 +46,7 @@ from compiler_ir.printer import print_ir  # noqa: I001
 from compiler_ir.types import (
     IDGenerator,
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -63,6 +64,7 @@ __all__ = [
     # Types
     "IDGenerator",
     "IrDataDecl",
+    "IrFloatImmediate",
     "IrImmediate",
     "IrInstruction",
     "IrLabel",

--- a/code/packages/python/compiler-ir/src/compiler_ir/ir_parser.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/ir_parser.py
@@ -40,9 +40,12 @@ adversarial input:
 
 from __future__ import annotations
 
+import re
+
 from compiler_ir.opcodes import IrOp, parse_op
 from compiler_ir.types import (
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -56,6 +59,13 @@ from compiler_ir.types import (
 _MAX_LINES = 1_000_000       # max lines in an IR text file
 _MAX_OPERANDS_PER_INSTR = 16  # max operands per instruction
 _MAX_REGISTER_INDEX = 65535   # max virtual register index (v0..v65535)
+_FLOAT_IMMEDIATE_RE = re.compile(
+    r"^[+-]?(?:"
+    r"(?:\d+\.\d*|\.\d+)(?:[eE][+-]?\d+)?"
+    r"|"
+    r"\d+[eE][+-]?\d+"
+    r")$"
+)
 
 
 class IrParseError(ValueError):
@@ -272,14 +282,15 @@ def _parse_operand(s: str, line_num: int) -> IrOperand:
 
     1. Starts with ``v`` followed by digits → ``IrRegister``
     2. Parseable as integer → ``IrImmediate``
-    3. Anything else → ``IrLabel``
+    3. Parseable as float literal → ``IrFloatImmediate``
+    4. Anything else → ``IrLabel``
 
     Args:
         s:        The operand text (already stripped).
         line_num: Line number for error messages.
 
     Returns:
-        An ``IrRegister``, ``IrImmediate``, or ``IrLabel``.
+        An ``IrRegister``, ``IrImmediate``, ``IrFloatImmediate``, or ``IrLabel``.
 
     Raises:
         IrParseError: If the register index is out of range.
@@ -302,6 +313,13 @@ def _parse_operand(s: str, line_num: int) -> IrOperand:
         return IrImmediate(value=int(s))
     except ValueError:
         pass
+
+    # Floating immediate: 1.5, -0.25, 1e3, ...
+    if _FLOAT_IMMEDIATE_RE.match(s):
+        try:
+            return IrFloatImmediate(value=float(s))
+        except ValueError:
+            pass
 
     # Label: _start, loop_0_end, tape, ...
     return IrLabel(name=s)

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -24,6 +24,7 @@ The opcodes are grouped by category:
   Arithmetic:   ADD, ADD_IMM, SUB, AND, AND_IMM, MUL, DIV
   Bitwise:      OR, OR_IMM, XOR, XOR_IMM, NOT
   Comparison:   CMP_EQ, CMP_NE, CMP_LT, CMP_GT
+  Floating:     LOAD_F64_IMM, LOAD_F64, STORE_F64, F64_ADD, ..., F64_FROM_I32
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
@@ -141,6 +142,53 @@ class IrOp(IntEnum):
     # On WASM i32, it becomes i32.xor with 0xFFFF_FFFF.
     #   NOT v2, v1  →  v2 = ~v1
     NOT = 31
+
+    # ── Floating-point ───────────────────────────────────────────────────────
+    # Load an immediate 64-bit float into a register.
+    #   LOAD_F64_IMM v0, 1.5  →  v0 = 1.5
+    LOAD_F64_IMM = 32
+
+    # Load a 64-bit float from memory: dst = *(double*)(base + offset).
+    #   LOAD_F64 v2, v0, v1  →  v2 = *(double*)(v0 + v1)
+    LOAD_F64 = 33
+
+    # Store a 64-bit float to memory: *(double*)(base + offset) = src.
+    #   STORE_F64 v2, v0, v1  →  *(double*)(v0 + v1) = v2
+    STORE_F64 = 34
+
+    # Register-register f64 addition: dst = lhs + rhs.
+    F64_ADD = 35
+
+    # Register-register f64 subtraction: dst = lhs - rhs.
+    F64_SUB = 36
+
+    # Register-register f64 multiplication: dst = lhs * rhs.
+    F64_MUL = 37
+
+    # Register-register f64 division: dst = lhs / rhs.
+    F64_DIV = 38
+
+    # Set dst = 1 if lhs == rhs, else 0.
+    F64_CMP_EQ = 39
+
+    # Set dst = 1 if lhs != rhs, else 0.
+    F64_CMP_NE = 40
+
+    # Set dst = 1 if lhs < rhs, else 0.
+    F64_CMP_LT = 41
+
+    # Set dst = 1 if lhs > rhs, else 0.
+    F64_CMP_GT = 42
+
+    # Set dst = 1 if lhs <= rhs, else 0.
+    F64_CMP_LE = 43
+
+    # Set dst = 1 if lhs >= rhs, else 0.
+    F64_CMP_GE = 44
+
+    # Convert a signed i32 value to f64.
+    #   F64_FROM_I32 v1, v2  →  v1 = float(v2)
+    F64_FROM_I32 = 45
 
     # ── Comparison ────────────────────────────────────────────────────────────
     # Set dst = 1 if lhs == rhs, else 0.

--- a/code/packages/python/compiler-ir/src/compiler_ir/printer.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/printer.py
@@ -39,6 +39,8 @@ from __future__ import annotations
 from compiler_ir.opcodes import IrOp
 from compiler_ir.types import IrProgram
 
+_OPCODE_COLUMN_WIDTH = max(len(op.name) for op in IrOp) + 1
+
 
 def print_ir(program: IrProgram) -> str:
     """Convert an IrProgram to its canonical text representation.
@@ -94,7 +96,7 @@ def print_ir(program: IrProgram) -> str:
         opcode_name = instr.opcode.name
         operand_str = ", ".join(str(op) for op in instr.operands)
 
-        line = f"  {opcode_name:<11}"
+        line = f"  {opcode_name:<{_OPCODE_COLUMN_WIDTH}}"
         if operand_str:
             line += operand_str
         line += f"  ; #{instr.id}\n"

--- a/code/packages/python/compiler-ir/src/compiler_ir/types.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/types.py
@@ -3,10 +3,11 @@
 Overview
 --------
 
-Every IR instruction operates on **operands**. There are three kinds:
+Every IR instruction operates on **operands**. There are four kinds:
 
   IrRegister  — a virtual register (v0, v1, v2, ...)
   IrImmediate — a literal integer value
+  IrFloatImmediate — a literal floating-point value
   IrLabel     — a named jump target or data label
 
 These three operand types are combined into ``IrInstruction`` objects, which
@@ -14,7 +15,7 @@ live inside an ``IrProgram``.
 
 The type hierarchy::
 
-  IrOperand (base type — IrRegister | IrImmediate | IrLabel)
+  IrOperand (base type — IrRegister | IrImmediate | IrFloatImmediate | IrLabel)
   IrInstruction (opcode + operands + unique ID)
   IrDataDecl (named data segment: label, size, init byte)
   IrProgram (full program: instructions + data + entry label + version)
@@ -48,7 +49,8 @@ from compiler_ir.opcodes import IrOp
 # ---------------------------------------------------------------------------
 #
 # Python does not have sealed interfaces like Go, so we use a Union type.
-# The three concrete operand types are IrRegister, IrImmediate, and IrLabel.
+# The concrete operand types are IrRegister, IrImmediate, IrFloatImmediate,
+# and IrLabel.
 # ---------------------------------------------------------------------------
 
 
@@ -102,6 +104,24 @@ class IrImmediate:
 
 
 @dataclass(frozen=True)
+class IrFloatImmediate:
+    """A literal floating-point value operand.
+
+    Floating immediates are IEEE-754 double-precision values that appear
+    directly in instructions.
+
+    Attributes:
+        value: The floating-point value.
+    """
+
+    value: float
+
+    def __str__(self) -> str:
+        """Return the canonical text form: the float as a string."""
+        return str(self.value)
+
+
+@dataclass(frozen=True)
 class IrLabel:
     """A named jump target or data reference operand.
 
@@ -126,7 +146,7 @@ class IrLabel:
 
 # The Union type for any IR operand. Used in type annotations throughout
 # the compiler and backend packages.
-IrOperand = IrRegister | IrImmediate | IrLabel
+IrOperand = IrRegister | IrImmediate | IrFloatImmediate | IrLabel
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -22,6 +22,7 @@ from compiler_ir import (
     OP_NAMES,
     IDGenerator,
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -81,10 +82,24 @@ class TestIrOp:
         assert IrOp.XOR == 29
         assert IrOp.XOR_IMM == 30
         assert IrOp.NOT == 31
+        assert IrOp.LOAD_F64_IMM == 32
+        assert IrOp.LOAD_F64 == 33
+        assert IrOp.STORE_F64 == 34
+        assert IrOp.F64_ADD == 35
+        assert IrOp.F64_SUB == 36
+        assert IrOp.F64_MUL == 37
+        assert IrOp.F64_DIV == 38
+        assert IrOp.F64_CMP_EQ == 39
+        assert IrOp.F64_CMP_NE == 40
+        assert IrOp.F64_CMP_LT == 41
+        assert IrOp.F64_CMP_GT == 42
+        assert IrOp.F64_CMP_LE == 43
+        assert IrOp.F64_CMP_GE == 44
+        assert IrOp.F64_FROM_I32 == 45
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 32 opcodes (0–26, plus five bitwise ops at 27–31)."""
-        assert len(IrOp) == 32
+        """There are exactly 46 opcodes after adding the initial f64 support set."""
+        assert len(IrOp) == 46
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -184,6 +199,25 @@ class TestIrLabel:
         lbl = IrLabel("x")
         with pytest.raises(Exception):
             lbl.name = "y"  # type: ignore[misc]
+
+
+class TestIrFloatImmediate:
+    """Tests for IrFloatImmediate operands."""
+
+    def test_str_positive(self) -> None:
+        assert str(IrFloatImmediate(1.5)) == "1.5"
+
+    def test_str_negative(self) -> None:
+        assert str(IrFloatImmediate(-0.25)) == "-0.25"
+
+    def test_equality(self) -> None:
+        assert IrFloatImmediate(3.5) == IrFloatImmediate(3.5)
+        assert IrFloatImmediate(3.5) != IrFloatImmediate(4.5)
+
+    def test_frozen(self) -> None:
+        imm = IrFloatImmediate(2.5)
+        with pytest.raises(Exception):
+            imm.value = 6.0  # type: ignore[misc]
 
 
 # =============================================================================
@@ -514,6 +548,13 @@ class TestParseIr:
         prog = parse_ir(text)
         instr = prog.instructions[0]
         assert instr.operands[2] == IrImmediate(-1)
+
+    def test_float_immediate_parsed(self) -> None:
+        text = ".version 1\n.entry _start\n  LOAD_F64_IMM v2, 1.5 ; #7\n"
+        prog = parse_ir(text)
+        instr = prog.instructions[0]
+        assert instr.opcode == IrOp.LOAD_F64_IMM
+        assert instr.operands == [IrRegister(2), IrFloatImmediate(1.5)]
 
     def test_label_operand_parsed(self) -> None:
         text = ".version 1\n.entry _start\n  JUMP       loop_0_start  ; #7\n"
@@ -949,6 +990,20 @@ class TestAllOpcodesPrintParse:
             IrOp.XOR:        [IrRegister(3), IrRegister(1), IrRegister(2)],
             IrOp.XOR_IMM:    [IrRegister(2), IrRegister(2), IrImmediate(0xFF)],
             IrOp.NOT:        [IrRegister(2), IrRegister(1)],
+            IrOp.LOAD_F64_IMM: [IrRegister(2), IrFloatImmediate(1.5)],
+            IrOp.LOAD_F64:     [IrRegister(2), IrRegister(0), IrRegister(1)],
+            IrOp.STORE_F64:    [IrRegister(2), IrRegister(0), IrRegister(1)],
+            IrOp.F64_ADD:      [IrRegister(3), IrRegister(1), IrRegister(2)],
+            IrOp.F64_SUB:      [IrRegister(3), IrRegister(1), IrRegister(2)],
+            IrOp.F64_MUL:      [IrRegister(3), IrRegister(1), IrRegister(2)],
+            IrOp.F64_DIV:      [IrRegister(3), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_EQ:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_NE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_LT:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_GT:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_LE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_CMP_GE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
+            IrOp.F64_FROM_I32: [IrRegister(2), IrRegister(1)],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/packages/python/ir-to-jvm-class-file/tests/test_ir_to_jvm_class_file.py
+++ b/code/packages/python/ir-to-jvm-class-file/tests/test_ir_to_jvm_class_file.py
@@ -16,7 +16,7 @@ from ir_to_jvm_class_file import (
     validate_for_jvm,
     write_class_file,
 )
-from ir_to_jvm_class_file.backend import JvmBackendError
+from ir_to_jvm_class_file.backend import JvmBackendError, _JVM_SUPPORTED_OPCODES
 
 
 def compile_brainfuck_program(source: str) -> bytes:
@@ -381,17 +381,13 @@ class TestValidateForJvm:
         assert validate_for_jvm(prog) == []
 
     # ── Rule 1: opcode support ───────────────────────────────────────────────
-    # The V1 JVM backend now handles all IrOp opcodes including the five
-    # bitwise ops (OR, OR_IMM, XOR, XOR_IMM, NOT).  If a new opcode is added
-    # to IrOp and the JVM backend is not updated, this test will fail,
-    # prompting the developer to either implement or explicitly defer it.
+    # The V1 JVM backend handles the subset listed in _JVM_SUPPORTED_OPCODES.
+    # Shared IR may grow beyond that; those additions should be explicitly
+    # rejected until the JVM backend learns them.
 
     def test_all_supported_opcodes_pass_opcode_check(self) -> None:
-        """Every opcode in IrOp passes the opcode-support check in the V1
-        JVM backend.  This includes OR, OR_IMM, XOR, XOR_IMM, and NOT which
-        were added in compiler-ir v0.3.0 and implemented using native JVM
-        ior/ixor bytecodes."""
-        for op in IrOp:
+        """Every opcode claimed by the JVM backend passes rule 1 validation."""
+        for op in _JVM_SUPPORTED_OPCODES:
             program = _prog(_instr(op))
             errors = validate_for_jvm(program)
             # Filter out any errors that are not about opcode support —
@@ -401,6 +397,31 @@ class TestValidateForJvm:
             assert rule1_errors == [], (
                 f"IrOp.{op.name} was unexpectedly rejected by the JVM "
                 f"opcode-support check: {rule1_errors}"
+            )
+
+    def test_new_f64_opcodes_are_explicitly_rejected(self) -> None:
+        """The V1 JVM backend still rejects the new floating-point IR ops."""
+        unsupported = {
+            IrOp.LOAD_F64_IMM,
+            IrOp.LOAD_F64,
+            IrOp.STORE_F64,
+            IrOp.F64_ADD,
+            IrOp.F64_SUB,
+            IrOp.F64_MUL,
+            IrOp.F64_DIV,
+            IrOp.F64_CMP_EQ,
+            IrOp.F64_CMP_NE,
+            IrOp.F64_CMP_LT,
+            IrOp.F64_CMP_GT,
+            IrOp.F64_CMP_LE,
+            IrOp.F64_CMP_GE,
+            IrOp.F64_FROM_I32,
+        }
+        for op in unsupported:
+            program = _prog(_instr(op))
+            errors = validate_for_jvm(program)
+            assert any("unsupported opcode" in error for error in errors), (
+                f"IrOp.{op.name} should remain unsupported in the V1 JVM backend"
             )
 
     # ── Bitwise opcode integration tests ─────────────────────────────────────

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import math
 import re
+import struct
 from dataclasses import dataclass
 
 from compiler_ir import (
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -52,6 +54,8 @@ _MEMORY_OPS = frozenset(
         IrOp.STORE_BYTE,
         IrOp.LOAD_WORD,
         IrOp.STORE_WORD,
+        IrOp.LOAD_F64,
+        IrOp.STORE_F64,
     }
 )
 
@@ -87,6 +91,20 @@ _OPCODE = {
         "i32.xor",
         "i32.mul",
         "i32.div_s",
+        "f64.load",
+        "f64.store",
+        "f64.const",
+        "f64.eq",
+        "f64.ne",
+        "f64.lt",
+        "f64.gt",
+        "f64.le",
+        "f64.ge",
+        "f64.add",
+        "f64.sub",
+        "f64.mul",
+        "f64.div",
+        "f64.convert_i32_s",
         "drop",
     )
 }
@@ -125,6 +143,20 @@ _WASM_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     IrOp.XOR,
     IrOp.XOR_IMM,
     IrOp.NOT,
+    IrOp.LOAD_F64_IMM,
+    IrOp.LOAD_F64,
+    IrOp.STORE_F64,
+    IrOp.F64_ADD,
+    IrOp.F64_SUB,
+    IrOp.F64_MUL,
+    IrOp.F64_DIV,
+    IrOp.F64_CMP_EQ,
+    IrOp.F64_CMP_NE,
+    IrOp.F64_CMP_LT,
+    IrOp.F64_CMP_GT,
+    IrOp.F64_CMP_LE,
+    IrOp.F64_CMP_GE,
+    IrOp.F64_FROM_I32,
     IrOp.MUL,
     IrOp.DIV,
     IrOp.CMP_EQ,
@@ -225,6 +257,29 @@ class FunctionSignature:
     param_count: int
     export_name: str | None = None
     require_explicit_args: bool = False
+    param_types: tuple[ValueType, ...] | None = None
+    result_types: tuple[ValueType, ...] = (ValueType.I32,)
+
+    def __post_init__(self) -> None:
+        if self.param_types is not None and len(self.param_types) != self.param_count:
+            raise ValueError(
+                f"FunctionSignature({self.label!r}) param_types length "
+                f"{len(self.param_types)} does not match param_count {self.param_count}"
+            )
+        if len(self.result_types) > 1:
+            raise ValueError(
+                f"FunctionSignature({self.label!r}) supports at most one result"
+            )
+
+    @property
+    def wasm_param_types(self) -> tuple[ValueType, ...]:
+        if self.param_types is not None:
+            return self.param_types
+        return (ValueType.I32,) * self.param_count
+
+    @property
+    def wasm_result_types(self) -> tuple[ValueType, ...]:
+        return self.result_types
 
 
 @dataclass(frozen=True)
@@ -233,6 +288,7 @@ class _FunctionIR:
     instructions: list[IrInstruction]
     signature: FunctionSignature
     max_reg: int
+    register_types: tuple[ValueType, ...]
 
 
 @dataclass(frozen=True)
@@ -365,8 +421,8 @@ class IrToWasmCompiler:
 
         for function in functions:
             func_type = FuncType(
-                params=(ValueType.I32,) * function.signature.param_count,
-                results=(ValueType.I32,),
+                params=function.signature.wasm_param_types,
+                results=function.signature.wasm_result_types,
             )
             if func_type not in type_indices:
                 type_indices[func_type] = len(function_types)
@@ -492,6 +548,7 @@ class _FunctionLowerer:
         self.data_offsets = data_offsets
         self.wasi_context = wasi_context
         self.param_count = function.signature.param_count
+        self._register_types = function.register_types
         self._bytes = bytearray()
         self._instructions = function.instructions
         self._label_to_index = {
@@ -508,7 +565,7 @@ class _FunctionLowerer:
         self._emit_opcode("end")
 
         return FunctionBody(
-            locals=(ValueType.I32,) * (self.function.max_reg + 1),
+            locals=self.function.register_types,
             code=bytes(self._bytes),
         )
 
@@ -619,6 +676,13 @@ class _FunctionLowerer:
                 imm = _expect_immediate(instruction.operands[1], "LOAD_IMM imm")
                 self._emit_i32_const(imm.value)
                 self._emit_local_set(dst.index)
+            case IrOp.LOAD_F64_IMM:
+                dst = _expect_register(instruction.operands[0], "LOAD_F64_IMM dst")
+                imm = _expect_float_immediate(
+                    instruction.operands[1], "LOAD_F64_IMM imm"
+                )
+                self._emit_f64_const(imm.value)
+                self._emit_local_set(dst.index)
             case IrOp.LOAD_ADDR:
                 dst = _expect_register(instruction.operands[0], "LOAD_ADDR dst")
                 label = _expect_label(instruction.operands[1], "LOAD_ADDR label")
@@ -658,6 +722,22 @@ class _FunctionLowerer:
                 self._emit_local_get(src.index)
                 self._emit_opcode("i32.store")
                 self._emit_memarg(2, 0)
+            case IrOp.LOAD_F64:
+                dst = _expect_register(instruction.operands[0], "LOAD_F64 dst")
+                base = _expect_register(instruction.operands[1], "LOAD_F64 base")
+                offset = _expect_register(instruction.operands[2], "LOAD_F64 offset")
+                self._emit_address(base.index, offset.index)
+                self._emit_opcode("f64.load")
+                self._emit_memarg(3, 0)
+                self._emit_local_set(dst.index)
+            case IrOp.STORE_F64:
+                src = _expect_register(instruction.operands[0], "STORE_F64 src")
+                base = _expect_register(instruction.operands[1], "STORE_F64 base")
+                offset = _expect_register(instruction.operands[2], "STORE_F64 offset")
+                self._emit_address(base.index, offset.index)
+                self._emit_local_get(src.index)
+                self._emit_opcode("f64.store")
+                self._emit_memarg(3, 0)
             case IrOp.ADD:
                 self._emit_binary_numeric("i32.add", instruction)
             case IrOp.ADD_IMM:
@@ -716,6 +796,14 @@ class _FunctionLowerer:
                 self._emit_i32_const(0xFFFFFFFF)
                 self._emit_opcode("i32.xor")
                 self._emit_local_set(dst.index)
+            case IrOp.F64_ADD:
+                self._emit_binary_numeric("f64.add", instruction)
+            case IrOp.F64_SUB:
+                self._emit_binary_numeric("f64.sub", instruction)
+            case IrOp.F64_MUL:
+                self._emit_binary_numeric("f64.mul", instruction)
+            case IrOp.F64_DIV:
+                self._emit_binary_numeric("f64.div", instruction)
             case IrOp.CMP_EQ:
                 self._emit_binary_numeric("i32.eq", instruction)
             case IrOp.CMP_NE:
@@ -724,6 +812,24 @@ class _FunctionLowerer:
                 self._emit_binary_numeric("i32.lt_s", instruction)
             case IrOp.CMP_GT:
                 self._emit_binary_numeric("i32.gt_s", instruction)
+            case IrOp.F64_CMP_EQ:
+                self._emit_binary_numeric("f64.eq", instruction)
+            case IrOp.F64_CMP_NE:
+                self._emit_binary_numeric("f64.ne", instruction)
+            case IrOp.F64_CMP_LT:
+                self._emit_binary_numeric("f64.lt", instruction)
+            case IrOp.F64_CMP_GT:
+                self._emit_binary_numeric("f64.gt", instruction)
+            case IrOp.F64_CMP_LE:
+                self._emit_binary_numeric("f64.le", instruction)
+            case IrOp.F64_CMP_GE:
+                self._emit_binary_numeric("f64.ge", instruction)
+            case IrOp.F64_FROM_I32:
+                dst = _expect_register(instruction.operands[0], "F64_FROM_I32 dst")
+                src = _expect_register(instruction.operands[1], "F64_FROM_I32 src")
+                self._emit_local_get(src.index)
+                self._emit_opcode("f64.convert_i32_s")
+                self._emit_local_set(dst.index)
             case IrOp.CALL:
                 label = _expect_label(instruction.operands[0], "CALL target")
                 signature = self.signatures.get(label.name)
@@ -750,17 +856,34 @@ class _FunctionLowerer:
                         f"argument register(s), got {len(explicit_args)}"
                     )
                 if explicit_args:
-                    for operand in explicit_args:
+                    for operand, expected_type in zip(
+                        explicit_args, signature.wasm_param_types, strict=True
+                    ):
                         arg = _expect_register(operand, "CALL argument")
+                        actual_type = self._register_types[arg.index]
+                        if actual_type != expected_type:
+                            raise WasmLoweringError(
+                                f"CALL {label.name} argument v{arg.index} has type "
+                                f"{actual_type.name}, expected {expected_type.name}"
+                            )
                         self._emit_local_get(arg.index)
                 else:
                     for param_index in range(signature.param_count):
+                        actual_type = self._register_types[_REG_VAR_BASE + param_index]
+                        expected_type = signature.wasm_param_types[param_index]
+                        if actual_type != expected_type:
+                            raise WasmLoweringError(
+                                f"CALL {label.name} implicit argument v{_REG_VAR_BASE + param_index} "
+                                f"has type {actual_type.name}, expected {expected_type.name}"
+                            )
                         self._emit_local_get(_REG_VAR_BASE + param_index)
                 self._emit_opcode("call")
                 self._emit_u32(self.function_indices[label.name])
-                self._emit_local_set(_REG_SCRATCH)
+                if signature.wasm_result_types:
+                    self._emit_local_set(_REG_SCRATCH)
             case IrOp.RET | IrOp.HALT:
-                self._emit_local_get(_REG_SCRATCH)
+                if self.function.signature.wasm_result_types:
+                    self._emit_local_get(_REG_SCRATCH)
                 self._emit_opcode("return")
             case IrOp.NOP:
                 self._emit_opcode("nop")
@@ -881,6 +1004,10 @@ class _FunctionLowerer:
         self._emit_opcode("i32.const")
         self._bytes.extend(encode_signed(value))
 
+    def _emit_f64_const(self, value: float) -> None:
+        self._emit_opcode("f64.const")
+        self._bytes.extend(struct.pack("<d", value))
+
     def _emit_memarg(self, align: int, offset: int) -> None:
         self._emit_u32(align)
         self._emit_u32(offset)
@@ -982,13 +1109,14 @@ class _DispatchLoopLowerer(_FunctionLowerer):
         # end block $prog_end
         self._emit_opcode("end")
 
-        # Function return value (0 on normal exit; HALT via br 2 lands here)
-        self._emit_local_get(_REG_SCRATCH)
+        # Function return value (HALT via br 2 lands here)
+        if self.function.signature.wasm_result_types:
+            self._emit_local_get(_REG_SCRATCH)
         self._emit_opcode("end")
 
         return FunctionBody(
             # max_reg + 1 IR virtual-register slots, plus one for $pc
-            locals=(ValueType.I32,) * (self.function.max_reg + 2),
+            locals=self.function.register_types + (ValueType.I32,),
             code=bytes(self._bytes),
         )
 
@@ -1166,6 +1294,12 @@ def _make_function_ir(
         instructions=instructions,
         signature=signature,
         max_reg=max_reg,
+        register_types=_infer_register_types(
+            instructions=instructions,
+            signature=signature,
+            max_reg=max_reg,
+            signatures=signatures,
+        ),
     )
 
 
@@ -1206,6 +1340,12 @@ def _expect_immediate(operand: object, context: str) -> IrImmediate:
     return operand
 
 
+def _expect_float_immediate(operand: object, context: str) -> IrFloatImmediate:
+    if not isinstance(operand, IrFloatImmediate):
+        raise WasmLoweringError(f"{context}: expected float immediate, got {operand!r}")
+    return operand
+
+
 def _expect_label(operand: object, context: str) -> IrLabel:
     if not isinstance(operand, IrLabel):
         raise WasmLoweringError(f"{context}: expected label, got {operand!r}")
@@ -1218,3 +1358,107 @@ def _align_up(value: int, alignment: int) -> int:
 
 _REG_SCRATCH = 1
 _REG_VAR_BASE = 2
+
+
+def _infer_register_types(
+    *,
+    instructions: list[IrInstruction],
+    signature: FunctionSignature,
+    max_reg: int,
+    signatures: dict[str, FunctionSignature],
+) -> tuple[ValueType, ...]:
+    reg_types: list[ValueType | None] = [None] * (max_reg + 1)
+
+    for param_index, param_type in enumerate(signature.wasm_param_types):
+        _assign_register_type(
+            reg_types,
+            _REG_VAR_BASE + param_index,
+            param_type,
+            f"{signature.label} param {param_index}",
+        )
+
+    if signature.wasm_result_types:
+        _assign_register_type(
+            reg_types,
+            _REG_SCRATCH,
+            signature.wasm_result_types[0],
+            f"{signature.label} result",
+        )
+
+    for instruction in instructions:
+        match instruction.opcode:
+            case IrOp.LOAD_F64_IMM | IrOp.LOAD_F64:
+                dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")
+                _assign_register_type(
+                    reg_types, dst.index, ValueType.F64, instruction.opcode.name
+                )
+            case (
+                IrOp.LOAD_IMM
+                | IrOp.LOAD_ADDR
+                | IrOp.LOAD_BYTE
+                | IrOp.LOAD_WORD
+                | IrOp.ADD
+                | IrOp.ADD_IMM
+                | IrOp.SUB
+                | IrOp.AND
+                | IrOp.AND_IMM
+                | IrOp.OR
+                | IrOp.OR_IMM
+                | IrOp.XOR
+                | IrOp.XOR_IMM
+                | IrOp.NOT
+                | IrOp.MUL
+                | IrOp.DIV
+                | IrOp.CMP_EQ
+                | IrOp.CMP_NE
+                | IrOp.CMP_LT
+                | IrOp.CMP_GT
+                | IrOp.F64_CMP_EQ
+                | IrOp.F64_CMP_NE
+                | IrOp.F64_CMP_LT
+                | IrOp.F64_CMP_GT
+                | IrOp.F64_CMP_LE
+                | IrOp.F64_CMP_GE
+            ):
+                dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")
+                _assign_register_type(
+                    reg_types, dst.index, ValueType.I32, instruction.opcode.name
+                )
+            case IrOp.F64_ADD | IrOp.F64_SUB | IrOp.F64_MUL | IrOp.F64_DIV | IrOp.F64_FROM_I32:
+                dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")
+                _assign_register_type(
+                    reg_types, dst.index, ValueType.F64, instruction.opcode.name
+                )
+            case IrOp.CALL:
+                target = _expect_label(instruction.operands[0], "CALL target")
+                callee = signatures.get(target.name)
+                if callee is None:
+                    raise WasmLoweringError(f"missing function signature for {target.name}")
+                if callee.wasm_result_types:
+                    _assign_register_type(
+                        reg_types,
+                        _REG_SCRATCH,
+                        callee.wasm_result_types[0],
+                        f"CALL {target.name}",
+                    )
+            case _:
+                continue
+
+    return tuple(
+        reg_type if reg_type is not None else ValueType.I32 for reg_type in reg_types
+    )
+
+
+def _assign_register_type(
+    reg_types: list[ValueType | None],
+    reg_index: int,
+    value_type: ValueType,
+    context: str,
+) -> None:
+    existing = reg_types[reg_index]
+    if existing is not None and existing != value_type:
+        raise WasmLoweringError(
+            f"{context}: register v{reg_index} has conflicting WASM types "
+            f"{existing.name} and {value_type.name}"
+        )
+    reg_types[reg_index] = value_type

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -4,6 +4,7 @@ import pytest
 from compiler_ir import (
     IDGenerator,
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -13,6 +14,7 @@ from compiler_ir import (
 )
 from wasm_module_encoder import encode_module
 from wasm_runtime import ProcExitError, WasiConfig, WasiHost, WasmRuntime
+from wasm_types import ValueType
 
 from ir_to_wasm_compiler import (
     FunctionSignature,
@@ -23,7 +25,7 @@ from ir_to_wasm_compiler import (
 )
 
 
-def _runtime_result(module, export_name: str, args: list[int], host=None) -> list[int | float]:
+def _runtime_result(module, export_name: str, args: list[int | float], host=None) -> list[int | float]:
     runtime = WasmRuntime(host=host)
     wasm_bytes = encode_module(module)
     return runtime.load_and_run(wasm_bytes, export_name, args)
@@ -145,6 +147,124 @@ def test_compile_memory_ops_and_data_layout() -> None:
 
     assert any(export.name == "memory" for export in module.exports)
     assert _runtime_result(module, "store_read", []) == [90]
+
+
+def test_compile_f64_function_with_typed_signature() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_add_real")
+    program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_fn_add_real")], id=-1))
+    program.add_instruction(
+        IrInstruction(
+            IrOp.F64_ADD,
+            [IrRegister(1), IrRegister(2), IrRegister(3)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_add_real",
+                param_count=2,
+                export_name="add_real",
+                param_types=(ValueType.F64, ValueType.F64),
+                result_types=(ValueType.F64,),
+            )
+        ],
+    )
+
+    assert _runtime_result(module, "add_real", [1.25, 2.5]) == [3.75]
+
+
+def test_compile_f64_memory_load_store() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_store_read_real")
+    program.add_data(IrDataDecl(label="real_buf", size=8, init=0))
+    program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_fn_store_read_real")], id=-1))
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_ADDR, [IrRegister(2), IrLabel("real_buf")], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(3), IrImmediate(0)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.LOAD_F64_IMM,
+            [IrRegister(4), IrFloatImmediate(6.5)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.STORE_F64,
+            [IrRegister(4), IrRegister(2), IrRegister(3)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.LOAD_F64,
+            [IrRegister(1), IrRegister(2), IrRegister(3)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_store_read_real",
+                param_count=0,
+                export_name="store_read_real",
+                result_types=(ValueType.F64,),
+            )
+        ],
+    )
+
+    assert _runtime_result(module, "store_read_real", []) == [6.5]
+
+
+def test_compile_i32_to_f64_conversion_and_compare() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_gt_three_point_five")
+    program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_fn_gt_three_point_five")], id=-1))
+    program.add_instruction(
+        IrInstruction(IrOp.F64_FROM_I32, [IrRegister(3), IrRegister(2)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.LOAD_F64_IMM,
+            [IrRegister(4), IrFloatImmediate(3.5)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.F64_CMP_GT,
+            [IrRegister(1), IrRegister(3), IrRegister(4)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_gt_three_point_five",
+                param_count=1,
+                export_name="gt_three_point_five",
+                param_types=(ValueType.I32,),
+                result_types=(ValueType.I32,),
+            )
+        ],
+    )
+
+    assert _runtime_result(module, "gt_three_point_five", [4]) == [1]
+    assert _runtime_result(module, "gt_three_point_five", [3]) == [0]
 
 
 def test_compile_function_call_and_run_it() -> None:


### PR DESCRIPTION
## Summary
- add initial `f64` support to shared `compiler_ir` with float immediates, parser/printer round-tripping, and new floating-point opcodes
- teach `ir-to-wasm-compiler` typed function signatures and register locals so `f64` params/results can lower to real WASM `f64` instructions
- add focused compiler-ir and ir-to-wasm tests covering float immediates, f64 arithmetic, f64 memory load/store, and i32-to-f64 conversion/comparison

## Notes
- this is the substrate PR for upcoming ALGOL 60 `real` support
- `CALL` still writes through the existing scratch return register, so mixed result types in the same caller remain intentionally constrained by that model for now

## Validation
- `uv run --python 3.12 --with pytest --with pytest-cov python -m pytest -q -o addopts='' tests/test_compiler_ir.py::TestParseIr::test_float_immediate_parsed tests/test_compiler_ir.py::TestAllOpcodesPrintParse::test_all_opcodes_roundtrip`
- `.venv/bin/python -m pytest -q -o addopts='' tests/test_ir_to_wasm_compiler.py::test_compile_f64_function_with_typed_signature tests/test_ir_to_wasm_compiler.py::test_compile_f64_memory_load_store tests/test_ir_to_wasm_compiler.py::test_compile_i32_to_f64_conversion_and_compare tests/test_ir_to_wasm_compiler.py::test_compile_simple_function_with_addition tests/test_ir_to_wasm_compiler.py::test_compile_function_call_and_run_it`
- `uv run --python 3.12 --with ruff ruff check --select F401,F821,F822,F823,I001 src/compiler_ir`
- `uv run --python 3.12 python -m py_compile code/packages/python/compiler-ir/src/compiler_ir/*.py code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/*.py code/packages/python/compiler-ir/tests/test_compiler_ir.py code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py`
- `git diff --check`
