### PR TITLE
feat(prolog): add parsed source loader

### DIFF
--- a/code/packages/python/prolog-loader/BUILD
+++ b/code/packages/python/prolog-loader/BUILD
@@ -1,4 +1,4 @@
 uv venv --quiet --clear
-uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../lang-parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ".[dev]" --quiet
+uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ".[dev]" --quiet
 .venv/bin/python -c "import pathlib, platform; [p.unlink() for p in pathlib.Path('.venv/lib').glob('python*/site-packages/coverage/tracer*.so')] if platform.system() == 'Darwin' else None"
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/prolog-loader/BUILD
+++ b/code/packages/python/prolog-loader/BUILD
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../lang-parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ".[dev]" --quiet
+.venv/bin/python -c "import pathlib, platform; [p.unlink() for p in pathlib.Path('.venv/lib').glob('python*/site-packages/coverage/tracer*.so')] if platform.system() == 'Darwin' else None"
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/prolog-loader/BUILD_windows
+++ b/code/packages/python/prolog-loader/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ..\symbol-core -e ..\logic-core -e ..\logic-engine -e ..\lexer -e ..\parser -e ..\lang-parser -e ..\grammar-tools -e ..\graph -e ..\directed-graph -e ..\state-machine -e ..\prolog-core -e ..\prolog-lexer -e ..\iso-prolog-lexer -e ..\swi-prolog-lexer -e ..\prolog-parser -e ..\prolog-operator-parser -e ..\iso-prolog-parser -e ..\swi-prolog-parser -e ..\logic-builtins -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests\ -v

