### PR TITLE
feat(algol): add real by-name parameters

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -76,6 +76,8 @@ _VALUE_MODE = "value"
 _NAME_MODE = "name"
 _THUNK_EVAL_LABEL = "_fn_algol_eval_thunk"
 _THUNK_STORE_LABEL = "_fn_algol_store_thunk"
+_THUNK_EVAL_REAL_LABEL = "_fn_algol_eval_real_thunk"
+_THUNK_STORE_REAL_LABEL = "_fn_algol_store_real_thunk"
 _THUNK_DESCRIPTOR_SIZE = 12
 _THUNK_CODE_ID_OFFSET = 0
 _THUNK_CALLER_FRAME_OFFSET = 4
@@ -150,6 +152,7 @@ class _EvalThunk:
     thunk_id: int
     expression: ASTNode
     block_id: int
+    type_name: str
     is_array_element: bool = False
     store_capable: bool = False
 
@@ -299,7 +302,12 @@ class AlgolIrCompiler:
                 param_types=(
                     _INTEGER_TYPE,
                     _INTEGER_TYPE,
-                    *(parameter.type_name for parameter in procedure.parameters),
+                    *(
+                        _INTEGER_TYPE
+                        if parameter.mode == _NAME_MODE
+                        else parameter.type_name
+                        for parameter in procedure.parameters
+                    ),
                 ),
                 return_type=procedure.return_type,
             )
@@ -313,6 +321,18 @@ class AlgolIrCompiler:
             self.procedure_signatures[_THUNK_STORE_LABEL] = ProcedureSignaturePlan(
                 param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
                 return_type=_INTEGER_TYPE,
+            )
+            self.procedure_signatures[_THUNK_EVAL_REAL_LABEL] = (
+                ProcedureSignaturePlan(
+                    param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
+                    return_type=_REAL_TYPE,
+                )
+            )
+            self.procedure_signatures[_THUNK_STORE_REAL_LABEL] = (
+                ProcedureSignaturePlan(
+                    param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _REAL_TYPE),
+                    return_type=_INTEGER_TYPE,
+                )
             )
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
         self.variable_slots = self._collect_variable_slots(self.semantic_blocks)
@@ -399,8 +419,22 @@ class AlgolIrCompiler:
         self._emit(IrOp.HALT)
         self._compile_procedures(type_result.semantic.procedures)
         if self.has_by_name_parameters:
-            self._compile_eval_thunk_dispatcher()
-            self._compile_store_thunk_dispatcher()
+            self._compile_eval_thunk_dispatcher(
+                label=_THUNK_EVAL_LABEL,
+                thunk_kind="word",
+            )
+            self._compile_eval_thunk_dispatcher(
+                label=_THUNK_EVAL_REAL_LABEL,
+                thunk_kind=_REAL_TYPE,
+            )
+            self._compile_store_thunk_dispatcher(
+                label=_THUNK_STORE_LABEL,
+                thunk_kind="word",
+            )
+            self._compile_store_thunk_dispatcher(
+                label=_THUNK_STORE_REAL_LABEL,
+                thunk_kind=_REAL_TYPE,
+            )
 
         return CompileResult(
             program=self.program,
@@ -1498,7 +1532,11 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         descriptor: int,
     ) -> int:
-        thunk = self._register_eval_thunk(argument, scope.block_id)
+        thunk = self._register_eval_thunk(
+            argument,
+            scope.block_id,
+            type_name=parameter.type_name,
+        )
         self._emit_write_eval_thunk_descriptor(thunk, scope, descriptor)
         tagged_descriptor = self._fresh_reg()
         self._emit(
@@ -1519,6 +1557,7 @@ class AlgolIrCompiler:
         thunk = self._register_eval_thunk(
             variable,
             scope.block_id,
+            type_name=parameter.type_name,
             is_array_element=True,
             store_capable=parameter.may_write,
         )
@@ -1545,6 +1584,7 @@ class AlgolIrCompiler:
         argument: ASTNode,
         block_id: int,
         *,
+        type_name: str,
         is_array_element: bool = False,
         store_capable: bool = False,
     ) -> _EvalThunk:
@@ -1557,6 +1597,7 @@ class AlgolIrCompiler:
             thunk_id=len(self.eval_thunks) + 1,
             expression=argument,
             block_id=block_id,
+            type_name=type_name,
             is_array_element=is_array_element,
             store_capable=store_capable,
         )
@@ -1630,8 +1671,12 @@ class AlgolIrCompiler:
         for procedure in procedures:
             self._compile_procedure(procedure)
 
-    def _compile_eval_thunk_dispatcher(self) -> None:
-        self._label(_THUNK_EVAL_LABEL)
+    def _compile_eval_thunk_dispatcher(self, *, label: str, thunk_kind: str) -> None:
+        previous_return_type = self.current_function_return_type
+        self.current_function_return_type = (
+            _REAL_TYPE if thunk_kind == _REAL_TYPE else _INTEGER_TYPE
+        )
+        self._label(label)
         descriptor = _STATIC_LINK_PARAM_REG
         active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
         code_id = self._fresh_reg()
