### PR TITLE
feat(rust): add HTML1 compatibility lexer artifact

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -10,6 +10,9 @@ documented in this file.
 - Statically linked HTML skeleton state machine over the generic
   `state-machine-tokenizer` runtime.
 - Build-time `html-skeleton.lexer.states.toml` authoring artifact.
+- Build-time `html1.lexer.states.toml` authoring artifact for the Mosaic-era
+  HTML compatibility floor, covering tags, attributes, comments, doctypes, and
+  EOF recovery without runtime TOML loading.
 - Checked-in generated Rust module for the HTML skeleton lexer definition, so
   the crate links static source instead of loading TOML at runtime.
 - Fixture-backed tests proving the generated lexer definition and emitted

--- a/code/packages/rust/html-lexer/Cargo.toml
+++ b/code/packages/rust/html-lexer/Cargo.toml
@@ -7,3 +7,6 @@ description = "HTML lexer built from state-machine lexer definitions"
 [dependencies]
 state-machine = { path = "../state-machine" }
 state-machine-tokenizer = { path = "../state-machine-tokenizer" }
+
+[dev-dependencies]
+state-machine-markup-deserializer = { path = "../state-machine-markup-deserializer" }

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -14,9 +14,15 @@ The generic `state-machine` crate executes ordered transitions. The
 buffers, current token construction, diagnostics, source positions, and traces.
 This crate owns the HTML-specific state machine and exposes a Rust lexer API.
 
-The TOML file in this package is an authoring artifact. Production code links a
+The TOML files in this package are authoring artifacts. Production code links a
 checked-in generated Rust module built to match the output shape of
 `state-machine-source-compiler`, so the runtime never loads TOML or JSON.
