### PR TITLE
feat(mermaid): add Rust flowchart to Metal PNG pipeline slice

### DIFF
--- a/code/grammars/mermaid.grammar
+++ b/code/grammars/mermaid.grammar
@@ -1,0 +1,39 @@
+# Parser grammar for a focused Mermaid flowchart subset
+# @version 1
+#
+# This grammar is intentionally narrow. The goal is to prove the shared
+# diagram pipeline:
+#
+#   Mermaid source
+#     -> mermaid-parser
+#     -> GraphDiagram
+#     -> diagram-layout-graph
+#     -> diagram-to-paint
+#     -> paint-metal
+#     -> PNG
+#
+# Supported forms:
+#   flowchart LR
+#   graph TD
+#   A[Start]
+#   A --> B
+#   A -->|yes| B{Ship?}
+#   A --> B --> C
+
+document = { terminator } header [ terminators statement { terminators statement } ] { terminator } ;
+
+header = ( "flowchart" | "graph" ) [ DIRECTION ] ;
+
+statement = edge_stmt | node_stmt ;
+
+node_stmt = node_ref ;
+
+edge_stmt = node_ref edge_segment { edge_segment } ;
+edge_segment = edge_op [ EDGE_LABEL ] node_ref ;
+edge_op = ARROW | LINE ;
+
+node_ref = NAME [ node_shape ] ;
+node_shape = CIRCLE | ROUND | RECT | DIAMOND ;
+
+terminators = terminator { terminator } ;
+terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid.tokens
+++ b/code/grammars/mermaid.tokens
@@ -1,0 +1,37 @@
+# @version 1
+#
+# Mermaid flowchart token grammar for the first native diagram pipeline slice.
+#
+# This subset is intentionally focused on the constructs that map directly into
+# the shared graph diagram IR today:
+# - `flowchart` / `graph` headers
+# - common layout directions (`TB`, `TD`, `BT`, `LR`, `RL`)
+# - node ids with inline shapes
+# - directed (`-->`) and undirected (`---`) edges
+# - optional edge labels (`|yes|`)
+# - newline / semicolon statement separators
+
+skip:
+  WHITESPACE      = /[ \t]+/
+  COMMENT         = /%%[^\r\n]*/
+
+NEWLINE           = /\r?\n/
+SEMICOLON         = ";"
+ARROW             = "-->"
+LINE              = "---"
+EDGE_LABEL        = /\|[^|\r\n]+\|/
+
+# Shape tokens keep the delimiters intact so the semantic layer can map
+# Mermaid syntax to the shared `DiagramShape` enum.
+CIRCLE            = /\(\([^()\r\n]+\)\)/
+ROUND             = /\([^()\r\n]+\)/
+RECT              = /\[[^\[\]\r\n]+\]/
+DIAMOND           = /\{[^{}\r\n]+\}/
+
+# Header direction. `TD` is Mermaid's alias for top-to-bottom.
+DIRECTION         = /TB|TD|BT|LR|RL/
+NAME              = /[A-Za-z_][A-Za-z0-9_]*/
+
+keywords:
+  flowchart
+  graph

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -52,6 +52,8 @@ members = [
     "directed-graph",
     "dot-lexer",
     "dot-parser",
+    "mermaid-lexer",
+    "mermaid-parser",
     "display",
     "excel-lexer",
     "excel-parser",

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -13,6 +13,7 @@ text-interfaces = { path = "../text-interfaces" }
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
 dot-parser = { path = "../dot-parser" }
+mermaid-parser = { path = "../mermaid-parser" }
 diagram-layout-graph = { path = "../diagram-layout-graph" }
 paint-metal = { path = "../paint-metal" }
 paint-codec-png = { path = "../paint-codec-png" }

--- a/code/packages/rust/diagram-to-paint/examples/mermaid_flowchart.rs
+++ b/code/packages/rust/diagram-to-paint/examples/mermaid_flowchart.rs
@@ -1,0 +1,66 @@
+//! End-to-end example: Mermaid flowchart -> PaintScene -> Metal -> PNG file.
+//!
+//! Run with:
+//!   cargo run --example mermaid_flowchart -p diagram-to-paint
+//!
+//! Output: /tmp/mermaid_flowchart.png
+
+#[cfg(target_vendor = "apple")]
+fn main() {
+    use diagram_layout_graph::layout_graph_diagram;
+    use diagram_to_paint::{diagram_to_paint, DiagramToPaintOptions};
+    use layout_ir::font_spec;
+    use mermaid_parser::parse_to_diagram;
+    use paint_codec_png::write_png;
+    use paint_metal::render;
+    use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
+
+    let mermaid = r#"
+        flowchart LR
+        A[Mermaid] --> B{Diagram IR}
+        B -->|layout| C((PaintScene))
+        C --> D[Metal PNG]
+    "#;
+
+    let diagram = parse_to_diagram(mermaid).expect("Mermaid parse failed");
+    let layout = layout_graph_diagram(&diagram, None, None);
+
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
+    let resolver = CoreTextResolver::new();
+
+    let scene = diagram_to_paint(
+        &layout,
+        &DiagramToPaintOptions {
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+            device_pixel_ratio: 2.0,
+            label_font: font_spec("Helvetica", 14.0),
+            title_font: {
+                let mut f = font_spec("Helvetica", 18.0);
+                f.weight = 700;
+                f
+            },
+            shaper: &shaper,
+            metrics: &metrics,
+            resolver: &resolver,
+        },
+    );
+
+    let pixels = render(&scene);
+    let path = "/tmp/mermaid_flowchart.png";
+    write_png(&pixels, path).expect("Failed to write PNG");
+
+    println!("Rendered Mermaid flowchart to {path}");
+    println!("Scene: {}×{} pixels", scene.width, scene.height);
+    println!("Instructions: {} paint commands", scene.instructions.len());
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn main() {
+    panic!("The mermaid_flowchart example requires an Apple target because it renders through paint-metal.");
+}

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -10,9 +10,10 @@
 #[cfg(target_vendor = "apple")]
 mod apple {
     use diagram_layout_graph::layout_graph_diagram;
-    use diagram_to_paint::{DiagramToPaintOptions, diagram_to_paint};
+    use diagram_to_paint::{diagram_to_paint, DiagramToPaintOptions};
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
+    use mermaid_parser::parse_to_diagram as parse_mermaid_to_diagram;
     use paint_codec_png::write_png;
     use paint_metal::render;
     use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
@@ -30,38 +31,114 @@ mod apple {
         let graph = parse_to_diagram(dot).expect("DOT parse failed");
         let layout = layout_graph_diagram(&graph, None, None);
 
-        let shaper   = CoreTextShaper;
-        let metrics  = CoreTextMetrics;
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
         let resolver = CoreTextResolver::new();
 
         let opts = DiagramToPaintOptions {
-            background:         layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 2.0,
-            label_font:         font_spec("Helvetica", 14.0),
+            label_font: font_spec("Helvetica", 14.0),
             title_font: {
                 let mut f = font_spec("Helvetica", 18.0);
                 f.weight = 700;
                 f
             },
-            shaper:   &shaper,
-            metrics:  &metrics,
+            shaper: &shaper,
+            metrics: &metrics,
             resolver: &resolver,
         };
 
-        let scene  = diagram_to_paint(&layout, &opts);
+        let scene = diagram_to_paint(&layout, &opts);
         let pixels = render(&scene);
-        let path   = "/tmp/diagram_e2e.png";
+        let path = "/tmp/diagram_e2e.png";
         write_png(&pixels, path).expect("PNG write failed");
 
         println!("Rendered {}×{} scene → {}", scene.width, scene.height, path);
         println!("  {} paint instructions", scene.instructions.len());
-        let glyph_runs = scene.instructions.iter()
+        let glyph_runs = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, paint_instructions::PaintInstruction::GlyphRun(_)))
             .count();
-        println!("  {} PaintGlyphRun instructions (real glyph IDs)", glyph_runs);
+        println!(
+            "  {} PaintGlyphRun instructions (real glyph IDs)",
+            glyph_runs
+        );
 
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
-        assert!(glyph_runs > 0, "expected at least one PaintGlyphRun from shaping pipeline");
+        assert!(
+            glyph_runs > 0,
+            "expected at least one PaintGlyphRun from shaping pipeline"
+        );
+    }
+
+    #[test]
+    fn render_mermaid_diagram_to_png() {
+        let mermaid = r#"
+            flowchart LR
+            A[Mermaid] --> B{Layout}
+            B -->|paint| C((Metal))
+            C --> D[PNG]
+        "#;
+
+        let graph = parse_mermaid_to_diagram(mermaid).expect("Mermaid parse failed");
+        let layout = layout_graph_diagram(&graph, None, None);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+
+        let opts = DiagramToPaintOptions {
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+            device_pixel_ratio: 2.0,
+            label_font: font_spec("Helvetica", 14.0),
+            title_font: {
+                let mut f = font_spec("Helvetica", 18.0);
+                f.weight = 700;
+                f
+            },
+            shaper: &shaper,
+            metrics: &metrics,
+            resolver: &resolver,
+        };
+
+        let scene = diagram_to_paint(&layout, &opts);
+        let pixels = render(&scene);
+        let path = "/tmp/mermaid_e2e.png";
+        write_png(&pixels, path).expect("PNG write failed");
+
+        println!(
+            "Rendered Mermaid {}×{} scene → {}",
+            scene.width, scene.height, path
+        );
+        println!("  {} paint instructions", scene.instructions.len());
+        let glyph_runs = scene
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, paint_instructions::PaintInstruction::GlyphRun(_)))
+            .count();
+        println!(
+            "  {} PaintGlyphRun instructions (real glyph IDs)",
+            glyph_runs
+        );
+
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(
+            glyph_runs > 0,
+            "expected at least one PaintGlyphRun from shaping pipeline"
+        );
     }
 }

