### PR TITLE
Add Algol own arrays

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -58,6 +58,7 @@ block        = "begin" { declaration SEMICOLON } [ statement { SEMICOLON stateme
 
 declaration  = type_decl
              | own_decl
+             | own_array_decl
              | array_decl
              | switch_decl
              | procedure_decl ;
@@ -71,8 +72,12 @@ type_decl    = type ident_list ;
 # OWN declaration: static-lifetime scalar storage with lexical visibility.
 #   own integer counter
 #   own real total
-# Array support for own is deferred to a later phase.
 own_decl     = "own" type ident_list ;
+
+# OWN array declaration: static-lifetime array descriptor with lexical visibility.
+#   own integer array counts[1:3]
+#   own array values[lo:hi]
+own_array_decl = "own" [ type ] "array" array_segment { COMMA array_segment } ;
 
 type         = "integer" | "real" | "boolean" | "string" ;
 

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -570,6 +570,31 @@ class AlgolIrCompiler:
             self._allocate_array(array, scope)
 
     def _allocate_array(self, array: ArrayDescriptor, scope: _FrameScope) -> None:
+        static_base_reg: int | None = None
+        if array.storage_class == "static":
+            static_base_reg = self._fresh_reg()
+            existing_descriptor = self._fresh_reg()
+            initialized = self._fresh_reg()
+            end_label = f"algol_label_static_array_{array.array_id}_ready"
+            self._emit(
+                IrOp.LOAD_ADDR,
+                IrRegister(static_base_reg),
+                IrLabel(_STATIC_MEMORY_LABEL),
+            )
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(existing_descriptor),
+                IrRegister(static_base_reg),
+                IrRegister(self._const_reg(array.slot_offset)),
+            )
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(initialized),
+                IrRegister(existing_descriptor),
+                IrRegister(_ZERO_REG),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(initialized), IrLabel(end_label))
+
         lower_regs: list[int] = []
         upper_regs: list[int] = []
         length_regs: list[int] = []
@@ -761,6 +786,19 @@ class AlgolIrCompiler:
                 base_reg=bounds_pointer,
                 offset=offset + _ARRAY_DIM_STRIDE_OFFSET,
             )
+
+        if array.storage_class == "static":
+            if static_base_reg is None:
+                raise CompileError(
+                    f"static array {array.name!r} is missing a static base register"
+                )
+            self._store_word_reg(
+                value_reg=heap_pointer,
+                base_reg=static_base_reg,
+                offset=array.slot_offset,
+            )
+            self._label(end_label)
+            return
 
         self._store_word_reg(
             value_reg=heap_pointer,
@@ -2724,6 +2762,23 @@ class AlgolIrCompiler:
         access: ResolvedArrayAccess,
         scope: _FrameScope,
     ) -> int:
+        array = self.arrays[access.array_id]
+        if array.storage_class == "static":
+            static_base_reg = self._fresh_reg()
+            descriptor_pointer = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_ADDR,
+                IrRegister(static_base_reg),
+                IrLabel(_STATIC_MEMORY_LABEL),
+            )
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(descriptor_pointer),
+                IrRegister(static_base_reg),
+                IrRegister(self._const_reg(access.slot_offset)),
+            )
+            return descriptor_pointer
+
         frame_reg = self._emit_frame_for_array_access(access, scope)
         descriptor_pointer = self._fresh_reg()
         self._emit(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -100,6 +100,24 @@ class TestAlgolIrCompiler:
         ]
         assert load_addr_labels.count("__algol_static") >= 2
 