+
+`html-skeleton.lexer.states.toml` is the bootstrap machine already wired into
+the package API today. `html1.lexer.states.toml` is the broader compatibility
+floor for Venture's Mosaic-era target: it is not the end state of the project,
+but the first real HTML authoring artifact that must keep HTML 1.0-era content
+working as the lexer grows forward toward newer standards.
 
 ## Usage
 

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1,0 +1,1316 @@
+format = "state-machine/v1"
+profile = "lexer/v1"
+name = "html1-lexer"
+kind = "transducer"
+version = "0.1.0"
+runtime_min = "state-machine-tokenizer/0.1"
+initial = "data"
+done = "done"
+includes = []
+alphabet = [
+  "<",
+  ">",
+  "/",
+  "=",
+  "!",
+  "-",
+  "\"",
+  "'",
+  " ",
+  "\n",
+  "\t",
+  "\r",
+  "D",
+  "d",
+  "O",
+  "o",
+  "C",
+  "c",
+  "T",
+  "t",
+  "Y",
+  "y",
+  "P",
+  "p",
+  "E",
+  "e",
+]
+
+[[tokens]]
+name = "Text"
+fields = ["data"]
+
+[[tokens]]
+name = "StartTag"
+fields = ["name", "attributes", "self_closing"]
+
+[[tokens]]
+name = "EndTag"
+fields = ["name"]
+
+[[tokens]]
+name = "Comment"
+fields = ["data"]
+
+[[tokens]]
+name = "Doctype"
+fields = ["name", "force_quirks"]
+
+[[tokens]]
+name = "EOF"
+fields = []
+
+[[registers]]
+id = "text_buffer"
+type = "string"
+
+[[registers]]
+id = "current_token"
+type = "token?"
+
+[[registers]]
+id = "current_attribute"
+type = "attribute?"
+
+[[registers]]
+id = "temporary_buffer"
+type = "string"
+
+[[registers]]
+id = "return_state"
+type = "state?"
+
+[[states]]
+id = "data"
+initial = true
+
+[[states]]
+id = "tag_open"
+
+[[states]]
+id = "end_tag_open"
+
+[[states]]
+id = "tag_name"
+
+[[states]]
+id = "end_tag_name"
+
+[[states]]
+id = "before_attribute_name"
+
+[[states]]
+id = "attribute_name"
+
+[[states]]
+id = "after_attribute_name"
+
+[[states]]
+id = "before_attribute_value"
+
+[[states]]
+id = "attribute_value_double_quoted"
+
+[[states]]
+id = "attribute_value_single_quoted"
+
+[[states]]
+id = "attribute_value_unquoted"
+
+[[states]]
+id = "after_attribute_value_quoted"
+
+[[states]]
+id = "self_closing_start_tag"
+
+[[states]]
+id = "markup_declaration_open"
+
+[[states]]
+id = "comment_start"
+
+[[states]]
+id = "comment"
+
+[[states]]
+id = "comment_end_dash"
+
+[[states]]
+id = "comment_end"
+
+[[states]]
+id = "bogus_comment"
+
+[[states]]
+id = "doctype_keyword_o"
+
+[[states]]
+id = "doctype_keyword_c"
+
+[[states]]
+id = "doctype_keyword_t"
+
+[[states]]
+id = "doctype_keyword_y"
+
+[[states]]
+id = "doctype_keyword_p"
+
+[[states]]
+id = "doctype_keyword_e"
+
+[[states]]
+id = "doctype_after_keyword"
+
+[[states]]
+id = "before_doctype_name"
+
+[[states]]
+id = "doctype_name"
+
+[[states]]
+id = "after_doctype_name"
+
+[[states]]
+id = "before_end_tag_close"
+
+[[states]]
+id = "done"
+final = true
+
+[[transitions]]
+from = "data"
+matcher = { literal = "<" }
+to = "tag_open"
+actions = ["flush_text"]
+
+[[transitions]]
+from = "data"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["flush_text", "emit(EOF)"]
+
+[[transitions]]
+from = "data"
+matcher = { anything = true }
+to = "data"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "tag_open"
+matcher = { literal = "/" }
+to = "end_tag_open"
+
+[[transitions]]
+from = "tag_open"
+matcher = { literal = "!" }
+to = "markup_declaration_open"
+
+[[transitions]]
+from = "tag_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag-open-state)",
+  "append_text(<)",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "tag_open"
+matcher = { anything = true }
+to = "tag_name"
+actions = ["create_start_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "end_tag_open"
+matcher = { literal = ">" }
+to = "data"
+actions = ["parse_error(missing-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-end-tag-open-state)",
+  "append_text(</)",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "end_tag_open"
+matcher = { anything = true }
+to = "end_tag_name"
+actions = ["create_end_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = " " }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = "\n" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = "\t" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = "\r" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+
+[[transitions]]
+from = "tag_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "tag_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag-name-state)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "tag_name"
+matcher = { anything = true }
+to = "tag_name"
+actions = ["append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = " " }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "\n" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "\t" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "\r" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "=" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-equals-before-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(=)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { anything = true }
+to = "attribute_name"
+actions = ["start_attribute", "append_attribute_name(current_lowercase)"]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = " " }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "\n" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "\t" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "\r" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "=" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { anything = true }
+to = "attribute_name"
+actions = ["append_attribute_name(current_lowercase)"]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = " " }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\n" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\t" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\r" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "=" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["commit_attribute", "emit_current_token"]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "commit_attribute",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { anything = true }
+to = "attribute_name"
+actions = [
+  "commit_attribute",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = " " }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "\n" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "\t" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "\r" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "\"" }
+to = "attribute_value_double_quoted"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "'" }
+to = "attribute_value_single_quoted"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = ">" }
+to = "data"
+actions = [
+  "parse_error(missing-attribute-value)",
+  "commit_attribute",
+  "emit_current_token",
+]
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "commit_attribute",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { anything = true }
+to = "attribute_value_unquoted"
+actions = ["append_attribute_value(current)"]
+
+[[transitions]]
+from = "attribute_value_double_quoted"
+matcher = { literal = "\"" }
+to = "after_attribute_value_quoted"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_double_quoted"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "commit_attribute",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "attribute_value_double_quoted"
+matcher = { anything = true }
+to = "attribute_value_double_quoted"
+actions = ["append_attribute_value(current)"]
+
+[[transitions]]
+from = "attribute_value_single_quoted"
+matcher = { literal = "'" }
+to = "after_attribute_value_quoted"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_single_quoted"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "commit_attribute",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "attribute_value_single_quoted"
+matcher = { anything = true }
+to = "attribute_value_single_quoted"
+actions = ["append_attribute_value(current)"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = " " }
+to = "before_attribute_name"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "\n" }
+to = "before_attribute_name"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "\t" }
+to = "before_attribute_name"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "\r" }
+to = "before_attribute_name"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+actions = ["commit_attribute"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = ">" }
+to = "data"
+actions = ["commit_attribute", "emit_current_token"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "commit_attribute",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { anything = true }
+to = "attribute_value_unquoted"
+actions = ["append_attribute_value(current)"]
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = " " }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = "\n" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = "\t" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = "\r" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = "/" }
+to = "self_closing_start_tag"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "after_attribute_value_quoted"
+matcher = { anything = true }
+to = "attribute_name"
+actions = [
+  "parse_error(missing-whitespace-between-attributes)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "self_closing_start_tag"
+matcher = { literal = ">" }
+to = "data"
+actions = ["mark_self_closing", "emit_current_token"]
+
+[[transitions]]
+from = "self_closing_start_tag"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-tag)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "self_closing_start_tag"
+matcher = { anything = true }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-solidus-in-tag)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "markup_declaration_open"
+matcher = { literal = "-" }
+to = "comment_start"
+actions = ["create_comment"]
+
+[[transitions]]
+from = "markup_declaration_open"
+matcher = { literal = "D" }
+to = "doctype_keyword_o"
+actions = ["create_doctype"]
+
+[[transitions]]
+from = "markup_declaration_open"
+matcher = { literal = "d" }
+to = "doctype_keyword_o"
+actions = ["create_doctype"]
+
+[[transitions]]
+from = "markup_declaration_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-markup-declaration-open-state)",
+  "append_text(<!)",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "markup_declaration_open"
+matcher = { anything = true }
+to = "bogus_comment"
+actions = ["create_comment", "append_comment(current)"]
+
+[[transitions]]
+from = "comment_start"
+matcher = { literal = "-" }
+to = "comment"
+
+[[transitions]]
+from = "comment_start"
+matcher = { literal = ">" }
+to = "data"
+actions = [
+  "parse_error(abrupt-closing-of-empty-comment)",
+  "emit_current_token",
+]
+
+[[transitions]]
+from = "comment_start"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "comment_start"
+matcher = { anything = true }
+to = "bogus_comment"
+actions = ["append_comment(-)", "append_comment(current)"]
+
+[[transitions]]
+from = "comment"
+matcher = { literal = "-" }
+to = "comment_end_dash"
+
+[[transitions]]
+from = "comment"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "comment"
+matcher = { anything = true }
+to = "comment"
+actions = ["append_comment(current)"]
+
+[[transitions]]
+from = "comment_end_dash"
+matcher = { literal = "-" }
+to = "comment_end"
+
+[[transitions]]
+from = "comment_end_dash"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-comment)",
+  "append_comment(-)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "comment_end_dash"
+matcher = { anything = true }
+to = "comment"
+actions = ["append_comment(-)", "append_comment(current)"]
+
+[[transitions]]
+from = "comment_end"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "comment_end"
+matcher = { literal = "-" }
+to = "comment_end"
+actions = ["append_comment(-)"]
+
+[[transitions]]
+from = "comment_end"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-comment)",
+  "append_comment(--)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "comment_end"
+matcher = { anything = true }
+to = "comment"
+actions = ["append_comment(--)", "append_comment(current)"]
+
+[[transitions]]
+from = "bogus_comment"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "bogus_comment"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "bogus_comment"
+matcher = { anything = true }
+to = "bogus_comment"
+actions = ["append_comment(current)"]
+
+[[transitions]]
+from = "doctype_keyword_o"
+matcher = { literal = "O" }
+to = "doctype_keyword_c"
+
+[[transitions]]
+from = "doctype_keyword_o"
+matcher = { literal = "o" }
+to = "doctype_keyword_c"
+
+[[transitions]]
+from = "doctype_keyword_o"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_o"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(d)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_keyword_c"
+matcher = { literal = "C" }
+to = "doctype_keyword_t"
+
+[[transitions]]
+from = "doctype_keyword_c"
+matcher = { literal = "c" }
+to = "doctype_keyword_t"
+
+[[transitions]]
+from = "doctype_keyword_c"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_c"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(do)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_keyword_t"
+matcher = { literal = "T" }
+to = "doctype_keyword_y"
+
+[[transitions]]
+from = "doctype_keyword_t"
+matcher = { literal = "t" }
+to = "doctype_keyword_y"
+
+[[transitions]]
+from = "doctype_keyword_t"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_t"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(doc)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_keyword_y"
+matcher = { literal = "Y" }
+to = "doctype_keyword_p"
+
+[[transitions]]
+from = "doctype_keyword_y"
+matcher = { literal = "y" }
+to = "doctype_keyword_p"
+
+[[transitions]]
+from = "doctype_keyword_y"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_y"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(doct)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_keyword_p"
+matcher = { literal = "P" }
+to = "doctype_keyword_e"
+
+[[transitions]]
+from = "doctype_keyword_p"
+matcher = { literal = "p" }
+to = "doctype_keyword_e"
+
+[[transitions]]
+from = "doctype_keyword_p"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_p"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(docty)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_keyword_e"
+matcher = { literal = "E" }
+to = "doctype_after_keyword"
+
+[[transitions]]
+from = "doctype_keyword_e"
+matcher = { literal = "e" }
+to = "doctype_after_keyword"
+
+[[transitions]]
+from = "doctype_keyword_e"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_keyword_e"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(invalid-doctype-keyword)",
+  "append_doctype_name(doctyp)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { literal = " " }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { literal = "\n" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { literal = "\t" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { literal = "\r" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_after_keyword"
+matcher = { anything = true }
+to = "doctype_name"
+actions = [
+  "parse_error(missing-whitespace-before-doctype-name)",
+  "append_doctype_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { literal = " " }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { literal = "\n" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { literal = "\t" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { literal = "\r" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["parse_error(missing-doctype-name)", "emit_current_token"]
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "before_doctype_name"
+matcher = { anything = true }
+to = "doctype_name"
+actions = ["append_doctype_name(current_lowercase)"]
+
+[[transitions]]
+from = "doctype_name"
+matcher = { literal = " " }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "doctype_name"
+matcher = { literal = "\n" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "doctype_name"
+matcher = { literal = "\t" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "doctype_name"
+matcher = { literal = "\r" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "doctype_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "doctype_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "doctype_name"
+matcher = { anything = true }
+to = "doctype_name"
+actions = ["append_doctype_name(current_lowercase)"]
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = " " }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = "\n" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = "\t" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = "\r" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { anything = true }
+to = "after_doctype_name"
+actions = ["parse_error(unexpected-character-after-doctype-name)"]
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = " " }
+to = "before_end_tag_close"
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = "\n" }
+to = "before_end_tag_close"
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = "\t" }
+to = "before_end_tag_close"
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = "\r" }
+to = "before_end_tag_close"
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-end-tag-name-state)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { anything = true }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-character-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = " " }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = "\n" }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = "\t" }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = "\r" }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-end-tag-name-state)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { anything = true }
+to = "end_tag_name"
+actions = ["append_tag_name(current_lowercase)"]
+
+[[fixtures]]
+name = "mosaic-text-and-tag"
+input = "<TITLE>Hello</TITLE>"
+tokens = [
+  "StartTag(name=title, attributes=[], self_closing=false)",
+  "Text(data=Hello)",
+  "EndTag(name=title)",
+  "EOF",
+]
+
+[[fixtures]]
+name = "mosaic-attributes-and-self-closing"
+input = "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>"
+tokens = [
+  "StartTag(name=img, attributes=[src=mosaic.gif, alt=Splash, hidden=1], self_closing=true)",
+  "EOF",
+]
+
+[[fixtures]]
+name = "mosaic-comment"
+input = "Before<!--note-->After"
+tokens = [
+  "Text(data=Before)",
+  "Comment(data=note)",
+  "Text(data=After)",
+  "EOF",
+]
+
+[[fixtures]]
+name = "mosaic-doctype-and-heading"
+input = "<!DOCTYPE HTML><H1 class=test>Hello</H1>"
+tokens = [
+  "Doctype(name=html, force_quirks=false)",
+  "StartTag(name=h1, attributes=[class=test], self_closing=false)",
+  "Text(data=Hello)",
+  "EndTag(name=h1)",
+  "EOF",
+]
+
+[[fixtures]]
+name = "comment-eof-recovery"
+input = "<!--open"
+tokens = ["Comment(data=open)", "EOF"]

