### PR TITLE
Add nested ALGOL switch designators and nonlocal conditionals

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -339,10 +339,11 @@ class TestAlgolIrCompiler:
                 "begin integer result, flag; "
                 "switch s := if flag = 0 then left else right; "
                 "procedure escape; begin flag := 1; goto s[1] end; "
+                "escape; "
+                "result := 0; "
                 "left: result := 1; goto done; "
                 "right: result := 2; "
                 "done: "
-                "escape "
                 "end"
             )
         )
@@ -355,6 +356,72 @@ class TestAlgolIrCompiler:
 
         assert IrOp.CALL in opcodes
         assert opcodes.count(IrOp.RET) >= 2
+        assert any(label.startswith("algol_label_") for label in labels)
+
+    def test_compiles_nested_switch_selection_entry(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i; "
+                "switch inner := first, second; "
+                "switch outer := inner[i]; "
+                "i := 2; goto outer[1]; "
+                "first: result := 1; goto done; "
+                "second: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert any(label.startswith("switch_0_1_next") for label in labels)
+        assert any(label.startswith("switch_1_1_next") for label in labels)
+
+    def test_compiles_nonlocal_conditional_designational_goto(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, flag; "
+                "begin goto if flag = 0 then left else right end; "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.BRANCH_Z in opcodes
+        assert any(label.startswith("algol_label_") for label in labels)
+
+    def test_compiles_procedure_crossing_conditional_designational_goto(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, flag; "
+                "procedure escape; begin goto if flag = 0 then left else right end; "
+                "flag := 1; escape; result := 0; "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.CALL in opcodes
+        assert IrOp.BRANCH_Z in opcodes
         assert any(label.startswith("algol_label_") for label in labels)
 
     def test_repeated_switch_selections_get_distinct_dispatch_labels(self) -> None:

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -717,7 +717,8 @@ class AlgolTypeChecker:
                 entry,
                 scope,
                 allow_nonlocal_label=False,
-                allow_switch_selection=False,
+                allow_switch_selection=True,
+                active_switch_id=switch_id,
             )
         self.semantic_switches.append(
             SwitchDescriptor(
@@ -1006,6 +1007,7 @@ class AlgolTypeChecker:
         *,
         allow_nonlocal_label: bool = True,
         allow_switch_selection: bool = True,
+        active_switch_id: int | None = None,
     ) -> ResolvedGoto | None:
         if any(token.value == "if" for token in _direct_tokens(node)):
             bool_expr = _first_direct_node(node, "bool_expr")
@@ -1020,15 +1022,17 @@ class AlgolTypeChecker:
                 self._check_simple_designational(
                     then_desig,
                     scope,
-                    allow_nonlocal_label=False,
+                    allow_nonlocal_label=allow_nonlocal_label,
                     allow_switch_selection=allow_switch_selection,
+                    active_switch_id=active_switch_id,
                 )
             if else_desig is not None:
                 self._check_designational(
                     else_desig,
                     scope,
-                    allow_nonlocal_label=False,
+                    allow_nonlocal_label=allow_nonlocal_label,
                     allow_switch_selection=allow_switch_selection,
+                    active_switch_id=active_switch_id,
                 )
             return ResolvedGoto(
                 token_id=id(node),
@@ -1053,6 +1057,7 @@ class AlgolTypeChecker:
             outer_node=node,
             allow_nonlocal_label=allow_nonlocal_label,
             allow_switch_selection=allow_switch_selection,
+            active_switch_id=active_switch_id,
         )
 
     def _check_simple_designational(
@@ -1063,6 +1068,7 @@ class AlgolTypeChecker:
         outer_node: ASTNode | None = None,
         allow_nonlocal_label: bool = True,
         allow_switch_selection: bool = True,
+        active_switch_id: int | None = None,
     ) -> ResolvedGoto | None:
         target_token = _direct_label_from_simple_designational(node)
         if target_token is not None:
@@ -1081,7 +1087,11 @@ class AlgolTypeChecker:
                     "dispatch lowering",
                 )
                 return None
-            self._check_switch_selection(node, scope)
+            self._check_switch_selection(
+                node,
+                scope,
+                active_switch_id=active_switch_id,
+            )
             return ResolvedGoto(
                 token_id=id(outer_node or node),
                 label_id=-1,
@@ -1102,6 +1112,7 @@ class AlgolTypeChecker:
                 scope,
                 allow_nonlocal_label=allow_nonlocal_label,
                 allow_switch_selection=allow_switch_selection,
+                active_switch_id=active_switch_id,
             )
 
         self._error(node, "unsupported designational expression")
@@ -1156,7 +1167,13 @@ class AlgolTypeChecker:
             designational_node_id=id(outer_node),
         )
 
-    def _check_switch_selection(self, node: ASTNode, scope: Scope) -> None:
+    def _check_switch_selection(
+        self,
+        node: ASTNode,
+        scope: Scope,
+        *,
+        active_switch_id: int | None = None,
+    ) -> None:
         name_token = next(
             (token for token in _direct_tokens(node) if token.type_name == "NAME"),
             None,
@@ -1171,6 +1188,12 @@ class AlgolTypeChecker:
         symbol, declaring_scope, lexical_depth_delta = resolved
         if symbol.kind != SWITCH:
             self._error(name_token, f"{name_token.value!r} is not a switch")
+            return
+        if active_switch_id is not None and symbol.switch_id == active_switch_id:
+            self._error(
+                name_token,
+                f"switch {name_token.value!r} cannot select itself recursively",
+            )
             return
         if symbol.switch_id is None:
             self._error(name_token, f"switch {name_token.value!r} has no descriptor")

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -125,7 +125,7 @@ class TestAlgolTypeChecker:
         assert result.semantic is not None
         assert result.semantic.gotos[0].target_name == "done"
 
-    def test_rejects_conditional_nonlocal_designational_goto_for_now(self) -> None:
+    def test_accepts_conditional_nonlocal_designational_goto(self) -> None:
         ast = parse_algol(
             "begin integer result; "
             "begin integer inner; goto if true then done else done end; "
@@ -134,8 +134,8 @@ class TestAlgolTypeChecker:
         )
         result = check_algol(ast)
 
-        assert not result.ok
-        assert "nonlocal designational label 'done'" in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
 
     def test_accepts_conditional_designational_goto(self) -> None:
         ast = parse_algol(
@@ -206,7 +206,24 @@ class TestAlgolTypeChecker:
         assert selection.use_block_id != selection.declaration_block_id
         assert selection.lexical_depth_delta == 1
 
-    def test_rejects_nested_switch_selection_entries_for_now(self) -> None:
+    def test_accepts_nested_switch_selection_entries(self) -> None:
+        ast = parse_algol(
+            "begin integer result, i; "
+            "switch inner := first, second; "
+            "switch outer := inner[i]; "
+            "i := 2; goto outer[1]; "
+            "first: result := 1; goto done; "
+            "second: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert len(result.semantic.switch_selections) == 2
+
+    def test_rejects_self_recursive_switch_selection_entry(self) -> None:
         ast = parse_algol(
             "begin integer result; "
             "switch s := s[1]; "
@@ -216,7 +233,34 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
 
         assert not result.ok
-        assert "select another switch require Phase 7b" in result.diagnostics[0].message
+        assert "cannot select itself recursively" in result.diagnostics[0].message
+
+    def test_accepts_nonlocal_conditional_designational_goto(self) -> None:
+        ast = parse_algol(
+            "begin integer result, flag; "
+            "begin goto if flag = 0 then left else right end; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_accepts_procedure_crossing_conditional_designational_goto(self) -> None:
+        ast = parse_algol(
+            "begin integer result, flag; "
+            "procedure escape; begin goto if flag = 0 then left else right end; "
+            "flag := 1; escape; result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
 
     def test_reports_missing_program_block(self) -> None:
         result = check_algol(ASTNode("program", []))

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,8 @@ already supports a substantial ALGOL 60 surface:
 - arrays with runtime bounds and checked element access
 - value and by-name parameters, including Jensen-style expression thunks
 - labels, local and nonlocal `goto`, switch designators, and conditional
-  designational expressions
+  designational expressions, including nonlocal branches and nested
+  non-recursive switch entries
 - builtin `print(...)` / `output(...)` for integers, booleans, reals, strings,
   and string variables
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -381,6 +381,19 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_nested_switch_selection_entry_dispatches_through_inner_switch(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "switch inner := first, second; "
+            "switch outer := inner[i]; "
+            "i := 2; goto outer[1]; "
+            "first: result := 1; goto done; "
+            "second: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_switch_entry_can_be_conditional_designational(self) -> None:
         result = compile_source(
             "begin integer result, i; "
@@ -388,6 +401,31 @@ class TestAlgolWasmCompiler:
             "i := 2; goto s[1]; "
             "first: result := 1; goto done; "
             "second: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_nonlocal_conditional_designational_goto_selects_outer_label(self) -> None:
+        result = compile_source(
+            "begin integer result, flag; "
+            "begin goto if flag = 0 then left else right end; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_procedure_crossing_conditional_designational_goto_selects_outer_label(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result, flag; "
+            "procedure escape; begin goto if flag = 0 then left else right end; "
+            "flag := 1; escape; result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
             "done: "
             "end"
         )

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1036,8 +1036,9 @@ and jumps through the selected designational entry. Indexes outside the
 declared switch range follow the existing runtime-failure path and return `0`.
 Switch selections may cross ALGOL frame boundaries by evaluating the chosen
 entry in the switch's declaring scope while still using the active execution
-scope for frame unwinding and pending-goto propagation. Switch entries that
-select another switch remain guarded to avoid recursive descriptor expansion.
+scope for frame unwinding and pending-goto propagation. Switch entries may
+select another switch when that expansion does not recurse back to the same
+switch.
 
 ## Expressions
 
@@ -1369,9 +1370,9 @@ Status: Phase 7a is complete for local switch declarations, local switch
 selections, and local conditional designational `goto` forms. Phase 7b-1 is
 complete for direct nonlocal block `goto` statements inside one lowered
 function. Procedure-crossing `goto`, nonlocal conditional designational
-branches, and nonlocal switch selections now execute through the same pending
-goto machinery. Nested switch entries that select another switch remain future
-Phase 7 work.
+branches, nonlocal switch selections, and nested non-recursive switch entries
+now execute through the same pending goto machinery and designational
+evaluation model.
 
 Deliverables:
 


### PR DESCRIPTION
## Summary
- add nested non-recursive switch-entry selection support
- allow and cover nonlocal conditional designational gotos, including procedure-crossing cases
- refresh the ALGOL WASM README and PL04 spec text to match the expanded control-flow surface

## Testing
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `PYTHONPATH="$(find code/packages/python -mindepth 2 -maxdepth 2 -type d -name src -print | tr '\n' ':' | sed 's/:$//')" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`