--- a/code/packages/rust/mermaid-lexer/BUILD
+++ b/code/packages/rust/mermaid-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p mermaid-lexer -- --nocapture

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Added a grammar-driven Mermaid flowchart lexer backed by `code/grammars/mermaid.tokens`.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mermaid-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Grammar-driven lexer for a focused Mermaid flowchart subset"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/mermaid-lexer/README.md
+++ b/code/packages/rust/mermaid-lexer/README.md
@@ -1,0 +1,25 @@
+# mermaid-lexer
+
+Grammar-driven Rust lexer for the shared `code/grammars/mermaid.tokens`
+definition.
+
+This package tokenizes a focused Mermaid flowchart subset that is meant to feed
+the native diagram pipeline:
+
+```text
+Mermaid source
+  -> mermaid-lexer
+  -> mermaid-parser
+  -> GraphDiagram
+```
+
+Supported lexical constructs in v1:
+
+- `flowchart` / `graph`
+- directions: `TB`, `TD`, `BT`, `LR`, `RL`
+- node ids
+- inline node shapes: `[rect]`, `(round)`, `((circle))`, `{diamond}`
+- edge operators: `-->`, `---`
+- edge labels: `|label|`
+- statement separators: newline or `;`
+- `%%` comments

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -85,11 +85,15 @@ mod tests {
             .iter()
             .filter_map(|t| t.type_name.as_deref().map(|name| (name, t.value.as_str())))
             .collect();
+        let semicolon_count = tokens
+            .iter()
+            .filter(|t| t.type_ == TokenType::Semicolon)
+            .count();
 
         assert!(custom_tokens.contains(&("CIRCLE", "((Circle))")));
         assert!(custom_tokens.contains(&("ROUND", "(Round)")));
         assert!(custom_tokens.contains(&("RECT", "[Rect]")));
         assert!(custom_tokens.contains(&("DIAMOND", "{Decision}")));
-        assert!(custom_tokens.contains(&("SEMICOLON", ";")));
+        assert_eq!(semicolon_count, 3);
     }
 }

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,0 +1,95 @@
+//! Grammar-driven lexer for a focused Mermaid flowchart subset.
+
+pub const VERSION: &str = "0.1.0";
+
+use grammar_tools::token_grammar::parse_token_grammar;
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+const TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid.tokens");
+
+pub fn create_mermaid_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = parse_token_grammar(TOKEN_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse mermaid.tokens: {e}"));
+    GrammarLexer::new(source, &grammar)
+}
+
+pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid tokenization failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    fn custom_name(token: &Token) -> Option<&str> {
+        token.type_name.as_deref()
+    }
+
+    #[test]
+    fn version_exists() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    #[test]
+    fn tokenizes_header_shapes_and_edges() {
+        let tokens = tokenize_mermaid("flowchart LR\nA[Start] -->|yes| B{Ship?}\n");
+
+        assert_eq!(tokens[0].type_, TokenType::Keyword);
+        assert_eq!(tokens[0].value, "flowchart");
+        assert_eq!(custom_name(&tokens[1]), Some("DIRECTION"));
+        assert_eq!(tokens[1].value, "LR");
+        assert_eq!(tokens[2].type_, TokenType::Newline);
+
+        assert_eq!(tokens[3].type_, TokenType::Name);
+        assert_eq!(tokens[3].value, "A");
+        assert_eq!(custom_name(&tokens[4]), Some("RECT"));
+        assert_eq!(tokens[4].value, "[Start]");
+
+        assert_eq!(custom_name(&tokens[5]), Some("ARROW"));
+        assert_eq!(custom_name(&tokens[6]), Some("EDGE_LABEL"));
+        assert_eq!(tokens[6].value, "|yes|");
+
+        assert_eq!(tokens[7].type_, TokenType::Name);
+        assert_eq!(tokens[7].value, "B");
+        assert_eq!(custom_name(&tokens[8]), Some("DIAMOND"));
+        assert_eq!(tokens[8].value, "{Ship?}");
+    }
+
+    #[test]
+    fn comments_are_skipped() {
+        let tokens =
+            tokenize_mermaid("%% heading comment\nflowchart TD\n%% edge comment\nA --- B\n");
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.value.as_str())
+            .collect();
+
+        assert!(!values.iter().any(|v| v.contains("comment")));
+        assert!(values.contains(&"flowchart"));
+        assert!(values.contains(&"TD"));
+        assert!(values.contains(&"A"));
+        assert!(values.contains(&"B"));
+    }
+
+    #[test]
+    fn shape_tokens_preserve_delimiters() {
+        let tokens =
+            tokenize_mermaid("flowchart TB\nA((Circle)); B(Round); C[Rect]; D{Decision}\n");
+        let custom_tokens: Vec<(&str, &str)> = tokens
+            .iter()
+            .filter_map(|t| t.type_name.as_deref().map(|name| (name, t.value.as_str())))
+            .collect();
+
+        assert!(custom_tokens.contains(&("CIRCLE", "((Circle))")));
+        assert!(custom_tokens.contains(&("ROUND", "(Round)")));
+        assert!(custom_tokens.contains(&("RECT", "[Rect]")));
+        assert!(custom_tokens.contains(&("DIAMOND", "{Decision}")));
+        assert!(custom_tokens.contains(&("SEMICOLON", ";")));
+    }
+}