--- a/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
+++ b/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
@@ -1,0 +1,94 @@
+use coding_adventures_html_lexer::{Attribute, HtmlLexer, Token};
+use state_machine::EffectfulStateMachine;
+use state_machine_markup_deserializer::from_states_toml;
+
+const HTML1_LEXER_TOML: &str = include_str!("../html1.lexer.states.toml");
+
+#[test]
+fn html1_authoring_artifact_parses_as_mosaic_era_floor() {
+    let definition = from_states_toml(HTML1_LEXER_TOML).unwrap();
+
+    assert_eq!(definition.name, "html1-lexer");
+    assert_eq!(definition.profile.as_deref(), Some("lexer/v1"));
+    assert_eq!(definition.fixtures.len(), 5);
+    assert!(definition.states.iter().any(|state| state.id == "comment"));
+    assert!(definition
+        .states
+        .iter()
+        .any(|state| state.id == "doctype_name"));
+}
+
+#[test]
+fn html1_authoring_fixtures_execute_through_generic_runtime() {
+    let definition = from_states_toml(HTML1_LEXER_TOML).unwrap();
+
+    for fixture in &definition.fixtures {
+        let machine = EffectfulStateMachine::from_definition(&definition).unwrap();
+        let mut lexer = HtmlLexer::new(machine);
+        lexer.push(&fixture.input).unwrap();
+        lexer.finish().unwrap();
+        let actual = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual, fixture.tokens,
+            "fixture `{}` should match",
+            fixture.name
+        );
+    }
+}
+
+#[test]
+fn html1_authoring_reports_comment_eof_diagnostic() {
+    let definition = from_states_toml(HTML1_LEXER_TOML).unwrap();
+    let machine = EffectfulStateMachine::from_definition(&definition).unwrap();
+    let mut lexer = HtmlLexer::new(machine);
+
+    lexer.push("<!--open").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![Token::Comment("open".to_string()), Token::Eof]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-comment"));
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype { name, force_quirks } => match name {
+            Some(name) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+            None => format!("Doctype(name=null, force_quirks={force_quirks})"),
+        },
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -681,6 +681,15 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "append_text_replacement"
         | "create_start_tag"
         | "create_end_tag"
+        | "create_comment"
+        | "create_doctype"
+        | "start_attribute"
+        | "commit_attribute"
+        | "mark_self_closing"
+        | "mark_force_quirks"
+        | "clear_temporary_buffer"
+        | "append_temporary_buffer_to_text"
+        | "switch_to_return_state"
         | "emit_current_token" => return Ok(()),
         _ => {}
     }
