### PR TITLE
Guard ALGOL string output

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -56,7 +56,8 @@ _RUNTIME_THUNK_HEAP_MARK_OFFSET = 20
 _RUNTIME_THUNK_FAILURE_OFFSET = 24
 _RUNTIME_THUNK_HELPER_DEPTH_OFFSET = 28
 _RUNTIME_PENDING_GOTO_LABEL_OFFSET = 32
-_RUNTIME_STATE_BYTES = 36
+_RUNTIME_OUTPUT_BYTES_OFFSET = 36
+_RUNTIME_STATE_BYTES = 40
 _STATIC_LINK_PARAM_REG = 2
 _THUNK_HEAP_MARK_PARAM_REG = 3
 _VALUE_PARAM_BASE_REG = 4
@@ -95,6 +96,8 @@ _STRING_TYPE = "string"
 _STRING_DESCRIPTOR_LENGTH_OFFSET = 0
 _STRING_DESCRIPTOR_DATA_POINTER_OFFSET = 4
 _STRING_DESCRIPTOR_SIZE = 8
+_MAX_STRING_OUTPUT_BYTES = 4096
+_MAX_TOTAL_OUTPUT_BYTES = 8192
 _BUILTIN_PRINT_LABEL = "__algol_builtin_print"
 _BUILTIN_OUTPUT_LABEL = "__algol_builtin_output"
 _WRITE_SYSCALL = 1
@@ -422,6 +425,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
         self._store_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, _ZERO_REG)
         self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)
+        self._store_runtime_state(_RUNTIME_OUTPUT_BYTES_OFFSET, _ZERO_REG)
 
         block = _first_node(type_result.ast, "block")
         if block is None:
@@ -1610,13 +1614,13 @@ class AlgolIrCompiler:
             saved_arg_reg = self._fresh_reg()
             self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
         if actual_type == _STRING_TYPE:
-            self._emit_output_string(actual_reg)
+            self._emit_output_string(actual_reg, scope)
         elif actual_type == _BOOLEAN_TYPE:
-            self._emit_output_boolean(actual_reg)
+            self._emit_output_boolean(actual_reg, scope)
         elif actual_type == _INTEGER_TYPE:
-            self._emit_output_integer(actual_reg)
+            self._emit_output_integer(actual_reg, scope)
         elif actual_type == _REAL_TYPE:
-            self._emit_output_real(actual_reg)
+            self._emit_output_real(actual_reg, scope)
         else:
             raise CompileError(
                 "builtin output currently supports integer, boolean, real, "
@@ -1627,11 +1631,29 @@ class AlgolIrCompiler:
             self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
         return _ZERO_REG
 
-    def _emit_output_chars(self, text: str) -> None:
+    def _emit_output_chars(self, text: str, scope: _FrameScope) -> None:
         for char in text:
-            self._emit_output_reg(self._const_reg(ord(char)))
+            self._emit_output_reg(self._const_reg(ord(char)), scope)
 
-    def _emit_output_reg(self, value_reg: int) -> None:
+    def _emit_output_reg(self, value_reg: int, scope: _FrameScope) -> None:
+        total_output_reg = self._fresh_reg()
+        next_total_reg = self._fresh_reg()
+        limit_exceeded_reg = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_OUTPUT_BYTES_OFFSET, total_output_reg)
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_total_reg),
+            IrRegister(total_output_reg),
+            IrImmediate(1),
+        )
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(limit_exceeded_reg),
+            IrRegister(next_total_reg),
+            IrRegister(self._const_reg(_MAX_TOTAL_OUTPUT_BYTES)),
+        )
+        self._emit_runtime_failure_guard(limit_exceeded_reg, scope)
+        self._store_runtime_state(_RUNTIME_OUTPUT_BYTES_OFFSET, next_total_reg)
         self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=value_reg)
         self._emit(
             IrOp.SYSCALL,
@@ -1639,15 +1661,19 @@ class AlgolIrCompiler:
             IrRegister(_VALUE_PARAM_BASE_REG),
         )
 
-    def _emit_output_string(self, pointer_reg: int) -> None:
+    def _emit_output_string(self, pointer_reg: int, scope: _FrameScope) -> None:
         index = self.output_count
         self.output_count += 1
         loop_label = f"algol_label_output_string_{index}_loop"
         end_label = f"algol_label_output_string_{index}_end"