--- a/code/packages/python/prolog-loader/BUILD_windows
+++ b/code/packages/python/prolog-loader/BUILD_windows
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ..\symbol-core -e ..\logic-core -e ..\logic-engine -e ..\lexer -e ..\parser -e ..\lang-parser -e ..\grammar-tools -e ..\graph -e ..\directed-graph -e ..\state-machine -e ..\prolog-core -e ..\prolog-lexer -e ..\iso-prolog-lexer -e ..\swi-prolog-lexer -e ..\prolog-parser -e ..\prolog-operator-parser -e ..\iso-prolog-parser -e ..\swi-prolog-parser -e ..\logic-builtins -e ".[dev]" --quiet
+uv pip install -e ..\symbol-core -e ..\logic-core -e ..\logic-engine -e ..\lexer -e ..\parser -e ..\grammar-tools -e ..\graph -e ..\directed-graph -e ..\state-machine -e ..\prolog-core -e ..\prolog-lexer -e ..\iso-prolog-lexer -e ..\swi-prolog-lexer -e ..\prolog-parser -e ..\prolog-operator-parser -e ..\iso-prolog-parser -e ..\swi-prolog-parser -e ..\logic-builtins -e ".[dev]" --quiet
 .venv\Scripts\python -m pytest tests\ -v

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- add `LoadedPrologSource` as a shared loader result over dialect parser outputs
+- add `load_iso_prolog_source(...)` and `load_swi_prolog_source(...)`
+- add explicit `run_initialization_goals(...)` execution with ordered
+  `initialization/1` handling
+- support optional goal adaptation so parsed initialization goals can be mapped
+  into richer runtime or builtin goals before execution

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -1,0 +1,15 @@
+# prolog-loader
+
+`prolog-loader` is the first explicit loading layer above the Prolog dialect
+parsers.
+
+It keeps parsing side-effect free, then exposes helpers to:
+
+- normalize dialect-specific parsed sources into one shared loaded shape
+- collect `initialization/1` directives in source order
+- run those initialization goals explicitly against the loaded `Program`
+- optionally adapt parsed goals into richer runtime or builtin goals before
+  execution
+
+This package is the bridge between “we parsed a Prolog file” and “we loaded a
+Prolog file and are ready to run its startup behavior.”

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -1,0 +1,72 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-prolog-loader"
+version = "0.1.0"
+description = "Loader helpers for parsed Prolog sources and explicit initialization execution"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = [
+    "coding-adventures-iso-prolog-parser>=0.1.0",
+    "coding-adventures-logic-engine>=0.10.0",
+    "coding-adventures-prolog-core>=0.1.0",
+    "coding-adventures-prolog-parser>=0.1.0",
+    "coding-adventures-swi-prolog-parser>=0.1.0",
+]
+keywords = ["prolog", "loader", "logic-programming", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/PR09-prolog-loader.md"
+
+[project.optional-dependencies]
+dev = [
+    "coding-adventures-logic-builtins>=0.13.0",
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+[tool.uv.sources]
+coding-adventures-iso-prolog-parser = { path = "../iso-prolog-parser", editable = true }
+coding-adventures-logic-builtins = { path = "../logic-builtins", editable = true }
+coding-adventures-logic-engine = { path = "../logic-engine", editable = true }
+coding-adventures-prolog-core = { path = "../prolog-core", editable = true }
+coding-adventures-prolog-parser = { path = "../prolog-parser", editable = true }
+coding-adventures-swi-prolog-parser = { path = "../swi-prolog-parser", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/prolog_loader"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=prolog_loader --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/prolog_loader"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
@@ -1,0 +1,23 @@
+"""Loader helpers for parsed Prolog sources and explicit initialization runs."""
+
+from prolog_loader.loader import (
+    GoalAdapter,
+    LoadedPrologSource,
+    PrologInitializationError,
+    __version__,
+    load_iso_prolog_source,
+    load_parsed_prolog_source,
+    load_swi_prolog_source,
+    run_initialization_goals,
+)
+
+__all__ = [
+    "__version__",
+    "GoalAdapter",
+    "LoadedPrologSource",
+    "PrologInitializationError",
+    "load_iso_prolog_source",
+    "load_parsed_prolog_source",
+    "load_swi_prolog_source",
+    "run_initialization_goals",
+]

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -1,0 +1,181 @@
+"""Loader helpers that bridge parsed Prolog sources into runnable artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from logic_engine import (
+    Clause,
+    Compound,
+    GoalExpr,
+    Program,
+    State,
+    Term,
+    goal_from_term,
+    solve_from,
+)
+from prolog_core import OperatorTable, PredicateRegistry, PrologDirective
+from prolog_parser import ParsedQuery
+
+__version__ = "0.1.0"
+
+type GoalAdapter = Callable[[GoalExpr], object]
+
+
+class ParsedSourceLike(Protocol):
+    """The shared surface returned by dialect-specific Prolog parsers."""
+
+    program: Program
+    clauses: tuple[Clause, ...]
+    queries: tuple[ParsedQuery, ...]
+    directives: tuple[PrologDirective, ...]
+    operator_table: OperatorTable
+    predicate_registry: PredicateRegistry
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedPrologSource:
+    """A parsed-and-loaded Prolog source with derived initialization metadata."""
+
+    program: Program
+    clauses: tuple[Clause, ...]
+    queries: tuple[ParsedQuery, ...]
+    directives: tuple[PrologDirective, ...]
+    operator_table: OperatorTable
+    predicate_registry: PredicateRegistry
+    initialization_directives: tuple[PrologDirective, ...]
+    initialization_terms: tuple[Term, ...]
+    initialization_goals: tuple[GoalExpr, ...]
+
+
+class PrologInitializationError(RuntimeError):
+    """Raised when a loader initialization directive cannot complete."""
+
+    def __init__(
+        self,
+        index: int,
+        directive: PrologDirective,
+        goal_term: Term,
+        reason: str,
+    ) -> None:
+        self.index = index
+        self.directive = directive
+        self.goal_term = goal_term
+        super().__init__(
+            f"initialization directive {index} {reason}: {goal_term}",
+        )
+
+
+def load_parsed_prolog_source(parsed_source: ParsedSourceLike) -> LoadedPrologSource:
+    """Normalize a dialect-specific parsed source into one loader result."""
+
+    predicate_registry = parsed_source.predicate_registry
+    initialization_directives = predicate_registry.initialization_directives
+    initialization_terms = tuple(
+        _initialization_term(directive_value)
+        for directive_value in initialization_directives
+    )
+    return LoadedPrologSource(
+        program=parsed_source.program,
+        clauses=parsed_source.clauses,
+        queries=parsed_source.queries,
+        directives=parsed_source.directives,
+        operator_table=parsed_source.operator_table,
+        predicate_registry=predicate_registry,
+        initialization_directives=initialization_directives,
+        initialization_terms=initialization_terms,
+        initialization_goals=tuple(
+            goal_from_term(term_value) for term_value in initialization_terms
+        ),
+    )
+
+
+def load_iso_prolog_source(
+    source: str,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> LoadedPrologSource:
+    """Parse and load one ISO/Core Prolog source file."""
+
+    from iso_prolog_parser import parse_iso_source
+
+    return load_parsed_prolog_source(
+        parse_iso_source(source, operator_table=operator_table),
+    )
+
+
+def load_swi_prolog_source(
+    source: str,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> LoadedPrologSource:
+    """Parse and load one SWI-Prolog source file."""
+
+    from swi_prolog_parser import parse_swi_source
+
+    return load_parsed_prolog_source(
+        parse_swi_source(source, operator_table=operator_table),
+    )
+
+
+def run_initialization_goals(
+    loaded_source: LoadedPrologSource,
+    *,
+    state: State | None = None,
+    goal_adapter: GoalAdapter | None = None,
+) -> State:
+    """Execute collected ``initialization/1`` directives in source order.
+
+    Parsing and loading stay side-effect free. This helper gives callers an
+    explicit place to run startup goals later, optionally adapting parsed goals
+    into richer runtime/builtin goals before execution.
+    """
+
+    current_state = State() if state is None else state
+    for index, (directive_value, goal_term, goal_value) in enumerate(
+        zip(
+            loaded_source.initialization_directives,
+            loaded_source.initialization_terms,
+            loaded_source.initialization_goals,
+            strict=True,
+        ),
+        start=1,
+    ):
+        active_goal: object = goal_value
+        if goal_adapter is not None:
+            active_goal = goal_adapter(goal_value)
+
+        try:
+            next_state = next(
+                solve_from(loaded_source.program, active_goal, current_state),
+                None,
+            )
+        except Exception as error:
+            raise PrologInitializationError(
+                index,
+                directive_value,
+                goal_term,
+                "raised an exception while running",
+            ) from error
+
+        if next_state is None:
+            raise PrologInitializationError(
+                index,
+                directive_value,
+                goal_term,
+                "failed",
+            )
+
+        current_state = next_state
+
+    return current_state
+
+
+def _initialization_term(directive_value: PrologDirective) -> Term:
+    term_value = directive_value.term
+    if not isinstance(term_value, Compound) or len(term_value.args) != 1:
+        msg = "initialization directives must have the form initialization(Goal)"
+        raise TypeError(msg)
+    return term_value.args[0]

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1,0 +1,110 @@
+"""Tests for parsed-source loading and explicit initialization execution."""
+
+from __future__ import annotations
+
+import pytest
+from logic_builtins import assertzo, dynamico
+from logic_engine import (
+    GoalExpr,
+    RelationCall,
+    atom,
+    reify,
+    relation,
+    visible_clauses_for,
+)
+
+from prolog_loader import (
+    PrologInitializationError,
+    __version__,
+    load_iso_prolog_source,
+    load_swi_prolog_source,
+    run_initialization_goals,
+)
+
+
+class TestVersion:
+    """Verify the package is importable and versioned."""
+
+    def test_version_exists(self) -> None:
+        assert __version__ == "0.1.0"
+
+
+class TestPrologLoader:
+    """Loading should keep parsing separate from explicit initialization."""
+
+    def test_load_iso_source_collects_initialization_metadata(self) -> None:
+        loaded = load_iso_prolog_source(
+            """
+            :- dynamic(parent/2).
+            :- initialization(main(Result)).
+            parent(homer, bart).
+            main(done).
+            """,
+        )
+
+        assert len(loaded.initialization_directives) == 1
+        assert str(loaded.initialization_terms[0]) == "main(Result)"
+        assert loaded.program.dynamic_relations == frozenset(
+            {relation("parent", 2).key()},
+        )
+        assert loaded.predicate_registry.get("parent", 2) is not None
+
+    def test_load_swi_source_collects_initialization_metadata(self) -> None:
+        loaded = load_swi_prolog_source(
+            """
+            :- initialization(main).
+            main.
+            """,
+        )
+
+        assert len(loaded.initialization_goals) == 1
+        assert str(loaded.initialization_terms[0]) == "main"
+
+    def test_run_initialization_goals_executes_clause_backed_startup_goals(
+        self,
+    ) -> None:
+        loaded = load_iso_prolog_source(
+            """
+            :- initialization(main(Result)).
+            main(done).
+            """,
+        )
+
+        state = run_initialization_goals(loaded)
+        result_var = loaded.initialization_directives[0].variables["Result"]
+
+        assert reify(result_var, state.substitution) == atom("done")
+
+    def test_run_initialization_goals_accepts_goal_adapters_for_builtins(
+        self,
+    ) -> None:
+        loaded = load_iso_prolog_source(
+            """
+            :- initialization(dynamico(memo, 1)).
+            :- initialization(assertzo(memo(ok))).
+            """,
+        )
+
+        def adapt(goal: GoalExpr) -> object:
+            if isinstance(goal, RelationCall):
+                if goal.relation == relation("dynamico", 2):
+                    return dynamico(*goal.args)
+                if goal.relation == relation("assertzo", 1):
+                    return assertzo(goal.args[0])
+            return goal
+
+        state = run_initialization_goals(loaded, goal_adapter=adapt)
+        memo = relation("memo", 1)
+        visible = visible_clauses_for(loaded.program, memo, state)
+
+        assert len(visible) == 1
+        assert visible[0].head == memo("ok")
+
+    def test_run_initialization_goals_raises_for_failed_startup_goals(self) -> None:
+        loaded = load_iso_prolog_source(":- initialization(missing_goal).\n")
+
+        with pytest.raises(
+            PrologInitializationError,
+            match=r"initialization directive 1 failed: missing_goal",
+        ):
+            run_initialization_goals(loaded)

--- a/code/specs/PR09-prolog-loader.md
+++ b/code/specs/PR09-prolog-loader.md
@@ -1,0 +1,71 @@
+# PR09 - Prolog Loader And Explicit `initialization/1` Execution
+
+## Overview
+
+PR08 added predicate-property directives and started collecting structured
+`initialization/1` metadata, but the system still stopped at “parsed source”.
+This batch adds the first shared loading layer above the dialect frontends.
+
+The loader keeps parsing side-effect free, then exposes an explicit API that:
+
+- normalizes dialect-specific parsed sources into one loaded shape
+- collects startup directives in source order
+- runs those initialization goals later and on purpose
+
+## Scope
+
+### New `prolog-loader` package
+
+Add a new Python package that exports:
+
+- `LoadedPrologSource`
+- `load_parsed_prolog_source(parsed_source)`
+- `load_iso_prolog_source(source, *, operator_table=None)`
+- `load_swi_prolog_source(source, *, operator_table=None)`
+- `run_initialization_goals(loaded_source, *, state=None, goal_adapter=None)`
+- `PrologInitializationError`
+
+`LoadedPrologSource` retains the parsed executable artifacts:
+
+- `program`
+- `clauses`
+- `queries`
+- `directives`
+- `operator_table`
+- `predicate_registry`
+
+and adds derived loader-facing startup views:
+
+- `initialization_directives`
+- `initialization_goals`
+- `initialization_terms`
+
+### Explicit startup execution
+
+`run_initialization_goals(...)` executes initialization goals in source order
+against the loaded `Program`.
+
+Important behavior:
+
+- parsing still does not auto-run startup code
+- startup goals run only when the caller asks
+- each startup goal starts from the state produced by the previous one
+- failure raises `PrologInitializationError`
+- callers may supply `goal_adapter` to rewrite parsed goals into richer runtime
+  or builtin goals before execution
+
+The adapter hook is how we can start bridging parser-lowered goals into more
+complete Prolog runtime behavior without hardwiring every future builtin into
+the parser or loader immediately.
+
+## Non-Goals
+
+This PR does not yet implement:
+
+- automatic builtin translation from plain Prolog callable terms
+- module-aware loading
+- `consult/1` or file inclusion
+- DCG expansion
+- auto-running `initialization/1` during parsing
+
+Those follow naturally on top of the loader boundary introduced here.


### PR DESCRIPTION
## Summary
- add a new `prolog-loader` package for normalizing parsed dialect sources into one shared loaded shape
- collect `initialization/1` directives as executable startup goals and explicit startup terms
- add `run_initialization_goals(...)` with an optional goal adapter so startup can be executed later and mapped into richer runtime or builtin goals

## Testing
- `python3.12 -m ruff check code/packages/python/prolog-loader`
- `PYTHONPATH=... python3.12 -m pytest code/packages/python/prolog-loader/tests -v`
- `git diff --check`

## Notes
- I also tried the package `BUILD` script, but the local `uv venv --quiet --clear` step hung in this desktop environment before test execution, which matches the earlier local `uv` issue we’ve seen on these Prolog batches. The focused `ruff` and `pytest` runs above completed successfully.