### PR TITLE
Use string descriptors in Algol IR

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -92,6 +92,9 @@ _INTEGER_TYPE = "integer"
 _BOOLEAN_TYPE = "boolean"
 _REAL_TYPE = "real"
 _STRING_TYPE = "string"
+_STRING_DESCRIPTOR_LENGTH_OFFSET = 0
+_STRING_DESCRIPTOR_DATA_POINTER_OFFSET = 4
+_STRING_DESCRIPTOR_SIZE = 8
 _BUILTIN_PRINT_LABEL = "__algol_builtin_print"
 _BUILTIN_OUTPUT_LABEL = "__algol_builtin_output"
 _WRITE_SYSCALL = 1
@@ -1642,18 +1645,31 @@ class AlgolIrCompiler:
         loop_label = f"algol_label_output_string_{index}_loop"
         end_label = f"algol_label_output_string_{index}_end"
         current_reg = self._fresh_reg()
+        remaining_reg = self._fresh_reg()
         char_reg = self._fresh_reg()
+        next_remaining_reg = self._fresh_reg()
 
-        self._copy_reg(dst=current_reg, src=pointer_reg)
-        self._emit(IrOp.BRANCH_Z, IrRegister(current_reg), IrLabel(end_label))
+        self._emit(IrOp.BRANCH_Z, IrRegister(pointer_reg), IrLabel(end_label))
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            remaining_reg,
+            pointer_reg,
+            _STRING_DESCRIPTOR_LENGTH_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            current_reg,
+            pointer_reg,
+            _STRING_DESCRIPTOR_DATA_POINTER_OFFSET,
+        )
         self._label(loop_label)
+        self._emit(IrOp.BRANCH_Z, IrRegister(remaining_reg), IrLabel(end_label))
         self._emit(
             IrOp.LOAD_BYTE,
             IrRegister(char_reg),
             IrRegister(current_reg),
             IrRegister(_ZERO_REG),
         )
-        self._emit(IrOp.BRANCH_Z, IrRegister(char_reg), IrLabel(end_label))
         self._emit_output_reg(char_reg)
         self._emit(
             IrOp.ADD_IMM,
@@ -1661,6 +1677,13 @@ class AlgolIrCompiler:
             IrRegister(current_reg),
             IrImmediate(1),
         )
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_remaining_reg),
+            IrRegister(remaining_reg),
+            IrImmediate(-1),
+        )
+        self._copy_reg(dst=remaining_reg, src=next_remaining_reg)
         self._emit(IrOp.JUMP, IrLabel(loop_label))
         self._label(end_label)
 
@@ -3441,7 +3464,7 @@ class AlgolIrCompiler:
             if text in self.string_literal_offsets:
                 continue
             self.string_literal_offsets[text] = offset
-            offset += len(text) + 1
+            offset += _STRING_DESCRIPTOR_SIZE + len(text)
         return offset
 
     def _initialize_string_literals(self) -> None:
@@ -3454,17 +3477,29 @@ class AlgolIrCompiler:
             IrLabel(_STATIC_MEMORY_LABEL),
         )
         for text, offset in self.string_literal_offsets.items():
+            self._store_word_const(
+                static_base_reg,
+                offset + _STRING_DESCRIPTOR_LENGTH_OFFSET,
+                len(text),
+            )
+            data_pointer = self._fresh_reg()
+            self._emit(
+                IrOp.ADD_IMM,
+                IrRegister(data_pointer),
+                IrRegister(static_base_reg),
+                IrImmediate(offset + _STRING_DESCRIPTOR_SIZE),
+            )
+            self._store_word_reg(
+                value_reg=data_pointer,
+                base_reg=static_base_reg,
+                offset=offset + _STRING_DESCRIPTOR_DATA_POINTER_OFFSET,
+            )
             for index, char in enumerate(text):
                 self._store_byte_const(
                     base_reg=static_base_reg,
-                    offset=offset + index,
+                    offset=offset + _STRING_DESCRIPTOR_SIZE + index,
                     value=ord(char),
                 )
-            self._store_byte_const(
-                base_reg=static_base_reg,
-                offset=offset + len(text),
-                value=0,
-            )
 
     def _emit_string_literal_pointer(self, text: str) -> int:
         offset = self.string_literal_offsets.get(text)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -139,7 +139,7 @@ class TestAlgolIrCompiler:
         assert "loop_0_start" in labels
         assert "loop_0_end" in labels
 
-    def test_compiles_string_variable_assignment_to_static_literal_pointer(self) -> None:
+    def test_compiles_string_variable_assignment_to_static_literal_descriptor(self) -> None:
         result = compile_algol(
             parse_algol("begin string msg; integer result; msg := 'Hi'; result := 1 end")
         )
@@ -153,9 +153,10 @@ class TestAlgolIrCompiler:
 
         assert "__algol_static" in data_labels
         assert IrOp.STORE_BYTE in opcodes
+        assert IrOp.STORE_WORD in opcodes
         assert "__algol_static" in load_addr_labels
 
-    def test_compiles_string_variable_output_to_byte_loop(self) -> None:
+    def test_compiles_string_variable_output_to_descriptor_loop(self) -> None:
         result = compile_algol(
             parse_algol(
                 "begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end"
@@ -168,6 +169,7 @@ class TestAlgolIrCompiler:
             if instr.opcode == IrOp.LABEL
         ]
 
+        assert opcodes.count(IrOp.LOAD_WORD) >= 2
         assert IrOp.LOAD_BYTE in opcodes
         assert any(label.startswith("algol_label_output_string_") for label in labels)
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -128,6 +128,16 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [8]
         assert "".join(captured) == "OK"
 
+    def test_empty_string_output_writes_nothing(self) -> None:
+        result = compile_source(
+            "begin string msg; integer result; msg := ''; print(msg); result := 9 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [9]
+        assert "".join(captured) == ""
+
     def test_own_integer_persists_across_procedure_calls(self) -> None:
         result = compile_source(
             "begin own integer counter; integer result; "


### PR DESCRIPTION
## Summary
- represent ALGOL strings as `(length, data_ptr)` descriptors in static storage instead of raw NUL-terminated byte pointers
- update builtin string output to read descriptor length/data and emit exactly that many bytes
- add focused IR/WASM coverage for descriptor-backed string lowering, including empty-string output

## Testing
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`