### PR TITLE
feat(algol): add builtin string literal output

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -90,6 +90,10 @@ _MAX_EVAL_THUNKS = 256
 _INTEGER_TYPE = "integer"
 _BOOLEAN_TYPE = "boolean"
 _REAL_TYPE = "real"
+_STRING_TYPE = "string"
+_BUILTIN_PRINT_LABEL = "__algol_builtin_print"
+_BUILTIN_OUTPUT_LABEL = "__algol_builtin_output"
+_WRITE_SYSCALL = 1
 
 
 @dataclass(frozen=True)
@@ -1402,6 +1406,8 @@ class AlgolIrCompiler:
             raise CompileError("procedure call is missing a name")
         role = "statement" if node.rule_name == "proc_stmt" else "expression"
         call = self._require_procedure_call(name, role)
+        if call.label in {_BUILTIN_PRINT_LABEL, _BUILTIN_OUTPUT_LABEL}:
+            return self._compile_builtin_output(node)
         procedure = self.procedures[call.procedure_id]
         static_link = self._emit_static_link_for_call(call, scope)
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
@@ -1504,6 +1510,35 @@ class AlgolIrCompiler:
             src=_REAL_RESULT_REG if call.return_type == _REAL_TYPE else _RESULT_REG,
         )
         return result
+
+    def _compile_builtin_output(self, node: ASTNode) -> int:
+        actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
+        if len(actuals) != 1:
+            raise CompileError("builtin output expects exactly 1 argument")
+        literal = next(
+            (token for token in _tokens(actuals[0]) if token.type_name == "STRING_LIT"),
+            None,
+        )
+        if literal is None:
+            raise CompileError("builtin output currently requires a string literal")
+
+        saved_arg_reg: int | None = None
+        if self.next_reg > _VALUE_PARAM_BASE_REG:
+            saved_arg_reg = self._fresh_reg()
+            self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
+
+        for char in literal.value[1:-1]:
+            value_reg = self._const_reg(ord(char))
+            self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=value_reg)
+            self._emit(
+                IrOp.SYSCALL,
+                IrImmediate(_WRITE_SYSCALL),
+                IrRegister(_VALUE_PARAM_BASE_REG),
+            )
+
+        if saved_arg_reg is not None:
+            self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
+        return _ZERO_REG
 
     def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
         variable = _single_variable_expr(argument)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -619,7 +619,9 @@ class TestAlgolIrCompiler:
             result.procedure_signatures["_fn_algol_eval_real_thunk"].return_type
             == "real"
         )
-        assert any(call.operands[0].name == "_fn_algol_eval_real_thunk" for call in calls)
+        assert any(
+            call.operands[0].name == "_fn_algol_eval_real_thunk" for call in calls
+        )
 
     def test_compiles_array_element_by_name_eval_and_store_thunks(
         self,
@@ -733,3 +735,23 @@ class TestAlgolIrCompiler:
 
         assert "_fn_algol_eval_thunk" in calls
         assert any(label.startswith("_fn_algol_") for label in calls)
+
+    def test_compiles_builtin_print_string_literal_to_syscalls(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; print('Hi'); result := 1 end")
+        )
+        instructions = result.program.instructions
+        syscall_count = sum(
+            1 for instruction in instructions if instruction.opcode == IrOp.SYSCALL
+        )
+        immediates = [
+            operand.value
+            for instruction in instructions
+            if instruction.opcode == IrOp.LOAD_IMM
+            for operand in instruction.operands[1:]
+            if hasattr(operand, "value")
+        ]
+
+        assert syscall_count == 2
+        assert 72 in immediates
+        assert 105 in immediates

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -10,6 +10,7 @@ from lexer import Token
 INTEGER = "integer"
 BOOLEAN = "boolean"
 REAL = "real"
+STRING = "string"
 ERROR = "error"
 FRAME_HEADER_SIZE = 20
 FRAME_WORD_SIZE = 4
@@ -1355,6 +1356,8 @@ class AlgolTypeChecker:
             return INTEGER
         if token.type_name == "REAL_LIT":
             return REAL
+        if token.type_name == "STRING_LIT":
+            return STRING
         if token.value in {"true", "false"}:
             return BOOLEAN
         if token.type_name == "NAME":
@@ -1460,6 +1463,8 @@ class AlgolTypeChecker:
 
         resolved = self._resolve_procedure(name_token, scope)
         if resolved is None:
+            resolved = self._resolve_builtin_procedure(name_token, scope)
+        if resolved is None:
             self._error(
                 name_token,
                 f"{name_token.value!r} is not a procedure visible from block "
@@ -1533,6 +1538,35 @@ class AlgolTypeChecker:
         )
         self.resolved_procedure_calls.append(call)
         return call
+
+    def _resolve_builtin_procedure(
+        self,
+        token: Token,
+        scope: Scope,
+    ) -> tuple[ProcedureDescriptor, Scope, int] | None:
+        if token.value not in {"print", "output"}:
+            return None
+        descriptor = ProcedureDescriptor(
+            procedure_id=-1,
+            name=token.value,
+            label=f"__algol_builtin_{token.value}",
+            declaring_block_id=scope.block_id,
+            body_block_id=scope.block_id,
+            body_node_id=-1,
+            return_type=None,
+            parameters=(
+                ProcedureParameter(
+                    name="value",
+                    type_name=STRING,
+                    mode=VALUE,
+                    symbol_id=-1,
+                    slot_offset=0,
+                ),
+            ),
+            line=token.line,
+            column=token.column,
+        )
+        return descriptor, scope, 0
 
     def _record_assignable_actual_write(self, argument: ASTNode, scope: Scope) -> None:
         variable = _single_variable_expr(argument)

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -888,3 +888,28 @@ class TestAlgolTypeChecker:
 
         assert not result.ok
         assert "does not return a value" in result.diagnostics[0].message
+
+    def test_accepts_builtin_print_with_string_literal(self) -> None:
+        ast = parse_algol("begin integer result; print('Hi'); result := 1 end")
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.procedure_calls[-1].label == "__algol_builtin_print"
+
+    def test_rejects_builtin_print_with_non_string_argument(self) -> None:
+        ast = parse_algol("begin integer result; print(1); result := 0 end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "parameter 'value' expects string, got integer"
+            in result.diagnostics[0].message
+        )
+
+    def test_rejects_builtin_print_in_expression(self) -> None:
+        ast = parse_algol("begin integer result; result := print('Hi') end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "does not return a value" in result.diagnostics[0].message

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import pytest
-from wasm_runtime import WasmRuntime
+from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
 
 from algol_wasm_compiler import (
     AlgolWasmError,
@@ -65,6 +65,14 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
+
+    def test_builtin_print_string_literal_writes_stdout(self) -> None:
+        result = compile_source("begin integer result; print('Hi'); result := 7 end")
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "Hi"
 
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- add builtin `print(...)` and `output(...)` support for string literals in the ALGOL type checker
- lower those builtins through the existing WASI byte-write syscall path in the IR compiler
- add focused checker, IR, and WASM tests for literal output and diagnostics

## Testing
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
- python3.12 -m ruff check /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py