### PR TITLE
feat(rust): add web-core generic HTTP application layer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -353,6 +353,7 @@ members = [
     "state-machine-tokenizer",
     "embeddable-tcp-server",
     "embeddable-http-server",
+    "web-core",
     "generic-job-protocol",
     "generic-job-runtime",
 ]

--- a/code/packages/rust/web-core/CHANGELOG.md
+++ b/code/packages/rust/web-core/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — web-core
+
+## 0.1.0 (2026-04-23)
+
+Initial release.
+
+### Added
+
+- `WebRequest` — enriched HTTP request with pre-parsed `route_params`,
+  `query_params`, and `path` (query string stripped). Wraps `HttpRequest`
+  from `embeddable-http-server`.
+- `WebResponse` — fluent response builder with helpers `ok`, `text`, `json`,
+  `not_found`, `method_not_allowed`, `internal_error`, `new`,
+  `with_header`, `with_content_type`. Converts to/from `HttpResponse`.
+- `Router` — route table with `add`, `get`, `post`, `put`, `delete`, `patch`.
+  Uses `RoutePattern` from `http-core`. `lookup` returns `Matched`,
+  `NotFound`, or `MethodNotAllowed`. First-registered route wins on overlap.
+  Method comparison is ASCII case-insensitive.
+- `HookRegistry` — 12 lifecycle hook points (`on_server_start`,
+  `on_server_stop`, `on_connect`, `on_disconnect`, `before_routing`,
+  `on_not_found`, `on_method_not_allowed`, `before_handler`,
+  `on_handler_error`, `after_handler`, `after_send`, `on_log`).
+  All hooks are `Arc<dyn Fn + Send + Sync + 'static>`.
+- `WebApp` — composes `Router` and `HookRegistry`. `handle(HttpRequest)`
+  runs the full dispatch pipeline including panic recovery via
+  `std::panic::catch_unwind`.
+- `WebServer` — thin wrapper around `HttpServer` with platform-specific
+  constructors (`bind_kqueue`, `bind_epoll`, `bind_windows`). Fires
+  `on_server_start` hooks after bind and `on_server_stop` hooks after
+  `serve` returns.
+- Query string parser (`query` module): percent-decoding (`%HH`), plus-as-space,
+  empty keys skipped, duplicate keys keep last value.
+- 37 tests: 8 query-parser unit tests, 20 hook/pipeline tests via
+  `WebApp::handle`, 9 end-to-end tests over real TCP connections.

--- a/code/packages/rust/web-core/Cargo.toml
+++ b/code/packages/rust/web-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "web-core"
+version = "0.1.0"
+edition = "2021"
+description = "Generic Rack/WSGI-like HTTP application layer built on embeddable-http-server"
+license = "MIT"
+
+[dependencies]
+embeddable-http-server = { path = "../embeddable-http-server" }
+http-core = { path = "../http-core" }
+tcp-runtime = { path = "../tcp-runtime" }
+transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/web-core/README.md
+++ b/code/packages/rust/web-core/README.md
@@ -1,0 +1,105 @@
+# web-core
+
+A generic Rack/WSGI-like HTTP application layer for the Rust native runtime stack.
+
+`web-core` sits between `embeddable-http-server` (HTTP/1 framing and the native
+event loop) and language bridges (Ruby, Python, Lua, Perl, …). It owns routing,
+request enrichment, response building, and a lifecycle hook registry so that
+every language that embeds the Rust runtime gets the same set of features
+without reimplementing them.
+
+## Layer map
+
+```
+Language DSL (Ruby/conduit, Python, Lua, …)
+    ↓
+web-core          ← you are here
+    ↓
+embeddable-http-server
+    ↓
+tcp-runtime + transport-platform (kqueue / epoll / IOCP)
+```
+
+## What it provides
+
+| Concern              | Provided by |
+|----------------------|-------------|
+| Route table          | `Router` — `RoutePattern` from `http-core`, first-match wins |
+| Request enrichment   | `WebRequest` — route params, query params, path split |
+| Response building    | `WebResponse` — fluent builder, converts to `HttpResponse` |
+| Lifecycle hooks      | `HookRegistry` — 12 hook points, `Arc<dyn Fn>` closures |
+| Dispatch pipeline    | `WebApp::handle` — full lifecycle in one call |
+| Server binding       | `WebServer` — thin wrapper around `HttpServer` |
+
+## Quick start
+
+```rust
+use std::sync::Arc;
+use web_core::{WebApp, WebResponse};
+use embeddable_http_server::HttpServerOptions;
+
+let mut app = WebApp::new();
+
+app.get("/hello/:name", |req| {
+    let name = req.route_params.get("name").map(|s| s.as_str()).unwrap_or("world");
+    WebResponse::text(format!("Hello {name}"))
+});
+
+// Add a CORS header to every response.
+app.after_handler(|_req, mut res| {
+    res.headers.push(("Access-Control-Allow-Origin".into(), "*".into()));
+    res
+});
+
+// Log every request.
+app.after_send(|req, res, elapsed_ms| {
+    eprintln!("{} {} → {} ({elapsed_ms}ms)", req.method(), req.path(), res.status);
+});
+
+let app = Arc::new(app);
+
+// macOS / BSD:
+let mut server = web_core::WebServer::bind_kqueue("127.0.0.1:3000", HttpServerOptions::default(), app)?;
+println!("listening on {}", server.local_addr());
+server.serve()?;
+```
+
+## Hook points
+
+| Hook                    | When                              | Return / effect         |
+|-------------------------|-----------------------------------|-------------------------|
+| `on_server_start`       | After bind, before first accept   | fire-and-forget         |
+| `on_server_stop`        | After event loop exits            | fire-and-forget         |
+| `on_connect`            | TCP connection accepted           | fire-and-forget         |
+| `on_disconnect`         | TCP connection closed             | fire-and-forget         |
+| `before_routing`        | Before route lookup               | `Some(res)` short-circuits |
+| `on_not_found`          | No route matched                  | replaces 404 default    |
+| `on_method_not_allowed` | Path matched, wrong method        | replaces 405 default    |
+| `before_handler`        | After routing, before handler     | `Some(res)` short-circuits |
+| `on_handler_error`      | Handler panicked                  | replaces 500 default    |
+| `after_handler`         | Handler returned successfully     | chains the response     |
+| `after_send`            | Response handed to transport      | fire-and-forget         |
+| `on_log`                | Any log event                     | all hooks receive it    |
+
+## Dependencies
+
+- `embeddable-http-server` — HTTP/1 framing, `HttpRequest` / `HttpResponse`
+- `http-core` — `RoutePattern`, `RequestHead`, shared HTTP types
+- `tcp-runtime` — `StopHandle`, `PlatformError`, `BindAddress`
+- `transport-platform` — kqueue / epoll / IOCP abstractions
+
+## Testing
+
+```
+cargo test -p web-core
+```
+
+37 tests: 8 unit tests (query string parser), 20 pipeline unit tests
+(hook ordering, route matching, panic recovery), 9 end-to-end tests
+(real TCP socket on port 0).
+
+## Status
+
+Phase 1 (this crate): complete.
+Phase 2: conduit Ruby refactor — see `WEB00-web-core.md`.
+Phase 3: async promotion via `embeddable-tcp-server::new_inprocess_mailbox`.

