### PR TITLE
feat(prolog): add builtin goal adapter

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -8,3 +8,8 @@
   `initialization/1` handling
 - support optional goal adaptation so parsed initialization goals can be mapped
   into richer runtime or builtin goals before execution
+- add `adapt_prolog_goal(...)` as a shared builtin adapter for parsed Prolog
+  goals
+- add `run_prolog_initialization_goals(...)` so loader callers can execute
+  `call/1`, `dynamic/1`, `assertz/1`, `predicate_property/2`, and related
+  builtins without writing custom Python adapters

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -8,8 +8,10 @@ It keeps parsing side-effect free, then exposes helpers to:
 - normalize dialect-specific parsed sources into one shared loaded shape
 - collect `initialization/1` directives in source order
 - run those initialization goals explicitly against the loaded `Program`
-- optionally adapt parsed goals into richer runtime or builtin goals before
-  execution
+- adapt parsed Prolog builtin calls like `call/1`, `dynamic/1`, `assertz/1`,
+  and `predicate_property/2` into runtime goals before execution
+- expose a convenience runner for executing initialization goals with the shared
+  Prolog builtin adapter enabled
 
 This package is the bridge between “we parsed a Prolog file” and “we loaded a
 Prolog file and are ready to run its startup behavior.”

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -12,6 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
+    "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",

--- a/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
@@ -1,5 +1,6 @@
 """Loader helpers for parsed Prolog sources and explicit initialization runs."""
 
