### PR TITLE
feat(qr-code): add TypeScript and Rust QR Code encoder packages

### DIFF
--- a/code/packages/rust/qr-code/src/lib.rs
+++ b/code/packages/rust/qr-code/src/lib.rs
@@ -516,16 +516,35 @@ fn compute_format_bits(ecc: EccLevel, mask: u32) -> u32 {
 }
 
 fn write_format_info(g: &mut WorkGrid, fmt: u32) {
+    // The 15-bit format information word `fmt` is labeled f14..f0 (f14 = MSB).
+    //
+    // ISO/IEC 18004 — Copy 1 (around top-left finder):
+    //
+    //   Row 8, col 0 → f14   col 1 → f13  …  col 5 → f9
+    //   Row 8, col 7 → f8    (col 6 is the timing column, skipped)
+    //   Row 8, col 8 → f7
+    //   Col 8, row 7 → f6    (row 6 is the timing row, skipped)
+    //   Col 8, row 5 → f5  …  row 0 → f0
+    //
+    // Copy 2 (around top-right / bottom-left finders):
+    //   Row 8, col n-1 → f0   col n-2 → f1  …  col n-8 → f7
+    //   Col 8, row n-7 → f8   row n-6 → f9  …  row n-1 → f14
     let sz = g.size;
-    // Copy 1
-    for i in 0u32..=5 { g.modules[8][i as usize] = (fmt >> i) & 1 == 1; }
-    g.modules[8][7] = (fmt >> 6) & 1 == 1;
-    g.modules[8][8] = (fmt >> 7) & 1 == 1;
-    g.modules[7][8] = (fmt >> 8) & 1 == 1;
-    for i in 9u32..=14 { g.modules[(14 - i) as usize][8] = (fmt >> i) & 1 == 1; }
-    // Copy 2
-    for i in 0u32..=6 { g.modules[sz - 1 - i as usize][8] = (fmt >> i) & 1 == 1; }
-    for i in 7u32..=14 { g.modules[8][sz - 15 + i as usize] = (fmt >> i) & 1 == 1; }
+
+    // ── Copy 1 ──────────────────────────────────────────────────────────────
+    // Row 8, cols 0-5: f14 down to f9 (MSB first, left-to-right)
+    for i in 0u32..=5 { g.modules[8][i as usize] = (fmt >> (14 - i)) & 1 == 1; }
+    g.modules[8][7] = (fmt >> 8) & 1 == 1;  // f8
+    g.modules[8][8] = (fmt >> 7) & 1 == 1;  // f7
+    g.modules[7][8] = (fmt >> 6) & 1 == 1;  // f6
+    // Col 8, rows 0-5: f0 at row 0 … f5 at row 5 (LSB at top)
+    for i in 0u32..=5 { g.modules[i as usize][8] = (fmt >> i) & 1 == 1; }
+
+    // ── Copy 2 ──────────────────────────────────────────────────────────────
+    // Row 8, cols n-1 down to n-8: f0 at col n-1 … f7 at col n-8
+    for i in 0u32..=7 { g.modules[8][sz - 1 - i as usize] = (fmt >> i) & 1 == 1; }
+    // Col 8, rows n-7 to n-1: f8 at row n-7 … f14 at row n-1
+    for i in 8u32..=14 { g.modules[sz - 15 + i as usize][8] = (fmt >> i) & 1 == 1; }
 }
 
 fn reserve_version_info(g: &mut WorkGrid, version: usize) {
@@ -848,17 +867,23 @@ mod tests {
         true
     }
 
-    // Read copy-1 format bits and BCH-verify them
+    // Read copy-1 format bits (standard order: f14 at (8,0) → f0 at (0,8))
+    // and BCH-verify them.
     fn format_info_valid(mods: &[Vec<bool>], _sz: usize) -> Option<(u32, u32)> {
+        // Standard ISO 18004 copy-1 positions, ordered f14 → f0.
+        // Each position i carries bit (14-i) of the format word.
         let positions: [(usize, usize); 15] = [
             (8,0),(8,1),(8,2),(8,3),(8,4),(8,5),(8,7),(8,8),
             (7,8),(5,8),(4,8),(3,8),(2,8),(1,8),(0,8),
         ];
         let mut raw = 0u32;
         for (i, &(r, c)) in positions.iter().enumerate() {
-            if mods[r][c] { raw |= 1 << i; }
+            if mods[r][c] { raw |= 1 << (14 - i); }  // f14 at i=0 → bit 14
         }
+        // raw is now the 15-bit format word; XOR off the ISO masking sequence.
         let fmt = raw ^ 0x5412;
+        // BCH check: recompute the 10-bit parity from the 5-bit data portion
+        // and compare against the stored parity.
         let mut rem = (fmt >> 10) << 10;
         for i in (10u32..=14).rev() {
             if (rem >> i) & 1 == 1 { rem ^= 0x537 << (i - 10); }

--- a/code/packages/typescript/qr-code/src/index.ts
+++ b/code/packages/typescript/qr-code/src/index.ts
@@ -325,10 +325,24 @@ function encodeNumeric(input: string, w: BitWriter): void {
 function encodeAlphanumeric(input: string, w: BitWriter): void {
   let i = 0;
   while (i + 1 < input.length) {
-    w.write(ALPHANUM_CHARS.indexOf(input[i]) * 45 + ALPHANUM_CHARS.indexOf(input[i + 1]), 11);
+    const idx0 = ALPHANUM_CHARS.indexOf(input[i]);
+    const idx1 = ALPHANUM_CHARS.indexOf(input[i + 1]);
+    // Guard: selectMode() must have confirmed every character is in the
+    // alphanumeric set before this function is called.  indexOf returning -1
+    // would silently produce a corrupt bit stream, so we fail fast here.
+    if (idx0 < 0 || idx1 < 0) throw new QRCodeError(
+      `encodeAlphanumeric: character not in QR alphanumeric set (precondition violated)`
+    );
+    w.write(idx0 * 45 + idx1, 11);
     i += 2;
   }
-  if (i < input.length) w.write(ALPHANUM_CHARS.indexOf(input[i]), 6);
+  if (i < input.length) {
+    const idx = ALPHANUM_CHARS.indexOf(input[i]);
+    if (idx < 0) throw new QRCodeError(
+      `encodeAlphanumeric: character not in QR alphanumeric set (precondition violated)`
+    );
+    w.write(idx, 6);
+  }
 }
 
 /** Each UTF-8 byte → 8 bits. */
@@ -863,6 +877,16 @@ function buildGrid(version: number): WorkGrid {
  * ```
  */
 export function encode(input: string, eccLevel: EccLevel): ModuleGrid {
+  // Early-exit guard: QR Code v40 holds at most 7089 numeric characters
+  // (~2953 bytes in byte mode).  Without this guard, selectVersion() would
+  // call `new TextEncoder().encode(input)` up to 40 times for a huge input,
+  // allocating O(n) memory 40 times before finally throwing InputTooLongError.
+  // In a server-side Node.js context this is a cheap DoS amplifier.
+  if (input.length > 7089) {
+    throw new InputTooLongError(
+      `Input length ${input.length} exceeds 7089 (QR Code v40 numeric-mode maximum).`
+    );
+  }
   const version = selectVersion(input, eccLevel);
   const sz      = symbolSize(version);
 
@@ -913,10 +937,22 @@ export function encodeAndLayout(
  *
  * Returns a complete `<svg>…</svg>` document.
  *
+ * @security Do NOT inject the returned string via `innerHTML` or `outerHTML`.
+ * Use `DOMParser` + `appendChild` instead, or a trusted HTML sanitizer:
+ * ```typescript
+ * const parser = new DOMParser();
+ * const svgDoc = parser.parseFromString(svg, "image/svg+xml");
+ * document.body.appendChild(svgDoc.documentElement);
+ * ```
+ *
  * @example
  * ```typescript
  * const svg = renderSvg("https://example.com", "M");
- * document.body.innerHTML = svg;
+ * // Safe: parse, then append
+ * const parser = new DOMParser();
+ * document.body.appendChild(
+ *   parser.parseFromString(svg, "image/svg+xml").documentElement
+ * );
  * ```
  */
 export function renderSvg(

--- a/code/packages/typescript/qr-code/tests/qr-code.test.ts
+++ b/code/packages/typescript/qr-code/tests/qr-code.test.ts
@@ -333,7 +333,10 @@ describe("error handling", () => {
   });
 
   it("error message mentions the ECC level", () => {
-    const giant = "A".repeat(8000);
+    // 2000 ASCII bytes is under the 7089-char early-exit guard but exceeds
+    // v40-H byte-mode capacity (~1273 bytes), so selectVersion throws with
+    // the ECC level in the message.
+    const giant = "A".repeat(2000);
     try {
       encode(giant, "H");
     } catch (e) {

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,38 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-23: QR format info `write_format_info` — bit ordering is MSB-first in row 8
+
+ISO/IEC 18004 places format information bits **MSB-first** (f14 → f9) going
+left-to-right across row 8 (cols 0–5) and **LSB-first** (f0 → f5) going
+top-to-bottom down col 8 (rows 0–5).  Copy 2 mirrors this: f0 → f7 going
+right-to-left across row 8 (cols n−1 → n−8), and f8 → f14 going top-to-bottom
+down col 8 (rows n−7 → n−1).
+
+**The bug:** `write_format_info` was placing bits in LSB-first order everywhere,
+producing a reversed 15-bit word.  Both copies read `0x1F3D` instead of `0x5E7C`
+for ECC=M/mask=2.  BCH remainder was `0x3DA` (non-zero) for both copies, so
+every standard decoder (zbarimg, iPhone camera, ZXing) rejected the format info
+and could not determine the correct mask pattern or ECC level — the QR code
+appeared structurally correct but was completely unscannable.
+
+**Root cause:** The manual decoder written to debug the issue used the same
+reversed reading order, so it incorrectly confirmed the format info as valid.
+The bug was only caught by comparing pixel values at specific grid positions
+against the expected standard layout.
+
+**Fix:**
+- Copy 1, row 8 cols 0–5: use `(fmt >> (14 - i))` (f14 at col 0, not f0).
+- Copy 1, (8,7) = f8, (8,8) = f7, (7,8) = f6.
+- Copy 1, col 8 rows 0–5: use `(fmt >> i)` (f0 at row 0 … f5 at row 5).
+- Copy 2, row 8 cols n−1..n−8: use `(fmt >> i)` for i=0..7 (f0 at rightmost).
+- Copy 2, col 8 rows n−7..n−1: use `(fmt >> i)` for i=8..14.
+
+**Always verify with `zbarimg` (or equivalent standard decoder) immediately
+after implementing format info — the BCH check is the ground truth.**
+
+---
+
 ### 2026-04-21: BUILD files must be updated whenever package.json dependencies change
 
 The build-tool validates that every `BUILD` / `BUILD_windows` shell script lists


### PR DESCRIPTION
## Summary

- **TypeScript `@coding-adventures/qr-code`**: Full ISO/IEC 18004:2015 QR Code encoder. Supports L/M/Q/H ECC, numeric/alphanumeric/byte modes, versions 1–40, mask evaluation, format info, SVG output. 46 tests, 99.2% coverage.
- **Rust `qr-code` 0.1.0**: Identical pipeline in Rust — GF(256) RS codes, interleaving, zigzag placement, penalty scoring. Outputs `ModuleGrid` to `barcode-2d → paint-metal → PNG`. 24 tests pass. Metal-rendered PNGs confirmed scannable by zbarimg and iPhone.
- **Bug fix**: `write_format_info` was placing format bits in LSB-first order; standard decoders require MSB-first. Both copies read `0x1F3D` (BCH invalid) before fix, `0x5E7C` (BCH valid) after. Root cause documented in `lessons.md`.
- **Security hardening**: input length guard (DoS), `encodeAlphanumeric` precondition guard (silent corruption), `renderSvg` JSDoc XSS warning.

## Test plan

- [ ] CI passes all checks
- [ ] `cargo test -p qr-code` — 24 tests pass
- [ ] TypeScript vitest — 46 tests pass, ≥90% coverage
- [ ] `zbarimg google.png` decodes `https://www.google.com`
- [ ] `zbarimg my-site.png` decodes `https://adhithyan15.github.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)