--- a/code/packages/rust/web-core/src/app.rs
+++ b/code/packages/rust/web-core/src/app.rs
@@ -1,0 +1,303 @@
+//! `WebApp`: the full request dispatch pipeline.
+//!
+//! `WebApp` composes a `Router` and a `HookRegistry` and implements the
+//! pipeline described in WEB00-web-core.md. `WebServer` (and language bridges
+//! that embed their own server) pass every `HttpRequest` to `WebApp::handle`,
+//! which runs the full lifecycle and returns an `HttpResponse`.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! HttpRequest arrives
+//!   → parse query string, split path
+//!   → build partial WebRequest (no route_params yet)
+//!   → run before_routing hooks  →  short-circuit if Some(response)
+//!   → Router::lookup(method, path)
+//!       NotFound          → run on_not_found hook
+//!       MethodNotAllowed  → run on_method_not_allowed hook
+//!       Matched           → fill route_params
+//!           → run before_handler hooks  →  short-circuit if Some(response)
+//!           → call handler inside catch_unwind
+//!               panic  → run on_handler_error hook
+//!               ok     → response
+//!   → run after_handler hooks (chain)
+//!   → convert WebResponse → HttpResponse
+//!   → fire after_send hooks (fire-and-forget)
+//!   → return HttpResponse
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use embeddable_http_server::HttpRequest;
+use embeddable_http_server::HttpResponse;
+
+use crate::hooks::{HookRegistry, LogLevel};
+use crate::query::{parse_query_string, split_target};
+use crate::request::WebRequest;
+use crate::response::WebResponse;
+use crate::router::{Router, RouteLookupResult};
+
+/// Generic Rack/WSGI-like HTTP application.
+///
+/// Build one with `WebApp::new()`, register routes and hooks, then wrap it in
+/// an `Arc` and pass it to `WebServer::bind_*`.
+pub struct WebApp {
+    router: Router,
+    hooks: HookRegistry,
+}
+
+impl WebApp {
+    pub fn new() -> Self {
+        Self {
+            router: Router::new(),
+            hooks: HookRegistry::new(),
+        }
+    }
+
+    // --- Route registration ---
+
+    pub fn add(
+        &mut self,
+        method: impl Into<String>,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.add(method, pattern, handler);
+    }
+
+    pub fn get(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.get(pattern, handler);
+    }
+
+    pub fn post(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.post(pattern, handler);
+    }
+
+    pub fn put(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.put(pattern, handler);
+    }
+
+    pub fn delete(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.delete(pattern, handler);
+    }
+
+    pub fn patch(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.router.patch(pattern, handler);
+    }
+
+    // --- Hook registration ---
+
+    pub fn on_server_start(&mut self, hook: impl Fn(std::net::SocketAddr) + Send + Sync + 'static) {
+        self.hooks.on_server_start(hook);
+    }
+
+    pub fn on_server_stop(&mut self, hook: impl Fn() + Send + Sync + 'static) {
+        self.hooks.on_server_stop(hook);
+    }
+
+    pub fn on_connect(
+        &mut self,
+        hook: impl Fn(u64, std::net::SocketAddr) + Send + Sync + 'static,
+    ) {
+        self.hooks.on_connect(hook);
+    }
+
+    pub fn on_disconnect(&mut self, hook: impl Fn(u64) + Send + Sync + 'static) {
+        self.hooks.on_disconnect(hook);
+    }
+
+    pub fn before_routing(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static,
+    ) {
+        self.hooks.before_routing(hook);
+    }
+
+    pub fn on_not_found(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.hooks.on_not_found(hook);
+    }
+
+    pub fn on_method_not_allowed(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.hooks.on_method_not_allowed(hook);
+    }
+
+    pub fn before_handler(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static,
+    ) {
+        self.hooks.before_handler(hook);
+    }
+
+    pub fn on_handler_error(
+        &mut self,
+        hook: impl Fn(&WebRequest, &str) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.hooks.on_handler_error(hook);
+    }
+
+    pub fn after_handler(
+        &mut self,
+        hook: impl Fn(&WebRequest, WebResponse) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.hooks.after_handler(hook);
+    }
+
+    pub fn after_send(
+        &mut self,
+        hook: impl Fn(&WebRequest, &WebResponse, u64) + Send + Sync + 'static,
+    ) {
+        self.hooks.after_send(hook);
+    }
+
+    pub fn on_log(
+        &mut self,
+        hook: impl Fn(LogLevel, &str, &HashMap<String, String>) + Send + Sync + 'static,
+    ) {
+        self.hooks.on_log(hook);
+    }
+
+    // --- Application helpers ---
+
+    /// Emit a structured log event through the hook registry.
+    pub fn log(&self, level: LogLevel, message: &str, fields: &HashMap<String, String>) {
+        self.hooks.log(level, message, fields);
+    }
+
+    /// Fire the on_server_start hooks. Call this after the socket is bound but
+    /// before calling `serve`.
+    pub fn fire_server_start(&self, addr: std::net::SocketAddr) {
+        self.hooks.fire_server_start(addr);
+    }
+
+    /// Fire the on_server_stop hooks. Call this after `serve` returns.
+    pub fn fire_server_stop(&self) {
+        self.hooks.fire_server_stop();
+    }
+
+    // --- Request dispatch ---
+
+    /// Process one HTTP request through the full lifecycle pipeline.
+    ///
+    /// This method is the sole entry point called by `WebServer` (or a
+    /// language bridge) for every incoming request.
+    pub fn handle(&self, request: HttpRequest) -> HttpResponse {
+        let start = Instant::now();
+
+        // Parse the request target into path and query string.
+        let (path, query_str) = split_target(request.target());
+        let path = path.to_string();
+        let query_params = parse_query_string(query_str);
+        let method = request.method().to_string();
+
+        // Build a partial WebRequest (no route_params yet).
+        let partial = WebRequest::new(
+            request,
+            path.clone(),
+            HashMap::new(),
+            query_params.clone(),
+        );
+
+        // before_routing hooks — first winner short-circuits.
+        if let Some(early) = self.hooks.run_before_routing(&partial) {
+            let response = self.hooks.run_after_handler(&partial, early);
+            let elapsed = start.elapsed().as_millis() as u64;
+            self.hooks.fire_after_send(&partial, &response, elapsed);
+            return response.into();
+        }
+
+        // Route lookup.
+        let matched = match self.router.lookup(&method, &path) {
+            RouteLookupResult::NotFound => {
+                let not_found = self.hooks.run_on_not_found(&partial);
+                let response = self.hooks.run_after_handler(&partial, not_found);
+                let elapsed = start.elapsed().as_millis() as u64;
+                self.hooks.fire_after_send(&partial, &response, elapsed);
+                return response.into();
+            }
+            RouteLookupResult::MethodNotAllowed => {
+                let mna = self.hooks.run_on_method_not_allowed(&partial);
+                let response = self.hooks.run_after_handler(&partial, mna);
+                let elapsed = start.elapsed().as_millis() as u64;
+                self.hooks.fire_after_send(&partial, &response, elapsed);
+                return response.into();
+            }
+            RouteLookupResult::Matched(m) => m,
+        };
+
+        // Build full WebRequest with route params.
+        let route_params: HashMap<String, String> = matched.params.into_iter().collect();
+        let full_request = WebRequest::new(
+            partial.http,
+            path,
+            route_params,
+            query_params,
+        );
+
+        // before_handler hooks — first winner short-circuits.
+        if let Some(early) = self.hooks.run_before_handler(&full_request) {
+            let response = self.hooks.run_after_handler(&full_request, early);
+            let elapsed = start.elapsed().as_millis() as u64;
+            self.hooks.fire_after_send(&full_request, &response, elapsed);
+            return response.into();
+        }
+
+        // Call the route handler, catching panics.
+        let handler = Arc::clone(&matched.route.handler);
+        let handler_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            handler(&full_request)
+        }));
+
+        let web_response = match handler_result {
+            Ok(response) => response,
+            Err(panic) => {
+                let message = panic
+                    .downcast_ref::<&str>()
+                    .copied()
+                    .or_else(|| panic.downcast_ref::<String>().map(|s| s.as_str()))
+                    .unwrap_or("handler panicked");
+                self.hooks.run_on_handler_error(&full_request, message)
+            }
+        };
+
+        // after_handler hooks chain.
+        let final_response = self.hooks.run_after_handler(&full_request, web_response);
+        let elapsed = start.elapsed().as_millis() as u64;
+        self.hooks.fire_after_send(&full_request, &final_response, elapsed);
+
+        final_response.into()
+    }
+}
+
+impl Default for WebApp {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/code/packages/rust/web-core/src/hooks.rs
+++ b/code/packages/rust/web-core/src/hooks.rs
@@ -1,0 +1,265 @@
+//! Lifecycle hook registry.
+//!
+//! `HookRegistry` holds zero or more listeners for each lifecycle event in the
+//! request pipeline. All hooks are heap-allocated closures
+//! (`Arc<dyn Fn + Send + Sync>`) so they can be registered from any thread and
+//! remain alive for the lifetime of the server.
+//!
+//! Language bridges install hooks by wrapping their VM callbacks in these
+//! closures. For GVL-constrained runtimes like Ruby, the closure body calls
+//! `rb_thread_call_with_gvl` before invoking application code, exactly as
+//! `conduit_native` does today.
+//!
+//! ## Ordering rules
+//!
+//! - `before_routing` and `before_handler` — first-wins short-circuit: the
+//!   first hook to return `Some(response)` ends the chain; later hooks are
+//!   skipped.
+//! - `on_not_found`, `on_method_not_allowed`, `on_handler_error` — last-wins:
+//!   only the most recently registered hook fires (so a bridge can override the
+//!   default with one registration).
+//! - `after_handler` — chained: each hook receives the response returned by the
+//!   previous hook and may return a modified response.
+//! - `after_send`, `on_connect`, `on_disconnect`, `on_server_start`,
+//!   `on_server_stop`, `on_log` — all registered hooks fire in order.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use crate::request::WebRequest;
+use crate::response::WebResponse;
+
+/// Severity level for log events emitted by `web-core` or application code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+// --- Hook type aliases ---
+
+type ServerStartHook = Arc<dyn Fn(SocketAddr) + Send + Sync>;
+type ServerStopHook = Arc<dyn Fn() + Send + Sync>;
+type ConnectHook = Arc<dyn Fn(u64, SocketAddr) + Send + Sync>;
+type DisconnectHook = Arc<dyn Fn(u64) + Send + Sync>;
+type BeforeRoutingHook = Arc<dyn Fn(&WebRequest) -> Option<WebResponse> + Send + Sync>;
+type NotFoundHook = Arc<dyn Fn(&WebRequest) -> WebResponse + Send + Sync>;
+type MethodNotAllowedHook = Arc<dyn Fn(&WebRequest) -> WebResponse + Send + Sync>;
+type BeforeHandlerHook = Arc<dyn Fn(&WebRequest) -> Option<WebResponse> + Send + Sync>;
+type HandlerErrorHook = Arc<dyn Fn(&WebRequest, &str) -> WebResponse + Send + Sync>;
+type AfterHandlerHook = Arc<dyn Fn(&WebRequest, WebResponse) -> WebResponse + Send + Sync>;
+type AfterSendHook = Arc<dyn Fn(&WebRequest, &WebResponse, u64) + Send + Sync>;
+type LogHook = Arc<dyn Fn(LogLevel, &str, &HashMap<String, String>) + Send + Sync>;
+
+/// Lifecycle hook registry.
+#[derive(Default)]
+pub struct HookRegistry {
+    on_server_start: Vec<ServerStartHook>,
+    on_server_stop: Vec<ServerStopHook>,
+    on_connect: Vec<ConnectHook>,
+    on_disconnect: Vec<DisconnectHook>,
+    before_routing: Vec<BeforeRoutingHook>,
+    on_not_found: Vec<NotFoundHook>,
+    on_method_not_allowed: Vec<MethodNotAllowedHook>,
+    before_handler: Vec<BeforeHandlerHook>,
+    on_handler_error: Vec<HandlerErrorHook>,
+    after_handler: Vec<AfterHandlerHook>,
+    after_send: Vec<AfterSendHook>,
+    on_log: Vec<LogHook>,
+}
+
+impl HookRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // --- Registration ---
+
+    /// Register a hook that fires once after the server socket is bound.
+    pub fn on_server_start(&mut self, hook: impl Fn(SocketAddr) + Send + Sync + 'static) {
+        self.on_server_start.push(Arc::new(hook));
+    }
+
+    /// Register a hook that fires once when the server event loop exits.
+    pub fn on_server_stop(&mut self, hook: impl Fn() + Send + Sync + 'static) {
+        self.on_server_stop.push(Arc::new(hook));
+    }
+
+    /// Register a hook that fires when a TCP connection is accepted.
+    pub fn on_connect(&mut self, hook: impl Fn(u64, SocketAddr) + Send + Sync + 'static) {
+        self.on_connect.push(Arc::new(hook));
+    }
+
+    /// Register a hook that fires when a TCP connection closes.
+    pub fn on_disconnect(&mut self, hook: impl Fn(u64) + Send + Sync + 'static) {
+        self.on_disconnect.push(Arc::new(hook));
+    }
+
+    /// Register a before-routing hook.
+    ///
+    /// Return `Some(response)` to short-circuit the rest of the pipeline.
+    pub fn before_routing(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static,
+    ) {
+        self.before_routing.push(Arc::new(hook));
+    }
+
+    /// Register a custom not-found handler (replaces the 404 default).
+    pub fn on_not_found(&mut self, hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static) {
+        self.on_not_found.push(Arc::new(hook));
+    }
+
+    /// Register a custom method-not-allowed handler (replaces the 405 default).
+    pub fn on_method_not_allowed(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.on_method_not_allowed.push(Arc::new(hook));
+    }
+
+    /// Register a before-handler hook.
+    ///
+    /// Return `Some(response)` to short-circuit the handler.
+    pub fn before_handler(
+        &mut self,
+        hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static,
+    ) {
+        self.before_handler.push(Arc::new(hook));
+    }
+
+    /// Register a handler-error hook (fires when the handler panics).
+    pub fn on_handler_error(
+        &mut self,
+        hook: impl Fn(&WebRequest, &str) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.on_handler_error.push(Arc::new(hook));
+    }
+
+    /// Register an after-handler hook for response transformation.
+    pub fn after_handler(
+        &mut self,
+        hook: impl Fn(&WebRequest, WebResponse) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.after_handler.push(Arc::new(hook));
+    }
+
+    /// Register an after-send hook for logging and metrics.
+    pub fn after_send(
+        &mut self,
+        hook: impl Fn(&WebRequest, &WebResponse, u64) + Send + Sync + 'static,
+    ) {
+        self.after_send.push(Arc::new(hook));
+    }
+
+    /// Register a structured log sink.
+    pub fn on_log(
+        &mut self,
+        hook: impl Fn(LogLevel, &str, &HashMap<String, String>) + Send + Sync + 'static,
+    ) {
+        self.on_log.push(Arc::new(hook));
+    }
+
+    // --- Execution (called by WebApp) ---
+
+    pub(crate) fn fire_server_start(&self, addr: SocketAddr) {
+        for hook in &self.on_server_start {
+            hook(addr);
+        }
+    }
+
+    pub(crate) fn fire_server_stop(&self) {
+        for hook in &self.on_server_stop {
+            hook();
+        }
+    }
+
+    // fire_connect and fire_disconnect are wired in Phase 3 when the async
+    // promotion lands and tcp-runtime gains a connection-open callback.
+    #[allow(dead_code)]
+    pub(crate) fn fire_connect(&self, connection_id: u64, peer_addr: SocketAddr) {
+        for hook in &self.on_connect {
+            hook(connection_id, peer_addr);
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn fire_disconnect(&self, connection_id: u64) {
+        for hook in &self.on_disconnect {
+            hook(connection_id);
+        }
+    }
+
+    /// Run before-routing hooks. Returns the first non-None response, or None.
+    pub(crate) fn run_before_routing(&self, req: &WebRequest) -> Option<WebResponse> {
+        for hook in &self.before_routing {
+            if let Some(response) = hook(req) {
+                return Some(response);
+            }
+        }
+        None
+    }
+
+    /// Run the not-found handler. Falls back to 404 if none is registered.
+    pub(crate) fn run_on_not_found(&self, req: &WebRequest) -> WebResponse {
+        match self.on_not_found.last() {
+            Some(hook) => hook(req),
+            None => WebResponse::not_found(),
+        }
+    }
+
+    /// Run the method-not-allowed handler. Falls back to 405 if none.
+    pub(crate) fn run_on_method_not_allowed(&self, req: &WebRequest) -> WebResponse {
+        match self.on_method_not_allowed.last() {
+            Some(hook) => hook(req),
+            None => WebResponse::method_not_allowed(),
+        }
+    }
+
+    /// Run before-handler hooks. Returns the first non-None response, or None.
+    pub(crate) fn run_before_handler(&self, req: &WebRequest) -> Option<WebResponse> {
+        for hook in &self.before_handler {
+            if let Some(response) = hook(req) {
+                return Some(response);
+            }
+        }
+        None
+    }
+
+    /// Run the handler-error handler. Falls back to 500 if none is registered.
+    pub(crate) fn run_on_handler_error(&self, req: &WebRequest, error: &str) -> WebResponse {
+        match self.on_handler_error.last() {
+            Some(hook) => hook(req, error),
+            None => WebResponse::internal_error(error),
+        }
+    }
+
+    /// Run after-handler hooks, chaining the response through each one.
+    pub(crate) fn run_after_handler(&self, req: &WebRequest, mut response: WebResponse) -> WebResponse {
+        for hook in &self.after_handler {
+            response = hook(req, response);
+        }
+        response
+    }
+
+    pub(crate) fn fire_after_send(&self, req: &WebRequest, response: &WebResponse, duration_ms: u64) {
+        for hook in &self.after_send {
+            hook(req, response, duration_ms);
+        }
+    }
+
+    pub(crate) fn log(
+        &self,
+        level: LogLevel,
+        message: &str,
+        fields: &HashMap<String, String>,
+    ) {
+        for hook in &self.on_log {
+            hook(level, message, fields);
+        }
+    }
+}

--- a/code/packages/rust/web-core/src/lib.rs
+++ b/code/packages/rust/web-core/src/lib.rs
@@ -1,0 +1,60 @@
+//! # web-core
+//!
+//! A generic Rack/WSGI-like HTTP application layer built on
+//! `embeddable-http-server`.
+//!
+//! `web-core` owns routing, request enrichment, response building, and a
+//! lifecycle hook registry. Language packages — Ruby, Python, Lua, Perl, and
+//! others — only need to implement their own application layer. All shared
+//! plumbing lives here.
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use web_core::{WebApp, WebResponse};
+//!
+//! let mut app = WebApp::new();
+//!
+//! app.get("/hello/:name", |req| {
+//!     let name = req.route_params.get("name").map(|s| s.as_str()).unwrap_or("world");
+//!     WebResponse::text(format!("Hello {name}"))
+//! });
+//!
+//! app.after_handler(|_req, mut res| {
+//!     res.headers.push(("X-Powered-By".into(), "web-core".into()));
+//!     res
+//! });
+//!
+//! // Wrap in Arc and hand to WebServer::bind_kqueue / bind_epoll / bind_windows.
+//! let _app = Arc::new(app);
+//! ```
+//!
+//! ## Layer map
+//!
+//! ```text
+//! Language DSL (Ruby/conduit, Python, Lua, …)
+//!     ↓
+//! web-core  ← you are here
+//!     ↓
+//! embeddable-http-server
+//!     ↓
+//! tcp-runtime + transport-platform (kqueue / epoll / IOCP)
+//! ```
+
+pub mod app;
+pub mod hooks;
+pub mod query;
+pub mod request;
+pub mod response;
+pub mod router;
+pub mod server;
+
+pub use app::WebApp;
+pub use hooks::{HookRegistry, LogLevel};
+pub use request::WebRequest;
+pub use response::WebResponse;
+pub use router::{Handler, Route, Router, RouteLookupResult, RouteMatch};
+pub use server::WebServer;
+
+pub const VERSION: &str = "0.1.0";

--- a/code/packages/rust/web-core/src/query.rs
+++ b/code/packages/rust/web-core/src/query.rs
@@ -1,0 +1,154 @@
+//! Query string parsing.
+//!
+//! Splits `key=value&key2=value2` into a `HashMap<String, String>`.
+//! Percent-decoding follows the `application/x-www-form-urlencoded` convention:
+//! `+` decodes to a space, `%HH` decodes to the corresponding byte.
+//! Keys and values that decode to non-UTF-8 byte sequences are replaced with
+//! the Unicode replacement character.
+
+use std::collections::HashMap;
+
+/// Parse a query string (without the leading `?`) into a map.
+///
+/// Empty string produces an empty map.
+/// Keys with no `=` get an empty string value.
+/// Duplicate keys keep only the last value.
+pub fn parse_query_string(query: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    if query.is_empty() {
+        return map;
+    }
+
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (raw_key, raw_value) = match pair.split_once('=') {
+            Some((k, v)) => (k, v),
+            None => (pair, ""),
+        };
+        let key = percent_decode(raw_key);
+        if key.is_empty() {
+            continue;
+        }
+        let value = percent_decode(raw_value);
+        map.insert(key, value);
+    }
+
+    map
+}
+
+/// Split a request target into `(path, query_string)`.
+///
+/// The returned query string does not include the leading `?`.
+pub fn split_target(target: &str) -> (&str, &str) {
+    match target.split_once('?') {
+        Some((path, query)) => (path, query),
+        None => (target, ""),
+    }
+}
+
+/// Decode a percent-encoded URL component.
+///
+/// `+` → space.  `%HH` → byte.  Invalid sequences are passed through as-is.
+fn percent_decode(input: &str) -> String {
+    // Most components contain no special characters; avoid allocation in the
+    // common case by scanning for `%` or `+` first.
+    if !input.contains(['%', '+']) {
+        return input.to_string();
+    }
+
+    let mut output: Vec<u8> = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                output.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                if let (Some(hi), Some(lo)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2]))
+                {
+                    output.push(hi << 4 | lo);
+                    i += 3;
+                } else {
+                    output.push(b'%');
+                    i += 1;
+                }
+            }
+            b => {
+                output.push(b);
+                i += 1;
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_key_value_pairs() {
+        let map = parse_query_string("name=Adhithya&lang=rust");
+        assert_eq!(map["name"], "Adhithya");
+        assert_eq!(map["lang"], "rust");
+    }
+
+    #[test]
+    fn empty_string_returns_empty_map() {
+        assert!(parse_query_string("").is_empty());
+    }
+
+    #[test]
+    fn key_without_equals_gets_empty_value() {
+        let map = parse_query_string("flag");
+        assert_eq!(map["flag"], "");
+    }
+
+    #[test]
+    fn plus_decodes_to_space() {
+        let map = parse_query_string("msg=hello+world");
+        assert_eq!(map["msg"], "hello world");
+    }
+
+    #[test]
+    fn percent_encoding_is_decoded() {
+        let map = parse_query_string("q=hello%20world&emoji=%F0%9F%A6%80");
+        assert_eq!(map["q"], "hello world");
+        assert_eq!(map["emoji"], "🦀");
+    }
+
+    #[test]
+    fn empty_key_is_skipped() {
+        let map = parse_query_string("=value&key=ok");
+        assert!(!map.contains_key(""));
+        assert_eq!(map["key"], "ok");
+    }
+
+    #[test]
+    fn duplicate_key_keeps_last_value() {
+        let map = parse_query_string("x=1&x=2");
+        assert_eq!(map["x"], "2");
+    }
+
+    #[test]
+    fn split_target_separates_path_and_query() {
+        assert_eq!(split_target("/hello?name=Adhithya"), ("/hello", "name=Adhithya"));
+        assert_eq!(split_target("/hello"), ("/hello", ""));
+        assert_eq!(split_target("/"), ("/", ""));
+    }
+}

