### PR TITLE
feat(algol): add real procedure values

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/__init__.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/__init__.py
@@ -8,6 +8,7 @@ from algol_ir_compiler.compiler import (
     AlgolIrCompiler,
     CompileError,
     CompileResult,
+    ProcedureSignaturePlan,
     compile_algol,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "AlgolIrCompiler",
     "CompileError",
     "CompileResult",
+    "ProcedureSignaturePlan",
     "compile_algol",
 ]

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -38,6 +38,7 @@ _FRAME_MEMORY_LABEL = "__algol_frames"
 _HEAP_MEMORY_LABEL = "__algol_heap"
 _ZERO_REG = 0
 _RESULT_REG = 1
+_REAL_RESULT_REG = 31
 _DYNAMIC_LINK_OFFSET = 0
 _STATIC_LINK_OFFSET = 4
 _RETURN_TOKEN_OFFSET = 8
@@ -88,6 +89,18 @@ _REAL_TYPE = "real"
 
 
 @dataclass(frozen=True)
+class ProcedureSignaturePlan:
+    """WASM-relevant procedure signature facts produced by ALGOL lowering."""
+
+    param_types: tuple[str, ...]
+    return_type: str | None
+
+    @property
+    def param_count(self) -> int:
+        return len(self.param_types)
+
+
+@dataclass(frozen=True)
 class CompileResult:
     """The IR compiler output and useful frame metadata.
 
@@ -103,7 +116,9 @@ class CompileResult:
     frame_offsets: dict[int, int] = field(default_factory=dict)
     frame_memory_label: str = _FRAME_MEMORY_LABEL
     heap_memory_label: str = _HEAP_MEMORY_LABEL
-    procedure_signatures: dict[str, int] = field(default_factory=dict)
+    procedure_signatures: dict[str, ProcedureSignaturePlan] = field(
+        default_factory=dict
+    )
 
 
 class CompileError(Exception):
@@ -181,8 +196,9 @@ class AlgolIrCompiler:
         self.frame_offsets: dict[int, int] = {}
         self.variable_slots: dict[str, int] = {}
         self.legacy_variable_slots: dict[str, int] = {}
-        self.procedure_signatures: dict[str, int] = {}
+        self.procedure_signatures: dict[str, ProcedureSignaturePlan] = {}
         self.expression_types: dict[int, str] = {}
+        self.current_function_return_type: str | None = _INTEGER_TYPE
         self.eval_thunks: list[_EvalThunk] = []
         self.has_by_name_parameters = False
 
@@ -279,12 +295,25 @@ class AlgolIrCompiler:
         for array in type_result.semantic.arrays:
             self.arrays_by_block.setdefault(array.declaring_block_id, []).append(array)
         self.procedure_signatures = {
-            procedure.label: 2 + len(procedure.parameters)
+            procedure.label: ProcedureSignaturePlan(
+                param_types=(
+                    _INTEGER_TYPE,
+                    _INTEGER_TYPE,
+                    *(parameter.type_name for parameter in procedure.parameters),
+                ),
+                return_type=procedure.return_type,
+            )
             for procedure in type_result.semantic.procedures
         }
         if self.has_by_name_parameters:
-            self.procedure_signatures[_THUNK_EVAL_LABEL] = 2
-            self.procedure_signatures[_THUNK_STORE_LABEL] = 3
+            self.procedure_signatures[_THUNK_EVAL_LABEL] = ProcedureSignaturePlan(
+                param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
+                return_type=_INTEGER_TYPE,
+            )
+            self.procedure_signatures[_THUNK_STORE_LABEL] = ProcedureSignaturePlan(
+                param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
+                return_type=_INTEGER_TYPE,
+            )
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
         self.variable_slots = self._collect_variable_slots(self.semantic_blocks)
         self.legacy_variable_slots = self._collect_legacy_variable_slots(
@@ -358,6 +387,7 @@ class AlgolIrCompiler:
         block = _first_node(type_result.ast, "block")
         if block is None:
             raise CompileError("ALGOL program must contain a block")
+        self.current_function_return_type = _INTEGER_TYPE
         root_scope = self._compile_block(block, parent=None)
 
         result_symbol = root_scope.semantic_block.scope.symbols.get("result")
@@ -1349,7 +1379,12 @@ class AlgolIrCompiler:
             zip(actuals, procedure.parameters, strict=True)
         ):
             if parameter.mode == _VALUE_MODE:
-                arguments[index] = self._compile_expr(argument, scope)
+                value = self._compile_expr(argument, scope)
+                arguments[index] = self._coerce_reg_to_type(
+                    value,
+                    self._expr_type(argument),
+                    expected_type=parameter.type_name,
+                )
 
         descriptor_heap_mark = (
             self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
@@ -1409,7 +1444,11 @@ class AlgolIrCompiler:
             self._emit_helper_return_on_thunk_failure(scope)
         self._emit_handle_pending_goto_after_call(scope)
         result = self._fresh_reg()
-        self._copy_reg(dst=result, src=_RESULT_REG)
+        self._copy_scalar_reg(
+            type_name=call.return_type or _INTEGER_TYPE,
+            dst=result,
+            src=_REAL_RESULT_REG if call.return_type == _REAL_TYPE else _RESULT_REG,
+        )
         return result
 
     def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
@@ -1730,6 +1769,8 @@ class AlgolIrCompiler:
         if body is None:
             raise CompileError(f"missing body AST for procedure {procedure.name!r}")
         semantic_block = self.semantic_blocks_by_id[procedure.body_block_id]
+        previous_return_type = self.current_function_return_type
+        self.current_function_return_type = procedure.return_type
         self._label(procedure.label)
         heap_mark_reg = self._snapshot_heap_pointer()
         frame_base_reg = self._emit_enter_frame(
@@ -1777,7 +1818,8 @@ class AlgolIrCompiler:
         )
         self._initialize_scalar_slots(scope)
         for index, parameter in enumerate(procedure.parameters):
-            self._store_word_reg(
+            self._store_scalar_reg(
+                type_name=parameter.type_name,
                 value_reg=_VALUE_PARAM_BASE_REG + index,
                 base_reg=scope.frame_base_reg,
                 offset=parameter.slot_offset,
@@ -1801,6 +1843,7 @@ class AlgolIrCompiler:
             self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit_leave_frame(scope)
         self._emit(IrOp.RET)
+        self.current_function_return_type = previous_return_type
 
     def _compile_array_load(self, variable: ASTNode, scope: _FrameScope) -> int:
         data_pointer, byte_offset = self._compile_array_element_address(
@@ -2248,6 +2291,19 @@ class AlgolIrCompiler:
             IrRegister(offset_reg),
         )
 
+    def _store_scalar_reg(
+        self,
+        *,
+        type_name: str,
+        value_reg: int,
+        base_reg: int,
+        offset: int,
+    ) -> None:
+        if type_name == _REAL_TYPE:
+            self._store_f64_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
+            return
+        self._store_word_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
+
     def _store_word_const(self, base_reg: int, offset: int, value: int) -> None:
         value_reg = self._const_reg(value)
         self._store_word_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
@@ -2261,6 +2317,18 @@ class AlgolIrCompiler:
 
     def _copy_reg(self, *, dst: int, src: int) -> None:
         self._emit(IrOp.ADD_IMM, IrRegister(dst), IrRegister(src), IrImmediate(0))
+
+    def _copy_scalar_reg(self, *, type_name: str, dst: int, src: int) -> None:
+        if type_name == _REAL_TYPE:
+            zero = self._const_f64_reg(0.0)
+            self._emit(
+                IrOp.F64_ADD,
+                IrRegister(dst),
+                IrRegister(src),
+                IrRegister(zero),
+            )
+            return
+        self._copy_reg(dst=dst, src=src)
 
     def _const_reg(self, value: int) -> int:
         reg = self._fresh_reg()
@@ -2359,13 +2427,23 @@ class AlgolIrCompiler:
         )
         self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, token_reg)
 
+    def _emit_zero_result_reg(self) -> None:
+        if self.current_function_return_type == _REAL_TYPE:
+            self._emit(
+                IrOp.LOAD_F64_IMM,
+                IrRegister(_RESULT_REG),
+                IrFloatImmediate(0.0),
+            )
+            return
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+
     def _emit_stack_overflow_guard(self, overflow_reg: int) -> None:
         index = self.if_count
         self.if_count += 1
         else_label = f"if_{index}_else"
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(overflow_reg), IrLabel(else_label))
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         self._emit(IrOp.RET)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(else_label)
@@ -2378,7 +2456,7 @@ class AlgolIrCompiler:
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
         self._emit_mark_thunk_failure_if_helper_active()
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         self._emit_unwind_for_return(scope)
         if scope.helper_failure:
             self._emit_leave_thunk_helper()
@@ -2397,7 +2475,7 @@ class AlgolIrCompiler:
             _RUNTIME_PENDING_GOTO_LABEL_OFFSET,
             self._const_reg(label_id),
         )
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         if not scope.helper_failure:
             self._emit_unwind_for_return(scope)
         if scope.helper_failure:
@@ -2414,7 +2492,7 @@ class AlgolIrCompiler:
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(pending_label), IrLabel(no_pending_label))
         if scope.helper_failure:
-            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_zero_result_reg()
             self._emit_leave_thunk_helper()
             self._emit_restore_active_thunk_heap_mark(scope)
             self._emit(IrOp.RET)
@@ -2447,13 +2525,13 @@ class AlgolIrCompiler:
             self._label(next_end_label)
 
         if scope.function_owner_procedure_id is not None:
-            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_zero_result_reg()
             self._emit_unwind_for_return(scope)
             self._emit_restore_active_thunk_heap_mark(scope)
             self._emit(IrOp.RET)
         else:
             self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)
-            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_zero_result_reg()
             self._emit(IrOp.HALT)
 
         self._emit(IrOp.JUMP, IrLabel(end_label))
@@ -2540,7 +2618,7 @@ class AlgolIrCompiler:
         else_label = f"if_{index}_else"
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(failed), IrLabel(else_label))
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         self._emit_leave_thunk_helper()
         self._emit_restore_active_thunk_heap_mark(scope)
         self._emit(IrOp.RET)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -408,7 +408,7 @@ class TestAlgolIrCompiler:
         assert calls[0].operands[0].name.startswith("_fn_algol_")
         assert len(calls[0].operands) == 4
         assert any(label.startswith("_fn_algol_") for label in labels)
-        assert result.procedure_signatures[calls[0].operands[0].name] == 3
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
 
     def test_compiles_boolean_value_procedure_call(self) -> None:
         result = compile_algol(
@@ -428,8 +428,48 @@ class TestAlgolIrCompiler:
         opcodes = [instr.opcode for instr in result.program.instructions]
 
         assert calls[0].operands[0].name.startswith("_fn_algol_")
-        assert result.procedure_signatures[calls[0].operands[0].name] == 3
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
         assert IrOp.AND_IMM in opcodes
+
+    def test_compiles_real_value_procedure_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "real procedure half(x); value x; real x; "
+                "begin half := x / 2 end; "
+                "y := half(3); "
+                "if y > 1.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        signature = result.procedure_signatures[calls[0].operands[0].name]
+
+        assert signature.param_count == 3
+        assert signature.param_types == ("integer", "integer", "real")
+        assert signature.return_type == "real"
+        assert IrOp.F64_DIV in opcodes
+        assert IrOp.F64_CMP_GT in opcodes
+
+    def test_compiles_integer_actual_promoted_for_real_value_parameter(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "real procedure id(x); value x; real x; "
+                "begin id := x end; "
+                "y := id(1); "
+                "if y = 1.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.F64_FROM_I32 in opcodes
 
     def test_compiles_recursive_procedure_call(self) -> None:
         result = compile_algol(
@@ -482,7 +522,7 @@ class TestAlgolIrCompiler:
         opcodes = [instruction.opcode for instruction in result.program.instructions]
 
         assert len(calls[0].operands) == 4
-        assert result.procedure_signatures[calls[0].operands[0].name] == 3
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
         assert IrOp.ADD_IMM in opcodes
         assert opcodes.count(IrOp.LOAD_WORD) >= 4
         assert opcodes.count(IrOp.STORE_WORD) >= 8
@@ -506,7 +546,7 @@ class TestAlgolIrCompiler:
         opcodes = [instruction.opcode for instruction in result.program.instructions]
 
         assert len(calls[0].operands) == 4
-        assert result.procedure_signatures[calls[0].operands[0].name] == 3
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
         assert opcodes.count(IrOp.LOAD_WORD) >= 4
         assert opcodes.count(IrOp.STORE_WORD) >= 8
 
@@ -531,7 +571,7 @@ class TestAlgolIrCompiler:
         ]
 
         assert "_fn_algol_eval_thunk" in labels
-        assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
+        assert result.procedure_signatures["_fn_algol_eval_thunk"].param_count == 2
         assert any(call.operands[0].name == "_fn_algol_eval_thunk" for call in calls)
 
     def test_compiles_array_element_by_name_eval_and_store_thunks(
@@ -561,8 +601,8 @@ class TestAlgolIrCompiler:
         assert "_fn_algol_store_thunk" in labels
         assert "_fn_algol_eval_thunk" in calls
         assert "_fn_algol_store_thunk" in calls
-        assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
-        assert result.procedure_signatures["_fn_algol_store_thunk"] == 3
+        assert result.procedure_signatures["_fn_algol_eval_thunk"].param_count == 2
+        assert result.procedure_signatures["_fn_algol_store_thunk"].param_count == 3
 
     def test_compiles_array_read_inside_expression_eval_thunk(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -678,7 +678,7 @@ class AlgolTypeChecker:
             return
 
         return_type = _procedure_return_type(node)
-        if return_type is not None and return_type not in {INTEGER, BOOLEAN}:
+        if return_type is not None and return_type not in {INTEGER, BOOLEAN, REAL}:
             self._error(
                 name_token,
                 f"{return_type} procedure results are not supported yet",
@@ -707,11 +707,11 @@ class AlgolTypeChecker:
                     f"by-name parameter {formal.value!r} must have an integer "
                     "or boolean specifier",
                 )
-            elif mode == VALUE and parameter_type not in {INTEGER, BOOLEAN}:
+            elif mode == VALUE and parameter_type not in {INTEGER, BOOLEAN, REAL}:
                 self._error(
                     formal,
-                    f"value parameter {formal.value!r} must have an integer or "
-                    "boolean specifier",
+                    f"value parameter {formal.value!r} must have an integer, "
+                    "boolean, or real specifier",
                 )
 
         procedure_id = self._next_procedure_id
@@ -772,7 +772,7 @@ class AlgolTypeChecker:
                 name=formal.value,
                 type_name=(
                     parameter_type
-                    if parameter_type in {INTEGER, BOOLEAN}
+                    if parameter_type in {INTEGER, BOOLEAN, REAL}
                     else INTEGER
                 ),
                 line=formal.line,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -462,6 +462,25 @@ class TestAlgolTypeChecker:
         call = result.semantic.procedure_calls[0]
         assert call.return_type == "boolean"
 
+    def test_accepts_real_value_procedure_signature_and_call(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "real procedure half(x); value x; real x; "
+            "begin half := x / 2 end; "
+            "y := half(3); "
+            "if y > 1.0 then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        descriptor = result.semantic.procedures[0]
+        assert descriptor.return_type == "real"
+        assert descriptor.parameters[0].type_name == "real"
+        call = result.semantic.procedure_calls[0]
+        assert call.return_type == "real"
+
     def test_accepts_boolean_by_name_parameter_writeback(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
@@ -12,7 +12,7 @@ from compiler_ir import IrLabel, IrOp, IrProgram
 from ir_to_wasm_compiler import FunctionSignature, IrToWasmCompiler
 from ir_to_wasm_validator import validate as validate_ir_to_wasm
 from wasm_module_encoder import encode_module
-from wasm_types import WasmModule
+from wasm_types import ValueType, WasmModule
 from wasm_validator import ValidatedModule, ValidationError, validate
 
 
@@ -73,10 +73,18 @@ class AlgolWasmCompiler:
         signatures.extend(
             FunctionSignature(
                 label=label,
-                param_count=param_count,
+                param_count=plan.param_count,
                 require_explicit_args=True,
+                param_types=tuple(
+                    _wasm_value_type(type_name) for type_name in plan.param_types
+                ),
+                result_types=(
+                    (_wasm_value_type(plan.return_type),)
+                    if plan.return_type is not None
+                    else ()
+                ),
             )
-            for label, param_count in sorted(ir.procedure_signatures.items())
+            for label, plan in sorted(ir.procedure_signatures.items())
         )
         strategy = _wasm_lowering_strategy(ir.program)
         lowering_errors = validate_ir_to_wasm(
@@ -150,3 +158,9 @@ def _wasm_lowering_strategy(program: IrProgram) -> str:
         ):
             return "dispatch_loop"
     return "structured"
+
+
+def _wasm_value_type(type_name: str | None) -> ValueType:
+    if type_name == "real":
+        return ValueType.F64
+    return ValueType.I32

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -288,6 +288,28 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_real_value_procedure_returns_real_result(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "real procedure half(x); value x; real x; "
+            "begin half := x / 2 end; "
+            "y := half(3); "
+            "if y > 1.0 then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_integer_actual_promotes_for_real_value_parameter(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "real procedure id(x); value x; real x; "
+            "begin id := x end; "
+            "y := id(1); "
+            "if y = 1.0 then result := 9 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_void_procedure_statement_writes_outer_frame(self) -> None:
         result = compile_source(
             "begin integer result; "

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -880,7 +880,12 @@ class _FunctionLowerer:
                 self._emit_opcode("call")
                 self._emit_u32(self.function_indices[label.name])
                 if signature.wasm_result_types:
-                    self._emit_local_set(_REG_SCRATCH)
+                    result_reg = (
+                        _REG_F64_SCRATCH
+                        if signature.wasm_result_types[0] == ValueType.F64
+                        else _REG_SCRATCH
+                    )
+                    self._emit_local_set(result_reg)
             case IrOp.RET | IrOp.HALT:
                 if self.function.signature.wasm_result_types:
                     self._emit_local_get(_REG_SCRATCH)
@@ -1280,7 +1285,11 @@ def _make_function_ir(
             raise WasmLoweringError(f"missing function signature for {label}")
 
     max_reg = max(
-        [1, _REG_VAR_BASE + max(signature.param_count - 1, 0)]
+        [
+            1,
+            _REG_VAR_BASE + max(signature.param_count - 1, 0),
+            _REG_F64_SCRATCH if _needs_f64_scratch(instructions, signatures) else 1,
+        ]
         + [
             operand.index
             for instruction in instructions
@@ -1301,6 +1310,22 @@ def _make_function_ir(
             signatures=signatures,
         ),
     )
+
+
+def _needs_f64_scratch(
+    instructions: list[IrInstruction],
+    signatures: dict[str, FunctionSignature],
+) -> bool:
+    for instruction in instructions:
+        if instruction.opcode != IrOp.CALL:
+            continue
+        target = instruction.operands[0]
+        if not isinstance(target, IrLabel):
+            continue
+        callee = signatures.get(target.name)
+        if callee is not None and callee.wasm_result_types == (ValueType.F64,):
+            return True
+    return False
 
 
 def _const_expr(value: int) -> bytes:
@@ -1357,6 +1382,7 @@ def _align_up(value: int, alignment: int) -> int:
 
 
 _REG_SCRATCH = 1
+_REG_F64_SCRATCH = 31
 _REG_VAR_BASE = 2
 
 
@@ -1435,9 +1461,14 @@ def _infer_register_types(
                 if callee is None:
                     raise WasmLoweringError(f"missing function signature for {target.name}")
                 if callee.wasm_result_types:
+                    result_reg = (
+                        _REG_F64_SCRATCH
+                        if callee.wasm_result_types[0] == ValueType.F64
+                        else _REG_SCRATCH
+                    )
                     _assign_register_type(
                         reg_types,
-                        _REG_SCRATCH,
+                        result_reg,
                         callee.wasm_result_types[0],
                         f"CALL {target.name}",
                     )


### PR DESCRIPTION
## Summary
- allow `real` procedure results and `real` value parameters in the ALGOL type checker
- carry typed ALGOL procedure signatures through IR/WASM lowering so real-valued procedures call and return correctly
- add focused checker, IR, and WASM coverage for real procedure returns and integer-to-real promotion at real call sites

## Testing
- `/Users/adhithya/.local/bin/python3.12 -m py_compile code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_type_checker.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=../compiler-ir/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-encoder/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../virtual-machine/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_ir_to_wasm_compiler.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:../algol-ir-compiler/src:../virtual-machine/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../wasm-module-encoder/src:../ir-to-wasm-compiler/src:../ir-to-wasm-validator/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_wasm_compiler.py -q`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/__init__.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py`
- `git diff --check`