### PR TITLE
feat(algol): add scalar builtin output

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -179,6 +179,7 @@ class AlgolIrCompiler:
         self.if_count = 0
         self.loop_count = 0
         self.switch_count = 0
+        self.output_count = 0
         self.current_frame_reg = -1
         self.stack_base_reg = -1
         self.stack_pointer_reg = -1
@@ -231,6 +232,7 @@ class AlgolIrCompiler:
         self.if_count = 0
         self.loop_count = 0
         self.switch_count = 0
+        self.output_count = 0
         self.heap_base_reg = -1
         self.heap_pointer_reg = -1
         self.heap_limit_reg = -1
@@ -1407,7 +1409,7 @@ class AlgolIrCompiler:
         role = "statement" if node.rule_name == "proc_stmt" else "expression"
         call = self._require_procedure_call(name, role)
         if call.label in {_BUILTIN_PRINT_LABEL, _BUILTIN_OUTPUT_LABEL}:
-            return self._compile_builtin_output(node)
+            return self._compile_builtin_output(node, scope)
         procedure = self.procedures[call.procedure_id]
         static_link = self._emit_static_link_for_call(call, scope)
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
@@ -1511,34 +1513,226 @@ class AlgolIrCompiler:
         )
         return result
 
-    def _compile_builtin_output(self, node: ASTNode) -> int:
+    def _compile_builtin_output(self, node: ASTNode, scope: _FrameScope) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
         if len(actuals) != 1:
             raise CompileError("builtin output expects exactly 1 argument")
-        literal = next(
-            (token for token in _tokens(actuals[0]) if token.type_name == "STRING_LIT"),
-            None,
-        )
-        if literal is None:
-            raise CompileError("builtin output currently requires a string literal")
-
+        actual = actuals[0]
+        actual_type = self._expr_type(actual)
         saved_arg_reg: int | None = None
         if self.next_reg > _VALUE_PARAM_BASE_REG:
             saved_arg_reg = self._fresh_reg()
             self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