--- a/code/packages/rust/web-core/src/request.rs
+++ b/code/packages/rust/web-core/src/request.rs
@@ -1,0 +1,95 @@
+//! Enriched HTTP request type.
+//!
+//! `WebRequest` wraps the raw `HttpRequest` from `embeddable-http-server` and
+//! adds pre-parsed fields that handlers always need: route parameters extracted
+//! by the `Router` and query string parameters parsed from the request target.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use embeddable_http_server::HttpRequest;
+
+/// An HTTP request enriched with routing context and parsed query parameters.
+///
+/// Constructed by `WebApp::handle` after the router matches a route. Handlers
+/// and hooks receive a shared reference and must not modify the request.
+#[derive(Debug, Clone)]
+pub struct WebRequest {
+    /// The raw HTTP request from the transport layer.
+    pub http: HttpRequest,
+
+    /// Named route parameters extracted by the router.
+    ///
+    /// For pattern `/hello/:name` matched against `/hello/Adhithya`, this map
+    /// contains `{"name" => "Adhithya"}`. Empty for requests that bypassed
+    /// routing (e.g. those short-circuited by a `before_routing` hook).
+    pub route_params: HashMap<String, String>,
+
+    /// Parsed query string parameters.
+    ///
+    /// For target `/search?q=rust&limit=10`, this map contains
+    /// `{"q" => "rust", "limit" => "10"}`. Percent-encoding is decoded.
+    pub query_params: HashMap<String, String>,
+
+    /// The path component of the request target (no query string).
+    path: String,
+}
+
+impl WebRequest {
+    /// Build a `WebRequest` from a raw `HttpRequest`.
+    ///
+    /// `route_params` and `path` are supplied by the router after matching.
+    /// `query_params` is parsed from the request target.
+    pub(crate) fn new(
+        http: HttpRequest,
+        path: String,
+        route_params: HashMap<String, String>,
+        query_params: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            http,
+            route_params,
+            query_params,
+            path,
+        }
+    }
+
+    /// HTTP method, e.g. `"GET"`, `"POST"`.
+    pub fn method(&self) -> &str {
+        self.http.method()
+    }
+
+    /// Request path without the query string, e.g. `/hello/Adhithya`.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// First matching header value, ASCII case-insensitive.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.http.header(name)
+    }
+
+    /// Request body bytes.
+    pub fn body(&self) -> &[u8] {
+        &self.http.body
+    }
+
+    /// Parsed `Content-Type` media type, e.g. `"application/json"`.
+    ///
+    /// Returns `None` if the header is absent or unparseable.
+    pub fn content_type(&self) -> Option<&str> {
+        self.http.header("Content-Type")
+    }
+
+    /// Parsed `Content-Length` value.
+    ///
+    /// Returns `None` if the header is absent or not a valid integer.
+    pub fn content_length(&self) -> Option<usize> {
+        self.http.head.content_length()
+    }
+
+    /// Peer socket address of the TCP connection.
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.http.connection.peer_addr
+    }
+}

