### PR TITLE
Support typed ALGOL arrays

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -667,6 +667,35 @@ class TestAlgolIrCompiler:
         assert IrOp.LOAD_F64 in opcodes
         assert IrOp.F64_CMP_GT in opcodes
 
+    def test_compiles_boolean_array_descriptor_and_element_accesses(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean array flags[1:2]; "
+                "flags[1] := true; "
+                "if flags[1] then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.STORE_WORD in opcodes
+        assert IrOp.LOAD_WORD in opcodes
+        assert IrOp.BRANCH_Z in opcodes
+
+    def test_compiles_string_array_element_output(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; string array messages[1:2]; "
+                "messages[1] := 'Hi'; print(messages[1]); result := 1 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.STORE_WORD in opcodes
+        assert IrOp.LOAD_WORD in opcodes
+        assert IrOp.SYSCALL in opcodes
+
     def test_compiles_dynamic_multidimensional_array_bounds(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -592,11 +592,10 @@ class AlgolTypeChecker:
         element_type = (
             _first_keyword_value(type_node) if type_node is not None else REAL
         )
-        if element_type not in {INTEGER, REAL}:
+        if element_type not in {INTEGER, BOOLEAN, REAL, STRING}:
             self._error(
                 node,
-                f"{element_type} arrays are not supported yet; "
-                "use integer or real array",
+                f"{element_type} arrays are not supported yet",
             )
             return
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -678,6 +678,31 @@ class TestAlgolTypeChecker:
         assert result.semantic is not None
         assert result.semantic.arrays[0].element_type == "real"
 
+    def test_accepts_boolean_array_element_assignment(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean array flags[1:2]; "
+            "flags[1] := true; "
+            "if flags[1] then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.arrays[0].element_type == "boolean"
+
+    def test_accepts_string_array_element_assignment(self) -> None:
+        ast = parse_algol(
+            "begin integer result; string array messages[1:2]; "
+            "messages[1] := 'Hi'; print(messages[1]); result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.arrays[0].element_type == "string"
+
     def test_rejects_wrong_array_subscript_count(self) -> None:
         ast = parse_algol(
             "begin integer result; integer array a[1:3, 1:3]; result := a[1] end"
@@ -703,6 +728,16 @@ class TestAlgolTypeChecker:
 
         assert not result.ok
         assert "cannot assign boolean to real variable" in result.diagnostics[0].message
+
+    def test_rejects_non_string_array_element_assignment(self) -> None:
+        ast = parse_algol("begin string array messages[1:2]; messages[1] := 1 end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "cannot assign integer to string variable"
+            in result.diagnostics[0].message
+        )
 
     def test_rejects_array_used_without_subscripts(self) -> None:
         ast = parse_algol("begin integer result; integer array a[1:3]; result := a end")

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -15,7 +15,8 @@ already supports a substantial ALGOL 60 surface:
 - nested blocks and nested procedures with lexical access through static links
 - `integer`, `boolean`, `real`, and `string` scalar values
 - `own` scalars and arrays with static lifetime
-- arrays with runtime bounds and checked element access
+- arrays of `integer`, `boolean`, `real`, and `string` values with runtime
+  bounds and checked element access
 - value and by-name parameters, including Jensen-style expression thunks
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -888,6 +888,40 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_boolean_array_element_store_and_load(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean array flags[1:2]; "
+            "flags[1] := true; "
+            "if flags[1] then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_string_array_element_store_and_output(self) -> None:
+        result = compile_source(
+            "begin integer result; string array messages[1:2]; "
+            "messages[1] := 'Hi'; print(messages[1]); result := 8 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [8]
+        assert "".join(captured) == "Hi"
+
+    def test_string_array_element_by_name_uses_word_thunks(self) -> None:
+        result = compile_source(
+            "begin integer result; string array messages[1:1]; "
+            "procedure setmsg(x); string x; begin x := 'Bye' end; "
+            "messages[1] := 'Hi'; setmsg(messages[1]); print(messages[1]); result := 9 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [9]
+        assert "".join(captured) == "Bye"
+
     def test_multidimensional_real_array_uses_row_major_offsets(self) -> None:
         result = compile_source(
             "begin integer result; real array a[1:2, 1:2]; "


### PR DESCRIPTION
## Summary
- allow `boolean array` and `string array` declarations in the ALGOL checker
- add end-to-end coverage for boolean array reads/writes, string array output, and string array elements passed by name
- update the ALGOL WASM README so the documented array surface matches the implementation

## Validation
- `python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/README.md`
- `git diff --check`