### PR TITLE
feat(algol): add real scalar storage and lowering

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -23,6 +23,7 @@ from algol_type_checker import (
 from compiler_ir import (
     IDGenerator,
     IrDataDecl,
+    IrFloatImmediate,
     IrImmediate,
     IrInstruction,
     IrLabel,
@@ -81,6 +82,9 @@ _THUNK_FLAGS_OFFSET = 8
 _THUNK_DESCRIPTOR_TAG = 1
 _THUNK_FLAG_STORE = 1
 _MAX_EVAL_THUNKS = 256
+_INTEGER_TYPE = "integer"
+_BOOLEAN_TYPE = "boolean"
+_REAL_TYPE = "real"
 
 
 @dataclass(frozen=True)
@@ -178,6 +182,7 @@ class AlgolIrCompiler:
         self.variable_slots: dict[str, int] = {}
         self.legacy_variable_slots: dict[str, int] = {}
         self.procedure_signatures: dict[str, int] = {}
+        self.expression_types: dict[int, str] = {}
         self.eval_thunks: list[_EvalThunk] = []
         self.has_by_name_parameters = False
 
@@ -285,6 +290,7 @@ class AlgolIrCompiler:
         self.legacy_variable_slots = self._collect_legacy_variable_slots(
             self.semantic_blocks
         )
+        self.expression_types = dict(type_result.expression_types)
 
         total_frame_bytes = sum(
             block.frame_layout.frame_size for block in self.semantic_blocks
@@ -474,7 +480,10 @@ class AlgolIrCompiler:
 
     def _initialize_scalar_slots(self, scope: _FrameScope) -> None:
         for slot in scope.semantic_block.frame_layout.slots:
-            self._store_word_const(scope.frame_base_reg, slot.offset, 0)
+            if slot.type_name == _REAL_TYPE:
+                self._store_f64_const(scope.frame_base_reg, slot.offset, 0.0)
+            else:
+                self._store_word_const(scope.frame_base_reg, slot.offset, 0)
 
     def _allocate_arrays(self, scope: _FrameScope) -> None:
         for array in self.arrays_by_block.get(scope.block_id, []):
@@ -858,6 +867,11 @@ class AlgolIrCompiler:
         if name is None:
             raise CompileError("only scalar assignments are supported")
         target = self._require_reference(name, "write")
+        value = self._coerce_reg_to_type(
+            value,
+            self._expr_type(expr),
+            expected_type=target.type_name,
+        )
         self._emit_store_reference(target, scope, value)
 
     def _compile_if(self, cond: ASTNode, scope: _FrameScope) -> None:
@@ -973,6 +987,20 @@ class AlgolIrCompiler:
             if operator == "+":
                 return value
             if operator == "-":
+                if self._expr_type(expr) == _REAL_TYPE:
+                    zero = self._const_f64_reg(0.0)
+                    operand = self._coerce_reg_to_type(
+                        value,
+                        self._expr_type(meaningful[1]),
+                    )
+                    dst = self._fresh_reg()
+                    self._emit(
+                        IrOp.F64_SUB,
+                        IrRegister(dst),
+                        IrRegister(zero),
+                        IrRegister(operand),
+                    )
+                    return dst
                 dst = self._fresh_reg()
                 self._emit(IrOp.SUB, IrRegister(dst), IrRegister(0), IrRegister(value))
                 return dst
@@ -1025,6 +1053,8 @@ class AlgolIrCompiler:
     def _compile_token(self, token: Token, scope: _FrameScope) -> int:
         if token.type_name == "INTEGER_LIT":
             return self._const_reg(int(token.value))
+        if token.type_name == "REAL_LIT":
+            return self._const_f64_reg(float(token.value))
         if token.value in {"true", "false"}:
             return self._const_reg(1 if token.value == "true" else 0)
         if token.type_name == "NAME":
@@ -1036,13 +1066,26 @@ class AlgolIrCompiler:
         self, children: list[ASTNode | Token], scope: _FrameScope
     ) -> int:
         current = self._compile_expr(children[0], scope)
+        current_type = self._expr_type(children[0])
         index = 1
         while index < len(children):
             operator = children[index]
             right = self._compile_expr(children[index + 1], scope)
             if not isinstance(operator, Token):
                 raise CompileError("expected numeric operator")
-            current = self._emit_numeric(operator.value, current, right)
+            right_type = self._expr_type(children[index + 1])
+            current = self._emit_numeric(
+                operator.value,
+                current,
+                current_type,
+                right,
+                right_type,
+            )
+            current_type = self._result_type_for_numeric_operator(
+                operator.value,
+                current_type,
+                right_type,
+            )
             index += 2
         return current
 
@@ -1087,43 +1130,157 @@ class AlgolIrCompiler:
         left = self._compile_expr(children[0], scope)
         operator = children[1]
         right = self._compile_expr(children[2], scope)
+        left_type = self._expr_type(children[0])
+        right_type = self._expr_type(children[2])
         if not isinstance(operator, Token):
             raise CompileError("expected comparison operator")
         dst = self._fresh_reg()
-        if operator.value == "=":
-            self._emit(
-                IrOp.CMP_EQ, IrRegister(dst), IrRegister(left), IrRegister(right)
+        if _REAL_TYPE in {left_type, right_type}:
+            left = self._coerce_reg_to_type(
+                left,
+                left_type,
+                expected_type=_REAL_TYPE,
             )
-        elif operator.value == "!=":
-            self._emit(
-                IrOp.CMP_NE, IrRegister(dst), IrRegister(left), IrRegister(right)
+            right = self._coerce_reg_to_type(
+                right,
+                right_type,
+                expected_type=_REAL_TYPE,
             )
-        elif operator.value == "<":
-            self._emit(
-                IrOp.CMP_LT, IrRegister(dst), IrRegister(left), IrRegister(right)
-            )
-        elif operator.value == ">":
-            self._emit(
-                IrOp.CMP_GT, IrRegister(dst), IrRegister(left), IrRegister(right)
-            )
-        elif operator.value == "<=":
-            self._emit(
-                IrOp.CMP_GT, IrRegister(dst), IrRegister(left), IrRegister(right)
-            )
-            dst = self._invert_bool(dst)
-        elif operator.value == ">=":
-            self._emit(
-                IrOp.CMP_LT, IrRegister(dst), IrRegister(left), IrRegister(right)
-            )
-            dst = self._invert_bool(dst)
+            if operator.value == "=":
+                self._emit(
+                    IrOp.F64_CMP_EQ,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator.value == "!=":
+                self._emit(
+                    IrOp.F64_CMP_NE,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator.value == "<":
+                self._emit(
+                    IrOp.F64_CMP_LT,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator.value == ">":
+                self._emit(
+                    IrOp.F64_CMP_GT,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator.value == "<=":
+                self._emit(
+                    IrOp.F64_CMP_LE,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator.value == ">=":
+                self._emit(
+                    IrOp.F64_CMP_GE,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            else:
+                raise CompileError(
+                    f"comparison operator {operator.value!r} is not supported"
+                )
         else:
-            raise CompileError(
-                f"comparison operator {operator.value!r} is not supported"
-            )
+            if operator.value == "=":
+                self._emit(
+                    IrOp.CMP_EQ, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            elif operator.value == "!=":
+                self._emit(
+                    IrOp.CMP_NE, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            elif operator.value == "<":
+                self._emit(
+                    IrOp.CMP_LT, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            elif operator.value == ">":
+                self._emit(
+                    IrOp.CMP_GT, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            elif operator.value == "<=":
+                self._emit(
+                    IrOp.CMP_GT, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+                dst = self._invert_bool(dst)
+            elif operator.value == ">=":
+                self._emit(
+                    IrOp.CMP_LT, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+                dst = self._invert_bool(dst)
+            else:
+                raise CompileError(
+                    f"comparison operator {operator.value!r} is not supported"
+                )
         return dst
 
-    def _emit_numeric(self, operator: str, left: int, right: int) -> int:
+    def _emit_numeric(
+        self,
+        operator: str,
+        left: int,
+        left_type: str,
+        right: int,
+        right_type: str,
+    ) -> int:
         dst = self._fresh_reg()
+        result_type = self._result_type_for_numeric_operator(
+            operator,
+            left_type,
+            right_type,
+        )
+        if result_type == _REAL_TYPE:
+            left = self._coerce_reg_to_type(
+                left,
+                left_type,
+                expected_type=_REAL_TYPE,
+            )
+            right = self._coerce_reg_to_type(
+                right,
+                right_type,
+                expected_type=_REAL_TYPE,
+            )
+            if operator == "+":
+                self._emit(
+                    IrOp.F64_ADD,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator == "-":
+                self._emit(
+                    IrOp.F64_SUB,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator == "*":
+                self._emit(
+                    IrOp.F64_MUL,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            elif operator == "/":
+                self._emit(
+                    IrOp.F64_DIV,
+                    IrRegister(dst),
+                    IrRegister(left),
+                    IrRegister(right),
+                )
+            else:
+                raise CompileError(f"numeric operator {operator!r} is not supported")
+            return dst
         if operator == "+":
             self._emit(IrOp.ADD, IrRegister(dst), IrRegister(left), IrRegister(right))
         elif operator == "-":
@@ -1801,12 +1958,7 @@ class AlgolIrCompiler:
             return self._emit_load_by_name_reference(reference, scope)
         pointer = self._emit_reference_pointer(reference, scope)
         dst = self._fresh_reg()
-        self._emit(
-            IrOp.LOAD_WORD,
-            IrRegister(dst),
-            IrRegister(pointer),
-            IrRegister(self._const_reg(0)),
-        )
+        self._emit_load_scalar(reference.type_name, dst, pointer, 0)
         return dst
 
     def _emit_load_by_name_reference(
@@ -1851,12 +2003,7 @@ class AlgolIrCompiler:
         self._copy_reg(dst=dst, src=_RESULT_REG)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(storage_label)
-        self._emit(
-            IrOp.LOAD_WORD,
-            IrRegister(dst),
-            IrRegister(pointer),
-            IrRegister(self._const_reg(0)),
-        )
+        self._emit_load_scalar(reference.type_name, dst, pointer, 0)
         self._label(end_label)
         return dst
 
@@ -1951,20 +2098,15 @@ class AlgolIrCompiler:
             self._emit_handle_pending_goto_after_call(scope)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(storage_label)
-            self._emit(
-                IrOp.STORE_WORD,
-                IrRegister(value_reg),
-                IrRegister(pointer),
-                IrRegister(self._const_reg(0)),
+            self._emit_store_scalar(
+                reference.type_name,
+                value_reg,
+                pointer,
+                0,
             )
             self._label(end_label)
             return
-        self._emit(
-            IrOp.STORE_WORD,
-            IrRegister(value_reg),
-            IrRegister(pointer),
-            IrRegister(self._const_reg(0)),
-        )
+        self._emit_store_scalar(reference.type_name, value_reg, pointer, 0)
 
     def _emit_frame_for_reference(
         self, reference: ResolvedReference, scope: _FrameScope
@@ -2050,10 +2192,50 @@ class AlgolIrCompiler:
         if symbol.slot_offset is None:
             raise CompileError(f"symbol {symbol.name!r} has no planned frame slot")
         offset_reg = self._const_reg(symbol.slot_offset)
+        if symbol.type_name == _REAL_TYPE:
+            self._emit(
+                IrOp.LOAD_F64,
+                IrRegister(dst_reg),
+                IrRegister(scope.frame_base_reg),
+                IrRegister(offset_reg),
+            )
+            return
         self._emit(
             IrOp.LOAD_WORD,
             IrRegister(dst_reg),
             IrRegister(scope.frame_base_reg),
+            IrRegister(offset_reg),
+        )
+
+    def _emit_load_scalar(
+        self,
+        type_name: str,
+        dst_reg: int,
+        base_reg: int,
+        offset: int,
+    ) -> None:
+        offset_reg = self._const_reg(offset)
+        opcode = IrOp.LOAD_F64 if type_name == _REAL_TYPE else IrOp.LOAD_WORD
+        self._emit(
+            opcode,
+            IrRegister(dst_reg),
+            IrRegister(base_reg),
+            IrRegister(offset_reg),
+        )
+
+    def _emit_store_scalar(
+        self,
+        type_name: str,
+        value_reg: int,
+        base_reg: int,
+        offset: int,
+    ) -> None:
+        offset_reg = self._const_reg(offset)
+        opcode = IrOp.STORE_F64 if type_name == _REAL_TYPE else IrOp.STORE_WORD
+        self._emit(
+            opcode,
+            IrRegister(value_reg),
+            IrRegister(base_reg),
             IrRegister(offset_reg),
         )
 
@@ -2070,6 +2252,13 @@ class AlgolIrCompiler:
         value_reg = self._const_reg(value)
         self._store_word_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
 
+    def _store_f64_reg(self, *, value_reg: int, base_reg: int, offset: int) -> None:
+        self._emit_store_scalar(_REAL_TYPE, value_reg, base_reg, offset)
+
+    def _store_f64_const(self, base_reg: int, offset: int, value: float) -> None:
+        value_reg = self._const_f64_reg(value)
+        self._store_f64_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
+
     def _copy_reg(self, *, dst: int, src: int) -> None:
         self._emit(IrOp.ADD_IMM, IrRegister(dst), IrRegister(src), IrImmediate(0))
 
@@ -2077,6 +2266,53 @@ class AlgolIrCompiler:
         reg = self._fresh_reg()
         self._emit(IrOp.LOAD_IMM, IrRegister(reg), IrImmediate(value))
         return reg
+
+    def _const_f64_reg(self, value: float) -> int:
+        reg = self._fresh_reg()
+        self._emit(IrOp.LOAD_F64_IMM, IrRegister(reg), IrFloatImmediate(value))
+        return reg
+
+    def _coerce_reg_to_type(
+        self,
+        reg: int,
+        actual_type: str,
+        *,
+        expected_type: str | None = None,
+    ) -> int:
+        target_type = expected_type or actual_type
+        if actual_type == target_type:
+            return reg
+        if actual_type == _INTEGER_TYPE and target_type == _REAL_TYPE:
+            coerced = self._fresh_reg()
+            self._emit(IrOp.F64_FROM_I32, IrRegister(coerced), IrRegister(reg))
+            return coerced
+        raise CompileError(
+            f"cannot coerce {actual_type} value to {target_type} during lowering"
+        )
+
+    def _result_type_for_numeric_operator(
+        self,
+        operator: str,
+        left_type: str,
+        right_type: str,
+    ) -> str:
+        if operator == "/":
+            return _REAL_TYPE
+        if operator in {"+", "-", "*"}:
+            return (
+                _REAL_TYPE
+                if _REAL_TYPE in {left_type, right_type}
+                else _INTEGER_TYPE
+            )
+        return _INTEGER_TYPE
+
+    def _expr_type(self, expr: ASTNode | Token | None) -> str:
+        if expr is None:
+            raise CompileError("missing typed expression")
+        inferred = self.expression_types.get(id(expr))
+        if inferred is None:
+            raise CompileError(f"missing inferred type for {type(expr).__name__}")
+        return inferred
 
     def _load_runtime_state(self, offset: int, dst_reg: int) -> None:
         self._emit(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -242,6 +242,37 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.STORE_WORD) >= 2
         assert opcodes.count(IrOp.LOAD_WORD) >= 2
 
+    def test_compiles_real_variable_storage_and_comparison(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "real x; "
+                "x := 1.5; "
+                "if x > 1.0 then result := 7 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.LOAD_F64_IMM in opcodes
+        assert IrOp.STORE_F64 in opcodes
+        assert IrOp.LOAD_F64 in opcodes
+        assert IrOp.F64_CMP_GT in opcodes
+
+    def test_compiles_integer_to_real_promotion(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "real x; "
+                "x := 1; "
+                "if x = 1.0 then result := 9 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.F64_FROM_I32 in opcodes
+
     def test_compiles_greater_equal_via_less_than_inversion(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/__init__.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/__init__.py
@@ -6,6 +6,7 @@ implementation of the computing stack from transistors to operating systems.
 
 from algol_type_checker.checker import (
     FRAME_HEADER_SIZE,
+    FRAME_REAL_SIZE,
     FRAME_WORD_SIZE,
     AlgolTypeChecker,
     ArrayDescriptor,
@@ -41,6 +42,7 @@ __all__ = [
     "ArrayDimension",
     "Diagnostic",
     "FRAME_HEADER_SIZE",
+    "FRAME_REAL_SIZE",
     "FRAME_WORD_SIZE",
     "FrameLayout",
     "FrameSlot",

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -9,9 +9,11 @@ from lexer import Token
 
 INTEGER = "integer"
 BOOLEAN = "boolean"
+REAL = "real"
 ERROR = "error"
 FRAME_HEADER_SIZE = 20
 FRAME_WORD_SIZE = 4
+FRAME_REAL_SIZE = 8
 VALUE = "value"
 NAME = "name"
 ARRAY = "array"
@@ -82,12 +84,13 @@ class FrameLayout:
         return self.header_size + sum(slot.size for slot in self.slots)
 
     def allocate_scalar(self, symbol: Symbol) -> FrameSlot:
+        slot_size = FRAME_REAL_SIZE if symbol.type_name == REAL else self.word_size
         slot = FrameSlot(
             symbol_id=symbol.symbol_id,
             name=symbol.name,
             type_name=symbol.type_name,
-            offset=self.header_size + (len(self.slots) * self.word_size),
-            size=self.word_size,
+            offset=self.header_size + sum(existing.size for existing in self.slots),
+            size=slot_size,
         )
         self.slots.append(slot)
         symbol.slot_offset = slot.offset
@@ -501,7 +504,7 @@ class AlgolTypeChecker:
 
         type_node = _first_node(inner, "type")
         declared_type = _first_keyword_value(type_node) if type_node is not None else ""
-        if declared_type not in {INTEGER, BOOLEAN}:
+        if declared_type not in {INTEGER, BOOLEAN, REAL}:
             self._error(
                 inner, f"{declared_type or 'unknown'} variables are not supported yet"
             )
@@ -1157,7 +1160,11 @@ class AlgolTypeChecker:
 
         expr = _first_direct_node(assign, "expression")
         value_type = self._infer_expr(expr, scope) if expr is not None else ERROR
-        if target_type != ERROR and value_type != ERROR and target_type != value_type:
+        if (
+            target_type != ERROR
+            and value_type != ERROR
+            and not self._can_assign(target_type, value_type)
+        ):
             self._error(
                 name,
                 f"cannot assign {value_type} to {target_type} variable {name.value!r}",
@@ -1265,7 +1272,7 @@ class AlgolTypeChecker:
         ):
             operator = meaningful[0].value
             if operator in {"+", "-"}:
-                return self._require_unary(expr, meaningful[1], scope, INTEGER, INTEGER)
+                return self._require_numeric_unary(expr, meaningful[1], scope)
 
         if expr.rule_name in {
             "expr_eqv",
@@ -1284,19 +1291,11 @@ class AlgolTypeChecker:
                 and child.value in {"=", "!=", "<", "<=", ">", ">="}
                 for child in meaningful
             ):
-                return self._fold_binary(expr, meaningful, scope, INTEGER, BOOLEAN)
+                return self._infer_numeric_comparison(expr, meaningful, scope)
             return self._infer_expr(meaningful[0], scope)
 
         if expr.rule_name in {"expr_add", "simple_arith", "expr_mul", "term"}:
-            if any(
-                isinstance(child, Token) and child.value == "/" for child in meaningful
-            ):
-                self._error(
-                    expr,
-                    "real division is not supported yet; use div for integer division",
-                )
-                return ERROR
-            return self._fold_binary(expr, meaningful, scope, INTEGER, INTEGER)
+            return self._infer_numeric_chain(expr, meaningful, scope)
 
         if expr.rule_name in {"expr_pow", "factor"}:
             if any(
@@ -1330,6 +1329,8 @@ class AlgolTypeChecker:
     def _infer_token(self, token: Token, scope: Scope) -> str:
         if token.type_name == "INTEGER_LIT":
             return INTEGER
+        if token.type_name == "REAL_LIT":
+            return REAL
         if token.value in {"true", "false"}:
             return BOOLEAN
         if token.type_name == "NAME":
@@ -1455,7 +1456,11 @@ class AlgolTypeChecker:
             )
         for argument, parameter in zip(arguments, descriptor.parameters, strict=False):
             actual_type = self._infer_expr(argument, scope)
-            if actual_type != ERROR and actual_type != parameter.type_name:
+            if actual_type != ERROR and not self._parameter_accepts_type(
+                parameter.mode,
+                parameter.type_name,
+                actual_type,
+            ):
                 if parameter.mode == NAME:
                     self._error(
                         argument,
@@ -1591,6 +1596,107 @@ class AlgolTypeChecker:
             return ERROR
         return result_type
 
+    def _require_numeric_unary(
+        self,
+        node: ASTNode,
+        operand: ASTNode | Token,
+        scope: Scope,
+    ) -> str:
+        actual = self._infer_expr(operand, scope)
+        if actual == ERROR:
+            return ERROR
+        if not _is_numeric_type(actual):
+            self._error(node, f"operator requires numeric operand, got {actual}")
+            return ERROR
+        return actual
+
+    def _infer_numeric_chain(
+        self,
+        node: ASTNode,
+        children: list[ASTNode | Token],
+        scope: Scope,
+    ) -> str:
+        current_type = self._infer_expr(children[0], scope)
+        if current_type == ERROR:
+            return ERROR
+        if not _is_numeric_type(current_type):
+            self._error(node, f"operator requires numeric operand, got {current_type}")
+            return ERROR
+
+        saw_operator = False
+        index = 1
+        while index < len(children):
+            operator = children[index]
+            right = children[index + 1]
+            right_type = self._infer_expr(right, scope)
+            if right_type == ERROR:
+                return ERROR
+            if not isinstance(operator, Token):
+                self._error(node, "expected numeric operator")
+                return ERROR
+            if not _is_numeric_type(right_type):
+                self._error(
+                    node,
+                    f"operator requires numeric operand, got {right_type}",
+                )
+                return ERROR
+            saw_operator = True
+            if operator.value in {"div", "mod"}:
+                if current_type != INTEGER or right_type != INTEGER:
+                    self._error(
+                        node,
+                        f"operator {operator.value!r} requires integer operands",
+                    )
+                    return ERROR
+                current_type = INTEGER
+            elif operator.value == "/":
+                current_type = REAL
+            elif operator.value in {"+", "-", "*"}:
+                current_type = (
+                    REAL if REAL in {current_type, right_type} else INTEGER
+                )
+            else:
+                self._error(
+                    node,
+                    f"numeric operator {operator.value!r} is not supported",
+                )
+                return ERROR
+            index += 2
+        return current_type if saw_operator else self._infer_expr(children[0], scope)
+
+    def _infer_numeric_comparison(
+        self,
+        node: ASTNode,
+        children: list[ASTNode | Token],
+        scope: Scope,
+    ) -> str:
+        left = self._infer_expr(children[0], scope)
+        right = self._infer_expr(children[2], scope)
+        if left == ERROR or right == ERROR:
+            return ERROR
+        if not _is_numeric_type(left):
+            self._error(node, f"operator requires numeric operand, got {left}")
+            return ERROR
+        if not _is_numeric_type(right):
+            self._error(node, f"operator requires numeric operand, got {right}")
+            return ERROR
+        return BOOLEAN
+
+    def _can_assign(self, target_type: str, value_type: str) -> bool:
+        if target_type == value_type:
+            return True
+        return target_type == REAL and value_type == INTEGER
+
+    def _parameter_accepts_type(
+        self,
+        mode: str,
+        expected_type: str,
+        actual_type: str,
+    ) -> bool:
+        if expected_type == actual_type:
+            return True
+        return mode == VALUE and expected_type == REAL and actual_type == INTEGER
+
     def _fold_binary(
         self,
         node: ASTNode,
@@ -1616,6 +1722,10 @@ class AlgolTypeChecker:
 
 def check_algol(ast: ASTNode) -> TypeCheckResult:
     return AlgolTypeChecker().check(ast)
+
+
+def _is_numeric_type(type_name: str) -> bool:
+    return type_name in {INTEGER, REAL}
 
 
 def check(ast: ASTNode) -> TypeCheckResult:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -5,6 +5,7 @@ from lang_parser import ASTNode
 
 from algol_type_checker import (
     FRAME_HEADER_SIZE,
+    FRAME_REAL_SIZE,
     FRAME_WORD_SIZE,
     TypeCheckError,
     __version__,
@@ -186,7 +187,7 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
 
         assert not result.ok
-        assert "real division is not supported" in result.diagnostics[0].message
+        assert "switch index must be integer" in result.diagnostics[0].message
 
     def test_rejects_nonlocal_switch_selection_for_now(self) -> None:
         ast = parse_algol(
@@ -224,11 +225,15 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "already declared" in result.diagnostics[0].message
 
-    def test_reports_unsupported_real_declaration(self) -> None:
-        ast = parse_algol("begin real result; result := 1 end")
+    def test_accepts_real_variable_declaration_and_assignment(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; x := 1.5; "
+            "if x > 1.0 then result := 1 else result := 0 "
+            "end"
+        )
         result = check_algol(ast)
-        assert not result.ok
-        assert "real variables are not supported" in result.diagnostics[0].message
+        assert result.ok
+        assert result.root_scope.children[0].symbols["x"].type_name == "real"
 
     def test_accepts_boolean_variable_declaration_and_assignment(self) -> None:
         ast = parse_algol(
@@ -247,7 +252,7 @@ class TestAlgolTypeChecker:
         ast = parse_algol("begin integer result; result := true + 1 end")
         result = check_algol(ast)
         assert not result.ok
-        assert "operator requires integer" in result.diagnostics[0].message
+        assert "operator requires numeric operand" in result.diagnostics[0].message
 
     def test_accepts_boolean_operators_in_condition(self) -> None:
         ast = parse_algol(
@@ -263,11 +268,14 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "chained assignment" in result.diagnostics[0].message
 
-    def test_reports_unsupported_real_division(self) -> None:
-        ast = parse_algol("begin integer result; result := 1 / 2 end")
+    def test_accepts_real_division_and_integer_to_real_assignment(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; x := 1 / 2; "
+            "if x < 1.0 then result := 1 else result := 0 "
+            "end"
+        )
         result = check_algol(ast)
-        assert not result.ok
-        assert "real division is not supported" in result.diagnostics[0].message
+        assert result.ok
 
     def test_reports_unsupported_exponentiation(self) -> None:
         ast = parse_algol("begin integer result; result := 2 ** 3 end")
@@ -304,6 +312,21 @@ class TestAlgolTypeChecker:
         assert [(slot.name, slot.offset) for slot in layout.slots] == [
             ("result", 20),
             ("other", 24),
+        ]
+
+    def test_plans_real_scalar_frame_slot_with_eight_byte_size(self) -> None:
+        ast = parse_algol("begin integer result; real x; result := 0 end")
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.root_block is not None
+        layout = result.semantic.root_block.frame_layout
+        expected_size = FRAME_HEADER_SIZE + FRAME_WORD_SIZE + FRAME_REAL_SIZE
+        assert layout.frame_size == expected_size
+        assert [(slot.name, slot.offset, slot.size) for slot in layout.slots] == [
+            ("result", 20, FRAME_WORD_SIZE),
+            ("x", 24, FRAME_REAL_SIZE),
         ]
 
     def test_records_outer_scope_reference_static_link_delta(self) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -90,6 +90,26 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_real_variable_assignment_drives_comparison(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "real x; "
+            "x := 1.5; "
+            "if x > 1.0 then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_integer_to_real_assignment_promotes_before_store(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "real x; "
+            "x := 1; "
+            "if x = 1.0 then result := 9 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_forward_goto_skips_statements_until_label(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- add `real` scalar support to the ALGOL type checker, including real literals, numeric promotion, and 8-byte frame-slot metadata
- lower real scalar assignments, loads/stores, arithmetic, comparisons, and integer-to-real promotion through compiler IR into the existing WASM `f64` path
- add focused checker, IR, and WASM tests for real scalar storage, comparison, division, and integer-to-real assignment

## Testing
- `ruff check code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/src/algol_type_checker/__init__.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_type_checker.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:../algol-ir-compiler/src:../virtual-machine/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../wasm-module-encoder/src:../ir-to-wasm-compiler/src:../ir-to-wasm-validator/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_wasm_compiler.py -q`