### PR TITLE
Expand ALGOL control-flow completeness

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -892,7 +892,15 @@ class AlgolIrCompiler:
             raise CompileError("goto statement is missing a designational expression")
         self._compile_designational(desig_expr, scope)
 
-    def _compile_designational(self, node: ASTNode, scope: _FrameScope) -> None:
+    def _compile_designational(
+        self,
+        node: ASTNode,
+        scope: _FrameScope,
+        *,
+        execution_scope: _FrameScope | None = None,
+    ) -> None:
+        if execution_scope is None:
+            execution_scope = scope
         if any(token.value == "if" for token in _direct_tokens(node)):
             index = self.if_count
             self.if_count += 1
@@ -905,39 +913,59 @@ class AlgolIrCompiler:
             then_desig = _first_direct_node(node, "simple_desig")
             if then_desig is None:
                 raise CompileError("conditional designational is missing then target")
-            self._compile_simple_designational(then_desig, scope)
+            self._compile_simple_designational(
+                then_desig,
+                scope,
+                execution_scope=execution_scope,
+            )
             self._label(else_label)
             else_desig = _first_direct_node(node, "desig_expr")
             if else_desig is None:
                 raise CompileError("conditional designational is missing else target")
-            self._compile_designational(else_desig, scope)
+            self._compile_designational(
+                else_desig,
+                scope,
+                execution_scope=execution_scope,
+            )
             return
 
         simple = _first_direct_node(node, "simple_desig")
         if simple is None:
             raise CompileError("unsupported designational expression")
-        self._compile_simple_designational(simple, scope)
+        self._compile_simple_designational(simple, scope, execution_scope=execution_scope)
 
     def _compile_simple_designational(
         self,
         node: ASTNode,
         scope: _FrameScope,
+        *,
+        execution_scope: _FrameScope | None = None,
     ) -> None:
+        if execution_scope is None:
+            execution_scope = scope
         direct = _direct_label_from_simple_designational(node)
         if direct is not None:
             label = self._resolve_label_in_scope_chain(direct.value, scope)
             if label is None:
                 raise CompileError(f"goto target {direct.value!r} was not resolved")
-            self._emit_goto_label(label, scope)
+            self._emit_goto_label(label, execution_scope)
             return
 
         if any(token.value == "[" for token in _direct_tokens(node)):
-            self._compile_switch_selection(node, scope)
+            self._compile_switch_selection(
+                node,
+                scope,
+                execution_scope=execution_scope,
+            )
             return
 
         nested = _first_direct_node(node, "desig_expr")
         if nested is not None:
-            self._compile_designational(nested, scope)
+            self._compile_designational(
+                nested,
+                scope,
+                execution_scope=execution_scope,
+            )
             return
         raise CompileError("unsupported designational expression")
 
@@ -987,17 +1015,26 @@ class AlgolIrCompiler:
                 f"goto target block {target_block_id} is not active in this function"
             )
 
-    def _compile_switch_selection(self, node: ASTNode, scope: _FrameScope) -> None:
+    def _compile_switch_selection(
+        self,
+        node: ASTNode,
+        scope: _FrameScope,
+        *,
+        execution_scope: _FrameScope | None = None,
+    ) -> None:
         selection = self.switch_selections.get(id(node))
         if selection is None:
             raise CompileError("switch selection was not resolved")
         descriptor = self.switches.get(selection.switch_id)
         if descriptor is None:
             raise CompileError(f"switch {selection.name!r} has no descriptor")
+        if execution_scope is None:
+            execution_scope = scope
         indexes = _direct_nodes(node, "arith_expr")
         if len(indexes) != 1:
             raise CompileError("switch selection requires exactly one index")
         index_value = self._compile_expr(indexes[0], scope)
+        entry_scope = self._active_scope_for_block(selection.declaration_block_id, scope)
         dispatch_index = self.switch_count
         self.switch_count += 1
         for entry_index, entry_node_id in enumerate(descriptor.entry_node_ids, start=1):
@@ -1016,10 +1053,14 @@ class AlgolIrCompiler:
                 raise CompileError(
                     f"switch {selection.name!r} entry {entry_index} is missing"
                 )
-            self._compile_designational(entry, scope)
+            self._compile_designational(
+                entry,
+                entry_scope,
+                execution_scope=execution_scope,
+            )
             self._label(next_label)
         failed = self._const_reg(1)
-        self._emit_runtime_failure_guard(failed, scope)
+        self._emit_runtime_failure_guard(failed, execution_scope)
 
     def _compile_assignment(self, assign: ASTNode, scope: _FrameScope) -> None:
         left_part = _first_direct_node(assign, "left_part")
@@ -3313,6 +3354,18 @@ class AlgolIrCompiler:
             active_scopes.append(current)
             current = current.parent
         return active_scopes
