### PR TITLE
feat(rust): add html lexer conformance fixtures

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -24,3 +24,11 @@ documented in this file.
 - Kept the bootstrap skeleton helpers available for focused comparisons while
   the default wrapper now exercises attributes, comments, doctypes, and
   Mosaic-era fixtures.
+
+### Added
+- Repo-native JSON conformance fixture suites for the bootstrap skeleton and the
+  `html1` compatibility-floor lexer.
+- A shared Rust conformance harness that runs the fixture suites against both
+  explicit generated constructors and the default wrapper API.
+- Documentation for the fixture schema and the planned WHATWG/WPT normalization
+  path.

--- a/code/packages/rust/html-lexer/Cargo.toml
+++ b/code/packages/rust/html-lexer/Cargo.toml
@@ -9,4 +9,6 @@ state-machine = { path = "../state-machine" }
 state-machine-tokenizer = { path = "../state-machine-tokenizer" }
 
 [dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 state-machine-markup-deserializer = { path = "../state-machine-markup-deserializer" }

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -25,6 +25,24 @@ the project, but the first real HTML authoring artifact that must keep HTML
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 
+## Conformance
+
+Repo-native conformance fixtures live under
+[`tests/fixtures`](/tmp/coding-adventures-html-conformance/code/packages/rust/html-lexer/tests/fixtures).
+They use a documented JSON schema that Rust tests load with `include_str!`, so
+the test corpus is checked in and shared while production code still links only
+static Rust modules.
+
+Today the package carries two suites:
+
+- `html-skeleton.json` for narrow bootstrap regression coverage
+- `html1.json` for the current Mosaic-era compatibility floor
+
+The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
+same schema rather than teaching the Rust harness to parse raw upstream files
+directly. That gives us a clean expansion path from the HTML 1.x floor toward
+the living standard without reopening the runtime trust boundary.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -1,0 +1,142 @@
+use coding_adventures_html_lexer::{
+    create_html_lexer, html1_machine, html_skeleton_machine, Attribute, HtmlLexer, Token,
+};
+use serde::Deserialize;
+
+const HTML_SKELETON_FIXTURES: &str = include_str!("fixtures/html-skeleton.json");
+const HTML1_FIXTURES: &str = include_str!("fixtures/html1.json");
+
+#[derive(Debug, Deserialize)]
+struct FixtureSuite {
+    format: String,
+    suite: String,
+    description: String,
+    cases: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    id: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+}
+
+#[test]
+fn fixture_manifests_parse() {
+    let skeleton = load_suite(HTML_SKELETON_FIXTURES);
+    let html1 = load_suite(HTML1_FIXTURES);
+
+    assert_eq!(skeleton.format, "venture-html-lexer-fixtures/v1");
+    assert_eq!(skeleton.suite, "html-skeleton");
+    assert!(!skeleton.description.is_empty());
+    assert_eq!(skeleton.cases.len(), 3);
+
+    assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
+    assert_eq!(html1.suite, "html1");
+    assert!(!html1.description.is_empty());
+    assert_eq!(html1.cases.len(), 5);
+}
+
+#[test]
+fn bootstrap_skeleton_conformance_cases_match_generated_machine() {
+    let suite = load_suite(HTML_SKELETON_FIXTURES);
+    run_fixture_suite(&suite, || {
+        html_skeleton_machine()
+            .map(HtmlLexer::new)
+            .map_err(|error| error.to_string())
+    });
+}
+
+#[test]
+fn html1_conformance_cases_match_generated_machine() {
+    let suite = load_suite(HTML1_FIXTURES);
+    run_fixture_suite(&suite, || {
+        html1_machine()
+            .map(HtmlLexer::new)
+            .map_err(|error| error.to_string())
+    });
+}
+
+#[test]
+fn html1_conformance_cases_match_default_wrapper() {
+    let suite = load_suite(HTML1_FIXTURES);
+    run_fixture_suite(&suite, || {
+        create_html_lexer().map_err(|error| format!("{error:?}"))
+    });
+}
+
+fn load_suite(raw: &str) -> FixtureSuite {
+    serde_json::from_str(raw).expect("fixture suite should parse")
+}
+
+fn run_fixture_suite(suite: &FixtureSuite, create_lexer: impl Fn() -> Result<HtmlLexer, String>) {
+    for case in &suite.cases {
+        let mut lexer = create_lexer().unwrap_or_else(|error| {
+            panic!("suite `{}` failed to construct lexer: {error}", suite.suite)
+        });
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_tokens, case.tokens,
+            "suite `{}` case `{}` token mismatch",
+            suite.suite, case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "suite `{}` case `{}` diagnostic mismatch",
+            suite.suite, case.id
+        );
+    }
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype { name, force_quirks } => match name {
+            Some(name) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+            None => format!("Doctype(name=null, force_quirks={force_quirks})"),
+        },
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -1,0 +1,60 @@
+# HTML Lexer Conformance Fixtures
+
+These JSON files are the repo-native conformance layer for the Rust HTML lexer.
+They are intentionally separate from the authored state-machine TOML so we can:
+
+- test the public Rust wrapper against a shared corpus
+- run the same cases against bootstrap and generated constructors
+- grow coverage without making production code load text fixtures at runtime
+
+## Format
+
+Each file is a JSON object with this shape:
+
+```json
+{
+  "format": "venture-html-lexer-fixtures/v1",
+  "suite": "html1",
+  "description": "human-readable summary",
+  "cases": [
+    {
+      "id": "stable-case-id",
+      "input": "<P>Hello</P>",
+      "tokens": [
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=p)",
+        "EOF"
+      ],
+      "diagnostics": ["optional-diagnostic-code"]
+    }
+  ]
+}
+```
+
+`tokens` and `diagnostics` are summarized strings so the corpus stays portable
+across generated constructors and future language ports. Rust tests deserialize
+these files with `include_str!`, so the fixtures are compiled into the test
+binary while production code continues to link only static Rust source.
+
+## Current Suites
+
+- `html-skeleton.json`: narrow bootstrap regression cases
+- `html1.json`: Mosaic-era compatibility-floor cases for the current default wrapper
+
+## WPT Path
+
+The next layer should normalize WHATWG/WPT tokenizer coverage into this same
+schema instead of making the Rust test harness understand raw upstream files.
+That keeps the runtime boundary stable while still letting us mirror broader
+living-standard cases.
+
+Planned flow:
+
+1. Import or mirror selected upstream tokenizer cases into a generator script.
+2. Lower them into `venture-html-lexer-fixtures/v1` JSON files with stable IDs.
+3. Keep provenance metadata alongside the generated fixture file or in the
+   import script, rather than coupling the Rust test harness to WPT internals.
+
+This keeps Venture's Mosaic compatibility floor protected while making it easy
+to add newer HTML tokenizer behavior as the authored state machine grows.

--- a/code/packages/rust/html-lexer/tests/fixtures/html-skeleton.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html-skeleton.json
@@ -1,0 +1,36 @@
+{
+  "format": "venture-html-lexer-fixtures/v1",
+  "suite": "html-skeleton",
+  "description": "Bootstrap lexer conformance cases kept intentionally small for narrow regression checks.",
+  "cases": [
+    {
+      "id": "simple-element",
+      "input": "<p>Hello</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "plain-text",
+      "input": "plain text",
+      "tokens": [
+        "Text(data=plain text)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "tag-open-eof-recovery",
+      "input": "<",
+      "tokens": [
+        "Text(data=<)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-tag-open-state"
+      ]
+    }
+  ]
+}

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -1,0 +1,57 @@
+{
+  "format": "venture-html-lexer-fixtures/v1",
+  "suite": "html1",
+  "description": "Mosaic-era HTML compatibility-floor cases for the current generated Rust wrapper.",
+  "cases": [
+    {
+      "id": "mosaic-text-and-tag",
+      "input": "<TITLE>Hello</TITLE>",
+      "tokens": [
+        "StartTag(name=title, attributes=[], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "mosaic-attributes-and-self-closing",
+      "input": "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>",
+      "tokens": [
+        "StartTag(name=img, attributes=[src=mosaic.gif, alt=Splash, hidden=1], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "mosaic-comment",
+      "input": "Before<!--note-->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=note)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "mosaic-doctype-and-heading",
+      "input": "<!DOCTYPE HTML><H1 class=test>Hello</H1>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "StartTag(name=h1, attributes=[class=test], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=h1)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "comment-eof-recovery",
+      "input": "<!--open",
+      "tokens": [
+        "Comment(data=open)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-comment"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add repo-native JSON conformance fixture suites for the bootstrap HTML skeleton and the current `html1` compatibility-floor lexer
- add a shared Rust conformance harness that runs the suites against generated constructors and the default wrapper API
- document the fixture schema and the intended WHATWG/WPT normalization path

## Testing
- `cargo fmt -p coding-adventures-html-lexer`
- `git diff --check`
- parsed `tests/fixtures/html-skeleton.json` and `tests/fixtures/html1.json` successfully with Python `json`
- attempted `cargo check -p coding-adventures-html-lexer --tests`
- attempted `cargo test -p coding-adventures-html-lexer --no-run`

The new Cargo dev-dependencies compile up through `coding-adventures-html-lexer`, but this environment hit the same local Cargo stall we have seen before after reaching the package itself, so I’m leaning on CI for the final pass here.

Closes #1116