@@ -691,10 +700,42 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
     if matches!(
         action,
         "append_tag_name(current)" | "append_tag_name(current_lowercase)"
+    ) || matches!(
+        action,
+        "append_attribute_name(current)"
+            | "append_attribute_name(current_lowercase)"
+            | "append_attribute_value(current)"
+            | "append_comment(current)"
+            | "append_comment(current_lowercase)"
+            | "append_doctype_name(current)"
+            | "append_doctype_name(current_lowercase)"
+            | "append_temporary_buffer(current)"
+            | "append_temporary_buffer(current_lowercase)"
     ) {
         return Ok(());
     }
+    if action.starts_with("append_attribute_name(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("append_attribute_value(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("append_comment(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("append_doctype_name(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("append_temporary_buffer(") && action.ends_with(')') {
+        return Ok(());
+    }
     if action.starts_with("parse_error(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("set_return_state(") && action.ends_with(')') {
+        return Ok(());
+    }
+    if action.starts_with("switch_to(") && action.ends_with(')') {
         return Ok(());
     }
     if action.starts_with("emit(") && action.ends_with(')') {

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -33,6 +33,7 @@ initial = true
 
 const HTML_SKELETON_LEXER_TOML: &str =
     include_str!("../../html-lexer/html-skeleton.lexer.states.toml");
+const HTML1_LEXER_TOML: &str = include_str!("../../html-lexer/html1.lexer.states.toml");
 
 #[test]
 fn dfa_serializer_output_round_trips_through_deserializer() {
@@ -107,6 +108,35 @@ fn lexer_profile_html_skeleton_toml_parses_into_typed_definition() {
         .unwrap();
     assert_eq!(eof.on, None);
     assert!(!eof.consume);
+}
+
+#[test]
+fn lexer_profile_html1_toml_parses_into_typed_definition() {
+    let definition = from_states_toml(HTML1_LEXER_TOML).unwrap();
+
+    assert_eq!(definition.name, "html1-lexer");
+    assert_eq!(definition.profile.as_deref(), Some("lexer/v1"));
+    assert_eq!(
+        definition
+            .tokens
+            .iter()
+            .map(|token| token.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Text", "StartTag", "EndTag", "Comment", "Doctype", "EOF"]
+    );
+    assert!(definition
+        .registers
+        .iter()
+        .any(|register| register.id == "temporary_buffer"));
+    assert!(definition.transitions.iter().any(|transition| transition
+        .actions
+        .iter()
+        .any(|action| action == "create_comment")));
+    assert!(definition.transitions.iter().any(|transition| transition
+        .actions
+        .iter()
+        .any(|action| action == "create_doctype")));
+    assert_eq!(definition.fixtures.len(), 5);
 }
 
 #[test]

--- a/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
+++ b/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
@@ -5,9 +5,12 @@ use state_machine::{
     PDATransition, PushdownAutomaton, RegisterDefinition, StateDefinition, StateMachineDefinition,
     TokenDefinition, TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
 };
+use state_machine_markup_deserializer::from_states_toml;
 use state_machine_source_compiler::{
     to_rust_source, StateMachineRustSourceCompiler, StateMachineSourceError,
 };
+
+const HTML1_LEXER_TOML: &str = include_str!("../../html-lexer/html1.lexer.states.toml");
 
 fn set(values: &[&str]) -> HashSet<String> {
     values.iter().map(|value| value.to_string()).collect()
@@ -186,6 +189,22 @@ fn transducer_definition_emits_effect_tables_and_constructor() {
     assert!(source.contains("guard: Some(\"can_emit\".to_string())"));
     assert!(source.contains("\"flush_text\".to_string()"));
     assert!(source.contains("consume: false"));
+}
+
+#[test]
+fn html1_toml_compiles_to_rust_source() {
+    let definition = from_states_toml(HTML1_LEXER_TOML).unwrap();
+    let source = to_rust_source(&definition).unwrap();
+
+    assert!(source.contains("pub fn html1_lexer_definition()"));
+    assert!(source.contains(
+        "pub fn html1_lexer_transducer() -> std::result::Result<EffectfulStateMachine, String>"
+    ));
+    assert!(source.contains("definition.profile = Some(\"lexer/v1\".to_string())"));
+    assert!(source.contains("name: \"Comment\".to_string()"));
+    assert!(source.contains("name: \"Doctype\".to_string()"));
+    assert!(source.contains("\"create_comment\".to_string()"));
+    assert!(source.contains("\"create_doctype\".to_string()"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `html1.lexer.states.toml` as the first real authored HTML compatibility-floor artifact for Venture's Mosaic-era target
- validate that artifact through the Rust deserializer, Rust source compiler, and a package-level fixture runner over the generic tokenizer runtime
- document explicitly that HTML 1.0 is the compatibility floor, not the endpoint of the HTML lexer roadmap

## Verification
- `cargo fmt -p coding-adventures-html-lexer -p state-machine-markup-deserializer -p state-machine-source-compiler`
- `cargo check -p coding-adventures-html-lexer --tests`
- `cargo check -p state-machine-markup-deserializer --tests`
- `cargo check -p state-machine-source-compiler --tests`
- `cargo test -p state-machine-markup-deserializer --test toml_test --no-run`
- `cargo test -p state-machine-source-compiler --test rust_source_test --no-run`
- `cargo test -p coding-adventures-html-lexer --test html1_authoring_test --no-run`
- `git diff --check`
- Python `tomli` syntax parse of `code/packages/rust/html-lexer/html1.lexer.states.toml`

## Notes
- The local environment still stalls after Rust test binaries start, so I verified compilation of the affected test targets with `--no-run` and added a cross-check TOML parse for the authored artifact.
- This PR keeps the public package API on the existing skeleton machine. It adds the broader authored HTML1/Mosaic compatibility floor without switching Venture over yet.

Closes #1114