+
+    def _active_scope_for_block(
+        self,
+        block_id: int,
+        scope: _FrameScope,
+    ) -> _FrameScope:
+        current: _FrameScope | None = scope
+        while current is not None:
+            if current.block_id == block_id:
+                return current
+            current = current.goto_parent
+        raise CompileError(f"block {block_id} is not active for switch selection")
 
     def _emit_helper_runtime_failure_guard(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -308,6 +308,55 @@ class TestAlgolIrCompiler:
         assert IrOp.CMP_EQ in opcodes
         assert any(label.startswith("switch_0_1_next") for label in labels)
 
+    def test_compiles_nonlocal_switch_designational_goto(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i; "
+                "switch s := first, second; "
+                "i := 2; "
+                "begin goto s[i] end; "
+                "first: result := 1; goto done; "
+                "second: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.CMP_EQ in opcodes
+        assert any(label.startswith("switch_0_1_next") for label in labels)
+
+    def test_compiles_procedure_crossing_nonlocal_switch_with_pending_transfer(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, flag; "
+                "switch s := if flag = 0 then left else right; "
+                "procedure escape; begin flag := 1; goto s[1] end; "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "escape "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.CALL in opcodes
+        assert opcodes.count(IrOp.RET) >= 2
+        assert any(label.startswith("algol_label_") for label in labels)
+
     def test_repeated_switch_selections_get_distinct_dispatch_labels(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1172,13 +1172,6 @@ class AlgolTypeChecker:
         if symbol.kind != SWITCH:
             self._error(name_token, f"{name_token.value!r} is not a switch")
             return
-        if lexical_depth_delta != 0:
-            self._error(
-                name_token,
-                f"nonlocal switch {name_token.value!r} requires Phase 7b frame "
-                "unwinding",
-            )
-            return
         if symbol.switch_id is None:
             self._error(name_token, f"switch {name_token.value!r} has no descriptor")
             return

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -189,7 +189,7 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "switch index must be integer" in result.diagnostics[0].message
 
-    def test_rejects_nonlocal_switch_selection_for_now(self) -> None:
+    def test_accepts_nonlocal_switch_selection(self) -> None:
         ast = parse_algol(
             "begin integer result; "
             "switch s := done; "
@@ -199,8 +199,12 @@ class TestAlgolTypeChecker:
         )
         result = check_algol(ast)
 
-        assert not result.ok
-        assert "nonlocal switch 's'" in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
+        assert len(result.semantic.switch_selections) == 1
+        selection = result.semantic.switch_selections[0]
+        assert selection.use_block_id != selection.declaration_block_id
+        assert selection.lexical_depth_delta == 1
 
     def test_rejects_nested_switch_selection_entries_for_now(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -368,6 +368,19 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_nonlocal_switch_designational_goto_selects_outer_entry(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "switch s := first, second; "
+            "i := 2; "
+            "begin goto s[i] end; "
+            "first: result := 1; goto done; "
+            "second: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_switch_entry_can_be_conditional_designational(self) -> None:
         result = compile_source(
             "begin integer result, i; "
@@ -375,6 +388,22 @@ class TestAlgolWasmCompiler:
             "i := 2; goto s[1]; "
             "first: result := 1; goto done; "
             "second: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_procedure_crossing_nonlocal_switch_selection_uses_declaring_scope(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result, flag; "
+            "switch s := if flag = 0 then left else right; "
+            "procedure escape; begin flag := 1; goto s[1] end; "
+            "escape; "
+            "result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
             "done: "
             "end"
         )

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1032,11 +1032,12 @@ The completed Phase 7a implementation keeps switch descriptors in semantic
 metadata rather than runtime memory. Local switch declarations may contain
 direct labels and conditional designational expressions over local labels. A
 `goto s[i]` evaluates `i` once, uses ALGOL's one-based switch entry numbering,
-and jumps through the selected local designational entry. Indexes outside the
+and jumps through the selected designational entry. Indexes outside the
 declared switch range follow the existing runtime-failure path and return `0`.
-Switch entries that select another switch remain guarded to avoid recursive
-descriptor expansion. Switch selections that require crossing an ALGOL frame
-boundary remain Phase 7b work.
+Switch selections may cross ALGOL frame boundaries by evaluating the chosen
+entry in the switch's declaring scope while still using the active execution
+scope for frame unwinding and pending-goto propagation. Switch entries that
+select another switch remain guarded to avoid recursive descriptor expansion.
 
 ## Expressions
 
@@ -1368,7 +1369,9 @@ Status: Phase 7a is complete for local switch declarations, local switch
 selections, and local conditional designational `goto` forms. Phase 7b-1 is
 complete for direct nonlocal block `goto` statements inside one lowered
 function. Procedure-crossing `goto`, nonlocal conditional designational
-branches, and nonlocal switch selections remain future Phase 7 work.
+branches, and nonlocal switch selections now execute through the same pending
+goto machinery. Nested switch entries that select another switch remain future
+Phase 7 work.
 
 Deliverables:
 


### PR DESCRIPTION
## Summary
- support nonlocal ALGOL switch selections end to end
- add nested non-recursive switch-entry selection and nonlocal conditional designational coverage
- refresh the README and PL04 spec text so the documented control-flow surface matches the implementation

## Testing
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`