-
-        for char in literal.value[1:-1]:
-            value_reg = self._const_reg(ord(char))
-            self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=value_reg)
-            self._emit(
-                IrOp.SYSCALL,
-                IrImmediate(_WRITE_SYSCALL),
-                IrRegister(_VALUE_PARAM_BASE_REG),
+        if actual_type == _STRING_TYPE:
+            literal = next(
+                (token for token in _tokens(actual) if token.type_name == "STRING_LIT"),
+                None,
+            )
+            if literal is None:
+                raise CompileError(
+                    "builtin output currently requires a string literal"
+                )
+            self._emit_output_chars(literal.value[1:-1])
+        elif actual_type == _BOOLEAN_TYPE:
+            self._emit_output_boolean(self._compile_expr(actual, scope))
+        elif actual_type == _INTEGER_TYPE:
+            self._emit_output_integer(self._compile_expr(actual, scope))
+        else:
+            raise CompileError(
+                "builtin output currently supports integer, boolean, and string"
             )
 
         if saved_arg_reg is not None:
             self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
         return _ZERO_REG
+
+    def _emit_output_chars(self, text: str) -> None:
+        for char in text:
+            self._emit_output_reg(self._const_reg(ord(char)))
+
+    def _emit_output_reg(self, value_reg: int) -> None:
+        self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=value_reg)
+        self._emit(
+            IrOp.SYSCALL,
+            IrImmediate(_WRITE_SYSCALL),
+            IrRegister(_VALUE_PARAM_BASE_REG),
+        )
+
+    def _emit_output_boolean(self, value_reg: int) -> None:
+        index = self.output_count
+        self.output_count += 1
+        false_label = f"algol_label_output_bool_{index}_false"
+        end_label = f"algol_label_output_bool_{index}_end"
+        self._emit(IrOp.BRANCH_Z, IrRegister(value_reg), IrLabel(false_label))
+        self._emit_output_chars("true")
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(false_label)
+        self._emit_output_chars("false")
+        self._label(end_label)
+
+    def _emit_output_integer(self, value_reg: int) -> None:
+        index = self.output_count
+        self.output_count += 1
+        extract_loop_label = f"algol_label_output_int_{index}_extract_loop"
+        emit_label = f"algol_label_output_int_{index}_emit"
+        emit_loop_label = f"algol_label_output_int_{index}_emit_loop"
+        end_label = f"algol_label_output_int_{index}_end"
+        negative_label = f"algol_label_output_int_{index}_negative"
+        zero_label = f"algol_label_output_int_{index}_zero"
+
+        work_reg = self._fresh_reg()
+        digit_count_reg = self._fresh_reg()
+        buffer_base_reg = self._snapshot_heap_pointer()
+        ten_reg = self._const_reg(10)
+        ascii_zero_reg = self._const_reg(ord("0"))
+        self._copy_reg(dst=work_reg, src=value_reg)
+        self._emit(IrOp.LOAD_IMM, IrRegister(digit_count_reg), IrImmediate(0))
+
+        is_negative_reg = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(is_negative_reg),
+            IrRegister(work_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(is_negative_reg), IrLabel(zero_label))
+        self._label(negative_label)
+        self._emit_output_chars("-")
+        self._label(zero_label)
+        is_zero_reg = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(is_zero_reg),
+            IrRegister(work_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(is_zero_reg), IrLabel(extract_loop_label))
+        self._emit_output_chars("0")
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+
+        self._label(extract_loop_label)
+        self._emit_extract_integer_digit(
+            work_reg,
+            digit_count_reg,
+            buffer_base_reg,
+            ten_reg,
+            ascii_zero_reg,
+            negative_reg=is_negative_reg,
+        )
+        continue_reg = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_NE,
+            IrRegister(continue_reg),
+            IrRegister(work_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(continue_reg),
+            IrLabel(extract_loop_label),
+        )
+
+        self._label(emit_label)
+        emit_index_reg = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(emit_index_reg),
+            IrRegister(digit_count_reg),
+            IrImmediate(-1),
+        )
+        self._label(emit_loop_label)
+        done_reg = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(done_reg),
+            IrRegister(emit_index_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(done_reg), IrLabel(end_label))
+        char_reg = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_BYTE,
+            IrRegister(char_reg),
+            IrRegister(buffer_base_reg),
+            IrRegister(emit_index_reg),
+        )
+        self._emit_output_reg(char_reg)
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(emit_index_reg),
+            IrRegister(emit_index_reg),
+            IrImmediate(-1),
+        )
+        self._emit(IrOp.JUMP, IrLabel(emit_loop_label))
+        self._label(end_label)
+
+    def _emit_extract_integer_digit(
+        self,
+        work_reg: int,
+        digit_count_reg: int,
+        buffer_base_reg: int,
+        ten_reg: int,
+        ascii_zero_reg: int,
+        *,
+        negative_reg: int,
+    ) -> None:
+        quotient_reg = self._fresh_reg()
+        product_reg = self._fresh_reg()
+        digit_reg = self._fresh_reg()
+        ascii_reg = self._fresh_reg()
+        self._emit(
+            IrOp.DIV,
+            IrRegister(quotient_reg),
+            IrRegister(work_reg),
+            IrRegister(ten_reg),
+        )
+        self._emit(
+            IrOp.MUL,
+            IrRegister(product_reg),
+            IrRegister(quotient_reg),
+            IrRegister(ten_reg),
+        )
+        self._emit(
+            IrOp.SUB,
+            IrRegister(digit_reg),
+            IrRegister(work_reg),
+            IrRegister(product_reg),
+        )
+        invert_label = f"algol_label_output_digit_{self.output_count}_invert"
+        continue_label = f"algol_label_output_digit_{self.output_count}_continue"
+        self.output_count += 1
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(negative_reg),
+            IrLabel(continue_label),
+        )
+        self._label(invert_label)
+        self._emit(
+            IrOp.SUB,
+            IrRegister(digit_reg),
+            IrRegister(_ZERO_REG),
+            IrRegister(digit_reg),
+        )
+        self._label(continue_label)
+        self._emit(
+            IrOp.ADD,
+            IrRegister(ascii_reg),
+            IrRegister(digit_reg),
+            IrRegister(ascii_zero_reg),
+        )
+        self._emit(
+            IrOp.STORE_BYTE,
+            IrRegister(ascii_reg),
+            IrRegister(buffer_base_reg),
+            IrRegister(digit_count_reg),
+        )
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(digit_count_reg),
+            IrRegister(digit_count_reg),
+            IrImmediate(1),
+        )
+        self._copy_reg(dst=work_reg, src=quotient_reg)
 
     def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
         variable = _single_variable_expr(argument)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -755,3 +755,31 @@ class TestAlgolIrCompiler:
         assert syscall_count == 2
         assert 72 in immediates
         assert 105 in immediates
