### PR TITLE
Add own scalar storage for ALGOL WASM

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -57,6 +57,7 @@ block        = "begin" { declaration SEMICOLON } [ statement { SEMICOLON stateme
 # ---------------------------------------------------------------------------
 
 declaration  = type_decl
+             | own_decl
              | array_decl
              | switch_decl
              | procedure_decl ;
@@ -66,6 +67,12 @@ declaration  = type_decl
 #   real sum, average
 #   boolean flag
 type_decl    = type ident_list ;
+
+# OWN declaration: static-lifetime scalar storage with lexical visibility.
+#   own integer counter
+#   own real total
+# Array support for own is deferred to a later phase.
+own_decl     = "own" type ident_list ;
 
 type         = "integer" | "real" | "boolean" | "string" ;
 

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -36,6 +36,7 @@ from lexer import Token
 
 _FRAME_MEMORY_LABEL = "__algol_frames"
 _HEAP_MEMORY_LABEL = "__algol_heap"
+_STATIC_MEMORY_LABEL = "__algol_static"
 _ZERO_REG = 0
 _RESULT_REG = 1
 _REAL_RESULT_REG = 31
@@ -362,6 +363,9 @@ class AlgolIrCompiler:
             )
         self.program.add_data(IrDataDecl(_FRAME_MEMORY_LABEL, _FRAME_MEMORY_BYTES, 0))
         self.program.add_data(IrDataDecl(_HEAP_MEMORY_LABEL, _HEAP_MEMORY_BYTES, 0))
+        static_bytes = self._static_storage_bytes(type_result.semantic.symbols)
+        if static_bytes > 0:
+            self.program.add_data(IrDataDecl(_STATIC_MEMORY_LABEL, static_bytes, 0))
 
         self._label("_start")
         self._emit(IrOp.LOAD_IMM, IrRegister(_ZERO_REG), IrImmediate(0))
@@ -2548,6 +2552,23 @@ class AlgolIrCompiler:
     def _emit_reference_pointer(
         self, reference: ResolvedReference, scope: _FrameScope
     ) -> int:
+        if reference.storage_class == "static":
+            pointer = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_ADDR,
+                IrRegister(pointer),
+                IrLabel(_STATIC_MEMORY_LABEL),
+            )
+            if reference.slot_offset != 0:
+                adjusted = self._fresh_reg()
+                self._emit(
+                    IrOp.ADD_IMM,
+                    IrRegister(adjusted),
+                    IrRegister(pointer),
+                    IrImmediate(reference.slot_offset),
+                )
+                return adjusted
+            return pointer
         frame_reg = self._emit_frame_for_reference(reference, scope)
         if self._is_by_name_reference(reference):
             pointer = self._fresh_reg()
@@ -2729,6 +2750,17 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         dst_reg: int,
     ) -> None:
+        if symbol.storage_class == "static":
+            if symbol.slot_offset is None:
+                raise CompileError(f"symbol {symbol.name!r} has no planned static slot")
+            base_reg = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_ADDR,
+                IrRegister(base_reg),
+                IrLabel(_STATIC_MEMORY_LABEL),
+            )
+            self._emit_load_scalar(symbol.type_name, dst_reg, base_reg, symbol.slot_offset)
+            return
         if symbol.declaring_block_id != scope.block_id:
             raise CompileError(f"symbol {symbol.name!r} does not belong to root block")
         if symbol.slot_offset is None:
@@ -3261,6 +3293,18 @@ class AlgolIrCompiler:
                 if symbol.slot_offset is not None:
                     slots.setdefault(symbol.name, symbol.slot_offset)
         return slots
+
+    def _static_storage_bytes(self, symbols: list[Symbol]) -> int:
+        total = 0
+        for symbol in symbols:
+            if symbol.storage_class != "static":
+                continue
+            if symbol.slot_offset is None or symbol.slot_size is None:
+                raise CompileError(
+                    f"static symbol {symbol.name!r} is missing storage layout"
+                )
+            total = max(total, symbol.slot_offset + symbol.slot_size)
+        return total
 
     def _fresh_reg(self) -> int:
         reg = self.next_reg

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -70,6 +70,36 @@ class TestAlgolIrCompiler:
         assert "loop_0_start" in labels
         assert "loop_0_end" in labels
 
