### PR TITLE
Add string variables to ALGOL WASM

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -212,6 +212,7 @@ class AlgolIrCompiler:
         self.current_function_return_type: str | None = _INTEGER_TYPE
         self.eval_thunks: list[_EvalThunk] = []
         self.has_by_name_parameters = False
+        self.string_literal_offsets: dict[str, int] = {}
 
     def compile(self, typed: TypeCheckResult | ASTNode) -> CompileResult:
         type_result = (
@@ -239,6 +240,7 @@ class AlgolIrCompiler:
         self.heap_limit_reg = -1
         self.eval_thunks = []
         self.has_by_name_parameters = False
+        self.string_literal_offsets = {}
         self.semantic_blocks = list(type_result.semantic.blocks)
         self.semantic_blocks_by_ast = {
             block.ast_node_id: block
@@ -364,6 +366,7 @@ class AlgolIrCompiler:
         self.program.add_data(IrDataDecl(_FRAME_MEMORY_LABEL, _FRAME_MEMORY_BYTES, 0))
         self.program.add_data(IrDataDecl(_HEAP_MEMORY_LABEL, _HEAP_MEMORY_BYTES, 0))
         static_bytes = self._static_storage_bytes(type_result.semantic.symbols)
+        static_bytes = self._plan_string_literals(type_result.ast, static_bytes)
         if static_bytes > 0:
             self.program.add_data(IrDataDecl(_STATIC_MEMORY_LABEL, static_bytes, 0))
 
@@ -398,6 +401,7 @@ class AlgolIrCompiler:
             IrRegister(self.heap_base_reg),
             IrLabel(_HEAP_MEMORY_LABEL),
         )
+        self._initialize_string_literals()
         self._copy_reg(dst=self.heap_pointer_reg, src=self.heap_base_reg)
         self._emit(
             IrOp.ADD_IMM,
@@ -1149,6 +1153,8 @@ class AlgolIrCompiler:
             return self._const_reg(int(token.value))
         if token.type_name == "REAL_LIT":
             return self._const_f64_reg(float(token.value))
+        if token.type_name == "STRING_LIT":
+            return self._emit_string_literal_pointer(token.value[1:-1])
         if token.value in {"true", "false"}:
             return self._const_reg(1 if token.value == "true" else 0)
         if token.type_name == "NAME":
@@ -1523,26 +1529,19 @@ class AlgolIrCompiler:
             raise CompileError("builtin output expects exactly 1 argument")
         actual = actuals[0]
         actual_type = self._expr_type(actual)
+        actual_reg = self._compile_expr(actual, scope)
         saved_arg_reg: int | None = None
         if self.next_reg > _VALUE_PARAM_BASE_REG:
             saved_arg_reg = self._fresh_reg()
             self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
         if actual_type == _STRING_TYPE:
-            literal = next(
-                (token for token in _tokens(actual) if token.type_name == "STRING_LIT"),
-                None,
-            )
-            if literal is None:
-                raise CompileError(
-                    "builtin output currently requires a string literal"
-                )
-            self._emit_output_chars(literal.value[1:-1])
+            self._emit_output_string(actual_reg)
         elif actual_type == _BOOLEAN_TYPE:
-            self._emit_output_boolean(self._compile_expr(actual, scope))
+            self._emit_output_boolean(actual_reg)
         elif actual_type == _INTEGER_TYPE:
-            self._emit_output_integer(self._compile_expr(actual, scope))
+            self._emit_output_integer(actual_reg)
         elif actual_type == _REAL_TYPE:
-            self._emit_output_real(self._compile_expr(actual, scope))
+            self._emit_output_real(actual_reg)
         else:
             raise CompileError(
                 "builtin output currently supports integer, boolean, real, "
@@ -1564,6 +1563,34 @@ class AlgolIrCompiler:
             IrImmediate(_WRITE_SYSCALL),
             IrRegister(_VALUE_PARAM_BASE_REG),
         )
+
+    def _emit_output_string(self, pointer_reg: int) -> None:
+        index = self.output_count
+        self.output_count += 1
+        loop_label = f"algol_label_output_string_{index}_loop"
+        end_label = f"algol_label_output_string_{index}_end"
+        current_reg = self._fresh_reg()
+        char_reg = self._fresh_reg()
+
+        self._copy_reg(dst=current_reg, src=pointer_reg)
+        self._emit(IrOp.BRANCH_Z, IrRegister(current_reg), IrLabel(end_label))
+        self._label(loop_label)
+        self._emit(
+            IrOp.LOAD_BYTE,
+            IrRegister(char_reg),
+            IrRegister(current_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(char_reg), IrLabel(end_label))
+        self._emit_output_reg(char_reg)
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(current_reg),
+            IrRegister(current_reg),
+            IrImmediate(1),
+        )
+        self._emit(IrOp.JUMP, IrLabel(loop_label))
+        self._label(end_label)
 
     def _emit_output_boolean(self, value_reg: int) -> None:
         index = self.output_count
@@ -2872,6 +2899,16 @@ class AlgolIrCompiler:
         value_reg = self._const_reg(value)
         self._store_word_reg(value_reg=value_reg, base_reg=base_reg, offset=offset)
 
+    def _store_byte_const(self, *, base_reg: int, offset: int, value: int) -> None:
+        value_reg = self._const_reg(value)
+        offset_reg = self._const_reg(offset)
+        self._emit(
+            IrOp.STORE_BYTE,
+            IrRegister(value_reg),
+            IrRegister(base_reg),
+            IrRegister(offset_reg),
+        )
+
     def _store_f64_reg(self, *, value_reg: int, base_reg: int, offset: int) -> None:
         self._emit_store_scalar(_REAL_TYPE, value_reg, base_reg, offset)
 
@@ -3305,6 +3342,61 @@ class AlgolIrCompiler:
                 )
             total = max(total, symbol.slot_offset + symbol.slot_size)
         return total
+
+    def _plan_string_literals(self, ast: ASTNode, start_offset: int) -> int:
+        offset = start_offset
+        for token in _tokens(ast):
+            if token.type_name != "STRING_LIT":
+                continue
+            text = token.value[1:-1]
+            if text in self.string_literal_offsets:
+                continue
+            self.string_literal_offsets[text] = offset
+            offset += len(text) + 1
+        return offset
+
+    def _initialize_string_literals(self) -> None:
+        if not self.string_literal_offsets:
+            return
+        static_base_reg = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_ADDR,
+            IrRegister(static_base_reg),
+            IrLabel(_STATIC_MEMORY_LABEL),
+        )
+        for text, offset in self.string_literal_offsets.items():
+            for index, char in enumerate(text):
+                self._store_byte_const(
+                    base_reg=static_base_reg,
+                    offset=offset + index,
+                    value=ord(char),
+                )
+            self._store_byte_const(
+                base_reg=static_base_reg,
+                offset=offset + len(text),
+                value=0,
+            )
+
+    def _emit_string_literal_pointer(self, text: str) -> int:
+        offset = self.string_literal_offsets.get(text)
+        if offset is None:
+            raise CompileError(f"string literal {text!r} was not planned")
+        pointer_reg = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_ADDR,
+            IrRegister(pointer_reg),
+            IrLabel(_STATIC_MEMORY_LABEL),
+        )
+        if offset != 0:
+            adjusted_reg = self._fresh_reg()
+            self._emit(
+                IrOp.ADD_IMM,
+                IrRegister(adjusted_reg),
+                IrRegister(pointer_reg),
+                IrImmediate(offset),
+            )
+            return adjusted_reg
+        return pointer_reg
 
     def _fresh_reg(self) -> int:
         reg = self.next_reg

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -100,6 +100,38 @@ class TestAlgolIrCompiler:
         ]
         assert load_addr_labels.count("__algol_static") >= 2
 
