### PR TITLE
feat(algol): add real array support

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -62,6 +62,7 @@ _VALUE_PARAM_BASE_REG = 4
 _FIRST_GENERAL_REG = 32
 _ARRAY_DESCRIPTOR_SIZE = 24
 _ARRAY_ELEMENT_TYPE_INTEGER = 1
+_ARRAY_ELEMENT_TYPE_REAL = 2
 _ARRAY_DIMENSION_ENTRY_SIZE = 12
 _ARRAY_DIM_LOWER_OFFSET = 0
 _ARRAY_DIM_UPPER_OFFSET = 4
@@ -71,6 +72,7 @@ _ARRAY_ELEMENT_WIDTH_OFFSET = 12
 _ARRAY_DATA_POINTER_OFFSET = 16
 _ARRAY_BOUNDS_POINTER_OFFSET = 20
 _ARRAY_WORD_BYTES = 4
+_ARRAY_REAL_BYTES = 8
 _ARRAY_MAX_ELEMENTS = 4096
 _VALUE_MODE = "value"
 _NAME_MODE = "name"
@@ -647,7 +649,8 @@ class AlgolIrCompiler:
         self._load_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, heap_limit)
 
         data_bytes = self._fresh_reg()
-        word_bytes = self._const_reg(_ARRAY_WORD_BYTES)
+        element_width = self._array_element_width(array.element_type)
+        word_bytes = self._const_reg(element_width)
         self._emit(
             IrOp.MUL,
             IrRegister(data_bytes),
@@ -696,7 +699,15 @@ class AlgolIrCompiler:
             IrImmediate(len(array.dimensions) * _ARRAY_DIMENSION_ENTRY_SIZE),
         )
 
