### PR TITLE
feat(rust): track rcdata fixture contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -37,3 +37,6 @@ documented in this file.
 - A checked-in importer script and generated normalized `html5lib-smoke.json`
   corpus so broader upstream-style cases can be regenerated instead of
   hand-maintained in Rust tests.
+- RCDATA and `lastStartTag` support in the html5lib importer, with normalized
+  fixture metadata that lets Rust tests distinguish executable cases from
+  runtime gaps that still need lexer support.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -46,6 +46,12 @@ upstream-style file. This makes the future WPT/html5lib import path concrete
 without coupling the shared harness to upstream file formats or requiring raw
 fixture normalization logic to live forever inside the Rust tests.
 
+The normalized corpus now carries optional tokenizer-context metadata such as
+`initial_state` and `last_start_tag`, so upstream RCDATA cases can already live
+in the shared Venture fixture format even before the Rust wrapper knows how to
+execute them. Current Rust conformance tests run the executable subset and
+report the RCDATA cases as runtime gaps to drive the next lexer expansion.
+
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files
 directly. That gives us a clean expansion path from the HTML 1.x floor toward

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -20,10 +20,16 @@ struct FixtureSuite {
 #[derive(Debug, Clone, Deserialize)]
 struct FixtureCase {
     id: String,
+    #[serde(default)]
+    description: String,
     input: String,
     tokens: Vec<String>,
     #[serde(default)]
     diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,7 +96,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 7);
+    assert_eq!(file.tests.len(), 9);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -106,6 +112,11 @@ fn html5lib_smoke_fixture_file_parses() {
         vec!["RCDATA state".to_string()]
     );
     assert_eq!(file.tests[6].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        file.tests[8].initial_states,
+        vec!["RAWTEXT state".to_string()]
+    );
+    assert_eq!(file.tests[8].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -119,19 +130,29 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     assert_eq!(normalized.generator, "normalize_html5lib_fixtures.py");
     assert_eq!(
         normalized.supported_initial_states,
-        vec!["Data state".to_string()]
+        vec!["Data state".to_string(), "RCDATA state".to_string()]
     );
-    assert_eq!(normalized.cases.len(), 6);
+    assert_eq!(normalized.cases.len(), 8);
     assert_eq!(normalized.skipped.len(), 1);
-    assert_eq!(normalized.skipped[0].id, "html5lib-smoke-7");
+    assert_eq!(normalized.skipped[0].id, "html5lib-smoke-9");
     assert_eq!(
         normalized.skipped[0].description,
-        "unsupported rcdata fixture is skipped by the importer"
+        "unsupported rawtext fixture is skipped by the importer"
     );
     assert_eq!(
         normalized.skipped[0].reason,
-        "unsupported initialStates=['RCDATA state']"
+        "unsupported initialStates=['RAWTEXT state']"
     );
+    assert_eq!(
+        normalized.cases[6].initial_state.as_deref(),
+        Some("RCDATA state")
+    );
+    assert_eq!(normalized.cases[6].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        normalized.cases[7].initial_state.as_deref(),
+        Some("RCDATA state")
+    );
+    assert_eq!(normalized.cases[7].last_start_tag.as_deref(), Some("title"));
 }
 
 #[test]
@@ -165,7 +186,7 @@ fn html1_conformance_cases_match_default_wrapper() {
 #[test]
 fn normalized_html5lib_cases_match_default_wrapper() {
     let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
-    let suite = fixture_suite_from_normalized(&normalized);
+    let suite = executable_suite_from_normalized(&normalized);
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
@@ -179,13 +200,36 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 #[test]
 fn normalized_html5lib_cases_match_generated_html1_machine() {
     let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
-    let suite = fixture_suite_from_normalized(&normalized);
+    let suite = executable_suite_from_normalized(&normalized);
 
     run_fixture_suite(&suite, || {
         html1_machine()
             .map(HtmlLexer::new)
             .map_err(|error| error.to_string())
     });
+}
+
+#[test]
+fn normalized_html5lib_cases_report_runtime_gaps_for_rcdata_context() {
+    let normalized = load_html5lib_normalized_suite(HTML5LIB_NORMALIZED_FIXTURES);
+    let unsupported = unsupported_runtime_cases(&normalized);
+
+    assert_eq!(unsupported.len(), 2);
+    assert_eq!(unsupported[0].id, "html5lib-smoke-7");
+    assert_eq!(
+        unsupported[0].description,
+        "rcdata matching end tag emits end tag token"
+    );
+    assert_eq!(
+        unsupported[0].initial_state.as_deref(),
+        Some("RCDATA state")
+    );
+    assert_eq!(unsupported[0].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(unsupported[1].id, "html5lib-smoke-8");
+    assert_eq!(
+        unsupported[1].description,
+        "rcdata non matching end tag stays text"
+    );
 }
 
 fn load_suite(raw: &str) -> FixtureSuite {
@@ -200,12 +244,33 @@ fn load_html5lib_normalized_suite(raw: &str) -> Html5libNormalizedSuite {
     serde_json::from_str(raw).expect("normalized html5lib fixture suite should parse")
 }
 
-fn fixture_suite_from_normalized(normalized: &Html5libNormalizedSuite) -> FixtureSuite {
+fn executable_suite_from_normalized(normalized: &Html5libNormalizedSuite) -> FixtureSuite {
     FixtureSuite {
         format: normalized.format.clone(),
         suite: normalized.suite.clone(),
-        description: normalized.description.clone(),
-        cases: normalized.cases.clone(),
+        description: format!("{} (runtime-executable subset)", normalized.description),
+        cases: normalized
+            .cases
+            .iter()
+            .filter(|case| is_supported_by_current_runtime(case))
+            .cloned()
+            .collect(),
+    }
+}
+
+fn unsupported_runtime_cases(normalized: &Html5libNormalizedSuite) -> Vec<FixtureCase> {
+    normalized
+        .cases
+        .iter()
+        .filter(|case| !is_supported_by_current_runtime(case))
+        .cloned()
+        .collect()
+}
+
+fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
+    match case.initial_state.as_deref() {
+        None | Some("Data state") => case.last_start_tag.is_none(),
+        Some(_) => false,
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -19,6 +19,7 @@ Each file is a JSON object with this shape:
   "cases": [
     {
       "id": "stable-case-id",
+      "description": "human-readable case summary",
       "input": "<P>Hello</P>",
       "tokens": [
         "StartTag(name=p, attributes=[], self_closing=false)",
@@ -26,6 +27,8 @@ Each file is a JSON object with this shape:
         "EndTag(name=p)",
         "EOF"
       ],
+      "initial_state": "optional tokenizer state context",
+      "last_start_tag": "optional tokenizer tag context",
       "diagnostics": ["optional-diagnostic-code"]
     }
   ]
@@ -65,6 +68,7 @@ currently supports:
 
 - default data-state cases
 - explicit `initialStates: ["Data state"]`
+- `initialStates: ["RCDATA state"]` together with `lastStartTag`
 - `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens
 - html5lib start-tag self-closing booleans
 - tokenizer error codes lowered into Venture diagnostics
@@ -72,7 +76,10 @@ currently supports:
 Unsupported raw cases are skipped into metadata in the generated file rather
 than silently disappearing. Rust conformance tests execute the generated
 `html5lib-smoke.json` corpus and separately parse the raw upstream-style file to
-keep the intake path visible.
+keep the intake path visible. Cases that require tokenizer context the current
+Rust wrapper cannot yet execute, such as RCDATA, stay in the generated corpus
+with `initial_state` / `last_start_tag` metadata so they can be reported as
+runtime gaps instead of being discarded.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -5,7 +5,8 @@
   "source": "upstream-html5lib-smoke.test",
   "generator": "normalize_html5lib_fixtures.py",
   "supported_initial_states": [
-    "Data state"
+    "Data state",
+    "RCDATA state"
   ],
   "cases": [
     {
@@ -42,7 +43,8 @@
         "EndTag(name=em)",
         "EOF"
       ],
-      "diagnostics": []
+      "diagnostics": [],
+      "initial_state": "Data state"
     },
     {
       "id": "html5lib-smoke-4",
@@ -78,13 +80,38 @@
       "diagnostics": [
         "eof-in-comment"
       ]
+    },
+    {
+      "id": "html5lib-smoke-7",
+      "description": "rcdata matching end tag emits end tag token",
+      "input": "Hello</title>",
+      "tokens": [
+        "Text(data=Hello)",
+        "EndTag(name=title)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-8",
+      "description": "rcdata non matching end tag stays text",
+      "input": "Hello&lt;/title>",
+      "tokens": [
+        "Text(data=Hello</title>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
     }
   ],
   "skipped": [
     {
-      "id": "html5lib-smoke-7",
-      "description": "unsupported rcdata fixture is skipped by the importer",
-      "reason": "unsupported initialStates=['RCDATA state']"
+      "id": "html5lib-smoke-9",
+      "description": "unsupported rawtext fixture is skipped by the importer",
+      "reason": "unsupported initialStates=['RAWTEXT state']"
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 
-SUPPORTED_INITIAL_STATES = {"Data state"}
+SUPPORTED_INITIAL_STATES = {"Data state", "RCDATA state"}
 
 
 def parse_args() -> argparse.Namespace:
@@ -63,11 +63,17 @@ def main() -> int:
 
 def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     initial_states = test.get("initialStates", [])
-    if initial_states and set(initial_states) != SUPPORTED_INITIAL_STATES:
+    if len(initial_states) > 1:
+        return False, f"unsupported initialStates={initial_states!r}"
+
+    if initial_states and initial_states[0] not in SUPPORTED_INITIAL_STATES:
         return False, f"unsupported initialStates={initial_states!r}"
 
     last_start_tag = test.get("lastStartTag")
-    if last_start_tag is not None:
+    if initial_states == ["RCDATA state"] and not isinstance(last_start_tag, str):
+        return False, "RCDATA state requires lastStartTag"
+
+    if initial_states != ["RCDATA state"] and last_start_tag is not None:
         return False, f"unsupported lastStartTag={last_start_tag!r}"
 
     for token in test.get("output", []):
@@ -107,13 +113,23 @@ def normalize_case(index: int, test: dict[str, Any]) -> dict[str, Any]:
 
     tokens.append("EOF")
 
-    return {
+    normalized = {
         "id": f"html5lib-smoke-{index}",
         "description": test.get("description", f"case {index}"),
         "input": test["input"],
         "tokens": tokens,
         "diagnostics": [error["code"] for error in test.get("errors", [])],
     }
+
+    initial_states = test.get("initialStates", [])
+    if initial_states:
+        normalized["initial_state"] = initial_states[0]
+
+    last_start_tag = test.get("lastStartTag")
+    if last_start_tag is not None:
+        normalized["last_start_tag"] = last_start_tag
+
+    return normalized
 
 
 def normalize_start_tag(token: list[Any]) -> str:

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -56,7 +56,17 @@
       ]
     },
     {
-      "description": "unsupported rcdata fixture is skipped by the importer",
+      "description": "rcdata matching end tag emits end tag token",
+      "initialStates": ["RCDATA state"],
+      "lastStartTag": "title",
+      "input": "Hello</title>",
+      "output": [
+        ["Character", "Hello"],
+        ["EndTag", "title"]
+      ]
+    },
+    {
+      "description": "rcdata non matching end tag stays text",
       "initialStates": ["RCDATA state"],
       "lastStartTag": "title",
       "input": "Hello&lt;/title>",
@@ -64,6 +74,16 @@
         ["Character", "Hello"],
         ["Character", "<"],
         ["Character", "/title>"]
+      ]
+    },
+    {
+      "description": "unsupported rawtext fixture is skipped by the importer",
+      "initialStates": ["RAWTEXT state"],
+      "lastStartTag": "style",
+      "input": "body { color: red; }</style>",
+      "output": [
+        ["Character", "body { color: red; }"],
+        ["EndTag", "style"]
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- extend the html5lib importer and normalized fixture schema to carry tokenizer context such as `initial_state` and `last_start_tag`
- add real RCDATA raw fixtures plus generated normalized cases, while still skipping unsupported RAWTEXT input in importer metadata
- update the Rust conformance harness to execute only the currently supported subset and report RCDATA cases as runtime gaps for the next lexer expansion

## Testing
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo fmt -p coding-adventures-html-lexer`
- `git diff --check`
- attempted `cargo check -p coding-adventures-html-lexer --tests`

The normalized corpus regenerates cleanly. The local Cargo environment still hit the same hang after `coding-adventures-html-lexer` started checking, so I’m leaning on CI for the final verification again.

Follow-up to #1213.