### PR TITLE
feat(rust): add html5lib fixture importer

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -34,3 +34,6 @@ documented in this file.
   path.
 - A first raw html5lib-style tokenizer smoke file plus a Rust normalizer that
   lowers supported upstream cases into Venture's portable conformance schema.
+- A checked-in importer script and generated normalized `html5lib-smoke.json`
+  corpus so broader upstream-style cases can be regenerated instead of
+  hand-maintained in Rust tests.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -40,9 +40,11 @@ Today the package carries two suites:
 
 There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
 html5lib tokenizer JSON shape in a small supported subset. The Rust test
-harness lowers that upstream-style file into Venture's portable fixture schema
-before execution, which makes the future WPT/html5lib import path concrete
-without coupling the shared harness to upstream file formats.
+harness now targets a checked-in generated `html5lib-smoke.json` corpus, which
+is produced by `tests/fixtures/normalize_html5lib_fixtures.py` from that raw
+upstream-style file. This makes the future WPT/html5lib import path concrete
+without coupling the shared harness to upstream file formats or requiring raw
+fixture normalization logic to live forever inside the Rust tests.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -6,7 +6,8 @@ use serde_json::Value;
 
 const HTML_SKELETON_FIXTURES: &str = include_str!("fixtures/html-skeleton.json");
 const HTML1_FIXTURES: &str = include_str!("fixtures/html1.json");