+from prolog_loader.adapters import adapt_prolog_goal
 from prolog_loader.loader import (
     GoalAdapter,
     LoadedPrologSource,
@@ -9,10 +10,12 @@ from prolog_loader.loader import (
     load_parsed_prolog_source,
     load_swi_prolog_source,
     run_initialization_goals,
+    run_prolog_initialization_goals,
 )
 
 __all__ = [
     "__version__",
+    "adapt_prolog_goal",
     "GoalAdapter",
     "LoadedPrologSource",
     "PrologInitializationError",
@@ -20,4 +23,5 @@ __all__ = [
     "load_parsed_prolog_source",
     "load_swi_prolog_source",
     "run_initialization_goals",
+    "run_prolog_initialization_goals",
 ]

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -1,0 +1,242 @@
+"""Adapters that translate parsed Prolog builtin calls into runtime goals."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from logic_builtins import (
+    abolisho,
+    argo,
+    assertao,
+    assertzo,
+    atomico,
+    atomo,
+    callableo,
+    calltermo,
+    clauseo,
+    compare_termo,
+    compoundo,
+    current_predicateo,
+    dynamico,
+    functoro,
+    groundo,
+    nonvaro,
+    noto,
+    numbero,
+    onceo,
+    predicate_propertyo,
+    retractallo,
+    retracto,
+    same_termo,
+    stringo,
+    termo_geqo,
+    termo_gto,
+    termo_leqo,
+    termo_lto,
+    univo,
+    varo,
+)
+from logic_engine import (
+    Atom,
+    Compound,
+    ConjExpr,
+    DisjExpr,
+    FreshExpr,
+    GoalExpr,
+    LogicVar,
+    RelationCall,
+    Term,
+    atom,
+    conj,
+    disj,
+    eq,
+    fresh,
+    relation,
+    term,
+)
+
+_PREDICATE_INDICATOR = relation("/", 2)
+type IndicatorBuilder = Callable[[Term, Term], GoalExpr]
+
+
+def adapt_prolog_goal(goal: GoalExpr) -> GoalExpr:
+    """Adapt parsed Prolog builtin calls into executable runtime goals.
+
+    Goals with no builtin mapping are returned unchanged, so ordinary predicate
+    calls still flow through to the loaded program as-is.
+    """
+
+    if isinstance(goal, RelationCall):
+        return _adapt_relation_call(goal)
+    if isinstance(goal, ConjExpr):
+        return conj(*(adapt_prolog_goal(child) for child in goal.goals))
+    if isinstance(goal, DisjExpr):
+        return disj(*(adapt_prolog_goal(child) for child in goal.goals))
+    if isinstance(goal, FreshExpr):
+        return FreshExpr(
+            template_vars=goal.template_vars,
+            body=adapt_prolog_goal(goal.body),
+        )
+    return goal
+
+
+def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
+    name = goal.relation.symbol.name
+    args = goal.args
+
+    unary_term_builtins: dict[str, Callable[[object], GoalExpr]] = {
+        "var": varo,
+        "nonvar": nonvaro,
+        "ground": groundo,
+        "atom": atomo,
+        "atomic": atomico,
+        "number": numbero,
+        "string": stringo,
+        "compound": compoundo,
+        "callable": callableo,
+    }
+    if goal.relation.arity == 1 and name in unary_term_builtins:
+        return unary_term_builtins[name](args[0])
+
+    if name == "call" and goal.relation.arity == 1:
+        return calltermo(args[0])
+    if name == "once" and goal.relation.arity == 1:
+        return onceo(calltermo(args[0]))
+    if name in {"not", "\\+"} and goal.relation.arity == 1:
+        return noto(calltermo(args[0]))
+    if name == "functor" and goal.relation.arity == 3:
+        return functoro(*args)
+    if name == "arg" and goal.relation.arity == 3:
+        return argo(*args)
+    if name == "=.." and goal.relation.arity == 2:
+        return univo(*args)
+    if name == "==" and goal.relation.arity == 2:
+        return same_termo(*args)
+    if name == "compare" and goal.relation.arity == 3:
+        return compare_termo(*args)
+    if name == "@<" and goal.relation.arity == 2:
+        return termo_lto(*args)
+    if name == "@=<" and goal.relation.arity == 2:
+        return termo_leqo(*args)
+    if name == "@>" and goal.relation.arity == 2:
+        return termo_gto(*args)
+    if name == "@>=" and goal.relation.arity == 2:
+        return termo_geqo(*args)
+    if name == "asserta" and goal.relation.arity == 1:
+        return assertao(args[0])
+    if name == "assertz" and goal.relation.arity == 1:
+        return assertzo(args[0])
+    if name == "retract" and goal.relation.arity == 1:
+        return retracto(args[0])
+    if name == "retractall" and goal.relation.arity == 1:
+        return retractallo(args[0])
+    if name == "clause" and goal.relation.arity == 2:
+        return clauseo(*args)
+    if name == "dynamic" and goal.relation.arity == 1:
+        dynamic_goal = _adapt_indicator_declaration(args[0], dynamico)
+        return goal if dynamic_goal is None else dynamic_goal
+    if name == "abolish" and goal.relation.arity == 1:
+        abolish_goal = _adapt_indicator_declaration(args[0], abolisho)
+        return goal if abolish_goal is None else abolish_goal
+    if name == "current_predicate" and goal.relation.arity == 1:
+        current_goal = _adapt_current_predicate(args[0])
+        return goal if current_goal is None else current_goal
+    if name == "predicate_property" and goal.relation.arity == 2:
+        property_goal = _adapt_predicate_property(args[0], args[1])
+        return goal if property_goal is None else property_goal
+
+    return goal
+
+
+def _adapt_indicator_declaration(
+    indicator_term: Term,
+    builder: IndicatorBuilder,
+) -> GoalExpr | None:
+    if isinstance(indicator_term, LogicVar):
+        return None
+
+    indicator = _indicator_parts(indicator_term)
+    if indicator is not None:
+        return builder(*indicator)
+
+    items = _logic_list_items(indicator_term)
+    if items is None:
+        return None
+
+    goals: list[GoalExpr] = []
+    for item in items:
+        parts = _indicator_parts(item)
+        if parts is None:
+            return None
+        goals.append(builder(*parts))
+    return conj(*goals)
+
+
+def _adapt_current_predicate(indicator_term: Term) -> GoalExpr | None:
+    parts = _indicator_parts(indicator_term)
+    if parts is not None:
+        return current_predicateo(*parts)
+    if isinstance(indicator_term, LogicVar):
+        return fresh(
+            2,
+            lambda name_term, arity_term: conj(
+                current_predicateo(name_term, arity_term),
+                eq(indicator_term, term("/", name_term, arity_term)),
+            ),
+        )
+    return None
+
+
+def _adapt_predicate_property(
+    indicator_or_head: Term,
+    property_term: Term,
+) -> GoalExpr | None:
+    parts = _indicator_parts(indicator_or_head)
+    if parts is not None:
+        return predicate_propertyo(parts[0], parts[1], property_term)
+
+    if isinstance(indicator_or_head, LogicVar):
+        return fresh(
+            2,
+            lambda name_term, arity_term: conj(
+                predicate_propertyo(name_term, arity_term, property_term),
+                eq(indicator_or_head, term("/", name_term, arity_term)),
+            ),
+        )
+
+    if isinstance(indicator_or_head, Atom):
+        return predicate_propertyo(atom(indicator_or_head.symbol), 0, property_term)
+    if isinstance(indicator_or_head, Compound):
+        return predicate_propertyo(
+            atom(indicator_or_head.functor),
+            len(indicator_or_head.args),
+            property_term,
+        )
+    return None
+
+
+def _indicator_parts(term_value: Term) -> tuple[Term, Term] | None:
+    if (
+        isinstance(term_value, Compound)
+        and term_value.functor == _PREDICATE_INDICATOR.symbol
+        and len(term_value.args) == 2
+    ):
+        return (term_value.args[0], term_value.args[1])
+    return None
+
+
+def _logic_list_items(term_value: Term) -> list[Term] | None:
+    items: list[Term] = []
+    current = term_value
+    while True:
+        if isinstance(current, Atom) and current.symbol.name == "[]":
+            return items
+        if (
+            isinstance(current, Compound)
+            and current.functor.name == "."
+            and len(current.args) == 2
+        ):
+            items.append(current.args[0])
+            current = current.args[1]
+            continue
+        return None

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -19,6 +19,8 @@ from logic_engine import (
 from prolog_core import OperatorTable, PredicateRegistry, PrologDirective
 from prolog_parser import ParsedQuery
 
+from prolog_loader.adapters import adapt_prolog_goal
+
 __version__ = "0.1.0"
 
 type GoalAdapter = Callable[[GoalExpr], object]
@@ -171,6 +173,20 @@ def run_initialization_goals(
         current_state = next_state
 
     return current_state
+
+
+def run_prolog_initialization_goals(
+    loaded_source: LoadedPrologSource,
+    *,
+    state: State | None = None,
+) -> State:
+    """Run initialization directives with the shared Prolog builtin adapter."""
+
+    return run_initialization_goals(
+        loaded_source,
+        state=state,
+        goal_adapter=adapt_prolog_goal,
+    )
 
 
 def _initialization_term(directive_value: PrologDirective) -> Term:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -3,22 +3,32 @@
 from __future__ import annotations
 
 import pytest
-from logic_builtins import assertzo, dynamico
 from logic_engine import (
-    GoalExpr,
+    ConjExpr,
+    DisjExpr,
+    FreshExpr,
+    LogicVar,
     RelationCall,
+    State,
     atom,
+    conj,
+    disj,
+    eq,
+    fresh,
     reify,
     relation,
+    term,
     visible_clauses_for,
 )
 
 from prolog_loader import (
     PrologInitializationError,
     __version__,
+    adapt_prolog_goal,
     load_iso_prolog_source,
     load_swi_prolog_source,
     run_initialization_goals,
+    run_prolog_initialization_goals,
 )
 
 
@@ -75,30 +85,61 @@ class TestPrologLoader:
 
         assert reify(result_var, state.substitution) == atom("done")
 
-    def test_run_initialization_goals_accepts_goal_adapters_for_builtins(
+    def test_run_prolog_initialization_goals_executes_builtin_runtime_goals(
         self,
     ) -> None:
         loaded = load_iso_prolog_source(
             """
-            :- initialization(dynamico(memo, 1)).
-            :- initialization(assertzo(memo(ok))).
+            :- initialization(dynamic(memo/1)).
+            :- initialization(assertz(memo(ok))).
+            :- initialization(call(memo(ok))).
+            :- initialization(once(memo(ok))).
+            :- initialization(not(memo(missing))).
+            :- initialization(current_predicate(memo/1)).
+            :- initialization(predicate_property(memo/1, dynamic)).
             """,
         )
 
-        def adapt(goal: GoalExpr) -> object:
-            if isinstance(goal, RelationCall):
-                if goal.relation == relation("dynamico", 2):
-                    return dynamico(*goal.args)
-                if goal.relation == relation("assertzo", 1):
-                    return assertzo(goal.args[0])
-            return goal
-
-        state = run_initialization_goals(loaded, goal_adapter=adapt)
+        state = run_prolog_initialization_goals(loaded)
         memo = relation("memo", 1)
         visible = visible_clauses_for(loaded.program, memo, state)
 
         assert len(visible) == 1
         assert visible[0].head == memo("ok")
+
+    def test_run_initialization_goals_accepts_shared_prolog_goal_adapter(
+        self,
+    ) -> None:
+        loaded = load_iso_prolog_source(
+            """
+            :- initialization(dynamic(memo/1)).
+            :- initialization(assertz(memo(ok))).
+            """,
+        )
+
+        state = run_initialization_goals(loaded, goal_adapter=adapt_prolog_goal)
+        memo = relation("memo", 1)
+        visible = visible_clauses_for(loaded.program, memo, state)
+
+        assert len(visible) == 1
+        assert visible[0].head == memo("ok")
+
+    def test_run_initialization_goals_still_accepts_custom_goal_adapters(
+        self,
+    ) -> None:
+        loaded = load_iso_prolog_source(":- initialization(custom_startup).\n")
+
+        def adapt(goal: object) -> object:
+            if isinstance(goal, RelationCall) and goal.relation == relation(
+                "custom_startup",
+                0,
+            ):
+                return eq(atom("ok"), atom("ok"))
+            return goal
+
+        state = run_initialization_goals(loaded, goal_adapter=adapt)
+
+        assert state == State()
 
     def test_run_initialization_goals_raises_for_failed_startup_goals(self) -> None:
         loaded = load_iso_prolog_source(":- initialization(missing_goal).\n")
@@ -108,3 +149,121 @@ class TestPrologLoader:
             match=r"initialization directive 1 failed: missing_goal",
         ):
             run_initialization_goals(loaded)
+
+
+class TestPrologGoalAdapter:
+    """The shared adapter should translate common Prolog builtin shapes."""
+
+    @pytest.mark.parametrize(
+        "goal",
+        [
+            relation("var", 1)(atom("X")),
+            relation("nonvar", 1)(atom("x")),
+            relation("ground", 1)(atom("x")),
+            relation("atom", 1)(atom("x")),
+            relation("atomic", 1)(atom("x")),
+            relation("number", 1)(1),
+            relation("string", 1)("hello"),
+            relation("compound", 1)(term("pair", atom("a"), atom("b"))),
+            relation("callable", 1)(term("memo", atom("ok"))),
+            relation("call", 1)(term("memo", atom("ok"))),
+            relation("once", 1)(term("memo", atom("ok"))),
+            relation("not", 1)(term("memo", atom("missing"))),
+            relation("\\+", 1)(term("memo", atom("missing"))),
+            relation("functor", 3)(term("memo", atom("ok")), atom("memo"), 1),
+            relation("arg", 3)(1, term("memo", atom("ok")), atom("ok")),
+            relation("=..", 2)(
+                term("memo", atom("ok")),
+                term(".", atom("memo"), term(".", atom("ok"), atom("[]"))),
+            ),
+            relation("==", 2)(atom("a"), atom("a")),
+            relation("compare", 3)(atom("<"), atom("a"), atom("b")),
+            relation("@<", 2)(atom("a"), atom("b")),
+            relation("@=<", 2)(atom("a"), atom("b")),
+            relation("@>", 2)(atom("b"), atom("a")),
+            relation("@>=", 2)(atom("b"), atom("a")),
+            relation("asserta", 1)(term("memo", atom("ok"))),
+            relation("assertz", 1)(term("memo", atom("ok"))),
+            relation("retract", 1)(term("memo", atom("ok"))),
+            relation("retractall", 1)(term("memo", atom("ok"))),
+            relation("clause", 2)(term("memo", atom("ok")), atom("true")),
+            relation("dynamic", 1)(term("/", atom("memo"), 1)),
+            relation("abolish", 1)(term("/", atom("memo"), 1)),
+            relation("current_predicate", 1)(term("/", atom("memo"), 1)),
+            relation("predicate_property", 2)(
+                term("/", atom("memo"), 1),
+                atom("dynamic"),
+            ),
+            relation("predicate_property", 2)(atom("memo"), atom("defined")),
+            relation("predicate_property", 2)(
+                term("memo", atom("ok")),
+                atom("defined"),
+            ),
+        ],
+    )
+    def test_adapt_prolog_goal_rewrites_supported_relation_calls(
+        self,
+        goal: RelationCall,
+    ) -> None:
+        adapted = adapt_prolog_goal(goal)
+
+        assert adapted is not goal
+
+    def test_adapt_prolog_goal_rewrites_indicator_lists(self) -> None:
+        goal = relation("dynamic", 1)(
+            term(
+                ".",
+                term("/", atom("memo"), 1),
+                term(".", term("/", atom("cache"), 2), atom("[]")),
+            ),
+        )
+
+        adapted = adapt_prolog_goal(goal)
+
+        assert isinstance(adapted, ConjExpr)
+        assert len(adapted.goals) == 2
+
+    def test_adapt_prolog_goal_recurses_through_composite_expressions(self) -> None:
+        composite = conj(
+            relation("call", 1)(term("memo", atom("ok"))),
+            disj(
+                relation("dynamic", 1)(term("/", atom("memo"), 1)),
+                relation("unknown", 1)(atom("value")),
+            ),
+            fresh(
+                1,
+                lambda pred: relation("predicate_property", 2)(
+                    pred,
+                    atom("defined"),
+                ),
+            ),
+        )
+
+        adapted = adapt_prolog_goal(composite)
+
+        assert isinstance(adapted, ConjExpr)
+        assert isinstance(adapted.goals[1], DisjExpr)
+        assert isinstance(adapted.goals[2], FreshExpr)
+
+    def test_adapt_prolog_goal_preserves_unsupported_shapes(self) -> None:
+        variable_indicator = LogicVar(id=1)
+        bad_dynamic = relation("dynamic", 1)(variable_indicator)
+        bad_abolish = relation("abolish", 1)(atom("memo"))
+        bad_current = relation("current_predicate", 1)(atom("memo"))
+        unknown = relation("unknown_builtin", 1)(atom("memo"))
+
+        assert adapt_prolog_goal(bad_dynamic) is bad_dynamic
+        assert adapt_prolog_goal(bad_abolish) is bad_abolish
+        assert adapt_prolog_goal(bad_current) is bad_current
+        assert adapt_prolog_goal(unknown) is unknown
+
+    def test_adapt_prolog_goal_exposes_variable_indicator_forms(self) -> None:
+        predicate_indicator = LogicVar(id=2)
+        current_goal = relation("current_predicate", 1)(predicate_indicator)
+        property_goal = relation("predicate_property", 2)(
+            predicate_indicator,
+            atom("defined"),
+        )
+
+        assert isinstance(adapt_prolog_goal(current_goal), FreshExpr)
+        assert isinstance(adapt_prolog_goal(property_goal), FreshExpr)

--- a/code/specs/PR10-prolog-builtin-goal-adapter.md
+++ b/code/specs/PR10-prolog-builtin-goal-adapter.md
@@ -1,0 +1,47 @@
+# PR10: Prolog Builtin Goal Adapter
+
+## Summary
+
+Add a shared builtin-goal adapter to `prolog-loader` so parsed Prolog goals can
+run against the existing Python runtime without per-call-site glue code.
+
+## Goals
+
+- keep parsing and loading side-effect free
+- preserve the existing explicit `run_initialization_goals(...)` hook
+- add a shared `adapt_prolog_goal(...)` entry point for parsed Prolog goals
+- add a convenience initialization runner that uses the shared adapter by
+  default
+- map common Prolog builtin names onto `logic-builtins` runtime goals
+
+## Scope
+
+This batch covers:
+
+- term-inspection builtins like `var/1`, `nonvar/1`, `ground/1`, `atom/1`,
+  `atomic/1`, `number/1`, `string/1`, `compound/1`, and `callable/1`
+- meta/runtime builtins like `call/1`, `once/1`, `not/1`, and `\\+/1`
+- term-structure builtins like `functor/3`, `arg/3`, `=../2`, `==/2`,
+  `compare/3`, and the standard term-order predicates
+- dynamic database builtins like `dynamic/1`, `asserta/1`, `assertz/1`,
+  `retract/1`, `retractall/1`, and `abolish/1`
+- predicate-inspection builtins like `current_predicate/1`,
+  `predicate_property/2`, and `clause/2`
+
+## Design
+
+- `prolog-loader.adapters` owns the shared Prolog-to-runtime builtin lowering
+- unmapped goals remain unchanged so ordinary user predicates still execute
+  through the loaded `Program`
+- declaration-style builtins that consume predicate indicators should support
+  both `name/arity` and proper lists of indicators where that form is valid
+- `run_prolog_initialization_goals(...)` should simply delegate to
+  `run_initialization_goals(...)` with `adapt_prolog_goal(...)`
+
+## Validation
+
+- loader package lint passes
+- loader tests cover direct initialization execution with real Prolog builtin
+  names instead of handwritten adapter shims
+- end-to-end tests prove dynamic declaration, assertion, meta-call, and
+  predicate-property checks work through the loader boundary


### PR DESCRIPTION
## Summary
- add a shared `adapt_prolog_goal(...)` layer in `prolog-loader` for parsed Prolog builtin calls
- add `run_prolog_initialization_goals(...)` plus real `logic-builtins` dependency wiring
- expand loader tests to cover end-to-end builtin initialization execution and direct adapter behavior

## Testing
- `python3.12 -m ruff check code/packages/python/prolog-loader`
- `PYTHONPATH="/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/symbol-core/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/logic-core/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/logic-engine/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/lexer/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/parser/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/grammar-tools/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/graph/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/directed-graph/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/state-machine/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/prolog-core/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/prolog-lexer/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/iso-prolog-lexer/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/swi-prolog-lexer/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/prolog-parser/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/prolog-operator-parser/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/iso-prolog-parser/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/swi-prolog-parser/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/logic-builtins/src:/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-builtin-adapter/code/packages/python/prolog-loader/src" python3.12 -m pytest code/packages/python/prolog-loader/tests -v`
- `git diff --check`