### PR TITLE
feat(rust): normalize html5lib smoke fixtures

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -32,3 +32,5 @@ documented in this file.
   explicit generated constructors and the default wrapper API.
 - Documentation for the fixture schema and the planned WHATWG/WPT normalization
   path.
+- A first raw html5lib-style tokenizer smoke file plus a Rust normalizer that
+  lowers supported upstream cases into Venture's portable conformance schema.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -38,6 +38,12 @@ Today the package carries two suites:
 - `html-skeleton.json` for narrow bootstrap regression coverage
 - `html1.json` for the current Mosaic-era compatibility floor
 
+There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
+html5lib tokenizer JSON shape in a small supported subset. The Rust test
+harness lowers that upstream-style file into Venture's portable fixture schema
+before execution, which makes the future WPT/html5lib import path concrete
+without coupling the shared harness to upstream file formats.
+
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files
 directly. That gives us a clean expansion path from the HTML 1.x floor toward

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -2,9 +2,11 @@ use coding_adventures_html_lexer::{
     create_html_lexer, html1_machine, html_skeleton_machine, Attribute, HtmlLexer, Token,
 };
 use serde::Deserialize;
+use serde_json::Value;
 
 const HTML_SKELETON_FIXTURES: &str = include_str!("fixtures/html-skeleton.json");
 const HTML1_FIXTURES: &str = include_str!("fixtures/html1.json");