@@ -1649,6 +1694,8 @@ class AlgolIrCompiler:
             IrRegister(self._const_reg(_THUNK_CALLER_FRAME_OFFSET)),
         )
         for thunk in self.eval_thunks:
+            if (thunk_kind == _REAL_TYPE) != (thunk.type_name == _REAL_TYPE):
+                continue
             index = self.if_count
             self.if_count += 1
             else_label = f"if_{index}_else"
@@ -1681,24 +1728,27 @@ class AlgolIrCompiler:
                 )
                 value = self._fresh_reg()
                 self._emit(
-                    IrOp.LOAD_WORD,
+                    IrOp.LOAD_F64 if thunk.type_name == _REAL_TYPE else IrOp.LOAD_WORD,
                     IrRegister(value),
                     IrRegister(data_pointer),
                     IrRegister(byte_offset),
                 )
             else:
                 value = self._compile_expr(thunk.expression, thunk_scope)
-            self._copy_reg(dst=_RESULT_REG, src=value)
+            self._copy_scalar_reg(type_name=thunk.type_name, dst=_RESULT_REG, src=value)
             self._emit_leave_thunk_helper()
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
             self._label(end_label)
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         self._emit(IrOp.RET)
+        self.current_function_return_type = previous_return_type
 
-    def _compile_store_thunk_dispatcher(self) -> None:
-        self._label(_THUNK_STORE_LABEL)
+    def _compile_store_thunk_dispatcher(self, *, label: str, thunk_kind: str) -> None:
+        previous_return_type = self.current_function_return_type
+        self.current_function_return_type = _INTEGER_TYPE
+        self._label(label)
         descriptor = _STATIC_LINK_PARAM_REG
         active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
         value_reg = _VALUE_PARAM_BASE_REG
@@ -1718,6 +1768,8 @@ class AlgolIrCompiler:
         )
         for thunk in self.eval_thunks:
             if not thunk.store_capable:
+                continue
+            if (thunk_kind == _REAL_TYPE) != (thunk.type_name == _REAL_TYPE):
                 continue
             index = self.if_count
             self.if_count += 1
@@ -1749,7 +1801,7 @@ class AlgolIrCompiler:
                 helper_failure=True,
             )
             self._emit(
-                IrOp.STORE_WORD,
+                IrOp.STORE_F64 if thunk.type_name == _REAL_TYPE else IrOp.STORE_WORD,
                 IrRegister(value_reg),
                 IrRegister(data_pointer),
                 IrRegister(byte_offset),
@@ -1763,6 +1815,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit(IrOp.RET)
+        self.current_function_return_type = previous_return_type
 
     def _compile_procedure(self, procedure: ProcedureDescriptor) -> None:
         body = self._find_ast_by_id(procedure.body_node_id)
@@ -1818,12 +1871,19 @@ class AlgolIrCompiler:
         )
         self._initialize_scalar_slots(scope)
         for index, parameter in enumerate(procedure.parameters):
-            self._store_scalar_reg(
-                type_name=parameter.type_name,
-                value_reg=_VALUE_PARAM_BASE_REG + index,
-                base_reg=scope.frame_base_reg,
-                offset=parameter.slot_offset,
-            )
+            if parameter.mode == _NAME_MODE:
+                self._store_word_reg(
+                    value_reg=_VALUE_PARAM_BASE_REG + index,
+                    base_reg=scope.frame_base_reg,
+                    offset=parameter.slot_offset,
+                )
+            else:
+                self._store_scalar_reg(
+                    type_name=parameter.type_name,
+                    value_reg=_VALUE_PARAM_BASE_REG + index,
+                    base_reg=scope.frame_base_reg,
+                    offset=parameter.slot_offset,
+                )
         self._allocate_arrays(scope)
 
         if body.rule_name == "block":
@@ -2037,13 +2097,21 @@ class AlgolIrCompiler:
         )
         self._emit(
             IrOp.CALL,
-            IrLabel(_THUNK_EVAL_LABEL),
+            IrLabel(
+                _THUNK_EVAL_REAL_LABEL
+                if reference.type_name == _REAL_TYPE
+                else _THUNK_EVAL_LABEL
+            ),
             IrRegister(descriptor),
             IrRegister(active_thunk_heap_mark),
         )
         self._emit_propagate_thunk_failure(scope)
         self._emit_handle_pending_goto_after_call(scope)
-        self._copy_reg(dst=dst, src=_RESULT_REG)
+        self._copy_scalar_reg(
+            type_name=reference.type_name,
+            dst=dst,
+            src=_REAL_RESULT_REG if reference.type_name == _REAL_TYPE else _RESULT_REG,
+        )
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(storage_label)
         self._emit_load_scalar(reference.type_name, dst, pointer, 0)
