### PR TITLE
feat(riscv): add Dartmouth BASIC Go IR lane

### DIFF
--- a/code/packages/go/dartmouth-basic-ir-compiler/BUILD
+++ b/code/packages/go/dartmouth-basic-ir-compiler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/dartmouth-basic-ir-compiler/compiler.go
+++ b/code/packages/go/dartmouth-basic-ir-compiler/compiler.go
@@ -1,0 +1,698 @@
+package dartmouthbasicircompiler
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	dartmouthbasicparser "github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/lexer"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/parser"
+)
+
+const (
+	syscallWriteByte = 1
+
+	variableRegisterCount = 286
+)
+
+type BuildConfig struct {
+	CharEncoding       string
+	SyscallArgRegister int
+	VariableBase       int
+}
+
+func ReleaseConfig() BuildConfig {
+	return BuildConfig{
+		CharEncoding:       "ascii",
+		SyscallArgRegister: 4,
+		VariableBase:       5,
+	}
+}
+
+type CompileResult struct {
+	Program *ir.IrProgram
+	VarRegs map[string]int
+}
+
+type CompileError struct {
+	Message string
+}
+
+func (e *CompileError) Error() string {
+	return e.Message
+}
+
+type Compiler struct {
+	config     BuildConfig
+	idGen      *ir.IDGenerator
+	program    *ir.IrProgram
+	nextReg    int
+	labelCount int
+	varRegs    map[string]int
+}
+
+func CompileDartmouthBasic(ast *parser.ASTNode, config *BuildConfig) (*CompileResult, error) {
+	if ast == nil {
+		return nil, &CompileError{Message: "program AST is nil"}
+	}
+	if ast.RuleName != "program" {
+		return nil, &CompileError{Message: fmt.Sprintf("expected program AST, got %q", ast.RuleName)}
+	}
+
+	cfg := ReleaseConfig()
+	if config != nil {
+		cfg = *config
+	}
+	if cfg.CharEncoding == "" {
+		cfg.CharEncoding = "ascii"
+	}
+	if cfg.SyscallArgRegister < 0 {
+		return nil, &CompileError{Message: "syscall arg register must be >= 0"}
+	}
+	if cfg.VariableBase <= cfg.SyscallArgRegister {
+		return nil, &CompileError{Message: "variable base must live after the syscall arg register"}
+	}
+
+	compiler := &Compiler{
+		config:  cfg,
+		idGen:   ir.NewIDGenerator(),
+		program: ir.NewIrProgram("_start"),
+		nextReg: cfg.VariableBase + variableRegisterCount,
+		varRegs: fixedVariableRegisters(cfg.VariableBase),
+	}
+	if err := compiler.compile(ast); err != nil {
+		return nil, err
+	}
+	return &CompileResult{Program: compiler.program, VarRegs: compiler.varRegs}, nil
+}
+
+func CompileSource(source string, config *BuildConfig) (*CompileResult, error) {
+	ast, err := dartmouthbasicparser.ParseDartmouthBasic(source)
+	if err != nil {
+		return nil, err
+	}
+	return CompileDartmouthBasic(ast, config)
+}
+
+func fixedVariableRegisters(variableBase int) map[string]int {
+	result := map[string]int{}
+	for letter := 0; letter < 26; letter++ {
+		name := string(rune('A' + letter))
+		result[name] = scalarRegister(variableBase, name)
+		for digit := 0; digit < 10; digit++ {
+			twoChar := fmt.Sprintf("%s%d", name, digit)
+			result[twoChar] = scalarRegister(variableBase, twoChar)
+		}
+	}
+	return result
+}
+
+func scalarRegister(variableBase int, name string) int {
+	upper := strings.ToUpper(name)
+	if len(upper) == 1 {
+		return variableBase + int(upper[0]-'A')
+	}
+	letterIndex := int(upper[0] - 'A')
+	digitIndex := int(upper[1] - '0')
+	return variableBase + 26 + letterIndex*10 + digitIndex
+}
+
+func (c *Compiler) compile(ast *parser.ASTNode) error {
+	c.emitLabel("_start")
+	for _, child := range childNodes(ast) {
+		if child.RuleName != "line" {
+			continue
+		}
+		if err := c.compileLine(child); err != nil {
+			return err
+		}
+	}
+	c.emit(ir.OpHalt)
+	return nil
+}
+
+func (c *Compiler) compileLine(node *parser.ASTNode) error {
+	lineNumber := ""
+	var statement *parser.ASTNode
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			if tokenTypeName(value) == "LINE_NUM" {
+				lineNumber = value.Value
+			}
+		case *parser.ASTNode:
+			if value.RuleName == "statement" {
+				statement = value
+			}
+		}
+	}
+	if lineNumber == "" {
+		return nil
+	}
+	c.emitLabel("_line_" + lineNumber)
+	if statement == nil {
+		return nil
+	}
+	return c.compileStatement(statement)
+}
+
+func (c *Compiler) compileStatement(node *parser.ASTNode) error {
+	for _, child := range childNodes(node) {
+		switch child.RuleName {
+		case "rem_stmt":
+			c.emit(ir.OpComment, ir.IrLabel{Name: "REM"})
+			return nil
+		case "let_stmt":
+			return c.compileLet(child)
+		case "print_stmt":
+			return c.compilePrint(child)
+		case "goto_stmt":
+			return c.compileGoto(child)
+		case "if_stmt":
+			return c.compileIf(child)
+		case "end_stmt", "stop_stmt":
+			c.emit(ir.OpHalt)
+			return nil
+		case "gosub_stmt", "return_stmt", "for_stmt", "next_stmt", "input_stmt",
+			"read_stmt", "data_stmt", "restore_stmt", "dim_stmt", "def_stmt":
+			return &CompileError{Message: fmt.Sprintf("%s is not supported in the Go Dartmouth BASIC RISC-V lane yet", strings.ToUpper(strings.TrimSuffix(child.RuleName, "_stmt")))}
+		}
+	}
+	return nil
+}
+
+func (c *Compiler) compileLet(node *parser.ASTNode) error {
+	var variableNode *parser.ASTNode
+	var expressionNode *parser.ASTNode
+	seenEquals := false
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			if tokenTypeName(value) == "EQ" {
+				seenEquals = true
+			}
+		case *parser.ASTNode:
+			if value.RuleName == "variable" && !seenEquals && variableNode == nil {
+				variableNode = value
+			} else if isExpressionNode(value) && seenEquals && expressionNode == nil {
+				expressionNode = value
+			}
+		}
+	}
+	if variableNode == nil || expressionNode == nil {
+		return &CompileError{Message: "malformed LET statement"}
+	}
+	name, err := extractScalarVariableName(variableNode)
+	if err != nil {
+		return err
+	}
+	valueReg, err := c.compileExpr(expressionNode)
+	if err != nil {
+		return err
+	}
+	c.copyRegister(scalarRegister(c.config.VariableBase, name), valueReg)
+	return nil
+}
+
+func (c *Compiler) compilePrint(node *parser.ASTNode) error {
+	var printList *parser.ASTNode
+	for _, child := range childNodes(node) {
+		if child.RuleName == "print_list" {
+			printList = child
+			break
+		}
+	}
+	if printList != nil {
+		for _, item := range childNodes(printList) {
+			if item.RuleName != "print_item" {
+				continue
+			}
+			if err := c.compilePrintItem(item); err != nil {
+				return err
+			}
+		}
+	}
+	c.emitPrintByte('\n')
+	return nil
+}
+
+func (c *Compiler) compilePrintItem(node *parser.ASTNode) error {
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			if tokenTypeName(value) == "STRING" {
+				for _, r := range value.Value {
+					if r > 127 {
+						return &CompileError{Message: fmt.Sprintf("non-ASCII print character %q is not supported yet", r)}
+					}
+					c.emitPrintByte(byte(r))
+				}
+				return nil
+			}
+		case *parser.ASTNode:
+			if isExpressionNode(value) {
+				return &CompileError{Message: "numeric PRINT is not supported in the Go Dartmouth BASIC RISC-V lane yet"}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Compiler) compileGoto(node *parser.ASTNode) error {
+	lineNumber, err := extractLineNumber(node)
+	if err != nil {
+		return err
+	}
+	c.emit(ir.OpJump, ir.IrLabel{Name: "_line_" + lineNumber})
+	return nil
+}
+
+func (c *Compiler) compileIf(node *parser.ASTNode) error {
+	var exprs []*parser.ASTNode
+	var relop lexer.Token
+	var haveRelop bool
+	lineNumber := ""
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			if tokenTypeName(value) == "NUMBER" {
+				lineNumber = value.Value
+			}
+		case *parser.ASTNode:
+			if value.RuleName == "relop" {
+				token, ok := firstToken(value)
+				if ok {
+					relop = token
+					haveRelop = true
+				}
+			} else if isExpressionNode(value) {
+				exprs = append(exprs, value)
+			}
+		}
+	}
+	if len(exprs) < 2 || !haveRelop || lineNumber == "" {
+		return &CompileError{Message: "malformed IF statement"}
+	}
+	leftReg, err := c.compileExpr(exprs[0])
+	if err != nil {
+		return err
+	}
+	rightReg, err := c.compileExpr(exprs[1])
+	if err != nil {
+		return err
+	}
+	conditionReg := c.newReg()
+	target := ir.IrLabel{Name: "_line_" + lineNumber}
+	switch relop.Value {
+	case "<":
+		c.emit(ir.OpCmpLt, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchNz, ir.IrRegister{Index: conditionReg}, target)
+	case ">":
+		c.emit(ir.OpCmpGt, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchNz, ir.IrRegister{Index: conditionReg}, target)
+	case "=":
+		c.emit(ir.OpCmpEq, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchNz, ir.IrRegister{Index: conditionReg}, target)
+	case "<>":
+		c.emit(ir.OpCmpNe, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchNz, ir.IrRegister{Index: conditionReg}, target)
+	case "<=":
+		c.emit(ir.OpCmpGt, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchZ, ir.IrRegister{Index: conditionReg}, target)
+	case ">=":
+		c.emit(ir.OpCmpLt, ir.IrRegister{Index: conditionReg}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		c.emit(ir.OpBranchZ, ir.IrRegister{Index: conditionReg}, target)
+	default:
+		return &CompileError{Message: fmt.Sprintf("unsupported IF relational operator %q", relop.Value)}
+	}
+	return nil
+}
+
+func (c *Compiler) compileExpr(node *parser.ASTNode) (int, error) {
+	switch node.RuleName {
+	case "expr":
+		return c.compileAddChain(node)
+	case "term":
+		return c.compileMulChain(node)
+	case "power":
+		if len(node.Children) > 1 {
+			return 0, &CompileError{Message: "power operator is not supported in the Go Dartmouth BASIC RISC-V lane yet"}
+		}
+		return c.compileExprNode(node.Children[0])
+	case "unary":
+		if len(node.Children) == 2 {
+			if token, ok := node.Children[0].(lexer.Token); ok && tokenTypeName(token) == "MINUS" {
+				valueReg, err := c.compileExprNode(node.Children[1])
+				if err != nil {
+					return 0, err
+				}
+				zeroReg := c.newImmediateRegister(0)
+				result := c.newReg()
+				c.emit(ir.OpSub, ir.IrRegister{Index: result}, ir.IrRegister{Index: zeroReg}, ir.IrRegister{Index: valueReg})
+				return result, nil
+			}
+		}
+		return c.compileExprNode(node.Children[0])
+	case "primary":
+		return c.compilePrimary(node)
+	case "variable":
+		name, err := extractScalarVariableName(node)
+		if err != nil {
+			return 0, err
+		}
+		return scalarRegister(c.config.VariableBase, name), nil
+	default:
+		if len(node.Children) == 1 {
+			return c.compileExprNode(node.Children[0])
+		}
+	}
+	return 0, &CompileError{Message: fmt.Sprintf("unsupported expression node %q", node.RuleName)}
+}
+
+func (c *Compiler) compileAddChain(node *parser.ASTNode) (int, error) {
+	if len(node.Children) == 0 {
+		return 0, &CompileError{Message: "empty expr node"}
+	}
+	leftReg, err := c.compileExprNode(node.Children[0])
+	if err != nil {
+		return 0, err
+	}
+	for index := 1; index < len(node.Children)-1; index += 2 {
+		operator, ok := node.Children[index].(lexer.Token)
+		if !ok {
+			continue
+		}
+		rightReg, err := c.compileExprNode(node.Children[index+1])
+		if err != nil {
+			return 0, err
+		}
+		result := c.newReg()
+		switch tokenTypeName(operator) {
+		case "PLUS":
+			c.emit(ir.OpAdd, ir.IrRegister{Index: result}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		case "MINUS":
+			c.emit(ir.OpSub, ir.IrRegister{Index: result}, ir.IrRegister{Index: leftReg}, ir.IrRegister{Index: rightReg})
+		default:
+			return 0, &CompileError{Message: fmt.Sprintf("unsupported additive operator %q", operator.Value)}
+		}
+		leftReg = result
+	}
+	return leftReg, nil
+}
+
+func (c *Compiler) compileMulChain(node *parser.ASTNode) (int, error) {
+	if len(node.Children) == 0 {
+		return 0, &CompileError{Message: "empty term node"}
+	}
+	leftReg, err := c.compileExprNode(node.Children[0])
+	if err != nil {
+		return 0, err
+	}
+	for index := 1; index < len(node.Children)-1; index += 2 {
+		operator, ok := node.Children[index].(lexer.Token)
+		if !ok {
+			continue
+		}
+		rightReg, err := c.compileExprNode(node.Children[index+1])
+		if err != nil {
+			return 0, err
+		}
+		switch tokenTypeName(operator) {
+		case "STAR":
+			leftReg = c.emitMultiply(leftReg, rightReg)
+		case "SLASH":
+			leftReg = c.emitDivide(leftReg, rightReg)
+		default:
+			return 0, &CompileError{Message: fmt.Sprintf("unsupported multiplicative operator %q", operator.Value)}
+		}
+	}
+	return leftReg, nil
+}
+
+func (c *Compiler) compilePrimary(node *parser.ASTNode) (int, error) {
+	if len(node.Children) == 0 {
+		return 0, &CompileError{Message: "empty primary node"}
+	}
+	switch value := node.Children[0].(type) {
+	case lexer.Token:
+		if tokenTypeName(value) != "NUMBER" {
+			return 0, &CompileError{Message: fmt.Sprintf("unsupported primary token %q", value.Value)}
+		}
+		literal, err := parseIntegerLiteral(value.Value)
+		if err != nil {
+			return 0, err
+		}
+		return c.newImmediateRegister(literal), nil
+	case *parser.ASTNode:
+		return c.compileExpr(value)
+	default:
+		return 0, &CompileError{Message: "unsupported primary expression"}
+	}
+}
+
+func (c *Compiler) compileExprNode(node any) (int, error) {
+	switch value := node.(type) {
+	case *parser.ASTNode:
+		return c.compileExpr(value)
+	case lexer.Token:
+		if tokenTypeName(value) == "NUMBER" {
+			literal, err := parseIntegerLiteral(value.Value)
+			if err != nil {
+				return 0, err
+			}
+			return c.newImmediateRegister(literal), nil
+		}
+		return 0, &CompileError{Message: fmt.Sprintf("unexpected token %q in expression", value.Value)}
+	default:
+		return 0, &CompileError{Message: "unsupported expression fragment"}
+	}
+}
+
+func (c *Compiler) emitMultiply(leftReg int, rightReg int) int {
+	zero := c.newImmediateRegister(0)
+	left := c.newReg()
+	right := c.newReg()
+	result := c.newImmediateRegister(0)
+	leftNeg := c.newReg()
+	rightNeg := c.newReg()
+	sign := c.newReg()
+	temp := c.newReg()
+
+	c.copyRegister(left, leftReg)
+	c.copyRegister(right, rightReg)
+
+	leftPositive := c.newLabel("mul_left_positive")
+	rightPositive := c.newLabel("mul_right_positive")
+	loopLabel := c.newLabel("mul_loop")
+	doneLabel := c.newLabel("mul_done")
+	signedDone := c.newLabel("mul_signed_done")
+
+	c.emit(ir.OpCmpLt, ir.IrRegister{Index: leftNeg}, ir.IrRegister{Index: left}, ir.IrRegister{Index: zero})
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: leftNeg}, ir.IrLabel{Name: leftPositive})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: left})
+	c.copyRegister(left, temp)
+	c.emitLabel(leftPositive)
+
+	c.emit(ir.OpCmpLt, ir.IrRegister{Index: rightNeg}, ir.IrRegister{Index: right}, ir.IrRegister{Index: zero})
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: rightNeg}, ir.IrLabel{Name: rightPositive})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: right})
+	c.copyRegister(right, temp)
+	c.emitLabel(rightPositive)
+
+	c.emit(ir.OpAdd, ir.IrRegister{Index: sign}, ir.IrRegister{Index: leftNeg}, ir.IrRegister{Index: rightNeg})
+	c.emit(ir.OpAndImm, ir.IrRegister{Index: sign}, ir.IrRegister{Index: sign}, ir.IrImmediate{Value: 1})
+
+	c.emitLabel(loopLabel)
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: right}, ir.IrLabel{Name: doneLabel})
+	c.emit(ir.OpAdd, ir.IrRegister{Index: result}, ir.IrRegister{Index: result}, ir.IrRegister{Index: left})
+	c.emit(ir.OpAddImm, ir.IrRegister{Index: right}, ir.IrRegister{Index: right}, ir.IrImmediate{Value: -1})
+	c.emit(ir.OpJump, ir.IrLabel{Name: loopLabel})
+	c.emitLabel(doneLabel)
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: sign}, ir.IrLabel{Name: signedDone})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: result})
+	c.copyRegister(result, temp)
+	c.emitLabel(signedDone)
+
+	return result
+}
+
+func (c *Compiler) emitDivide(leftReg int, rightReg int) int {
+	zero := c.newImmediateRegister(0)
+	dividend := c.newReg()
+	divisor := c.newReg()
+	quotient := c.newImmediateRegister(0)
+	leftNeg := c.newReg()
+	rightNeg := c.newReg()
+	sign := c.newReg()
+	temp := c.newReg()
+	compare := c.newReg()
+
+	c.copyRegister(dividend, leftReg)
+	c.copyRegister(divisor, rightReg)
+
+	leftPositive := c.newLabel("div_left_positive")
+	rightPositive := c.newLabel("div_right_positive")
+	divZero := c.newLabel("div_zero")
+	loopLabel := c.newLabel("div_loop")
+	doneLabel := c.newLabel("div_done")
+	finalLabel := c.newLabel("div_final")
+
+	c.emit(ir.OpCmpLt, ir.IrRegister{Index: leftNeg}, ir.IrRegister{Index: dividend}, ir.IrRegister{Index: zero})
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: leftNeg}, ir.IrLabel{Name: leftPositive})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: dividend})
+	c.copyRegister(dividend, temp)
+	c.emitLabel(leftPositive)
+
+	c.emit(ir.OpCmpLt, ir.IrRegister{Index: rightNeg}, ir.IrRegister{Index: divisor}, ir.IrRegister{Index: zero})
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: rightNeg}, ir.IrLabel{Name: rightPositive})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: divisor})
+	c.copyRegister(divisor, temp)
+	c.emitLabel(rightPositive)
+
+	c.emit(ir.OpAdd, ir.IrRegister{Index: sign}, ir.IrRegister{Index: leftNeg}, ir.IrRegister{Index: rightNeg})
+	c.emit(ir.OpAndImm, ir.IrRegister{Index: sign}, ir.IrRegister{Index: sign}, ir.IrImmediate{Value: 1})
+
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: divisor}, ir.IrLabel{Name: divZero})
+	c.emitLabel(loopLabel)
+	c.emit(ir.OpCmpLt, ir.IrRegister{Index: compare}, ir.IrRegister{Index: dividend}, ir.IrRegister{Index: divisor})
+	c.emit(ir.OpBranchNz, ir.IrRegister{Index: compare}, ir.IrLabel{Name: doneLabel})
+	c.emit(ir.OpSub, ir.IrRegister{Index: dividend}, ir.IrRegister{Index: dividend}, ir.IrRegister{Index: divisor})
+	c.emit(ir.OpAddImm, ir.IrRegister{Index: quotient}, ir.IrRegister{Index: quotient}, ir.IrImmediate{Value: 1})
+	c.emit(ir.OpJump, ir.IrLabel{Name: loopLabel})
+
+	c.emitLabel(divZero)
+	c.emit(ir.OpLoadImm, ir.IrRegister{Index: quotient}, ir.IrImmediate{Value: -1})
+	c.emit(ir.OpJump, ir.IrLabel{Name: finalLabel})
+
+	c.emitLabel(doneLabel)
+	c.emit(ir.OpBranchZ, ir.IrRegister{Index: sign}, ir.IrLabel{Name: finalLabel})
+	c.emit(ir.OpSub, ir.IrRegister{Index: temp}, ir.IrRegister{Index: zero}, ir.IrRegister{Index: quotient})
+	c.copyRegister(quotient, temp)
+	c.emitLabel(finalLabel)
+
+	return quotient
+}
+
+func (c *Compiler) emitPrintByte(value byte) {
+	c.emit(ir.OpLoadImm, ir.IrRegister{Index: c.config.SyscallArgRegister}, ir.IrImmediate{Value: int(value)})
+	c.emit(ir.OpSyscall, ir.IrImmediate{Value: syscallWriteByte})
+}
+
+func (c *Compiler) copyRegister(destination int, source int) {
+	c.emit(ir.OpAddImm, ir.IrRegister{Index: destination}, ir.IrRegister{Index: source}, ir.IrImmediate{Value: 0})
+}
+
+func (c *Compiler) newImmediateRegister(value int) int {
+	register := c.newReg()
+	c.emit(ir.OpLoadImm, ir.IrRegister{Index: register}, ir.IrImmediate{Value: value})
+	return register
+}
+
+func (c *Compiler) newReg() int {
+	register := c.nextReg
+	c.nextReg++
+	return register
+}
+
+func (c *Compiler) newLabel(prefix string) string {
+	label := fmt.Sprintf("__db_%s_%d", prefix, c.labelCount)
+	c.labelCount++
+	return label
+}
+
+func (c *Compiler) emit(opcode ir.IrOp, operands ...ir.IrOperand) int {
+	id := c.idGen.Next()
+	c.program.AddInstruction(ir.IrInstruction{Opcode: opcode, Operands: operands, ID: id})
+	return id
+}
+
+func (c *Compiler) emitLabel(name string) {
+	c.program.AddInstruction(ir.IrInstruction{Opcode: ir.OpLabel, Operands: []ir.IrOperand{ir.IrLabel{Name: name}}, ID: -1})
+}
+
+func extractScalarVariableName(node *parser.ASTNode) (string, error) {
+	name := ""
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			if tokenTypeName(value) == "NAME" && name == "" {
+				name = strings.ToUpper(value.Value)
+			}
+		case *parser.ASTNode:
+			if value.RuleName == "expr" {
+				return "", &CompileError{Message: "array variables are not supported in the Go Dartmouth BASIC RISC-V lane yet"}
+			}
+		}
+	}
+	if name == "" {
+		return "", &CompileError{Message: "could not extract scalar variable name"}
+	}
+	return name, nil
+}
+
+func extractLineNumber(node *parser.ASTNode) (string, error) {
+	for _, child := range node.Children {
+		if token, ok := child.(lexer.Token); ok && tokenTypeName(token) == "NUMBER" {
+			return token.Value, nil
+		}
+	}
+	return "", &CompileError{Message: "expected line number"}
+}
+
+func parseIntegerLiteral(value string) (int, error) {
+	parsed, err := strconv.Atoi(value)
+	if err == nil {
+		return parsed, nil
+	}
+	floatValue, floatErr := strconv.ParseFloat(value, 64)
+	if floatErr != nil {
+		return 0, &CompileError{Message: fmt.Sprintf("numeric literal %q is not supported yet", value)}
+	}
+	if math.Trunc(floatValue) != floatValue {
+		return 0, &CompileError{Message: fmt.Sprintf("non-integer numeric literal %q is not supported yet", value)}
+	}
+	return int(floatValue), nil
+}
+
+func tokenTypeName(token lexer.Token) string {
+	if token.TypeName != "" {
+		return token.TypeName
+	}
+	return strings.ToUpper(token.Type.String())
+}
+
+func childNodes(node *parser.ASTNode) []*parser.ASTNode {
+	nodes := []*parser.ASTNode{}
+	for _, child := range node.Children {
+		if inner, ok := child.(*parser.ASTNode); ok {
+			nodes = append(nodes, inner)
+		}
+	}
+	return nodes
+}
+
+func firstToken(node *parser.ASTNode) (lexer.Token, bool) {
+	for _, child := range node.Children {
+		switch value := child.(type) {
+		case lexer.Token:
+			return value, true
+		case *parser.ASTNode:
+			if token, ok := firstToken(value); ok {
+				return token, true
+			}
+		}
+	}
+	return lexer.Token{}, false
+}
+
+func isExpressionNode(node *parser.ASTNode) bool {
+	switch node.RuleName {
+	case "expr", "term", "power", "unary", "primary", "variable":
+		return true
+	default:
+		return false
+	}
+}