--- a/code/packages/rust/web-core/src/response.rs
+++ b/code/packages/rust/web-core/src/response.rs
@@ -1,0 +1,102 @@
+//! HTTP response builder.
+//!
+//! `WebResponse` has a fluent builder API that is slightly richer than the raw
+//! `HttpResponse` from `embeddable-http-server`. It converts losslessly into
+//! `HttpResponse` for transport.
+
+use embeddable_http_server::HttpResponse;
+use http_core::Header;
+
+/// An HTTP response produced by a handler or hook.
+#[derive(Debug, Clone)]
+pub struct WebResponse {
+    /// HTTP status code, e.g. 200, 404, 500.
+    pub status: u16,
+    /// Response headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+    /// Response body bytes.
+    pub body: Vec<u8>,
+}
+
+impl WebResponse {
+    /// 200 OK with the given bytes as body.
+    pub fn ok(body: impl Into<Vec<u8>>) -> Self {
+        Self::new(200, body)
+    }
+
+    /// 200 OK with a `text/plain; charset=utf-8` body.
+    pub fn text(body: impl Into<String>) -> Self {
+        Self::ok(body.into().into_bytes()).with_content_type("text/plain; charset=utf-8")
+    }
+
+    /// 200 OK with an `application/json` body.
+    pub fn json(body: impl Into<Vec<u8>>) -> Self {
+        Self::ok(body).with_content_type("application/json")
+    }
+
+    /// 404 Not Found with a plain-text body.
+    pub fn not_found() -> Self {
+        Self::new(404, b"Not Found".to_vec()).with_content_type("text/plain")
+    }
+
+    /// 405 Method Not Allowed with a plain-text body.
+    pub fn method_not_allowed() -> Self {
+        Self::new(405, b"Method Not Allowed".to_vec()).with_content_type("text/plain")
+    }
+
+    /// 500 Internal Server Error with the given message as body.
+    pub fn internal_error(message: impl AsRef<str>) -> Self {
+        Self::new(500, message.as_ref().as_bytes().to_vec()).with_content_type("text/plain")
+    }
+
+    /// Arbitrary status code with the given bytes as body.
+    pub fn new(status: u16, body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            body: body.into(),
+        }
+    }
+
+    /// Add a response header. Does not replace an existing header of the same
+    /// name — call this once per unique header name.
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+
+    /// Set the `Content-Type` header.
+    pub fn with_content_type(self, ct: impl Into<String>) -> Self {
+        self.with_header("content-type", ct)
+    }
+}
+
+impl From<WebResponse> for HttpResponse {
+    fn from(web: WebResponse) -> Self {
+        HttpResponse {
+            status: web.status,
+            reason: String::new(),
+            headers: web
+                .headers
+                .into_iter()
+                .map(|(name, value)| Header { name, value })
+                .collect(),
+            body: web.body,
+            close: false,
+        }
+    }
+}
+
+impl From<HttpResponse> for WebResponse {
+    fn from(http: HttpResponse) -> Self {
+        Self {
+            status: http.status,
+            headers: http
+                .headers
+                .into_iter()
+                .map(|h| (h.name, h.value))
+                .collect(),
+            body: http.body,
+        }
+    }
+}