-        self._store_word_const(heap_pointer, 0, _ARRAY_ELEMENT_TYPE_INTEGER)
+        self._store_word_const(
+            heap_pointer,
+            0,
+            (
+                _ARRAY_ELEMENT_TYPE_REAL
+                if array.element_type == _REAL_TYPE
+                else _ARRAY_ELEMENT_TYPE_INTEGER
+            ),
+        )
         self._store_word_const(heap_pointer, 4, len(array.dimensions))
         self._store_word_reg(
             value_reg=total_reg,
@@ -706,7 +717,7 @@ class AlgolIrCompiler:
         self._store_word_const(
             heap_pointer,
             _ARRAY_ELEMENT_WIDTH_OFFSET,
-            _ARRAY_WORD_BYTES,
+            element_width,
         )
         self._store_word_reg(
             value_reg=data_pointer,
@@ -925,6 +936,15 @@ class AlgolIrCompiler:
             raise CompileError("assignment needs a variable target and expression")
         value = self._compile_expr(expr, scope)
         if _variable_subscripts(variable):
+            name = _variable_head_name(variable)
+            if name is None:
+                raise CompileError("array assignment target is missing a name")
+            access = self._require_array_access(name, "write")
+            value = self._coerce_reg_to_type(
+                value,
+                self._expr_type(expr),
+                expected_type=self.arrays[access.array_id].element_type,
+            )
             self._compile_array_store(variable, scope, value)
             return
         name = _variable_name(variable)
@@ -1906,6 +1926,10 @@ class AlgolIrCompiler:
         self.current_function_return_type = previous_return_type
 
     def _compile_array_load(self, variable: ASTNode, scope: _FrameScope) -> int:
+        name = _variable_head_name(variable)
+        if name is None:
+            raise CompileError("array access is missing a name")
+        access = self._require_array_access(name, "read")
         data_pointer, byte_offset = self._compile_array_element_address(
             variable,
             scope,
@@ -1913,11 +1937,11 @@ class AlgolIrCompiler:
             helper_failure=scope.helper_failure,
         )
         dst = self._fresh_reg()
-        self._emit(
-            IrOp.LOAD_WORD,
-            IrRegister(dst),
-            IrRegister(data_pointer),
-            IrRegister(byte_offset),
+        self._emit_load_scalar_at_reg(
+            self.arrays[access.array_id].element_type,
+            dst,
+            data_pointer,
+            byte_offset,
         )
         return dst
 
@@ -1927,16 +1951,20 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         value_reg: int,
     ) -> None:
+        name = _variable_head_name(variable)
+        if name is None:
+            raise CompileError("array access is missing a name")
+        access = self._require_array_access(name, "write")
         data_pointer, byte_offset = self._compile_array_element_address(
             variable,
             scope,
             role="write",
         )
-        self._emit(
-            IrOp.STORE_WORD,
-            IrRegister(value_reg),
-            IrRegister(data_pointer),
-            IrRegister(byte_offset),
+        self._emit_store_scalar_at_reg(
+            self.arrays[access.array_id].element_type,
+            value_reg,
+            data_pointer,
+            byte_offset,
         )
 
     def _compile_array_element_address(
@@ -2045,12 +2073,19 @@ class AlgolIrCompiler:
             )
             element_index = next_index
 
+        element_width = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(element_width),
+            IrRegister(descriptor_pointer),
+            IrRegister(self._const_reg(_ARRAY_ELEMENT_WIDTH_OFFSET)),
+        )
         byte_offset = self._fresh_reg()
         self._emit(
             IrOp.MUL,
             IrRegister(byte_offset),
             IrRegister(element_index),
-            IrRegister(self._const_reg(_ARRAY_WORD_BYTES)),
+            IrRegister(element_width),
         )
         return data_pointer, byte_offset
 
@@ -2338,6 +2373,21 @@ class AlgolIrCompiler:
             IrRegister(offset_reg),
         )
 
+    def _emit_load_scalar_at_reg(
+        self,
+        type_name: str,
+        dst_reg: int,
+        base_reg: int,
+        offset_reg: int,
+    ) -> None:
+        opcode = IrOp.LOAD_F64 if type_name == _REAL_TYPE else IrOp.LOAD_WORD
+        self._emit(
+            opcode,
+            IrRegister(dst_reg),
+            IrRegister(base_reg),
+            IrRegister(offset_reg),
+        )
+
     def _emit_store_scalar(
         self,
         type_name: str,
@@ -2354,6 +2404,21 @@ class AlgolIrCompiler:
             IrRegister(offset_reg),
         )
 
+    def _emit_store_scalar_at_reg(
+        self,
+        type_name: str,
+        value_reg: int,
+        base_reg: int,
+        offset_reg: int,
+    ) -> None:
+        opcode = IrOp.STORE_F64 if type_name == _REAL_TYPE else IrOp.STORE_WORD
+        self._emit(
+            opcode,
+            IrRegister(value_reg),
+            IrRegister(base_reg),
+            IrRegister(offset_reg),
+        )
+
     def _store_word_reg(self, *, value_reg: int, base_reg: int, offset: int) -> None:
         offset_reg = self._const_reg(offset)
         self._emit(
@@ -2362,6 +2427,9 @@ class AlgolIrCompiler:
             IrRegister(base_reg),
             IrRegister(offset_reg),
         )
+
+    def _array_element_width(self, type_name: str) -> int:
+        return _ARRAY_REAL_BYTES if type_name == _REAL_TYPE else _ARRAY_WORD_BYTES
 
     def _store_scalar_reg(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -369,6 +369,21 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.STORE_WORD) >= 12
         assert IrOp.CMP_GT in opcodes
 
+    def test_compiles_real_array_descriptor_and_element_accesses(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real array a[1:3]; "
+                "a[2] := 1.5; "
+                "if a[2] > 1.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.STORE_F64 in opcodes
+        assert IrOp.LOAD_F64 in opcodes
+        assert IrOp.F64_CMP_GT in opcodes
+
     def test_compiles_dynamic_multidimensional_array_bounds(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -649,6 +664,36 @@ class TestAlgolIrCompiler:
         )
         opcodes = [instruction.opcode for instruction in result.program.instructions]
 
+        assert IrOp.LOAD_F64 in opcodes
+        assert IrOp.STORE_F64 in opcodes
+
+    def test_compiles_real_array_element_by_name_eval_and_store_thunks(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real array a[1:1]; "
+                "procedure bump(x); real x; begin x := x + 1.5 end; "
+                "a[1] := 2.0; "
+                "bump(a[1]); "
+                "if a[1] > 3.0 then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert "_fn_algol_eval_real_thunk" in labels
+        assert "_fn_algol_store_real_thunk" in labels
+        assert "_fn_algol_eval_real_thunk" in calls
+        assert "_fn_algol_store_real_thunk" in calls
         assert IrOp.LOAD_F64 in opcodes
         assert IrOp.STORE_F64 in opcodes
 

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -535,12 +535,14 @@ class AlgolTypeChecker:
 
     def _check_array_declaration(self, node: ASTNode, scope: Scope) -> None:
         type_node = _first_direct_node(node, "type")
-        element_type = _first_keyword_value(type_node) if type_node is not None else ""
-        if element_type != INTEGER:
+        element_type = (
+            _first_keyword_value(type_node) if type_node is not None else REAL
+        )
+        if element_type not in {INTEGER, REAL}:
             self._error(
                 node,
-                f"{element_type or 'real'} arrays are not supported yet; "
-                "use integer array",
+                f"{element_type} arrays are not supported yet; "
+                "use integer or real array",
             )
             return
 
@@ -1149,7 +1151,18 @@ class AlgolTypeChecker:
 
         if _variable_subscripts(variable):
             access = self._check_array_access(variable, scope, role="write")
-            target_type = ERROR if access is None else INTEGER
+            if access is None:
+                target_type = ERROR
+            else:
+                descriptor = next(
+                    (
+                        array
+                        for array in self.semantic_arrays
+                        if array.array_id == access.array_id
+                    ),
+                    None,
+                )
+                target_type = ERROR if descriptor is None else descriptor.element_type
         else:
             symbol = self._resolve_name(name, scope, role="write")
             if symbol is not None and symbol.kind == ARRAY:
@@ -1227,7 +1240,18 @@ class AlgolTypeChecker:
         if expr.rule_name == "variable":
             if _variable_subscripts(expr):
                 access = self._check_array_access(expr, scope, role="read")
-                inferred = ERROR if access is None else INTEGER
+                if access is None:
+                    inferred = ERROR
+                else:
+                    descriptor = next(
+                        (
+                            array
+                            for array in self.semantic_arrays
+                            if array.array_id == access.array_id
+                        ),
+                        None,
+                    )
+                    inferred = ERROR if descriptor is None else descriptor.element_type
             else:
                 name = _variable_head_name(expr)
                 if name is None:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -521,12 +521,21 @@ class TestAlgolTypeChecker:
             "read",
         ]
 
-    def test_rejects_array_without_integer_type_for_now(self) -> None:
+    def test_accepts_default_real_array_declaration(self) -> None:
         ast = parse_algol("begin array a[1:3]; a[1] := 7 end")
         result = check_algol(ast)
 
-        assert not result.ok
-        assert "real arrays are not supported" in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.arrays[0].element_type == "real"
+
+    def test_accepts_real_array_element_assignment(self) -> None:
+        ast = parse_algol("begin real array a[1:3]; a[1] := 1.5 end")
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.arrays[0].element_type == "real"
 
     def test_rejects_wrong_array_subscript_count(self) -> None:
         ast = parse_algol(
@@ -546,6 +555,13 @@ class TestAlgolTypeChecker:
             "cannot assign boolean to integer variable"
             in result.diagnostics[0].message
         )
+
+    def test_rejects_non_real_array_element_assignment(self) -> None:
+        ast = parse_algol("begin real array a[1:3]; a[1] := false end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "cannot assign boolean to real variable" in result.diagnostics[0].message
 
     def test_rejects_array_used_without_subscripts(self) -> None:
         ast = parse_algol("begin integer result; integer array a[1:3]; result := a end")

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -546,6 +546,17 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_real_array_element_by_name_uses_eval_and_store_thunks(self) -> None:
+        result = compile_source(
+            "begin integer result; real array a[1:1]; "
+            "procedure bump(x); real x; begin x := x + 1.5 end; "
+            "a[1] := 2.0; "
+            "bump(a[1]); "
+            "if a[1] > 3.0 then result := 5 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
     def test_nested_by_name_parameter_forwards_original_storage_pointer(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -594,6 +605,24 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
+    def test_real_array_element_store_and_load(self) -> None:
+        result = compile_source(
+            "begin integer result; real array a[1:3]; "
+            "a[2] := 1.5; "
+            "if a[2] > 1.0 then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_multidimensional_real_array_uses_row_major_offsets(self) -> None:
+        result = compile_source(
+            "begin integer result; real array a[1:2, 1:2]; "
+            "a[2, 2] := 3.5; "
+            "if a[2, 2] > 3.0 then result := 9 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
     def test_dynamic_array_bounds_are_evaluated_at_block_entry(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- allow `real` and default-typed arrays in the ALGOL type checker
- lower real array descriptors, element widths, loads, stores, and assignment coercions through the ALGOL IR path
- add focused checker, IR, and WASM coverage for real array access, multidimensional layout, and by-name real array elements

## Testing
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_type_checker.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=../graph/src:../directed-graph/src:../state-machine/src:../grammar-tools/src:../lexer/src:../parser/src:../algol-lexer/src:../algol-parser/src:../algol-type-checker/src:../compiler-ir/src:../algol-ir-compiler/src:../virtual-machine/src:../wasm-leb128/src:../wasm-types/src:../wasm-opcodes/src:../wasm-module-parser/src:../wasm-validator/src:../wasm-execution/src:../wasm-runtime/src:../wasm-module-encoder/src:../ir-to-wasm-compiler/src:../ir-to-wasm-validator/src:src /Users/adhithya/.local/bin/python3.12 -m pytest tests/test_algol_wasm_compiler.py -q`
- `/Users/adhithya/.local/bin/python3.12 -m py_compile code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`