+    def test_compiles_string_variable_assignment_to_static_literal_pointer(self) -> None:
+        result = compile_algol(
+            parse_algol("begin string msg; integer result; msg := 'Hi'; result := 1 end")
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        data_labels = [decl.label for decl in result.program.data]
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+
+        assert "__algol_static" in data_labels
+        assert IrOp.STORE_BYTE in opcodes
+        assert "__algol_static" in load_addr_labels
+
+    def test_compiles_string_variable_output_to_byte_loop(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.LOAD_BYTE in opcodes
+        assert any(label.startswith("algol_label_output_string_") for label in labels)
+
     def test_compiles_local_goto_to_algol_label(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -770,21 +802,17 @@ class TestAlgolIrCompiler:
         result = compile_algol(
             parse_algol("begin integer result; print('Hi'); result := 1 end")
         )
-        instructions = result.program.instructions
-        syscall_count = sum(
-            1 for instruction in instructions if instruction.opcode == IrOp.SYSCALL
-        )
-        immediates = [
-            operand.value
-            for instruction in instructions
-            if instruction.opcode == IrOp.LOAD_IMM
-            for operand in instruction.operands[1:]
-            if hasattr(operand, "value")
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+        load_addr_labels = [
+            instruction.operands[1].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LOAD_ADDR and len(instruction.operands) == 2
         ]
 
-        assert syscall_count == 2
-        assert 72 in immediates
-        assert 105 in immediates
+        assert IrOp.STORE_BYTE in opcodes
+        assert IrOp.LOAD_BYTE in opcodes
+        assert IrOp.SYSCALL in opcodes
+        assert "__algol_static" in load_addr_labels
 
     def test_compiles_builtin_print_integer_to_digit_buffer_ops(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -521,7 +521,7 @@ class AlgolTypeChecker:
     ) -> None:
         type_node = _first_node(node, "type")
         declared_type = _first_keyword_value(type_node) if type_node is not None else ""
-        if declared_type not in {INTEGER, BOOLEAN, REAL}:
+        if declared_type not in {INTEGER, BOOLEAN, REAL, STRING}:
             self._error(
                 node, f"{declared_type or 'unknown'} variables are not supported yet"
             )

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -984,3 +984,16 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
 
         assert result.ok
+
+    def test_accepts_string_variable_declaration_and_assignment(self) -> None:
+        ast = parse_algol("begin string msg; msg := 'Hi' end")
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.root_scope.children[0].symbols["msg"].type_name == "string"
+
+    def test_accepts_builtin_print_with_string_variable(self) -> None:
+        ast = parse_algol("begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end")
+        result = check_algol(ast)
+
+        assert result.ok

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -104,6 +104,30 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [4]
         assert "".join(captured) == "3.500-0.125"
 
+    def test_string_variable_assignment_and_output_write_stdout(self) -> None:
+        result = compile_source(
+            "begin string msg; integer result; "
+            "msg := 'Hi'; print(msg); result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "Hi"
+
+    def test_string_variable_copy_preserves_pointer_value(self) -> None:
+        result = compile_source(
+            "begin string first, second; integer result; "
+            "first := 'OK'; second := first; output(second); result := 8 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [8]
+        assert "".join(captured) == "OK"
+
     def test_own_integer_persists_across_procedure_calls(self) -> None:
         result = compile_source(
             "begin own integer counter; integer result; "


### PR DESCRIPTION
## Summary
- allow `string` scalar declarations in the ALGOL type checker
- lower string literals into static null-terminated storage and treat string variables as word-sized pointers
- support `print(...)` / `output(...)` on string variables, including variable-to-variable copy

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`