+        data_guard_done_label = f"algol_label_output_string_{index}_data_guard_done"
         current_reg = self._fresh_reg()
         remaining_reg = self._fresh_reg()
         char_reg = self._fresh_reg()
         next_remaining_reg = self._fresh_reg()
+        negative_length_reg = self._fresh_reg()
+        too_large_reg = self._fresh_reg()
+        missing_data_reg = self._fresh_reg()
 
         self._emit(IrOp.BRANCH_Z, IrRegister(pointer_reg), IrLabel(end_label))
         self._emit_load_scalar(
@@ -1662,6 +1688,33 @@ class AlgolIrCompiler:
             pointer_reg,
             _STRING_DESCRIPTOR_DATA_POINTER_OFFSET,
         )
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(negative_length_reg),
+            IrRegister(remaining_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit_runtime_failure_guard(negative_length_reg, scope)
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(too_large_reg),
+            IrRegister(remaining_reg),
+            IrRegister(self._const_reg(_MAX_STRING_OUTPUT_BYTES)),
+        )
+        self._emit_runtime_failure_guard(too_large_reg, scope)
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(remaining_reg),
+            IrLabel(data_guard_done_label),
+        )
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(missing_data_reg),
+            IrRegister(current_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit_runtime_failure_guard(missing_data_reg, scope)
+        self._label(data_guard_done_label)
         self._label(loop_label)
         self._emit(IrOp.BRANCH_Z, IrRegister(remaining_reg), IrLabel(end_label))
         self._emit(
@@ -1670,7 +1723,7 @@ class AlgolIrCompiler:
             IrRegister(current_reg),
             IrRegister(_ZERO_REG),
         )
-        self._emit_output_reg(char_reg)
+        self._emit_output_reg(char_reg, scope)
         self._emit(
             IrOp.ADD_IMM,
             IrRegister(current_reg),
@@ -1687,19 +1740,19 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(loop_label))
         self._label(end_label)
 
-    def _emit_output_boolean(self, value_reg: int) -> None:
+    def _emit_output_boolean(self, value_reg: int, scope: _FrameScope) -> None:
         index = self.output_count
         self.output_count += 1
         false_label = f"algol_label_output_bool_{index}_false"
         end_label = f"algol_label_output_bool_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(value_reg), IrLabel(false_label))
-        self._emit_output_chars("true")
+        self._emit_output_chars("true", scope)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(false_label)
-        self._emit_output_chars("false")
+        self._emit_output_chars("false", scope)
         self._label(end_label)
 
-    def _emit_output_integer(self, value_reg: int) -> None:
+    def _emit_output_integer(self, value_reg: int, scope: _FrameScope) -> None:
         index = self.output_count
         self.output_count += 1
         extract_loop_label = f"algol_label_output_int_{index}_extract_loop"
@@ -1726,7 +1779,7 @@ class AlgolIrCompiler:
         )
         self._emit(IrOp.BRANCH_Z, IrRegister(is_negative_reg), IrLabel(zero_label))
         self._label(negative_label)
-        self._emit_output_chars("-")
+        self._emit_output_chars("-", scope)
         self._label(zero_label)
         is_zero_reg = self._fresh_reg()
         self._emit(
@@ -1736,7 +1789,7 @@ class AlgolIrCompiler:
             IrRegister(_ZERO_REG),
         )
         self._emit(IrOp.BRANCH_Z, IrRegister(is_zero_reg), IrLabel(extract_loop_label))
-        self._emit_output_chars("0")
+        self._emit_output_chars("0", scope)
         self._emit(IrOp.JUMP, IrLabel(end_label))
 
         self._label(extract_loop_label)
@@ -1785,7 +1838,7 @@ class AlgolIrCompiler:
             IrRegister(buffer_base_reg),
             IrRegister(emit_index_reg),
         )
-        self._emit_output_reg(char_reg)
+        self._emit_output_reg(char_reg, scope)
         self._emit(
             IrOp.ADD_IMM,
             IrRegister(emit_index_reg),
@@ -1795,7 +1848,7 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(emit_loop_label))
         self._label(end_label)
 
-    def _emit_output_real(self, value_reg: int) -> None:
+    def _emit_output_real(self, value_reg: int, scope: _FrameScope) -> None:
         index = self.output_count
         self.output_count += 1
         positive_label = f"algol_label_output_real_{index}_positive"