+    def test_compiles_own_scalar_to_static_storage(self) -> None:
+        result = compile_algol(
+            parse_algol("begin own integer counter; integer result; result := counter end")
+        )
+        data_labels = [decl.label for decl in result.program.data]
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+
+        assert "__algol_static" in data_labels
+        assert "__algol_static" in load_addr_labels
+
+    def test_compiles_own_scalar_updates_across_procedure_calls(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin own integer counter; integer result; "
+                "procedure bump; begin counter := counter + 1; result := counter end; "
+                "bump; bump "
+                "end"
+            )
+        )
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+        assert load_addr_labels.count("__algol_static") >= 2
+
     def test_compiles_local_goto_to_algol_label(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -486,6 +486,12 @@ class TestDeclarations:
         type_decl_nodes = find_nodes(ast, "type_decl")
         assert len(type_decl_nodes) >= 3
 
+    def test_own_scalar_declaration(self) -> None:
+        """Own scalar declaration produces an own_decl node."""
+        ast = parse("begin own integer counter; counter := 1 end")
+        own_decl_nodes = find_nodes(ast, "own_decl")
+        assert len(own_decl_nodes) >= 1
+
 
 # ---------------------------------------------------------------------------
 # Procedure call tests

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -20,6 +20,7 @@ NAME = "name"
 ARRAY = "array"
 LABEL = "label"
 SWITCH = "switch"
+STATIC = "static"
 MAX_ARRAY_DIMENSIONS = 4
 
 
@@ -163,6 +164,7 @@ class ResolvedReference:
     use_block_id: int
     declaration_block_id: int
     lexical_depth_delta: int
+    storage_class: str
     slot_offset: int
     line: int
     column: int
@@ -376,6 +378,7 @@ class AlgolTypeChecker:
         self._next_array_id = 0
         self._next_label_id = 0
         self._next_switch_id = 0
+        self._next_static_offset = 0
 
     def check(self, ast: ASTNode) -> TypeCheckResult:
         self.diagnostics = []
@@ -397,6 +400,7 @@ class AlgolTypeChecker:
         self._next_array_id = 0
         self._next_label_id = 0
         self._next_switch_id = 0
+        self._next_static_offset = 0
         root_scope = Scope()
         block = _first_node(ast, "block")
         if block is None:
@@ -493,6 +497,9 @@ class AlgolTypeChecker:
         if inner.rule_name == "procedure_decl":
             self._check_procedure_declaration(inner, scope)
             return
+        if inner.rule_name == "own_decl":
+            self._check_scalar_declaration(inner, scope, storage_class=STATIC)
+            return
         if inner.rule_name == "array_decl":
             self._check_array_declaration(inner, scope)
             return
@@ -503,15 +510,24 @@ class AlgolTypeChecker:
             self._error(inner, f"{inner.rule_name} declarations are not supported yet")
             return
 
-        type_node = _first_node(inner, "type")
+        self._check_scalar_declaration(inner, scope, storage_class="frame")
+
+    def _check_scalar_declaration(
+        self,
+        node: ASTNode,
+        scope: Scope,
+        *,
+        storage_class: str,
+    ) -> None:
+        type_node = _first_node(node, "type")
         declared_type = _first_keyword_value(type_node) if type_node is not None else ""
         if declared_type not in {INTEGER, BOOLEAN, REAL}:
             self._error(
-                inner, f"{declared_type or 'unknown'} variables are not supported yet"
+                node, f"{declared_type or 'unknown'} variables are not supported yet"
             )
             return
 
-        ident_list = _first_node(inner, "ident_list")
+        ident_list = _first_node(node, "ident_list")
         for name_token in _tokens(ident_list):
             if name_token.type_name != "NAME":
                 continue
@@ -521,6 +537,7 @@ class AlgolTypeChecker:
                 line=name_token.line,
                 column=name_token.column,
                 symbol_id=self._next_symbol_id,
+                storage_class=storage_class,
                 declaring_block_id=scope.block_id,
             )
             if not scope.declare(symbol):