@@ -2132,7 +2200,11 @@ class AlgolIrCompiler:
             )
             self._emit(
                 IrOp.CALL,
-                IrLabel(_THUNK_STORE_LABEL),
+                IrLabel(
+                    _THUNK_STORE_REAL_LABEL
+                    if reference.type_name == _REAL_TYPE
+                    else _THUNK_STORE_LABEL
+                ),
                 IrRegister(descriptor),
                 IrRegister(active_thunk_heap_mark),
                 IrRegister(value_reg),
@@ -2559,7 +2631,7 @@ class AlgolIrCompiler:
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
-        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_zero_result_reg()
         self._emit_leave_thunk_helper()
         self._emit_restore_active_thunk_heap_mark(scope)
         self._emit(IrOp.RET)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -574,6 +574,38 @@ class TestAlgolIrCompiler:
         assert result.procedure_signatures["_fn_algol_eval_thunk"].param_count == 2
         assert any(call.operands[0].name == "_fn_algol_eval_thunk" for call in calls)
 
+    def test_compiles_read_only_real_by_name_expression_eval_thunk(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "real procedure id(x); real x; begin id := x end; "
+                "y := id(1.5); "
+                "if y > 1.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+
+        assert "_fn_algol_eval_real_thunk" in labels
+        assert result.procedure_signatures["_fn_algol_eval_real_thunk"].param_types == (
+            "integer",
+            "integer",
+        )
+        assert (
+            result.procedure_signatures["_fn_algol_eval_real_thunk"].return_type
+            == "real"
+        )
+        assert any(call.operands[0].name == "_fn_algol_eval_real_thunk" for call in calls)
+
     def test_compiles_array_element_by_name_eval_and_store_thunks(
         self,
     ) -> None:
@@ -603,6 +635,22 @@ class TestAlgolIrCompiler:
         assert "_fn_algol_store_thunk" in calls
         assert result.procedure_signatures["_fn_algol_eval_thunk"].param_count == 2
         assert result.procedure_signatures["_fn_algol_store_thunk"].param_count == 3
+
+    def test_compiles_real_by_name_scalar_write_through_storage_pointer(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "procedure bump(x); real x; begin x := x + 1.5 end; "
+                "y := 2.0; "
+                "bump(y); "
+                "if y > 3.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert IrOp.LOAD_F64 in opcodes
+        assert IrOp.STORE_F64 in opcodes
 
     def test_compiles_array_read_inside_expression_eval_thunk(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -701,11 +701,11 @@ class AlgolTypeChecker:
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
             parameter_type = spec_types.get(formal.value)
-            if mode == NAME and parameter_type not in {INTEGER, BOOLEAN}:
+            if mode == NAME and parameter_type not in {INTEGER, BOOLEAN, REAL}:
                 self._error(
                     formal,
-                    f"by-name parameter {formal.value!r} must have an integer "
-                    "or boolean specifier",
+                    f"by-name parameter {formal.value!r} must have an integer, "
+                    "boolean, or real specifier",
                 )
             elif mode == VALUE and parameter_type not in {INTEGER, BOOLEAN, REAL}:
                 self._error(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -816,6 +816,23 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "by-name parameter 'x' expects integer" in result.diagnostics[0].message
 
+    def test_accepts_real_by_name_parameter(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "procedure bump(x); real x; begin x := x + 1.5 end; "
+            "y := 1.5; bump(y); "
+            "if y > 2.0 then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.mode == "name"
+        assert parameter.type_name == "real"
+        assert parameter.may_write
+
     def test_rejects_wrong_type_for_boolean_value_parameter(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -525,6 +525,27 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_read_only_real_by_name_expression_runs_through_eval_thunk(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "real procedure id(x); real x; begin id := x end; "
+            "y := id(1.5); "
+            "if y > 1.0 then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_real_by_name_scalar_write_through_storage_pointer(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "procedure bump(x); real x; begin x := x + 1.5 end; "
+            "y := 2.0; "
+            "bump(y); "
+            "if y > 3.0 then result := 9 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_nested_by_name_parameter_forwards_original_storage_pointer(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- allow `real` by-name formals in the ALGOL type checker
- lower real by-name procedure calls correctly by keeping the call ABI pointer-shaped while using real-specific thunk evaluation paths when a descriptor is dereferenced
- add focused checker, IR, and WASM coverage for writable real by-name scalar formals and read-only real expression thunks

## Testing
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_type_checker.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=../compiler-ir/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-encoder/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../virtual-machine/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_ir_to_wasm_compiler.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:../algol-ir-compiler/src:../virtual-machine/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../wasm-module-encoder/src:../ir-to-wasm-compiler/src:../ir-to-wasm-validator/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_wasm_compiler.py -q`
- `/Users/adhithya/.local/bin/python3.12 -m py_compile code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`