-const HTML5LIB_SMOKE_FIXTURES: &str = include_str!("fixtures/upstream-html5lib-smoke.test");
+const HTML5LIB_RAW_FIXTURES: &str = include_str!("fixtures/upstream-html5lib-smoke.test");
+const HTML5LIB_NORMALIZED_FIXTURES: &str = include_str!("fixtures/html5lib-smoke.json");
 
 #[derive(Debug, Deserialize)]
 struct FixtureSuite {
@@ -16,7 +17,7 @@ struct FixtureSuite {
     cases: Vec<FixtureCase>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct FixtureCase {
     id: String,
     input: String,
@@ -50,6 +51,25 @@ struct Html5libTokenizerError {
     col: usize,
 }
 
+#[derive(Debug, Deserialize)]
+struct Html5libNormalizedSuite {
+    format: String,
+    suite: String,
+    description: String,
+    source: String,
+    generator: String,
+    supported_initial_states: Vec<String>,
+    cases: Vec<FixtureCase>,
+    skipped: Vec<Html5libSkippedCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Html5libSkippedCase {
+    id: String,
+    description: String,
+    reason: String,
+}
+
 #[test]
 fn fixture_manifests_parse() {
     let skeleton = load_suite(HTML_SKELETON_FIXTURES);
@@ -68,18 +88,50 @@ fn fixture_manifests_parse() {
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
-    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
+    let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 4);
+    assert_eq!(file.tests.len(), 7);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
     );
     assert!(file.tests[0].initial_states.is_empty());
     assert!(file.tests[0].last_start_tag.is_none());
-    assert_eq!(file.tests[3].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[3].errors[0].line, 1);
-    assert_eq!(file.tests[3].errors[0].col, 9);
+    assert_eq!(file.tests[2].initial_states, vec!["Data state".to_string()]);
+    assert_eq!(file.tests[5].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[5].errors[0].line, 1);
+    assert_eq!(file.tests[5].errors[0].col, 9);
+    assert_eq!(
+        file.tests[6].initial_states,
+        vec!["RCDATA state".to_string()]
+    );
+    assert_eq!(file.tests[6].last_start_tag.as_deref(), Some("title"));
+}
+
+#[test]
+fn normalized_html5lib_fixture_parses_with_importer_metadata() {
+    let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
+
+    assert_eq!(normalized.format, "venture-html-lexer-fixtures/v1");
+    assert_eq!(normalized.suite, "html5lib-smoke");
+    assert!(!normalized.description.is_empty());
+    assert_eq!(normalized.source, "upstream-html5lib-smoke.test");
+    assert_eq!(normalized.generator, "normalize_html5lib_fixtures.py");
+    assert_eq!(
+        normalized.supported_initial_states,
+        vec!["Data state".to_string()]
+    );
+    assert_eq!(normalized.cases.len(), 6);
+    assert_eq!(normalized.skipped.len(), 1);
+    assert_eq!(normalized.skipped[0].id, "html5lib-smoke-7");
+    assert_eq!(
+        normalized.skipped[0].description,
+        "unsupported rcdata fixture is skipped by the importer"
+    );
+    assert_eq!(
+        normalized.skipped[0].reason,
+        "unsupported initialStates=['RCDATA state']"
+    );
 }
 
 #[test]
@@ -112,12 +164,12 @@ fn html1_conformance_cases_match_default_wrapper() {
 
 #[test]
 fn normalized_html5lib_cases_match_default_wrapper() {
-    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
-    let suite = normalize_html5lib_suite(&file);
+    let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
+    let suite = fixture_suite_from_normalized(&normalized);
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 4);
+    assert_eq!(suite.cases.len(), 6);
 
     run_fixture_suite(&suite, || {
         create_html_lexer().map_err(|error| format!("{error:?}"))
@@ -126,8 +178,8 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
 #[test]
 fn normalized_html5lib_cases_match_generated_html1_machine() {
-    let file = load_html5lib_file(HTML5LIB_SMOKE_FIXTURES);
-    let suite = normalize_html5lib_suite(&file);
+    let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
+    let suite = fixture_suite_from_normalized(&normalized);
 
     run_fixture_suite(&suite, || {
         html1_machine()
@@ -144,149 +196,17 @@ fn load_html5lib_file(raw: &str) -> Html5libTokenizerFile {
     serde_json::from_str(raw).expect("html5lib tokenizer fixture file should parse")
 }
 
-fn normalize_html5lib_suite(file: &Html5libTokenizerFile) -> FixtureSuite {
+fn load_html5lib_normalized_suite(raw: &str) -> Html5libNormalizedSuite {
+    serde_json::from_str(raw).expect("normalized html5lib fixture suite should parse")
+}
+
+fn fixture_suite_from_normalized(normalized: &Html5libNormalizedSuite) -> FixtureSuite {
     FixtureSuite {
-        format: "venture-html-lexer-fixtures/v1".to_string(),
-        suite: "html5lib-smoke".to_string(),
-        description:
-            "Normalized html5lib-style tokenizer smoke cases lowered into the Venture fixture schema"
-                .to_string(),
-        cases: file
-            .tests
-            .iter()
-            .enumerate()
-            .map(|(index, test)| normalize_html5lib_case(index, test))
-            .collect(),
+        format: normalized.format.clone(),
+        suite: normalized.suite.clone(),
+        description: normalized.description.clone(),
+        cases: normalized.cases.clone(),
     }
-}
-
-fn normalize_html5lib_case(index: usize, test: &Html5libTokenizerTest) -> FixtureCase {
-    assert!(
-        test.initial_states.is_empty() || test.initial_states == ["Data state".to_string()],
-        "html5lib smoke normalizer currently supports only the data state"
-    );
-    assert!(
-        test.last_start_tag.is_none(),
-        "html5lib smoke normalizer does not yet support lastStartTag"
-    );
-
-    let mut tokens = Vec::new();
-    let mut pending_text = String::new();
-
-    for token in &test.output {
-        let items = token
-            .as_array()
-            .expect("html5lib tokenizer output tokens should be arrays");
-        let kind = items
-            .first()
-            .and_then(Value::as_str)
-            .expect("html5lib tokenizer token kind should be a string");
-
-        match kind {
-            "Character" => {
-                pending_text.push_str(
-                    items
-                        .get(1)
-                        .and_then(Value::as_str)
-                        .expect("Character token should carry data"),
-                );
-            }
-            "StartTag" => {
-                flush_pending_text(&mut pending_text, &mut tokens);
-                tokens.push(normalize_html5lib_start_tag(items));
-            }
-            "EndTag" => {
-                flush_pending_text(&mut pending_text, &mut tokens);
-                tokens.push(format!(
-                    "EndTag(name={})",
-                    items
-                        .get(1)
-                        .and_then(Value::as_str)
-                        .expect("EndTag token should carry a name")
-                ));
-            }
-            "Comment" => {
-                flush_pending_text(&mut pending_text, &mut tokens);
-                tokens.push(format!(
-                    "Comment(data={})",
-                    items
-                        .get(1)
-                        .and_then(Value::as_str)
-                        .expect("Comment token should carry data")
-                ));
-            }
-            "DOCTYPE" => {
-                flush_pending_text(&mut pending_text, &mut tokens);
-                tokens.push(normalize_html5lib_doctype(items));
-            }
-            other => panic!("unsupported html5lib smoke token kind `{other}`"),
-        }
-    }
-
-    flush_pending_text(&mut pending_text, &mut tokens);
-    tokens.push("EOF".to_string());
-
-    FixtureCase {
-        id: format!("html5lib-smoke-{}", index + 1),
-        input: test.input.clone(),
-        tokens,
-        diagnostics: test.errors.iter().map(|error| error.code.clone()).collect(),
-    }
-}
-
-fn flush_pending_text(pending_text: &mut String, tokens: &mut Vec<String>) {
-    if pending_text.is_empty() {
-        return;
-    }
-
-    tokens.push(format!("Text(data={pending_text})"));
-    pending_text.clear();
-}
-
-fn normalize_html5lib_start_tag(items: &[Value]) -> String {
-    let name = items
-        .get(1)
-        .and_then(Value::as_str)
-        .expect("StartTag token should carry a name");
-    let attributes = items
-        .get(2)
-        .and_then(Value::as_object)
-        .expect("StartTag token should carry an attribute map");
-    let attribute_summary = if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|(name, value)| {
-                format!(
-                    "{}={}",
-                    name,
-                    value
-                        .as_str()
-                        .expect("attribute values should be strings in smoke fixtures")
-                )
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    };
-    let self_closing = items.get(3).and_then(Value::as_bool).unwrap_or(false);
-
-    format!("StartTag(name={name}, attributes={attribute_summary}, self_closing={self_closing})")
-}
-
-fn normalize_html5lib_doctype(items: &[Value]) -> String {
-    let name = items
-        .get(1)
-        .and_then(Value::as_str)
-        .expect("DOCTYPE token should carry a name");
-    let correctness = items
-        .get(4)
-        .and_then(Value::as_bool)
-        .expect("DOCTYPE token should carry correctness");
-    let force_quirks = !correctness;
-
-    format!("Doctype(name={name}, force_quirks={force_quirks})")
 }
 
 fn run_fixture_suite(suite: &FixtureSuite, create_lexer: impl Fn() -> Result<HtmlLexer, String>) {

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -41,8 +41,12 @@ binary while production code continues to link only static Rust source.
 
 - `html-skeleton.json`: narrow bootstrap regression cases
 - `html1.json`: Mosaic-era compatibility-floor cases for the current default wrapper
+- `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
+  the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
   exercise the normalization path toward broader upstream corpora
+- `normalize_html5lib_fixtures.py`: importer that lowers supported raw
+  html5lib-style tokenizer cases into Venture's portable fixture schema
 
 ## WPT Path
 
@@ -55,8 +59,28 @@ letting us mirror broader living-standard cases.
 uses the tokenizer JSON structure documented by the html5lib tokenizer tests:
 top-level `tests`, with each test carrying `description`, `input`, `output`,
 optional `initialStates`, optional `lastStartTag`, and optional `errors`.
-Rust tests parse that raw upstream-style file and lower it into
-`venture-html-lexer-fixtures/v1` before running the shared conformance harness.
+
+`normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
+currently supports:
+
+- default data-state cases
+- explicit `initialStates: ["Data state"]`
+- `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens
+- html5lib start-tag self-closing booleans
+- tokenizer error codes lowered into Venture diagnostics
+
+Unsupported raw cases are skipped into metadata in the generated file rather
+than silently disappearing. Rust conformance tests execute the generated
+`html5lib-smoke.json` corpus and separately parse the raw upstream-style file to
+keep the intake path visible.
+
+To regenerate the normalized corpus:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py \
+  code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test \
+  code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+```
 
 Planned flow:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1,0 +1,90 @@
+{
+  "format": "venture-html-lexer-fixtures/v1",
+  "suite": "html5lib-smoke",
+  "description": "Normalized html5lib-style tokenizer smoke cases lowered into the Venture fixture schema.",
+  "source": "upstream-html5lib-smoke.test",
+  "generator": "normalize_html5lib_fixtures.py",
+  "supported_initial_states": [
+    "Data state"
+  ],
+  "cases": [
+    {
+      "id": "html5lib-smoke-1",
+      "description": "simple start and end tag in data state",
+      "input": "<b>Hello</b>",
+      "tokens": [
+        "StartTag(name=b, attributes=[], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=b)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-2",
+      "description": "comment token surrounded by characters",
+      "input": "Before<!--note-->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=note)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-3",
+      "description": "explicit data state fixture still normalizes",
+      "input": "<em>Hi</em>",
+      "tokens": [
+        "StartTag(name=em, attributes=[], self_closing=false)",
+        "Text(data=Hi)",
+        "EndTag(name=em)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-4",
+      "description": "doctype plus single attribute start tag",
+      "input": "<!DOCTYPE html><p class=test>Hi</p>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "StartTag(name=p, attributes=[class=test], self_closing=false)",
+        "Text(data=Hi)",
+        "EndTag(name=p)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-5",
+      "description": "self closing start tag uses html5lib boolean slot",
+      "input": "<br/>",
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-6",
+      "description": "comment eof recovery reports tokenizer error",
+      "input": "<!--open",
+      "tokens": [
+        "Comment(data=open)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-comment"
+      ]
+    }
+  ],
+  "skipped": [
+    {
+      "id": "html5lib-smoke-7",
+      "description": "unsupported rcdata fixture is skipped by the importer",
+      "reason": "unsupported initialStates=['RCDATA state']"
+    }
+  ]
+}

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+"""Normalize html5lib-style tokenizer fixtures into Venture's lexer schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_INITIAL_STATES = {"Data state"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Normalize html5lib-style tokenizer tests into Venture fixture JSON."
+    )
+    parser.add_argument("input", type=Path, help="Path to raw html5lib-style tokenizer fixture")
+    parser.add_argument(
+        "output", type=Path, help="Path to write normalized venture-html-lexer fixture JSON"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw = json.loads(args.input.read_text())
+    tests = raw.get("tests", [])
+
+    normalized_cases: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+
+    for index, test in enumerate(tests, start=1):
+        supported, reason = is_supported(test)
+        if not supported:
+            skipped.append(
+                {
+                    "id": f"html5lib-smoke-{index}",
+                    "description": test.get("description", f"case {index}"),
+                    "reason": reason,
+                }
+            )
+            continue
+
+        normalized_cases.append(normalize_case(index, test))
+
+    normalized = {
+        "format": "venture-html-lexer-fixtures/v1",
+        "suite": "html5lib-smoke",
+        "description": "Normalized html5lib-style tokenizer smoke cases lowered into the Venture fixture schema.",
+        "source": args.input.name,
+        "generator": "normalize_html5lib_fixtures.py",
+        "supported_initial_states": sorted(SUPPORTED_INITIAL_STATES),
+        "cases": normalized_cases,
+        "skipped": skipped,
+    }
+
+    args.output.write_text(json.dumps(normalized, indent=2) + "\n")
+    return 0
+
+
+def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
+    initial_states = test.get("initialStates", [])
+    if initial_states and set(initial_states) != SUPPORTED_INITIAL_STATES:
+        return False, f"unsupported initialStates={initial_states!r}"
+
+    last_start_tag = test.get("lastStartTag")
+    if last_start_tag is not None:
+        return False, f"unsupported lastStartTag={last_start_tag!r}"
+
+    for token in test.get("output", []):
+        kind = token[0]
+        if kind not in {"Character", "StartTag", "EndTag", "Comment", "DOCTYPE"}:
+            return False, f"unsupported token kind `{kind}`"
+
+    return True, ""
+
+
+def normalize_case(index: int, test: dict[str, Any]) -> dict[str, Any]:
+    tokens: list[str] = []
+    pending_text = ""
+
+    for token in test["output"]:
+        kind = token[0]
+        if kind == "Character":
+            pending_text += token[1]
+            continue
+
+        if pending_text:
+            tokens.append(f"Text(data={pending_text})")
+            pending_text = ""
+
+        if kind == "StartTag":
+            tokens.append(normalize_start_tag(token))
+        elif kind == "EndTag":
+            tokens.append(f"EndTag(name={token[1]})")
+        elif kind == "Comment":
+            tokens.append(f"Comment(data={token[1]})")
+        elif kind == "DOCTYPE":
+            force_quirks = not bool(token[4])
+            tokens.append(f"Doctype(name={token[1]}, force_quirks={str(force_quirks).lower()})")
+
+    if pending_text:
+        tokens.append(f"Text(data={pending_text})")
+
+    tokens.append("EOF")
+
+    return {
+        "id": f"html5lib-smoke-{index}",
+        "description": test.get("description", f"case {index}"),
+        "input": test["input"],
+        "tokens": tokens,
+        "diagnostics": [error["code"] for error in test.get("errors", [])],
+    }
+
+
+def normalize_start_tag(token: list[Any]) -> str:
+    name = token[1]
+    attributes = token[2]
+    self_closing = bool(token[3]) if len(token) > 3 else False
+
+    if not attributes:
+        attribute_summary = "[]"
+    else:
+        pairs = ", ".join(f"{key}={value}" for key, value in attributes.items())
+        attribute_summary = f"[{pairs}]"
+
+    return (
+        f"StartTag(name={name}, attributes={attribute_summary}, "
+        f"self_closing={str(self_closing).lower()})"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -19,6 +19,16 @@
       ]
     },
     {
+      "description": "explicit data state fixture still normalizes",
+      "initialStates": ["Data state"],
+      "input": "<em>Hi</em>",
+      "output": [
+        ["StartTag", "em", {}],
+        ["Character", "Hi"],
+        ["EndTag", "em"]
+      ]
+    },
+    {
       "description": "doctype plus single attribute start tag",
       "input": "<!DOCTYPE html><p class=test>Hi</p>",
       "output": [
@@ -29,6 +39,13 @@
       ]
     },
     {
+      "description": "self closing start tag uses html5lib boolean slot",
+      "input": "<br/>",
+      "output": [
+        ["StartTag", "br", {}, true]
+      ]
+    },
+    {
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "output": [
@@ -36,6 +53,17 @@
       ],
       "errors": [
         {"code": "eof-in-comment", "line": 1, "col": 9}
+      ]
+    },
+    {
+      "description": "unsupported rcdata fixture is skipped by the importer",
+      "initialStates": ["RCDATA state"],
+      "lastStartTag": "title",
+      "input": "Hello&lt;/title>",
+      "output": [
+        ["Character", "Hello"],
+        ["Character", "<"],
+        ["Character", "/title>"]
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add a checked-in html5lib fixture importer script plus a generated normalized `html5lib-smoke.json` corpus
- move the Rust conformance harness to consume the generated normalized corpus while still parsing the raw upstream-style fixture for metadata checks
- broaden the raw html5lib smoke file with explicit data-state coverage, self-closing tags, and a skipped unsupported case so the importer path is visible

## Testing
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo fmt -p coding-adventures-html-lexer`
- `git diff --check`
- attempted `cargo check -p coding-adventures-html-lexer --tests`

The normalized corpus regenerates cleanly. The local Cargo environment still hit the same hang after `coding-adventures-html-lexer` started checking, so I’m leaning on CI for the final verification again.

Follow-up to #1189.