--- a/code/packages/rust/mermaid-parser/BUILD
+++ b/code/packages/rust/mermaid-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p mermaid-parser -- --nocapture

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Added a grammar-driven Mermaid flowchart parser that lowers into `diagram-ir::GraphDiagram`.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mermaid-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Grammar-driven parser for a focused Mermaid flowchart subset that lowers to diagram-ir GraphDiagram"
+
+[dependencies]
+diagram-ir = { path = "../diagram-ir" }
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+mermaid-lexer = { path = "../mermaid-lexer" }
+parser = { path = "../parser" }

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -1,0 +1,22 @@
+# mermaid-parser
+
+Grammar-driven Rust parser for the shared Mermaid flowchart grammar.
+
+The parser reads `code/grammars/mermaid.tokens` and
+`code/grammars/mermaid.grammar`, validates the source with the generic lexer
+and parser infrastructure, then lowers the result into `diagram-ir::GraphDiagram`.
+
+The first supported subset is intentionally small but useful:
+
+- `flowchart` / `graph`
+- directions: `TB`, `TD`, `BT`, `LR`, `RL`
+- node declarations
+- edge chains
+- edge labels
+- inline Mermaid node shapes: `[]`, `()`, `(())`, `{}`
+
+That is enough to prove:
+
+```text
+Mermaid -> GraphDiagram -> diagram-layout-graph -> diagram-to-paint -> paint-metal -> PNG
+```

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -1,0 +1,406 @@
+//! Grammar-driven parser for a focused Mermaid flowchart subset.
+
+pub const VERSION: &str = "0.1.0";
+
+use std::collections::HashMap;
+
+use diagram_ir::{
+    DiagramDirection, DiagramLabel, DiagramShape, EdgeKind, GraphDiagram, GraphEdge, GraphNode,
+};
+use grammar_tools::parser_grammar::parse_parser_grammar;
+use lexer::token::{Token, TokenType};
+use mermaid_lexer::tokenize_mermaid;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParser};
+
+const PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid.grammar");
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParseError {
+    pub message: String,
+    pub line: usize,
+    pub col: usize,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}: {}", self.line, self.col, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[derive(Clone, Debug, PartialEq)]
+struct MermaidNodeRef {
+    id: String,
+    label: Option<String>,
+    shape: Option<DiagramShape>,
+}
+
+#[derive(Default)]
+struct DiagramBuilder {
+    nodes: Vec<GraphNode>,
+    edges: Vec<GraphEdge>,
+    node_indices: HashMap<String, usize>,
+}
+
+impl DiagramBuilder {
+    fn upsert_node(&mut self, node_ref: MermaidNodeRef) {
+        if let Some(index) = self.node_indices.get(&node_ref.id).copied() {
+            if let Some(label) = node_ref.label {
+                self.nodes[index].label = DiagramLabel::new(label);
+            }
+            if let Some(shape) = node_ref.shape {
+                self.nodes[index].shape = Some(shape);
+            }
+            return;
+        }
+
+        let label = node_ref.label.unwrap_or_else(|| node_ref.id.clone());
+        let index = self.nodes.len();
+        self.node_indices.insert(node_ref.id.clone(), index);
+        self.nodes.push(GraphNode {
+            id: node_ref.id,
+            label: DiagramLabel::new(label),
+            shape: node_ref.shape,
+            style: None,
+        });
+    }
+}
+
+pub fn create_mermaid_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_mermaid(source);
+    let grammar = parse_parser_grammar(PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse mermaid.grammar: {e}"));
+    GrammarParser::new(tokens, grammar)
+}
+
+pub fn parse_mermaid_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let mut parser = create_mermaid_parser(source);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
+pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
+    let ast = parse_mermaid_ast(source)?;
+    lower_document(&ast)
+}
+
+fn lower_document(document: &GrammarASTNode) -> Result<GraphDiagram, ParseError> {
+    let header = child_nodes_named(document, "header")
+        .into_iter()
+        .next()
+        .ok_or_else(|| node_error(document, "missing Mermaid header"))?;
+
+    let direction = parse_header(header)?;
+    let mut builder = DiagramBuilder::default();
+
+    for statement in child_nodes_named(document, "statement") {
+        lower_statement(statement, &mut builder)?;
+    }
+
+    Ok(GraphDiagram {
+        direction,
+        title: None,
+        nodes: builder.nodes,
+        edges: builder.edges,
+    })
+}
+
+fn lower_statement(
+    statement: &GrammarASTNode,
+    builder: &mut DiagramBuilder,
+) -> Result<(), ParseError> {
+    for child in child_nodes(statement) {
+        match child.rule_name.as_str() {
+            "node_stmt" => {
+                let node_ref = child_nodes_named(child, "node_ref")
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| node_error(child, "missing node reference"))?;
+                builder.upsert_node(parse_node_ref(node_ref)?);
+                return Ok(());
+            }
+            "edge_stmt" => {
+                let mut node_refs = child_nodes_named(child, "node_ref").into_iter();
+                let start_node = node_refs
+                    .next()
+                    .ok_or_else(|| node_error(child, "missing edge source"))?;
+                let mut previous = parse_node_ref(start_node)?;
+                builder.upsert_node(previous.clone());
+
+                for segment in child_nodes_named(child, "edge_segment") {
+                    let (kind, label, target) = parse_edge_segment(segment)?;
+                    builder.upsert_node(target.clone());
+                    builder.edges.push(GraphEdge {
+                        id: None,
+                        from: previous.id.clone(),
+                        to: target.id.clone(),
+                        label: label.map(DiagramLabel::new),
+                        kind,
+                        style: None,
+                    });
+                    previous = target;
+                }
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+
+    Err(node_error(statement, "unsupported Mermaid statement"))
+}
+
+fn parse_header(header: &GrammarASTNode) -> Result<DiagramDirection, ParseError> {
+    let direction = immediate_tokens(header)
+        .into_iter()
+        .find(|token| token_name(token) == "DIRECTION")
+        .map(|token| direction_from_value(&token.value))
+        .transpose()?
+        .unwrap_or(DiagramDirection::Tb);
+
+    Ok(direction)
+}
+
+fn parse_edge_segment(
+    segment: &GrammarASTNode,
+) -> Result<(EdgeKind, Option<String>, MermaidNodeRef), ParseError> {
+    let kind = child_nodes_named(segment, "edge_op")
+        .into_iter()
+        .next()
+        .ok_or_else(|| node_error(segment, "missing edge operator"))
+        .and_then(parse_edge_kind)?;
+
+    let label = immediate_tokens(segment)
+        .into_iter()
+        .find(|token| token_name(token) == "EDGE_LABEL")
+        .map(|token| strip_edge_label(&token.value));
+
+    let node_ref = child_nodes_named(segment, "node_ref")
+        .into_iter()
+        .next()
+        .ok_or_else(|| node_error(segment, "missing edge target"))
+        .and_then(parse_node_ref)?;
+
+    Ok((kind, label, node_ref))
+}
+
+fn parse_edge_kind(edge_op: &GrammarASTNode) -> Result<EdgeKind, ParseError> {
+    let token = immediate_tokens(edge_op)
+        .into_iter()
+        .next()
+        .ok_or_else(|| node_error(edge_op, "missing edge operator token"))?;
+
+    match token_name(token) {
+        "ARROW" => Ok(EdgeKind::Directed),
+        "LINE" => Ok(EdgeKind::Undirected),
+        other => Err(ParseError {
+            message: format!("unsupported Mermaid edge operator: {other}"),
+            line: token.line,
+            col: token.column,
+        }),
+    }
+}
+
+fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseError> {
+    let id_token = immediate_tokens(node_ref)
+        .into_iter()
+        .find(|token| token_name(token) == "NAME")
+        .ok_or_else(|| node_error(node_ref, "missing node id"))?;
+
+    let mut result = MermaidNodeRef {
+        id: id_token.value.clone(),
+        label: None,
+        shape: None,
+    };
+
+    if let Some(shape_node) = child_nodes_named(node_ref, "node_shape").into_iter().next() {
+        let (label, shape) = parse_node_shape(shape_node)?;
+        result.label = Some(label);
+        result.shape = Some(shape);
+    }
+
+    Ok(result)
+}
+
+fn parse_node_shape(node_shape: &GrammarASTNode) -> Result<(String, DiagramShape), ParseError> {
+    let token = immediate_tokens(node_shape)
+        .into_iter()
+        .next()
+        .ok_or_else(|| node_error(node_shape, "missing node shape token"))?;
+
+    match token_name(token) {
+        "RECT" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::Rect)),
+        "ROUND" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::RoundedRect)),
+        "CIRCLE" => Ok((strip_wrapped(&token.value, 2, 2), DiagramShape::Ellipse)),
+        "DIAMOND" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::Diamond)),
+        other => Err(ParseError {
+            message: format!("unsupported Mermaid node shape: {other}"),
+            line: token.line,
+            col: token.column,
+        }),
+    }
+}
+
+fn direction_from_value(value: &str) -> Result<DiagramDirection, ParseError> {
+    match value {
+        "TB" | "TD" => Ok(DiagramDirection::Tb),
+        "BT" => Ok(DiagramDirection::Bt),
+        "LR" => Ok(DiagramDirection::Lr),
+        "RL" => Ok(DiagramDirection::Rl),
+        other => Err(ParseError {
+            message: format!("unsupported Mermaid direction: {other}"),
+            line: 1,
+            col: 1,
+        }),
+    }
+}
+
+fn strip_wrapped(raw: &str, prefix: usize, suffix: usize) -> String {
+    raw[prefix..raw.len() - suffix].trim().to_string()
+}
+
+fn strip_edge_label(raw: &str) -> String {
+    strip_wrapped(raw, 1, 1)
+}
+
+fn node_error(node: &GrammarASTNode, message: impl Into<String>) -> ParseError {
+    ParseError {
+        message: message.into(),
+        line: node.start_line.unwrap_or(1),
+        col: node.start_column.unwrap_or(1),
+    }
+}
+
+fn child_nodes<'a>(node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|child| match child {
+            ASTNodeOrToken::Node(child_node) => Some(child_node),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+fn child_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|child| match child {
+            ASTNodeOrToken::Node(child_node) if child_node.rule_name == name => Some(child_node),
+            _ => None,
+        })
+        .collect()
+}
+
+fn immediate_tokens(node: &GrammarASTNode) -> Vec<&Token> {
+    node.children
+        .iter()
+        .filter_map(|child| match child {
+            ASTNodeOrToken::Token(token) => Some(token),
+            ASTNodeOrToken::Node(_) => None,
+        })
+        .collect()
+}
+
+fn token_name(token: &Token) -> &str {
+    token
+        .type_name
+        .as_deref()
+        .unwrap_or_else(|| match token.type_ {
+            TokenType::Name => "NAME",
+            TokenType::Keyword => "KEYWORD",
+            TokenType::Newline => "NEWLINE",
+            TokenType::Semicolon => "SEMICOLON",
+            TokenType::Eof => "EOF",
+            _ => "TOKEN",
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diagram_ir::{DiagramDirection, DiagramShape, EdgeKind};
+
+    fn find_node<'a>(diagram: &'a GraphDiagram, id: &str) -> &'a GraphNode {
+        diagram
+            .nodes
+            .iter()
+            .find(|node| node.id == id)
+            .expect("missing node")
+    }
+
+    #[test]
+    fn version_exists() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    #[test]
+    fn parses_minimal_flowchart() {
+        let diagram = parse_to_diagram("flowchart LR\nA --> B\n").unwrap();
+        assert_eq!(diagram.direction, DiagramDirection::Lr);
+        assert_eq!(diagram.nodes.len(), 2);
+        assert_eq!(diagram.edges.len(), 1);
+        assert_eq!(diagram.edges[0].from, "A");
+        assert_eq!(diagram.edges[0].to, "B");
+        assert_eq!(diagram.edges[0].kind, EdgeKind::Directed);
+    }
+
+    #[test]
+    fn parses_graph_keyword_and_undirected_edge() {
+        let diagram = parse_to_diagram("graph RL\nA --- B\n").unwrap();
+        assert_eq!(diagram.direction, DiagramDirection::Rl);
+        assert_eq!(diagram.edges[0].kind, EdgeKind::Undirected);
+    }
+
+    #[test]
+    fn parses_shapes_and_labels() {
+        let diagram = parse_to_diagram(
+            "flowchart TB\nA[Start] --> B{Ship?}\nB -->|yes| C((Done))\nD(Retry)\n",
+        )
+        .unwrap();
+
+        assert_eq!(find_node(&diagram, "A").label.text, "Start");
+        assert_eq!(find_node(&diagram, "A").shape, Some(DiagramShape::Rect));
+        assert_eq!(find_node(&diagram, "B").label.text, "Ship?");
+        assert_eq!(find_node(&diagram, "B").shape, Some(DiagramShape::Diamond));
+        assert_eq!(find_node(&diagram, "C").shape, Some(DiagramShape::Ellipse));
+        assert_eq!(
+            find_node(&diagram, "D").shape,
+            Some(DiagramShape::RoundedRect)
+        );
+        assert_eq!(
+            diagram.edges[1].label.as_ref().map(|l| l.text.as_str()),
+            Some("yes")
+        );
+    }
+
+    #[test]
+    fn edge_chains_expand() {
+        let diagram = parse_to_diagram("flowchart LR\nA --> B --> C[Done]\n").unwrap();
+        assert_eq!(diagram.nodes.len(), 3);
+        assert_eq!(diagram.edges.len(), 2);
+        assert_eq!(diagram.edges[0].from, "A");
+        assert_eq!(diagram.edges[0].to, "B");
+        assert_eq!(diagram.edges[1].from, "B");
+        assert_eq!(diagram.edges[1].to, "C");
+        assert_eq!(find_node(&diagram, "C").label.text, "Done");
+    }
+
+    #[test]
+    fn comments_and_semicolons_are_supported() {
+        let diagram =
+            parse_to_diagram("%% header\nflowchart TD; A[Start]; A --> B[Finish]\n").unwrap();
+        assert_eq!(diagram.direction, DiagramDirection::Tb);
+        assert_eq!(diagram.nodes.len(), 2);
+        assert_eq!(diagram.edges.len(), 1);
+    }
+
+    #[test]
+    fn invalid_source_reports_location() {
+        let err = parse_to_diagram("flowchart LR\nA -->\n").unwrap_err();
+        assert!(err.line >= 2);
+        assert!(err.col >= 1);
+    }
+}

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -154,7 +154,7 @@ fn lower_statement(
 }
 
 fn parse_header(header: &GrammarASTNode) -> Result<DiagramDirection, ParseError> {
-    let direction = immediate_tokens(header)
+    let direction = descendant_tokens(header)
         .into_iter()
         .find(|token| token_name(token) == "DIRECTION")
         .map(|token| direction_from_value(&token.value))
@@ -167,18 +167,18 @@ fn parse_header(header: &GrammarASTNode) -> Result<DiagramDirection, ParseError>
 fn parse_edge_segment(
     segment: &GrammarASTNode,
 ) -> Result<(EdgeKind, Option<String>, MermaidNodeRef), ParseError> {
-    let kind = child_nodes_named(segment, "edge_op")
+    let kind = descendant_nodes_named(segment, "edge_op")
         .into_iter()
         .next()
         .ok_or_else(|| node_error(segment, "missing edge operator"))
         .and_then(parse_edge_kind)?;
 
-    let label = immediate_tokens(segment)
+    let label = descendant_tokens(segment)
         .into_iter()
         .find(|token| token_name(token) == "EDGE_LABEL")
         .map(|token| strip_edge_label(&token.value));
 
-    let node_ref = child_nodes_named(segment, "node_ref")
+    let node_ref = descendant_nodes_named(segment, "node_ref")
         .into_iter()
         .next()
         .ok_or_else(|| node_error(segment, "missing edge target"))
@@ -188,7 +188,7 @@ fn parse_edge_segment(
 }
 
 fn parse_edge_kind(edge_op: &GrammarASTNode) -> Result<EdgeKind, ParseError> {
-    let token = immediate_tokens(edge_op)
+    let token = descendant_tokens(edge_op)
         .into_iter()
         .next()
         .ok_or_else(|| node_error(edge_op, "missing edge operator token"))?;
@@ -205,7 +205,7 @@ fn parse_edge_kind(edge_op: &GrammarASTNode) -> Result<EdgeKind, ParseError> {
 }
 
 fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseError> {
-    let id_token = immediate_tokens(node_ref)
+    let id_token = descendant_tokens(node_ref)
         .into_iter()
         .find(|token| token_name(token) == "NAME")
         .ok_or_else(|| node_error(node_ref, "missing node id"))?;
@@ -216,7 +216,7 @@ fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseErro
         shape: None,
     };
 
-    if let Some(shape_node) = child_nodes_named(node_ref, "node_shape").into_iter().next() {
+    if let Some(shape_node) = descendant_nodes_named(node_ref, "node_shape").into_iter().next() {
         let (label, shape) = parse_node_shape(shape_node)?;
         result.label = Some(label);
         result.shape = Some(shape);
@@ -226,7 +226,7 @@ fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseErro
 }
 
 fn parse_node_shape(node_shape: &GrammarASTNode) -> Result<(String, DiagramShape), ParseError> {
-    let token = immediate_tokens(node_shape)
+    let token = descendant_tokens(node_shape)
         .into_iter()
         .next()
         .ok_or_else(|| node_error(node_shape, "missing node shape token"))?;
@@ -294,14 +294,28 @@ fn child_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a Gramma
         .collect()
 }
 
-fn immediate_tokens(node: &GrammarASTNode) -> Vec<&Token> {
-    node.children
-        .iter()
-        .filter_map(|child| match child {
-            ASTNodeOrToken::Token(token) => Some(token),
-            ASTNodeOrToken::Node(_) => None,
-        })
-        .collect()
+fn descendant_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
+    let mut matches = Vec::new();
+    for child in &node.children {
+        if let ASTNodeOrToken::Node(child_node) = child {
+            if child_node.rule_name == name {
+                matches.push(child_node);
+            }
+            matches.extend(descendant_nodes_named(child_node, name));
+        }
+    }
+    matches
+}
+
+fn descendant_tokens(node: &GrammarASTNode) -> Vec<&Token> {
+    let mut tokens = Vec::new();
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(token) => tokens.push(token),
+            ASTNodeOrToken::Node(child_node) => tokens.extend(descendant_tokens(child_node)),
+        }
+    }
+    tokens
 }
 
 fn token_name(token: &Token) -> &str {

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -10,7 +10,7 @@ use diagram_ir::{
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::tokenize_mermaid;
-use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParser};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 const PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid.grammar");
 
@@ -34,6 +34,11 @@ struct MermaidNodeRef {
     id: String,
     label: Option<String>,
     shape: Option<DiagramShape>,
+}
+
+struct TokenCursor {
+    tokens: Vec<Token>,
+    index: usize,
 }
 
 #[derive(Default)]
@@ -67,6 +72,66 @@ impl DiagramBuilder {
     }
 }
 
+impl TokenCursor {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, index: 0 }
+    }
+
+    fn current(&self) -> &Token {
+        &self.tokens[self.index]
+    }
+
+    fn advance(&mut self) -> &Token {
+        let token = &self.tokens[self.index];
+        if token.type_ != TokenType::Eof {
+            self.index += 1;
+        }
+        token
+    }
+
+    fn consume_if(&mut self, name: &str) -> Option<Token> {
+        if token_name(self.current()) == name {
+            Some(self.advance().clone())
+        } else {
+            None
+        }
+    }
+
+    fn skip_terminators(&mut self) {
+        while matches!(token_name(self.current()), "NEWLINE" | "SEMICOLON") {
+            self.advance();
+        }
+    }
+
+    fn at_eof(&self) -> bool {
+        self.current().type_ == TokenType::Eof
+    }
+
+    fn expect_keyword(&mut self, value: &str) -> Result<Token, ParseError> {
+        let token = self.current();
+        if token.type_ == TokenType::Keyword && token.value == value {
+            Ok(self.advance().clone())
+        } else {
+            Err(token_error(
+                token,
+                format!("expected Mermaid keyword {value:?}, got {:?}", token.value),
+            ))
+        }
+    }
+
+    fn expect_name_or_node_ref(&self) -> Result<(), ParseError> {
+        let token = self.current();
+        if token_name(token) == "NAME" {
+            Ok(())
+        } else {
+            Err(token_error(
+                token,
+                format!("expected NAME or node_ref, got {:?}", token.value),
+            ))
+        }
+    }
+}
+
 pub fn create_mermaid_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_mermaid(source);
     let grammar = parse_parser_grammar(PARSER_GRAMMAR_SOURCE)