@@ -1816,7 +1869,7 @@ class AlgolIrCompiler:
             IrRegister(negative_reg),
             IrLabel(positive_label),
         )
-        self._emit_output_chars("-")
+        self._emit_output_chars("-", scope)
         self._emit(
             IrOp.F64_SUB,
             IrRegister(abs_reg),
@@ -1894,11 +1947,11 @@ class AlgolIrCompiler:
         )
         self._label(no_carry_label)
 
-        self._emit_output_integer(integer_part_reg)
-        self._emit_output_chars(".")
-        self._emit_output_three_digits(fraction_digits_reg)
+        self._emit_output_integer(integer_part_reg, scope)
+        self._emit_output_chars(".", scope)
+        self._emit_output_three_digits(fraction_digits_reg, scope)
 
-    def _emit_output_three_digits(self, value_reg: int) -> None:
+    def _emit_output_three_digits(self, value_reg: int, scope: _FrameScope) -> None:
         hundred_reg = self._const_reg(100)
         ten_reg = self._const_reg(10)
         ascii_zero_reg = self._const_reg(ord("0"))
@@ -1953,7 +2006,7 @@ class AlgolIrCompiler:
                 IrRegister(digit_reg),
                 IrRegister(ascii_zero_reg),
             )
-            self._emit_output_reg(ascii_reg)
+            self._emit_output_reg(ascii_reg, scope)
 
     def _emit_extract_integer_digit(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -2,6 +2,7 @@
 
 import pytest
 from algol_parser import parse_algol
+from algol_ir_compiler.compiler import _MAX_STRING_OUTPUT_BYTES, _MAX_TOTAL_OUTPUT_BYTES
 from algol_type_checker import FRAME_WORD_SIZE, FrameSlot, check_algol
 from compiler_ir import IrOp
 from lang_parser import ASTNode
@@ -172,6 +173,25 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.LOAD_WORD) >= 2
         assert IrOp.LOAD_BYTE in opcodes
         assert any(label.startswith("algol_label_output_string_") for label in labels)
+
+    def test_compiles_string_output_guards_for_length_and_total_bytes(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        immediate_values = [
+            operand.value
+            for instr in result.program.instructions
+            for operand in instr.operands
+            if hasattr(operand, "value")
+        ]
+
+        assert IrOp.CMP_LT in opcodes
+        assert IrOp.CMP_GT in opcodes
+        assert _MAX_STRING_OUTPUT_BYTES in immediate_values
+        assert _MAX_TOTAL_OUTPUT_BYTES in immediate_values
 
     def test_compiles_local_goto_to_algol_label(self) -> None:
         result = compile_algol(
@@ -452,7 +472,7 @@ class TestAlgolIrCompiler:
                 )
         )
 
-        with pytest.raises(CompileError, match="frame bytes plus 36 runtime bytes"):
+        with pytest.raises(CompileError, match="frame bytes plus 40 runtime bytes"):
             compile_algol(typed)
 
     def test_compiles_integer_array_descriptor_and_element_accesses(self) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from algol_ir_compiler.compiler import _MAX_STRING_OUTPUT_BYTES, _MAX_TOTAL_OUTPUT_BYTES
 from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
 
 from algol_wasm_compiler import (
@@ -137,6 +138,32 @@ class TestAlgolWasmCompiler:
 
         assert runtime.load_and_run(result.binary, "_start", []) == [9]
         assert "".join(captured) == ""
+
+    def test_oversized_string_output_returns_zero_without_writing_stdout(self) -> None:
+        oversized = "A" * (_MAX_STRING_OUTPUT_BYTES + 1)
+        result = compile_source(
+            f"begin integer result; print('{oversized}'); result := 9 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == ""
+
+    def test_total_output_budget_caps_multiple_print_calls(self) -> None:
+        chunk = "A" * _MAX_STRING_OUTPUT_BYTES
+        result = compile_source(
+            "begin integer result; "
+            f"print('{chunk}'); "
+            f"print('{chunk}'); "
+            "print('B'); "
+            "result := 9 end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == "A" * _MAX_TOTAL_OUTPUT_BYTES
 
     def test_own_integer_persists_across_procedure_calls(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- add runtime guards for descriptor-backed ALGOL string output
- cap per-string and total program output bytes through the existing runtime-failure path
- cover the new guardrails in IR and WASM tests

## Testing
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`