### PR TITLE
Add Algol string procedures

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -533,6 +533,27 @@ class TestAlgolIrCompiler:
         assert IrOp.F64_DIV in opcodes
         assert IrOp.F64_CMP_GT in opcodes
 
+    def test_compiles_string_value_procedure_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin string msg; integer result; "
+                "string procedure id(x); value x; string x; "
+                "begin id := x end; "
+                "msg := id('Hi'); print(msg); result := 1 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        signature = result.procedure_signatures[calls[0].operands[0].name]
+
+        assert signature.param_count == 3
+        assert signature.param_types == ("integer", "integer", "string")
+        assert signature.return_type == "string"
+
     def test_compiles_integer_actual_promoted_for_real_value_parameter(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -612,6 +633,27 @@ class TestAlgolIrCompiler:
                 "procedure settrue(x); boolean x; begin x := true end; "
                 "flag := false; settrue(flag); "
                 "if flag then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert len(calls[0].operands) == 4
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
+        assert opcodes.count(IrOp.LOAD_WORD) >= 4
+        assert opcodes.count(IrOp.STORE_WORD) >= 8
+
+    def test_compiles_string_by_name_parameter_as_storage_pointer(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin string msg; integer result; "
+                "procedure setmsg(x); string x; begin x := 'OK' end; "
+                "msg := 'Hi'; setmsg(msg); print(msg); result := 1 "
                 "end"
             )
         )

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -706,7 +706,12 @@ class AlgolTypeChecker:
             return
 
         return_type = _procedure_return_type(node)
-        if return_type is not None and return_type not in {INTEGER, BOOLEAN, REAL}:
+        if return_type is not None and return_type not in {
+            INTEGER,
+            BOOLEAN,
+            REAL,
+            STRING,
+        }:
             self._error(
                 name_token,
                 f"{return_type} procedure results are not supported yet",
@@ -729,17 +734,27 @@ class AlgolTypeChecker:
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
             parameter_type = spec_types.get(formal.value)
-            if mode == NAME and parameter_type not in {INTEGER, BOOLEAN, REAL}:
+            if mode == NAME and parameter_type not in {
+                INTEGER,
+                BOOLEAN,
+                REAL,
+                STRING,
+            }:
                 self._error(
                     formal,
                     f"by-name parameter {formal.value!r} must have an integer, "
-                    "boolean, or real specifier",
+                    "boolean, real, or string specifier",
                 )
-            elif mode == VALUE and parameter_type not in {INTEGER, BOOLEAN, REAL}:
+            elif mode == VALUE and parameter_type not in {
+                INTEGER,
+                BOOLEAN,
+                REAL,
+                STRING,
+            }:
                 self._error(
                     formal,
                     f"value parameter {formal.value!r} must have an integer, "
-                    "boolean, or real specifier",
+                    "boolean, real, or string specifier",
                 )
 
         procedure_id = self._next_procedure_id
@@ -800,7 +815,7 @@ class AlgolTypeChecker:
                 name=formal.value,
                 type_name=(
                     parameter_type
-                    if parameter_type in {INTEGER, BOOLEAN, REAL}
+                    if parameter_type in {INTEGER, BOOLEAN, REAL, STRING}
                     else INTEGER
                 ),
                 line=formal.line,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -904,6 +904,39 @@ class TestAlgolTypeChecker:
         assert parameter.type_name == "real"
         assert parameter.may_write
 
+    def test_accepts_string_value_procedure_result(self) -> None:
+        ast = parse_algol(
+            "begin string msg; integer result; "
+            "string procedure id(x); value x; string x; "
+            "begin id := x end; "
+            "msg := id('Hi'); print(msg); result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        procedure = result.semantic.procedures[0]
+        assert procedure.return_type == "string"
+        assert procedure.parameters[0].mode == "value"
+        assert procedure.parameters[0].type_name == "string"
+
+    def test_accepts_string_by_name_parameter(self) -> None:
+        ast = parse_algol(
+            "begin string msg; integer result; "
+            "procedure setmsg(x); string x; begin x := 'OK' end; "
+            "msg := 'Hi'; setmsg(msg); print(msg); result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.mode == "name"
+        assert parameter.type_name == "string"
+        assert parameter.may_write
+
     def test_rejects_wrong_type_for_boolean_value_parameter(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -374,6 +374,20 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_string_value_procedure_returns_string_result(self) -> None:
+        result = compile_source(
+            "begin string msg; integer result; "
+            "string procedure id(x); value x; string x; "
+            "begin id := x end; "
+            "msg := id('Hi'); print(msg); result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "Hi"
+
     def test_integer_actual_promotes_for_real_value_parameter(self) -> None:
         result = compile_source(
             "begin integer result; real y; "
@@ -423,6 +437,19 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_string_by_name_parameter_assignment_writes_back(self) -> None:
+        result = compile_source(
+            "begin string msg; integer result; "
+            "procedure setmsg(x); string x; begin x := 'OK' end; "
+            "msg := 'Hi'; setmsg(msg); print(msg); result := 8 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [8]
+        assert "".join(captured) == "OK"
 
     def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- allow `string` procedure results and `string` value/by-name parameters in the Algol type checker
- add focused checker, IR, and WASM coverage for string-returning procedures and writable by-name string parameters
- verify the existing pointer-shaped IR/WASM call path handles string procedure values end to end

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`