--- a/code/packages/rust/web-core/src/router.rs
+++ b/code/packages/rust/web-core/src/router.rs
@@ -1,0 +1,150 @@
+//! Route table and request matching.
+//!
+//! `Router` holds a list of `Route` values in registration order. The first
+//! route whose pattern and method both match a request wins. Patterns use the
+//! `RoutePattern` type from `http-core`: literal segments must match exactly,
+//! `:param` segments match any single path segment and capture its value.
+//!
+//! Path matching strips the query string before comparing. Method comparison
+//! is ASCII case-insensitive.
+//!
+//! When a path matches a registered pattern but the method is wrong,
+//! `Router::lookup` returns `MethodNotAllowed` rather than `NotFound`. This
+//! distinction lets the application return an accurate 405 instead of 404.
+
+use std::sync::Arc;
+
+use http_core::RoutePattern;
+
+use crate::request::WebRequest;
+use crate::response::WebResponse;
+
+/// A handler function: takes a shared request reference and returns a response.
+pub type Handler = Arc<dyn Fn(&WebRequest) -> WebResponse + Send + Sync + 'static>;
+
+/// One registered route.
+pub struct Route {
+    /// HTTP method that this route responds to, stored uppercase.
+    pub method: String,
+    /// The parsed path pattern.
+    pub pattern: RoutePattern,
+    /// The application handler.
+    pub handler: Handler,
+}
+
+/// Result of looking up a request in the router.
+pub enum RouteLookupResult<'r> {
+    /// A route matched both path and method.
+    Matched(RouteMatch<'r>),
+    /// The path matched a registered pattern but the method did not.
+    MethodNotAllowed,
+    /// No registered pattern matched the path at all.
+    NotFound,
+}
+
+/// A successful route lookup: the matched route and extracted named params.
+pub struct RouteMatch<'r> {
+    /// The matched route (for access to the handler).
+    pub route: &'r Route,
+    /// Named path parameters in the order they appear in the pattern.
+    pub params: Vec<(String, String)>,
+}
+
+/// Route table.
+pub struct Router {
+    routes: Vec<Route>,
+}
+
+impl Router {
+    pub fn new() -> Self {
+        Self { routes: Vec::new() }
+    }
+
+    /// Register a handler for the given method and path pattern.
+    ///
+    /// Method is stored in uppercase. Pattern is parsed into a `RoutePattern`.
+    pub fn add(
+        &mut self,
+        method: impl Into<String>,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.routes.push(Route {
+            method: method.into().to_ascii_uppercase(),
+            pattern: RoutePattern::parse(pattern),
+            handler: Arc::new(handler),
+        });
+    }
+
+    pub fn get(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.add("GET", pattern, handler);
+    }
+
+    pub fn post(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.add("POST", pattern, handler);
+    }
+
+    pub fn put(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.add("PUT", pattern, handler);
+    }
+
+    pub fn delete(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.add("DELETE", pattern, handler);
+    }
+
+    pub fn patch(
+        &mut self,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    ) {
+        self.add("PATCH", pattern, handler);
+    }
+
+    /// Find the first matching route for the given method and path.
+    ///
+    /// See `RouteLookupResult` for the three possible outcomes.
+    pub fn lookup<'r>(&'r self, method: &str, path: &str) -> RouteLookupResult<'r> {
+        let method_upper = method.to_ascii_uppercase();
+        let mut path_matched = false;
+
+        for route in &self.routes {
+            if let Some(params) = route.pattern.match_path(path) {
+                path_matched = true;
+                if route.method == method_upper {
+                    return RouteLookupResult::Matched(RouteMatch {
+                        route,
+                        params,
+                    });
+                }
+            }
+        }
+
+        if path_matched {
+            RouteLookupResult::MethodNotAllowed
+        } else {
+            RouteLookupResult::NotFound
+        }
+    }
+}
+
+impl Default for Router {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/code/packages/rust/web-core/src/server.rs
+++ b/code/packages/rust/web-core/src/server.rs
@@ -1,0 +1,136 @@
+//! `WebServer`: a thin wrapper around `HttpServer` that accepts a `WebApp`.
+//!
+//! Language packages typically expose their own server type that owns a
+//! `WebServer` internally. `WebServer` itself is useful when writing pure Rust
+//! consumers of `web-core`.
+//!
+//! `WebServer` fires the `on_server_start` hooks immediately after binding and
+//! before returning control to the caller. `on_server_stop` hooks fire after
+//! `serve()` returns. Both calls are synchronous on the calling thread.
+
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+
+use embeddable_http_server::{HttpServerOptions, HttpServer};
+use tcp_runtime::PlatformError;
+
+use crate::app::WebApp;
+
+/// HTTP server wired to a `WebApp` for request dispatch.
+pub struct WebServer<P> {
+    inner: HttpServer<P>,
+    app: Arc<WebApp>,
+}
+
+impl<P> WebServer<P>
+where
+    P: transport_platform::TransportPlatform,
+{
+    /// Bind a server on the given platform and address.
+    ///
+    /// The `app`'s `on_server_start` hooks fire before this method returns.
+    pub fn bind(
+        platform: P,
+        address: tcp_runtime::BindAddress,
+        options: HttpServerOptions,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let app_clone = Arc::clone(&app);
+        let inner = HttpServer::bind(platform, address, options, move |request| {
+            app_clone.handle(request)
+        })?;
+        let local_addr = inner.local_addr();
+        app.fire_server_start(local_addr);
+        Ok(Self { inner, app })
+    }
+
+    /// The local socket address the server is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// A handle that can stop the server from another thread.
+    pub fn stop_handle(&self) -> tcp_runtime::StopHandle {
+        self.inner.stop_handle()
+    }
+
+    /// Run the event loop until stopped.
+    ///
+    /// Blocks the calling thread. After this returns, the `on_server_stop`
+    /// hooks fire.
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        let result = self.inner.serve();
+        self.app.fire_server_stop();
+        result
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl WebServer<transport_platform::bsd::KqueueTransportPlatform> {
+    /// Bind a kqueue-backed server (macOS / BSD).
+    pub fn bind_kqueue<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let address = resolve_addr(addr)?;
+        let platform = transport_platform::bsd::KqueueTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            app,
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl WebServer<transport_platform::linux::EpollTransportPlatform> {
+    /// Bind an epoll-backed server (Linux).
+    pub fn bind_epoll<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let address = resolve_addr(addr)?;
+        let platform = transport_platform::linux::EpollTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            app,
+        )
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl WebServer<transport_platform::windows::WindowsTransportPlatform> {
+    /// Bind a Windows IOCP-backed server.
+    pub fn bind_windows<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let address = resolve_addr(addr)?;
+        let platform = transport_platform::windows::WindowsTransportPlatform::new()?;
+        Self::bind(
+            platform,
+            tcp_runtime::BindAddress::Ip(address),
+            options,
+            app,
+        )
+    }
+}
+
+fn resolve_addr<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr, PlatformError> {
+    addr.to_socket_addrs()
+        .map_err(PlatformError::from)?
+        .next()
+        .ok_or_else(|| PlatformError::Io("no socket addresses resolved".into()))
+}

--- a/code/packages/rust/web-core/tests/web_core_test.rs
+++ b/code/packages/rust/web-core/tests/web_core_test.rs
@@ -1,0 +1,508 @@
+//! Integration tests for web-core.
+//!
+//! Hook and pipeline tests exercise `WebApp::handle` with synthesised
+//! `HttpRequest` values. End-to-end tests spin up a real server on port 0.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use embeddable_http_server::{HttpRequest, HttpServerOptions};
+use http_core::{Header, HttpVersion, RequestHead};
+use tcp_runtime::{ConnectionId, TcpConnectionInfo};
+use web_core::{LogLevel, RouteLookupResult, Router, WebApp, WebResponse, WebServer};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_http_request(method: &str, target: &str) -> HttpRequest {
+    HttpRequest {
+        connection: TcpConnectionInfo {
+            id: ConnectionId(0),
+            peer_addr: SocketAddr::from(([127, 0, 0, 1], 1024)),
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 3000)),
+        },
+        head: RequestHead {
+            method: method.to_string(),
+            target: target.to_string(),
+            version: HttpVersion { major: 1, minor: 1 },
+            headers: vec![Header {
+                name: "Host".into(),
+                value: "localhost".into(),
+            }],
+        },
+        body: Vec::new(),
+    }
+}
+
+fn http_request(port: u16, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let req_str = format!(
+        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(req_str.as_bytes()).expect("write request");
+
+    let mut reader = BufReader::new(&stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line).expect("read status line");
+
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .expect("status code field")
+        .parse()
+        .expect("parse status code");
+
+    let mut content_length = 0usize;
+    let mut response_headers: Vec<String> = Vec::new();
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
+            break;
+        }
+        if trimmed.to_ascii_lowercase().starts_with("content-length:") {
+            content_length = trimmed
+                .splitn(2, ':')
+                .nth(1)
+                .unwrap_or("")
+                .trim()
+                .parse()
+                .unwrap_or(0);
+        }
+        response_headers.push(trimmed);
+    }
+
+    let mut body_buf = vec![0u8; content_length];
+    std::io::Read::read_exact(&mut reader, &mut body_buf).unwrap_or(());
+    (status, String::from_utf8_lossy(&body_buf).into_owned())
+}
+
+fn http_get(port: u16, path: &str) -> (u16, String) {
+    http_request(port, "GET", path, "")
+}
+
+/// Bind and start a `WebServer` on port 0, returning the port and stop handle.
+fn start_server(app: WebApp) -> (u16, tcp_runtime::StopHandle) {
+    let app = Arc::new(app);
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    let mut server =
+        WebServer::bind_kqueue("127.0.0.1:0", HttpServerOptions::default(), Arc::clone(&app))
+            .expect("bind kqueue");
+
+    #[cfg(target_os = "linux")]
+    let mut server =
+        WebServer::bind_epoll("127.0.0.1:0", HttpServerOptions::default(), Arc::clone(&app))
+            .expect("bind epoll");
+
+    #[cfg(target_os = "windows")]
+    let mut server =
+        WebServer::bind_windows("127.0.0.1:0", HttpServerOptions::default(), Arc::clone(&app))
+            .expect("bind windows");
+
+    let port = server.local_addr().port();
+    let stop = server.stop_handle();
+    thread::spawn(move || {
+        let _ = server.serve();
+    });
+    thread::sleep(Duration::from_millis(20));
+    (port, stop)
+}
+
+// ---------------------------------------------------------------------------
+// Router unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn router_matches_static_path() {
+    let mut router = Router::new();
+    router.get("/hello", |_| WebResponse::text("hi"));
+    assert!(matches!(router.lookup("GET", "/hello"), RouteLookupResult::Matched(_)));
+}
+
+#[test]
+fn router_extracts_named_params() {
+    let mut router = Router::new();
+    router.get("/hello/:name", |_| WebResponse::text("hi"));
+    match router.lookup("GET", "/hello/Adhithya") {
+        RouteLookupResult::Matched(m) => {
+            assert_eq!(m.params, vec![("name".into(), "Adhithya".into())]);
+        }
+        _ => panic!("expected Matched"),
+    }
+}
+
+#[test]
+fn router_returns_not_found_for_unknown_path() {
+    let mut router = Router::new();
+    router.get("/hello/:name", |_| WebResponse::text("hi"));
+    assert!(matches!(router.lookup("GET", "/goodbye"), RouteLookupResult::NotFound));
+}
+
+#[test]
+fn router_returns_method_not_allowed_when_path_matches_wrong_method() {
+    let mut router = Router::new();
+    router.get("/hello/:name", |_| WebResponse::text("hi"));
+    assert!(matches!(
+        router.lookup("POST", "/hello/Adhithya"),
+        RouteLookupResult::MethodNotAllowed
+    ));
+}
+
+#[test]
+fn router_first_registered_route_wins() {
+    let mut router = Router::new();
+    // `by-id` registered first, `special` second — `:id` should win.
+    router.get("/items/:id", |_| WebResponse::text("by-id"));
+    router.get("/items/special", |_| WebResponse::text("special"));
+    match router.lookup("GET", "/items/special") {
+        RouteLookupResult::Matched(m) => {
+            // `m.params` has `id = "special"` because the first route won.
+            assert_eq!(m.params, vec![("id".into(), "special".into())]);
+        }
+        _ => panic!("expected Matched"),
+    }
+}
+
+#[test]
+fn router_method_is_case_insensitive() {
+    let mut router = Router::new();
+    router.get("/ping", |_| WebResponse::text("pong"));
+    assert!(matches!(router.lookup("get", "/ping"), RouteLookupResult::Matched(_)));
+    assert!(matches!(router.lookup("Get", "/ping"), RouteLookupResult::Matched(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Hook pipeline tests (via WebApp::handle)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn before_routing_can_short_circuit() {
+    let mut app = WebApp::new();
+    app.get("/secret", |_| WebResponse::text("secret content"));
+    app.before_routing(|_| Some(WebResponse::new(401, b"Unauthorized".to_vec())));
+
+    let resp = app.handle(make_http_request("GET", "/secret"));
+    assert_eq!(resp.status, 401);
+    assert_eq!(resp.body, b"Unauthorized");
+}
+
+#[test]
+fn before_routing_passes_through_when_none() {
+    let mut app = WebApp::new();
+    app.get("/hello", |_| WebResponse::text("hello"));
+    app.before_routing(|_| None);
+
+    let resp = app.handle(make_http_request("GET", "/hello"));
+    assert_eq!(resp.status, 200);
+}
+
+#[test]
+fn on_not_found_overrides_default_404() {
+    let mut app = WebApp::new();
+    app.on_not_found(|_| WebResponse::new(404, b"custom not found".to_vec()));
+
+    let resp = app.handle(make_http_request("GET", "/missing"));
+    assert_eq!(resp.status, 404);
+    assert_eq!(resp.body, b"custom not found");
+}
+
+#[test]
+fn default_404_when_no_hook_registered() {
+    let mut app = WebApp::new();
+    app.get("/exists", |_| WebResponse::text("exists"));
+
+    let resp = app.handle(make_http_request("GET", "/missing"));
+    assert_eq!(resp.status, 404);
+}
+
+#[test]
+fn on_method_not_allowed_overrides_default_405() {
+    let mut app = WebApp::new();
+    app.get("/items", |_| WebResponse::text("items"));
+    app.on_method_not_allowed(|_| WebResponse::new(405, b"custom 405".to_vec()));
+
+    let resp = app.handle(make_http_request("DELETE", "/items"));
+    assert_eq!(resp.status, 405);
+    assert_eq!(resp.body, b"custom 405");
+}
+
+#[test]
+fn default_405_when_no_hook_registered() {
+    let mut app = WebApp::new();
+    app.get("/items", |_| WebResponse::text("items"));
+
+    let resp = app.handle(make_http_request("DELETE", "/items"));
+    assert_eq!(resp.status, 405);
+}
+
+#[test]
+fn panicking_handler_triggers_on_handler_error() {
+    let mut app = WebApp::new();
+    app.get("/boom", |_| panic!("intentional panic"));
+    app.on_handler_error(|_, _| WebResponse::new(500, b"caught panic".to_vec()));
+
+    let resp = app.handle(make_http_request("GET", "/boom"));
+    assert_eq!(resp.status, 500);
+    assert_eq!(resp.body, b"caught panic");
+}
+
+#[test]
+fn default_500_on_panic_when_no_error_hook() {
+    let mut app = WebApp::new();
+    app.get("/boom", |_| panic!("intentional panic"));
+
+    let resp = app.handle(make_http_request("GET", "/boom"));
+    assert_eq!(resp.status, 500);
+}
+
+#[test]
+fn after_handler_hooks_chain_in_registration_order() {
+    let mut app = WebApp::new();
+    app.get("/chain", |_| WebResponse::text("base"));
+    app.after_handler(|_, mut r| {
+        r.headers.push(("x-step".into(), "one".into()));
+        r
+    });
+    app.after_handler(|_, mut r| {
+        r.headers.push(("x-step".into(), "two".into()));
+        r
+    });
+
+    let resp = app.handle(make_http_request("GET", "/chain"));
+    let steps: Vec<_> = resp
+        .headers
+        .iter()
+        .filter(|h| h.name.eq_ignore_ascii_case("x-step"))
+        .map(|h| h.value.as_str())
+        .collect();
+    assert_eq!(steps, ["one", "two"]);
+}
+
+#[test]
+fn route_params_are_injected_into_request() {
+    let mut app = WebApp::new();
+    app.get("/hello/:name", |req| {
+        let name = req.route_params.get("name").cloned().unwrap_or_default();
+        WebResponse::text(name)
+    });
+
+    let resp = app.handle(make_http_request("GET", "/hello/Adhithya"));
+    assert_eq!(resp.status, 200);
+    assert_eq!(resp.body, b"Adhithya");
+}
+
+#[test]
+fn query_params_are_parsed_from_target() {
+    let mut app = WebApp::new();
+    app.get("/search", |req| {
+        let q = req.query_params.get("q").cloned().unwrap_or_default();
+        WebResponse::text(q)
+    });
+
+    let resp = app.handle(make_http_request("GET", "/search?q=rust"));
+    assert_eq!(resp.status, 200);
+    assert_eq!(resp.body, b"rust");
+}
+
+#[test]
+fn after_send_fires_after_response() {
+    let fired = Arc::new(AtomicUsize::new(0));
+    let fired_clone = Arc::clone(&fired);
+
+    let mut app = WebApp::new();
+    app.get("/ping", |_| WebResponse::text("pong"));
+    app.after_send(move |_, _, _| {
+        fired_clone.fetch_add(1, Ordering::SeqCst);
+    });
+
+    app.handle(make_http_request("GET", "/ping"));
+    assert_eq!(fired.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn on_log_hook_receives_application_events() {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+    let log_clone = Arc::clone(&log);
+
+    let mut app = WebApp::new();
+    app.on_log(move |level, msg, _| {
+        log_clone.lock().unwrap().push(format!("{level:?}: {msg}"));
+    });
+    app.log(LogLevel::Info, "hello from app", &HashMap::new());
+
+    let entries = log.lock().unwrap().clone();
+    assert_eq!(entries, ["Info: hello from app"]);
+}
+
+#[test]
+fn before_handler_can_short_circuit() {
+    let handler_called = Arc::new(AtomicUsize::new(0));
+    let handler_clone = Arc::clone(&handler_called);
+
+    let mut app = WebApp::new();
+    app.get("/gated", move |_| {
+        handler_clone.fetch_add(1, Ordering::SeqCst);
+        WebResponse::text("handler ran")
+    });
+    app.before_handler(|_| Some(WebResponse::new(403, b"Forbidden".to_vec())));
+
+    let resp = app.handle(make_http_request("GET", "/gated"));
+    assert_eq!(resp.status, 403);
+    assert_eq!(handler_called.load(Ordering::SeqCst), 0, "handler should not have run");
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn e2e_hello_route_with_name_param() {
+    let mut app = WebApp::new();
+    app.get("/hello/:name", |req| {
+        let name = req.route_params.get("name").cloned().unwrap_or_default();
+        WebResponse::text(format!("Hello {name}"))
+    });
+    let (port, stop) = start_server(app);
+    let (status, body) = http_get(port, "/hello/Adhithya");
+    stop.stop();
+    assert_eq!(status, 200);
+    assert_eq!(body, "Hello Adhithya");
+}
+
+#[test]
+fn e2e_missing_path_returns_404() {
+    let mut app = WebApp::new();
+    app.get("/hello/:name", |_| WebResponse::text("hi"));
+    let (port, stop) = start_server(app);
+    let (status, _) = http_get(port, "/missing");
+    stop.stop();
+    assert_eq!(status, 404);
+}
+
+#[test]
+fn e2e_wrong_method_returns_405() {
+    let mut app = WebApp::new();
+    app.get("/hello/:name", |_| WebResponse::text("hi"));
+    let (port, stop) = start_server(app);
+    let (status, _) = http_request(port, "DELETE", "/hello/Adhithya", "");
+    stop.stop();
+    assert_eq!(status, 405);
+}
+
+#[test]
+fn e2e_query_string_accessible_in_handler() {
+    let mut app = WebApp::new();
+    app.get("/search", |req| {
+        let q = req.query_params.get("q").cloned().unwrap_or_default();
+        WebResponse::text(format!("query={q}"))
+    });
+    let (port, stop) = start_server(app);
+    let (status, body) = http_get(port, "/search?q=rust");
+    stop.stop();
+    assert_eq!(status, 200);
+    assert_eq!(body, "query=rust");
+}
+
+#[test]
+fn e2e_before_routing_rejects_request() {
+    let mut app = WebApp::new();
+    app.get("/secret", |_| WebResponse::text("secret"));
+    app.before_routing(|_| Some(WebResponse::new(401, b"Unauthorized".to_vec())));
+    let (port, stop) = start_server(app);
+    let (status, body) = http_get(port, "/secret");
+    stop.stop();
+    assert_eq!(status, 401);
+    assert_eq!(body, "Unauthorized");
+}
+
+#[test]
+fn e2e_after_handler_adds_header() {
+    let mut app = WebApp::new();
+    app.get("/ping", |_| WebResponse::text("pong"));
+    app.after_handler(|_, mut r| {
+        r.headers.push(("x-powered-by".into(), "web-core".into()));
+        r
+    });
+    let (port, stop) = start_server(app);
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    write!(stream, "GET /ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").unwrap();
+
+    let mut reader = BufReader::new(&stream);
+    let mut all_headers: Vec<String> = Vec::new();
+    let mut content_length = 0usize;
+    let mut first = true;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let trimmed = line.trim().to_string();
+        if first { first = false; continue; } // skip status line
+        if trimmed.is_empty() { break; }
+        if trimmed.to_ascii_lowercase().starts_with("content-length:") {
+            content_length = trimmed.splitn(2, ':').nth(1).unwrap_or("").trim().parse().unwrap_or(0);
+        }
+        all_headers.push(trimmed);
+    }
+    let mut body_buf = vec![0u8; content_length];
+    std::io::Read::read_exact(&mut reader, &mut body_buf).unwrap_or(());
+    stop.stop();
+
+    assert!(
+        all_headers.iter().any(|h| h.to_ascii_lowercase().starts_with("x-powered-by:")),
+        "x-powered-by header missing; got: {all_headers:?}"
+    );
+    assert_eq!(String::from_utf8_lossy(&body_buf), "pong");
+}
+
+#[test]
+fn e2e_on_server_start_fires() {
+    let started = Arc::new(AtomicUsize::new(0));
+    let started_clone = Arc::clone(&started);
+
+    let mut app = WebApp::new();
+    app.get("/ping", |_| WebResponse::text("pong"));
+    app.on_server_start(move |_| {
+        started_clone.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let (port, stop) = start_server(app);
+    assert_eq!(started.load(Ordering::SeqCst), 1, "on_server_start should have fired once");
+    http_get(port, "/ping");
+    stop.stop();
+}
+
+#[test]
+fn e2e_on_server_stop_fires_after_serve_exits() {
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let stopped_clone = Arc::clone(&stopped);
+
+    let mut app = WebApp::new();
+    app.get("/ping", |_| WebResponse::text("pong"));
+    app.on_server_stop(move || {
+        stopped_clone.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let (port, stop) = start_server(app);
+    http_get(port, "/ping");
+    stop.stop();
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(stopped.load(Ordering::SeqCst), 1, "on_server_stop should have fired once");
+}

--- a/code/specs/WEB00-web-core.md
+++ b/code/specs/WEB00-web-core.md
@@ -1,0 +1,748 @@
+# WEB00 — web-core
+
+## Overview
+
+`web-core` is a generic Rack/WSGI-like HTTP application layer built on top of
+`embeddable-http-server`. It owns routing, request enrichment, response
+building, and a lifecycle hook registry. Language packages — Ruby, Python, Lua,
+Perl, and others — only need to implement their own application layer. All
+shared concerns belong to `web-core` in Rust.
+
+The design goal is that a Ruby developer writing a Sinatra-like DSL, a Python
+developer writing a Flask-like DSL, or a Lua developer writing a lightweight
+handler should all reach `web-core` as the single point of authority for:
+
+- Path pattern matching with named parameters
+- Request enrichment (query strings, route params, content type)
+- Lifecycle hook dispatch (authentication, logging, error recovery)
+- Response building with sane defaults
+
+The TCP socket, HTTP/1 framing, and native platform event loop stay in the
+layers below. The route handler logic and DSL idioms stay in the layers above.
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│  Language DSL layer                                       │
+│  Ruby/conduit  Python/web  Lua/web  Perl/web  ...        │
+│  Registers routes, hooks, and handler closures           │
+└──────────────────────────┬──────────────────────────────┘
+                           │  WebApp::handle(HttpRequest) → HttpResponse
+┌──────────────────────────▼──────────────────────────────┐
+│  web-core  (this crate)                                   │
+│  WebRequest  WebResponse  Router  HookRegistry  WebApp   │
+│  WebServer                                               │
+└──────────────────────────┬──────────────────────────────┘
+                           │  HttpHandler: Fn(HttpRequest) → HttpResponse
+┌──────────────────────────▼──────────────────────────────┐
+│  embeddable-http-server                                   │
+│  HttpConnectionState  HttpServer                          │
+└──────────────────────────┬──────────────────────────────┘
+                           │  TcpHandlerResult
+┌──────────────────────────▼──────────────────────────────┐
+│  tcp-runtime + transport-platform                         │
+│  native kqueue / epoll / IOCP event loop                  │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Why This Exists
+
+`embeddable-http-server` provides raw `HttpRequest` and `HttpResponse` types and
+calls a closure for every complete request. That is the right level of
+abstraction for the transport layer, but it is too low for application code:
+
+- Every language bridge independently reimplements path matching.
+- Every bridge independently parses query strings.
+- Every bridge independently applies routing parameters to request state.
+- There is no shared lifecycle hook surface. Logging, authentication, and error
+  recovery hooks are invented and discarded per bridge.
+
+`web-core` moves these shared concerns into one Rust crate so that language
+bridges stop duplicating them.
+
+## Non-Goals
+
+`web-core` is not:
+
+- A replacement for the job queue / thread-pool mailbox pattern for CPU-bound
+  or GVL-blocked work. That belongs to `embeddable-tcp-server` with its
+  `new_inprocess_mailbox()` mode. `web-core` focuses on the synchronous request
+  dispatch path first.
+- A full-featured framework with sessions, cookies, templating, or asset
+  serving. Those are language-layer concerns.
+- An async framework. The HTTP/1 server is currently synchronous (one request
+  at a time per connection). The async promotion path is described in
+  `WEB01-async-web-core.md`.
+- A multi-language runtime. `web-core` is a Rust crate. Language bridges
+  produce `WebApp` values through safe Rust APIs and wire them into the server.
+
+## Core Types
+
+### WebRequest
+
+`WebRequest` is the enriched request that handlers receive. It carries the raw
+`HttpRequest` from `embeddable-http-server` plus pre-parsed fields that
+handlers always need.
+
+```rust
+pub struct WebRequest {
+    /// The raw HTTP request from the transport layer.
+    pub http: HttpRequest,
+
+    /// Named route parameters extracted by the router.
+    ///
+    /// For pattern `/hello/:name` matched against `/hello/Adhithya`,
+    /// this map contains `{"name" => "Adhithya"}`.
+    pub route_params: HashMap<String, String>,
+
+    /// Parsed query string parameters.
+    ///
+    /// For target `/search?q=rust&limit=10`, this map contains
+    /// `{"q" => "rust", "limit" => "10"}`.
+    pub query_params: HashMap<String, String>,
+}
+
+impl WebRequest {
+    /// HTTP method, e.g. `"GET"`, `"POST"`.
+    pub fn method(&self) -> &str;
+
+    /// Request path without the query string, e.g. `/hello/Adhithya`.
+    pub fn path(&self) -> &str;
+
+    /// First matching header value, ASCII case-insensitive.
+    pub fn header(&self, name: &str) -> Option<&str>;
+
+    /// Request body bytes.
+    pub fn body(&self) -> &[u8];
+
+    /// Parsed `Content-Type` media type, e.g. `"application/json"`.
+    pub fn content_type(&self) -> Option<&str>;
+
+    /// Parsed `Content-Length` in bytes.
+    pub fn content_length(&self) -> Option<usize>;
+
+    /// Peer socket address.
+    pub fn peer_addr(&self) -> std::net::SocketAddr;
+}
+```
+
+`WebRequest` is never constructed outside `web-core`. The router builds it from
+`HttpRequest` after matching a route.
+
+### WebResponse
+
+`WebResponse` is the response returned by handlers and hooks. It is slightly
+richer than `HttpResponse` in its builder API, but converts to `HttpResponse`
+for transport.
+
+```rust
+pub struct WebResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl WebResponse {
+    /// 200 OK with the given bytes as body.
+    pub fn ok(body: impl Into<Vec<u8>>) -> Self;
+
+    /// 200 OK with a `text/plain` body.
+    pub fn text(body: impl Into<String>) -> Self;
+
+    /// 200 OK with an `application/json` body.
+    pub fn json(body: impl Into<Vec<u8>>) -> Self;
+
+    /// 404 Not Found with a `text/plain` body.
+    pub fn not_found() -> Self;
+
+    /// 405 Method Not Allowed with a `text/plain` body.
+    pub fn method_not_allowed() -> Self;
+
+    /// 500 Internal Server Error with the given message.
+    pub fn internal_error(message: impl AsRef<str>) -> Self;
+
+    /// Arbitrary status code with the given bytes as body.
+    pub fn new(status: u16, body: impl Into<Vec<u8>>) -> Self;
+
+    /// Add or replace a response header.
+    pub fn with_header(self, name: impl Into<String>, value: impl Into<String>) -> Self;
+
+    /// Set the `Content-Type` header.
+    pub fn with_content_type(self, ct: impl Into<String>) -> Self;
+}
+
+impl From<WebResponse> for HttpResponse { ... }
+impl From<HttpResponse> for WebResponse { ... }
+```
+
+### Router
+
+`Router` owns the route table. Routes are registered with an HTTP method, a
+path pattern, and a handler closure. The pattern syntax reuses `RoutePattern`
+from `http-core`.
+
+```rust
+/// A handler function: takes an enriched request and returns a response.
+pub type Handler = Arc<dyn Fn(&WebRequest) -> WebResponse + Send + Sync + 'static>;
+
+/// A matched route plus the extracted named parameters.
+pub struct RouteMatch<'r> {
+    pub route: &'r Route,
+    pub params: Vec<(String, String)>,
+}
+
+pub struct Route {
+    pub method: String,
+    pub pattern: RoutePattern,
+    pub handler: Handler,
+}
+
+pub struct Router {
+    routes: Vec<Route>,
+}
+
+impl Router {
+    pub fn new() -> Self;
+
+    /// Register a handler for the given method and path pattern.
+    pub fn add(
+        &mut self,
+        method: impl Into<String>,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    );
+
+    /// Convenience wrapper for GET.
+    pub fn get(&mut self, pattern: &str, handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Convenience wrapper for POST.
+    pub fn post(&mut self, pattern: &str, handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Convenience wrapper for PUT.
+    pub fn put(&mut self, pattern: &str, handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Convenience wrapper for DELETE.
+    pub fn delete(&mut self, pattern: &str, handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Convenience wrapper for PATCH.
+    pub fn patch(&mut self, pattern: &str, handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Find the first route matching the given method and path.
+    ///
+    /// Returns `None` when no route matches.
+    /// Returns the first match in registration order for overlapping patterns.
+    pub fn match_request<'r>(&'r self, method: &str, path: &str) -> Option<RouteMatch<'r>>;
+}
+```
+
+Route matching rules:
+
+- Method comparison is ASCII case-insensitive.
+- Path matching is exact for `Literal` segments and wildcard for `Param`
+  segments. Query strings are stripped before matching.
+- Routes are checked in registration order; the first match wins.
+- A request with a path that matches a registered pattern but the wrong method
+  returns a `405 Method Not Allowed` rather than a `404 Not Found`. The router
+  surfaces this distinction through `RouteLookupResult`.
+
+```rust
+pub enum RouteLookupResult<'r> {
+    Matched(RouteMatch<'r>),
+    MethodNotAllowed,
+    NotFound,
+}
+
+impl Router {
+    pub fn lookup<'r>(&'r self, method: &str, path: &str) -> RouteLookupResult<'r>;
+}
+```
+
+### HookRegistry
+
+`HookRegistry` holds zero or more listeners for each lifecycle event. All hooks
+are heap-allocated closures (`Arc<dyn Fn + Send + Sync>`), so they can be
+registered from any thread and survive across request cycles.
+
+Language bridges install hooks by wrapping their VM callbacks in these
+closures. For GVL-constrained languages like Ruby, the closure body will call
+`rb_thread_call_with_gvl` as the existing `conduit_native` dispatch already
+does.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// A log entry produced by web-core or by application code.
+pub struct LogEvent<'a> {
+    pub level: LogLevel,
+    pub message: &'a str,
+    pub fields: &'a HashMap<String, String>,
+}
+
+pub struct HookRegistry {
+    // Each field holds a Vec of registered listeners.
+    // See registration methods below for types.
+}
+
+impl HookRegistry {
+    pub fn new() -> Self;
+
+    // --- Registration ---
+
+    /// Called once after the server socket is bound and ready to accept.
+    pub fn on_server_start(&mut self, hook: impl Fn(std::net::SocketAddr) + Send + Sync + 'static);
+
+    /// Called once when the server event loop exits cleanly.
+    pub fn on_server_stop(&mut self, hook: impl Fn() + Send + Sync + 'static);
+
+    /// Called when a new TCP connection is accepted.
+    pub fn on_connect(&mut self, hook: impl Fn(u64, std::net::SocketAddr) + Send + Sync + 'static);
+
+    /// Called when a TCP connection closes (graceful or reset).
+    pub fn on_disconnect(&mut self, hook: impl Fn(u64) + Send + Sync + 'static);
+
+    /// Called before routing. Returning `Some(response)` short-circuits the
+    /// rest of the pipeline and sends that response immediately.
+    ///
+    /// Use case: authentication, rate limiting, redirect.
+    pub fn before_routing(&mut self, hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static);
+
+    /// Called when no route matches. The return value is the response sent to
+    /// the client.
+    ///
+    /// Default: 404 Not Found.
+    pub fn on_not_found(&mut self, hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Called when a route matches but the method does not.
+    ///
+    /// Default: 405 Method Not Allowed.
+    pub fn on_method_not_allowed(&mut self, hook: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static);
+
+    /// Called after routing but before the handler. Returning `Some(response)`
+    /// short-circuits the handler.
+    ///
+    /// Use case: request validation, body size checks.
+    pub fn before_handler(&mut self, hook: impl Fn(&WebRequest) -> Option<WebResponse> + Send + Sync + 'static);
+
+    /// Called when a handler panics. The `error` string is the panic message
+    /// (or a generic message if the panic value was not a string). The return
+    /// value replaces the response.
+    ///
+    /// Default: 500 Internal Server Error.
+    pub fn on_handler_error(&mut self, hook: impl Fn(&WebRequest, &str) -> WebResponse + Send + Sync + 'static);
+
+    /// Called after the handler returns successfully. Each hook receives the
+    /// current response and returns a (possibly modified) response.
+    ///
+    /// Use case: CORS headers, response compression, security headers.
+    pub fn after_handler(&mut self, hook: impl Fn(&WebRequest, WebResponse) -> WebResponse + Send + Sync + 'static);
+
+    /// Called after the response is handed to the transport layer. The third
+    /// argument is the request duration in milliseconds.
+    ///
+    /// Hooks registered here must not block. Fire-and-forget is fine.
+    /// Use case: access logging, metrics, tracing.
+    pub fn after_send(&mut self, hook: impl Fn(&WebRequest, &WebResponse, u64) + Send + Sync + 'static);
+
+    /// Structured log sink. web-core emits internal log events here.
+    /// Application code can call `WebApp::log()` to emit through the same
+    /// sink.
+    pub fn on_log(&mut self, hook: impl Fn(LogLevel, &str, &HashMap<String, String>) + Send + Sync + 'static);
+
+    // --- Execution (called by WebApp, not by application code) ---
+
+    pub(crate) fn fire_server_start(&self, addr: std::net::SocketAddr);
+    pub(crate) fn fire_server_stop(&self);
+    pub(crate) fn fire_connect(&self, connection_id: u64, peer_addr: std::net::SocketAddr);
+    pub(crate) fn fire_disconnect(&self, connection_id: u64);
+    pub(crate) fn run_before_routing(&self, req: &WebRequest) -> Option<WebResponse>;
+    pub(crate) fn run_on_not_found(&self, req: &WebRequest) -> WebResponse;
+    pub(crate) fn run_on_method_not_allowed(&self, req: &WebRequest) -> WebResponse;
+    pub(crate) fn run_before_handler(&self, req: &WebRequest) -> Option<WebResponse>;
+    pub(crate) fn run_on_handler_error(&self, req: &WebRequest, error: &str) -> WebResponse;
+    pub(crate) fn run_after_handler(&self, req: &WebRequest, response: WebResponse) -> WebResponse;
+    pub(crate) fn fire_after_send(&self, req: &WebRequest, response: &WebResponse, duration_ms: u64);
+    pub(crate) fn log(&self, level: LogLevel, message: &str, fields: &HashMap<String, String>);
+}
+```
+
+Ordering rules for hooks:
+
+- Hooks of the same type fire in registration order.
+- `before_routing` hooks fire sequentially. The first one to return `Some`
+  wins; subsequent hooks are skipped.
+- `before_handler` hooks follow the same first-wins rule.
+- `on_not_found`, `on_method_not_allowed`, and `on_handler_error` fire the last
+  registered hook. This lets language bridges override the default with a
+  single registration.
+- `after_handler` hooks fire sequentially, each receiving the response
+  produced by the previous hook.
+- `after_send` hooks fire in registration order; errors are logged but do not
+  affect the response.
+- `on_log` hooks all receive every log event.
+
+### WebApp
+
+`WebApp` composes a `Router` and a `HookRegistry` into the full request
+dispatch pipeline. It implements `Fn(HttpRequest) -> HttpResponse` so it can be
+passed directly to `HttpServer::bind`.
+
+```rust
+pub struct WebApp {
+    router: Router,
+    hooks: HookRegistry,
+}
+
+impl WebApp {
+    pub fn new() -> Self;
+
+    // --- Route registration (delegates to Router) ---
+
+    pub fn add(
+        &mut self,
+        method: impl Into<String>,
+        pattern: &str,
+        handler: impl Fn(&WebRequest) -> WebResponse + Send + Sync + 'static,
+    );
+    pub fn get(&mut self, pattern: &str, handler: impl ...);
+    pub fn post(&mut self, pattern: &str, handler: impl ...);
+    pub fn put(&mut self, pattern: &str, handler: impl ...);
+    pub fn delete(&mut self, pattern: &str, handler: impl ...);
+    pub fn patch(&mut self, pattern: &str, handler: impl ...);
+
+    // --- Hook registration (delegates to HookRegistry) ---
+
+    pub fn on_server_start(&mut self, hook: impl ...);
+    pub fn on_server_stop(&mut self, hook: impl ...);
+    pub fn on_connect(&mut self, hook: impl ...);
+    pub fn on_disconnect(&mut self, hook: impl ...);
+    pub fn before_routing(&mut self, hook: impl ...);
+    pub fn on_not_found(&mut self, hook: impl ...);
+    pub fn on_method_not_allowed(&mut self, hook: impl ...);
+    pub fn before_handler(&mut self, hook: impl ...);
+    pub fn on_handler_error(&mut self, hook: impl ...);
+    pub fn after_handler(&mut self, hook: impl ...);
+    pub fn after_send(&mut self, hook: impl ...);
+    pub fn on_log(&mut self, hook: impl ...);
+
+    // --- Application helpers ---
+
+    /// Emit a structured log event through the hook registry.
+    pub fn log(&self, level: LogLevel, message: &str, fields: &HashMap<String, String>);
+
+    /// Process one HTTP request through the full pipeline.
+    ///
+    /// This is the entry point called by `WebServer` for every request.
+    pub fn handle(&self, request: HttpRequest) -> HttpResponse;
+}
+```
+
+### Request Dispatch Pipeline
+
+The `handle` method implements this pipeline in order:
+
+```text
+1. Record start time (for after_send duration).
+
+2. Parse query string from request target into a HashMap.
+
+3. Build a partial WebRequest with empty route_params and the parsed
+   query_params.
+
+4. Fire HookRegistry::run_before_routing(partial_request).
+   → If any hook returns Some(response), jump to step 12.
+
+5. Call Router::lookup(method, path).
+   → NotFound     → run_on_not_found    → jump to step 12.
+   → MethodNotAllowed → run_on_method_not_allowed → jump to step 12.
+   → Matched(m)   → continue.
+
+6. Fill WebRequest::route_params from m.params.
+
+7. Fire HookRegistry::run_before_handler(full_request).
+   → If any hook returns Some(response), jump to step 11.
+
+8. Call handler(full_request) inside std::panic::catch_unwind.
+   → Ok(response)  → continue.
+   → Err(panic)    → run_on_handler_error(full_request, message) → step 11.
+
+9. WebResponse produced by handler → step 11.
+
+10. (step 11) Fire HookRegistry::run_after_handler(full_request, response).
+    → Produces final WebResponse.
+
+12. Convert WebResponse to HttpResponse.
+
+13. Fire HookRegistry::fire_after_send(full_request, response, elapsed_ms).
+    (non-blocking, errors are discarded)
+
+14. Return HttpResponse to transport layer.
+```
+
+The numbers above are chosen so step 12 is always "produce the HTTP response"
+regardless of how we got there.
+
+### WebServer
+
+`WebServer` is a thin wrapper around `HttpServer` that accepts a `WebApp`.
+Language packages typically do not need to use `WebServer` directly — they
+expose their own server type that owns a `WebServer` internally.
+
+```rust
+pub struct WebServer<P> {
+    inner: HttpServer<P>,
+}
+
+impl<P> WebServer<P>
+where
+    P: transport_platform::TransportPlatform,
+{
+    pub fn bind(
+        platform: P,
+        address: tcp_runtime::BindAddress,
+        options: HttpServerOptions,
+        app: Arc<WebApp>,
+    ) -> Result<Self, tcp_runtime::PlatformError>;
+
+    pub fn local_addr(&self) -> std::net::SocketAddr;
+    pub fn stop_handle(&self) -> tcp_runtime::StopHandle;
+    pub fn serve(&mut self) -> Result<(), tcp_runtime::PlatformError>;
+}
+```
+
+Platform-specific convenience constructors follow the same pattern as
+`HttpServer`:
+
+```rust
+// macOS / BSD:
+impl WebServer<transport_platform::bsd::KqueueTransportPlatform> {
+    pub fn bind_kqueue(addr: impl ToSocketAddrs, options: HttpServerOptions, app: Arc<WebApp>)
+        -> Result<Self, PlatformError>;
+}
+
+// Linux:
+impl WebServer<transport_platform::linux::EpollTransportPlatform> {
+    pub fn bind_epoll(addr: impl ToSocketAddrs, options: HttpServerOptions, app: Arc<WebApp>)
+        -> Result<Self, PlatformError>;
+}
+
+// Windows:
+impl WebServer<transport_platform::windows::WindowsTransportPlatform> {
+    pub fn bind_windows(addr: impl ToSocketAddrs, options: HttpServerOptions, app: Arc<WebApp>)
+        -> Result<Self, PlatformError>;
+}
+```
+
+## Hook Lifecycle Reference
+
+This table summarises every hook, the moment it fires, and how its return value
+is used.
+
+| Hook                    | When                           | Return value          | Default if absent           |
+|-------------------------|--------------------------------|-----------------------|-----------------------------|
+| `on_server_start`       | Server bound, before accept()  | `()` — fire-and-forget | nothing                    |
+| `on_server_stop`        | Event loop exited              | `()` — fire-and-forget | nothing                    |
+| `on_connect`            | TCP connection accepted        | `()` — fire-and-forget | nothing                    |
+| `on_disconnect`         | TCP connection closed          | `()` — fire-and-forget | nothing                    |
+| `before_routing`        | Before route lookup            | `Option<WebResponse>` | continue pipeline           |
+| `on_not_found`          | No matching route              | `WebResponse`         | 404 Not Found               |
+| `on_method_not_allowed` | Route exists, wrong method     | `WebResponse`         | 405 Method Not Allowed      |
+| `before_handler`        | After routing, before handler  | `Option<WebResponse>` | continue pipeline           |
+| `on_handler_error`      | Handler panicked               | `WebResponse`         | 500 Internal Server Error   |
+| `after_handler`         | Handler returned successfully  | `WebResponse`         | pass response through       |
+| `after_send`            | Response handed to transport   | `()` — fire-and-forget | nothing                    |
+| `on_log`                | Any internal or app log event  | `()` — all receive it | nothing (events dropped)   |
+
+## Language Bridge Protocol
+
+Language packages that embed `web-core` follow this pattern:
+
+### Step 1: Build a WebApp
+
+The bridge creates a `WebApp` and registers routes and hooks using the Rust API.
+Route handlers and hook bodies are Rust closures that call back into the
+language runtime.
+
+For Ruby with a GVL:
+
+```rust
+let app = Arc::new(Mutex::new(WebApp::new()));
+
+// Register a GET route. The closure body re-acquires the GVL
+// before calling into Ruby, using the same pattern as conduit_native.
+app.lock().get("/hello/:name", move |req| {
+    let request_copy = req.clone();
+    let response = call_into_ruby_with_gvl(owner, request_copy);
+    response
+});
+
+// Register a logging hook. The closure must NOT block; it queues
+// a log message for Ruby to drain on its own thread.
+app.lock().on_log(move |level, message, _fields| {
+    ruby_log_mailbox.push(format!("[{level:?}] {message}"));
+});
+```
+
+For Python with a GIL the pattern is identical, using the Python C-API GIL
+acquire functions.
+
+### Step 2: Bind a WebServer
+
+```rust
+let server = WebServer::bind_kqueue("127.0.0.1:3000", options, Arc::new(app))?;
+server.fire_server_start_hook();  // fires on_server_start hooks
+server.serve()?;
+server.fire_server_stop_hook();   // fires on_server_stop hooks
+```
+
+`fire_server_start_hook` and `fire_server_stop_hook` are separate from `serve`
+because `serve` blocks until the server stops. The language bridge must call
+the hooks at the right time.
+
+### Step 3: Access route parameters from the language side
+
+When a handler closure fires, it receives a `&WebRequest`. The bridge extracts
+the fields it needs and converts them into the language's native types:
+
+```rust
+// In a Ruby bridge handler closure:
+move |req: &WebRequest| -> WebResponse {
+    let params = req.route_params.clone();       // HashMap<String, String>
+    let query  = req.query_params.clone();        // HashMap<String, String>
+    let body   = req.body().to_vec();
+    let method = req.method().to_string();
+    let path   = req.path().to_string();
+
+    // Build the Rack/WSGI env hash in the language, call the app.
+    let response = dispatch_to_language_app(method, path, params, query, body);
+    response.into()
+}
+```
+
+## Conduit Ruby Refactor
+
+`conduit_native` currently:
+
+1. Receives raw `HttpRequest` from `embeddable-http-server`.
+2. Builds a Rack-like env hash in Rust.
+3. Dispatches to the Ruby application via `rb_thread_call_with_gvl`.
+4. Calls the Ruby `dispatch_request` method.
+5. Parses the `[status, headers, body]` triple returned by Ruby.
+
+After this refactor:
+
+1. `conduit_native` creates a `WebApp` at load time.
+2. Each `get`/`post`/… DSL call in Ruby's `Conduit.app {}` block registers a
+   route on the `WebApp`.
+3. The handler closure for each route builds a Rack env hash, acquires the GVL,
+   calls into Ruby, and converts the response.
+4. `conduit_native`'s `NativeServer` wraps a `WebServer` instead of an
+   `HttpServer`.
+5. Route matching logic in Rust (`match_route_native`) is retired; the `Router`
+   handles it.
+
+The Ruby API surface is unchanged. The Ruby tests continue to pass without
+modification.
+
+## Testing Strategy
+
+### Unit tests (within the `web-core` crate)
+
+- `Router::lookup` returns `Matched`, `NotFound`, `MethodNotAllowed` as
+  expected.
+- Named parameters are correctly extracted from matched routes.
+- Routes are matched in registration order.
+- Query strings are parsed correctly, including percent-encoded values and
+  empty values.
+- `WebResponse` builders produce correct status codes and headers.
+- `HookRegistry` fires hooks in the documented order.
+- A `before_routing` hook that returns `Some` short-circuits the handler.
+- A panicking handler triggers `on_handler_error` instead of unwinding.
+- `after_handler` hooks chain in order, each seeing the previous output.
+- `on_not_found` and `on_method_not_allowed` produce correct defaults.
+
+### Integration tests (within the `web-core` crate)
+
+- Full round-trip via `WebServer::bind_*` on `127.0.0.1:0` (OS-assigned port).
+- `GET /hello/Adhithya` matches `/hello/:name` and injects `name = Adhithya`.
+- `POST /missing` returns 404 when no route matches.
+- `DELETE /hello/Adhithya` returns 405 when only GET is registered.
+- A `before_routing` hook can reject unauthenticated requests.
+- An `after_handler` hook adds a `X-Request-Id` header to every response.
+- An `on_log` hook captures internal log events.
+
+## Crate Location
+
+```text
+code/packages/rust/web-core/
+  Cargo.toml
+  src/
+    lib.rs
+    router.rs
+    request.rs
+    response.rs
+    hooks.rs
+    app.rs
+    server.rs
+    query.rs   (query string parser)
+  tests/
+    web_core_test.rs
+  README.md
+  CHANGELOG.md
+```
+
+## Dependencies
+
+```toml
+[dependencies]
+embeddable-http-server = { path = "../embeddable-http-server" }
+http-core              = { path = "../http-core" }
+tcp-runtime            = { path = "../tcp-runtime" }
+transport-platform     = { path = "../transport-platform" }
+```
+
+No additional third-party dependencies beyond what `embeddable-http-server`
+already pulls in.
+
+## Phase Plan
+
+### Phase 1: Core crate (this spec)
+
+Implement `WebRequest`, `WebResponse`, `Router`, `HookRegistry`, `WebApp`,
+`WebServer` with full unit and integration tests.
+
+### Phase 2: conduit refactor
+
+Refactor `conduit_native` to use `WebApp` and `WebServer`. The Ruby API stays
+identical; only the native internals change. Retire `match_route_native`.
+
+### Phase 3: Async promotion (WEB01)
+
+Wire the `WebApp::handle` pipeline through
+`embeddable-tcp-server::new_inprocess_mailbox()` so the HTTP I/O thread submits
+work and returns immediately. Each language bridge provides a `worker_fn` that
+receives `(JobRequest<HttpRequest>, AppHandle)` and calls
+`AppHandle::handle(request)`.
+
+This phase enables parallel request handling under the Rust thread pool without
+requiring any change to the language-layer DSLs.
+
+## Open Questions
+
+- Should `WebApp::handle` be `&self` (shared, immutable after construction) or
+  `Arc<WebApp>` cloned into each closure? Recommendation: `Arc<WebApp>` to
+  keep the door open for async promotion.
+- Should `Router` support wildcard segments (`:*rest`) for catch-all routes?
+  Not needed for phase 1; reserve segment syntax for later.
+- Should `after_send` hooks run on a detached thread to avoid adding latency to
+  the request cycle? Yes, but thread spawning has overhead. Phase 1 runs them
+  inline.
+- Should `WebServer` also surface `on_connect`/`on_disconnect` hooks? These
+  require `TcpRuntime` to support callbacks, which it currently does through
+  the `on_close` callback. Phase 1 wires `on_disconnect` through the existing
+  `on_close` hook; `on_connect` requires a new `TcpRuntime` callback.


### PR DESCRIPTION
## Summary

- Adds `WEB00-web-core.md` spec: full architecture, 12-hook lifecycle surface, language bridge protocol, phase roadmap
- Adds `web-core` Rust crate: `Router`, `WebRequest`, `WebResponse`, `HookRegistry`, `WebApp`, `WebServer`
- 37 tests: query-parser unit tests, hook/pipeline tests via `WebApp::handle`, 9 end-to-end tests over real TCP connections

`web-core` is the shared Rack/WSGI-like layer between `embeddable-http-server` and language bridges (Ruby, Python, Lua, etc.). Every language that embeds the Rust HTTP runtime now gets routing, query string parsing, panic recovery, and 12 lifecycle hooks (before_routing, on_not_found, before_handler, on_handler_error, after_handler, after_send, on_log, …) for free.

Phase 2 (separate PR): refactor `conduit_native` to use `WebApp` + `WebServer`.
Phase 3 (separate PR): async promotion via `embeddable-tcp-server::new_inprocess_mailbox`.

## Test plan

- [x] `cargo test -p web-core` — 37 tests pass (unit + e2e)
- [x] `cargo build --workspace` clean (no regressions)
- [x] No new warnings beyond `#[allow(dead_code)]` on `fire_connect`/`fire_disconnect` (wired in Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)