### PR TITLE
fix(diagram-to-paint): text now renders inside nodes (fix coordinate-space mismatch)

### DIFF
--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — diagram-to-paint
 
+## 0.1.2 — Fix text coordinate-space mismatch (text now inside nodes)
+
+### Fixed
+- **Text rendered below/off canvas on Retina** — `layout_to_paint` with `device_pixel_ratio > 1`
+  emits glyph positions in device pixels, but `paint-metal` creates its CGBitmap at `scene.height`
+  logical pixels and flips y as `height − gy`. With DPR=2 the glyph y (≈106 dp) exceeded the
+  100-logical-pixel canvas height, placing text off the bottom edge. Fixed by passing
+  `device_pixel_ratio: 1.0` to the text bridge so glyph coordinates stay in the same logical-pixel
+  space as all node/edge geometry. A future DPR-aware pass can scale the full scene consistently.
+
 ## 0.1.1 — Real text shaping via layout-to-paint
 
 ### Changed (breaking)

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 
@@ -10,3 +10,11 @@ paint-instructions = { path = "../paint-instructions" }
 layout-ir = { path = "../layout-ir" }
 layout-to-paint = { path = "../layout-to-paint" }
 text-interfaces = { path = "../text-interfaces" }
+
+[target.'cfg(target_vendor = "apple")'.dev-dependencies]
+dot-parser = { path = "../dot-parser" }
+diagram-layout-graph = { path = "../diagram-layout-graph" }
+paint-metal = { path = "../paint-metal" }
+paint-codec-png = { path = "../paint-codec-png" }
+text-native-coretext = { path = "../text-native-coretext" }
+layout-ir = { path = "../layout-ir" }

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.1.2";
 
 use std::collections::HashMap;
 
@@ -375,11 +375,18 @@ where
         ext: HashMap::new(),
     };
 
+    // Use DPR=1 for the text bridge. `diagram_to_paint` emits all geometry
+    // (rects, paths) in logical pixels and the PaintScene dimensions are
+    // logical. layout_to_paint with DPR>1 would emit glyph positions in
+    // device pixels, causing a mismatch: paint-metal creates the CGBitmap at
+    // scene.height logical pixels and flips y as (height - gy), so a device-
+    // pixel y value would land off-canvas. Keeping everything in logical pixel
+    // space is consistent. A future pass can scale the whole scene by DPR.
     let text_opts = LayoutToPaintOptions {
         width: diagram.width,
         height: diagram.height,
         background: Color { r: 0, g: 0, b: 0, a: 0 }, // transparent root
-        device_pixel_ratio: options.device_pixel_ratio,
+        device_pixel_ratio: 1.0,
         shaper:   options.shaper,
         metrics:  options.metrics,
         resolver: options.resolver,
@@ -560,7 +567,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.1.0");
+        assert_eq!(VERSION, "0.1.2");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -1,0 +1,67 @@
+// End-to-end rendering test: DOT → diagram-ir → layout → paint → Metal → PNG
+//
+// Run with:
+//   cargo test -p diagram-to-paint --test e2e_render -- --nocapture
+//
+// Output: /tmp/diagram_e2e.png
+//
+// This test only compiles on Apple platforms (CoreText + Metal).
+
+#[cfg(target_vendor = "apple")]
+mod apple {
+    use diagram_layout_graph::layout_graph_diagram;
+    use diagram_to_paint::{DiagramToPaintOptions, diagram_to_paint};
+    use dot_parser::parse_to_diagram;
+    use layout_ir::font_spec;
+    use paint_codec_png::write_png;
+    use paint_metal::render;
+    use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
+
+    #[test]
+    fn render_dot_diagram_to_png() {
+        let dot = r#"
+            digraph Pipeline {
+                rankdir=LR;
+                DOT -> Parser -> Layout -> Paint -> Metal;
+                Metal -> PNG;
+            }
+        "#;
+
+        let graph = parse_to_diagram(dot).expect("DOT parse failed");
+        let layout = layout_graph_diagram(&graph, None, None);
+
+        let shaper   = CoreTextShaper;
+        let metrics  = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+
+        let opts = DiagramToPaintOptions {
+            background:         layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            device_pixel_ratio: 2.0,
+            label_font:         font_spec("Helvetica", 14.0),
+            title_font: {
+                let mut f = font_spec("Helvetica", 18.0);
+                f.weight = 700;
+                f
+            },
+            shaper:   &shaper,
+            metrics:  &metrics,
+            resolver: &resolver,
+        };
+
+        let scene  = diagram_to_paint(&layout, &opts);
+        let pixels = render(&scene);
+        let path   = "/tmp/diagram_e2e.png";
+        write_png(&pixels, path).expect("PNG write failed");
+
+        println!("Rendered {}×{} scene → {}", scene.width, scene.height, path);
+        println!("  {} paint instructions", scene.instructions.len());
+        let glyph_runs = scene.instructions.iter()
+            .filter(|i| matches!(i, paint_instructions::PaintInstruction::GlyphRun(_)))
+            .count();
+        println!("  {} PaintGlyphRun instructions (real glyph IDs)", glyph_runs);
+
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(glyph_runs > 0, "expected at least one PaintGlyphRun from shaping pipeline");
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `layout_to_paint` with `device_pixel_ratio: 2.0` emits glyph positions in device pixels (y≈106), but `paint-metal` creates its CGBitmap at `scene.height = 100` (logical pixels) and flips y as `height − gy = 100 − 106 = −6`, placing all text off the canvas bottom.
- **Fix**: Pass `device_pixel_ratio: 1.0` to the `layout_to_paint` call inside `diagram_to_paint` so glyph coordinates stay in the same logical-pixel space as node rects and edge paths.
- **Verified**: e2e render test produces a PNG with "DOT", "Parser", "Layout", "Paint", "Metal", "PNG" labels correctly centered inside their node boxes.

## Test plan

- [x] `cargo test -p diagram-to-paint` — all 16 tests pass (15 unit + 1 e2e)
- [x] `/tmp/diagram_e2e.png` visually confirms text is inside node boxes
- [x] Bumped version to 0.1.2 with CHANGELOG entry explaining the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)