@@ -530,9 +547,17 @@ class AlgolTypeChecker:
                 )
                 continue
             self._next_symbol_id += 1
-            if scope.frame_layout is not None:
+            if storage_class == STATIC:
+                self._allocate_static_scalar(symbol)
+            elif scope.frame_layout is not None:
                 scope.frame_layout.allocate_scalar(symbol)
             self.semantic_symbols.append(symbol)
+
+    def _allocate_static_scalar(self, symbol: Symbol) -> None:
+        slot_size = FRAME_REAL_SIZE if symbol.type_name == REAL else FRAME_WORD_SIZE
+        symbol.slot_offset = self._next_static_offset
+        symbol.slot_size = slot_size
+        self._next_static_offset += slot_size
 
     def _check_array_declaration(self, node: ASTNode, scope: Scope) -> None:
         type_node = _first_direct_node(node, "type")
@@ -1646,6 +1671,7 @@ class AlgolTypeChecker:
                 use_block_id=scope.block_id,
                 declaration_block_id=declaring_scope.block_id,
                 lexical_depth_delta=lexical_depth_delta,
+                storage_class=symbol.storage_class,
                 slot_offset=symbol.slot_offset,
                 line=token.line,
                 column=token.column,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -384,6 +384,61 @@ class TestAlgolTypeChecker:
         assert inner_write.symbol_id != outer_x.symbol_id
         assert inner_write.lexical_depth_delta == 0
 
+    def test_own_scalar_uses_static_storage_outside_frame_layout(self) -> None:
+        ast = parse_algol(
+            "begin own integer counter; integer result; result := counter end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        counter = next(
+            symbol for symbol in result.semantic.symbols if symbol.name == "counter"
+        )
+        result_symbol = next(
+            symbol for symbol in result.semantic.symbols if symbol.name == "result"
+        )
+        assert counter.storage_class == "static"
+        assert counter.slot_offset == 0
+        assert result_symbol.storage_class == "frame"
+        assert result.semantic.root_block is not None
+        layout = result.semantic.root_block.frame_layout
+        assert [slot.name for slot in layout.slots] == ["result"]
+
+        counter_read = next(
+            ref
+            for ref in result.semantic.references
+            if ref.name == "counter" and ref.role == "read"
+        )
+        assert counter_read.storage_class == "static"
+        assert counter_read.slot_offset == 0
+
+    def test_own_scalar_remains_lexically_visible_inside_nested_procedure(self) -> None:
+        ast = parse_algol(
+            "begin own integer counter; integer result; "
+            "procedure bump; begin counter := counter + 1; result := counter end; "
+            "bump "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        reads = [
+            ref
+            for ref in result.semantic.references
+            if ref.name == "counter" and ref.role == "read"
+        ]
+        writes = [
+            ref
+            for ref in result.semantic.references
+            if ref.name == "counter" and ref.role == "write"
+        ]
+        assert reads
+        assert writes
+        assert all(ref.storage_class == "static" for ref in [*reads, *writes])
+        assert all(ref.lexical_depth_delta == 1 for ref in [*reads, *writes])
+
     def test_accepts_integer_value_procedure_descriptor(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -104,6 +104,19 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [4]
         assert "".join(captured) == "3.500-0.125"
 
+    def test_own_integer_persists_across_procedure_calls(self) -> None:
+        result = compile_source(
+            "begin own integer counter; integer result; "
+            "procedure bump; begin integer local; "
+            "local := 1; "
+            "counter := counter + 1; "
+            "result := local * 10 + counter "
+            "end; "
+            "bump; bump "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
+
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- add `own` scalar declarations to the ALGOL grammar and type checker
- allocate `own` scalars in static storage instead of activation frames
- lower static `own` references through the existing ALGOL IR/WASM pipeline and cover persistence across procedure calls

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -k own_scalar_declaration`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-parser/tests/test_algol_parser.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Notes
- The full `algol-parser` test suite currently has two unrelated baseline failures on `main` (`test_block_has_begin_end` and `test_multiplication_precedence`), so this PR verifies the new parser coverage with the focused `-k own_scalar_declaration` case instead of widening the change scope.