### PR TITLE
Support ALGOL impl and eqv boolean operators

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1822,6 +1822,7 @@ class AlgolIrCompiler:
             "expr_and",
             "simple_bool",
             "implication",
+            "bool_factor",
             "bool_term",
         }:
             return self._compile_bool_chain(expr.rule_name, meaningful, scope)
@@ -1909,13 +1910,13 @@ class AlgolIrCompiler:
             if not isinstance(operator, Token):
                 raise CompileError("expected boolean operator")
             value = operator.value
-            if value == "and" or rule_name in {"expr_and", "bool_term"}:
+            if value == "and":
                 dst = self._fresh_reg()
                 self._emit(
                     IrOp.AND, IrRegister(dst), IrRegister(current), IrRegister(right)
                 )
                 current = dst
-            elif value == "or" or rule_name in {"expr_or", "simple_bool"}:
+            elif value == "or":
                 summed = self._fresh_reg()
                 dst = self._fresh_reg()
                 self._emit(
@@ -1923,6 +1924,26 @@ class AlgolIrCompiler:
                 )
                 self._emit(
                     IrOp.CMP_NE, IrRegister(dst), IrRegister(summed), IrRegister(0)
+                )
+                current = dst
+            elif value == "impl":
+                inverted = self._invert_bool(current)
+                summed = self._fresh_reg()
+                dst = self._fresh_reg()
+                self._emit(
+                    IrOp.ADD,
+                    IrRegister(summed),
+                    IrRegister(inverted),
+                    IrRegister(right),
+                )
+                self._emit(
+                    IrOp.CMP_NE, IrRegister(dst), IrRegister(summed), IrRegister(0)
+                )
+                current = dst
+            elif value == "eqv":
+                dst = self._fresh_reg()
+                self._emit(
+                    IrOp.CMP_EQ, IrRegister(dst), IrRegister(current), IrRegister(right)
                 )
                 current = dst
             else:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -510,6 +510,32 @@ class TestAlgolIrCompiler:
         assert IrOp.CMP_GT in opcodes
         assert IrOp.AND in opcodes
 
+    def test_compiles_boolean_implication_form(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "if true impl false then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.ADD_IMM in opcodes
+        assert IrOp.AND_IMM in opcodes
+        assert IrOp.CMP_NE in opcodes
+
+    def test_compiles_boolean_equivalence_form(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "if true eqv false then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.CMP_EQ in opcodes
+
     def test_compiles_boolean_variable_storage_and_readback(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -460,6 +460,52 @@ class TestBooleanExpression:
         )
         assert ast.rule_name == "program"
 
+    def test_implication_expression(self) -> None:
+        """Boolean expression with IMPL."""
+        ast = parse(
+            "begin integer x; "
+            "if true impl false then x := 1 else x := 0 "
+            "end"
+        )
+        impl_nodes = find_nodes(ast, "implication")
+        assert any(
+            token.value == "impl"
+            for node in impl_nodes
+            for token in child_tokens(node)
+        )
+
+    def test_equivalence_expression(self) -> None:
+        """Boolean expression with EQV."""
+        ast = parse(
+            "begin integer x; "
+            "if true eqv false then x := 1 else x := 0 "
+            "end"
+        )
+        eqv_nodes = find_nodes(ast, "simple_bool")
+        assert any(
+            token.value == "eqv"
+            for node in eqv_nodes
+            for token in child_tokens(node)
+        )
+
+    def test_or_binds_tighter_than_implication(self) -> None:
+        """``or`` should parse inside the left operand of ``impl``."""
+        ast = parse(
+            "begin integer x; "
+            "if true or false impl false then x := 1 else x := 0 "
+            "end"
+        )
+        impl_nodes = find_nodes(ast, "implication")
+        assert any(
+            any(
+                child.rule_name == "bool_term"
+                and any(token.value == "or" for token in child_tokens(child))
+                for child in child_nodes(node)
+            )
+            and any(token.value == "impl" for token in child_tokens(node))
+            for node in impl_nodes
+        )
+
     def test_complex_boolean(self) -> None:
         """A complex boolean expression with multiple operators."""
         ast = parse(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1453,6 +1453,7 @@ class AlgolTypeChecker:
             "expr_and",
             "simple_bool",
             "implication",
+            "bool_factor",
             "bool_term",
         }:
             return self._fold_binary(expr, meaningful, scope, BOOLEAN, BOOLEAN)

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -310,6 +310,14 @@ class TestAlgolTypeChecker:
         )
         assert check_algol(ast).ok
 
+    def test_accepts_boolean_implication_and_equivalence(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "if (true impl false) eqv false then result := 1 else result := 0 "
+            "end"
+        )
+        assert check_algol(ast).ok
+
     def test_reports_chained_assignment(self) -> None:
         ast = parse_algol("begin integer result, other; result := other := 1 end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -269,6 +269,38 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_boolean_implication_truth_table(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "result := 0; "
+            "if true impl false then result := result + 8 else result := result; "
+            "if true impl true then result := result + 4 else result := result; "
+            "if false impl false then result := result + 2 else result := result; "
+            "if false impl true then result := result + 1 else result := result "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_boolean_equivalence_truth_table(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "result := 0; "
+            "if true eqv true then result := result + 8 else result := result; "
+            "if true eqv false then result := result + 4 else result := result; "
+            "if false eqv false then result := result + 2 else result := result; "
+            "if false eqv true then result := result + 1 else result := result "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
+
+    def test_or_binds_tighter_than_implication(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "if true or false impl false then result := 1 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
     def test_real_variable_assignment_drives_comparison(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- lower ALGOL `impl` and `eqv` boolean operators through the IR compiler
- fix boolean-condition `and` handling in the `bool_factor` grammar lane used by conditional expressions
- add parser, type-checker, IR, and WASM coverage for implication, equivalence, and `or`/`impl` precedence

## Validation
- `python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -k 'implication_expression or equivalence_expression or or_binds_tighter_than_implication' -q`
- `python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k 'not array_failure_in_procedure_unwinds_before_caller_continues' -q`
- `python3.12 -m ruff check --select F,E9 ...`
- `git diff --check`

## Notes
- The full parser test file still has the same two unrelated baseline failures already present on `main` (`test_block_has_begin_end` and `test_multiplication_precedence`).
- The full WASM test file still stalls on the existing stress test `test_array_failure_in_procedure_unwinds_before_caller_continues`; the rest of the file passes, and the new boolean-runtime tests pass directly.