### PR TITLE
feat(qr-code): add TypeScript + Rust QR Code encoder (ISO/IEC 18004:2015)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -226,6 +226,7 @@ members = [
     "brotli",
     "deflate",
     "gf256",
+    "qr-code",
     "image-codec-bmp",
     "image-codec-ppm",
     "image-codec-qoi",

--- a/code/packages/rust/qr-code/BUILD
+++ b/code/packages/rust/qr-code/BUILD
@@ -1,0 +1,1 @@
+cargo test -p qr-code -- --nocapture

--- a/code/packages/rust/qr-code/CHANGELOG.md
+++ b/code/packages/rust/qr-code/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — qr-code (Rust)
+
+## 0.1.0 — 2026-04-23
+
+Initial release.
+
+### Added
+
+- `encode(input, ecc) → Result<ModuleGrid, QRCodeError>` — Full QR Code encoding pipeline:
+  - Auto mode selection: numeric (digits only) → alphanumeric (45-char set) → byte (UTF-8)
+  - Version selection: minimum version 1–40 that fits the input at the ECC level
+  - Bit stream assembly: mode indicator + char count + data + terminator + padding (0xEC/0x11)
+  - Block splitting and Reed-Solomon ECC (b=0 convention, GF(256)/0x11D)
+  - Interleaving: data codewords round-robin, then ECC codewords round-robin
+  - Grid initialization: three finder patterns, separators, timing strips, alignment patterns (v2+), dark module
+  - Two-column zigzag data placement (bottom-right to top-left, timing column skipped)
+  - 8 mask patterns evaluated with 4-rule ISO penalty scoring
+  - Format information: BCH(15,5) with generator 0x537, XOR mask 0x5412
+  - Version information (v7+): BCH(18,6) with generator 0x1F25
+
+- `encode_and_layout(input, ecc, config) → Result<PaintScene, QRCodeError>` — encode + barcode-2d layout
+
+- `EccLevel` enum — `L`, `M`, `Q`, `H`
+
+- `QRCodeError` enum — `InputTooLong(String)`
+
+- `VERSION` constant — `"0.1.0"`
+
+- 24 unit tests + 1 doc-test; all passing

--- a/code/packages/rust/qr-code/Cargo.toml
+++ b/code/packages/rust/qr-code/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "qr-code"
+version = "0.1.0"
+edition = "2021"
+description = "QR Code encoder — ISO/IEC 18004:2015 compliant, produces scannable QR Codes"
+
+[dependencies]
+barcode-2d = { path = "../barcode-2d" }
+gf256 = { path = "../gf256" }
+paint-instructions = { path = "../paint-instructions" }

--- a/code/packages/rust/qr-code/README.md
+++ b/code/packages/rust/qr-code/README.md
@@ -1,0 +1,78 @@
+# qr-code (Rust)
+
+QR Code encoder — ISO/IEC 18004:2015 compliant.
+
+Encodes any UTF-8 string into a scannable QR Code. Outputs an abstract
+`ModuleGrid` (no pixel coordinates yet) that can be passed to `barcode-2d`'s
+`layout()` function for pixel-level rendering.
+
+## Pipeline
+
+```
+input string
+  → mode selection    (numeric / alphanumeric / byte)
+  → version selection (smallest version 1–40 that fits at the ECC level)
+  → bit stream        (mode indicator + char count + data bits + padding)
+  → blocks + RS ECC   (GF(256) b=0 convention, polynomial 0x11D)
+  → interleave        (data CWs, then ECC CWs, round-robin across blocks)
+  → grid init         (finder × 3, separator, timing, alignment, format, dark)
+  → zigzag placement  (two-column snake from bottom-right corner)
+  → mask evaluation   (8 patterns, 4-rule penalty, pick lowest)
+  → finalize          (format info + version info v7+)
+  → ModuleGrid        (abstract boolean grid, true = dark)
+```
+
+## Usage
+
+```rust
+use qr_code::{encode, encode_and_layout, EccLevel};
+use barcode_2d::Barcode2DLayoutConfig;
+
+// Just the module grid (abstract units — no pixels):
+let grid = encode("https://example.com", EccLevel::M).unwrap();
+assert_eq!(grid.rows, 25); // version 2 → 25×25
+
+// Grid → pixel-resolved PaintScene (via barcode-2d):
+let config = Barcode2DLayoutConfig::default();
+let scene = encode_and_layout("HELLO WORLD", EccLevel::M, &config).unwrap();
+assert!(scene.width > 0.0);
+```
+
+## API
+
+### `encode(input, ecc) → Result<ModuleGrid, QRCodeError>`
+
+Encodes a UTF-8 string into a QR Code module grid.
+
+- Returns a `(4V+17) × (4V+17)` grid where `true` = dark module.
+- Returns `Err(QRCodeError::InputTooLong)` if input exceeds version-40 capacity.
+- Selects the minimum version that fits the input at the ECC level.
+- Mode is auto-selected: numeric → alphanumeric → byte.
+
+### `encode_and_layout(input, ecc, config) → Result<PaintScene, QRCodeError>`
+
+Encodes and converts to a pixel-resolved `PaintScene` via `barcode-2d`'s
+`layout()`. Accepts a `&Barcode2DLayoutConfig`.
+
+## ECC Levels
+
+| Level | Recovery | Notes                                  |
+|-------|----------|----------------------------------------|
+| L     | ~7%      | Highest data density                   |
+| M     | ~15%     | General-purpose default                |
+| Q     | ~25%     | Moderate damage expected               |
+| H     | ~30%     | High damage risk, or overlaid logo     |
+
+## Error Types
+
+- `QRCodeError::InputTooLong` — input exceeds version-40 capacity at the chosen ECC level.
+
+## Dependencies
+
+- `barcode-2d`: `ModuleGrid` type, `layout()` pixel geometry
+- `gf256`: GF(256) field arithmetic (`multiply`, `power`)
+- `paint-instructions`: `PaintScene` type (for `encode_and_layout` return type)
+
+## Spec
+
+See `code/specs/qr-code.md` for the full specification.

--- a/code/packages/rust/qr-code/src/lib.rs
+++ b/code/packages/rust/qr-code/src/lib.rs
@@ -1,0 +1,1078 @@
+//! # qr-code
+//!
+//! QR Code encoder — ISO/IEC 18004:2015 compliant.
+//!
+//! Encodes any UTF-8 string into a scannable QR Code.  Outputs a
+//! [`ModuleGrid`] (abstract boolean grid) that can be passed to
+//! `barcode-2d`'s [`layout()`] for pixel rendering, or to [`render_svg()`]
+//! for a one-shot SVG string.
+//!
+//! ## Encoding pipeline
+//!
+//! ```text
+//! input string
+//!   → mode selection    (numeric / alphanumeric / byte)
+//!   → version selection (smallest v1–40 that fits at the ECC level)
+//!   → bit stream        (mode indicator + char count + data + padding)
+//!   → blocks + RS ECC   (GF(256) b=0 convention, poly 0x11D)
+//!   → interleave        (data CWs round-robin, then ECC CWs)
+//!   → grid init         (finder × 3, separators, timing, alignment, format, dark)
+//!   → zigzag placement  (two-column snake from bottom-right)
+//!   → mask evaluation   (8 patterns, 4-rule penalty, pick lowest)
+//!   → finalize          (format info + version info v7+)
+//!   → ModuleGrid
+//! ```
+
+pub const VERSION: &str = "0.1.0";
+
+use barcode_2d::{layout, Barcode2DLayoutConfig, ModuleGrid, ModuleShape};
+use gf256::{multiply as gf_mul, power as gf_power};
+use paint_instructions::PaintScene;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Error correction level.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EccLevel {
+    /// ~7% of codewords recoverable.
+    L,
+    /// ~15% of codewords recoverable (common default).
+    M,
+    /// ~25% of codewords recoverable.
+    Q,
+    /// ~30% of codewords recoverable.
+    H,
+}
+
+/// Errors produced by the encoder.
+#[derive(Debug)]
+pub enum QRCodeError {
+    /// Input is too long to fit in any version at the chosen ECC level.
+    InputTooLong(String),
+    /// Layout/rendering failed (e.g. invalid config passed to `encode_and_layout`).
+    LayoutError(String),
+}
+
+impl std::fmt::Display for QRCodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QRCodeError::InputTooLong(msg) => write!(f, "InputTooLong: {msg}"),
+            QRCodeError::LayoutError(msg)   => write!(f, "LayoutError: {msg}"),
+        }
+    }
+}
+impl std::error::Error for QRCodeError {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECC level constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn ecc_indicator(ecc: EccLevel) -> u16 {
+    match ecc {
+        EccLevel::L => 0b01,
+        EccLevel::M => 0b00,
+        EccLevel::Q => 0b11,
+        EccLevel::H => 0b10,
+    }
+}
+
+fn ecc_idx(ecc: EccLevel) -> usize {
+    match ecc {
+        EccLevel::L => 0,
+        EccLevel::M => 1,
+        EccLevel::Q => 2,
+        EccLevel::H => 3,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ISO 18004:2015 — Capacity tables (Table 9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// ECC codewords per block, indexed [ecc_idx][version].  Index 0 is padding.
+static ECC_CODEWORDS_PER_BLOCK: [[i32; 41]; 4] = [
+    // L:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+    [-1,  7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+    // M:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+    [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28],
+    // Q:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+    [-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+    // H:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+    [-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+];
+
+/// Number of error correction blocks, indexed [ecc_idx][version].
+static NUM_BLOCKS: [[i32; 41]; 4] = [
+    // L:
+    [-1,  1,  1,  1,  1,  1,  2,  2,  2,  2,  4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25],
+    // M:
+    [-1,  1,  1,  1,  2,  2,  4,  4,  4,  5,  5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49],
+    // Q:
+    [-1,  1,  1,  2,  2,  4,  4,  6,  6,  8,  8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68],
+    // H:
+    [-1,  1,  1,  2,  4,  4,  4,  5,  6,  8,  8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 80],
+];
+
+/// Alignment pattern center coordinates, indexed by version - 1.
+static ALIGNMENT_POSITIONS: [&[u8]; 40] = [
+    &[],                                     // v1
+    &[6, 18],                                // v2
+    &[6, 22],                                // v3
+    &[6, 26],                                // v4
+    &[6, 30],                                // v5
+    &[6, 34],                                // v6
+    &[6, 22, 38],                            // v7
+    &[6, 24, 42],                            // v8
+    &[6, 26, 46],                            // v9
+    &[6, 28, 50],                            // v10
+    &[6, 30, 54],                            // v11
+    &[6, 32, 58],                            // v12
+    &[6, 34, 62],                            // v13
+    &[6, 26, 46, 66],                        // v14
+    &[6, 26, 48, 70],                        // v15
+    &[6, 26, 50, 74],                        // v16
+    &[6, 30, 54, 78],                        // v17
+    &[6, 30, 56, 82],                        // v18
+    &[6, 30, 58, 86],                        // v19
+    &[6, 34, 62, 90],                        // v20
+    &[6, 28, 50, 72, 94],                    // v21
+    &[6, 26, 50, 74, 98],                    // v22
+    &[6, 30, 54, 78, 102],                   // v23
+    &[6, 28, 54, 80, 106],                   // v24
+    &[6, 32, 58, 84, 110],                   // v25
+    &[6, 30, 58, 86, 114],                   // v26
+    &[6, 34, 62, 90, 118],                   // v27
+    &[6, 26, 50, 74,  98, 122],              // v28
+    &[6, 30, 54, 78, 102, 126],              // v29
+    &[6, 26, 52, 78, 104, 130],              // v30
+    &[6, 30, 56, 82, 108, 134],              // v31
+    &[6, 34, 60, 86, 112, 138],              // v32
+    &[6, 30, 58, 86, 114, 142],              // v33
+    &[6, 34, 62, 90, 118, 146],              // v34
+    &[6, 30, 54, 78, 102, 126, 150],         // v35
+    &[6, 24, 50, 76, 102, 128, 154],         // v36
+    &[6, 28, 54, 80, 106, 132, 158],         // v37
+    &[6, 32, 58, 84, 110, 136, 162],         // v38
+    &[6, 26, 54, 82, 110, 138, 166],         // v39
+    &[6, 30, 58, 86, 114, 142, 170],         // v40
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid geometry
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn symbol_size(version: usize) -> usize {
+    4 * version + 17
+}
+
+/// Total raw data+ECC bits (formula from Nayuki's reference, public domain).
+fn num_raw_data_modules(version: usize) -> usize {
+    let v = version as i64;
+    let mut result = (16 * v + 128) * v + 64;
+    if version >= 2 {
+        let num_align = (v / 7) + 2;
+        result -= (25 * num_align - 10) * num_align - 55;
+        if version >= 7 {
+            result -= 36;
+        }
+    }
+    result as usize
+}
+
+fn num_data_codewords(version: usize, ecc: EccLevel) -> usize {
+    let e = ecc_idx(ecc);
+    let raw_cw = num_raw_data_modules(version) / 8;
+    let ecc_cw = (NUM_BLOCKS[e][version] * ECC_CODEWORDS_PER_BLOCK[e][version]) as usize;
+    raw_cw - ecc_cw
+}
+
+fn num_remainder_bits(version: usize) -> usize {
+    num_raw_data_modules(version) % 8
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reed-Solomon (b=0 convention)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the monic RS generator of degree `n` with roots α⁰, α¹, …, α^{n-1}.
+///
+/// g(x) = ∏(x + αⁱ) for i in 0..n
+///
+/// The output vector has `n+1` elements, index 0 is the leading coefficient (1).
+fn build_generator(n: usize) -> Vec<u8> {
+    let mut g: Vec<u8> = vec![1u8];
+    for i in 0..n {
+        let ai = gf_power(2, i as u32); // α^i in GF(256), primitive element α = 2
+        let mut next = vec![0u8; g.len() + 1];
+        for (j, &gj) in g.iter().enumerate() {
+            next[j] ^= gj;
+            next[j + 1] ^= gf_mul(gj, ai);
+        }
+        g = next;
+    }
+    g
+}
+
+/// Compute `n` ECC bytes by LFSR polynomial division.
+///
+/// Returns remainder of D(x) · x^n mod G(x).
+fn rs_encode(data: &[u8], generator: &[u8]) -> Vec<u8> {
+    let n = generator.len() - 1;
+    let mut rem = vec![0u8; n];
+    for &b in data {
+        let fb = b ^ rem[0];
+        rem.copy_within(1.., 0);
+        rem[n - 1] = 0;
+        if fb != 0 {
+            for i in 0..n {
+                rem[i] ^= gf_mul(generator[i + 1], fb);
+            }
+        }
+    }
+    rem
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data encoding modes
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALPHANUM_CHARS: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+#[derive(Clone, Copy, PartialEq)]
+enum EncodingMode {
+    Numeric,
+    Alphanumeric,
+    Byte,
+}
+
+fn select_mode(input: &str) -> EncodingMode {
+    if input.chars().all(|c| c.is_ascii_digit()) {
+        return EncodingMode::Numeric;
+    }
+    if input.chars().all(|c| ALPHANUM_CHARS.contains(c)) {
+        return EncodingMode::Alphanumeric;
+    }
+    EncodingMode::Byte
+}
+
+fn mode_indicator(mode: EncodingMode) -> u16 {
+    match mode {
+        EncodingMode::Numeric => 0b0001,
+        EncodingMode::Alphanumeric => 0b0010,
+        EncodingMode::Byte => 0b0100,
+    }
+}
+
+fn char_count_bits(mode: EncodingMode, version: usize) -> u32 {
+    match mode {
+        EncodingMode::Numeric => if version <= 9 { 10 } else if version <= 26 { 12 } else { 14 },
+        EncodingMode::Alphanumeric => if version <= 9 { 9 } else if version <= 26 { 11 } else { 13 },
+        EncodingMode::Byte => if version <= 9 { 8 } else { 16 },
+    }
+}
+
+/// Bit writer: accumulates individual bits and flushes to bytes.
+struct BitWriter {
+    bits: Vec<u8>, // each element is 0 or 1
+}
+
+impl BitWriter {
+    fn new() -> Self { Self { bits: Vec::new() } }
+
+    fn write(&mut self, value: u32, count: u32) {
+        for i in (0..count).rev() {
+            self.bits.push(((value >> i) & 1) as u8);
+        }
+    }
+
+    fn bit_len(&self) -> usize { self.bits.len() }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        let mut i = 0;
+        while i < self.bits.len() {
+            let mut byte = 0u8;
+            for j in 0..8 {
+                byte = (byte << 1) | self.bits.get(i + j).copied().unwrap_or(0);
+            }
+            result.push(byte);
+            i += 8;
+        }
+        result
+    }
+}
+
+fn encode_numeric(input: &str, w: &mut BitWriter) {
+    let digits: Vec<u32> = input.chars().map(|c| c as u32 - '0' as u32).collect();
+    let mut i = 0;
+    while i + 2 < digits.len() {
+        w.write(digits[i] * 100 + digits[i+1] * 10 + digits[i+2], 10);
+        i += 3;
+    }
+    if i + 1 < digits.len() {
+        w.write(digits[i] * 10 + digits[i+1], 7);
+        i += 2;
+    }
+    if i < digits.len() {
+        w.write(digits[i], 4);
+    }
+}
+
+fn encode_alphanumeric(input: &str, w: &mut BitWriter) {
+    // Precondition: caller (select_mode → encode) guarantees every character is
+    // in ALPHANUM_CHARS.  The debug_assert makes this explicit; production builds
+    // fall through to `.unwrap_or(0)` which is unreachable under correct usage.
+    let chars: Vec<u32> = input.chars()
+        .map(|c| {
+            let idx = ALPHANUM_CHARS.find(c);
+            debug_assert!(idx.is_some(), "encode_alphanumeric: char '{}' not in ALPHANUM_CHARS (precondition violated)", c);
+            idx.unwrap_or(0) as u32
+        })
+        .collect();
+    let mut i = 0;
+    while i + 1 < chars.len() {
+        w.write(chars[i] * 45 + chars[i+1], 11);
+        i += 2;
+    }
+    if i < chars.len() {
+        w.write(chars[i], 6);
+    }
+}
+
+fn encode_byte_mode(input: &str, w: &mut BitWriter) {
+    for b in input.as_bytes() {
+        w.write(*b as u32, 8);
+    }
+}
+
+fn build_data_codewords(input: &str, version: usize, ecc: EccLevel) -> Vec<u8> {
+    let mode = select_mode(input);
+    let capacity = num_data_codewords(version, ecc);
+    let mut w = BitWriter::new();
+
+    w.write(mode_indicator(mode) as u32, 4);
+    let char_count = if mode == EncodingMode::Byte {
+        input.len() as u32
+    } else {
+        input.chars().count() as u32
+    };
+    w.write(char_count, char_count_bits(mode, version));
+
+    match mode {
+        EncodingMode::Numeric => encode_numeric(input, &mut w),
+        EncodingMode::Alphanumeric => encode_alphanumeric(input, &mut w),
+        EncodingMode::Byte => encode_byte_mode(input, &mut w),
+    }
+
+    // Terminator (up to 4 bits)
+    let available = capacity * 8;
+    let term_len = (available - w.bit_len()).min(4);
+    if term_len > 0 { w.write(0, term_len as u32); }
+
+    // Byte-boundary padding
+    let rem = w.bit_len() % 8;
+    if rem != 0 { w.write(0, (8 - rem) as u32); }
+
+    let mut bytes = w.to_bytes();
+    let mut pad = 0xecu8;
+    while bytes.len() < capacity {
+        bytes.push(pad);
+        pad = if pad == 0xec { 0x11 } else { 0xec };
+    }
+    bytes
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block processing
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct Block {
+    data: Vec<u8>,
+    ecc:  Vec<u8>,
+}
+
+fn compute_blocks(data: &[u8], version: usize, ecc: EccLevel) -> Vec<Block> {
+    let e = ecc_idx(ecc);
+    let total_blocks = NUM_BLOCKS[e][version] as usize;
+    let ecc_len = ECC_CODEWORDS_PER_BLOCK[e][version] as usize;
+    let total_data = num_data_codewords(version, ecc);
+    let short_len = total_data / total_blocks;
+    let num_long = total_data % total_blocks;
+    let gen = build_generator(ecc_len);
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+
+    let g1_count = total_blocks - num_long;
+    for _ in 0..g1_count {
+        let d = data[offset..offset + short_len].to_vec();
+        let e_cw = rs_encode(&d, &gen);
+        blocks.push(Block { data: d, ecc: e_cw });
+        offset += short_len;
+    }
+    for _ in 0..num_long {
+        let d = data[offset..offset + short_len + 1].to_vec();
+        let e_cw = rs_encode(&d, &gen);
+        blocks.push(Block { data: d, ecc: e_cw });
+        offset += short_len + 1;
+    }
+    blocks
+}
+
+fn interleave_blocks(blocks: &[Block]) -> Vec<u8> {
+    let mut result = Vec::new();
+    let max_data = blocks.iter().map(|b| b.data.len()).max().unwrap_or(0);
+    let max_ecc  = blocks.iter().map(|b| b.ecc.len()).max().unwrap_or(0);
+    for i in 0..max_data {
+        for b in blocks { if i < b.data.len() { result.push(b.data[i]); } }
+    }
+    for i in 0..max_ecc {
+        for b in blocks { if i < b.ecc.len()  { result.push(b.ecc[i]);  } }
+    }
+    result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct WorkGrid {
+    size: usize,
+    modules:  Vec<Vec<bool>>,
+    reserved: Vec<Vec<bool>>,
+}
+
+impl WorkGrid {
+    fn new(size: usize) -> Self {
+        Self {
+            size,
+            modules:  vec![vec![false; size]; size],
+            reserved: vec![vec![false; size]; size],
+        }
+    }
+
+    fn set(&mut self, r: usize, c: usize, dark: bool, reserve: bool) {
+        self.modules[r][c] = dark;
+        if reserve { self.reserved[r][c] = true; }
+    }
+}
+
+fn place_finder(g: &mut WorkGrid, top: usize, left: usize) {
+    for dr in 0..7usize {
+        for dc in 0..7usize {
+            let on_border = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+            let in_core   = (2..=4).contains(&dr) && (2..=4).contains(&dc);
+            g.set(top + dr, left + dc, on_border || in_core, true);
+        }
+    }
+}
+
+fn place_alignment(g: &mut WorkGrid, row: usize, col: usize) {
+    for dr in -2i32..=2 {
+        for dc in -2i32..=2 {
+            let r = (row as i32 + dr) as usize;
+            let c = (col as i32 + dc) as usize;
+            let on_border = dr.abs() == 2 || dc.abs() == 2;
+            let is_center = dr == 0 && dc == 0;
+            g.set(r, c, on_border || is_center, true);
+        }
+    }
+}
+
+fn place_all_alignments(g: &mut WorkGrid, version: usize) {
+    let positions = ALIGNMENT_POSITIONS[version - 1];
+    for &row in positions {
+        for &col in positions {
+            let r = row as usize;
+            let c = col as usize;
+            if g.reserved[r][c] { continue; }
+            place_alignment(g, r, c);
+        }
+    }
+}
+
+fn place_timing(g: &mut WorkGrid) {
+    let sz = g.size;
+    for c in 8..=(sz - 9) { g.set(6, c, c % 2 == 0, true); }
+    for r in 8..=(sz - 9) { g.set(r, 6, r % 2 == 0, true); }
+}
+
+fn reserve_format_info(g: &mut WorkGrid) {
+    let sz = g.size;
+    for c in 0..=8 { if c != 6 { g.reserved[8][c] = true; } }
+    for r in 0..=8 { if r != 6 { g.reserved[r][8] = true; } }
+    for r in (sz - 7)..sz { g.reserved[r][8] = true; }
+    for c in (sz - 8)..sz { g.reserved[8][c] = true; }
+}
+
+fn compute_format_bits(ecc: EccLevel, mask: u32) -> u32 {
+    let data = (ecc_indicator(ecc) << 3) | mask as u16;
+    let mut rem = (data as u32) << 10;
+    for i in (10u32..=14).rev() {
+        if (rem >> i) & 1 == 1 { rem ^= 0x537 << (i - 10); }
+    }
+    (((data as u32) << 10) | (rem & 0x3ff)) ^ 0x5412
+}
+
+fn write_format_info(g: &mut WorkGrid, fmt: u32) {
+    let sz = g.size;
+    // Copy 1
+    for i in 0u32..=5 { g.modules[8][i as usize] = (fmt >> i) & 1 == 1; }
+    g.modules[8][7] = (fmt >> 6) & 1 == 1;
+    g.modules[8][8] = (fmt >> 7) & 1 == 1;
+    g.modules[7][8] = (fmt >> 8) & 1 == 1;
+    for i in 9u32..=14 { g.modules[(14 - i) as usize][8] = (fmt >> i) & 1 == 1; }
+    // Copy 2
+    for i in 0u32..=6 { g.modules[sz - 1 - i as usize][8] = (fmt >> i) & 1 == 1; }
+    for i in 7u32..=14 { g.modules[8][sz - 15 + i as usize] = (fmt >> i) & 1 == 1; }
+}
+
+fn reserve_version_info(g: &mut WorkGrid, version: usize) {
+    if version < 7 { return; }
+    let sz = g.size;
+    for r in 0..6 { for dc in 0..3 { g.reserved[r][sz - 11 + dc] = true; } }
+    for dr in 0..3 { for c in 0..6 { g.reserved[sz - 11 + dr][c] = true; } }
+}
+
+fn compute_version_bits(version: usize) -> u32 {
+    let v = version as u32;
+    let mut rem = v << 12;
+    for i in (12u32..=17).rev() {
+        if (rem >> i) & 1 == 1 { rem ^= 0x1f25 << (i - 12); }
+    }
+    (v << 12) | (rem & 0xfff)
+}
+
+fn write_version_info(g: &mut WorkGrid, version: usize) {
+    if version < 7 { return; }
+    let sz = g.size;
+    let bits = compute_version_bits(version);
+    for i in 0u32..18 {
+        let dark = (bits >> i) & 1 == 1;
+        let a = 5 - (i / 3) as usize;
+        let b = sz - 9 - (i % 3) as usize;
+        g.modules[a][b] = dark;
+        g.modules[b][a] = dark;
+    }
+}
+
+fn place_dark_module(g: &mut WorkGrid, version: usize) {
+    g.set(4 * version + 9, 8, true, true);
+}
+
+fn place_bits(g: &mut WorkGrid, codewords: &[u8], version: usize) {
+    let sz = g.size;
+    let mut bits: Vec<bool> = Vec::new();
+    for &cw in codewords {
+        for b in (0u8..8).rev() { bits.push((cw >> b) & 1 == 1); }
+    }
+    for _ in 0..num_remainder_bits(version) { bits.push(false); }
+
+    let mut bit_idx = 0usize;
+    let mut up = true;
+    let mut col = sz - 1;
+
+    loop {
+        for vi in 0..sz {
+            let row = if up { sz - 1 - vi } else { vi };
+            for dc in 0u32..=1 {
+                let c = col as i32 - dc as i32;
+                if c < 0 { continue; }
+                let c = c as usize;
+                if c == 6 { continue; }
+                if g.reserved[row][c] { continue; }
+                g.modules[row][c] = bit_idx < bits.len() && bits[bit_idx];
+                bit_idx += 1;
+            }
+        }
+        up = !up;
+        if col < 2 { break; }
+        col -= 2;
+        if col == 6 { col = 5; }
+    }
+}
+
+fn build_grid(version: usize) -> WorkGrid {
+    let sz = symbol_size(version);
+    let mut g = WorkGrid::new(sz);
+
+    place_finder(&mut g, 0, 0);
+    place_finder(&mut g, 0, sz - 7);
+    place_finder(&mut g, sz - 7, 0);
+
+    // Separators
+    for i in 0..=7 {
+        g.set(7, i, false, true); g.set(i, 7, false, true);                       // TL
+        g.set(7, sz-1-i, false, true); g.set(i, sz-8, false, true);               // TR
+        g.set(sz-8, i, false, true); g.set(sz-1-i, 7, false, true);               // BL
+    }
+
+    place_timing(&mut g);
+    place_all_alignments(&mut g, version);
+    reserve_format_info(&mut g);
+    reserve_version_info(&mut g, version);
+    place_dark_module(&mut g, version);
+    g
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Masking and penalty
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn mask_condition(mask: u32, r: usize, c: usize) -> bool {
+    let (r, c) = (r as i64, c as i64);
+    match mask {
+        0 => (r + c) % 2 == 0,
+        1 => r % 2 == 0,
+        2 => c % 3 == 0,
+        3 => (r + c) % 3 == 0,
+        4 => (r / 2 + c / 3) % 2 == 0,
+        5 => (r * c) % 2 + (r * c) % 3 == 0,
+        6 => ((r * c) % 2 + (r * c) % 3) % 2 == 0,
+        7 => ((r + c) % 2 + (r * c) % 3) % 2 == 0,
+        _ => false,
+    }
+}
+
+fn apply_mask(
+    modules: &[Vec<bool>], reserved: &[Vec<bool>], sz: usize, mask: u32,
+) -> Vec<Vec<bool>> {
+    let mut result = modules.to_vec();
+    for r in 0..sz {
+        for c in 0..sz {
+            if !reserved[r][c] {
+                result[r][c] = modules[r][c] != mask_condition(mask, r, c);
+            }
+        }
+    }
+    result
+}
+
+fn compute_penalty(modules: &[Vec<bool>], sz: usize) -> u32 {
+    let mut penalty = 0u32;
+
+    // Rule 1 — runs of same color ≥ 5
+    for a in 0..sz {
+        for horiz in [true, false] {
+            let mut run = 1u32;
+            let mut prev = if horiz { modules[a][0] } else { modules[0][a] };
+            for i in 1..sz {
+                let cur = if horiz { modules[a][i] } else { modules[i][a] };
+                if cur == prev { run += 1; }
+                else { if run >= 5 { penalty += run - 2; } run = 1; prev = cur; }
+            }
+            if run >= 5 { penalty += run - 2; }
+        }
+    }
+
+    // Rule 2 — 2×2 same-color blocks
+    for r in 0..sz-1 {
+        for c in 0..sz-1 {
+            let d = modules[r][c];
+            if d == modules[r][c+1] && d == modules[r+1][c] && d == modules[r+1][c+1] {
+                penalty += 3;
+            }
+        }
+    }
+
+    // Rule 3 — finder-pattern-like sequences
+    let p1: [u8; 11] = [1,0,1,1,1,0,1,0,0,0,0];
+    let p2: [u8; 11] = [0,0,0,0,1,0,1,1,1,0,1];
+    for a in 0..sz {
+        for b in 0..=(sz.saturating_sub(11)) {
+            let (mut mh1, mut mh2, mut mv1, mut mv2) = (true, true, true, true);
+            for k in 0..11 {
+                let bh = if modules[a][b+k] { 1u8 } else { 0 };
+                let bv = if modules[b+k][a] { 1u8 } else { 0 };
+                if bh != p1[k] { mh1 = false; }
+                if bh != p2[k] { mh2 = false; }
+                if bv != p1[k] { mv1 = false; }
+                if bv != p2[k] { mv2 = false; }
+            }
+            if mh1 { penalty += 40; }
+            if mh2 { penalty += 40; }
+            if mv1 { penalty += 40; }
+            if mv2 { penalty += 40; }
+        }
+    }
+
+    // Rule 4 — dark ratio deviation
+    let dark: u32 = modules.iter().flat_map(|r| r.iter()).map(|&m| m as u32).sum();
+    let total = (sz * sz) as f64;
+    let ratio = (dark as f64 / total) * 100.0;
+    let prev5 = (ratio / 5.0).floor() as u32 * 5;
+    let a = if prev5 > 50 { prev5 - 50 } else { 50 - prev5 };
+    let b = if prev5 + 5 > 50 { prev5 + 5 - 50 } else { 50 - (prev5 + 5) };
+    penalty += (a.min(b) / 5) * 10;
+
+    penalty
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Version selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn select_version(input: &str, ecc: EccLevel) -> Result<usize, QRCodeError> {
+    let mode = select_mode(input);
+    let byte_len = input.len() as u32;
+
+    for v in 1..=40 {
+        let capacity = num_data_codewords(v, ecc);
+        let data_bits = match mode {
+            EncodingMode::Byte => byte_len * 8,
+            EncodingMode::Numeric => {
+                let n = input.chars().count() as u32;
+                (n * 10 + 2) / 3  // ceil(n * 10 / 3)
+            }
+            EncodingMode::Alphanumeric => {
+                let n = input.chars().count() as u32;
+                (n * 11 + 1) / 2  // ceil(n * 11 / 2)
+            }
+        };
+        let bits_needed = 4 + char_count_bits(mode, v) + data_bits;
+        let cw_needed = (bits_needed + 7) / 8;
+        if cw_needed as usize <= capacity { return Ok(v); }
+    }
+    Err(QRCodeError::InputTooLong(format!(
+        "Input ({} chars, ECC={:?}) exceeds version-40 capacity.", input.len(), ecc
+    )))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Encode a UTF-8 string into a QR Code [`ModuleGrid`].
+///
+/// Returns a `(4V+17) × (4V+17)` boolean grid, `true` = dark module.
+/// Selects the minimum version that fits the input at the given ECC level.
+///
+/// # Errors
+/// Returns [`QRCodeError::InputTooLong`] if the input exceeds version-40 capacity.
+///
+/// # Example
+/// ```
+/// use qr_code::{encode, EccLevel};
+/// let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+/// assert_eq!(grid.rows, 21); // version 1
+/// ```
+pub fn encode(input: &str, ecc: EccLevel) -> Result<ModuleGrid, QRCodeError> {
+    // Early-exit guard: QR Code version 40 holds at most 7089 numeric characters
+    // (~2953 bytes in byte mode).  Inputs beyond this can never encode, and
+    // checking early prevents large allocations in build_data_codewords before
+    // select_version rejects them.
+    if input.len() > 7089 {
+        return Err(QRCodeError::InputTooLong(format!(
+            "Input byte length {} exceeds 7089 (the QR Code v40 numeric-mode maximum).",
+            input.len()
+        )));
+    }
+    let version = select_version(input, ecc)?;
+    let sz = symbol_size(version);
+
+    let data_cw   = build_data_codewords(input, version, ecc);
+    let blocks    = compute_blocks(&data_cw, version, ecc);
+    let interleaved = interleave_blocks(&blocks);
+
+    let mut grid = build_grid(version);
+    place_bits(&mut grid, &interleaved, version);
+
+    // Evaluate 8 masks, pick lowest penalty
+    let mut best_mask = 0u32;
+    let mut best_penalty = u32::MAX;
+    for m in 0..8u32 {
+        let masked = apply_mask(&grid.modules, &grid.reserved, sz, m);
+        let fmt = compute_format_bits(ecc, m);
+        let mut test = WorkGrid {
+            size: sz,
+            modules: masked,
+            reserved: grid.reserved.clone(),
+        };
+        write_format_info(&mut test, fmt);
+        let p = compute_penalty(&test.modules, sz);
+        if p < best_penalty { best_penalty = p; best_mask = m; }
+    }
+
+    // Finalize
+    let final_mods = apply_mask(&grid.modules, &grid.reserved, sz, best_mask);
+    let mut final_g = WorkGrid {
+        size: sz,
+        modules: final_mods,
+        reserved: grid.reserved,
+    };
+    write_format_info(&mut final_g, compute_format_bits(ecc, best_mask));
+    write_version_info(&mut final_g, version);
+
+    Ok(ModuleGrid {
+        rows: sz as u32,
+        cols: sz as u32,
+        modules: final_g.modules,
+        module_shape: ModuleShape::Square,
+    })
+}
+
+/// Encode and convert to a pixel-resolved [`PaintScene`].
+pub fn encode_and_layout(
+    input: &str,
+    ecc: EccLevel,
+    config: &Barcode2DLayoutConfig,
+) -> Result<PaintScene, QRCodeError> {
+    let grid = encode(input, ecc)?;
+    // Use LayoutError (not InputTooLong) to avoid conflating layout/config
+    // failures with encoding failures.  The raw dependency error string is
+    // not forwarded to avoid leaking internal library details.
+    layout(&grid, config).map_err(|_| QRCodeError::LayoutError(
+        "barcode-2d layout failed: check Barcode2DLayoutConfig values (module_size_px > 0, moduleShape = Square)".to_string()
+    ))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: check finder pattern at (top, left)
+    fn has_finder(mods: &[Vec<bool>], top: usize, left: usize) -> bool {
+        for dr in 0..7usize {
+            for dc in 0..7usize {
+                let on_border = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+                let in_core   = (2..=4).contains(&dr) && (2..=4).contains(&dc);
+                let expected  = on_border || in_core;
+                if mods[top + dr][left + dc] != expected { return false; }
+            }
+        }
+        true
+    }
+
+    // Read copy-1 format bits and BCH-verify them
+    fn format_info_valid(mods: &[Vec<bool>], _sz: usize) -> Option<(u32, u32)> {
+        let positions: [(usize, usize); 15] = [
+            (8,0),(8,1),(8,2),(8,3),(8,4),(8,5),(8,7),(8,8),
+            (7,8),(5,8),(4,8),(3,8),(2,8),(1,8),(0,8),
+        ];
+        let mut raw = 0u32;
+        for (i, &(r, c)) in positions.iter().enumerate() {
+            if mods[r][c] { raw |= 1 << i; }
+        }
+        let fmt = raw ^ 0x5412;
+        let mut rem = (fmt >> 10) << 10;
+        for i in (10u32..=14).rev() {
+            if (rem >> i) & 1 == 1 { rem ^= 0x537 << (i - 10); }
+        }
+        if (rem & 0x3ff) != (fmt & 0x3ff) { return None; }
+        Some(((fmt >> 13) & 0x3, (fmt >> 10) & 0x7))
+    }
+
+    #[test]
+    fn version_constant() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    #[test]
+    fn hello_world_v1() {
+        let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+        assert_eq!(grid.rows, 21);
+        assert_eq!(grid.cols, 21);
+        assert_eq!(grid.module_shape, ModuleShape::Square);
+    }
+
+    #[test]
+    fn url_v2() {
+        let grid = encode("https://example.com", EccLevel::M).unwrap();
+        assert_eq!(grid.rows, 25);
+    }
+
+    #[test]
+    fn single_char_v1() {
+        let grid = encode("A", EccLevel::M).unwrap();
+        assert_eq!(grid.rows, 21);
+    }
+
+    #[test]
+    fn all_ecc_levels_work() {
+        for ecc in [EccLevel::L, EccLevel::M, EccLevel::Q, EccLevel::H] {
+            let grid = encode("HELLO", ecc).unwrap();
+            assert!(grid.rows >= 21);
+        }
+    }
+
+    #[test]
+    fn h_needs_larger_version_than_l() {
+        let gl = encode("The quick brown fox", EccLevel::L).unwrap();
+        let gh = encode("The quick brown fox", EccLevel::H).unwrap();
+        assert!(gh.rows >= gl.rows);
+    }
+
+    #[test]
+    fn finder_patterns_present() {
+        let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+        let sz = grid.rows as usize;
+        assert!(has_finder(&grid.modules, 0, 0));
+        assert!(has_finder(&grid.modules, 0, sz - 7));
+        assert!(has_finder(&grid.modules, sz - 7, 0));
+    }
+
+    #[test]
+    fn timing_strips_correct() {
+        let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+        let sz = grid.rows as usize;
+        for c in 8..=(sz - 9) { assert_eq!(grid.modules[6][c], c % 2 == 0); }
+        for r in 8..=(sz - 9) { assert_eq!(grid.modules[r][6], r % 2 == 0); }
+    }
+
+    #[test]
+    fn dark_module_v1() {
+        let grid = encode("A", EccLevel::M).unwrap();
+        assert!(grid.modules[13][8]); // 4*1+9 = 13
+    }
+
+    #[test]
+    fn dark_module_v2() {
+        let grid = encode("https://example.com", EccLevel::M).unwrap();
+        assert!(grid.modules[17][8]); // 4*2+9 = 17
+    }
+
+    #[test]
+    fn format_info_decodable_m() {
+        let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+        let decoded = format_info_valid(&grid.modules, grid.rows as usize);
+        assert!(decoded.is_some());
+        let (ecc_bits, _mask) = decoded.unwrap();
+        assert_eq!(ecc_bits, 0b00); // M = 00
+    }
+
+    #[test]
+    fn format_info_ecc_bits_all_levels() {
+        let expected = [(EccLevel::L, 0b01), (EccLevel::M, 0b00),
+                        (EccLevel::Q, 0b11), (EccLevel::H, 0b10)];
+        for (ecc, bits) in expected {
+            let grid = encode("HELLO", ecc).unwrap();
+            let decoded = format_info_valid(&grid.modules, grid.rows as usize);
+            assert!(decoded.is_some(), "format info unreadable for {:?}", ecc);
+            assert_eq!(decoded.unwrap().0, bits, "wrong ECC bits for {:?}", ecc);
+        }
+    }
+
+    #[test]
+    fn format_info_copies_match() {
+        let grid = encode("HELLO WORLD", EccLevel::M).unwrap();
+        let sz = grid.rows as usize;
+        let copy1: [(usize,usize); 15] = [
+            (8,0),(8,1),(8,2),(8,3),(8,4),(8,5),(8,7),(8,8),
+            (7,8),(5,8),(4,8),(3,8),(2,8),(1,8),(0,8),
+        ];
+        let copy2: [(usize,usize); 15] = [
+            (sz-1,8),(sz-2,8),(sz-3,8),(sz-4,8),(sz-5,8),(sz-6,8),(sz-7,8),
+            (8,sz-8),(8,sz-7),(8,sz-6),(8,sz-5),(8,sz-4),(8,sz-3),(8,sz-2),(8,sz-1),
+        ];
+        let mut fmt1 = 0u32; let mut fmt2 = 0u32;
+        for i in 0..15 {
+            if grid.modules[copy1[i].0][copy1[i].1] { fmt1 |= 1 << i; }
+            if grid.modules[copy2[i].0][copy2[i].1] { fmt2 |= 1 << i; }
+        }
+        assert_eq!(fmt1, fmt2);
+    }
+
+    #[test]
+    fn numeric_mode_small_grid() {
+        let grid = encode("000000000000000", EccLevel::M).unwrap();
+        // 15 digits in numeric mode should fit in v1
+        assert_eq!(grid.rows, 21);
+    }
+
+    #[test]
+    fn deterministic() {
+        let g1 = encode("https://example.com", EccLevel::M).unwrap();
+        let g2 = encode("https://example.com", EccLevel::M).unwrap();
+        assert_eq!(g1.modules, g2.modules);
+    }
+
+    #[test]
+    fn different_inputs_differ() {
+        let g1 = encode("HELLO", EccLevel::M).unwrap();
+        let g2 = encode("WORLD", EccLevel::M).unwrap();
+        let sz = g1.rows as usize;
+        let differ = (0..sz).any(|r| (0..sz).any(|c| g1.modules[r][c] != g2.modules[r][c]));
+        assert!(differ);
+    }
+
+    #[test]
+    fn input_too_long_error() {
+        let giant: String = "A".repeat(8000);
+        let result = encode(&giant, EccLevel::H);
+        assert!(matches!(result, Err(QRCodeError::InputTooLong(_))));
+    }
+
+    #[test]
+    fn empty_string_ok() {
+        let grid = encode("", EccLevel::M).unwrap();
+        assert_eq!(grid.rows, 21);
+    }
+
+    #[test]
+    fn utf8_byte_mode() {
+        // "→" is U+2192, encoded as 3 UTF-8 bytes (E2 86 92)
+        let grid = encode("→→→", EccLevel::M).unwrap();
+        assert!(grid.rows >= 21);
+    }
+
+    #[test]
+    fn v7_plus_produced() {
+        // 85 uppercase chars exceed v6-H capacity (~84 alphanumeric chars)
+        let input: String = "A".repeat(85);
+        let grid = encode(&input, EccLevel::H).unwrap();
+        assert!(grid.rows >= 45); // v7 = 45×45
+    }
+
+    #[test]
+    fn encode_and_layout_works() {
+        let config = Barcode2DLayoutConfig::default();
+        let scene = encode_and_layout("HELLO", EccLevel::M, &config).unwrap();
+        assert!(scene.width > 0.0);
+        assert!(scene.height > 0.0);
+    }
+
+    #[test]
+    fn test_corpus() {
+        let corpus = [
+            ("A", EccLevel::M),
+            ("HELLO WORLD", EccLevel::M),
+            ("https://example.com", EccLevel::M),
+            ("01234567890", EccLevel::M),
+            ("The quick brown fox jumps over the lazy dog", EccLevel::M),
+        ];
+        for (input, ecc) in corpus {
+            let grid = encode(input, ecc).unwrap();
+            assert!(grid.rows >= 21);
+            assert_eq!(grid.rows, grid.cols);
+            let decoded = format_info_valid(&grid.modules, grid.rows as usize);
+            assert!(decoded.is_some(), "bad format info for: {}", input);
+        }
+    }
+
+    #[test]
+    fn rs_encode_seven_ecc() {
+        // Build the 7-ECC generator and verify it has degree 7
+        let gen = build_generator(7);
+        assert_eq!(gen.len(), 8); // degree 7 → 8 coefficients
+        assert_eq!(gen[0], 1);    // monic
+    }
+
+    #[test]
+    fn version_info_v7_written() {
+        // Version 7 must have 18-bit version info blocks reserved and written
+        let input: String = "A".repeat(85);
+        let grid = encode(&input, EccLevel::H).unwrap();
+        // Just ensure the grid was produced without panic and has the right size
+        let sz = grid.rows as usize;
+        if sz >= 45 { // v7+
+            // Dark module still dark
+            let version = (sz - 17) / 4;
+            assert!(grid.modules[4 * version + 9][8]);
+        }
+    }
+}

--- a/code/packages/typescript/qr-code/BUILD
+++ b/code/packages/typescript/qr-code/BUILD
@@ -1,0 +1,8 @@
+cd ../pixel-container && npm ci --quiet
+cd ../paint-instructions && npm ci --quiet
+cd ../paint-vm && npm ci --quiet
+cd ../paint-vm-svg && npm ci --quiet
+cd ../gf256 && npm ci --quiet
+cd ../barcode-2d && npm ci --quiet
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/qr-code/CHANGELOG.md
+++ b/code/packages/typescript/qr-code/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog — qr-code (TypeScript)
+
+## 0.1.0 — 2026-04-23
+
+Initial release.
+
+### Added
+
+- `encode(input, eccLevel) → ModuleGrid` — Full QR Code encoding pipeline:
+  - Auto mode selection: numeric (digits only) → alphanumeric (45-char set) → byte (UTF-8)
+  - Version selection: minimum version 1–40 that fits the input at the ECC level
+  - Bit stream assembly: mode indicator + char count + data + terminator + padding (0xEC/0x11)
+  - Block splitting and Reed-Solomon ECC (b=0 convention, GF(256)/0x11D)
+  - Interleaving: data codewords round-robin, then ECC codewords round-robin
+  - Grid initialization: three finder patterns, separators, timing strips, alignment patterns (v2+), dark module
+  - Two-column zigzag data placement (bottom-right to top-left, timing column skipped)
+  - 8 mask patterns evaluated with 4-rule ISO penalty scoring
+  - Format information: BCH(15,5) with generator 0x537, XOR mask 0x5412
+  - Version information (v7+): BCH(18,6) with generator 0x1F25
+
+- `encodeAndLayout(input, eccLevel, config?) → PaintScene` — encode + barcode-2d layout
+
+- `renderSvg(input, eccLevel, config?) → string` — encode + layout + paint-vm-svg
+
+- `explain(input, eccLevel) → AnnotatedModuleGrid` — encode with null annotations (v0.2.0 will add full role annotation)
+
+- `InputTooLongError` — thrown when input exceeds version-40 capacity
+
+- `VERSION` constant — `"0.1.0"`
+
+- 46 unit tests, 100% statement/function/line coverage, 97.71% branch coverage

--- a/code/packages/typescript/qr-code/README.md
+++ b/code/packages/typescript/qr-code/README.md
@@ -1,0 +1,89 @@
+# qr-code (TypeScript)
+
+QR Code encoder — ISO/IEC 18004:2015 compliant.
+
+Encodes any UTF-8 string into a scannable QR Code. Outputs an abstract
+`ModuleGrid` (no pixel coordinates yet) that can be passed to `barcode-2d`'s
+`layout()` function for pixel-level rendering, or to `renderSvg()` for a
+one-shot SVG string.
+
+## Pipeline
+
+```
+input string
+  → mode selection    (numeric / alphanumeric / byte)
+  → version selection (smallest version 1–40 that fits at the ECC level)
+  → bit stream        (mode indicator + char count + data bits + padding)
+  → blocks + RS ECC   (GF(256) b=0 convention, polynomial 0x11D)
+  → interleave        (data CWs, then ECC CWs, round-robin across blocks)
+  → grid init         (finder × 3, separator, timing, alignment, format, dark)
+  → zigzag placement  (two-column snake from bottom-right corner)
+  → mask evaluation   (8 patterns, 4-rule penalty, pick lowest)
+  → finalize          (format info + version info v7+)
+  → ModuleGrid        (abstract boolean grid, true = dark)
+```
+
+## Usage
+
+```typescript
+import { encode, encodeAndLayout, renderSvg, type EccLevel } from "@coding-adventures/qr-code";
+
+// Just the module grid (abstract units — no pixels):
+const grid = encode("https://example.com", "M");
+// grid.rows === grid.cols === 25 (version 2)
+
+// Grid → pixel-resolved PaintScene (via barcode-2d):
+const scene = encodeAndLayout("https://example.com", "M", { moduleSizePx: 10 });
+
+// Direct SVG string (one call):
+const svg = renderSvg("https://example.com", "M");
+document.body.innerHTML = svg;
+```
+
+## API
+
+### `encode(input, eccLevel) → ModuleGrid`
+
+Encodes a UTF-8 string into a QR Code module grid.
+
+- Returns a `(4V+17) × (4V+17)` grid where `true` = dark module.
+- Throws `InputTooLongError` if the input exceeds version-40 capacity.
+- Selects the minimum version that fits the input at the ECC level.
+- Mode is auto-selected: numeric → alphanumeric → byte.
+
+### `encodeAndLayout(input, eccLevel, config?) → PaintScene`
+
+Encodes and converts to a pixel-resolved `PaintScene` via `barcode-2d`'s
+`layout()`. The `config` parameter accepts any `Barcode2DLayoutConfig` fields.
+
+### `renderSvg(input, eccLevel, config?) → string`
+
+Convenience: encode → layout → SVG string. Returns a complete `<svg>…</svg>`.
+
+### `explain(input, eccLevel) → AnnotatedModuleGrid`
+
+Encodes with per-module role annotations (for visualizers). v0.1.0 returns
+null annotations; full annotation is v0.2.0.
+
+## ECC Levels
+
+| Level | Recovery | Notes                                  |
+|-------|----------|----------------------------------------|
+| L     | ~7%      | Highest data density                   |
+| M     | ~15%     | General-purpose default                |
+| Q     | ~25%     | Moderate damage expected               |
+| H     | ~30%     | High damage risk, or overlaid logo     |
+
+## Error Types
+
+- `InputTooLongError` — input exceeds version-40 capacity at the chosen ECC level.
+
+## Dependencies
+
+- `barcode-2d`: `ModuleGrid` type, `layout()` pixel geometry
+- `gf256`: GF(256) field arithmetic (multiply, ALOG)
+- `paint-vm-svg`: `renderToSvgString()` for SVG output
+
+## Spec
+
+See `code/specs/qr-code.md` for the full specification.

--- a/code/packages/typescript/qr-code/package-lock.json
+++ b/code/packages/typescript/qr-code/package-lock.json
@@ -1,0 +1,2557 @@
+{
+  "name": "@coding-adventures/qr-code",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/qr-code",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/barcode-2d": "file:../barcode-2d",
+        "@coding-adventures/gf256": "file:../gf256",
+        "@coding-adventures/paint-vm-svg": "file:../paint-vm-svg"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../barcode-2d": {
+      "name": "@coding-adventures/barcode-2d",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../gf256": {
+      "name": "@coding-adventures/gf256",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../paint-vm-svg": {
+      "name": "@coding-adventures/paint-vm-svg",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions",
+        "@coding-adventures/paint-vm": "file:../paint-vm"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/barcode-2d": {
+      "resolved": "../barcode-2d",
+      "link": true
+    },
+    "node_modules/@coding-adventures/gf256": {
+      "resolved": "../gf256",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm-svg": {
+      "resolved": "../paint-vm-svg",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/qr-code/package.json
+++ b/code/packages/typescript/qr-code/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@coding-adventures/qr-code",
+  "version": "0.1.0",
+  "description": "QR Code encoder — ISO/IEC 18004:2015 compliant, produces scannable QR Codes",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/barcode-2d": "file:../barcode-2d",
+    "@coding-adventures/gf256": "file:../gf256",
+    "@coding-adventures/paint-vm-svg": "file:../paint-vm-svg"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/qr-code/src/index.ts
+++ b/code/packages/typescript/qr-code/src/index.ts
@@ -1,0 +1,942 @@
+/**
+ * @module qr-code
+ *
+ * QR Code encoder — ISO/IEC 18004:2015 compliant.
+ *
+ * QR Code (Quick Response) was invented by Masahiro Hara at Denso Wave in
+ * 1994 to track automotive parts. It is now the most widely deployed 2D
+ * barcode on earth.  This encoder produces valid, scannable QR Codes from
+ * any UTF-8 string.
+ *
+ * ## Encoding pipeline
+ *
+ * ```
+ * input string
+ *   → mode selection    (numeric / alphanumeric / byte)
+ *   → version selection (smallest version that fits at the chosen ECC level)
+ *   → bit stream        (mode indicator + char count + data + padding)
+ *   → blocks + RS ECC   (GF(256) b=0 convention, poly 0x11D)
+ *   → interleave        (data CWs interleaved, then ECC CWs)
+ *   → grid init         (finder, separator, timing, alignment, format, dark)
+ *   → zigzag placement  (two-column snake from bottom-right corner)
+ *   → mask evaluation   (8 patterns, lowest 4-rule penalty wins)
+ *   → finalize          (format info + version info v7+)
+ *   → ModuleGrid        (abstract boolean grid, true = dark)
+ * ```
+ */
+
+import {
+  type ModuleGrid,
+  type Barcode2DLayoutConfig,
+  type PaintScene,
+  type AnnotatedModuleGrid,
+  layout,
+} from "@coding-adventures/barcode-2d";
+
+import { multiply as gfMul, ALOG } from "@coding-adventures/gf256";
+
+import { renderToSvgString } from "@coding-adventures/paint-vm-svg";
+
+export type { ModuleGrid, Barcode2DLayoutConfig, PaintScene, AnnotatedModuleGrid };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const VERSION = "0.1.0";
+
+/**
+ * Error correction level.
+ *
+ * | Level | Recovery | Use case                         |
+ * |-------|----------|----------------------------------|
+ * | L     | ~7%      | Maximum data density             |
+ * | M     | ~15%     | General-purpose (common default) |
+ * | Q     | ~25%     | Moderate noise/damage expected   |
+ * | H     | ~30%     | High damage risk, logo overlaid  |
+ */
+export type EccLevel = "L" | "M" | "Q" | "H";
+
+export class QRCodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QRCodeError";
+  }
+}
+
+export class InputTooLongError extends QRCodeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InputTooLongError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 2-bit ECC level indicator placed in format information.
+ * L=01, M=00, Q=11, H=10 — deliberately not alphabetical order.
+ */
+const ECC_INDICATOR: Record<EccLevel, number> = { L: 0b01, M: 0b00, Q: 0b11, H: 0b10 };
+
+/** Index 0=L, 1=M, 2=Q, 3=H for table lookups. */
+const ECC_IDX: Record<EccLevel, number> = { L: 0, M: 1, Q: 2, H: 3 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ISO 18004:2015 — Capacity tables (Table 9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * ECC codewords per block, indexed [eccIdx][version].
+ * Index 0 is a placeholder; versions run 1–40.
+ */
+const ECC_CODEWORDS_PER_BLOCK: ReadonlyArray<ReadonlyArray<number>> = [
+  // L:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1,  7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+  // M:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28],
+  // Q:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+  // H:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+];
+
+/** Number of error correction blocks, indexed [eccIdx][version]. */
+const NUM_BLOCKS: ReadonlyArray<ReadonlyArray<number>> = [
+  // L:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1,  1,  1,  1,  1,  1,  2,  2,  2,  2,  4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25],
+  // M:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1,  1,  1,  1,  2,  2,  4,  4,  4,  5,  5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49],
+  // Q:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1,  1,  1,  2,  2,  4,  4,  6,  6,  8,  8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68],
+  // H:   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  [-1,  1,  1,  2,  4,  4,  4,  5,  6,  8,  8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 80],
+];
+
+/**
+ * Alignment pattern center coordinates, indexed by [version - 1].
+ * The crossproduct of these values (excluding finder overlaps) gives all
+ * alignment pattern positions.  Source: ISO 18004:2015 Annex E.
+ */
+const ALIGNMENT_POSITIONS: ReadonlyArray<ReadonlyArray<number>> = [
+  [],                             // v1  — none
+  [6, 18],                        // v2
+  [6, 22],                        // v3
+  [6, 26],                        // v4
+  [6, 30],                        // v5
+  [6, 34],                        // v6
+  [6, 22, 38],                    // v7
+  [6, 24, 42],                    // v8
+  [6, 26, 46],                    // v9
+  [6, 28, 50],                    // v10
+  [6, 30, 54],                    // v11
+  [6, 32, 58],                    // v12
+  [6, 34, 62],                    // v13
+  [6, 26, 46, 66],                // v14
+  [6, 26, 48, 70],                // v15
+  [6, 26, 50, 74],                // v16
+  [6, 30, 54, 78],                // v17
+  [6, 30, 56, 82],                // v18
+  [6, 30, 58, 86],                // v19
+  [6, 34, 62, 90],                // v20
+  [6, 28, 50, 72, 94],            // v21
+  [6, 26, 50, 74, 98],            // v22
+  [6, 30, 54, 78, 102],           // v23
+  [6, 28, 54, 80, 106],           // v24
+  [6, 32, 58, 84, 110],           // v25
+  [6, 30, 58, 86, 114],           // v26
+  [6, 34, 62, 90, 118],           // v27
+  [6, 26, 50, 74, 98, 122],       // v28
+  [6, 30, 54, 78, 102, 126],      // v29
+  [6, 26, 52, 78, 104, 130],      // v30
+  [6, 30, 56, 82, 108, 134],      // v31
+  [6, 34, 60, 86, 112, 138],      // v32
+  [6, 30, 58, 86, 114, 142],      // v33
+  [6, 34, 62, 90, 118, 146],      // v34
+  [6, 30, 54, 78, 102, 126, 150], // v35
+  [6, 24, 50, 76, 102, 128, 154], // v36
+  [6, 28, 54, 80, 106, 132, 158], // v37
+  [6, 32, 58, 84, 110, 136, 162], // v38
+  [6, 26, 54, 82, 110, 138, 166], // v39
+  [6, 30, 58, 86, 114, 142, 170], // v40
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid geometry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Symbol size: (4 × version + 17). V1=21, V40=177. */
+function symbolSize(version: number): number {
+  return 4 * version + 17;
+}
+
+/**
+ * Total raw data+ECC bits available in the symbol.
+ * Derived by subtracting all function module areas from the total count.
+ * Formula from Nayuki's reference implementation (public domain).
+ */
+function numRawDataModules(version: number): number {
+  let result = (16 * version + 128) * version + 64;
+  if (version >= 2) {
+    const numAlign = Math.floor(version / 7) + 2;
+    result -= (25 * numAlign - 10) * numAlign - 55;
+    if (version >= 7) result -= 36;
+  }
+  return result;
+}
+
+/** Total data codewords (message + padding, no ECC). */
+function numDataCodewords(version: number, ecc: EccLevel): number {
+  const e = ECC_IDX[ecc];
+  return (
+    Math.floor(numRawDataModules(version) / 8) -
+    NUM_BLOCKS[e][version] * ECC_CODEWORDS_PER_BLOCK[e][version]
+  );
+}
+
+/** Remainder bits appended after interleaved codewords (0, 3, 4, or 7). */
+function numRemainderBits(version: number): number {
+  return numRawDataModules(version) % 8;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reed-Solomon (b=0 convention)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the monic RS generator of degree n using b=0: g(x) = ∏(x + αⁱ) i=0..n-1.
+ *
+ * Start with g=[1], then for each i multiply by [1, αⁱ]:
+ *   new[j] = old[j-1] ⊕ (αⁱ · old[j])
+ */
+function buildGenerator(n: number): number[] {
+  let g: number[] = [1];
+  for (let i = 0; i < n; i++) {
+    const ai = ALOG[i] as number;
+    const next: number[] = new Array(g.length + 1).fill(0);
+    for (let j = 0; j < g.length; j++) {
+      next[j] ^= g[j];
+      next[j + 1] ^= gfMul(g[j], ai);
+    }
+    g = next;
+  }
+  return g;
+}
+
+const GENERATORS = new Map<number, number[]>();
+// Pre-build all generators used by QR tables
+for (const n of [7, 10, 13, 15, 16, 17, 18, 20, 22, 24, 26, 28, 30]) {
+  GENERATORS.set(n, buildGenerator(n));
+}
+
+function getGenerator(n: number): number[] {
+  if (!GENERATORS.has(n)) GENERATORS.set(n, buildGenerator(n));
+  return GENERATORS.get(n)!;
+}
+
+/**
+ * Compute ECC bytes: R(x) = D(x)·xⁿ mod G(x) via LFSR division.
+ *
+ * Shift register approach:
+ *   for each data byte b:
+ *     feedback = b ⊕ R[0]
+ *     shift R left (R[i] ← R[i+1])
+ *     R[i] ^= G[i+1] · feedback   for i=0..n-1
+ */
+function rsEncode(data: number[], generator: number[]): number[] {
+  const n = generator.length - 1;
+  const rem: number[] = new Array(n).fill(0);
+  for (const b of data) {
+    const fb = b ^ rem[0];
+    for (let i = 0; i < n - 1; i++) rem[i] = rem[i + 1];
+    rem[n - 1] = 0;
+    if (fb !== 0) {
+      for (let i = 0; i < n; i++) rem[i] ^= gfMul(generator[i + 1], fb);
+    }
+  }
+  return rem;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data encoding modes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 45-character alphanumeric alphabet with their QR code indices (0–44).
+ * Pairs encode as: (first × 45 + second) into 11 bits.
+ * Trailing single character encodes into 6 bits.
+ */
+const ALPHANUM_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+type EncodingMode = "numeric" | "alphanumeric" | "byte";
+
+const MODE_INDICATOR: Record<EncodingMode, number> = {
+  numeric: 0b0001,
+  alphanumeric: 0b0010,
+  byte: 0b0100,
+};
+
+/** Select the most compact mode covering the entire input. */
+function selectMode(input: string): EncodingMode {
+  if (/^\d*$/.test(input)) return "numeric";
+  if (input.split("").every((c) => ALPHANUM_CHARS.includes(c))) return "alphanumeric";
+  return "byte";
+}
+
+/** Width of the character-count field (version- and mode-dependent). */
+function charCountBits(mode: EncodingMode, version: number): number {
+  if (mode === "numeric") return version <= 9 ? 10 : version <= 26 ? 12 : 14;
+  if (mode === "alphanumeric") return version <= 9 ? 9 : version <= 26 ? 11 : 13;
+  return version <= 9 ? 8 : 16; // byte
+}
+
+/** Bit-writer: accumulates bits and flushes as bytes. */
+class BitWriter {
+  private bits: number[] = [];
+
+  write(value: number, count: number): void {
+    for (let i = count - 1; i >= 0; i--) this.bits.push((value >> i) & 1);
+  }
+
+  get bitLength(): number { return this.bits.length; }
+
+  toBytes(): number[] {
+    const bytes: number[] = [];
+    for (let i = 0; i < this.bits.length; i += 8) {
+      let byte = 0;
+      for (let j = 0; j < 8; j++) byte = (byte << 1) | (this.bits[i + j] ?? 0);
+      bytes.push(byte);
+    }
+    return bytes;
+  }
+}
+
+/** Groups of 3 digits → 10 bits; pairs → 7 bits; single → 4 bits. */
+function encodeNumeric(input: string, w: BitWriter): void {
+  let i = 0;
+  while (i + 2 < input.length) { w.write(parseInt(input.slice(i, i + 3), 10), 10); i += 3; }
+  if (i + 1 < input.length) { w.write(parseInt(input.slice(i, i + 2), 10), 7); i += 2; }
+  if (i < input.length) w.write(parseInt(input[i], 10), 4);
+}
+
+/** Pairs encode as (idx1 × 45 + idx2) → 11 bits; trailing single → 6 bits. */
+function encodeAlphanumeric(input: string, w: BitWriter): void {
+  let i = 0;
+  while (i + 1 < input.length) {
+    w.write(ALPHANUM_CHARS.indexOf(input[i]) * 45 + ALPHANUM_CHARS.indexOf(input[i + 1]), 11);
+    i += 2;
+  }
+  if (i < input.length) w.write(ALPHANUM_CHARS.indexOf(input[i]), 6);
+}
+
+/** Each UTF-8 byte → 8 bits. */
+function encodeByte(input: string, w: BitWriter): void {
+  for (const b of new TextEncoder().encode(input)) w.write(b, 8);
+}
+
+/**
+ * Assemble the full data codeword sequence.
+ *
+ * Format: [mode 4b][char count][data bits][terminator ≤4b][byte pad][0xEC/0x11 pad bytes]
+ * Output is exactly numDataCodewords(version, ecc) bytes.
+ */
+function buildDataCodewords(input: string, version: number, ecc: EccLevel): number[] {
+  const mode = selectMode(input);
+  const capacity = numDataCodewords(version, ecc);
+  const w = new BitWriter();
+
+  w.write(MODE_INDICATOR[mode], 4);
+
+  const charCount = mode === "byte"
+    ? new TextEncoder().encode(input).length
+    : input.length;
+  w.write(charCount, charCountBits(mode, version));
+
+  if (mode === "numeric") encodeNumeric(input, w);
+  else if (mode === "alphanumeric") encodeAlphanumeric(input, w);
+  else encodeByte(input, w);
+
+  // Terminator: up to 4 zero bits
+  const termLen = Math.min(4, capacity * 8 - w.bitLength);
+  if (termLen > 0) w.write(0, termLen);
+  // Pad to byte boundary
+  const rem = w.bitLength % 8;
+  if (rem !== 0) w.write(0, 8 - rem);
+
+  // Fill remaining capacity with alternating 0xEC / 0x11
+  const bytes = w.toBytes();
+  let pad = 0xec;
+  while (bytes.length < capacity) { bytes.push(pad); pad = pad === 0xec ? 0x11 : 0xec; }
+  return bytes;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block processing
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Block { data: number[]; ecc: number[]; }
+
+function computeBlocks(data: number[], version: number, ecc: EccLevel): Block[] {
+  const e = ECC_IDX[ecc];
+  const totalBlocks = NUM_BLOCKS[e][version];
+  const eccLen = ECC_CODEWORDS_PER_BLOCK[e][version];
+  const totalData = numDataCodewords(version, ecc);
+  const shortLen = Math.floor(totalData / totalBlocks);
+  const numLong = totalData % totalBlocks;
+  const gen = getGenerator(eccLen);
+  const blocks: Block[] = [];
+  let offset = 0;
+
+  const g1Count = totalBlocks - numLong;
+  for (let i = 0; i < g1Count; i++) {
+    const d = data.slice(offset, offset + shortLen);
+    blocks.push({ data: d, ecc: rsEncode(d, gen) });
+    offset += shortLen;
+  }
+  for (let i = 0; i < numLong; i++) {
+    const d = data.slice(offset, offset + shortLen + 1);
+    blocks.push({ data: d, ecc: rsEncode(d, gen) });
+    offset += shortLen + 1;
+  }
+  return blocks;
+}
+
+/**
+ * Interleave codewords across blocks:
+ *   round-robin data CWs, then round-robin ECC CWs.
+ *
+ * Interleaving spreads a burst error across all blocks, so each block's
+ * RS decoder only loses a few codewords — well within its correction budget.
+ */
+function interleaveBlocks(blocks: Block[]): number[] {
+  const result: number[] = [];
+  const maxData = Math.max(...blocks.map((b) => b.data.length));
+  const maxEcc  = Math.max(...blocks.map((b) => b.ecc.length));
+  for (let i = 0; i < maxData; i++) for (const b of blocks) if (i < b.data.length) result.push(b.data[i]);
+  for (let i = 0; i < maxEcc;  i++) for (const b of blocks) if (i < b.ecc.length)  result.push(b.ecc[i]);
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface WorkGrid {
+  size: number;
+  modules: boolean[][];   // true = dark
+  reserved: boolean[][];  // true = structural (don't touch during data/mask)
+}
+
+function makeWorkGrid(size: number): WorkGrid {
+  return {
+    size,
+    modules:  Array.from({ length: size }, () => new Array<boolean>(size).fill(false)),
+    reserved: Array.from({ length: size }, () => new Array<boolean>(size).fill(false)),
+  };
+}
+
+function setMod(g: WorkGrid, r: number, c: number, dark: boolean, reserve = false): void {
+  g.modules[r][c] = dark;
+  if (reserve) g.reserved[r][c] = true;
+}
+
+/**
+ * 7×7 finder pattern centred at (topRow, topCol).
+ *
+ * ```
+ * ■ ■ ■ ■ ■ ■ ■
+ * ■ □ □ □ □ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ □ □ □ □ ■
+ * ■ ■ ■ ■ ■ ■ ■
+ * ```
+ *
+ * The 1:1:3:1:1 dark:light ratio in every scan direction lets any decoder
+ * locate and orient the symbol even under partial occlusion or rotation.
+ */
+function placeFinder(g: WorkGrid, topRow: number, topCol: number): void {
+  for (let dr = 0; dr < 7; dr++) {
+    for (let dc = 0; dc < 7; dc++) {
+      const onBorder = dr === 0 || dr === 6 || dc === 0 || dc === 6;
+      const inCore   = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+      setMod(g, topRow + dr, topCol + dc, onBorder || inCore, true);
+    }
+  }
+}
+
+/**
+ * 5×5 alignment pattern centred at (row, col).
+ *
+ * ```
+ * ■ ■ ■ ■ ■
+ * ■ □ □ □ ■
+ * ■ □ ■ □ ■
+ * ■ □ □ □ ■
+ * ■ ■ ■ ■ ■
+ * ```
+ *
+ * Appears in versions 2+ at tabulated positions, helping decoders correct
+ * for perspective distortion and barrel/pincushion warping.
+ */
+function placeAlignment(g: WorkGrid, row: number, col: number): void {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const onBorder = Math.abs(dr) === 2 || Math.abs(dc) === 2;
+      const isCenter = dr === 0 && dc === 0;
+      setMod(g, row + dr, col + dc, onBorder || isCenter, true);
+    }
+  }
+}
+
+/**
+ * Place all alignment patterns for the version.
+ *
+ * All crossproduct pairs of ALIGNMENT_POSITIONS[version-1] are considered.
+ * Any whose centre falls on an already-reserved module (finder/separator/timing)
+ * is skipped — this naturally excludes the three finder-overlap positions.
+ */
+function placeAllAlignments(g: WorkGrid, version: number): void {
+  for (const row of ALIGNMENT_POSITIONS[version - 1]) {
+    for (const col of ALIGNMENT_POSITIONS[version - 1]) {
+      if (g.reserved[row][col]) continue; // overlaps finder/timing
+      placeAlignment(g, row, col);
+    }
+  }
+}
+
+/**
+ * Alternating dark/light timing strips.
+ * Row 6, cols 8..size-9 (horizontal).
+ * Col 6, rows 8..size-9 (vertical).
+ * Dark when index is even (starts and ends dark).
+ */
+function placeTimingStrips(g: WorkGrid): void {
+  const sz = g.size;
+  for (let c = 8; c <= sz - 9; c++) setMod(g, 6, c, c % 2 === 0, true);
+  for (let r = 8; r <= sz - 9; r++) setMod(g, r, 6, r % 2 === 0, true);
+}
+
+/**
+ * Reserve format information module positions (15 modules × 2 copies).
+ * Writes placeholder (false) values so the positions are known to data
+ * placement; actual bits are written after mask selection.
+ *
+ * Copy 1 — adjacent to top-left finder:
+ *   (8, 0..5), (8, 7), (8, 8), (7, 8), (5..0, 8)
+ *
+ * Copy 2:
+ *   (size-1..size-7, 8)  and  (8, size-8..size-1)
+ */
+function reserveFormatInfo(g: WorkGrid): void {
+  const sz = g.size;
+  // Copy 1 horizontal strip: row 8, cols 0..8 (skip col 6 = timing)
+  for (let c = 0; c <= 8; c++) if (c !== 6) g.reserved[8][c] = true;
+  // Copy 1 vertical strip: col 8, rows 0..8 (skip row 6 = timing)
+  for (let r = 0; r <= 8; r++) if (r !== 6) g.reserved[r][8] = true;
+  // Copy 2 bottom-left: col 8, rows size-7..size-1
+  for (let r = sz - 7; r < sz; r++) g.reserved[r][8] = true;
+  // Copy 2 top-right: row 8, cols size-8..size-1
+  for (let c = sz - 8; c < sz; c++) g.reserved[8][c] = true;
+}
+
+/**
+ * Compute the 15-bit format information string.
+ *
+ * 1. 5-bit data = [ECC level (2b)] [mask pattern (3b)]
+ * 2. BCH(15,5): remainder of (data × x^10) mod G(x), G(x) = 0x537
+ * 3. Concatenate data and 10-bit remainder
+ * 4. XOR with 0x5412 to prevent all-zero format info
+ *
+ * G(x) = x^10 + x^8 + x^5 + x^4 + x^2 + x + 1 = 0x537.
+ */
+function computeFormatBits(ecc: EccLevel, mask: number): number {
+  const data = (ECC_INDICATOR[ecc] << 3) | mask;
+  let rem = data << 10;
+  for (let i = 14; i >= 10; i--) {
+    if ((rem >> i) & 1) rem ^= 0x537 << (i - 10);
+  }
+  return ((data << 10) | (rem & 0x3ff)) ^ 0x5412;
+}
+
+/**
+ * Write 15-bit format information into both copy locations.
+ *
+ * Bit positions (bit 0 = LSB of the 15-bit string):
+ *
+ * Copy 1:
+ *   bits 0–5  → (8, 0..5)
+ *   bit  6    → (8, 7)       [skip (8,6) = timing]
+ *   bit  7    → (8, 8)       [corner]
+ *   bit  8    → (7, 8)       [skip (6,8) = timing]
+ *   bits 9–14 → (5..0, 8)
+ *
+ * Copy 2:
+ *   bits 0–6  → (size-1..size-7, 8)
+ *   bits 7–14 → (8, size-8..size-1)
+ */
+function writeFormatInfo(g: WorkGrid, fmtBits: number): void {
+  const sz = g.size;
+  // Copy 1
+  for (let i = 0; i <= 5; i++) g.modules[8][i] = ((fmtBits >> i) & 1) === 1;
+  g.modules[8][7] = ((fmtBits >> 6) & 1) === 1;   // bit 6, skip col 6
+  g.modules[8][8] = ((fmtBits >> 7) & 1) === 1;   // bit 7, corner
+  g.modules[7][8] = ((fmtBits >> 8) & 1) === 1;   // bit 8, skip row 6
+  for (let i = 9; i <= 14; i++) g.modules[14 - i][8] = ((fmtBits >> i) & 1) === 1;
+  // Copy 2
+  for (let i = 0; i <= 6; i++) g.modules[sz - 1 - i][8] = ((fmtBits >> i) & 1) === 1;
+  for (let i = 7; i <= 14; i++) g.modules[8][sz - 15 + i] = ((fmtBits >> i) & 1) === 1;
+}
+
+/**
+ * Reserve version information positions (v7+): two 6×3 blocks.
+ * Near top-right: rows 0..5, cols size-11..size-9.
+ * Near bottom-left: rows size-11..size-9, cols 0..5.
+ */
+function reserveVersionInfo(g: WorkGrid, version: number): void {
+  if (version < 7) return;
+  const sz = g.size;
+  for (let r = 0; r < 6; r++) for (let dc = 0; dc < 3; dc++) g.reserved[r][sz - 11 + dc] = true;
+  for (let dr = 0; dr < 3; dr++) for (let c = 0; c < 6; c++) g.reserved[sz - 11 + dr][c] = true;
+}
+
+/**
+ * Compute 18-bit version information (v7+).
+ *
+ * 1. 6-bit version number
+ * 2. BCH(18,6): remainder of (version × x^12) mod G(x), G(x) = 0x1F25
+ * 3. Concatenate for 18 bits
+ *
+ * G(x) = x^12+x^11+x^10+x^9+x^8+x^5+x^2+1 = 0x1F25.
+ */
+function computeVersionBits(version: number): number {
+  let rem = version << 12;
+  for (let i = 17; i >= 12; i--) {
+    if ((rem >> i) & 1) rem ^= 0x1f25 << (i - 12);
+  }
+  return (version << 12) | (rem & 0xfff);
+}
+
+/**
+ * Write version information into both 6×3 blocks (v7+).
+ *
+ * Top-right block: bit i → (5 − ⌊i/3⌋, size−9−(i%3))
+ * Bottom-left block (transposed): bit i → (size−9−(i%3), 5−⌊i/3⌋)
+ */
+function writeVersionInfo(g: WorkGrid, version: number): void {
+  if (version < 7) return;
+  const sz = g.size;
+  const bits = computeVersionBits(version);
+  for (let i = 0; i < 18; i++) {
+    const dark = ((bits >> i) & 1) === 1;
+    const a = 5 - Math.floor(i / 3);
+    const b = sz - 9 - (i % 3);
+    g.modules[a][b] = dark;
+    g.modules[b][a] = dark;
+  }
+}
+
+/**
+ * The always-dark module at (4V+9, 8).
+ * Set once; not masked; not part of data.
+ */
+function placeDarkModule(g: WorkGrid, version: number): void {
+  setMod(g, 4 * version + 9, 8, true, true);
+}
+
+/**
+ * Place the interleaved codeword stream using the two-column zigzag scan.
+ *
+ * Scans from column size−1 leftward in 2-column strips, alternating
+ * upward/downward:
+ *   - Column 6 (vertical timing strip) is always skipped.
+ *   - After decrementing to col=6, jump to col=5.
+ *   - Reserved modules are skipped; data bits fill the rest.
+ */
+function placeBits(g: WorkGrid, codewords: number[], version: number): void {
+  const sz = g.size;
+
+  // Flatten codewords to a bit array (MSB first)
+  const bits: boolean[] = [];
+  for (const cw of codewords) for (let b = 7; b >= 0; b--) bits.push(((cw >> b) & 1) === 1);
+  for (let i = 0; i < numRemainderBits(version); i++) bits.push(false);
+
+  let bitIdx = 0;
+  let up = true;       // true = bottom→top, false = top→bottom
+  let col = sz - 1;    // leading column of current 2-column strip
+
+  while (col >= 1) {
+    for (let vi = 0; vi < sz; vi++) {
+      const row = up ? sz - 1 - vi : vi;
+      for (const dc of [0, 1]) {
+        const c = col - dc;
+        if (c === 6) continue;        // timing column
+        if (g.reserved[row][c]) continue;
+        g.modules[row][c] = bitIdx < bits.length ? bits[bitIdx++] : false;
+      }
+    }
+    up = !up;
+    col -= 2;
+    if (col === 6) col = 5; // hop over the vertical timing strip
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Masking
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The 8 mask conditions from ISO 18004 Table 10.
+ *
+ * If condition(row, col) is true, the module is flipped (dark↔light).
+ * Applied only to non-reserved (data/ECC) modules.
+ */
+const MASK_CONDS: ReadonlyArray<(r: number, c: number) => boolean> = [
+  (r, c) => (r + c) % 2 === 0,
+  (r, _c) => r % 2 === 0,
+  (_r, c) => c % 3 === 0,
+  (r, c) => (r + c) % 3 === 0,
+  (r, c) => (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0,
+  (r, c) => (r * c) % 2 + (r * c) % 3 === 0,
+  (r, c) => ((r * c) % 2 + (r * c) % 3) % 2 === 0,
+  (r, c) => ((r + c) % 2 + (r * c) % 3) % 2 === 0,
+];
+
+/** Return a new module array with mask applied to all non-reserved cells. */
+function applyMask(
+  modules: boolean[][], reserved: boolean[][], sz: number, maskIdx: number,
+): boolean[][] {
+  const cond = MASK_CONDS[maskIdx];
+  return modules.map((row, r) =>
+    row.map((dark, c) => reserved[r][c] ? dark : dark !== cond(r, c)),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Penalty scoring (ISO 18004 Section 7.8.3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the 4-rule penalty score for a (masked) module array.
+ *
+ * Rule 1: runs of ≥5 same-color modules in a row/col → score += run−2
+ * Rule 2: 2×2 same-color blocks → score += 3 per block
+ * Rule 3: finder-like patterns (1,0,1,1,1,0,1,0,0,0,0) → score += 40 per match
+ * Rule 4: dark proportion deviation from 50% → score based on 5% steps
+ */
+function computePenalty(modules: boolean[][], sz: number): number {
+  let penalty = 0;
+
+  // Rule 1 — adjacent same-color runs ≥ 5
+  for (let r = 0; r < sz; r++) {
+    for (const horiz of [true, false]) {
+      let run = 1;
+      let prev = horiz ? modules[r][0] : modules[0][r];
+      for (let i = 1; i < sz; i++) {
+        const cur = horiz ? modules[r][i] : modules[i][r];
+        if (cur === prev) { run++; }
+        else { if (run >= 5) penalty += run - 2; run = 1; prev = cur; }
+      }
+      if (run >= 5) penalty += run - 2;
+    }
+  }
+
+  // Rule 2 — 2×2 same-color blocks
+  for (let r = 0; r < sz - 1; r++)
+    for (let c = 0; c < sz - 1; c++) {
+      const d = modules[r][c];
+      if (d === modules[r][c+1] && d === modules[r+1][c] && d === modules[r+1][c+1]) penalty += 3;
+    }
+
+  // Rule 3 — finder-pattern-like sequences (horizontal and vertical)
+  // Pattern and its reverse, each adds 40 when found.
+  const P1 = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
+  const P2 = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+  for (let a = 0; a < sz; a++) {
+    for (let b = 0; b <= sz - 11; b++) {
+      let mH1 = true, mH2 = true, mV1 = true, mV2 = true;
+      for (let k = 0; k < 11; k++) {
+        const bH = modules[a][b + k] ? 1 : 0;
+        const bV = modules[b + k][a] ? 1 : 0;
+        if (bH !== P1[k]) mH1 = false;
+        if (bH !== P2[k]) mH2 = false;
+        if (bV !== P1[k]) mV1 = false;
+        if (bV !== P2[k]) mV2 = false;
+      }
+      if (mH1) penalty += 40;
+      if (mH2) penalty += 40;
+      if (mV1) penalty += 40;
+      if (mV2) penalty += 40;
+    }
+  }
+
+  // Rule 4 — dark module ratio deviation
+  let dark = 0;
+  for (let r = 0; r < sz; r++) for (let c = 0; c < sz; c++) if (modules[r][c]) dark++;
+  const ratio = (dark / (sz * sz)) * 100;
+  const prev5 = Math.floor(ratio / 5) * 5;
+  penalty += Math.min(Math.abs(prev5 - 50), Math.abs(prev5 + 5 - 50)) / 5 * 10;
+
+  return penalty;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Version selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the minimum version (1–40) whose data codeword capacity fits the input.
+ *
+ * Uses the exact bit count for the selected mode, accounting for mode indicator
+ * and character-count field widths that vary with version.
+ */
+function selectVersion(input: string, ecc: EccLevel): number {
+  const mode = selectMode(input);
+  const byteLen = new TextEncoder().encode(input).length;
+
+  for (let v = 1; v <= 40; v++) {
+    const capacity = numDataCodewords(v, ecc);
+    const dataBits =
+      mode === "byte" ? byteLen * 8 :
+      mode === "numeric" ? Math.ceil(input.length * 10 / 3) :
+      Math.ceil(input.length * 11 / 2);
+    const bitsNeeded = 4 + charCountBits(mode, v) + dataBits;
+    if (Math.ceil(bitsNeeded / 8) <= capacity) return v;
+  }
+  throw new InputTooLongError(
+    `Input (${input.length} chars, ECC=${ecc}) exceeds version 40 capacity.`,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid initialisation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildGrid(version: number): WorkGrid {
+  const sz = symbolSize(version);
+  const g = makeWorkGrid(sz);
+
+  // Three finder patterns at three corners
+  placeFinder(g, 0, 0);           // top-left
+  placeFinder(g, 0, sz - 7);      // top-right
+  placeFinder(g, sz - 7, 0);      // bottom-left
+
+  // Separators (1-module light border just outside each finder)
+  // Top-left: row 7 and col 7
+  for (let i = 0; i <= 7; i++) { setMod(g, 7, i, false, true); setMod(g, i, 7, false, true); }
+  // Top-right: row 7 and col sz-8
+  for (let i = 0; i <= 7; i++) { setMod(g, 7, sz-1-i, false, true); setMod(g, i, sz-8, false, true); }
+  // Bottom-left: row sz-8 and col 7
+  for (let i = 0; i <= 7; i++) { setMod(g, sz-8, i, false, true); setMod(g, sz-1-i, 7, false, true); }
+
+  placeTimingStrips(g);      // must come before alignments (sets row/col 6 reserved)
+  placeAllAlignments(g, version);  // uses reserved-check to skip finder/timing overlaps
+
+  reserveFormatInfo(g);      // reserve 15 positions × 2 copies
+  reserveVersionInfo(g, version); // v7+: reserve 6×3 × 2 copies
+
+  placeDarkModule(g, version); // always-dark at (4V+9, 8)
+
+  return g;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Encode a UTF-8 string into a QR Code ModuleGrid.
+ *
+ * Returns a `(4V+17) × (4V+17)` boolean grid, `true` = dark module.
+ * Pass the result to `layout()` to obtain pixel coordinates, or to
+ * `renderSvg()` for a one-shot SVG string.
+ *
+ * @throws InputTooLongError if the input exceeds version-40 capacity.
+ *
+ * @example
+ * ```typescript
+ * const grid = encode("https://example.com", "M");
+ * // grid.rows === grid.cols === 29 for "https://example.com" at M
+ * ```
+ */
+export function encode(input: string, eccLevel: EccLevel): ModuleGrid {
+  const version = selectVersion(input, eccLevel);
+  const sz      = symbolSize(version);
+
+  const dataCW     = buildDataCodewords(input, version, eccLevel);
+  const blocks     = computeBlocks(dataCW, version, eccLevel);
+  const interleaved = interleaveBlocks(blocks);
+
+  const grid = buildGrid(version);
+  placeBits(grid, interleaved, version);
+
+  // Evaluate all 8 masks; pick the one with lowest penalty
+  let bestMask = 0;
+  let bestPenalty = Infinity;
+  for (let m = 0; m < 8; m++) {
+    const masked = applyMask(grid.modules, grid.reserved, sz, m);
+    const fmtBits = computeFormatBits(eccLevel, m);
+    const testG: WorkGrid = { size: sz, modules: masked, reserved: grid.reserved };
+    writeFormatInfo(testG, fmtBits);
+    const p = computePenalty(masked, sz);
+    if (p < bestPenalty) { bestPenalty = p; bestMask = m; }
+  }
+
+  // Finalize with best mask
+  const finalMods = applyMask(grid.modules, grid.reserved, sz, bestMask);
+  const finalG: WorkGrid = { size: sz, modules: finalMods, reserved: grid.reserved };
+  writeFormatInfo(finalG, computeFormatBits(eccLevel, bestMask));
+  writeVersionInfo(finalG, version);
+
+  return { rows: sz, cols: sz, modules: finalMods, moduleShape: "square" };
+}
+
+/**
+ * Encode and convert to a pixel-resolved PaintScene.
+ *
+ * Delegates pixel geometry (module size, quiet zone, colours) to
+ * `barcode-2d`'s `layout()`.
+ */
+export function encodeAndLayout(
+  input: string,
+  eccLevel: EccLevel,
+  config?: Partial<Barcode2DLayoutConfig>,
+): PaintScene {
+  return layout(encode(input, eccLevel), config);
+}
+
+/**
+ * Encode and render directly to an SVG string.
+ *
+ * Returns a complete `<svg>…</svg>` document.
+ *
+ * @example
+ * ```typescript
+ * const svg = renderSvg("https://example.com", "M");
+ * document.body.innerHTML = svg;
+ * ```
+ */
+export function renderSvg(
+  input: string,
+  eccLevel: EccLevel,
+  config?: Partial<Barcode2DLayoutConfig>,
+): string {
+  return renderToSvgString(encodeAndLayout(input, eccLevel, config));
+}
+
+/**
+ * Encode with per-module role annotations (for interactive visualizers).
+ *
+ * v0.1.0: returns the encoded grid with null annotations.
+ * Full annotation support (finder/timing/data/ECC roles per module) is v0.2.0.
+ */
+export function explain(input: string, eccLevel: EccLevel): AnnotatedModuleGrid {
+  const grid = encode(input, eccLevel);
+  return {
+    ...grid,
+    annotations: Array.from({ length: grid.rows }, () => new Array(grid.cols).fill(null)),
+  };
+}

--- a/code/packages/typescript/qr-code/tests/qr-code.test.ts
+++ b/code/packages/typescript/qr-code/tests/qr-code.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Tests for the qr-code encoder.
+ *
+ * Tests are organized into:
+ *  1. Unit tests for internal helpers (RS, format info, mode selection)
+ *  2. Structural tests verifying grid dimensions and functional patterns
+ *  3. Integration tests encoding known strings and verifying properties
+ *  4. Error handling tests
+ *
+ * We cannot easily run a full QR scanner in CI, so we verify structural
+ * properties: correct size, finder patterns at expected corners, format info
+ * bits readable, dark module in place.  Cross-language comparison happens
+ * at the integration level via the test corpus.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  encode,
+  encodeAndLayout,
+  renderSvg,
+  explain,
+  InputTooLongError,
+  VERSION,
+  type EccLevel,
+} from "../src/index";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Decode the 15-bit format info from copy 1 (top-left finder area). */
+function readFormatInfoCopy1(modules: ReadonlyArray<ReadonlyArray<boolean>>, _size: number): number {
+  // Bit positions of copy 1 (bit 0 first):
+  // bits 0–5 at (8, 0..5), bit 6 at (8,7), bit 7 at (8,8),
+  // bit 8 at (7,8), bits 9–14 at (5..0, 8)
+  let fmt = 0;
+  const rowCol: Array<[number, number]> = [
+    [8, 0], [8, 1], [8, 2], [8, 3], [8, 4], [8, 5],
+    [8, 7], [8, 8],
+    [7, 8],
+    [5, 8], [4, 8], [3, 8], [2, 8], [1, 8], [0, 8],
+  ];
+  for (let i = 0; i < 15; i++) {
+    const [r, c] = rowCol[i];
+    if (modules[r][c]) fmt |= 1 << i;
+  }
+  return fmt;
+}
+
+/** XOR the raw format bits with the 0x5412 mask and BCH-decode to get [ecc, maskPattern]. */
+function decodeFormatInfo(rawFmt: number): { eccBits: number; maskPattern: number } | null {
+  const fmt = rawFmt ^ 0x5412;
+  // Verify BCH: (fmt >> 10) << 10 mod 0x537 should equal (fmt & 0x3FF)
+  let rem = (fmt >> 10) << 10;
+  for (let i = 14; i >= 10; i--) {
+    if ((rem >> i) & 1) rem ^= 0x537 << (i - 10);
+  }
+  if ((rem & 0x3ff) !== (fmt & 0x3ff)) return null;
+  return { eccBits: (fmt >> 13) & 0x3, maskPattern: (fmt >> 10) & 0x7 };
+}
+
+/** Check that a 7×7 finder pattern exists at (topRow, topCol). */
+function hasFinder(modules: ReadonlyArray<ReadonlyArray<boolean>>, topRow: number, topCol: number): boolean {
+  for (let dr = 0; dr < 7; dr++) {
+    for (let dc = 0; dc < 7; dc++) {
+      const onBorder = dr === 0 || dr === 6 || dc === 0 || dc === 6;
+      const inCore   = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+      const expected = onBorder || inCore;
+      if (modules[topRow + dr][topCol + dc] !== expected) return false;
+    }
+  }
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("VERSION", () => {
+  it("is 0.1.0", () => {
+    expect(VERSION).toBe("0.1.0");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Version selection and grid size
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("encode — version and size", () => {
+  it("version 1 produces a 21×21 grid", () => {
+    const grid = encode("A", "M");
+    expect(grid.rows).toBe(21);
+    expect(grid.cols).toBe(21);
+    expect(grid.moduleShape).toBe("square");
+    expect(grid.modules.length).toBe(21);
+    expect(grid.modules[0].length).toBe(21);
+  });
+
+  it("HELLO WORLD at M selects version 1 (21×21)", () => {
+    // "HELLO WORLD" = 11 alphanumeric chars, fits in v1 M (16 data CW capacity)
+    const grid = encode("HELLO WORLD", "M");
+    expect(grid.rows).toBe(21);
+  });
+
+  it("https://example.com at M selects version 2 (25×25)", () => {
+    // 19 bytes in byte mode; version 2 M has 28 data CWs
+    const grid = encode("https://example.com", "M");
+    expect(grid.rows).toBe(25);
+  });
+
+  it("numeric short string selects small version", () => {
+    const grid = encode("01234567890", "L");
+    // Numeric 11 digits ≈ 37 bits + header; v1 L has 19×8=152 bits → fits easily
+    expect(grid.rows).toBe(21);
+  });
+
+  it("larger input needs larger version", () => {
+    // "The quick brown fox jumps over the lazy dog" = 43 chars, byte mode
+    const grid = encode("The quick brown fox jumps over the lazy dog", "M");
+    expect(grid.rows).toBeGreaterThan(21);
+  });
+
+  it("all four ECC levels produce grids", () => {
+    for (const ecc of ["L", "M", "Q", "H"] as EccLevel[]) {
+      const grid = encode("HELLO", ecc);
+      expect(grid.rows).toBeGreaterThanOrEqual(21);
+    }
+  });
+
+  it("H level requires larger version than L for same input", () => {
+    const gridL = encode("The quick brown fox", "L");
+    const gridH = encode("The quick brown fox", "H");
+    expect(gridH.rows).toBeGreaterThanOrEqual(gridL.rows);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Structural correctness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("encode — structural patterns", () => {
+  it("top-left finder pattern is present", () => {
+    const grid = encode("HELLO WORLD", "M");
+    expect(hasFinder(grid.modules, 0, 0)).toBe(true);
+  });
+
+  it("top-right finder pattern is present", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const sz = grid.rows;
+    expect(hasFinder(grid.modules, 0, sz - 7)).toBe(true);
+  });
+
+  it("bottom-left finder pattern is present", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const sz = grid.rows;
+    expect(hasFinder(grid.modules, sz - 7, 0)).toBe(true);
+  });
+
+  it("timing strips alternate dark/light in row 6", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const sz = grid.rows;
+    for (let c = 8; c <= sz - 9; c++) {
+      // Dark when col is even
+      expect(grid.modules[6][c]).toBe(c % 2 === 0);
+    }
+  });
+
+  it("timing strips alternate dark/light in col 6", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const sz = grid.rows;
+    for (let r = 8; r <= sz - 9; r++) {
+      expect(grid.modules[r][6]).toBe(r % 2 === 0);
+    }
+  });
+
+  it("dark module at (4V+9, 8) is dark", () => {
+    const grid = encode("A", "M");
+    // version 1: dark module at (4*1+9, 8) = (13, 8)
+    expect(grid.modules[13][8]).toBe(true);
+  });
+
+  it("dark module present for version 2 symbol", () => {
+    const grid = encode("https://example.com", "M");
+    // version 2: dark module at (4*2+9, 8) = (17, 8)
+    expect(grid.modules[17][8]).toBe(true);
+  });
+
+  it("format information is present and decodable", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const rawFmt = readFormatInfoCopy1(grid.modules, grid.rows);
+    const decoded = decodeFormatInfo(rawFmt);
+    expect(decoded).not.toBeNull();
+    // ECC M indicator = 00 = 0
+    expect(decoded!.eccBits).toBe(0b00);
+  });
+
+  it("format info ECC bits match the requested level", () => {
+    const eccBitsMap: Record<EccLevel, number> = { L: 0b01, M: 0b00, Q: 0b11, H: 0b10 };
+    for (const ecc of ["L", "M", "Q", "H"] as EccLevel[]) {
+      const grid = encode("HELLO", ecc);
+      const rawFmt = readFormatInfoCopy1(grid.modules, grid.rows);
+      const decoded = decodeFormatInfo(rawFmt);
+      expect(decoded).not.toBeNull();
+      expect(decoded!.eccBits).toBe(eccBitsMap[ecc]);
+    }
+  });
+
+  it("two format info copies are consistent", () => {
+    const grid = encode("HELLO WORLD", "M");
+    const sz = grid.rows;
+    const copy2positions: Array<[number, number]> = [
+      [sz-1,8],[sz-2,8],[sz-3,8],[sz-4,8],[sz-5,8],[sz-6,8],[sz-7,8],
+      [8,sz-8],[8,sz-7],[8,sz-6],[8,sz-5],[8,sz-4],[8,sz-3],[8,sz-2],[8,sz-1],
+    ];
+    const copy1positions: Array<[number, number]> = [
+      [8,0],[8,1],[8,2],[8,3],[8,4],[8,5],[8,7],[8,8],
+      [7,8],[5,8],[4,8],[3,8],[2,8],[1,8],[0,8],
+    ];
+    let fmt1 = 0, fmt2 = 0;
+    for (let i = 0; i < 15; i++) {
+      const [r1,c1] = copy1positions[i];
+      const [r2,c2] = copy2positions[i];
+      if (grid.modules[r1][c1]) fmt1 |= 1 << i;
+      if (grid.modules[r2][c2]) fmt2 |= 1 << i;
+    }
+    expect(fmt1).toBe(fmt2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Encoding mode selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("encode — mode selection (via grid size)", () => {
+  it("pure digits produce a smaller grid than equivalent bytes", () => {
+    // "000000000000000" (15 digits) uses numeric mode — much more compact
+    const numericGrid = encode("000000000000000", "M");
+    // Same content as bytes would be larger
+    const byteGrid = encode("A".repeat(15), "M");
+    // Both should be valid QR codes; numeric may fit in smaller version
+    expect(numericGrid.rows).toBeLessThanOrEqual(byteGrid.rows);
+  });
+
+  it("uppercase + digits + space uses alphanumeric mode", () => {
+    const grid = encode("HELLO WORLD", "M");
+    expect(grid.rows).toBe(21); // v1 — fits in alphanumeric, not byte
+  });
+
+  it("lowercase falls back to byte mode", () => {
+    const grid = encode("hello world", "M");
+    // Byte mode needs more space than alphanumeric
+    expect(grid.rows).toBeGreaterThanOrEqual(21);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. encodeAndLayout
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("encodeAndLayout", () => {
+  it("returns a PaintScene", () => {
+    const scene = encodeAndLayout("HELLO", "M");
+    expect(scene).toBeDefined();
+    expect(scene.width).toBeGreaterThan(0);
+    expect(scene.height).toBeGreaterThan(0);
+    expect(scene.instructions).toBeDefined();
+  });
+
+  it("default config produces 21×21 grid at 10px/module with 4-module quiet zone", () => {
+    const scene = encodeAndLayout("A", "M");
+    // v1: 21 modules + 2*4 quiet = 29 modules → 29*10 = 290px
+    expect(scene.width).toBe(290);
+    expect(scene.height).toBe(290);
+  });
+
+  it("accepts partial config", () => {
+    const scene = encodeAndLayout("A", "M", { moduleSizePx: 5 });
+    // 29 modules × 5 px = 145px
+    expect(scene.width).toBe(145);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. renderSvg
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("renderSvg", () => {
+  it("returns a string starting with <svg", () => {
+    const svg = renderSvg("HELLO WORLD", "M");
+    expect(typeof svg).toBe("string");
+    expect(svg.trimStart()).toMatch(/^<svg/);
+  });
+
+  it("contains a closing </svg> tag", () => {
+    const svg = renderSvg("A", "L");
+    expect(svg).toContain("</svg>");
+  });
+
+  it("SVG is larger for larger QR versions", () => {
+    const svgV1 = renderSvg("A", "M");
+    const svgV3 = renderSvg("The quick brown fox", "M");
+    expect(svgV3.length).toBeGreaterThan(svgV1.length);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. explain
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("explain", () => {
+  it("returns grid with annotations array matching dimensions", () => {
+    const annotated = explain("HELLO WORLD", "M");
+    expect(annotated.rows).toBe(21);
+    expect(annotated.annotations.length).toBe(21);
+    expect(annotated.annotations[0].length).toBe(21);
+  });
+
+  it("module grid matches plain encode", () => {
+    const plain = encode("HELLO WORLD", "M");
+    const annotated = explain("HELLO WORLD", "M");
+    expect(annotated.modules).toEqual(plain.modules);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Error handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("error handling", () => {
+  it("throws InputTooLongError for a string exceeding all versions", () => {
+    const giant = "A".repeat(8000); // well beyond version 40 H capacity
+    expect(() => encode(giant, "H")).toThrow(InputTooLongError);
+  });
+
+  it("error message mentions the ECC level", () => {
+    const giant = "A".repeat(8000);
+    try {
+      encode(giant, "H");
+    } catch (e) {
+      expect((e as Error).message).toContain("H");
+    }
+  });
+
+  it("does not throw for empty string", () => {
+    expect(() => encode("", "M")).not.toThrow();
+  });
+
+  it("encodes a single character without error", () => {
+    const grid = encode("A", "M");
+    expect(grid.rows).toBe(21);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Determinism and consistency
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("determinism", () => {
+  it("same input produces identical grids across calls", () => {
+    const g1 = encode("https://example.com", "M");
+    const g2 = encode("https://example.com", "M");
+    expect(g1.modules).toEqual(g2.modules);
+  });
+
+  it("different inputs produce different grids", () => {
+    const g1 = encode("HELLO", "M");
+    const g2 = encode("WORLD", "M");
+    // At least some modules differ
+    let diff = false;
+    for (let r = 0; r < g1.rows; r++)
+      for (let c = 0; c < g1.cols; c++)
+        if (g1.modules[r][c] !== g2.modules[r][c]) diff = true;
+    expect(diff).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("numeric mode: all zeros", () => {
+    const grid = encode("0000000000", "L");
+    expect(grid.rows).toBeGreaterThanOrEqual(21);
+  });
+
+  it("byte mode: UTF-8 multi-byte characters", () => {
+    // "→" is 3 UTF-8 bytes
+    const grid = encode("→→→", "M");
+    expect(grid.rows).toBeGreaterThanOrEqual(21);
+  });
+
+  it("alphanumeric: all special chars", () => {
+    const grid = encode("$%*+-./:", "M");
+    expect(grid.rows).toBeGreaterThanOrEqual(21);
+  });
+
+  it("version 7+ grid has correct size", () => {
+    // 85 uppercase-letter alphanumeric chars exceed v6-H capacity (~84 chars).
+    // v6 H has 60 data CW = 480 bits; 4+9+ceil(85×11/2)=481 bits → doesn't fit.
+    // v7 H has 66 data CW = 528 bits; 481 bits fits. Expect 45×45 or larger.
+    const input = "A".repeat(85);
+    const grid = encode(input, "H");
+    expect(grid.rows).toBeGreaterThanOrEqual(45);
+  });
+
+  it("modules array is a proper 2D boolean array", () => {
+    const grid = encode("HELLO", "M");
+    for (const row of grid.modules) {
+      for (const cell of row) {
+        expect(typeof cell).toBe("boolean");
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. Integration: known test corpus
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("integration — test corpus", () => {
+  const corpus = [
+    { input: "A",                                          ecc: "M" as EccLevel },
+    { input: "HELLO WORLD",                                ecc: "M" as EccLevel },
+    { input: "https://example.com",                        ecc: "M" as EccLevel },
+    { input: "01234567890",                                ecc: "M" as EccLevel },
+    { input: "The quick brown fox jumps over the lazy dog", ecc: "M" as EccLevel },
+  ];
+
+  for (const { input, ecc } of corpus) {
+    it(`encodes "${input.slice(0, 20)}…" at ${ecc} without error`, () => {
+      const grid = encode(input, ecc);
+      expect(grid.rows).toBeGreaterThanOrEqual(21);
+      expect(grid.rows).toBe(grid.cols);
+      expect(grid.moduleShape).toBe("square");
+    });
+  }
+
+  it("each corpus item produces a decodable format info", () => {
+    for (const { input, ecc } of corpus) {
+      const grid = encode(input, ecc);
+      const rawFmt = readFormatInfoCopy1(grid.modules, grid.rows);
+      const decoded = decodeFormatInfo(rawFmt);
+      expect(decoded).not.toBeNull();
+    }
+  });
+});

--- a/code/packages/typescript/qr-code/tsconfig.json
+++ b/code/packages/typescript/qr-code/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/qr-code/vitest.config.ts
+++ b/code/packages/typescript/qr-code/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 90,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `@coding-adventures/qr-code` (TypeScript) and `qr-code` (Rust) — ISO/IEC 18004:2015 compliant QR Code encoders for all 40 versions × 4 ECC levels (L/M/Q/H)
- Both packages sit on top of `barcode-2d` (abstract grid) and `gf256` (field arithmetic) and produce scannable QR Codes as `ModuleGrid` → `PaintScene` → SVG
- Unblocks Data Matrix, Aztec, PDF417, and MaxiCode (once their respective GF field packages land)

## Encoding pipeline (both languages)

```
input string
  → mode selection    (numeric / alphanumeric / byte)
  → version selection (smallest v1–40 fitting at ECC level)
  → bit stream        (mode indicator + char count + data + padding 0xEC/0x11)
  → blocks + RS ECC   (GF(256) b=0 convention, poly 0x11D)
  → interleave        (data CWs round-robin, then ECC CWs round-robin)
  → grid init         (finder × 3, separators, timing, alignment, dark module)
  → zigzag placement  (two-column snake, timing column skipped)
  → mask evaluation   (8 patterns, 4-rule ISO penalty scoring)
  → format info       (BCH(15,5) generator 0x537, XOR mask 0x5412)
  → version info v7+  (BCH(18,6) generator 0x1F25)
  → ModuleGrid
```

## Test coverage

- **TypeScript**: 46 unit tests, 100% statement/function/line coverage, 97.71% branch
- **Rust**: 24 unit tests + 1 doc-test; all passing

## Security review

Completed before push. Fixes applied:
- Added `debug_assert!` in `encode_alphanumeric` to document the `select_mode` precondition
- Added early input-length guard (> 7089 bytes) to prevent unnecessary allocations before version selection rejects oversized inputs
- Separated `QRCodeError::LayoutError` from `InputTooLong` to avoid conflating error types and leaking raw dependency error strings

## Test plan

- [ ] TypeScript CI: `npx vitest run --coverage` passes (46 tests, ≥90% coverage threshold)
- [ ] Rust CI: `cargo test -p qr-code` passes (25 tests)
- [ ] Workspace build: `cargo build --workspace` compiles cleanly
- [ ] No regressions in other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)