+    def test_compiles_own_array_descriptor_to_static_storage(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin own integer array counts[1:2]; integer result; "
+                "counts[1] := 7; result := counts[1] "
+                "end"
+            )
+        )
+        data_labels = [decl.label for decl in result.program.data]
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+
+        assert "__algol_static" in data_labels
+        assert load_addr_labels.count("__algol_static") >= 2
+
     def test_compiles_string_variable_assignment_to_static_literal_pointer(self) -> None:
         result = compile_algol(
             parse_algol("begin string msg; integer result; msg := 'Hi'; result := 1 end")

--- a/code/packages/python/algol-parser/src/algol_parser/parser.py
+++ b/code/packages/python/algol-parser/src/algol_parser/parser.py
@@ -204,6 +204,8 @@ def parse_algol(source: str, version: str = "algol60") -> ASTNode:
     Declaration node types:
 
     - ``type_decl``       — ``integer x, y, z``
+    - ``own_decl``        — ``own integer counter``
+    - ``own_array_decl``  — ``own integer array A[1:10]``
     - ``array_decl``      — ``array A[1:10]``
     - ``switch_decl``     — ``switch s := label1, label2``
     - ``procedure_decl``  — ``procedure p(x); ...``

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -492,6 +492,12 @@ class TestDeclarations:
         own_decl_nodes = find_nodes(ast, "own_decl")
         assert len(own_decl_nodes) >= 1
 
+    def test_own_array_declaration(self) -> None:
+        """Own array declaration produces an own_array_decl node."""
+        ast = parse("begin own integer array counts[1:3]; counts[1] := 1 end")
+        own_array_decl_nodes = find_nodes(ast, "own_array_decl")
+        assert len(own_array_decl_nodes) >= 1
+
 
 # ---------------------------------------------------------------------------
 # Procedure call tests

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -99,6 +99,19 @@ class FrameLayout:
         symbol.slot_size = slot.size
         return slot
 
+    def allocate_descriptor(self, symbol: Symbol) -> FrameSlot:
+        slot = FrameSlot(
+            symbol_id=symbol.symbol_id,
+            name=symbol.name,
+            type_name=symbol.type_name,
+            offset=self.header_size + sum(existing.size for existing in self.slots),
+            size=self.word_size,
+        )
+        self.slots.append(slot)
+        symbol.slot_offset = slot.offset
+        symbol.slot_size = slot.size
+        return slot
+
 
 @dataclass
 class Scope:
@@ -232,6 +245,7 @@ class ArrayDescriptor:
     array_id: int
     name: str
     element_type: str
+    storage_class: str
     declaring_block_id: int
     dimensions: tuple[ArrayDimension, ...]
     symbol_id: int
@@ -500,8 +514,11 @@ class AlgolTypeChecker:
         if inner.rule_name == "own_decl":
             self._check_scalar_declaration(inner, scope, storage_class=STATIC)
             return
+        if inner.rule_name == "own_array_decl":
+            self._check_array_declaration(inner, scope, storage_class=STATIC)
+            return
         if inner.rule_name == "array_decl":
-            self._check_array_declaration(inner, scope)
+            self._check_array_declaration(inner, scope, storage_class="frame")
             return
         if inner.rule_name == "switch_decl":
             self._check_switch_declaration(inner, scope)
@@ -559,7 +576,18 @@ class AlgolTypeChecker:
         symbol.slot_size = slot_size
         self._next_static_offset += slot_size
 
-    def _check_array_declaration(self, node: ASTNode, scope: Scope) -> None:
+    def _allocate_static_descriptor(self, symbol: Symbol) -> None:
+        symbol.slot_offset = self._next_static_offset
+        symbol.slot_size = FRAME_WORD_SIZE
+        self._next_static_offset += FRAME_WORD_SIZE
+
+    def _check_array_declaration(
+        self,
+        node: ASTNode,
+        scope: Scope,
+        *,
+        storage_class: str,
+    ) -> None:
         type_node = _first_direct_node(node, "type")
         element_type = (
             _first_keyword_value(type_node) if type_node is not None else REAL
@@ -615,6 +643,7 @@ class AlgolTypeChecker:
                     column=name_token.column,
                     symbol_id=self._next_symbol_id,
                     kind=ARRAY,
+                    storage_class=storage_class,
                     declaring_block_id=scope.block_id,
                     array_id=array_id,
                 )
@@ -625,8 +654,10 @@ class AlgolTypeChecker:
                     )
                     continue
                 self._next_symbol_id += 1
-                if scope.frame_layout is not None:
-                    scope.frame_layout.allocate_scalar(symbol)
+                if storage_class == STATIC:
+                    self._allocate_static_descriptor(symbol)
+                elif scope.frame_layout is not None:
+                    scope.frame_layout.allocate_descriptor(symbol)
                 self.semantic_symbols.append(symbol)
                 if symbol.slot_offset is None:
                     continue
@@ -635,6 +666,7 @@ class AlgolTypeChecker:
                         array_id=array_id,
                         name=name_token.value,
                         element_type=element_type,
+                        storage_class=storage_class,
                         declaring_block_id=scope.block_id,
                         dimensions=tuple(dimensions),
                         symbol_id=symbol.symbol_id,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -439,6 +439,30 @@ class TestAlgolTypeChecker:
         assert all(ref.storage_class == "static" for ref in [*reads, *writes])
         assert all(ref.lexical_depth_delta == 1 for ref in [*reads, *writes])
 
+    def test_own_array_uses_static_descriptor_storage(self) -> None:
+        ast = parse_algol(
+            "begin own integer array counts[1:2]; integer result; "
+            "counts[1] := 7; result := counts[1] "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        counts = next(
+            symbol for symbol in result.semantic.symbols if symbol.name == "counts"
+        )
+        descriptor = next(
+            array for array in result.semantic.arrays if array.name == "counts"
+        )
+        assert counts.storage_class == "static"
+        assert counts.slot_offset == 0
+        assert counts.slot_size == 4
+        assert descriptor.storage_class == "static"
+        assert result.semantic.root_block is not None
+        layout = result.semantic.root_block.frame_layout
+        assert [slot.name for slot in layout.slots] == ["result"]
+
     def test_accepts_integer_value_procedure_descriptor(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -141,6 +141,15 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
 
+    def test_own_integer_array_persists_across_procedure_calls(self) -> None:
+        result = compile_source(
+            "begin own integer array counts[1:1]; integer result; "
+            "procedure bump; begin counts[1] := counts[1] + 1; result := counts[1] end; "
+            "counts[1] := 4; bump; bump "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [6]
+
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- add `own array` declarations to the ALGOL grammar and parser surface
- lower `own` arrays through static descriptor slots with initialize-once allocation on block entry
- add parser, type-checker, IR, and WASM tests for static array descriptor storage and persistence across procedure calls

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -k own`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-parser/src/algol_parser/parser.py code/packages/python/algol-parser/tests/test_algol_parser.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`