+
+    def test_compiles_builtin_print_integer_to_digit_buffer_ops(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; print(42); result := 1 end")
+        )
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert IrOp.STORE_BYTE in opcodes
+        assert IrOp.LOAD_BYTE in opcodes
+        assert IrOp.SYSCALL in opcodes
+
+    def test_compiles_builtin_print_boolean_to_branching_output(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; print(true); result := 1 end")
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        syscalls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.SYSCALL
+        ]
+
+        assert any(label.startswith("algol_label_output_bool_") for label in labels)
+        assert len(syscalls) >= 4

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1485,6 +1485,18 @@ class AlgolTypeChecker:
             )
         for argument, parameter in zip(arguments, descriptor.parameters, strict=False):
             actual_type = self._infer_expr(argument, scope)
+            if descriptor.procedure_id == -1:
+                if actual_type != ERROR and actual_type not in {
+                    INTEGER,
+                    BOOLEAN,
+                    STRING,
+                }:
+                    self._error(
+                        argument,
+                        f"builtin procedure {name_token.value!r} expects integer, "
+                        f"boolean, or string, got {actual_type}",
+                    )
+                continue
             if actual_type != ERROR and not self._parameter_accepts_type(
                 parameter.mode,
                 parameter.type_name,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -897,15 +897,11 @@ class TestAlgolTypeChecker:
         assert result.semantic is not None
         assert result.semantic.procedure_calls[-1].label == "__algol_builtin_print"
 
-    def test_rejects_builtin_print_with_non_string_argument(self) -> None:
+    def test_accepts_builtin_print_with_integer_argument(self) -> None:
         ast = parse_algol("begin integer result; print(1); result := 0 end")
         result = check_algol(ast)
 
-        assert not result.ok
-        assert (
-            "parameter 'value' expects string, got integer"
-            in result.diagnostics[0].message
-        )
+        assert result.ok
 
     def test_rejects_builtin_print_in_expression(self) -> None:
         ast = parse_algol("begin integer result; result := print('Hi') end")
@@ -913,3 +909,27 @@ class TestAlgolTypeChecker:
 
         assert not result.ok
         assert "does not return a value" in result.diagnostics[0].message
+
+    def test_accepts_builtin_print_with_integer_expression_argument(self) -> None:
+        ast = parse_algol("begin integer result; print(1 + 2); result := 1 end")
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_accepts_builtin_print_with_boolean_argument(self) -> None:
+        ast = parse_algol(
+            "begin integer result; print(1 < 2); result := 1 end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_rejects_builtin_print_with_real_argument(self) -> None:
+        ast = parse_algol("begin integer result; print(1.5); result := 0 end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "builtin procedure 'print' expects integer, boolean, or string, got real"
+            in result.diagnostics[0].message
+        )

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -74,6 +74,26 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [7]
         assert "".join(captured) == "Hi"
 
+    def test_builtin_print_integer_and_boolean_write_stdout(self) -> None:
+        result = compile_source(
+            "begin integer result; print(42); output(true); result := 7 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "42true"
+
+    def test_builtin_print_negative_integer_writes_stdout(self) -> None:
+        result = compile_source(
+            "begin integer result; print(-12); result := 3 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [3]
+        assert "".join(captured) == "-12"
+
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- broaden ALGOL builtin `print(...)` / `output(...)` to accept integers and booleans in addition to string literals
- lower integer formatting in the IR compiler using byte-buffer digit extraction and boolean output with literal branches
- add focused checker, IR, and WASM coverage for integer, boolean, and negative integer output

## Testing
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
- python3.12 -m pytest /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
- python3.12 -m ruff check /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py /Users/adhithya/Downloads/coding-adventures-origin-main/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py