### PR TITLE
Complete ALGOL for-loop support

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -170,6 +170,18 @@ class _EvalThunk:
     store_capable: bool = False
 
 
+@dataclass(frozen=True)
+class _ForElementPlan:
+    """A lowered for-list element and the labels needed to execute it."""
+
+    kind: str
+    node: ASTNode
+    entry_label: str
+    advance_label: str
+    dispatch_value: int
+    check_label: str | None = None
+
+
 class AlgolIrCompiler:
     """Compile a typed ALGOL AST into the repository's register IR.
 
@@ -1129,48 +1141,622 @@ class AlgolIrCompiler:
         if loop_token is None:
             raise CompileError("for loop is missing its control variable")
         loop_reference = self._require_reference(loop_token, "control")
-
-        elem = _first_direct_node(_first_direct_node(node, "for_list"), "for_elem")
-        pieces = _direct_nodes(elem, "arith_expr")
-        if elem is None or len(pieces) != 3:
-            raise CompileError("only step/until for-elements are supported")
-
-        start = self._compile_expr(pieces[0], scope)
-        self._emit_store_reference(loop_reference, scope, start)
+        body = _first_direct_node(node, "statement")
+        elements = _direct_nodes(_first_direct_node(node, "for_list"), "for_elem")
+        if not elements:
+            return
 
         index = self.loop_count
         self.loop_count += 1
-        start_label = f"loop_{index}_start"
+        if len(elements) == 1:
+            self._compile_single_for_element(
+                elements[0],
+                loop_reference=loop_reference,
+                body=body,
+                scope=scope,
+                index=index,
+            )
+            return
+
+        dispatch_label = f"loop_{index}_dispatch"
+        body_label = f"loop_{index}_body"
+        after_body_label = f"loop_{index}_after_body"
         end_label = f"loop_{index}_end"
-
-        self._label(start_label)
-        loop_value = self._emit_load_reference(loop_reference, scope)
-        limit = self._compile_expr(pieces[2], scope)
-        should_stop = self._fresh_reg()
+        active_element_reg = self._fresh_reg()
         self._emit(
-            IrOp.CMP_GT,
-            IrRegister(should_stop),
-            IrRegister(loop_value),
-            IrRegister(limit),
+            IrOp.LOAD_IMM,
+            IrRegister(active_element_reg),
+            IrImmediate(0),
         )
-        self._emit(IrOp.BRANCH_NZ, IrRegister(should_stop), IrLabel(end_label))
+        self._emit(IrOp.JUMP, IrLabel(dispatch_label))
 
-        body = _first_direct_node(node, "statement")
+        plans: list[_ForElementPlan] = []
+        for dispatch_value, elem in enumerate(elements):
+            kind = _for_element_kind(elem)
+            entry_label = f"loop_{index}_elem_{dispatch_value}_entry"
+            advance_label = f"loop_{index}_elem_{dispatch_value}_advance"
+            check_label = (
+                f"loop_{index}_elem_{dispatch_value}_check"
+                if kind == "step_until"
+                else None
+            )
+            plans.append(
+                _ForElementPlan(
+                    kind=kind,
+                    node=elem,
+                    entry_label=entry_label,
+                    advance_label=advance_label,
+                    dispatch_value=dispatch_value,
+                    check_label=check_label,
+                )
+            )
+
+        self._label(dispatch_label)
+        self._emit_for_dispatch(
+            active_element_reg,
+            dispatch_label,
+            tuple((plan.dispatch_value, plan.entry_label) for plan in plans),
+            default_label=end_label,
+        )
+
+        for plan_index, plan in enumerate(plans):
+            next_entry_label = (
+                plans[plan_index + 1].entry_label
+                if plan_index + 1 < len(plans)
+                else end_label
+            )
+            arith_nodes = _direct_nodes(plan.node, "arith_expr")
+            bool_node = _first_direct_node(plan.node, "bool_expr")
+
+            if plan.kind == "simple":
+                self._label(plan.entry_label)
+                value = self._compile_expr(arith_nodes[0], scope)
+                value = self._coerce_reg_to_type(
+                    value,
+                    self._expr_type(arith_nodes[0]),
+                    expected_type=loop_reference.type_name,
+                )
+                self._emit_store_reference(loop_reference, scope, value)
+                self._emit(
+                    IrOp.LOAD_IMM,
+                    IrRegister(active_element_reg),
+                    IrImmediate(plan.dispatch_value),
+                )
+                self._emit(IrOp.JUMP, IrLabel(body_label))
+                self._label(plan.advance_label)
+                self._emit(IrOp.JUMP, IrLabel(next_entry_label))
+                continue
+
+            if plan.kind == "while":
+                if bool_node is None:
+                    raise CompileError("for while-element is missing a condition")
+                self._label(plan.entry_label)
+                value = self._compile_expr(arith_nodes[0], scope)
+                value = self._coerce_reg_to_type(
+                    value,
+                    self._expr_type(arith_nodes[0]),
+                    expected_type=loop_reference.type_name,
+                )
+                self._emit_store_reference(loop_reference, scope, value)
+                condition = self._compile_expr(bool_node, scope)
+                self._emit(
+                    IrOp.BRANCH_Z,
+                    IrRegister(condition),
+                    IrLabel(next_entry_label),
+                )
+                self._emit(
+                    IrOp.LOAD_IMM,
+                    IrRegister(active_element_reg),
+                    IrImmediate(plan.dispatch_value),
+                )
+                self._emit(IrOp.JUMP, IrLabel(body_label))
+                self._label(plan.advance_label)
+                self._emit(IrOp.JUMP, IrLabel(plan.entry_label))
+                continue
+
+            if plan.kind != "step_until" or plan.check_label is None:
+                raise CompileError("unsupported for-element form")
+            self._label(plan.entry_label)
+            start = self._compile_expr(arith_nodes[0], scope)
+            start = self._coerce_reg_to_type(
+                start,
+                self._expr_type(arith_nodes[0]),
+                expected_type=loop_reference.type_name,
+            )
+            self._emit_store_reference(loop_reference, scope, start)
+            self._emit(IrOp.JUMP, IrLabel(plan.check_label))
+
+            self._label(plan.check_label)
+            step_value = self._compile_expr(arith_nodes[1], scope)
+            step_type = self._expr_type(arith_nodes[1])
+            limit_value = self._compile_expr(arith_nodes[2], scope)
+            limit_type = self._expr_type(arith_nodes[2])
+            self._emit_step_until_dispatch(
+                active_element_reg=active_element_reg,
+                dispatch_value=plan.dispatch_value,
+                loop_reference=loop_reference,
+                loop_scope=scope,
+                step_value=step_value,
+                step_type=step_type,
+                limit_value=limit_value,
+                limit_type=limit_type,
+                continue_label=body_label,
+                stop_label=next_entry_label,
+            )
+
+            self._label(plan.advance_label)
+            current_value = self._emit_load_reference(loop_reference, scope)
+            next_value = self._emit_numeric(
+                "+",
+                current_value,
+                loop_reference.type_name,
+                step_value,
+                step_type,
+            )
+            next_type = self._result_type_for_numeric_operator(
+                "+",
+                loop_reference.type_name,
+                step_type,
+            )
+            next_value = self._coerce_reg_to_type(
+                next_value,
+                next_type,
+                expected_type=loop_reference.type_name,
+            )
+            self._emit_store_reference(loop_reference, scope, next_value)
+            self._emit(IrOp.JUMP, IrLabel(plan.check_label))
+
+        self._label(body_label)
         if body is not None:
             self._compile_statement(body, scope)
+        self._label(after_body_label)
+        self._emit_for_dispatch(
+            active_element_reg,
+            after_body_label,
+            tuple((plan.dispatch_value, plan.advance_label) for plan in plans),
+            default_label=end_label,
+        )
+        self._label(end_label)
 
+    def _compile_single_for_element(
+        self,
+        elem: ASTNode,
+        *,
+        loop_reference: ResolvedReference,
+        body: ASTNode | None,
+        scope: _FrameScope,
+        index: int,
+    ) -> None:
+        kind = _for_element_kind(elem)
+        if kind == "simple":
+            value_node = _direct_nodes(elem, "arith_expr")[0]
+            value = self._compile_expr(value_node, scope)
+            value = self._coerce_reg_to_type(
+                value,
+                self._expr_type(value_node),
+                expected_type=loop_reference.type_name,
+            )
+            self._emit_store_reference(loop_reference, scope, value)
+            if body is not None:
+                self._compile_statement(body, scope)
+            return
+
+        if kind == "while":
+            value_node = _direct_nodes(elem, "arith_expr")[0]
+            condition_node = _first_direct_node(elem, "bool_expr")
+            if condition_node is None:
+                raise CompileError("for while-element is missing a condition")
+            start_label = f"loop_{index}_start"
+            end_label = f"loop_{index}_end"
+            self._label(start_label)
+            value = self._compile_expr(value_node, scope)
+            value = self._coerce_reg_to_type(
+                value,
+                self._expr_type(value_node),
+                expected_type=loop_reference.type_name,
+            )
+            self._emit_store_reference(loop_reference, scope, value)
+            condition = self._compile_expr(condition_node, scope)
+            self._emit(IrOp.BRANCH_Z, IrRegister(condition), IrLabel(end_label))
+            if body is not None:
+                self._compile_statement(body, scope)
+            self._emit(IrOp.JUMP, IrLabel(start_label))
+            self._label(end_label)
+            return
+
+        if kind != "step_until":
+            raise CompileError("unsupported for-element form")
+
+        nodes = _direct_nodes(elem, "arith_expr")
+        start_node = nodes[0]
+        step_node = nodes[1]
+        limit_node = nodes[2]
+        start = self._compile_expr(start_node, scope)
+        start = self._coerce_reg_to_type(
+            start,
+            self._expr_type(start_node),
+            expected_type=loop_reference.type_name,
+        )
+        self._emit_store_reference(loop_reference, scope, start)
+
+        start_label = f"loop_{index}_start"
+        body_label = f"loop_{index}_body"
+        end_label = f"loop_{index}_end"
+        self._label(start_label)
+        step_value = self._compile_expr(step_node, scope)
+        step_type = self._expr_type(step_node)
+        limit_value = self._compile_expr(limit_node, scope)
+        limit_type = self._expr_type(limit_node)
+        self._emit_step_until_branch(
+            loop_reference=loop_reference,
+            loop_scope=scope,
+            step_value=step_value,
+            step_type=step_type,
+            limit_value=limit_value,
+            limit_type=limit_type,
+            label_prefix=f"loop_{index}",
+            continue_label=body_label,
+            stop_label=end_label,
+        )
+        self._label(body_label)
+        if body is not None:
+            self._compile_statement(body, scope)
         current_value = self._emit_load_reference(loop_reference, scope)
-        step = self._compile_expr(pieces[1], scope)
-        next_value = self._fresh_reg()
-        self._emit(
-            IrOp.ADD,
-            IrRegister(next_value),
-            IrRegister(current_value),
-            IrRegister(step),
+        next_value = self._emit_numeric(
+            "+",
+            current_value,
+            loop_reference.type_name,
+            step_value,
+            step_type,
+        )
+        next_type = self._result_type_for_numeric_operator(
+            "+",
+            loop_reference.type_name,
+            step_type,
+        )
+        next_value = self._coerce_reg_to_type(
+            next_value,
+            next_type,
+            expected_type=loop_reference.type_name,
         )
         self._emit_store_reference(loop_reference, scope, next_value)
         self._emit(IrOp.JUMP, IrLabel(start_label))
         self._label(end_label)
+
+    def _emit_step_until_branch(
+        self,
+        *,
+        loop_reference: ResolvedReference,
+        loop_scope: _FrameScope,
+        step_value: int,
+        step_type: str,
+        limit_value: int,
+        limit_type: str,
+        label_prefix: str,
+        continue_label: str,
+        stop_label: str,
+    ) -> None:
+        positive_label = f"{label_prefix}_positive"
+        negative_or_zero_label = f"{label_prefix}_negative_or_zero"
+        negative_label = f"{label_prefix}_negative"
+        compare_type = (
+            _REAL_TYPE
+            if _REAL_TYPE in {loop_reference.type_name, limit_type}
+            else _INTEGER_TYPE
+        )
+        step_type_for_compare = self._result_type_for_numeric_operator(
+            "+",
+            step_type,
+            _INTEGER_TYPE,
+        )
+        zero = (
+            self._const_f64_reg(0.0)
+            if step_type_for_compare == _REAL_TYPE
+            else self._const_reg(0)
+        )
+        step_for_compare = self._coerce_reg_to_type(
+            step_value,
+            step_type,
+            expected_type=step_type_for_compare,
+        )
+        is_positive = self._fresh_reg()
+        if step_type_for_compare == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_GT,
+                IrRegister(is_positive),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_GT,
+                IrRegister(is_positive),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(is_positive),
+            IrLabel(positive_label),
+        )
+
+        self._label(negative_or_zero_label)
+        is_negative = self._fresh_reg()
+        if step_type_for_compare == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(is_negative),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_LT,
+                IrRegister(is_negative),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(is_negative),
+            IrLabel(negative_label),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
+
+        self._label(positive_label)
+        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        positive_loop = self._coerce_reg_to_type(
+            loop_value,
+            loop_reference.type_name,
+            expected_type=compare_type,
+        )
+        positive_limit = self._coerce_reg_to_type(
+            limit_value,
+            limit_type,
+            expected_type=compare_type,
+        )
+        should_stop_positive = self._fresh_reg()
+        if compare_type == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_GT,
+                IrRegister(should_stop_positive),
+                IrRegister(positive_loop),
+                IrRegister(positive_limit),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_GT,
+                IrRegister(should_stop_positive),
+                IrRegister(positive_loop),
+                IrRegister(positive_limit),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(should_stop_positive),
+            IrLabel(stop_label),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
+
+        self._label(negative_label)
+        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        negative_loop = self._coerce_reg_to_type(
+            loop_value,
+            loop_reference.type_name,
+            expected_type=compare_type,
+        )
+        negative_limit = self._coerce_reg_to_type(
+            limit_value,
+            limit_type,
+            expected_type=compare_type,
+        )
+        should_stop_negative = self._fresh_reg()
+        if compare_type == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(should_stop_negative),
+                IrRegister(negative_loop),
+                IrRegister(negative_limit),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_LT,
+                IrRegister(should_stop_negative),
+                IrRegister(negative_loop),
+                IrRegister(negative_limit),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(should_stop_negative),
+            IrLabel(stop_label),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
+
+    def _emit_for_dispatch(
+        self,
+        active_element_reg: int,
+        label_prefix: str,
+        branches: tuple[tuple[int, str], ...],
+        *,
+        default_label: str,
+    ) -> None:
+        for dispatch_value, target_label in branches:
+            next_label = f"{label_prefix}_{dispatch_value}_next"
+            expected = self._const_reg(dispatch_value)
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(active_element_reg),
+                IrRegister(expected),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(next_label))
+            self._emit(IrOp.JUMP, IrLabel(target_label))
+            self._label(next_label)
+        self._emit(IrOp.JUMP, IrLabel(default_label))
+
+    def _emit_step_until_dispatch(
+        self,
+        *,
+        active_element_reg: int,
+        dispatch_value: int,
+        loop_reference: ResolvedReference,
+        loop_scope: _FrameScope,
+        step_value: int,
+        step_type: str,
+        limit_value: int,
+        limit_type: str,
+        continue_label: str,
+        stop_label: str,
+    ) -> None:
+        positive_label = f"{continue_label}_{dispatch_value}_positive"
+        negative_or_zero_label = f"{continue_label}_{dispatch_value}_negative_or_zero"
+        negative_label = f"{continue_label}_{dispatch_value}_negative"
+        compare_type = (
+            _REAL_TYPE
+            if _REAL_TYPE in {loop_reference.type_name, limit_type}
+            else _INTEGER_TYPE
+        )
+        step_type_for_compare = self._result_type_for_numeric_operator(
+            "+",
+            step_type,
+            _INTEGER_TYPE,
+        )
+        zero = (
+            self._const_f64_reg(0.0)
+            if step_type_for_compare == _REAL_TYPE
+            else self._const_reg(0)
+        )
+        step_for_compare = self._coerce_reg_to_type(
+            step_value,
+            step_type,
+            expected_type=step_type_for_compare,
+        )
+        is_positive = self._fresh_reg()
+        if step_type_for_compare == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_GT,
+                IrRegister(is_positive),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_GT,
+                IrRegister(is_positive),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(is_positive),
+            IrLabel(positive_label),
+        )
+
+        self._label(negative_or_zero_label)
+        is_negative = self._fresh_reg()
+        if step_type_for_compare == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(is_negative),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_LT,
+                IrRegister(is_negative),
+                IrRegister(step_for_compare),
+                IrRegister(zero),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(is_negative),
+            IrLabel(negative_label),
+        )
+        self._emit(
+            IrOp.LOAD_IMM,
+            IrRegister(active_element_reg),
+            IrImmediate(dispatch_value),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
+
+        self._label(positive_label)
+        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        positive_loop = self._coerce_reg_to_type(
+            loop_value,
+            loop_reference.type_name,
+            expected_type=compare_type,
+        )
+        positive_limit = self._coerce_reg_to_type(
+            limit_value,
+            limit_type,
+            expected_type=compare_type,
+        )
+        should_stop_positive = self._fresh_reg()
+        if compare_type == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_GT,
+                IrRegister(should_stop_positive),
+                IrRegister(positive_loop),
+                IrRegister(positive_limit),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_GT,
+                IrRegister(should_stop_positive),
+                IrRegister(positive_loop),
+                IrRegister(positive_limit),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(should_stop_positive),
+            IrLabel(stop_label),
+        )
+        self._emit(
+            IrOp.LOAD_IMM,
+            IrRegister(active_element_reg),
+            IrImmediate(dispatch_value),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
+
+        self._label(negative_label)
+        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        negative_loop = self._coerce_reg_to_type(
+            loop_value,
+            loop_reference.type_name,
+            expected_type=compare_type,
+        )
+        negative_limit = self._coerce_reg_to_type(
+            limit_value,
+            limit_type,
+            expected_type=compare_type,
+        )
+        should_stop_negative = self._fresh_reg()
+        if compare_type == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(should_stop_negative),
+                IrRegister(negative_loop),
+                IrRegister(negative_limit),
+            )
+        else:
+            self._emit(
+                IrOp.CMP_LT,
+                IrRegister(should_stop_negative),
+                IrRegister(negative_loop),
+                IrRegister(negative_limit),
+            )
+        self._emit(
+            IrOp.BRANCH_NZ,
+            IrRegister(should_stop_negative),
+            IrLabel(stop_label),
+        )
+        self._emit(
+            IrOp.LOAD_IMM,
+            IrRegister(active_element_reg),
+            IrImmediate(dispatch_value),
+        )
+        self._emit(IrOp.JUMP, IrLabel(continue_label))
 
     def _compile_expr(self, expr: ASTNode | Token, scope: _FrameScope) -> int:
         if isinstance(expr, Token):
@@ -3681,6 +4267,18 @@ def _direct_tokens(node: ASTNode | None) -> list[Token]:
     if node is None:
         return []
     return [child for child in node.children if isinstance(child, Token)]
+
+
+def _for_element_kind(node: ASTNode) -> str:
+    arith_count = len(_direct_nodes(node, "arith_expr"))
+    has_bool = _first_direct_node(node, "bool_expr") is not None
+    if has_bool:
+        return "while"
+    if arith_count == 3:
+        return "step_until"
+    if arith_count == 1:
+        return "simple"
+    return "unsupported"
 
 
 def _tokens(node: ASTNode | None) -> list[Token]:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -69,7 +69,51 @@ class TestAlgolIrCompiler:
             if instr.opcode == IrOp.LABEL
         ]
         assert "loop_0_start" in labels
+        assert "loop_0_positive" in labels
+        assert "loop_0_body" in labels
         assert "loop_0_end" in labels
+
+    def test_compiles_while_for_element(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i, x; x := 3; "
+                "for i := x while x > 0 do begin result := result + i; x := x - 1 end "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert IrOp.BRANCH_Z in opcodes
+        assert opcodes.count(IrOp.JUMP) >= 2
+
+    def test_compiles_multiple_for_elements_with_shared_body(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i; "
+                "for i := 1, 2 do "
+                "begin result := result * 10 + i; result := result * 10 + i end "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        assert labels.count("loop_0_body") == 1
+        assert "loop_0_after_body" in labels
+
+    def test_compiles_real_step_until_for_element(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real x; "
+                "for x := 1.5 step -0.5 until 0.5 do result := result + 1 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert IrOp.F64_CMP_GT in opcodes
+        assert IrOp.F64_CMP_LT in opcodes
+        assert IrOp.F64_ADD in opcodes
 
     def test_compiles_own_scalar_to_static_storage(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -336,6 +336,36 @@ class TestForLoop:
         )
         assert ast.rule_name == "program"
 
+    def test_simple_for_element(self) -> None:
+        """Simple one-shot for-elements parse correctly."""
+        ast = parse(
+            "begin integer i; integer result; "
+            "for i := 5 do result := i "
+            "end"
+        )
+        for_nodes = find_nodes(ast, "for_stmt")
+        assert len(for_nodes) >= 1
+
+    def test_while_for_element(self) -> None:
+        """While for-elements parse correctly."""
+        ast = parse(
+            "begin integer i; integer x; "
+            "for i := x while x > 0 do x := x - 1 "
+            "end"
+        )
+        for_nodes = find_nodes(ast, "for_stmt")
+        assert len(for_nodes) >= 1
+
+    def test_multiple_for_elements(self) -> None:
+        """Comma-separated for-elements parse correctly."""
+        ast = parse(
+            "begin integer i; integer x; integer result; "
+            "for i := 1 step 1 until 3, 5, x while x > 0 do result := i "
+            "end"
+        )
+        for_nodes = find_nodes(ast, "for_stmt")
+        assert len(for_nodes) >= 1
+
 
 # ---------------------------------------------------------------------------
 # Nested block tests

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1301,18 +1301,78 @@ class AlgolTypeChecker:
             self._error(node, "for loop is missing its control variable")
             return
         symbol = self._resolve_name(loop_name, scope, role="control")
-        if symbol is not None and symbol.type_name != INTEGER:
-            self._error(loop_name, "for loop control variable must be integer")
+        loop_type = ERROR if symbol is None else symbol.type_name
+        if loop_type != ERROR and loop_type not in {INTEGER, REAL}:
+            self._error(loop_name, "for loop control variable must be integer or real")
 
         for elem in _direct_nodes(_first_direct_node(node, "for_list"), "for_elem"):
             arith_nodes = _direct_nodes(elem, "arith_expr")
-            if len(arith_nodes) != 3:
-                self._error(elem, "only step/until for-elements are supported")
+            bool_node = _first_direct_node(elem, "bool_expr")
+            if bool_node is not None:
+                if len(arith_nodes) != 1:
+                    self._error(elem, "for while-element must have one value expression")
+                    continue
+                start_type = self._infer_expr(arith_nodes[0], scope)
+                if (
+                    loop_type != ERROR
+                    and start_type != ERROR
+                    and not self._can_assign(loop_type, start_type)
+                ):
+                    self._error(
+                        arith_nodes[0],
+                        f"cannot assign {start_type} to {loop_type} for loop control "
+                        f"variable {loop_name.value!r}",
+                    )
+                condition_type = self._infer_expr(bool_node, scope)
+                if condition_type != ERROR and condition_type != BOOLEAN:
+                    self._error(bool_node, "for while-element condition must be boolean")
                 continue
-            for arith_node in arith_nodes:
-                expr_type = self._infer_expr(arith_node, scope)
-                if expr_type != ERROR and expr_type != INTEGER:
-                    self._error(arith_node, "for loop bounds must be integer")
+            if len(arith_nodes) == 1:
+                value_type = self._infer_expr(arith_nodes[0], scope)
+                if (
+                    loop_type != ERROR
+                    and value_type != ERROR
+                    and not self._can_assign(loop_type, value_type)
+                ):
+                    self._error(
+                        arith_nodes[0],
+                        f"cannot assign {value_type} to {loop_type} for loop control "
+                        f"variable {loop_name.value!r}",
+                    )
+                continue
+            if len(arith_nodes) != 3:
+                self._error(elem, "unsupported for-element form")
+                continue
+
+            start_type = self._infer_expr(arith_nodes[0], scope)
+            if (
+                loop_type != ERROR
+                and start_type != ERROR
+                and not self._can_assign(loop_type, start_type)
+            ):
+                self._error(
+                    arith_nodes[0],
+                    f"cannot assign {start_type} to {loop_type} for loop control "
+                    f"variable {loop_name.value!r}",
+                )
+
+            step_type = self._infer_expr(arith_nodes[1], scope)
+            if step_type != ERROR and not _is_numeric_type(step_type):
+                self._error(arith_nodes[1], "for loop step must be numeric")
+            elif (
+                loop_type != ERROR
+                and step_type != ERROR
+                and not self._can_assign(loop_type, step_type)
+            ):
+                self._error(
+                    arith_nodes[1],
+                    f"cannot assign {step_type} to {loop_type} for loop control "
+                    f"variable {loop_name.value!r}",
+                )
+
+            limit_type = self._infer_expr(arith_nodes[2], scope)
+            if limit_type != ERROR and not _is_numeric_type(limit_type):
+                self._error(arith_nodes[2], "for loop limit must be numeric")
 
         body = _first_direct_node(node, "statement")
         if body is not None:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -331,11 +331,25 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "exponentiation is not supported" in result.diagnostics[0].message
 
-    def test_reports_unsupported_simple_for_element(self) -> None:
+    def test_accepts_simple_for_element(self) -> None:
         ast = parse_algol("begin integer result, i; for i := 1 do result := i end")
-        result = check_algol(ast)
-        assert not result.ok
-        assert "only step/until" in result.diagnostics[0].message
+        assert check_algol(ast).ok
+
+    def test_accepts_while_for_element(self) -> None:
+        ast = parse_algol(
+            "begin integer result, i, x; x := 3; "
+            "for i := x while x > 0 do begin result := result + i; x := x - 1 end "
+            "end"
+        )
+        assert check_algol(ast).ok
+
+    def test_accepts_multiple_for_elements_and_real_control(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; "
+            "for x := 1.5 step -0.5 until 0.5, 2.0 do result := result + 1 "
+            "end"
+        )
+        assert check_algol(ast).ok
 
     def test_accepts_nested_block_scope(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
@@ -154,9 +154,16 @@ def _wasm_lowering_strategy(program: IrProgram) -> str:
         if (
             instruction.operands
             and isinstance(instruction.operands[0], IrLabel)
-            and instruction.operands[0].name.startswith("algol_label_")
         ):
-            return "dispatch_loop"
+            label_name = instruction.operands[0].name
+            if label_name.startswith("algol_label_"):
+                return "dispatch_loop"
+            if label_name.startswith("loop_") and "_dispatch" in label_name:
+                return "dispatch_loop"
+            if label_name.startswith("loop_") and (
+                "_positive" in label_name or "_negative" in label_name
+            ):
+                return "dispatch_loop"
     return "structured"
 
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -67,6 +67,44 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
 
+    def test_simple_for_element_executes_once(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "result := 0; "
+            "for i := 5 do result := result + i "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
+    def test_while_for_element_reevaluates_value_each_iteration(self) -> None:
+        result = compile_source(
+            "begin integer result, i, x; "
+            "result := 0; x := 3; "
+            "for i := x while x > 0 do "
+            "begin result := result + i; x := x - 1 end "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [6]
+
+    def test_multiple_for_elements_share_one_body(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "result := 0; "
+            "for i := 1, 2 do "
+            "begin result := result * 10 + i; result := result * 10 + i end "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1122]
+
+    def test_real_step_until_for_element_supports_negative_step(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "result := 0; "
+            "for x := 1.5 step -0.5 until 0.5 do result := result + 1 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [3]
+
     def test_builtin_print_string_literal_writes_stdout(self) -> None:
         result = compile_source("begin integer result; print('Hi'); result := 7 end")
         captured: list[str] = []


### PR DESCRIPTION
## Summary
- complete ALGOL `for` support across the checker and IR compiler for simple, `while`, multi-element, and real-controlled loops
- lower single-element loops through direct loop IR and multi-element for-lists through shared-body dispatch so the body is emitted once
- add parser, checker, IR, and WASM coverage for the new loop forms, including real negative-step loops and mixed for-lists

## Validation
- `python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -q -k 'simple_for_element or while_for_element or multiple_for_elements'`
- `python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-parser/tests/test_algol_parser.py code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`