--- a/code/packages/go/dartmouth-basic-ir-compiler/compiler_test.go
+++ b/code/packages/go/dartmouth-basic-ir-compiler/compiler_test.go
@@ -1,0 +1,97 @@
+package dartmouthbasicircompiler
+
+import (
+	"strings"
+	"testing"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	dartmouthbasicparser "github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser"
+)
+
+func compileSource(t *testing.T, source string) *CompileResult {
+	t.Helper()
+	ast, err := dartmouthbasicparser.ParseDartmouthBasic(source)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	result, err := CompileDartmouthBasic(ast, nil)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	return result
+}
+
+func TestCompileDartmouthBasicEmitsEntryAndLineLabels(t *testing.T) {
+	result := compileSource(t, "10 REM HI\n20 END\n")
+	labels := map[string]bool{}
+	for _, instruction := range result.Program.Instructions {
+		if instruction.Opcode != ir.OpLabel {
+			continue
+		}
+		label := instruction.Operands[0].(ir.IrLabel)
+		labels[label.Name] = true
+	}
+	for _, want := range []string{"_start", "_line_10", "_line_20"} {
+		if !labels[want] {
+			t.Fatalf("expected label %q in IR", want)
+		}
+	}
+}
+
+func TestCompileDartmouthBasicLowersMultiplyAndDivideWithHelperLabels(t *testing.T) {
+	result := compileSource(t, strings.Join([]string{
+		"10 LET A = 3 * 4",
+		"20 LET B = 12 / 3",
+		"30 END",
+	}, "\n")+"\n")
+	assemblyLike := []string{}
+	for _, instruction := range result.Program.Instructions {
+		if instruction.Opcode == ir.OpLabel {
+			assemblyLike = append(assemblyLike, instruction.Operands[0].(ir.IrLabel).Name)
+		}
+	}
+	joined := strings.Join(assemblyLike, "\n")
+	if !strings.Contains(joined, "__db_mul_loop_") {
+		t.Fatalf("expected multiply helper labels, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "__db_div_loop_") {
+		t.Fatalf("expected divide helper labels, got:\n%s", joined)
+	}
+}
+
+func TestCompileDartmouthBasicCompilesIfThenBranch(t *testing.T) {
+	result := compileSource(t, strings.Join([]string{
+		"10 LET A = 2",
+		"20 IF A = 2 THEN 40",
+		"30 END",
+		"40 END",
+	}, "\n")+"\n")
+	found := false
+	for _, instruction := range result.Program.Instructions {
+		if instruction.Opcode != ir.OpBranchNz {
+			continue
+		}
+		label := instruction.Operands[1].(ir.IrLabel)
+		if label.Name == "_line_40" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected IF ... THEN to branch to _line_40")
+	}
+}
+
+func TestCompileDartmouthBasicRejectsNumericPrintForNow(t *testing.T) {
+	ast, err := dartmouthbasicparser.ParseDartmouthBasic("10 PRINT 7\n20 END\n")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	_, err = CompileDartmouthBasic(ast, nil)
+	if err == nil {
+		t.Fatal("expected numeric PRINT compile error")
+	}
+	if !strings.Contains(err.Error(), "numeric PRINT") {
+		t.Fatalf("expected numeric PRINT error, got %v", err)
+	}
+}

--- a/code/packages/go/dartmouth-basic-ir-compiler/go.mod
+++ b/code/packages/go/dartmouth-basic-ir-compiler/go.mod
@@ -1,0 +1,33 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-ir-compiler
+
+go 1.23
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir => ../compiler-ir
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser => ../dartmouth-basic-parser
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-lexer => ../dartmouth-basic-lexer
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph

--- a/code/packages/go/dartmouth-basic-riscv-compiler/BUILD
+++ b/code/packages/go/dartmouth-basic-riscv-compiler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/dartmouth-basic-riscv-compiler/compiler.go
+++ b/code/packages/go/dartmouth-basic-riscv-compiler/compiler.go
@@ -1,0 +1,229 @@
+package dartmouthbasicriscvcompiler
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	dartmouthbasicircompiler "github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-ir-compiler"
+	dartmouthbasicparser "github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser"
+	iroptimizer "github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer"
+	irtoriscvcompiler "github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/parser"
+	riscvassembler "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler"
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+const DefaultMemorySize = 65536
+
+type DartmouthBasicRiscVCompilerOptions struct {
+	BuildConfig *dartmouthbasicircompiler.BuildConfig
+	OptimizeIR  *bool
+	MemorySize  int
+}
+
+type PackageResult struct {
+	Source       string
+	AST          *parser.ASTNode
+	RawIR        *ir.IrProgram
+	VarRegs      map[string]int
+	Optimization iroptimizer.OptimizationResult
+	OptimizedIR  *ir.IrProgram
+	MachineCode  *irtoriscvcompiler.MachineCodeResult
+	Assembled    *riscvassembler.AssembleResult
+	Assembly     string
+	Binary       []byte
+	AssemblyPath string
+	BinaryPath   string
+}
+
+type RunResult struct {
+	Package   *PackageResult
+	Output    string
+	ExitValue uint32
+	Halted    bool
+	Steps     int
+}
+
+type PackageError struct {
+	Stage   string
+	Message string
+	Cause   error
+}
+
+func (e *PackageError) Error() string {
+	return e.Message
+}
+
+func (e *PackageError) Unwrap() error {
+	return e.Cause
+}
+
+type DartmouthBasicRiscVCompiler struct {
+	buildConfig *dartmouthbasicircompiler.BuildConfig
+	optimizer   *iroptimizer.IrOptimizer
+	memorySize  int
+}
+
+func NewDartmouthBasicRiscVCompiler(options *DartmouthBasicRiscVCompilerOptions) *DartmouthBasicRiscVCompiler {
+	optimize := true
+	memorySize := DefaultMemorySize
+	var config *dartmouthbasicircompiler.BuildConfig
+	if options != nil {
+		config = options.BuildConfig
+		if options.OptimizeIR != nil {
+			optimize = *options.OptimizeIR
+		}
+		if options.MemorySize > 0 {
+			memorySize = options.MemorySize
+		}
+	}
+
+	optimizer := iroptimizer.DefaultPasses()
+	if !optimize {
+		optimizer = iroptimizer.NoOp()
+	}
+
+	return &DartmouthBasicRiscVCompiler{
+		buildConfig: config,
+		optimizer:   optimizer,
+		memorySize:  memorySize,
+	}
+}
+
+func (c *DartmouthBasicRiscVCompiler) CompileSource(source string) (*PackageResult, error) {
+	ast, err := dartmouthbasicparser.ParseDartmouthBasic(source)
+	if err != nil {
+		return nil, wrapStage("parse", err)
+	}
+
+	irResult, err := dartmouthbasicircompiler.CompileDartmouthBasic(ast, c.buildConfig)
+	if err != nil {
+		return nil, wrapStage("lower-basic", err)
+	}
+	rawIR := irResult.Program
+	optimization := c.optimizer.Optimize(rawIR)
+	optimizedIR := optimization.Program
+
+	machineCode, err := irtoriscvcompiler.NewIrToRiscVCompiler().Compile(optimizedIR)
+	if err != nil {
+		return nil, wrapStage("lower-riscv", err)
+	}
+
+	assembled, err := riscvassembler.Assemble(machineCode.Assembly)
+	if err != nil {
+		return nil, wrapStage("assemble-riscv", err)
+	}
+	if !bytes.Equal(assembled.Bytes, machineCode.Bytes) {
+		return nil, wrapStage("assemble-riscv", errors.New("assembler output does not match direct backend bytes"))
+	}
+
+	return &PackageResult{
+		Source:       source,
+		AST:          ast,
+		RawIR:        rawIR,
+		VarRegs:      irResult.VarRegs,
+		Optimization: optimization,
+		OptimizedIR:  optimizedIR,
+		MachineCode:  machineCode,
+		Assembled:    assembled,
+		Assembly:     machineCode.Assembly,
+		Binary:       assembled.Bytes,
+	}, nil
+}
+
+func (c *DartmouthBasicRiscVCompiler) RunSource(source string) (*RunResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+
+	host := riscv.NewHostIO(nil)
+	sim := riscv.NewRiscVSimulatorWithHost(c.memorySize, host)
+	traces := sim.Run(result.Binary)
+
+	return &RunResult{
+		Package:   result,
+		Output:    host.OutputString(),
+		ExitValue: sim.CPU.Registers.Read(10),
+		Halted:    sim.CPU.Halted,
+		Steps:     len(traces),
+	}, nil
+}
+
+func (c *DartmouthBasicRiscVCompiler) WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, []byte(result.Assembly)); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.AssemblyPath = outputPath
+	return result, nil
+}
+
+func (c *DartmouthBasicRiscVCompiler) WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, result.Binary); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.BinaryPath = outputPath
+	return result, nil
+}
+
+func CompileSource(source string) (*PackageResult, error) {
+	return NewDartmouthBasicRiscVCompiler(&DartmouthBasicRiscVCompilerOptions{
+		BuildConfig: configRef(dartmouthbasicircompiler.ReleaseConfig()),
+	}).CompileSource(source)
+}
+
+func PackSource(source string) (*PackageResult, error) {
+	return CompileSource(source)
+}
+
+func RunSource(source string) (*RunResult, error) {
+	return NewDartmouthBasicRiscVCompiler(&DartmouthBasicRiscVCompilerOptions{
+		BuildConfig: configRef(dartmouthbasicircompiler.ReleaseConfig()),
+	}).RunSource(source)
+}
+
+func WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	return NewDartmouthBasicRiscVCompiler(&DartmouthBasicRiscVCompilerOptions{
+		BuildConfig: configRef(dartmouthbasicircompiler.ReleaseConfig()),
+	}).WriteAssemblyFile(source, outputPath)
+}
+
+func WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	return NewDartmouthBasicRiscVCompiler(&DartmouthBasicRiscVCompilerOptions{
+		BuildConfig: configRef(dartmouthbasicircompiler.ReleaseConfig()),
+	}).WriteBinaryFile(source, outputPath)
+}
+
+func configRef(config dartmouthbasicircompiler.BuildConfig) *dartmouthbasicircompiler.BuildConfig {
+	copy := config
+	return &copy
+}
+
+func writeFile(outputPath string, data []byte) error {
+	if dir := filepath.Dir(outputPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+func wrapStage(stage string, err error) error {
+	return &PackageError{
+		Stage:   stage,
+		Message: strings.TrimSpace(err.Error()),
+		Cause:   err,
+	}
+}

--- a/code/packages/go/dartmouth-basic-riscv-compiler/compiler_test.go
+++ b/code/packages/go/dartmouth-basic-riscv-compiler/compiler_test.go
@@ -1,0 +1,113 @@
+package dartmouthbasicriscvcompiler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompileSourceReturnsPipelineArtifacts(t *testing.T) {
+	result, err := CompileSource("10 PRINT \"HI\"\n20 END\n")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if result.AST == nil {
+		t.Fatal("expected AST")
+	}
+	if len(result.RawIR.Instructions) == 0 {
+		t.Fatal("expected raw IR instructions")
+	}
+	if len(result.OptimizedIR.Instructions) == 0 {
+		t.Fatal("expected optimized IR instructions")
+	}
+	if !strings.Contains(result.Assembly, "_line_10:") {
+		t.Fatalf("expected assembly to contain BASIC line label, got:\n%s", result.Assembly)
+	}
+	if len(result.Binary) == 0 {
+		t.Fatal("expected RISC-V binary bytes")
+	}
+}
+
+func TestRunSourceExecutesStringPrintOnRiscVSimulator(t *testing.T) {
+	run, err := RunSource("10 PRINT \"HI\"\n20 END\n")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.Output != "HI\n" {
+		t.Fatalf("expected output %q, got %q", "HI\n", run.Output)
+	}
+}
+
+func TestRunSourceExecutesMultiplyAndIfProgram(t *testing.T) {
+	source := strings.Join([]string{
+		"10 LET A = 2 * 3",
+		"20 IF A = 6 THEN 50",
+		"30 PRINT \"BAD\"",
+		"40 END",
+		"50 PRINT \"OK\"",
+		"60 END",
+	}, "\n") + "\n"
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.Output != "OK\n" {
+		t.Fatalf("expected output %q, got %q", "OK\n", run.Output)
+	}
+}
+
+func TestRunSourceExecutesGotoAndDivisionProgram(t *testing.T) {
+	source := strings.Join([]string{
+		"10 GOTO 40",
+		"20 PRINT \"BAD\"",
+		"30 END",
+		"40 LET A = 8 / 2",
+		"50 IF A = 4 THEN 70",
+		"60 END",
+		"70 PRINT \"DIV\"",
+		"80 END",
+	}, "\n") + "\n"
+	run, err := RunSource(source)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.Output != "DIV\n" {
+		t.Fatalf("expected output %q, got %q", "DIV\n", run.Output)
+	}
+}
+
+func TestParseErrorsReportStage(t *testing.T) {
+	_, err := CompileSource("10 PRINT")
+	if err == nil {
+		t.Fatal("expected parse failure")
+	}
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Stage != "parse" {
+		t.Fatalf("expected parse stage, got %q", packageErr.Stage)
+	}
+}
+
+func TestLowerBasicErrorsReportStage(t *testing.T) {
+	_, err := CompileSource("10 PRINT 7\n20 END\n")
+	if err == nil {
+		t.Fatal("expected lower-basic failure")
+	}
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Stage != "lower-basic" {
+		t.Fatalf("expected lower-basic stage, got %q", packageErr.Stage)
+	}
+}

--- a/code/packages/go/dartmouth-basic-riscv-compiler/go.mod
+++ b/code/packages/go/dartmouth-basic-riscv-compiler/go.mod
@@ -1,0 +1,54 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-riscv-compiler
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-ir-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/core v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace (
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor => ../branch-predictor
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache => ../cache
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock => ../clock
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir => ../compiler-ir
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map => ../compiler-source-map
+	github.com/adhithyan15/coding-adventures/code/packages/go/core => ../core
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline => ../cpu-pipeline
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator => ../cpu-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-ir-compiler => ../dartmouth-basic-ir-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-lexer => ../dartmouth-basic-lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/dartmouth-basic-parser => ../dartmouth-basic-parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection => ../hazard-detection
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer => ../ir-optimizer
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler => ../ir-to-riscv-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler => ../riscv-assembler
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator => ../riscv-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+)

--- a/code/packages/go/ir-optimizer/optimizer.go
+++ b/code/packages/go/ir-optimizer/optimizer.go
@@ -108,6 +108,11 @@ func (ConstantFolder) Run(program *ir.IrProgram) *ir.IrProgram {
 	next := cloneProgram(program)
 	pending := map[int]int{}
 	for index, instruction := range next.Instructions {
+		if instruction.Opcode == ir.OpLabel {
+			pending = map[int]int{}
+			continue
+		}
+
 		if instruction.Opcode == ir.OpLoadImm {
 			if len(instruction.Operands) >= 2 {
 				if dest, ok := instruction.Operands[0].(ir.IrRegister); ok {
@@ -124,7 +129,7 @@ func (ConstantFolder) Run(program *ir.IrProgram) *ir.IrProgram {
 				dest, destOK := instruction.Operands[0].(ir.IrRegister)
 				src, srcOK := instruction.Operands[1].(ir.IrRegister)
 				immediate, immOK := instruction.Operands[2].(ir.IrImmediate)
-				base, hasBase := pending[dest.Index]
+				base, hasBase := pending[src.Index]
 				if destOK && srcOK && immOK && hasBase && dest.Index == src.Index {
 					value := base
 					if instruction.Opcode == ir.OpAddImm {

--- a/code/packages/go/ir-optimizer/optimizer_test.go
+++ b/code/packages/go/ir-optimizer/optimizer_test.go
@@ -17,3 +17,30 @@ func TestOptimizerProducesStats(t *testing.T) {
 		t.Fatal("expected optimization result")
 	}
 }
+
+func TestConstantFolderFoldsStraightLineSelfIncrement(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.AddInstruction(ir.IrInstruction{Opcode: ir.OpLoadImm, Operands: []ir.IrOperand{ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 1}}, ID: 1})
+	program.AddInstruction(ir.IrInstruction{Opcode: ir.OpAddImm, Operands: []ir.IrOperand{ir.IrRegister{Index: 0}, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 2}}, ID: 2})
+
+	result := ConstantFolder{}.Run(program)
+	if got := result.Instructions[1].Opcode; got != ir.OpLoadImm {
+		t.Fatalf("expected straight-line addi to fold into LOAD_IMM, got %s", got.String())
+	}
+	imm, ok := result.Instructions[1].Operands[1].(ir.IrImmediate)
+	if !ok || imm.Value != 3 {
+		t.Fatalf("expected folded immediate value 3, got %#v", result.Instructions[1].Operands[1])
+	}
+}
+
+func TestConstantFolderDoesNotFoldAcrossLabelBoundary(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.AddInstruction(ir.IrInstruction{Opcode: ir.OpLoadImm, Operands: []ir.IrOperand{ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 0}}, ID: 1})
+	program.AddInstruction(ir.IrInstruction{Opcode: ir.OpLabel, Operands: []ir.IrOperand{ir.IrLabel{Name: "loop"}}, ID: -1})
+	program.AddInstruction(ir.IrInstruction{Opcode: ir.OpAddImm, Operands: []ir.IrOperand{ir.IrRegister{Index: 0}, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 1}}, ID: 2})
+
+	result := ConstantFolder{}.Run(program)
+	if got := result.Instructions[2].Opcode; got != ir.OpAddImm {
+		t.Fatalf("expected addi after label to stay as ADD_IMM, got %s", got.String())
+	}
+}

--- a/code/packages/go/ir-to-riscv-compiler/compiler.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler.go
@@ -889,7 +889,8 @@ func emitBranch(instruction ir.IrInstruction, frame *functionFrame, pc int, plan
 	if !ok {
 		return nil, loweringError(instruction, "unknown label %q", label.Name)
 	}
-	offset := target - pc
+	branchPC := pc + len(setup)*4
+	offset := target - branchPC
 	if err := validateBranchOffset(offset); err != nil {
 		return nil, loweringError(instruction, "%v", err)
 	}

--- a/code/packages/go/ir-to-riscv-compiler/compiler_test.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler_test.go
@@ -357,6 +357,40 @@ func TestCompilePreservesSpilledRegistersAcrossCalls(t *testing.T) {
 	}
 }
 
+func TestCompileUsesCorrectBranchPcAfterSpillReload(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpLoadImm, ir.IrRegister{Index: 20}, ir.IrImmediate{Value: 3}),
+		label("loop"),
+		instr(2, ir.OpAddImm, ir.IrRegister{Index: 20}, ir.IrRegister{Index: 20}, ir.IrImmediate{Value: -1}),
+		instr(3, ir.OpBranchNz, ir.IrRegister{Index: 20}, ir.IrLabel{Name: "loop"}),
+		instr(4, ir.OpAddImm, ir.IrRegister{Index: 1}, ir.IrRegister{Index: 20}, ir.IrImmediate{Value: 0}),
+		instr(5, ir.OpHalt),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	assembled, err := riscvassembler.Assemble(result.Assembly)
+	if err != nil {
+		t.Fatalf("assemble emitted assembly failed: %v\n%s", err, result.Assembly)
+	}
+	if !bytes.Equal(assembled.Bytes, result.Bytes) {
+		t.Fatalf("expected emitted assembly to reassemble to compiler bytes")
+	}
+
+	loopRegister, _ := physicalRegister(1)
+	if got := sim.CPU.Registers.Read(loopRegister); got != 0 {
+		t.Fatalf("expected spilled loop counter to reach 0, got %d", got)
+	}
+}
+
 func instr(id int, opcode ir.IrOp, operands ...ir.IrOperand) ir.IrInstruction {
 	return ir.IrInstruction{ID: id, Opcode: opcode, Operands: operands}
 }


### PR DESCRIPTION
## Summary
- add a Go `dartmouth-basic-ir-compiler` package that lowers an initial Dartmouth BASIC subset into `compiler-ir`
- add a `dartmouth-basic-riscv-compiler` package that parses BASIC, lowers to IR, packages RISC-V assembly/binary, and runs on the RISC-V simulator
- add focused tests for IR lowering, string-print execution, arithmetic/control-flow programs, and stage-specific errors

## Supported in this slice
- `REM`
- `LET`
- `PRINT` of string literals
- `GOTO`
- `IF ... THEN`
- `END` / `STOP`
- `+`, `-`, `*`, `/` (with `*` and `/` lowered into IR helper loops for now)

## Not yet supported
- numeric `PRINT`
- arrays
- `FOR` / `NEXT`
- `INPUT`
- `GOSUB` / `RETURN`
- `READ` / `DATA` / `RESTORE`
- `DIM`
- `DEF`
- exponentiation

## Verification
- `go test -c ./...` in `code/packages/go/dartmouth-basic-ir-compiler`
- `go test -c ./...` in `code/packages/go/dartmouth-basic-riscv-compiler`

Full local Go test execution is currently unreliable in this desktop environment because launched Go test binaries freeze before real execution, so CI is the runtime signal for this PR.