### PR TITLE
Add real builtin output for ALGOL WASM

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1537,9 +1537,12 @@ class AlgolIrCompiler:
             self._emit_output_boolean(self._compile_expr(actual, scope))
         elif actual_type == _INTEGER_TYPE:
             self._emit_output_integer(self._compile_expr(actual, scope))
+        elif actual_type == _REAL_TYPE:
+            self._emit_output_real(self._compile_expr(actual, scope))
         else:
             raise CompileError(
-                "builtin output currently supports integer, boolean, and string"
+                "builtin output currently supports integer, boolean, real, "
+                "and string"
             )
 
         if saved_arg_reg is not None:
@@ -1665,6 +1668,166 @@ class AlgolIrCompiler:
         )
         self._emit(IrOp.JUMP, IrLabel(emit_loop_label))
         self._label(end_label)
+
+    def _emit_output_real(self, value_reg: int) -> None:
+        index = self.output_count
+        self.output_count += 1
+        positive_label = f"algol_label_output_real_{index}_positive"
+        normalized_label = f"algol_label_output_real_{index}_normalized"
+        no_carry_label = f"algol_label_output_real_{index}_no_carry"
+
+        zero_f64 = self._const_f64_reg(0.0)
+        abs_reg = self._fresh_reg()
+        negative_reg = self._fresh_reg()
+        self._emit(
+            IrOp.F64_CMP_LT,
+            IrRegister(negative_reg),
+            IrRegister(value_reg),
+            IrRegister(zero_f64),
+        )
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(negative_reg),
+            IrLabel(positive_label),
+        )
+        self._emit_output_chars("-")
+        self._emit(
+            IrOp.F64_SUB,
+            IrRegister(abs_reg),
+            IrRegister(zero_f64),
+            IrRegister(value_reg),
+        )
+        self._emit(IrOp.JUMP, IrLabel(normalized_label))
+        self._label(positive_label)
+        self._copy_scalar_reg(type_name=_REAL_TYPE, dst=abs_reg, src=value_reg)
+        self._label(normalized_label)
+
+        integer_part_reg = self._fresh_reg()
+        self._emit(
+            IrOp.I32_TRUNC_FROM_F64,
+            IrRegister(integer_part_reg),
+            IrRegister(abs_reg),
+        )
+        integer_part_f64 = self._coerce_reg_to_type(
+            integer_part_reg,
+            _INTEGER_TYPE,
+            expected_type=_REAL_TYPE,
+        )
+        fractional_reg = self._fresh_reg()
+        self._emit(
+            IrOp.F64_SUB,
+            IrRegister(fractional_reg),
+            IrRegister(abs_reg),
+            IrRegister(integer_part_f64),
+        )
+        thousand_f64 = self._const_f64_reg(1000.0)
+        half_f64 = self._const_f64_reg(0.5)
+        scaled_fraction_reg = self._fresh_reg()
+        self._emit(
+            IrOp.F64_MUL,
+            IrRegister(scaled_fraction_reg),
+            IrRegister(fractional_reg),
+            IrRegister(thousand_f64),
+        )
+        rounded_fraction_reg = self._fresh_reg()
+        self._emit(
+            IrOp.F64_ADD,
+            IrRegister(rounded_fraction_reg),
+            IrRegister(scaled_fraction_reg),
+            IrRegister(half_f64),
+        )
+        fraction_digits_reg = self._fresh_reg()
+        self._emit(
+            IrOp.I32_TRUNC_FROM_F64,
+            IrRegister(fraction_digits_reg),
+            IrRegister(rounded_fraction_reg),
+        )
+        carry_check_reg = self._fresh_reg()
+        thousand_i32 = self._const_reg(1000)
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(carry_check_reg),
+            IrRegister(fraction_digits_reg),
+            IrRegister(thousand_i32),
+        )
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(carry_check_reg),
+            IrLabel(no_carry_label),
+        )
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(integer_part_reg),
+            IrRegister(integer_part_reg),
+            IrImmediate(1),
+        )
+        self._emit(
+            IrOp.LOAD_IMM,
+            IrRegister(fraction_digits_reg),
+            IrImmediate(0),
+        )
+        self._label(no_carry_label)
+
+        self._emit_output_integer(integer_part_reg)
+        self._emit_output_chars(".")
+        self._emit_output_three_digits(fraction_digits_reg)
+
+    def _emit_output_three_digits(self, value_reg: int) -> None:
+        hundred_reg = self._const_reg(100)
+        ten_reg = self._const_reg(10)
+        ascii_zero_reg = self._const_reg(ord("0"))
+
+        hundreds_reg = self._fresh_reg()
+        self._emit(
+            IrOp.DIV,
+            IrRegister(hundreds_reg),
+            IrRegister(value_reg),
+            IrRegister(hundred_reg),
+        )
+        hundreds_product_reg = self._fresh_reg()
+        self._emit(
+            IrOp.MUL,
+            IrRegister(hundreds_product_reg),
+            IrRegister(hundreds_reg),
+            IrRegister(hundred_reg),
+        )
+        remainder_reg = self._fresh_reg()
+        self._emit(
+            IrOp.SUB,
+            IrRegister(remainder_reg),
+            IrRegister(value_reg),
+            IrRegister(hundreds_product_reg),
+        )
+        tens_reg = self._fresh_reg()
+        self._emit(
+            IrOp.DIV,
+            IrRegister(tens_reg),
+            IrRegister(remainder_reg),
+            IrRegister(ten_reg),
+        )
+        tens_product_reg = self._fresh_reg()
+        self._emit(
+            IrOp.MUL,
+            IrRegister(tens_product_reg),
+            IrRegister(tens_reg),
+            IrRegister(ten_reg),
+        )
+        ones_reg = self._fresh_reg()
+        self._emit(
+            IrOp.SUB,
+            IrRegister(ones_reg),
+            IrRegister(remainder_reg),
+            IrRegister(tens_product_reg),
+        )
+        for digit_reg in (hundreds_reg, tens_reg, ones_reg):
+            ascii_reg = self._fresh_reg()
+            self._emit(
+                IrOp.ADD,
+                IrRegister(ascii_reg),
+                IrRegister(digit_reg),
+                IrRegister(ascii_zero_reg),
+            )
+            self._emit_output_reg(ascii_reg)
 
     def _emit_extract_integer_digit(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -783,3 +783,19 @@ class TestAlgolIrCompiler:
 
         assert any(label.startswith("algol_label_output_bool_") for label in labels)
         assert len(syscalls) >= 4
+
+    def test_compiles_builtin_print_real_to_fixed_point_output(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; print(3.5); result := 1 end")
+        )
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.I32_TRUNC_FROM_F64 in opcodes
+        assert IrOp.F64_MUL in opcodes
+        assert IrOp.F64_ADD in opcodes
+        assert any(label.startswith("algol_label_output_real_") for label in labels)

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1489,12 +1489,13 @@ class AlgolTypeChecker:
                 if actual_type != ERROR and actual_type not in {
                     INTEGER,
                     BOOLEAN,
+                    REAL,
                     STRING,
                 }:
                     self._error(
                         argument,
                         f"builtin procedure {name_token.value!r} expects integer, "
-                        f"boolean, or string, got {actual_type}",
+                        f"boolean, real, or string, got {actual_type}",
                     )
                 continue
             if actual_type != ERROR and not self._parameter_accepts_type(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -924,12 +924,8 @@ class TestAlgolTypeChecker:
 
         assert result.ok
 
-    def test_rejects_builtin_print_with_real_argument(self) -> None:
+    def test_accepts_builtin_print_with_real_argument(self) -> None:
         ast = parse_algol("begin integer result; print(1.5); result := 0 end")
         result = check_algol(ast)
 
-        assert not result.ok
-        assert (
-            "builtin procedure 'print' expects integer, boolean, or string, got real"
-            in result.diagnostics[0].message
-        )
+        assert result.ok

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -94,6 +94,16 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [3]
         assert "".join(captured) == "-12"
 
+    def test_builtin_print_real_writes_fixed_three_decimal_stdout(self) -> None:
+        result = compile_source(
+            "begin integer result; print(3.5); output(-0.125); result := 4 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [4]
+        assert "".join(captured) == "3.500-0.125"
+
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(
             "begin integer result; "

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -24,7 +24,8 @@ The opcodes are grouped by category:
   Arithmetic:   ADD, ADD_IMM, SUB, AND, AND_IMM, MUL, DIV
   Bitwise:      OR, OR_IMM, XOR, XOR_IMM, NOT
   Comparison:   CMP_EQ, CMP_NE, CMP_LT, CMP_GT
-  Floating:     LOAD_F64_IMM, LOAD_F64, STORE_F64, F64_ADD, ..., F64_FROM_I32
+  Floating:     LOAD_F64_IMM, LOAD_F64, STORE_F64, F64_ADD, ..., F64_FROM_I32,
+                I32_TRUNC_FROM_F64
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
@@ -189,6 +190,10 @@ class IrOp(IntEnum):
     # Convert a signed i32 value to f64.
     #   F64_FROM_I32 v1, v2  →  v1 = float(v2)
     F64_FROM_I32 = 45
+
+    # Truncate an f64 value toward zero into a signed i32.
+    #   I32_TRUNC_FROM_F64 v1, v2  →  v1 = trunc(v2)
+    I32_TRUNC_FROM_F64 = 46
 
     # ── Comparison ────────────────────────────────────────────────────────────
     # Set dst = 1 if lhs == rhs, else 0.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -96,10 +96,11 @@ class TestIrOp:
         assert IrOp.F64_CMP_LE == 43
         assert IrOp.F64_CMP_GE == 44
         assert IrOp.F64_FROM_I32 == 45
+        assert IrOp.I32_TRUNC_FROM_F64 == 46
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 46 opcodes after adding the initial f64 support set."""
-        assert len(IrOp) == 46
+        """There are exactly 47 opcodes after adding f64-to-i32 truncation."""
+        assert len(IrOp) == 47
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1004,6 +1005,7 @@ class TestAllOpcodesPrintParse:
             IrOp.F64_CMP_LE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
             IrOp.F64_CMP_GE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
             IrOp.F64_FROM_I32: [IrRegister(2), IrRegister(1)],
+            IrOp.I32_TRUNC_FROM_F64: [IrRegister(2), IrRegister(1)],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -105,6 +105,7 @@ _OPCODE = {
         "f64.mul",
         "f64.div",
         "f64.convert_i32_s",
+        "i32.trunc_f64_s",
         "drop",
     )
 }
@@ -157,6 +158,7 @@ _WASM_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     IrOp.F64_CMP_LE,
     IrOp.F64_CMP_GE,
     IrOp.F64_FROM_I32,
+    IrOp.I32_TRUNC_FROM_F64,
     IrOp.MUL,
     IrOp.DIV,
     IrOp.CMP_EQ,
@@ -830,6 +832,16 @@ class _FunctionLowerer:
                 self._emit_local_get(src.index)
                 self._emit_opcode("f64.convert_i32_s")
                 self._emit_local_set(dst.index)
+            case IrOp.I32_TRUNC_FROM_F64:
+                dst = _expect_register(
+                    instruction.operands[0], "I32_TRUNC_FROM_F64 dst"
+                )
+                src = _expect_register(
+                    instruction.operands[1], "I32_TRUNC_FROM_F64 src"
+                )
+                self._emit_local_get(src.index)
+                self._emit_opcode("i32.trunc_f64_s")
+                self._emit_local_set(dst.index)
             case IrOp.CALL:
                 label = _expect_label(instruction.operands[0], "CALL target")
                 signature = self.signatures.get(label.name)
@@ -1445,6 +1457,7 @@ def _infer_register_types(
                 | IrOp.F64_CMP_GT
                 | IrOp.F64_CMP_LE
                 | IrOp.F64_CMP_GE
+                | IrOp.I32_TRUNC_FROM_F64
             ):
                 dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")
                 _assign_register_type(

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -267,6 +267,36 @@ def test_compile_i32_to_f64_conversion_and_compare() -> None:
     assert _runtime_result(module, "gt_three_point_five", [3]) == [0]
 
 
+def test_compile_f64_to_i32_truncation() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_trunc_real")
+    program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_fn_trunc_real")], id=-1))
+    program.add_instruction(
+        IrInstruction(
+            IrOp.I32_TRUNC_FROM_F64,
+            [IrRegister(1), IrRegister(2)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_trunc_real",
+                param_count=1,
+                export_name="trunc_real",
+                param_types=(ValueType.F64,),
+                result_types=(ValueType.I32,),
+            )
+        ],
+    )
+
+    assert _runtime_result(module, "trunc_real", [3.75]) == [3]
+    assert _runtime_result(module, "trunc_real", [-2.9]) == [-2]
+
+
 def test_compile_function_call_and_run_it() -> None:
     gen = IDGenerator()
     program = IrProgram(entry_label="_start")


### PR DESCRIPTION
## Summary
- add fixed three-decimal builtin output for `real` values in the ALGOL IR/WASM pipeline
- add shared IR support for truncating `f64` to `i32` and lower it in the WASM backend
- cover the checker, IR compiler, shared WASM compiler, and end-to-end ALGOL WASM output path with focused tests

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/compiler-ir/tests/test_compiler_ir.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/compiler-ir/src/compiler_ir/opcodes.py code/packages/python/compiler-ir/tests/test_compiler_ir.py code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`