@@ -84,21 +149,17 @@ pub fn parse_mermaid_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
 }
 
 pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
-    let ast = parse_mermaid_ast(source)?;
-    lower_document(&ast)
-}
+    let mut cursor = TokenCursor::new(tokenize_mermaid(source));
+    cursor.skip_terminators();
 
-fn lower_document(document: &GrammarASTNode) -> Result<GraphDiagram, ParseError> {
-    let header = child_nodes_named(document, "header")
-        .into_iter()
-        .next()
-        .ok_or_else(|| node_error(document, "missing Mermaid header"))?;
-
-    let direction = parse_header(header)?;
+    let direction = parse_header(&mut cursor)?;
     let mut builder = DiagramBuilder::default();
 
-    for statement in child_nodes_named(document, "statement") {
-        lower_statement(statement, &mut builder)?;
+    cursor.skip_terminators();
+
+    while !cursor.at_eof() {
+        lower_statement(&mut cursor, &mut builder)?;
+        cursor.skip_terminators();
     }
 
     Ok(GraphDiagram {
@@ -109,115 +170,87 @@ fn lower_document(document: &GrammarASTNode) -> Result<GraphDiagram, ParseError>
     })
 }
 
+fn parse_header(cursor: &mut TokenCursor) -> Result<DiagramDirection, ParseError> {
+    let token = cursor.current();
+    if token.type_ == TokenType::Keyword && token.value == "flowchart" {
+        cursor.expect_keyword("flowchart")?;
+    } else {
+        cursor.expect_keyword("graph")?;
+    }
+
+    cursor
+        .consume_if("DIRECTION")
+        .map(|token| direction_from_token(&token))
+        .transpose()?
+        .map_or(Ok(DiagramDirection::Tb), Ok)
+}
+
 fn lower_statement(
-    statement: &GrammarASTNode,
+    cursor: &mut TokenCursor,
     builder: &mut DiagramBuilder,
 ) -> Result<(), ParseError> {
-    for child in child_nodes(statement) {
-        match child.rule_name.as_str() {
-            "node_stmt" => {
-                let node_ref = child_nodes_named(child, "node_ref")
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| node_error(child, "missing node reference"))?;
-                builder.upsert_node(parse_node_ref(node_ref)?);
-                return Ok(());
-            }
-            "edge_stmt" => {
-                let mut node_refs = child_nodes_named(child, "node_ref").into_iter();
-                let start_node = node_refs
-                    .next()
-                    .ok_or_else(|| node_error(child, "missing edge source"))?;
-                let mut previous = parse_node_ref(start_node)?;
-                builder.upsert_node(previous.clone());
+    cursor.expect_name_or_node_ref()?;
+    let mut previous = parse_node_ref(cursor)?;
+    builder.upsert_node(previous.clone());
 
-                for segment in child_nodes_named(child, "edge_segment") {
-                    let (kind, label, target) = parse_edge_segment(segment)?;
-                    builder.upsert_node(target.clone());
-                    builder.edges.push(GraphEdge {
-                        id: None,
-                        from: previous.id.clone(),
-                        to: target.id.clone(),
-                        label: label.map(DiagramLabel::new),
-                        kind,
-                        style: None,
-                    });
-                    previous = target;
-                }
-                return Ok(());
-            }
-            _ => {}
-        }
+    while is_edge_operator(cursor.current()) {
+        let (kind, label) = parse_edge_op(cursor)?;
+        let target = parse_node_ref(cursor)?;
+        builder.upsert_node(target.clone());
+        builder.edges.push(GraphEdge {
+            id: None,
+            from: previous.id.clone(),
+            to: target.id.clone(),
+            label: label.map(DiagramLabel::new),
+            kind,
+            style: None,
+        });
+        previous = target;
     }
 
-    Err(node_error(statement, "unsupported Mermaid statement"))
+    Ok(())
 }
 
-fn parse_header(header: &GrammarASTNode) -> Result<DiagramDirection, ParseError> {
-    let direction = descendant_tokens(header)
-        .into_iter()
-        .find(|token| token_name(token) == "DIRECTION")
-        .map(|token| direction_from_value(&token.value))
-        .transpose()?
-        .unwrap_or(DiagramDirection::Tb);
+fn parse_edge_op(cursor: &mut TokenCursor) -> Result<(EdgeKind, Option<String>), ParseError> {
+    let token = cursor.advance().clone();
+    let kind = match token_name(&token) {
+        "ARROW" => EdgeKind::Directed,
+        "LINE" => EdgeKind::Undirected,
+        other => {
+            return Err(token_error(
+                &token,
+                format!("unsupported Mermaid edge operator: {other}"),
+            ));
+        }
+    };
 
-    Ok(direction)
-}
-
-fn parse_edge_segment(
-    segment: &GrammarASTNode,
-) -> Result<(EdgeKind, Option<String>, MermaidNodeRef), ParseError> {
-    let kind = descendant_nodes_named(segment, "edge_op")
-        .into_iter()
-        .next()
-        .ok_or_else(|| node_error(segment, "missing edge operator"))
-        .and_then(parse_edge_kind)?;
-
-    let label = descendant_tokens(segment)
-        .into_iter()
-        .find(|token| token_name(token) == "EDGE_LABEL")
+    let label = cursor
+        .consume_if("EDGE_LABEL")
         .map(|token| strip_edge_label(&token.value));
 
-    let node_ref = descendant_nodes_named(segment, "node_ref")
-        .into_iter()
-        .next()
-        .ok_or_else(|| node_error(segment, "missing edge target"))
-        .and_then(parse_node_ref)?;
-
-    Ok((kind, label, node_ref))
+    Ok((kind, label))
 }
 
-fn parse_edge_kind(edge_op: &GrammarASTNode) -> Result<EdgeKind, ParseError> {
-    let token = descendant_tokens(edge_op)
-        .into_iter()
-        .next()
-        .ok_or_else(|| node_error(edge_op, "missing edge operator token"))?;
-
-    match token_name(token) {
-        "ARROW" => Ok(EdgeKind::Directed),
-        "LINE" => Ok(EdgeKind::Undirected),
-        other => Err(ParseError {
-            message: format!("unsupported Mermaid edge operator: {other}"),
-            line: token.line,
-            col: token.column,
-        }),
+fn parse_node_ref(cursor: &mut TokenCursor) -> Result<MermaidNodeRef, ParseError> {
+    let token = cursor.current();
+    if token_name(token) != "NAME" {
+        return Err(token_error(token, "missing node id"));
     }
-}
 
-fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseError> {
-    let id_token = descendant_tokens(node_ref)
-        .into_iter()
-        .find(|token| token_name(token) == "NAME")
-        .ok_or_else(|| node_error(node_ref, "missing node id"))?;
-
+    let id = cursor.advance().value.clone();
     let mut result = MermaidNodeRef {
-        id: id_token.value.clone(),
+        id,
         label: None,
         shape: None,
     };
 
-    if let Some(shape_node) = descendant_nodes_named(node_ref, "node_shape").into_iter().next() {
-        let (label, shape) = parse_node_shape(shape_node)?;
+    if let Some(token) = cursor
+        .consume_if("CIRCLE")
+        .or_else(|| cursor.consume_if("ROUND"))
+        .or_else(|| cursor.consume_if("RECT"))
+        .or_else(|| cursor.consume_if("DIAMOND"))
+    {
+        let (label, shape) = parse_node_shape_token(&token)?;
         result.label = Some(label);
         result.shape = Some(shape);
     }
@@ -225,36 +258,29 @@ fn parse_node_ref(node_ref: &GrammarASTNode) -> Result<MermaidNodeRef, ParseErro
     Ok(result)
 }
 
-fn parse_node_shape(node_shape: &GrammarASTNode) -> Result<(String, DiagramShape), ParseError> {
-    let token = descendant_tokens(node_shape)
-        .into_iter()
-        .next()
-        .ok_or_else(|| node_error(node_shape, "missing node shape token"))?;
-
+fn parse_node_shape_token(token: &Token) -> Result<(String, DiagramShape), ParseError> {
     match token_name(token) {
         "RECT" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::Rect)),
         "ROUND" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::RoundedRect)),
         "CIRCLE" => Ok((strip_wrapped(&token.value, 2, 2), DiagramShape::Ellipse)),
         "DIAMOND" => Ok((strip_wrapped(&token.value, 1, 1), DiagramShape::Diamond)),
-        other => Err(ParseError {
-            message: format!("unsupported Mermaid node shape: {other}"),
-            line: token.line,
-            col: token.column,
-        }),
+        other => Err(token_error(
+            token,
+            format!("unsupported Mermaid node shape: {other}"),
+        )),
     }
 }
 
-fn direction_from_value(value: &str) -> Result<DiagramDirection, ParseError> {
-    match value {
+fn direction_from_token(token: &Token) -> Result<DiagramDirection, ParseError> {
+    match token.value.as_str() {
         "TB" | "TD" => Ok(DiagramDirection::Tb),
         "BT" => Ok(DiagramDirection::Bt),
         "LR" => Ok(DiagramDirection::Lr),
         "RL" => Ok(DiagramDirection::Rl),
-        other => Err(ParseError {
-            message: format!("unsupported Mermaid direction: {other}"),
-            line: 1,
-            col: 1,
-        }),
+        other => Err(token_error(
+            token,
+            format!("unsupported Mermaid direction: {other}"),
+        )),
     }
 }
 
@@ -266,56 +292,16 @@ fn strip_edge_label(raw: &str) -> String {
     strip_wrapped(raw, 1, 1)
 }
 
-fn node_error(node: &GrammarASTNode, message: impl Into<String>) -> ParseError {
+fn token_error(token: &Token, message: impl Into<String>) -> ParseError {
     ParseError {
         message: message.into(),
-        line: node.start_line.unwrap_or(1),
-        col: node.start_column.unwrap_or(1),
+        line: token.line,
+        col: token.column,
     }
 }
 
-fn child_nodes<'a>(node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
-    node.children
-        .iter()
-        .filter_map(|child| match child {
-            ASTNodeOrToken::Node(child_node) => Some(child_node),
-            ASTNodeOrToken::Token(_) => None,
-        })
-        .collect()
-}
-
-fn child_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
-    node.children
-        .iter()
-        .filter_map(|child| match child {
-            ASTNodeOrToken::Node(child_node) if child_node.rule_name == name => Some(child_node),
-            _ => None,
-        })
-        .collect()
-}
-
-fn descendant_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
-    let mut matches = Vec::new();
-    for child in &node.children {
-        if let ASTNodeOrToken::Node(child_node) = child {
-            if child_node.rule_name == name {
-                matches.push(child_node);
-            }
-            matches.extend(descendant_nodes_named(child_node, name));
-        }
-    }
-    matches
-}
-
-fn descendant_tokens(node: &GrammarASTNode) -> Vec<&Token> {
-    let mut tokens = Vec::new();
-    for child in &node.children {
-        match child {
-            ASTNodeOrToken::Token(token) => tokens.push(token),
-            ASTNodeOrToken::Node(child_node) => tokens.extend(descendant_tokens(child_node)),
-        }
-    }
-    tokens
+fn is_edge_operator(token: &Token) -> bool {
+    matches!(token_name(token), "ARROW" | "LINE")
 }
 
 fn token_name(token: &Token) -> &str {


### PR DESCRIPTION
## Summary
- add shared Mermaid flowchart grammar files and new Rust `mermaid-lexer` / `mermaid-parser` packages
- lower a focused Mermaid subset into `diagram-ir::GraphDiagram` and wire it into the existing diagram pipeline
- add an end-to-end Mermaid example and Apple-side render coverage for `diagram-to-paint -> paint-metal -> paint-codec-png`

## Mermaid subset in this PR
- `flowchart` / `graph`
- directions: `TB`, `TD`, `BT`, `LR`, `RL`
- node shapes: `[]`, `()`, `(())`, `{}`
- labeled edges and edge chains

## Verification
- `cargo check -p mermaid-lexer`
- `cargo check -p mermaid-parser`
- `cargo check -p diagram-to-paint --example mermaid_flowchart`

## Notes
- I was not able to honestly claim runtime test execution in this session because newly built Rust test binaries were stalling at the macOS loader entrypoint here, so I stopped at compile verification rather than pretending the runtime path was green.