### PR TITLE
Add golden ALGOL WASM fixtures

### DIFF
--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -8,49 +8,27 @@ This package is the orchestration layer for the first ALGOL 60 compiled lane:
 ALGOL source -> parse -> type-check -> IR -> WASM module -> WASM bytes
 ```
 
-The current subset is intentionally small and structured. A program declares an
-integer variable named `result`; `_start` returns that value after the outer
-block finishes.
+Programs still declare an integer variable named `result`; `_start` returns
+that value after the outer block finishes. Within that shape, the current lane
+already supports a substantial ALGOL 60 surface:
 
-Scalar locals are now backed by the ALGOL frame model from PL04. Nested blocks
-use static links to reach outer frame slots, so shadowing and outer-scope writes
-exercise the same storage path later procedures will need.
-Value-only integer procedures are compiled as WASM functions with explicit
-static-link arguments, fresh frame allocation per call, and procedure-name
-result slots for typed procedure returns.
-Integer arrays compile through the Phase 4 descriptor path: bounds are
-evaluated at block entry, descriptors live in frame slots, element storage lives
-in a bounded ALGOL heap segment, and every element access performs runtime
-bounds checks before touching WASM memory.
-Scalar by-name parameters now execute through the same WASM memory path by
-passing a storage pointer into the callee frame. A by-name formal assignment
-therefore writes back to the caller's scalar slot. Read-only integer expression
-actuals now compile as tagged eval thunk descriptors, so each by-name formal
-read re-evaluates the expression using the caller frame captured at the call
-site. Integer array-element by-name actuals now compile as tagged descriptors
-with eval/store helpers, so reads and assignments re-compute the current element
-address every time the formal is used. Read-only expression thunks can also
-read array elements, including Jensen-style terms such as `a[i] * i`.
-Expression thunks can call procedures, including procedures that receive nested
-by-name descriptors, and runtime failures from those callees propagate through
-the by-name formal read. Expression thunk stores remain guarded by IR
-compile-stage diagnostics until full Phase 5 store-helper coverage is
-available. The integer by-name acceptance tests cover the supported scalar,
-array, expression, nested-procedure, and Jensen's-device surface.
-Direct labels and direct local `goto` statements now execute through the
-unstructured IR-to-WASM lowering path, including forward jumps, backward jumps,
-terminal labels on empty statements, and direct nonlocal jumps from inner
-blocks to outer active labels. Nonlocal block jumps restore exited frames
-before entering later blocks. Local switch declarations, switch selections, and
-conditional designational `goto` forms execute through that same path,
-including conditional switch entries. Switch entries that select another switch
-remain guarded to avoid recursive descriptor expansion. Procedure-crossing
-gotos, nonlocal switch selections, procedure-valued parameters, whole-array
-by-name values, and non-integer by-name formals remain later phases.
+- nested blocks and nested procedures with lexical access through static links
+- `integer`, `boolean`, `real`, and `string` scalar values
+- `own` scalars and arrays with static lifetime
+- arrays with runtime bounds and checked element access
+- value and by-name parameters, including Jensen-style expression thunks
+- labels, local and nonlocal `goto`, switch designators, and conditional
+  designational expressions
+- builtin `print(...)` / `output(...)` for integers, booleans, reals, strings,
+  and string variables
+
+The implementation is not yet a full ALGOL 60 conformance lane, but it is well
+beyond a toy arithmetic subset and is now useful for representative block- and
+procedure-heavy programs.
 
 ```python
 from algol_wasm_compiler import compile_source
-from wasm_runtime import WasmRuntime
+from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
 
 compiled = compile_source("begin integer result; result := 7 end")
 assert WasmRuntime().load_and_run(compiled.binary, "_start", []) == [7]
@@ -60,7 +38,36 @@ with_array = compile_source(
     "a[2] := 9; result := a[2] end"
 )
 assert WasmRuntime().load_and_run(with_array.binary, "_start", []) == [9]