+const HTML5LIB_SMOKE_FIXTURES: &str = include_str!("fixtures/upstream-html5lib-smoke.test");
 
 #[derive(Debug, Deserialize)]
 struct FixtureSuite {
@@ -23,6 +25,31 @@ struct FixtureCase {
     diagnostics: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct Html5libTokenizerFile {
+    tests: Vec<Html5libTokenizerTest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Html5libTokenizerTest {
+    description: String,
+    input: String,
+    output: Vec<Value>,
+    #[serde(default, rename = "initialStates")]
+    initial_states: Vec<String>,
+    #[serde(default, rename = "lastStartTag")]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    errors: Vec<Html5libTokenizerError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Html5libTokenizerError {
+    code: String,
+    line: usize,
+    col: usize,
+}
+
 #[test]
 fn fixture_manifests_parse() {
     let skeleton = load_suite(HTML_SKELETON_FIXTURES);
@@ -37,6 +64,22 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
     assert_eq!(html1.cases.len(), 5);
+}
+
+#[test]
+fn html5lib_smoke_fixture_file_parses() {
+    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
+
+    assert_eq!(file.tests.len(), 4);
+    assert_eq!(
+        file.tests[0].description,
+        "simple start and end tag in data state"
+    );
+    assert!(file.tests[0].initial_states.is_empty());
+    assert!(file.tests[0].last_start_tag.is_none());
+    assert_eq!(file.tests[3].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[3].errors[0].line, 1);
+    assert_eq!(file.tests[3].errors[0].col, 9);
 }
 
 #[test]
@@ -67,8 +110,183 @@ fn html1_conformance_cases_match_default_wrapper() {
     });
 }
 
+#[test]
+fn normalized_html5lib_cases_match_default_wrapper() {
+    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
+    let suite = normalize_html5lib_suite(&file);
+
+    assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
+    assert_eq!(suite.suite, "html5lib-smoke");
+    assert_eq!(suite.cases.len(), 4);
+
+    run_fixture_suite(&suite, || {
+        create_html_lexer().map_err(|error| format!("{error:?}"))
+    });
+}
+
+#[test]
+fn normalized_html5lib_cases_match_generated_html1_machine() {
+    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
+    let suite = normalize_html5lib_suite(&file);
+
+    run_fixture_suite(&suite, || {
+        html1_machine()
+            .map(HtmlLexer::new)
+            .map_err(|error| error.to_string())
+    });
+}
+
 fn load_suite(raw: &str) -> FixtureSuite {
     serde_json::from_str(raw).expect("fixture suite should parse")
+}
+
+fn load_html5lib_file(raw: &str) -> Html5libTokenizerFile {
+    serde_json::from_str(raw).expect("html5lib tokenizer fixture file should parse")
+}
+
+fn normalize_html5lib_suite(file: &Html5libTokenizerFile) -> FixtureSuite {
+    FixtureSuite {
+        format: "venture-html-lexer-fixtures/v1".to_string(),
+        suite: "html5lib-smoke".to_string(),
+        description:
+            "Normalized html5lib-style tokenizer smoke cases lowered into the Venture fixture schema"
+                .to_string(),
+        cases: file
+            .tests
+            .iter()
+            .enumerate()
+            .map(|(index, test)| normalize_html5lib_case(index, test))
+            .collect(),
+    }
+}
+
+fn normalize_html5lib_case(index: usize, test: &Html5libTokenizerTest) -> FixtureCase {
+    assert!(
+        test.initial_states.is_empty() || test.initial_states == ["Data state".to_string()],
+        "html5lib smoke normalizer currently supports only the data state"
+    );
+    assert!(
+        test.last_start_tag.is_none(),
+        "html5lib smoke normalizer does not yet support lastStartTag"
+    );
+
+    let mut tokens = Vec::new();
+    let mut pending_text = String::new();
+
+    for token in &test.output {
+        let items = token
+            .as_array()
+            .expect("html5lib tokenizer output tokens should be arrays");
+        let kind = items
+            .first()
+            .and_then(Value::as_str)
+            .expect("html5lib tokenizer token kind should be a string");
+
+        match kind {
+            "Character" => {
+                pending_text.push_str(
+                    items
+                        .get(1)
+                        .and_then(Value::as_str)
+                        .expect("Character token should carry data"),
+                );
+            }
+            "StartTag" => {
+                flush_pending_text(&mut pending_text, &mut tokens);
+                tokens.push(normalize_html5lib_start_tag(items));
+            }
+            "EndTag" => {
+                flush_pending_text(&mut pending_text, &mut tokens);
+                tokens.push(format!(
+                    "EndTag(name={})",
+                    items
+                        .get(1)
+                        .and_then(Value::as_str)
+                        .expect("EndTag token should carry a name")
+                ));
+            }
+            "Comment" => {
+                flush_pending_text(&mut pending_text, &mut tokens);
+                tokens.push(format!(
+                    "Comment(data={})",
+                    items
+                        .get(1)
+                        .and_then(Value::as_str)
+                        .expect("Comment token should carry data")
+                ));
+            }
+            "DOCTYPE" => {
+                flush_pending_text(&mut pending_text, &mut tokens);
+                tokens.push(normalize_html5lib_doctype(items));
+            }
+            other => panic!("unsupported html5lib smoke token kind `{other}`"),
+        }
+    }
+
+    flush_pending_text(&mut pending_text, &mut tokens);
+    tokens.push("EOF".to_string());
+
+    FixtureCase {
+        id: format!("html5lib-smoke-{}", index + 1),
+        input: test.input.clone(),
+        tokens,
+        diagnostics: test.errors.iter().map(|error| error.code.clone()).collect(),
+    }
+}
+
+fn flush_pending_text(pending_text: &mut String, tokens: &mut Vec<String>) {
+    if pending_text.is_empty() {
+        return;
+    }
+
+    tokens.push(format!("Text(data={pending_text})"));
+    pending_text.clear();
+}
+
+fn normalize_html5lib_start_tag(items: &[Value]) -> String {
+    let name = items
+        .get(1)
+        .and_then(Value::as_str)
+        .expect("StartTag token should carry a name");
+    let attributes = items
+        .get(2)
+        .and_then(Value::as_object)
+        .expect("StartTag token should carry an attribute map");
+    let attribute_summary = if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|(name, value)| {
+                format!(
+                    "{}={}",
+                    name,
+                    value
+                        .as_str()
+                        .expect("attribute values should be strings in smoke fixtures")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    };
+    let self_closing = items.get(3).and_then(Value::as_bool).unwrap_or(false);
+
+    format!("StartTag(name={name}, attributes={attribute_summary}, self_closing={self_closing})")
+}
+
+fn normalize_html5lib_doctype(items: &[Value]) -> String {
+    let name = items
+        .get(1)
+        .and_then(Value::as_str)
+        .expect("DOCTYPE token should carry a name");
+    let correctness = items
+        .get(4)
+        .and_then(Value::as_bool)
+        .expect("DOCTYPE token should carry correctness");
+    let force_quirks = !correctness;
+
+    format!("Doctype(name={name}, force_quirks={force_quirks})")
 }
 
 fn run_fixture_suite(suite: &FixtureSuite, create_lexer: impl Fn() -> Result<HtmlLexer, String>) {

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -41,13 +41,22 @@ binary while production code continues to link only static Rust source.
 
 - `html-skeleton.json`: narrow bootstrap regression cases
 - `html1.json`: Mosaic-era compatibility-floor cases for the current default wrapper
+- `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
+  exercise the normalization path toward broader upstream corpora
 
 ## WPT Path
 
-The next layer should normalize WHATWG/WPT tokenizer coverage into this same
-schema instead of making the Rust test harness understand raw upstream files.
-That keeps the runtime boundary stable while still letting us mirror broader
-living-standard cases.
+The next layer normalizes WHATWG/WPT or html5lib-style tokenizer coverage into
+this same schema instead of making the Rust test harness understand raw
+upstream files directly. That keeps the runtime boundary stable while still
+letting us mirror broader living-standard cases.
+
+`upstream-html5lib-smoke.test` is the first concrete step in that direction. It
+uses the tokenizer JSON structure documented by the html5lib tokenizer tests:
+top-level `tests`, with each test carrying `description`, `input`, `output`,
+optional `initialStates`, optional `lastStartTag`, and optional `errors`.
+Rust tests parse that raw upstream-style file and lower it into
+`venture-html-lexer-fixtures/v1` before running the shared conformance harness.
 
 Planned flow:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1,0 +1,42 @@
+{
+  "tests": [
+    {
+      "description": "simple start and end tag in data state",
+      "input": "<b>Hello</b>",
+      "output": [
+        ["StartTag", "b", {}],
+        ["Character", "Hello"],
+        ["EndTag", "b"]
+      ]
+    },
+    {
+      "description": "comment token surrounded by characters",
+      "input": "Before<!--note-->After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "note"],
+        ["Character", "After"]
+      ]
+    },
+    {
+      "description": "doctype plus single attribute start tag",
+      "input": "<!DOCTYPE html><p class=test>Hi</p>",
+      "output": [
+        ["DOCTYPE", "html", null, null, true],
+        ["StartTag", "p", {"class": "test"}],
+        ["Character", "Hi"],
+        ["EndTag", "p"]
+      ]
+    },
+    {
+      "description": "comment eof recovery reports tokenizer error",
+      "input": "<!--open",
+      "output": [
+        ["Comment", "open"]
+      ],
+      "errors": [
+        {"code": "eof-in-comment", "line": 1, "col": 9}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the first raw html5lib-style tokenizer smoke fixture file under the Rust HTML lexer test fixtures
- teach the Rust conformance harness to parse that upstream-style JSON and normalize it into Venture's portable fixture schema
- run the normalized upstream-style cases against both the default wrapper and the generated html1 machine, and document the path in the fixture docs

## Testing
- `cargo fmt -p coding-adventures-html-lexer`
- `git diff --check`
- parsed `tests/fixtures/upstream-html5lib-smoke.test` successfully with Python `json`
- attempted `cargo check -p coding-adventures-html-lexer --tests`

The local Cargo environment still hit the same hang after `coding-adventures-html-lexer` began checking, so I’m leaning on CI for the final verification again.

Follow-up to the merged conformance work in #1187.