+
+showcase = compile_source(
+    "begin own integer counter; integer array a[1:3]; real average; "
+    "string msg; integer result; "
+    "integer procedure inc(x); value x; integer x; begin inc := x + 1 end; "
+    "procedure bump; begin counter := counter + 1 end; "
+    "msg := 'ALGOL'; "
+    "a[1] := 2; a[2] := inc(4); a[3] := 7; "
+    "bump; bump; "
+    "average := (a[1] + a[2] + a[3]) / 2; "
+    "print(msg); output(' '); print(counter); output(' '); print(average); "
+    "result := a[2] + a[3] "
+    "end"
+)
+captured: list[str] = []
+runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+assert runtime.load_and_run(showcase.binary, "_start", []) == [12]
+assert "".join(captured) == "ALGOL 2 7.000"
 ```
+
+## Golden Fixtures
+
+The package test suite includes end-to-end golden ALGOL programs that compile
+through the full parser -> type-checker -> IR -> WASM pipeline and run in the
+local WASM runtime. Those fixtures cover:
+
+- mixed scalar and array computation with output
+- Jensen-style by-name procedure calls
+- switch dispatch and procedure-crossing `goto`
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/control-flow.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/control-flow.alg
@@ -1,0 +1,11 @@
+begin integer result, i;
+switch choose := first, second;
+procedure escape;
+begin goto done end;
+result := 0;
+i := 2;
+goto choose[i];
+first: result := 1; goto done;
+second: begin i := i + 5; escape end;
+done: print('FLOW'); output(' '); print(i); result := result + i
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/jensens-device.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/jensens-device.alg
@@ -1,0 +1,10 @@
+begin integer result, i; integer array a[1:4];
+integer procedure sum(k, lo, hi, term);
+value lo, hi; integer k, lo, hi, term;
+begin sum := 0; for k := lo step 1 until hi do sum := sum + term end;
+a[1] := 1;
+a[2] := 2;
+a[3] := 3;
+a[4] := 4;
+result := sum(i, 1, 4, a[i] * i)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/showcase.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/showcase.alg
@@ -1,0 +1,20 @@
+begin own integer counter; integer array a[1:3]; real average;
+string msg; integer result;
+integer procedure inc(x); value x; integer x;
+begin inc := x + 1 end;
+procedure bump;
+begin counter := counter + 1 end;
+msg := 'ALGOL';
+a[1] := 2;
+a[2] := inc(4);
+a[3] := 7;
+bump;
+bump;
+average := (a[1] + a[2] + a[3]) / 2;
+print(msg);
+output(' ');
+print(counter);
+output(' ');
+print(average);
+result := a[2] + a[3]
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -1,0 +1,39 @@
+"""Golden end-to-end ALGOL programs executed through the local WASM runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
+
+from algol_wasm_compiler import compile_source
+
+
+@dataclass(frozen=True)
+class GoldenFixture:
+    """Expected runtime behavior for a golden ALGOL program."""
+
+    name: str
+    result: list[int]
+    stdout: str
+
+
+_FIXTURE_DIR = Path(__file__).with_name("fixtures")
+_GOLDEN_FIXTURES = (
+    GoldenFixture(name="showcase", result=[12], stdout="ALGOL 2 7.000"),
+    GoldenFixture(name="jensens-device", result=[30], stdout=""),
+    GoldenFixture(name="control-flow", result=[7], stdout="FLOW 7"),
+)
+
+
+@pytest.mark.parametrize("fixture", _GOLDEN_FIXTURES, ids=lambda fixture: fixture.name)
+def test_golden_algol_fixtures_execute_end_to_end(fixture: GoldenFixture) -> None:
+    source = (_FIXTURE_DIR / f"{fixture.name}.alg").read_text()
+    compiled = compile_source(source)
+    captured: list[str] = []
+    runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+    assert runtime.load_and_run(compiled.binary, "_start", []) == fixture.result
+    assert "".join(captured) == fixture.stdout


### PR DESCRIPTION
## Summary
- add end-to-end golden ALGOL fixture programs that compile and execute through the local WASM runtime
- refresh the algol-wasm-compiler README to describe the current supported surface and a richer runnable example
- cover representative procedure, by-name, control-flow, array, string, real, and output behavior through public package tests

## Testing
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py`
- `git diff --check`