### PR TITLE
feat(barcode-2d): add Elixir implementation

### DIFF
--- a/code/packages/elixir/barcode_2d/.gitignore
+++ b/code/packages/elixir/barcode_2d/.gitignore
@@ -1,0 +1,5 @@
+_build/
+deps/
+cover/
+*.beam
+erl_crash.dump

--- a/code/packages/elixir/barcode_2d/BUILD
+++ b/code/packages/elixir/barcode_2d/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/barcode_2d/CHANGELOG.md
+++ b/code/packages/elixir/barcode_2d/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog — coding_adventures_barcode_2d (Elixir)
+
+All notable changes to this package are documented here.
+
+---
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- `CodingAdventures.Barcode2D.ModuleGrid` struct — the universal intermediate
+  representation for all 2D barcode encoders. Holds `rows`, `cols`, a
+  list-of-lists boolean `modules` grid, and a `module_shape` (`:square` or
+  `:hex`).
+
+- `CodingAdventures.Barcode2D.Barcode2DLayoutConfig` struct — pixel-level
+  layout options with defaults matching the TypeScript implementation:
+  `module_size_px: 10.0`, `quiet_zone_modules: 4`, `foreground: "#000000"`,
+  `background: "#ffffff"`, `show_annotations: false`, `module_shape: :square`.
+
+- `make_module_grid/3` — creates an all-light `ModuleGrid` of the given
+  dimensions and module shape. Starting point for every encoder.
+
+- `set_module/4` — pure immutable single-module update. Returns
+  `{:ok, new_grid}` on success or `{:error, reason}` for out-of-bounds access.
+  Uses `List.replace_at/3` to avoid mutating the original grid.
+
+- `layout/2` — converts a `ModuleGrid` to a `PaintScene` (from the
+  `paint_instructions` package). Dispatches to `layout_square` or `layout_hex`
+  based on `module_shape`. Returns `{:ok, scene}` or `{:error, reason}`.
+
+- Square rendering: each dark module → one `paint_rect`. Total canvas size
+  includes quiet zone on all four sides.
+
+- Hex rendering (MaxiCode): each dark module → one `paint_path` with seven
+  commands (`move_to`, five `line_to`, `close`) tracing a flat-top regular
+  hexagon. Odd rows offset right by `hex_width / 2` for standard hexagonal
+  tiling.
+
+- Full ExUnit test suite with 100% coverage (61 tests, 0 failures), covering
+  all happy paths, edge cases, and all validation error branches.

--- a/code/packages/elixir/barcode_2d/README.md
+++ b/code/packages/elixir/barcode_2d/README.md
@@ -1,0 +1,108 @@
+# coding_adventures_barcode_2d
+
+Elixir port of the shared 2D barcode abstraction layer.
+
+## What it does
+
+This package provides the two building blocks every 2D barcode format needs:
+
+1. **`ModuleGrid`** — the universal intermediate representation produced by
+   every 2D barcode encoder (QR Code, Data Matrix, Aztec Code, PDF417,
+   MaxiCode). It is a 2D boolean grid: `true` = dark module, `false` = light
+   module.
+
+2. **`layout/2`** — the single function that converts abstract module
+   coordinates into pixel-level `PaintScene` instructions ready for the PaintVM
+   to render.
+
+## Where it fits in the pipeline
+
+```
+Input data
+  → format encoder (qr-code, data-matrix, aztec…)
+  → ModuleGrid          ← produced by the encoder
+  → layout/2            ← THIS PACKAGE converts to pixels
+  → PaintScene          ← consumed by paint-vm (P2D01)
+  → backend (SVG, Metal, Canvas, terminal…)
+```
+
+All coordinates before `layout/2` are measured in "module units" — abstract
+grid steps. Only `layout/2` multiplies by `module_size_px` to produce real
+pixel coordinates. Encoders never need to know about screen resolution or
+output format.
+
+## Usage
+
+```elixir
+alias CodingAdventures.Barcode2D
+alias CodingAdventures.Barcode2D.Barcode2DLayoutConfig
+
+# 1. Create an all-light grid (21×21 = QR Code version 1).
+grid = Barcode2D.make_module_grid(21, 21)
+
+# 2. Paint some dark modules (here: just the top-left corner for demo).
+{:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+{:ok, grid} = Barcode2D.set_module(grid, 0, 1, true)
+
+# 3. Convert to a PaintScene with default config.
+{:ok, scene} = Barcode2D.layout(grid)
+# scene.width  == 290.0  ((21 + 2*4) * 10)
+# scene.height == 290.0
+# scene.instructions contains 1 background rect + 2 dark rects
+
+# Custom config:
+config = %Barcode2DLayoutConfig{
+  module_size_px: 5.0,
+  quiet_zone_modules: 2,
+  foreground: "#000000",
+  background: "#ffffff"
+}
+{:ok, scene} = Barcode2D.layout(grid, config)
+
+# MaxiCode (hex modules, 33×30):
+hex_grid = Barcode2D.make_module_grid(33, 30, :hex)
+{:ok, hex_grid} = Barcode2D.set_module(hex_grid, 0, 0, true)
+hex_config = %Barcode2DLayoutConfig{module_shape: :hex}
+{:ok, hex_scene} = Barcode2D.layout(hex_grid, hex_config)
+```
+
+## Module shapes
+
+- **`:square`** (default) — used by QR Code, Data Matrix, Aztec Code, PDF417.
+  Each dark module becomes a `paint_rect`.
+
+- **`:hex`** — used by MaxiCode (ISO/IEC 16023). Uses flat-top hexagons in an
+  offset-row grid. Each dark module becomes a `paint_path` tracing six
+  vertices. Odd rows are offset right by `hex_width / 2`.
+
+## Hex geometry
+
+```
+hex_width  = module_size_px
+hex_height = module_size_px * (sqrt(3) / 2)   -- vertical row step
+circum_r   = module_size_px / sqrt(3)          -- center-to-vertex distance
+
+Vertices at angles 0°, 60°, 120°, 180°, 240°, 300° from center.
+```
+
+## Error handling
+
+Both `set_module/4` and `layout/2` return `{:ok, result}` or `{:error, reason}`.
+
+`layout/2` returns an error when:
+- `module_size_px <= 0`
+- `quiet_zone_modules < 0`
+- `config.module_shape` does not match `grid.module_shape`
+
+## Running tests
+
+```bash
+cd code/packages/elixir/barcode_2d
+mix deps.get
+mix test --cover
+```
+
+## Dependencies
+
+- [`coding_adventures_paint_instructions`](../paint_instructions) — provides
+  `paint_rect/6` and `paint_scene/5`.

--- a/code/packages/elixir/barcode_2d/lib/coding_adventures/barcode_2d.ex
+++ b/code/packages/elixir/barcode_2d/lib/coding_adventures/barcode_2d.ex
@@ -1,0 +1,582 @@
+defmodule CodingAdventures.Barcode2D do
+  @moduledoc """
+  Shared 2D barcode abstraction layer.
+
+  This module provides the two building blocks every 2D barcode format needs:
+
+    1. `ModuleGrid` — the universal intermediate representation produced by
+       every 2D barcode encoder (QR, Data Matrix, Aztec, PDF417, MaxiCode).
+       It is just a 2D boolean grid: `true` = dark module, `false` = light module.
+
+    2. `layout/2` — the single function that converts abstract module
+       coordinates into pixel-level `PaintScene` instructions ready for the
+       PaintVM to render.
+
+  ## Where this fits in the pipeline
+
+  ```
+  Input data
+    → format encoder (qr-code, data-matrix, aztec…)
+    → ModuleGrid          ← produced by the encoder
+    → layout/2            ← THIS MODULE converts to pixels
+    → PaintScene          ← consumed by paint-vm (P2D01)
+    → backend (SVG, Metal, Canvas, terminal…)
+  ```
+
+  All coordinates before `layout/2` are measured in "module units" — abstract
+  grid steps. Only `layout/2` multiplies by `module_size_px` to produce real
+  pixel coordinates. This means encoders never need to know anything about
+  screen resolution or output format.
+
+  ## Supported module shapes
+
+  - **square** (default): used by QR Code, Data Matrix, Aztec Code, PDF417.
+    Each module becomes a `paint_rect`.
+
+  - **hex** (flat-top hexagons): used by MaxiCode. Each module becomes a
+    `paint_path` tracing six vertices.
+
+  ## Immutability
+
+  `ModuleGrid` is a struct with a list-of-lists for modules. `set_module/4`
+  returns a new grid using `List.replace_at/3` without mutating the original.
+  This makes encoders easy to test, compose, and backtrack.
+
+  ## Elixir reserved word note
+
+  Elixir reserves words like `after`, `rescue`, `catch`, `else`, `end`.
+  These cannot be used as variable names. In this module we avoid them
+  entirely — for example "rest" instead of "after".
+  """
+
+  alias CodingAdventures.PaintInstructions
+
+  @version "0.1.0"
+  def version, do: @version
+
+  # ============================================================================
+  # ModuleGrid struct
+  # ============================================================================
+
+  defmodule ModuleGrid do
+    @moduledoc """
+    The universal intermediate representation produced by every 2D barcode
+    encoder.
+
+    Fields:
+
+    - `rows` — number of rows (height of the grid).
+    - `cols` — number of columns (width of the grid).
+    - `modules` — list of `rows` lists, each containing `cols` booleans.
+      `modules[row][col]` is `true` for a dark module, `false` for light.
+      Row 0 is the top row; column 0 is the leftmost column.
+    - `module_shape` — `:square` or `:hex`.
+
+    ## Example
+
+    A 3×3 grid with all modules light:
+
+    ```elixir
+    %ModuleGrid{
+      rows: 3,
+      cols: 3,
+      modules: [[false, false, false],
+                [false, false, false],
+                [false, false, false]],
+      module_shape: :square
+    }
+    ```
+    """
+
+    defstruct [:cols, :rows, :modules, :module_shape]
+
+    @type module_shape :: :square | :hex
+    @type t :: %__MODULE__{
+            cols: non_neg_integer(),
+            rows: non_neg_integer(),
+            modules: [[boolean()]],
+            module_shape: module_shape()
+          }
+  end
+
+  # ============================================================================
+  # Barcode2DLayoutConfig struct
+  # ============================================================================
+
+  defmodule Barcode2DLayoutConfig do
+    @moduledoc """
+    Configuration for `CodingAdventures.Barcode2D.layout/2`.
+
+    All fields have defaults so you can start with `%Barcode2DLayoutConfig{}`
+    and override only what you need.
+
+    | Field                | Default     | Notes                                      |
+    |----------------------|-------------|---------------------------------------------|
+    | `module_size_px`     | `10.0`      | Must be > 0. Width of one module in pixels. |
+    | `quiet_zone_modules` | `4`         | Quiet-zone width in module units (≥ 0).     |
+    | `foreground`         | `"#000000"` | Color for dark modules.                     |
+    | `background`         | `"#ffffff"` | Color for light modules and quiet zone.     |
+    | `show_annotations`   | `false`     | Reserved for future annotated rendering.    |
+    | `module_shape`       | `:square`   | Must match `ModuleGrid.module_shape`.        |
+
+    ## moduleSizePx / module_size_px
+
+    The size of one module in pixels. For square modules this is both width
+    and height. For hex modules it is the flat-to-flat hexagon width (also
+    equal to the side length for a regular hexagon).
+
+    ## quietZoneModules / quiet_zone_modules
+
+    Number of module-width units added as a quiet zone on **each** side of the
+    grid. QR Code requires a minimum of 4. Data Matrix requires 1.
+    """
+
+    defstruct module_size_px: 10.0,
+              quiet_zone_modules: 4,
+              foreground: "#000000",
+              background: "#ffffff",
+              show_annotations: false,
+              module_shape: :square
+
+    @type module_shape :: :square | :hex
+    @type t :: %__MODULE__{
+            module_size_px: float(),
+            quiet_zone_modules: non_neg_integer(),
+            foreground: String.t(),
+            background: String.t(),
+            show_annotations: boolean(),
+            module_shape: module_shape()
+          }
+  end
+
+  # ============================================================================
+  # make_module_grid/3 — create an all-light grid
+  # ============================================================================
+
+  @doc """
+  Create a new `ModuleGrid` with every module set to `false` (light).
+
+  This is the starting point for every 2D barcode encoder. The encoder calls
+  `make_module_grid(rows, cols)` and then uses `set_module/4` to paint dark
+  modules one by one as it places finder patterns, timing strips, data bits,
+  and error correction bits.
+
+  ## Parameters
+
+  - `rows` — number of rows (height). Must be a positive integer.
+  - `cols` — number of columns (width). Must be a positive integer.
+  - `module_shape` — `:square` (default) or `:hex`.
+
+  ## Example
+
+  Start a 21×21 QR Code v1 grid:
+
+  ```elixir
+  grid = CodingAdventures.Barcode2D.make_module_grid(21, 21)
+  # grid.rows == 21
+  # grid.cols == 21
+  # grid.modules |> List.first() |> List.first() == false  (all light)
+  ```
+  """
+  @spec make_module_grid(pos_integer(), pos_integer(), ModuleGrid.module_shape()) ::
+          ModuleGrid.t()
+  def make_module_grid(rows, cols, module_shape \\ :square) do
+    # Build rows*cols grid of false values.
+    # Each row is an independent list so set_module/4 can replace individual
+    # rows using List.replace_at/3 without copying the entire grid.
+    row_template = List.duplicate(false, cols)
+    modules = List.duplicate(row_template, rows)
+
+    %ModuleGrid{
+      rows: rows,
+      cols: cols,
+      modules: modules,
+      module_shape: module_shape
+    }
+  end
+
+  # ============================================================================
+  # set_module/4 — immutable single-module update
+  # ============================================================================
+
+  @doc """
+  Return a new `ModuleGrid` identical to `grid` except that module at
+  `(row, col)` is set to `dark`.
+
+  This function is **pure and immutable** — it never modifies the input grid.
+  Only the affected row is re-allocated via `List.replace_at/3`; all other
+  rows are shared between old and new grids.
+
+  Returns `{:ok, new_grid}` on success, or `{:error, reason}` if the
+  coordinates are out of bounds.
+
+  ## Why immutability matters
+
+  Barcode encoders often need to backtrack — e.g. trying all eight QR mask
+  patterns and keeping the best score. Immutable grids make this trivial:
+  save the grid before trying a mask, evaluate it, discard if the score is
+  worse. No undo stack needed.
+
+  ## Example
+
+  ```elixir
+  grid = CodingAdventures.Barcode2D.make_module_grid(3, 3)
+  {:ok, grid2} = CodingAdventures.Barcode2D.set_module(grid, 1, 1, true)
+  # grid.modules |> Enum.at(1) |> Enum.at(1) == false   (original unchanged)
+  # grid2.modules |> Enum.at(1) |> Enum.at(1) == true
+  ```
+  """
+  @spec set_module(ModuleGrid.t(), non_neg_integer(), non_neg_integer(), boolean()) ::
+          {:ok, ModuleGrid.t()} | {:error, String.t()}
+  def set_module(%ModuleGrid{} = grid, row, col, dark) do
+    cond do
+      row < 0 or row >= grid.rows ->
+        {:error,
+         "set_module: row #{row} out of range [0, #{grid.rows - 1}]"}
+
+      col < 0 or col >= grid.cols ->
+        {:error,
+         "set_module: col #{col} out of range [0, #{grid.cols - 1}]"}
+
+      true ->
+        # Replace only the affected row; Enum.at and List.replace_at work on
+        # Elixir lists in O(n) which is fine for typical barcode grid sizes.
+        old_row = Enum.at(grid.modules, row)
+        new_row = List.replace_at(old_row, col, dark)
+        new_modules = List.replace_at(grid.modules, row, new_row)
+        {:ok, %ModuleGrid{grid | modules: new_modules}}
+    end
+  end
+
+  # ============================================================================
+  # layout/2 — ModuleGrid → PaintScene
+  # ============================================================================
+
+  @doc """
+  Convert a `ModuleGrid` into a `PaintScene` ready for the PaintVM.
+
+  This is the **only** function in the entire 2D barcode stack that knows
+  about pixels. Everything above this step works in abstract module units.
+  Everything below this step is handled by the paint backend.
+
+  ## Square modules (the common case)
+
+  Each dark module at `(row, col)` becomes one `paint_rect`:
+
+  ```
+  quiet_zone_px = quiet_zone_modules * module_size_px
+  x = quiet_zone_px + col * module_size_px
+  y = quiet_zone_px + row * module_size_px
+  ```
+
+  Total symbol size (including quiet zone on all four sides):
+
+  ```
+  total_width  = (cols + 2 * quiet_zone_modules) * module_size_px
+  total_height = (rows + 2 * quiet_zone_modules) * module_size_px
+  ```
+
+  The scene always starts with one background `paint_rect` covering the full
+  symbol, ensuring the quiet zone and light modules are filled with the
+  background colour even if the backend has a transparent default.
+
+  ## Hex modules (MaxiCode)
+
+  Each dark module at `(row, col)` becomes one `paint_path` tracing a
+  flat-top regular hexagon. Odd-numbered rows are offset right by half a
+  hexagon width to produce the standard hexagonal tiling:
+
+  ```
+  Row 0:  ⬡ ⬡ ⬡ ⬡ ⬡
+  Row 1:   ⬡ ⬡ ⬡ ⬡ ⬡
+  Row 2:  ⬡ ⬡ ⬡ ⬡ ⬡
+  ```
+
+  Geometry for a flat-top hexagon with circumradius R (center to vertex):
+
+  ```
+  hex_width  = module_size_px
+  hex_height = module_size_px * (sqrt(3) / 2)
+  circum_r   = module_size_px / sqrt(3)
+
+  Vertex i:  ( cx + circum_r * cos(i * 60°),
+               cy + circum_r * sin(i * 60°) )
+  ```
+
+  Center coordinates including quiet zone offset:
+
+  ```
+  cx = quiet_zone_px + col * hex_width + (row rem 2) * (hex_width / 2)
+  cy = quiet_zone_px + row * hex_height
+  ```
+
+  ## Validation
+
+  Returns `{:error, reason}` if:
+  - `module_size_px <= 0`
+  - `quiet_zone_modules < 0`
+  - `config.module_shape != grid.module_shape`
+
+  ## Example
+
+  ```elixir
+  grid = CodingAdventures.Barcode2D.make_module_grid(5, 5)
+  {:ok, grid} = CodingAdventures.Barcode2D.set_module(grid, 2, 2, true)
+  {:ok, scene} = CodingAdventures.Barcode2D.layout(grid)
+  scene.width  # == 130.0  (5 + 2*4) * 10
+  scene.height # == 130.0
+  ```
+  """
+  @spec layout(ModuleGrid.t(), Barcode2DLayoutConfig.t()) ::
+          {:ok, PaintInstructions.paint_scene()} | {:error, String.t()}
+  def layout(%ModuleGrid{} = grid, %Barcode2DLayoutConfig{} = config \\ %Barcode2DLayoutConfig{}) do
+    with :ok <- validate_config(config, grid) do
+      if config.module_shape == :square do
+        {:ok, layout_square(grid, config)}
+      else
+        {:ok, layout_hex(grid, config)}
+      end
+    end
+  end
+
+  # ============================================================================
+  # validate_config/2 — internal config validation
+  # ============================================================================
+
+  # Validates the layout config against the grid. Returns :ok or {:error, msg}.
+  #
+  # Three things can go wrong:
+  #   1. module_size_px <= 0  — nonsensical pixel size
+  #   2. quiet_zone_modules < 0  — negative quiet zone
+  #   3. config.module_shape != grid.module_shape  — shape mismatch
+  defp validate_config(%Barcode2DLayoutConfig{} = config, %ModuleGrid{} = grid) do
+    cond do
+      config.module_size_px <= 0 ->
+        {:error, "module_size_px must be > 0, got #{config.module_size_px}"}
+
+      config.quiet_zone_modules < 0 ->
+        {:error, "quiet_zone_modules must be >= 0, got #{config.quiet_zone_modules}"}
+
+      config.module_shape != grid.module_shape ->
+        {:error,
+         "config.module_shape :#{config.module_shape} does not match " <>
+           "grid.module_shape :#{grid.module_shape}"}
+
+      true ->
+        :ok
+    end
+  end
+
+  # ============================================================================
+  # layout_square/2 — internal helper for square-module grids
+  # ============================================================================
+
+  # Render a square-module ModuleGrid into a PaintScene.
+  #
+  # Algorithm:
+  #   1. Compute total pixel dimensions including quiet zone.
+  #   2. Emit one background paint_rect covering the entire symbol.
+  #   3. For each dark module, emit one filled paint_rect.
+  #
+  # Light modules are covered by the background rect — no explicit light rects
+  # are emitted. This keeps the instruction count proportional to dark modules.
+  defp layout_square(%ModuleGrid{} = grid, %Barcode2DLayoutConfig{} = config) do
+    %{
+      module_size_px: module_size_px,
+      quiet_zone_modules: quiet_zone_modules,
+      foreground: foreground,
+      background: background
+    } = config
+
+    # Quiet zone in pixels on each side.
+    quiet_zone_px = quiet_zone_modules * module_size_px
+
+    # Total canvas dimensions including quiet zone on all four sides.
+    total_width = (grid.cols + 2 * quiet_zone_modules) * module_size_px
+    total_height = (grid.rows + 2 * quiet_zone_modules) * module_size_px
+
+    # Start with the background rect covering the whole symbol (quiet zone
+    # plus all modules). This ensures the background is filled even when the
+    # rendering backend defaults to transparent.
+    bg_rect = PaintInstructions.paint_rect(0, 0, total_width, total_height, background)
+
+    # Collect one paint_rect per dark module using Enum.with_index for indexed
+    # iteration (we need both the row index and the column index).
+    dark_rects =
+      grid.modules
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {row_data, row_idx} ->
+        row_data
+        |> Enum.with_index()
+        |> Enum.filter(fn {dark, _col_idx} -> dark end)
+        |> Enum.map(fn {_dark, col_idx} ->
+          # Pixel origin of this module (top-left corner of its square).
+          x = quiet_zone_px + col_idx * module_size_px
+          y = quiet_zone_px + row_idx * module_size_px
+          PaintInstructions.paint_rect(x, y, module_size_px, module_size_px, foreground)
+        end)
+      end)
+
+    instructions = [bg_rect | dark_rects]
+
+    PaintInstructions.paint_scene(
+      total_width,
+      total_height,
+      instructions,
+      background
+    )
+  end
+
+  # ============================================================================
+  # layout_hex/2 — internal helper for hex-module grids (MaxiCode)
+  # ============================================================================
+
+  # Render a hex-module ModuleGrid into a PaintScene.
+  #
+  # Used for MaxiCode (ISO/IEC 16023), which uses flat-top hexagons in an
+  # offset-row grid. Odd rows are shifted right by half a hexagon width.
+  #
+  # Flat-top hexagon geometry reminder:
+  #
+  #   A "flat-top" hexagon has two flat edges at the top and bottom:
+  #
+  #      ___
+  #     /   \      ← two vertices at top
+  #    |     |
+  #     \___/      ← two vertices at bottom
+  #
+  # For a flat-top hexagon centered at (cx, cy) with circumradius R:
+  #
+  #   Vertices at angles 0°, 60°, 120°, 180°, 240°, 300°:
+  #
+  #     angle  cos    sin    role
+  #       0°    1      0     right midpoint
+  #      60°   0.5   √3/2   bottom-right
+  #     120°  -0.5   √3/2   bottom-left
+  #     180°  -1      0     left midpoint
+  #     240°  -0.5  -√3/2   top-left
+  #     300°   0.5  -√3/2   top-right
+  #
+  # Tiling parameters:
+  #   hex_width  = module_size_px        (flat-to-flat = side length)
+  #   hex_height = module_size_px * √3/2  (vertical row step)
+  #   circum_r   = module_size_px / √3   (center-to-vertex distance)
+  defp layout_hex(%ModuleGrid{} = grid, %Barcode2DLayoutConfig{} = config) do
+    %{
+      module_size_px: module_size_px,
+      quiet_zone_modules: quiet_zone_modules,
+      foreground: foreground,
+      background: background
+    } = config
+
+    # Hex geometry constants.
+    hex_width = module_size_px
+    hex_height = module_size_px * (:math.sqrt(3) / 2.0)
+    circum_r = module_size_px / :math.sqrt(3)
+
+    quiet_zone_px = quiet_zone_modules * module_size_px
+
+    # Total canvas size. The +hex_width/2 accounts for the odd-row offset so
+    # the rightmost modules on odd rows don't clip outside the canvas.
+    total_width = (grid.cols + 2 * quiet_zone_modules) * hex_width + hex_width / 2
+    total_height = (grid.rows + 2 * quiet_zone_modules) * hex_height
+
+    # Background rect.
+    bg_rect = PaintInstructions.paint_rect(0, 0, total_width, total_height, background)
+
+    # One paint_path per dark module.
+    dark_paths =
+      grid.modules
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {row_data, row_idx} ->
+        row_data
+        |> Enum.with_index()
+        |> Enum.filter(fn {dark, _col_idx} -> dark end)
+        |> Enum.map(fn {_dark, col_idx} ->
+          # Center of this hexagon in pixel space.
+          # Odd rows shift right by hex_width/2 to interlock with even rows.
+          cx = quiet_zone_px + col_idx * hex_width + rem(row_idx, 2) * (hex_width / 2)
+          cy = quiet_zone_px + row_idx * hex_height
+
+          commands = build_flat_top_hex_path(cx, cy, circum_r)
+          paint_path(commands, foreground)
+        end)
+      end)
+
+    instructions = [bg_rect | dark_paths]
+
+    PaintInstructions.paint_scene(
+      total_width,
+      total_height,
+      instructions,
+      background
+    )
+  end
+
+  # ============================================================================
+  # build_flat_top_hex_path/3 — geometry helper
+  # ============================================================================
+
+  # Build the six path commands for a flat-top regular hexagon.
+  #
+  # The six vertices are placed at angles 0°, 60°, 120°, 180°, 240°, 300°
+  # from center (cx, cy) at circumradius circum_r:
+  #
+  #   vertex_i = ( cx + circum_r * cos(i * 60°),
+  #                cy + circum_r * sin(i * 60°) )
+  #
+  # The path is:
+  #   move_to  vertex 0
+  #   line_to  vertex 1
+  #   line_to  vertex 2
+  #   line_to  vertex 3
+  #   line_to  vertex 4
+  #   line_to  vertex 5
+  #   close
+  defp build_flat_top_hex_path(cx, cy, circum_r) do
+    deg_to_rad = :math.pi() / 180.0
+
+    # Compute all 6 vertices.
+    vertices =
+      Enum.map(0..5, fn i ->
+        angle = i * 60.0 * deg_to_rad
+        %{
+          x: cx + circum_r * :math.cos(angle),
+          y: cy + circum_r * :math.sin(angle)
+        }
+      end)
+
+    # Build path commands: move_to vertex 0, then line_to vertices 1-5, close.
+    [first_vertex | rest_vertices] = vertices
+
+    move_cmd = %{kind: :move_to, x: first_vertex.x, y: first_vertex.y}
+
+    line_cmds =
+      Enum.map(rest_vertices, fn v ->
+        %{kind: :line_to, x: v.x, y: v.y}
+      end)
+
+    close_cmd = %{kind: :close}
+
+    [move_cmd | line_cmds] ++ [close_cmd]
+  end
+
+  # ============================================================================
+  # paint_path/2 — local path instruction builder
+  # ============================================================================
+
+  # Build a paint_path instruction map.
+  #
+  # The Elixir paint_instructions package currently only exports paint_rect
+  # and paint_scene. Hex rendering needs a path instruction that carries a
+  # list of PathCommand maps. We represent it as a plain map with kind: :path,
+  # matching the convention used by the TypeScript paint-instructions package.
+  defp paint_path(commands, fill) do
+    %{
+      kind: :path,
+      commands: commands,
+      fill: fill,
+      metadata: %{}
+    }
+  end
+end

--- a/code/packages/elixir/barcode_2d/mix.exs
+++ b/code/packages/elixir/barcode_2d/mix.exs
@@ -1,0 +1,28 @@
+defmodule CodingAdventures.Barcode2D.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_barcode_2d,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"}
+    ]
+  end
+end

--- a/code/packages/elixir/barcode_2d/required_capabilities.json
+++ b/code/packages/elixir/barcode_2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/barcode_2d",
+  "capabilities": [],
+  "justification": "Pure 2D barcode layout and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/barcode_2d/test/barcode_2d_test.exs
+++ b/code/packages/elixir/barcode_2d/test/barcode_2d_test.exs
@@ -1,0 +1,607 @@
+defmodule CodingAdventures.Barcode2DTest do
+  use ExUnit.Case
+
+  alias CodingAdventures.Barcode2D
+  alias CodingAdventures.Barcode2D.ModuleGrid
+  alias CodingAdventures.Barcode2D.Barcode2DLayoutConfig
+
+  # ============================================================================
+  # version/0
+  # ============================================================================
+
+  describe "version/0" do
+    test "returns the package version string" do
+      assert Barcode2D.version() == "0.1.0"
+    end
+  end
+
+  # ============================================================================
+  # make_module_grid/3
+  # ============================================================================
+
+  describe "make_module_grid/3" do
+    test "creates a grid with correct dimensions" do
+      grid = Barcode2D.make_module_grid(5, 7)
+
+      assert grid.rows == 5
+      assert grid.cols == 7
+    end
+
+    test "all modules start as false (light)" do
+      grid = Barcode2D.make_module_grid(3, 4)
+
+      for row <- grid.modules do
+        for module <- row do
+          assert module == false
+        end
+      end
+    end
+
+    test "default module_shape is :square" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert grid.module_shape == :square
+    end
+
+    test "accepts :hex module_shape" do
+      grid = Barcode2D.make_module_grid(33, 30, :hex)
+
+      assert grid.module_shape == :hex
+      assert grid.rows == 33
+      assert grid.cols == 30
+    end
+
+    test "grid is a ModuleGrid struct" do
+      grid = Barcode2D.make_module_grid(2, 2)
+
+      assert %ModuleGrid{} = grid
+    end
+
+    test "modules list has correct row count" do
+      grid = Barcode2D.make_module_grid(6, 4)
+
+      assert length(grid.modules) == 6
+    end
+
+    test "each row has correct column count" do
+      grid = Barcode2D.make_module_grid(4, 9)
+
+      for row <- grid.modules do
+        assert length(row) == 9
+      end
+    end
+
+    test "creates a 21x21 QR Code v1 grid (smoke test)" do
+      # QR Code version 1 is always 21×21 modules.
+      grid = Barcode2D.make_module_grid(21, 21)
+
+      assert grid.rows == 21
+      assert grid.cols == 21
+      assert grid.module_shape == :square
+    end
+  end
+
+  # ============================================================================
+  # set_module/4
+  # ============================================================================
+
+  describe "set_module/4" do
+    test "sets a module to dark (true)" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 1, 1, true)
+
+      assert Enum.at(Enum.at(grid2.modules, 1), 1) == true
+    end
+
+    test "sets a module to light (false)" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      {:ok, grid2} = Barcode2D.set_module(grid, 0, 0, true)
+
+      {:ok, grid3} = Barcode2D.set_module(grid2, 0, 0, false)
+
+      assert Enum.at(Enum.at(grid3.modules, 0), 0) == false
+    end
+
+    test "original grid is unchanged after set_module" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, _grid2} = Barcode2D.set_module(grid, 1, 1, true)
+
+      # The original must still be all-light.
+      assert Enum.at(Enum.at(grid.modules, 1), 1) == false
+    end
+
+    test "only the specified position changes" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 0, 2, true)
+
+      # Position (0,2) is now dark.
+      assert Enum.at(Enum.at(grid2.modules, 0), 2) == true
+
+      # All other positions remain light.
+      assert Enum.at(Enum.at(grid2.modules, 0), 0) == false
+      assert Enum.at(Enum.at(grid2.modules, 0), 1) == false
+      assert Enum.at(Enum.at(grid2.modules, 1), 0) == false
+      assert Enum.at(Enum.at(grid2.modules, 2), 2) == false
+    end
+
+    test "returns error for negative row" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, msg} = Barcode2D.set_module(grid, -1, 0, true)
+      assert msg =~ "row"
+      assert msg =~ "-1"
+    end
+
+    test "returns error for row == rows" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, msg} = Barcode2D.set_module(grid, 3, 0, true)
+      assert msg =~ "row"
+    end
+
+    test "returns error for row > rows" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, _msg} = Barcode2D.set_module(grid, 100, 0, true)
+    end
+
+    test "returns error for negative col" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, msg} = Barcode2D.set_module(grid, 0, -1, true)
+      assert msg =~ "col"
+      assert msg =~ "-1"
+    end
+
+    test "returns error for col == cols" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, _msg} = Barcode2D.set_module(grid, 0, 3, true)
+    end
+
+    test "returns error for col > cols" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      assert {:error, _msg} = Barcode2D.set_module(grid, 0, 100, true)
+    end
+
+    test "set_module on top-left corner (0, 0)" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 0, 0, true)
+
+      assert Enum.at(Enum.at(grid2.modules, 0), 0) == true
+    end
+
+    test "set_module on bottom-right corner" do
+      grid = Barcode2D.make_module_grid(3, 4)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 2, 3, true)
+
+      assert Enum.at(Enum.at(grid2.modules, 2), 3) == true
+    end
+
+    test "chained set_module calls produce correct grid" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 0, 0, true)
+      {:ok, grid3} = Barcode2D.set_module(grid2, 1, 1, true)
+      {:ok, grid4} = Barcode2D.set_module(grid3, 2, 2, true)
+
+      # Diagonal should be dark.
+      assert Enum.at(Enum.at(grid4.modules, 0), 0) == true
+      assert Enum.at(Enum.at(grid4.modules, 1), 1) == true
+      assert Enum.at(Enum.at(grid4.modules, 2), 2) == true
+
+      # Off-diagonal should be light.
+      assert Enum.at(Enum.at(grid4.modules, 0), 1) == false
+      assert Enum.at(Enum.at(grid4.modules, 1), 0) == false
+    end
+
+    test "preserves rows, cols, module_shape" do
+      grid = Barcode2D.make_module_grid(5, 7, :hex)
+
+      {:ok, grid2} = Barcode2D.set_module(grid, 2, 3, true)
+
+      assert grid2.rows == 5
+      assert grid2.cols == 7
+      assert grid2.module_shape == :hex
+    end
+  end
+
+  # ============================================================================
+  # layout/2 — square modules (the common case)
+  # ============================================================================
+
+  describe "layout/2 with square modules" do
+    test "returns {:ok, scene} for a valid grid and default config" do
+      grid = Barcode2D.make_module_grid(5, 5)
+
+      assert {:ok, scene} = Barcode2D.layout(grid)
+      assert is_map(scene)
+    end
+
+    test "scene has correct total width including quiet zone" do
+      # (5 cols + 2*4 quiet) * 10 px = 130.0
+      grid = Barcode2D.make_module_grid(5, 5)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      assert scene.width == 130.0
+    end
+
+    test "scene has correct total height including quiet zone" do
+      grid = Barcode2D.make_module_grid(5, 5)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      assert scene.height == 130.0
+    end
+
+    test "scene background matches config" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, scene} = Barcode2D.layout(grid, %Barcode2DLayoutConfig{background: "#ff0000"})
+
+      assert scene.background == "#ff0000"
+    end
+
+    test "all-light grid produces 1 instruction (background only)" do
+      grid = Barcode2D.make_module_grid(5, 5)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      # Only the background rect; no dark modules.
+      assert length(scene.instructions) == 1
+    end
+
+    test "grid with one dark module produces 2 instructions" do
+      grid = Barcode2D.make_module_grid(5, 5)
+      {:ok, grid} = Barcode2D.set_module(grid, 2, 2, true)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      # Background + 1 dark rect.
+      assert length(scene.instructions) == 2
+    end
+
+    test "background instruction is a rect covering the whole canvas" do
+      grid = Barcode2D.make_module_grid(3, 3)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      bg = List.first(scene.instructions)
+      assert bg.kind == :rect
+      assert bg.x == 0
+      assert bg.y == 0
+      assert bg.width == scene.width
+      assert bg.height == scene.height
+    end
+
+    test "dark module rect has correct pixel position (square)" do
+      # Grid: 5×5, module_size_px 10, quiet_zone_modules 4
+      # Module at (row=1, col=2):
+      #   x = 4*10 + 2*10 = 60
+      #   y = 4*10 + 1*10 = 50
+      grid = Barcode2D.make_module_grid(5, 5)
+      {:ok, grid} = Barcode2D.set_module(grid, 1, 2, true)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      [_bg, dark_rect] = scene.instructions
+      assert dark_rect.x == 60.0
+      assert dark_rect.y == 50.0
+      assert dark_rect.width == 10.0
+      assert dark_rect.height == 10.0
+    end
+
+    test "dark module rect fill matches foreground color" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+
+      {:ok, scene} =
+        Barcode2D.layout(grid, %Barcode2DLayoutConfig{foreground: "#0000ff"})
+
+      [_bg, dark_rect] = scene.instructions
+      assert dark_rect.fill == "#0000ff"
+    end
+
+    test "custom module_size_px scales the scene correctly" do
+      # 3×3 grid, module_size_px=4, quiet_zone_modules=2
+      # total = (3 + 2*2) * 4 = 28
+      grid = Barcode2D.make_module_grid(3, 3)
+      config = %Barcode2DLayoutConfig{module_size_px: 4.0, quiet_zone_modules: 2}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      assert scene.width == 28.0
+      assert scene.height == 28.0
+    end
+
+    test "zero quiet_zone_modules is valid" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      config = %Barcode2DLayoutConfig{quiet_zone_modules: 0}
+
+      assert {:ok, scene} = Barcode2D.layout(grid, config)
+      # (3 + 0) * 10 = 30
+      assert scene.width == 30.0
+    end
+
+    test "all dark modules produces 1 + rows*cols instructions" do
+      grid = Barcode2D.make_module_grid(2, 2)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 1, true)
+      {:ok, grid} = Barcode2D.set_module(grid, 1, 0, true)
+      {:ok, grid} = Barcode2D.set_module(grid, 1, 1, true)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      # 1 background + 4 dark rects
+      assert length(scene.instructions) == 5
+    end
+
+    test "21x21 QR v1 empty grid layout" do
+      grid = Barcode2D.make_module_grid(21, 21)
+
+      {:ok, scene} = Barcode2D.layout(grid)
+
+      # (21 + 2*4) * 10 = 290
+      assert scene.width == 290.0
+      assert scene.height == 290.0
+      assert length(scene.instructions) == 1
+    end
+  end
+
+  # ============================================================================
+  # layout/2 — validation errors
+  # ============================================================================
+
+  describe "layout/2 validation" do
+    test "returns error when module_size_px == 0" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      config = %Barcode2DLayoutConfig{module_size_px: 0.0}
+
+      assert {:error, msg} = Barcode2D.layout(grid, config)
+      assert msg =~ "module_size_px"
+    end
+
+    test "returns error when module_size_px is negative" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      config = %Barcode2DLayoutConfig{module_size_px: -5.0}
+
+      assert {:error, msg} = Barcode2D.layout(grid, config)
+      assert msg =~ "module_size_px"
+    end
+
+    test "returns error when quiet_zone_modules is negative" do
+      grid = Barcode2D.make_module_grid(3, 3)
+      config = %Barcode2DLayoutConfig{quiet_zone_modules: -1}
+
+      assert {:error, msg} = Barcode2D.layout(grid, config)
+      assert msg =~ "quiet_zone_modules"
+    end
+
+    test "returns error when config.module_shape does not match grid.module_shape" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :square}
+
+      assert {:error, msg} = Barcode2D.layout(grid, config)
+      assert msg =~ "module_shape"
+    end
+
+    test "returns error when config is square but grid is hex" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+
+      # Default config has module_shape: :square.
+      assert {:error, _msg} = Barcode2D.layout(grid)
+    end
+
+    test "returns error when config is hex but grid is square" do
+      grid = Barcode2D.make_module_grid(3, 3, :square)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      assert {:error, _msg} = Barcode2D.layout(grid, config)
+    end
+  end
+
+  # ============================================================================
+  # layout/2 — hex modules (MaxiCode)
+  # ============================================================================
+
+  describe "layout/2 with hex modules" do
+    test "returns {:ok, scene} for a valid hex grid" do
+      grid = Barcode2D.make_module_grid(5, 5, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      assert {:ok, scene} = Barcode2D.layout(grid, config)
+      assert is_map(scene)
+    end
+
+    test "all-light hex grid produces 1 instruction (background only)" do
+      grid = Barcode2D.make_module_grid(5, 5, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      assert length(scene.instructions) == 1
+    end
+
+    test "one dark hex module produces 2 instructions" do
+      grid = Barcode2D.make_module_grid(5, 5, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      assert length(scene.instructions) == 2
+    end
+
+    test "dark hex module instruction has kind :path" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      assert path_instr.kind == :path
+    end
+
+    test "hex path has 7 commands (move_to + 5 line_to + close)" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      # 1 move_to + 5 line_to + 1 close = 7 commands
+      assert length(path_instr.commands) == 7
+    end
+
+    test "hex path first command is move_to" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      first_cmd = List.first(path_instr.commands)
+      assert first_cmd.kind == :move_to
+    end
+
+    test "hex path last command is close" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      last_cmd = List.last(path_instr.commands)
+      assert last_cmd.kind == :close
+    end
+
+    test "hex path commands 1-5 are line_to" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      # Commands index 1..5 (0-based) are line_to.
+      line_cmds = Enum.slice(path_instr.commands, 1, 5)
+      assert Enum.all?(line_cmds, fn c -> c.kind == :line_to end)
+    end
+
+    test "hex path fill matches foreground color" do
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 0, 0, true)
+      config = %Barcode2DLayoutConfig{module_shape: :hex, foreground: "#112233"}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      assert path_instr.fill == "#112233"
+    end
+
+    test "hex total width includes quiet zone and half-hex offset for odd rows" do
+      # hex_width = 10, quiet_zone_modules = 4, cols = 3
+      # total_width = (3 + 2*4) * 10 + 10/2 = 110 + 5 = 115
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :hex, module_size_px: 10.0, quiet_zone_modules: 4}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      assert scene.width == 115.0
+    end
+
+    test "hex total height uses sqrt(3)/2 row step" do
+      # hex_height = 10 * sqrt(3)/2 per row, rows=3, quiet_zone=4
+      # total_height = (3 + 8) * hex_height = 11 * (10 * sqrt(3)/2)
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :hex, module_size_px: 10.0, quiet_zone_modules: 4}
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      expected = 11 * 10.0 * (:math.sqrt(3) / 2.0)
+      assert_in_delta scene.height, expected, 1.0e-9
+    end
+
+    test "MaxiCode 33x30 hex grid layout smoke test" do
+      grid = Barcode2D.make_module_grid(33, 30, :hex)
+      config = %Barcode2DLayoutConfig{module_shape: :hex, quiet_zone_modules: 1}
+
+      assert {:ok, scene} = Barcode2D.layout(grid, config)
+      assert scene.width > 0
+      assert scene.height > 0
+    end
+
+    test "odd row hex module is offset right by half hex_width" do
+      # Row 1 (odd) at col 0 with module_size_px=10, quiet_zone_modules=0:
+      #   cx = 0 + 0*10 + 1*(10/2) = 5
+      #   cy = 0 + 1 * (10 * sqrt(3)/2)
+      grid = Barcode2D.make_module_grid(3, 3, :hex)
+      {:ok, grid} = Barcode2D.set_module(grid, 1, 0, true)
+
+      config = %Barcode2DLayoutConfig{
+        module_shape: :hex,
+        module_size_px: 10.0,
+        quiet_zone_modules: 0
+      }
+
+      {:ok, scene} = Barcode2D.layout(grid, config)
+
+      [_bg, path_instr] = scene.instructions
+      # First command is move_to vertex 0 at angle 0° (rightmost point).
+      # cx = 5.0, circumR = 10/sqrt(3)
+      # vertex 0 x = 5.0 + circumR
+      circum_r = 10.0 / :math.sqrt(3)
+      expected_x0 = 5.0 + circum_r
+
+      move_cmd = List.first(path_instr.commands)
+      assert_in_delta move_cmd.x, expected_x0, 1.0e-9
+    end
+  end
+
+  # ============================================================================
+  # Barcode2DLayoutConfig struct defaults
+  # ============================================================================
+
+  describe "Barcode2DLayoutConfig defaults" do
+    test "default module_size_px is 10.0" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.module_size_px == 10.0
+    end
+
+    test "default quiet_zone_modules is 4" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.quiet_zone_modules == 4
+    end
+
+    test "default foreground is #000000" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.foreground == "#000000"
+    end
+
+    test "default background is #ffffff" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.background == "#ffffff"
+    end
+
+    test "default show_annotations is false" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.show_annotations == false
+    end
+
+    test "default module_shape is :square" do
+      config = %Barcode2DLayoutConfig{}
+      assert config.module_shape == :square
+    end
+  end
+end

--- a/code/packages/elixir/barcode_2d/test/test_helper.exs
+++ b/code/packages/elixir/barcode_2d/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/specs/aztec-code.md
+++ b/code/specs/aztec-code.md
@@ -1,0 +1,1565 @@
+# Aztec Code
+
+## Overview
+
+This spec defines an **Aztec Code encoder** for the coding-adventures monorepo.
+
+Aztec Code was invented by Andrew Longacre Jr. at Welch Allyn in 1995 and
+published as a patent-free format. It is defined by **ISO/IEC 24778:2008** (with
+a 2014 corrigendum). The name comes from the central bullseye finder pattern,
+which resembles the stepped pyramid on the Aztec calendar.
+
+Where QR Code uses three square finder patterns at three corners, Aztec Code
+uses a single **bullseye at the center** of the symbol. This elegant design
+means there is no structural requirement for a large quiet zone — the scanner
+finds the center first, then reads outward. A 1-module quiet zone is
+recommended, but the standard does not mandate one.
+
+Aztec is in heavy operational use today:
+
+- **IATA boarding passes** — the barcode on every airline boarding pass
+- **Eurostar and Amtrak rail tickets** — printed and on-screen tickets
+- **US driver's licences** — AAMVA-standard PDF417 is common, but many states
+  also use Aztec
+- **PostNL, Deutsche Post, La Poste** — European postal routing
+- **US military ID cards**
+
+Understanding how to build an Aztec Code encoder from scratch teaches:
+
+- how a bullseye finder pattern enables orientation without corner anchors
+- how Reed-Solomon works in two different field sizes (GF(16) and GF(256))
+- how a spiral bit-layout algorithm works from the inside out
+- how variable-width codewords (4 bits, 5 bits, 8 bits) mix in one symbol
+- how bit stuffing prevents degenerate all-zero or all-one runs in a
+  two-dimensional code
+
+The encoder in this spec produces a **valid, scannable Aztec Code** for any
+input string or byte sequence that fits within a 32-layer full symbol. It does
+not implement decoding.
+
+---
+
+## Two Symbol Variants
+
+Aztec Code has two structurally different variants. The choice between them is
+determined automatically by the amount of data to encode, though the caller
+can force compact mode.
+
+### Compact Aztec
+
+Compact Aztec supports **1 to 4 layers**. The central bullseye is 11×11
+modules (radius 5 from the center module). Each added layer wraps a 4-module
+band around the symbol: 2 modules on each side.
+
+| Layers | Symbol size |
+|--------|-------------|
+| 1 | 15×15 |
+| 2 | 19×19 |
+| 3 | 23×23 |
+| 4 | 27×27 |
+
+Formula: `size = 11 + 4 * layers`
+
+The mode message (format information) for compact symbols occupies the 28-bit
+band in the innermost data layer (the ring immediately outside the bullseye),
+starting at the top-left corner of that ring and running clockwise.
+
+### Full Aztec
+
+Full Aztec supports **1 to 32 layers**. The central bullseye is 15×15 modules
+(radius 7 from the center). Same growth rule: 4 modules per layer.
+
+| Layers | Symbol size |
+|--------|-------------|
+| 1 | 19×19 |
+| 2 | 23×23 |
+| 3 | 27×27 |
+| 4 | 31×31 |
+| 5 | 35×35 |
+| 6 | 39×39 |
+| ... | ... |
+| 10 | 55×55 |
+| 15 | 75×75 |
+| 20 | 95×95 |
+| 22 | 103×103 |
+| 32 | 143×143 |
+
+Formula: `size = 15 + 4 * layers`
+
+The mode message for full symbols occupies the 40-bit band in the innermost
+data layer.
+
+### Choosing between compact and full
+
+The encoder selects the smallest symbol that fits the data at the requested
+ECC level:
+
+```
+1. Try compact layers 1, 2, 3, 4 in order.
+2. If none fit, try full layers 1, 2, 3, ..., 32 in order.
+3. If even full 32 layers cannot fit the data, raise InputTooLong.
+```
+
+The caller can override this with `compact: true` to force compact mode (and
+raise InputTooLong if the data does not fit in 4 compact layers).
+
+---
+
+## Symbol Structure
+
+A complete Aztec Code symbol has the following concentric structural zones,
+reading from the center outward:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   quiet zone (1 module)              │
+│  ┌────────────────────────────────────────────────┐  │
+│  │           data layers (N layers)               │  │
+│  │  ┌──────────────────────────────────────────┐  │  │
+│  │  │        reference grid (full only)        │  │  │
+│  │  │  ┌────────────────────────────────────┐  │  │  │
+│  │  │  │     mode message band              │  │  │  │
+│  │  │  │  ┌──────────────────────────────┐  │  │  │  │
+│  │  │  │  │       orientation marks      │  │  │  │  │
+│  │  │  │  │  ┌────────────────────────┐  │  │  │  │  │
+│  │  │  │  │  │                        │  │  │  │  │  │
+│  │  │  │  │  │     bullseye finder    │  │  │  │  │  │
+│  │  │  │  │  │       (center)         │  │  │  │  │  │
+│  │  │  │  │  │                        │  │  │  │  │  │
+│  │  │  │  │  └────────────────────────┘  │  │  │  │  │
+│  │  │  │  └──────────────────────────────┘  │  │  │  │
+│  │  │  └────────────────────────────────────┘  │  │  │
+│  │  └──────────────────────────────────────────┘  │  │
+│  └────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+Each zone is described in detail below.
+
+---
+
+## Bullseye Finder Pattern
+
+The bullseye is the heart of the symbol. A scanner searches for the bullseye's
+concentric ring structure to locate the symbol center, determine module size,
+and correct for perspective distortion.
+
+### Compact bullseye (11×11 modules, radius 5)
+
+```
+Ring index  Radius  Size   Color
+──────────  ──────  ─────  ──────────────────────────────
+Center         0    1×1    DARK
+Ring 1         1    3×3    DARK  (filled square)
+Ring 2         2    5×5    LIGHT (border only — forms ring)
+Ring 3         3    7×7    DARK  (border only)
+Ring 4         4    9×9    LIGHT (border only)
+Ring 5         5   11×11   DARK  (border only)
+```
+
+The "ring at radius r" means all modules at Chebyshev distance exactly r from
+the center module. The Chebyshev distance from (cx, cy) to (x, y) is
+`max(|x - cx|, |y - cy|)`. A ring of radius r forms the border of a square
+of side `2r + 1`.
+
+Let `cx = cy = center coordinate`. Then:
+
+```
+For each module (x, y):
+  d = max(|x - cx|, |y - cy|)    -- Chebyshev distance from center
+  if d == 0: DARK   (center)
+  if d == 1: DARK   (inner solid core — rings 0 and 1 merge into a 3×3 dark square)
+  if d == 2: LIGHT
+  if d == 3: DARK
+  if d == 4: LIGHT
+  if d == 5: DARK
+```
+
+Visualized (D = dark, L = light, · = not bullseye):
+
+```
+· · · · · · · · · · ·
+· D D D D D D D D D ·    row = cy - 5
+· D L L L L L L L D ·    row = cy - 4
+· D L D D D D D L D ·    row = cy - 3
+· D L D L L L D L D ·    row = cy - 2
+· D L D L D L D L D ·    row = cy - 1
+· D L D L D L D L D ·    row = cy     (center row)
+· D L D L D L D L D ·    row = cy + 1
+· D L D L L L D L D ·    row = cy + 2
+· D L D D D D D L D ·    row = cy + 3
+· D L L L L L L L D ·    row = cy + 4
+· D D D D D D D D D ·    row = cy + 5
+· · · · · · · · · · ·
+```
+
+Wait — this is slightly misleading. Rings 0 and 1 are both DARK, so the
+inner 3×3 is fully dark. Rings 2 and 4 are LIGHT, rings 3 and 5 are DARK.
+A cleaner visualization, showing only the 11×11 bullseye region:
+
+```
+Col: 0 1 2 3 4 5 6 7 8 9 A   (hex, A = 10)
+Row 0: D D D D D D D D D D D
+Row 1: D L L L L L L L L L D
+Row 2: D L D D D D D D D L D
+Row 3: D L D L L L L L D L D
+Row 4: D L D L D D D L D L D
+Row 5: D L D L D D D L D L D   ← center row (d=0 at col 5)
+Row 6: D L D L D D D L D L D
+Row 7: D L D L L L L L D L D
+Row 8: D L D D D D D D D L D
+Row 9: D L L L L L L L L L D
+Row A: D D D D D D D D D D D
+```
+
+Hmm — the center module is at (5, 5) in this coordinate. The 3×3 core
+(d ≤ 1) includes (4..6, 4..6) — all DARK. The ring at d = 2 is LIGHT.
+The ring at d = 3 is DARK. The ring at d = 4 is LIGHT. The ring at d = 5
+is the outermost DARK ring. This is exactly the standard pattern.
+
+Because rings 0 and 1 are both DARK, the center appears as a solid 3×3 dark
+square surrounded by alternating light and dark rings. This produces the
+visually distinctive "bull's eye" appearance. Scanners look for a region with
+a 1:1:1:1:1 ratio of module widths along any scan line through the center.
+
+### Full bullseye (15×15 modules, radius 7)
+
+Full Aztec adds two more rings beyond the compact bullseye:
+
+```
+d == 0: DARK   (center)
+d == 1: DARK   (inner core)
+d == 2: LIGHT
+d == 3: DARK
+d == 4: LIGHT
+d == 5: DARK
+d == 6: LIGHT   ← extra ring compared to compact
+d == 7: DARK    ← outermost ring of full bullseye
+```
+
+The outermost ring of the bullseye is always DARK in both variants. This
+means the transition from the bullseye (DARK) to the orientation mark band
+(which starts with a LIGHT module) is well-defined.
+
+### Why the bullseye is self-locating
+
+The key property: the bullseye's `1:1:1:1:1` cross-ratio can be read from
+any angle. A scanner casts many 1D scan lines across the captured image.
+When a scan line passes through the center, it sees a sequence of dark/light
+transitions at equal spacings. By finding this equal-spacing pattern in many
+scan directions, the scanner triangulates the center and orientation without
+requiring any corner markers.
+
+This is fundamentally different from QR Code, which requires three corner
+finder patterns to establish orientation. Aztec's single-center design means:
+
+1. No quiet zone required (there is no "which side is which" ambiguity that a
+   quiet zone would help resolve).
+2. The symbol can be printed right up to the edge of a label or ticket.
+3. The symbol can be rotated to any of four orientations; the scanner detects
+   the orientation from the mode message after finding the bullseye.
+
+---
+
+## Orientation Marks
+
+Immediately outside the bullseye, the innermost ring of the data-and-mode-message
+band contains **orientation marks** — four corner modules that are always dark.
+These break the rotational symmetry of the concentric rings and allow a scanner
+to determine which of the four 90-degree rotations the symbol is in.
+
+The orientation marks occupy the **four corner positions** of the mode message
+band (the ring just outside the bullseye):
+
+```
+For compact Aztec (bullseye is 11×11, center at (cx, cy)):
+  The mode message band occupies the 13×13 ring at radius 6 from the center.
+  Corners of this ring (Chebyshev distance = 6 from center):
+    Top-left:     (cx - 6, cy - 6)  → always DARK
+    Top-right:    (cx + 6, cy - 6)  → always DARK
+    Bottom-right: (cx + 6, cy + 6)  → always DARK
+    Bottom-left:  (cx - 6, cy + 6)  → always DARK
+
+For full Aztec (bullseye is 15×15, center at (cx, cy)):
+  The mode message band occupies the 17×17 ring at radius 8 from the center.
+  Corners:
+    Top-left:     (cx - 8, cy - 8)  → always DARK
+    Top-right:    (cx + 8, cy - 8)  → always DARK
+    Bottom-right: (cx + 8, cy + 8)  → always DARK
+    Bottom-left:  (cx + 8, cy + 8)  → always DARK
+```
+
+These four dark corners are fixed. The mode message bits occupy the remaining
+non-corner modules of the mode message band.
+
+---
+
+## Mode Message (Format Information Equivalent)
+
+The mode message is Aztec Code's equivalent of QR Code's format information.
+It encodes:
+
+- Whether the symbol is compact or full (implied by bullseye size, but
+  also encoded redundantly)
+- The number of layers (compact: 2 bits, full: 5 bits)
+- The number of data codewords (compact: 6 bits, full: 11 bits)
+- Reed-Solomon error correction protecting the mode message itself
+
+The mode message is placed in the ring immediately outside the bullseye
+(Chebyshev distance = bullseye_radius + 1 from center), starting just after
+the top-left orientation mark corner, running clockwise. The four corner
+modules of this ring are the orientation marks; the remaining modules carry
+the mode message bits.
+
+### Compact mode message layout
+
+The compact mode message ring is 13×13 (side = 13, perimeter = 4 × 12 = 48
+modules, minus 4 corners = 44 modules for bits). The mode message is
+**28 bits**, stored as **7 four-bit nibbles** in the ring. After the 28 bits,
+the remaining 16 modules in the ring are filled by the start of the first data
+layer.
+
+Wait — that is not how the ISO standard describes it. Let me be precise:
+
+The mode message band for compact Aztec has exactly **28 bits**:
+
+```
+bit[0..1]    : reserved = 0b01  (indicates compact mode when decoded)
+bit[2..3]    : layers - 1 (0b00 = 1 layer, ..., 0b11 = 4 layers)
+bit[4..9]    : data_codewords - 1 (6 bits, since compact max data words ≤ 64)
+bit[10..27]  : RS ECC of the above 10 data bits, using GF(16) Reed-Solomon
+               producing 18 ECC bits total (4.5 nibbles... this needs precision)
+```
+
+Actually, the ISO standard defines the mode message differently. The precise
+layout from ISO/IEC 24778:2008, Section 7.3.1.1:
+
+**Compact mode message** is exactly 28 bits, organized as 7 nibbles (4 bits
+each). It is protected by a (7, 2) Reed-Solomon code over GF(16) with
+primitive polynomial `x^4 + x + 1 = 0x13`:
+
+- 2 data nibbles  (8 bits of data: 2-bit mode-flag + 2-bit layers + 6-bit word-count — but these are bits 0..7 spread across 2 nibbles)
+  - Nibble 0 (bits 0..3): `d[3..0]` where `d = (layers-1) << 6 | (data_words-1)`
+  - Nibble 1 (bits 4..7): `d[7..4]`
+
+Hmm, the exact nibble encoding for compact mode message is:
+
+```
+total_data_bits = 0b00 | (layers - 1) | (data_words - 1)
+    -- where layers is 2 bits (0..3) and data_words is 6 bits (0..63)
+    -- combined: 8 bits total, split into 2 nibbles
+nibble_0 = bits 3..0 of combined_value
+nibble_1 = bits 7..4 of combined_value
+```
+
+Then 5 RS ECC nibbles are appended (using the (7,2) code over GF(16)):
+
+```
+compact mode message = [nibble_0, nibble_1, ecc_0, ecc_1, ecc_2, ecc_3, ecc_4]
+                       = 7 nibbles = 28 bits
+```
+
+**Full mode message** is exactly 40 bits, organized as 10 nibbles. It is
+protected by a (10, 4) RS code over GF(16) with the same primitive polynomial:
+
+- 4 data nibbles (16 bits of data):
+  - Nibbles 0..1 encode: `0b00` (mode flag, 2 bits) + `layers - 1` (5 bits)
+    + `data_words - 1` (11 bits) = 18 bits total? That's 4.5 nibbles.
+
+The ISO standard defines the encoding in terms of **bits**, then packs them
+into nibbles LSB-first for RS processing. The precise construction is:
+
+**Compact** (28-bit mode message):
+
+```
+Message bits (10 bits of data, 18 bits of RS ECC):
+  Bit  0:     0  (mode flag LSB — compact = 0)
+  Bit  1:     0  (mode flag MSB — compact = 0)
+  Bits 2..3:  layers - 1  (2 bits)
+  Bits 4..9:  data_codewords - 1  (6 bits)
+  Bits 10..27: RS ECC (18 bits = 4.5 nibbles ← doesn't divide evenly)
+```
+
+This doesn't divide cleanly into nibbles when you include the 2-bit mode flag.
+The ISO standard handles this by specifying the RS computation differently:
+the Reed-Solomon is computed over the **8 data bits** (ignoring the 2-bit mode
+flag), producing 5 ECC nibbles, for a total of:
+
+```
+2 data nibbles (8 bits) + 5 ECC nibbles (20 bits) = 7 nibbles = 28 bits
+```
+
+The 2-bit mode flag (`00` for compact) is effectively baked into the
+interpretation rather than encoded as explicit RS-protected bits.
+
+**Full** (40-bit mode message):
+
+```
+Data bits (16 bits → 4 nibbles):
+  Bit  0:     1  (mode flag LSB — full = 1)
+  Bit  1:     0  (mode flag MSB)
+  Bits 2..6:  layers - 1  (5 bits)
+  Bits 7..17: data_codewords - 1  (11 bits)
+  → Total data bits: 1 + 1 + 5 + 11 = 18 bits... still doesn't fit 4 nibbles cleanly
+
+Actually, the mode flag for full is NOT encoded in the RS-protected part.
+The RS data is exactly:
+  Bits 0..4:   layers - 1 (5 bits), padded to nibble boundary
+  Bits 5..15:  data_codewords - 1 (11 bits)
+  → 16 bits = 4 nibbles
+
+Then 6 ECC nibbles, for 10 nibbles = 40 bits total.
+```
+
+### Implementation note on mode message bits
+
+The cleanest way to implement this, following the ISO specification's intent:
+
+**Compact mode message encoding:**
+1. Compute `m = ((layers - 1) << 6) | (data_codewords - 1)` — an 8-bit value
+2. Pack as 2 nibbles (LSB first): nibble[0] = m & 0xF, nibble[1] = (m >> 4) & 0xF
+3. Compute 5 RS ECC nibbles using GF(16), primitive polynomial `x^4 + x + 1`
+   (0x13), generator polynomial with roots α^1 through α^5
+4. Concatenate: [nibble[0], nibble[1], ecc[0], ecc[1], ecc[2], ecc[3], ecc[4]]
+5. Flatten to 28 bits (nibble[0] LSB first, nibble[1] LSB first, etc.)
+
+**Full mode message encoding:**
+1. Compute `m = ((layers - 1) << 11) | (data_codewords - 1)` — a 16-bit value
+2. Pack as 4 nibbles: nibble[i] = (m >> (4 * i)) & 0xF
+3. Compute 6 RS ECC nibbles using GF(16), same polynomial
+4. Concatenate: 10 nibbles → 40 bits
+
+### Mode message bit placement
+
+The mode message bits are placed in the ring immediately outside the bullseye,
+starting **just right of the top-left corner** (the orientation mark), running
+**clockwise**:
+
+```
+For compact (ring at radius = 6 from center, side = 13):
+  Start position: column (cx - 5), row (cy - 6)  ← one right of top-left corner
+  Direction: clockwise (→ across top, ↓ down right, ← across bottom, ↑ up left)
+  Skip the 4 corner modules.
+  Place 28 bits in the 44 non-corner modules of this ring's perimeter.
+  Remaining 16 modules after the 28 mode message bits are the leading bits of
+  the first data layer. (Wait — this is only true if the ring is split between
+  mode message and data. The ISO standard says the mode message ring is
+  distinct from the data layers. The first data layer starts at radius 7 for
+  compact, radius 9 for full.)
+```
+
+Actually, the ISO standard is clear: the mode message occupies the entire
+perimeter ring immediately outside the bullseye. The perimeter of a
+13×13 square is 4 × 12 = 48 modules. Minus 4 corners = 44 non-corner modules.
+But the mode message is only 28 bits. The remaining 44 - 28 = 16 modules
+in the ring are filled by the first few bits of the data layers.
+
+Let me re-examine this: In ISO 24778, the mode message ring and the data layers
+share the same physical ring. The mode message bits take 28 positions; the
+data bits fill the remaining 16 positions in the ring. The data continues
+spiraling outward.
+
+### Precise mode message ring placement algorithm
+
+```
+-- For compact Aztec:
+ring_radius = bullseye_radius + 1  -- = 6 for compact, 8 for full
+side = 2 * ring_radius + 1          -- = 13 for compact, 17 for full
+perimeter_non_corner = 4 * (side - 2)  -- = 44 for compact, 60 for full
+
+-- Enumerate non-corner ring positions clockwise from (cx - ring_radius + 1, cy - ring_radius):
+positions = []
+for col in (cx - ring_radius + 1)..(cx + ring_radius):     -- top edge, left to right
+    positions.push( (col, cy - ring_radius) )
+for row in (cy - ring_radius + 1)..(cy + ring_radius):     -- right edge, top to bottom
+    positions.push( (cx + ring_radius, row) )
+for col in (cx + ring_radius - 1)..(cx - ring_radius):     -- bottom edge, right to left (reversed)
+    positions.push( (col, cy + ring_radius) )
+for row in (cy + ring_radius - 1)..(cy - ring_radius):     -- left edge, bottom to top (reversed)
+    positions.push( (cx - ring_radius, row) )
+
+-- Place mode message bits first, then data bits:
+for i, pos in enumerate(positions):
+    if i < mode_message_bit_count:
+        set_module(pos, mode_message[i])
+    else:
+        set_module(pos, data_bits[i - mode_message_bit_count])
+```
+
+For **compact**: 28 mode message bits, then 16 data bits in the ring.
+For **full**: 40 mode message bits, then 20 data bits in the ring.
+
+---
+
+## Reference Grid
+
+Full Aztec symbols with enough layers include a **reference grid** — a grid of
+alternating dark and light modules that helps scanners correct for severe
+perspective distortion. The reference grid does not appear in compact symbols.
+
+The reference grid consists of:
+
+- Horizontal lines of alternating dark/light modules, spaced every 16 modules
+  from the center row (row `cy`)
+- Vertical lines of alternating dark/light modules, spaced every 16 modules
+  from the center column (col `cx`)
+
+The alternating pattern along a reference grid line: the module at the
+intersection of a reference grid line and the center row/column is DARK;
+alternates every module from there.
+
+```
+Reference grid lines exist at:
+  Rows: cy, cy ± 16, cy ± 32, cy ± 48, ...  (as long as within symbol bounds)
+  Cols: cx, cx ± 16, cx ± 32, cx ± 48, ...
+
+The center row and column themselves (cy and cx) are reference grid lines.
+
+Module value at (row, col) on reference grid:
+  if (row == cy or row == cy ± 16n) and (col == cx or col == cx ± 16n):
+    -- intersection of two reference lines
+    DARK
+  else if row == cy or row == cy ± 16n:
+    -- on horizontal reference line: alternate dark/light from center column
+    (cx - col) mod 2 == 0 → DARK, else LIGHT
+  else if col == cx or col == cx ± 16n:
+    -- on vertical reference line: alternate dark/light from center row
+    (cy - row) mod 2 == 0 → DARK, else LIGHT
+```
+
+Reference grid modules are **fixed structural modules** — they are not data
+bits and are not altered by the data encoding. The data placement algorithm
+skips reference grid positions.
+
+For a **32-layer full** symbol (143×143), the reference grid lines at distance
+16n from center are:
+- Rows: cy ± 16, cy ± 32, cy ± 48, cy ± 64  (8 horizontal grid lines plus center)
+- Cols: cx ± 16, cx ± 32, cx ± 48, cx ± 64  (8 vertical grid lines plus center)
+
+For smaller full symbols, fewer reference lines fit:
+- Layers 1..4 (19×19 to 31×31): only the center row and center column (distance 0)
+- Layers 5..11 (35×35 to 59×59): center + ±16 lines
+- Layers 12..19 (63×63 to 91×91): center + ±16 + ±32 lines
+- Layers 20..27 (95×95 to 123×123): center + ±16 + ±32 + ±48 lines
+- Layers 28..32 (127×127 to 143×143): center + ±16 + ±32 + ±48 + ±64 lines
+
+The center row and center column are always reference grid lines in full
+symbols. In compact symbols, there is no reference grid at all.
+
+---
+
+## Data Encoding Modes
+
+Aztec Code uses a **latched mode-switching** encoding system with five base
+modes. Each mode uses a different codeword size. The encoder builds a sequence
+of variable-width codewords that represent the input, switching between modes
+as needed for compactness.
+
+This is similar to QR Code's mode system, but the codewords are narrower
+(mostly 5-bit) and there are more modes with richer switching semantics.
+
+### Mode overview
+
+| Mode | Codeword bits | Character set |
+|------|-------------|---------------|
+| Upper | 5 | A–Z, space, and control codes via shift |
+| Lower | 5 | a–z, space, and control codes via shift |
+| Mixed | 5 | digits 0–9, symbols, control chars |
+| Punct | 5 | punctuation, CR+LF pair |
+| Digit | 4 | 0–9, space, comma, period |
+
+### Upper mode character table (5 bits per codeword)
+
+Upper mode is the default starting mode.
+
+| Codeword | Character |
+|----------|-----------|
+| 00000 | Pad (null / filler) |
+| 00001 | Space |
+| 00010 | A |
+| 00011 | B |
+| 00100 | C |
+| ... | ... |
+| 11011 | Z |
+| 11100 | Shift to Lower |
+| 11101 | Latch to Mixed |
+| 11110 | Latch to Punct |
+| 11111 | Latch to Digit → or "shift" codeword (context-dependent) |
+
+The full Upper alphabet is:
+
+```
+Value 0:  PADDING (not a character; used to fill incomplete codewords)
+Value 1:  SP (space, ASCII 0x20)
+Value 2:  A   Value 3:  B   Value 4:  C   Value 5:  D   Value 6:  E
+Value 7:  F   Value 8:  G   Value 9:  H   Value 10: I   Value 11: J
+Value 12: K   Value 13: L   Value 14: M   Value 15: N   Value 16: O
+Value 17: P   Value 18: Q   Value 19: R   Value 20: S   Value 21: T
+Value 22: U   Value 23: V   Value 24: W   Value 25: X   Value 26: Y
+Value 27: Z
+Value 28: Latch to Lower
+Value 29: Latch to Mixed
+Value 30: Latch to Punct
+Value 31: Binary-Shift (shift to Byte mode for a specified count of bytes)
+```
+
+### Lower mode character table (5 bits per codeword)
+
+```
+Value 0:  PADDING
+Value 1:  SP (space)
+Value 2:  a   Value 3:  b   Value 4:  c   Value 5:  d   Value 6:  e
+Value 7:  f   Value 8:  g   Value 9:  h   Value 10: i   Value 11: j
+Value 12: k   Value 13: l   Value 14: m   Value 15: n   Value 16: o
+Value 17: p   Value 18: q   Value 19: r   Value 20: s   Value 21: t
+Value 22: u   Value 23: v   Value 24: w   Value 25: x   Value 26: y
+Value 27: z
+Value 28: Shift to Upper (single character only — returns to Lower after)
+Value 29: Latch to Mixed
+Value 30: Latch to Punct
+Value 31: Binary-Shift
+```
+
+### Mixed mode character table (5 bits per codeword)
+
+Mixed mode encodes digits, common symbols, and control characters.
+
+```
+Value 0:  PADDING
+Value 1:  SP
+Value 2:  0  (digit zero)
+...
+Value 11: 9
+Value 12: ,   (comma, ASCII 0x2C)
+Value 13: .   (period, ASCII 0x2E)
+Value 14: !   (ASCII 0x21)
+Value 15: "   (ASCII 0x22)
+Value 16: #   (ASCII 0x23)
+Value 17: $   (ASCII 0x24)
+Value 18: %   (ASCII 0x25)
+Value 19: &   (ASCII 0x26)
+Value 20: '   (ASCII 0x27)
+Value 21: (   (ASCII 0x28)
+Value 22: )   (ASCII 0x29)
+Value 23: *   (ASCII 0x2A)
+Value 24: +   (ASCII 0x2B)
+Value 25: -   (ASCII 0x2D)
+Value 26: /   (ASCII 0x2F)
+Value 27: :   (ASCII 0x3A)
+Value 28: Latch to Upper
+Value 29: Latch to Lower
+Value 30: Latch to Punct
+Value 31: Binary-Shift
+```
+
+### Punct mode character table (5 bits per codeword)
+
+Punctuation mode is optimized for common punctuation sequences.
+
+```
+Value 0:  PADDING
+Value 1:  CR+LF (two-character sequence, ASCII 0x0D 0x0A)
+Value 2:  .     (period)
+Value 3:  ,     (comma)
+Value 4:  :     (colon)
+Value 5:  !
+Value 6:  "
+Value 7:  (
+Value 8:  )
+Value 9:  ;
+Value 10: [
+Value 11: ]
+Value 12: {
+Value 13: }
+Value 14: @
+Value 15: \     (backslash)
+Value 16: ^
+Value 17: _
+Value 18: `
+Value 19: |
+Value 20: ~
+Value 21: DEL   (ASCII 0x7F)
+Value 22: ESC   (ASCII 0x1B)
+Value 23: SOH   (ASCII 0x01)
+Value 24: STX   (ASCII 0x02)
+Value 25: ETX   (ASCII 0x03)
+Value 26: EOT   (ASCII 0x04)
+Value 27: ENQ   (ASCII 0x05)
+Value 28: ACK   (ASCII 0x06)
+Value 29: BEL   (ASCII 0x07)
+Value 30: BS    (ASCII 0x08)
+Value 31: HT    (ASCII 0x09)
+```
+
+Note: there is no latch-back in Punct mode; the scanner returns to the
+previous mode automatically after one Punct codeword (Punct is a shift,
+not a latch). To encode multiple consecutive punctuation characters, you
+must re-enter Punct mode with repeated Latch-to-Punct codewords.
+
+Actually — the ISO standard specifies Punct differently. Punct can be entered
+via a latch (persistent) or via a two-codeword sequence from other modes. The
+above is a simplification. For v0.1.0, treat all mode transitions as latches.
+
+### Digit mode character table (4 bits per codeword)
+
+Digit mode is the most compact mode and uses 4-bit codewords.
+
+```
+Value 0:  PADDING
+Value 1:  SP
+Value 2:  0   Value 3:  1   Value 4:  2   Value 5:  3
+Value 6:  4   Value 7:  5   Value 8:  6   Value 9:  7
+Value 10: 8   Value 11: 9
+Value 12: ,   (comma)
+Value 13: .   (period)
+Value 14: Latch to Upper
+Value 15: Latch to Lower
+```
+
+Wait — this is a 4-bit codeword but there are 16 possible values (0..15), and
+the above table only has non-latch characters at 0..13, with 14 and 15 as latch
+codewords. Digit mode can latch to Upper or Lower. It cannot latch to Mixed or
+Punct (you must first latch to Upper, then to the target mode).
+
+### Binary / Byte mode
+
+To encode arbitrary bytes (including non-printable ASCII and raw binary data),
+the encoder inserts a **Binary Shift** escape:
+
+```
+In Upper or Lower mode, codeword value 31 is "Binary-Shift".
+Following the Binary-Shift codeword:
+  - A length prefix is encoded: if length ≤ 31, 5 bits; if length > 31, 11 bits
+    (first 5 bits = 00000, then 11 bits for the actual count)
+  - Then `length` bytes, each 8 bits, MSB first.
+  - After the byte sequence, the mode reverts to the mode active before Binary-Shift.
+```
+
+This means byte mode is not a persistent "latch" — it is a temporary escape
+with an explicit byte count. For encoding arbitrary binary data or UTF-8, this
+is the universal path.
+
+### Mode selection heuristic (v0.1.0)
+
+For v0.1.0, the encoder uses **byte mode exclusively** (via Binary-Shift from
+Upper mode) for any input that is not pure uppercase ASCII. This is always
+valid, though not maximally compact. Multi-mode optimization is a v0.2.0
+enhancement.
+
+For v0.1.0:
+1. Start in Upper mode.
+2. If a character is in the Upper alphabet (A–Z, space): emit Upper codeword.
+3. Otherwise: emit Binary-Shift with count = remaining bytes in the current
+   non-Upper run, emit bytes, return to Upper.
+
+In practice, for URLs and general strings, this reduces to: emit Binary-Shift
+once for the entire input if it contains any lowercase or special characters.
+
+### Codeword size selection for RS
+
+Reed-Solomon error correction for Aztec is applied to the **complete codeword
+sequence** — the bit stream after mode switching and padding, but before bit
+stuffing. The RS codewords have the same bit width as the data codewords.
+
+Since Aztec mixes codeword sizes (4-bit in Digit mode, 5-bit in Upper/Lower/
+Mixed/Punct, 8-bit in Binary), the RS computation must be done per-segment or
+on a normalized codeword sequence. For simplicity (and as mandated by the
+ISO standard for the general case), the encoder:
+
+1. Determines the **primary codeword size** for the symbol: if Binary-Shift
+   data exceeds 50% of total bits, use 8-bit codewords (GF(256)); otherwise
+   use 5-bit codewords (GF(32)) unless the data is entirely in Digit mode
+   (4-bit, GF(16)).
+2. Normalizes the bit stream to that codeword size for RS computation.
+
+For v0.1.0 (byte mode only via Binary-Shift from Upper), the codeword size
+is **8 bits** (GF(256)).
+
+---
+
+## Bit Stuffing
+
+Aztec Code applies a **bit-stuffing** rule to the final data bit stream (after
+RS encoding) to prevent long runs of identical bits that could interfere with
+the scanner's ability to read the reference grid.
+
+The rule is simple:
+
+> After placing 4 consecutive identical bits (all 0 or all 1), insert one bit
+> of the opposite value.
+
+This is applied to the **codeword data + RS ECC bits** as they are laid out
+in the data layers, NOT to the raw data before RS encoding.
+
+Wait — the ISO standard applies bit stuffing before laying bits into the symbol.
+The precise sequence is:
+
+1. Encode data into codewords (mode switches + data characters + padding).
+2. Append RS ECC codewords.
+3. Apply bit stuffing to the entire (data + ECC) bit string.
+4. Lay the stuffed bit string into the symbol's data layers.
+
+### Bit-stuffing algorithm
+
+```
+input:  bits[] -- the data + ECC bit stream
+output: stuffed[] -- the bit stream with inserted stuff bits
+
+run_val = -1
+run_len = 0
+stuffed = []
+
+for bit in bits:
+    if bit == run_val:
+        run_len += 1
+    else:
+        run_val = bit
+        run_len = 1
+
+    stuffed.push(bit)
+
+    if run_len == 4:
+        -- Insert a stuff bit of the opposite value
+        stuffed.push(1 - bit)
+        run_val = 1 - bit
+        run_len = 1   -- the stuff bit starts a new run of length 1
+```
+
+**Example:**
+
+```
+Input:   1 1 1 1 0 0 0 0 1 0
+After 4× 1:  stuff a 0  →  1 1 1 1 [0] 0 0 0 0 ...
+After 4× 0:  stuff a 1  →  ... 0 0 0 0 [1] 1 0
+Result:  1 1 1 1 0 0 0 0 0 1 1 0
+```
+
+Note that the run count **resets** after the stuffed bit. So five consecutive
+1-bits would be:
+
+```
+Input:   1 1 1 1 1
+Bits 1..4: emit, then stuff → 1 1 1 1 0
+Bit 5 (the 5th 1): emit normally → 1 1 1 1 0 1
+```
+
+Bit stuffing increases the total bit count. The decoder reverses this by
+removing the bit after every group of 4 identical bits.
+
+### Bit stuffing does NOT apply to
+
+- The bullseye finder pattern
+- The orientation marks
+- The mode message band
+- The reference grid lines
+
+Only the **data layer bits** are stuffed.
+
+---
+
+## Reed-Solomon Parameters
+
+Aztec Code uses Reed-Solomon error correction in two different field sizes,
+depending on the codeword bit width:
+
+### GF(16) — for mode message and 4-bit or 5-bit codeword sequences
+
+- **Field**: GF(2^4) = GF(16)
+- **Primitive polynomial**: x^4 + x + 1 = 0x13
+  (the binary representation is `10011`; in hex the polynomial coefficients
+   give 0x13 = 0b10011 = x^4 + x + 1)
+- **Generator polynomial convention**: b=1 (roots α^1 through α^n), matching
+  the MA02 convention
+- **Uses**: mode message RS (both compact and full), RS over 4-bit or 5-bit
+  codewords when the primary codeword size is ≤ 5 bits
+
+The GF(16) primitive polynomial `x^4 + x + 1`:
+
+```
+x^4 ≡ x + 1  (mod the primitive poly)
+```
+
+Multiplication table for GF(16) with this polynomial (element as 4-bit number,
+rows × cols = product):
+
+```
+α^0 = 0b0001 = 1
+α^1 = 0b0010 = 2
+α^2 = 0b0100 = 4
+α^3 = 0b1000 = 8
+α^4 = 0b0011 = 3  (since x^4 = x + 1)
+α^5 = 0b0110 = 6
+α^6 = 0b1100 = 12
+α^7 = 0b1011 = 11
+α^8 = 0b0101 = 5
+α^9 = 0b1010 = 10
+α^10= 0b0111 = 7
+α^11= 0b1110 = 14
+α^12= 0b1111 = 15
+α^13= 0b1101 = 13
+α^14= 0b1001 = 9
+α^15= α^0 = 1   (period = 15, so it is primitive)
+```
+
+### GF(256) — for 8-bit codeword sequences (byte mode)
+
+- **Field**: GF(2^8) = GF(256)
+- **Primitive polynomial**: x^8 + x^5 + x^4 + x^2 + x + 1 = 0x12D
+  (same polynomial used by Data Matrix ECC200)
+- **Generator polynomial convention**: b=1 (roots α^1 through α^n), matching
+  the MA02 convention exactly — `aztec-code` can call MA02 directly for full
+  byte-mode symbols
+- **Uses**: RS over 8-bit codewords (byte mode or binary data)
+
+Note: The GF(256) polynomial for Aztec (0x12D) is **different** from the
+QR Code polynomial (0x11D). Aztec's polynomial is the same as Data Matrix's.
+
+```
+QR Code:     x^8 + x^4 + x^3 + x^2 + 1 = 0x11D
+Data Matrix: x^8 + x^5 + x^4 + x^2 + x + 1 = 0x12D  ← Aztec uses this
+```
+
+### RS parameters by symbol configuration
+
+| Codeword size | Field | Poly | Convention | Package |
+|--------------|-------|------|------------|---------|
+| 4-bit (Digit) | GF(16) | 0x13 | b=1 | Custom |
+| 5-bit (Upper/Lower/Mixed) | GF(32) | 0x25 | b=1 | Custom |
+| 8-bit (Binary) | GF(256) | 0x12D | b=1 | MA02 |
+| Mode message (both sizes) | GF(16) | 0x13 | b=1 | Custom |
+
+**GF(32)** (for 5-bit codewords):
+- Primitive polynomial: x^5 + x^2 + 1 = 0x25 = 0b100101
+- α^31 = α^0 (period = 31, so it is primitive)
+
+### Error correction capacity
+
+The number of RS ECC codewords is determined by the requested minimum ECC
+percentage. The ECC percentage is the ratio of ECC codewords to **total
+codewords** (data + ECC):
+
+```
+ecc_ratio = ecc_codewords / (data_codewords + ecc_codewords)
+```
+
+The minimum is 10%; the default is 23%; the maximum is 90%.
+
+Because RS over GF(2^m) can correct up to ⌊n/2⌋ errors in a codeword
+sequence of length n (where n is the number of ECC codewords), a 23% ECC
+ratio means the symbol can recover from approximately 11.5% corrupted
+codewords.
+
+To achieve a target ECC ratio `e`:
+
+```
+ecc_count = ceil(e * (data_count + ecc_count))
+          = ceil(e * data_count / (1 - e))
+```
+
+In practice, the encoder picks the smallest symbol (layer count) such that
+the total codeword capacity minus the required ECC codewords is at least
+enough for the data codewords.
+
+### Capacity tables
+
+Total data bits available per layer count (before stuffing):
+
+**Compact Aztec** (5-bit codewords assumed for capacity calculation):
+
+| Layers | Symbol size | Total bits | Max 5-bit codewords |
+|--------|-------------|------------|---------------------|
+| 1 | 15×15 | 78 | 15 |
+| 2 | 19×19 | 200 | 40 |
+| 3 | 23×23 | 390 | 78 |
+| 4 | 27×27 | 648 | 129 |
+
+Bit counts above are the usable data layer bits (excluding bullseye, mode
+message, and orientation marks).
+
+**Full Aztec** (5-bit codewords, selected layers):
+
+| Layers | Symbol size | Total bits | Max 5-bit codewords |
+|--------|-------------|------------|---------------------|
+| 1 | 19×19 | 120 | 24 |
+| 2 | 23×23 | 304 | 60 |
+| 3 | 27×27 | 560 | 112 |
+| 4 | 31×31 | 888 | 177 |
+| 5 | 35×35 | 1288 | 257 |
+| 6 | 39×39 | 1760 | 352 |
+| 8 | 47×47 | 2888 | 577 |
+| 10 | 55×55 | 4224 | 844 |
+| 12 | 63×63 | 5776 | 1155 |
+| 16 | 79×79 | 9548 | 1909 |
+| 22 | 103×103 | 17048 | 3409 |
+| 32 | 143×143 | 36052 | 7210 |
+
+For byte mode (8-bit codewords), the max byte capacity at 23% ECC:
+- Compact 4 layers: ~50 bytes
+- Full 4 layers: ~85 bytes
+- Full 10 layers: ~406 bytes
+- Full 32 layers: ~3471 bytes
+
+### Computing usable bits per layer
+
+Each data layer wraps a band of 4 modules wide around the symbol. Within each
+layer band, the data bits spiral around the band in groups of 2 bits per module
+pair (see Data Layout section). The number of usable positions per layer:
+
+```
+-- For layer number L (1-indexed from innermost data layer):
+-- Compact: bullseye radius = 5, mode message ring = 6
+--   Innermost data layer L=1 is at radius 7..10 (4 module wide band)
+--   Side of this ring's outer boundary = 2 * (bullseye_radius + 1 + L * 2 - 1) + 1
+
+-- More directly:
+-- For compact, layer L's outer ring has side:
+side_outer = 11 + 2 * 2 * L + 2 = 11 + 4*L + 2... 
+-- hmm, let me compute from the symbol sizes directly.
+
+-- Compact 1 layer: 15×15. Bullseye = 11×11. Mode ring = 13×13.
+--   Data ring = 15×15 outer minus 13×13 inner = perimeter of 15×15 = 56 modules.
+--   But we must subtract reference grid intersections (none for compact).
+--   Usable = 56 modules, each holding 2 data bits = 112 bits.
+--   Wait but the mode message ring also overlaps... Let me re-derive.
+
+-- The symbol is 15×15 = 225 modules total.
+-- Bullseye (11×11) = 121 modules (fixed structural).
+-- Mode message ring (13×13 perimeter) = 44 non-corner modules (28 mode + 16 data).
+-- That leaves the 15×15 outer ring: perimeter = 4 * 14 = 56 modules = 56 data bits.
+-- Total data bits for compact layer 1: 16 (in mode ring) + 56 = 72.
+-- But actually, each module holds 2 bits in Aztec's zigzag layout (see below).
+-- The 56 modules in the outer ring hold 2 bits each? No — each module holds 1 bit.
+
+Actually each module (cell) holds exactly 1 bit (dark or light). The capacity
+count is simply the number of available (non-structural) modules.
+```
+
+For a precise capacity derivation, refer to ISO/IEC 24778:2008, Table 1.
+The implementation should embed the capacity table as a lookup rather than
+computing it dynamically.
+
+---
+
+## Data Layout Algorithm
+
+After computing the data + ECC bit stream and applying bit stuffing, the bits
+are placed into the symbol's data layers. The layout proceeds from the
+**innermost data layer** outward, one layer at a time. Within each layer, bits
+are placed in a **clockwise spiral**.
+
+### Overview of a single layer
+
+Each layer is a band 2 modules wide (not 4 — the 4-module per layer size
+is the total increase when adding a layer on both sides; each individual band
+is 2 modules wide on one pass). Actually — Aztec layers are each 2 modules
+thick as measured from the inner edge to the outer edge of the layer band.
+
+Wait — the standard uses "layer" to mean a band that is exactly 2 modules
+wide on each side of the bullseye, for a total of 4 extra modules per dimension.
+Each layer band forms a closed ring around the symbol.
+
+The data bits within a layer are arranged in **pairs** along the two rows/columns
+of the band:
+
+```
+For a layer at Chebyshev distance d_inner..d_outer from center:
+  (d_outer = d_inner + 1, since each layer is 2 modules wide and has inner and outer)
+
+Placement pattern in the layer band (clockwise from top-right):
+  1. Top edge:    columns (cx - d_inner + 1) to (cx + d_inner),  row (cy - d_outer)
+                  then row (cy - d_inner) paired below it
+  2. Right edge:  rows (cy - d_inner + 1) to (cy + d_inner),     col (cx + d_outer)
+                  then col (cx + d_inner) paired to its left
+  3. Bottom edge: columns (cx + d_inner) to (cx - d_inner + 1) (reversed), row (cy + d_outer)
+                  then row (cy + d_inner) paired above it
+  4. Left edge:   rows (cy + d_inner) to (cy - d_inner + 1) (reversed), col (cx - d_outer)
+                  then col (cx - d_inner) paired to its right
+```
+
+This gives a 2-wide clockwise spiral. At each position along the spiral,
+two bits are placed (one in the inner column/row of the band, one in the outer).
+
+### Precise layer spiral algorithm
+
+```
+-- Center is at (cx, cy).
+-- For compact, innermost data layer L=1 has:
+--   d_inner = bullseye_radius + 2 = 7 (since mode message ring is at radius 6)
+--   d_outer = d_inner + 1 = 8
+--
+-- For each subsequent layer L, d_inner += 2, d_outer += 2.
+-- (Each layer adds 2 to the radius from center.)
+
+-- For a layer with inner radius d_i and outer radius d_o = d_i + 1:
+
+procedure place_layer(d_i, bits, bit_index):
+    d_o = d_i + 1
+
+    -- Top edge: left to right, starting one column right of the top-left corner
+    for col from (cx - d_i + 1) to (cx + d_i):
+        place_bit(col, cy - d_o, bits[bit_index]);   bit_index++
+        place_bit(col, cy - d_i, bits[bit_index]);   bit_index++
+        -- outer row first, then inner row
+
+    -- Right edge: top to bottom, skipping corners already placed
+    for row from (cy - d_i + 1) to (cy + d_i):
+        place_bit(cx + d_o, row, bits[bit_index]);   bit_index++
+        place_bit(cx + d_i, row, bits[bit_index]);   bit_index++
+
+    -- Bottom edge: right to left
+    for col from (cx + d_i) downto (cx - d_i + 1):
+        place_bit(col, cy + d_o, bits[bit_index]);   bit_index++
+        place_bit(col, cy + d_i, bits[bit_index]);   bit_index++
+
+    -- Left edge: bottom to top
+    for row from (cy + d_i) downto (cy - d_i + 1):
+        place_bit(cx - d_o, row, bits[bit_index]);   bit_index++
+        place_bit(cx - d_i, row, bits[bit_index]);   bit_index++
+```
+
+This is the canonical Aztec data spiral. Note the pair order: outer then
+inner for all four sides. The full symbol's layers are traversed from
+L=1 (innermost) to L=N (outermost), each using this spiral.
+
+### Skipping reserved modules
+
+Before placing data bits, mark the following as reserved (not available for
+data):
+
+1. Bullseye modules (Chebyshev distance ≤ bullseye_radius from center)
+2. Orientation mark corners (four corners of the mode message ring)
+3. Mode message band (the non-corner perimeter of the mode message ring)
+4. Reference grid lines (full symbols only): all modules at rows or columns
+   that are multiples of 16 from the center
+
+The data placement algorithm skips any module that is reserved. The bit
+index only advances when an unreserved module is written.
+
+### Mode message ring shares the innermost data ring
+
+The ring immediately outside the bullseye is split between the mode message
+bits and the start of the data bits. The mode message occupies the first
+28 bits (compact) or 40 bits (full) of this ring's non-corner positions
+(clockwise from top-left corner + 1). The remaining positions in this ring
+are filled by the data bit stream starting from bit 0.
+
+For compact mode message ring (ring at radius 6):
+- 44 non-corner positions total
+- 28 used for mode message
+- 16 used for the first 16 data bits
+
+The layer spiral algorithm as described above already handles this: the "mode
+message ring" is ring at Chebyshev distance `d_i = bullseye_radius + 1`, and
+the first `mode_message_length` positions in the clockwise order are reserved
+for the mode message. The data spiral starts placing bits immediately after
+the mode message positions.
+
+---
+
+## Complete Encoding Algorithm
+
+The full encoding pipeline:
+
+```
+1. ENCODE DATA INTO CODEWORDS
+
+   a. Choose encoding: for v0.1.0, use Upper + Binary-Shift for all input.
+      For full multi-mode v0.2.0+, segment the input to minimize codeword count.
+   b. Build codeword list:
+      - Start in Upper mode (default starting mode)
+      - For uppercase A-Z or space: emit 5-bit Upper codeword
+      - For all other input: emit Binary-Shift (codeword 31 in Upper mode),
+        then 5-bit length (if ≤ 31 bytes) or 11-bit length, then raw bytes
+   c. Count the total bits in the codeword sequence.
+
+2. DETERMINE SYMBOL SIZE
+
+   a. Start with compact Aztec layers 1..4. For each:
+      - data_bits_available = total_bits_in_layer(compact, L)
+                              minus mode_message_bits (28)
+      - minimum_ecc_bits = ceil(requested_ecc_percent * data_bits_available)
+      - if (data_bits + ecc_bits) ≤ data_bits_available: this layer fits → use it
+   b. If no compact layer fits, try full Aztec layers 1..32 similarly
+      (using 40 bits for mode message).
+   c. If nothing fits → raise InputTooLong.
+
+3. PAD DATA CODEWORDS
+
+   The data codeword sequence must be padded to exactly `data_codeword_count`
+   codewords, where `data_codeword_count` is determined by the symbol size
+   minus ECC codeword count. Pad with PADDING codewords (value 0).
+
+   If the last codeword is a partial codeword (the total data bits are not a
+   multiple of the codeword bit width), zero-fill the trailing bits.
+
+   Exception: if the last codeword before ECC would be all zeros (value 0 in
+   GF), replace it with the maximum codeword value (all ones) to avoid RS
+   complications. This is the "all-zero codeword avoidance" rule.
+
+4. COMPUTE REED-SOLOMON ECC
+
+   a. Determine field size from codeword bit width:
+      - 4-bit codewords → GF(16), poly 0x13
+      - 5-bit codewords → GF(32), poly 0x25
+      - 8-bit codewords → GF(256), poly 0x12D  (use MA02 for this case)
+   b. Compute the RS generator polynomial for the chosen ECC codeword count.
+   c. Divide the data codeword polynomial by the generator to get the ECC
+      remainder. (Polynomial remainder / systematic encoding, same as MA02.)
+   d. Append ECC codewords to the data codewords.
+
+5. APPLY BIT STUFFING
+
+   Run the bit-stuffing algorithm on the combined (data + ECC) bit stream.
+
+6. COMPUTE MODE MESSAGE
+
+   a. Determine `layers - 1` (compact: 2 bits; full: 5 bits)
+   b. Determine `data_codeword_count - 1` (compact: 6 bits; full: 11 bits)
+   c. Pack into nibbles and compute GF(16) RS ECC.
+   d. Flatten to 28 bits (compact) or 40 bits (full).
+
+7. INITIALIZE GRID
+
+   a. Create an NxN grid (all light modules).
+   b. Place the bullseye (concentric rings from center, alternating D/L as
+      defined by Chebyshev distance).
+   c. Place orientation marks (4 dark corner modules of the mode message ring).
+   d. Place mode message bits in the non-corner perimeter of the mode message ring.
+   e. For full symbols: draw reference grid lines (center row/col, ±16, ±32, ...).
+   f. Mark all placed modules as "reserved" for the data placement step.
+
+8. PLACE DATA + ECC BITS
+
+   Run the layer spiral algorithm from the innermost data layer outward,
+   placing bits from the stuffed bit stream into non-reserved modules.
+   The first layer's spiral starts after the mode message positions.
+
+9. LAYOUT + PAINT
+
+   Pass the final ModuleGrid to barcode-2d's `layout(grid, config)` to
+   produce a PaintScene (P2D00). Pass the PaintScene to a PaintVM backend.
+```
+
+---
+
+## Implementation Notes
+
+### v0.1.0 simplifications
+
+The following simplifications are acceptable for v0.1.0 and should be
+explicitly noted in code comments:
+
+1. **Byte mode only**: encode all input via Binary-Shift from Upper mode.
+   Multi-mode optimization (Digit, Upper, Lower, Mixed, Punct) is v0.2.0.
+
+2. **8-bit codewords only**: treat all data as byte-mode (GF(256) RS via MA02).
+   This avoids implementing GF(16) and GF(32) RS for data codewords.
+   GF(16) is still required for the mode message.
+
+3. **No multi-segment encoding**: the entire input is one Binary-Shift segment.
+
+4. **Default ECC = 23%**: do not expose the ECC percentage knob in v0.1.0.
+
+5. **Auto-select compact vs full**: do not expose a `compact` option in v0.1.0.
+
+### Tables to embed
+
+The following constants must be embedded as lookup tables:
+
+1. **Layer capacity table**: for compact layers 1..4 and full layers 1..32:
+   - total usable data modules (after subtracting bullseye, mode message,
+     reference grid, orientation marks)
+   - number of full codewords (at 8-bit and 5-bit sizes) that fit
+   - number of RS ECC codewords for 23% default ECC
+
+2. **GF(16) log/antilog tables**: for mode message RS computation.
+
+3. **GF(16) RS generator polynomials**: for (7,2) compact and (10,4) full
+   mode message codes.
+
+4. **GF(256) = MA02** (already in repo): reused for 8-bit codeword RS.
+
+### GF(16) implementation
+
+GF(16) arithmetic uses the primitive polynomial `x^4 + x + 1 = 0x13`:
+
+```
+GF16_LOG  = [−∞, 0, 1, 4, 2, 8, 5, 10, 3, 14, 9, 7, 6, 13, 11, 12]
+GF16_ALOG = [1, 2, 4, 8, 3, 6, 12, 11, 5, 10, 7, 14, 15, 13, 9, 1]
+
+gf16_mul(a, b):
+  if a == 0 or b == 0: return 0
+  return GF16_ALOG[(GF16_LOG[a] + GF16_LOG[b]) mod 15]
+```
+
+### Mode message RS in detail
+
+**Compact mode message** uses a (7,2) code over GF(16):
+- 2 data nibbles → 5 ECC nibbles
+- RS generator polynomial with roots α^1 through α^5 over GF(16)
+
+The generator polynomial:
+```
+g(x) = (x + α^1)(x + α^2)(x + α^3)(x + α^4)(x + α^5)
+     = x^5 + g4*x^4 + g3*x^3 + g2*x^2 + g1*x + g0
+
+Computing over GF(16), poly 0x13:
+g(x) = x^5 + 0xF*x^4 + 0x1A*x^3 + ...
+```
+
+Rather than deriving this at runtime, embed the precomputed generator
+polynomial coefficients directly (ISO/IEC 24778:2008, Annex A).
+
+**Full mode message** uses a (10,4) code over GF(16):
+- 4 data nibbles → 6 ECC nibbles
+- RS generator polynomial with roots α^1 through α^6 over GF(16)
+
+### Bit stuffing interaction with RS
+
+Bit stuffing is applied **after** RS ECC is appended. This means:
+
+1. The RS check symbols are valid over the un-stuffed bit sequence.
+2. A decoder must de-stuff first, then perform RS decoding.
+3. The stuffed bit count exceeds the un-stuffed bit count by at most
+   1 extra bit for every 4 bits (25% overhead in the worst case; typical
+   data has much less overhead because perfectly alternating bits trigger
+   no stuffing).
+
+In practice the stuffing overhead is small: for random binary data, the
+expected overhead is `n / (4 * 2) = n/8` extra bits (one stuff per expected
+run of 4 same-value bits, which occurs on average every 16 bits for truly
+random data). The symbol size selection must account for stuffing overhead.
+A conservative estimate: add 20% to the bit count before comparing against
+layer capacity.
+
+### Reference grid conflicts with data layers
+
+The reference grid lines occupy modules that would otherwise be data modules.
+The data placement algorithm must skip these. The bit index does NOT advance
+when a skipped module is encountered — only when a bit is actually placed.
+
+This means the reference grid acts as a "gap" in the data layout. Decoders
+must know which modules are reference grid modules and skip them when
+extracting data bits — the data bit stream is continuous despite the gaps.
+
+### Coordinate system
+
+The symbol is a square grid. Use row-major order:
+
+```
+(row=0, col=0) = top-left corner of symbol
+(row=N-1, col=N-1) = bottom-right corner
+```
+
+The bullseye center is at:
+```
+cx = cy = (N - 1) / 2 = floor(N / 2)
+```
+
+Since N is always odd (from the formula `11 + 4L` and `15 + 4L`), the center
+is always an integer coordinate.
+
+---
+
+## Visualization Annotations
+
+| Color (suggested) | Role |
+|-------------------|------|
+| Deep blue | bullseye rings |
+| Blue-grey | orientation marks |
+| Purple | mode message bits |
+| Teal | reference grid lines |
+| Black/white | data module |
+| Green/light green | ECC module |
+| Orange | bit-stuffing bits |
+
+---
+
+## Error Types
+
+```
+AztecError::InputTooLong    -- input does not fit in a 32-layer full symbol
+AztecError::InvalidMode     -- internal: mode encoding produced an invalid codeword
+AztecError::LayerOverflow   -- bit stuffing caused data to overflow the layer
+                               (should not occur if sizing accounts for stuffing overhead)
+```
+
+---
+
+## Public API
+
+```
+encode(input: string | bytes, options?: AztecOptions) → ModuleGrid
+  -- Encodes input to an Aztec Code module grid (abstract module units, no pixels).
+  -- Raises InputTooLong if input exceeds 32-layer full symbol capacity.
+  -- ModuleGrid contains the dark/light module values for the complete symbol.
+
+layout(grid: ModuleGrid, config?: Barcode2DLayoutConfig) → PaintScene
+  -- Translate a ModuleGrid into a pixel-resolved PaintScene (P2D00).
+  -- Delegates to barcode-2d::layout() — aztec-code does not implement this itself.
+
+encode_and_layout(input: string | bytes, options?: AztecOptions,
+                  config?: Barcode2DLayoutConfig) → PaintScene
+  -- Convenience: encode + layout in one call.
+
+render_svg(input: string | bytes, options?: AztecOptions,
+           config?: Barcode2DLayoutConfig) → string
+  -- Convenience: encode + layout + paint-vm-svg backend → SVG string.
+
+explain(input: string | bytes, options?: AztecOptions) → AnnotatedModuleGrid
+  -- Encode with full per-module role annotations (for visualizers).
+
+AztecOptions {
+  min_ecc_percent?: number    -- minimum ECC percentage (default: 23, range: 10..90)
+  compact?:         boolean   -- force compact form; error if data does not fit (default: false)
+  -- v0.2.0 additions:
+  -- encoding_mode?: "auto" | "bytes" | "text"
+}
+```
+
+---
+
+## Package Matrix
+
+| Language | Directory | Depends on |
+|----------|-----------|------------|
+| Rust | `code/packages/rust/aztec-code/` | barcode-2d, gf256 (MA01), reed-solomon (MA02) |
+| TypeScript | `code/packages/typescript/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Python | `code/packages/python/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Go | `code/packages/go/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Ruby | `code/packages/ruby/aztec_code/` | barcode-2d, gf256, reed-solomon |
+| Elixir | `code/packages/elixir/aztec_code/` | barcode_2d, gf256, reed_solomon |
+| Lua | `code/packages/lua/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Perl | `code/packages/perl/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Swift | `code/packages/swift/aztec-code/` | Barcode2D, GF256, ReedSolomon |
+| C# | `code/packages/csharp/aztec-code/` | Barcode2D, GF256, ReedSolomon |
+| F# | `code/packages/fsharp/aztec-code/` | Barcode2D, GF256, ReedSolomon |
+| Kotlin | `code/packages/kotlin/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Java | `code/packages/java/aztec-code/` | barcode-2d, gf256, reed-solomon |
+| Dart | `code/packages/dart/aztec-code/` | barcode_2d, gf256, reed_solomon |
+| Haskell | `code/packages/haskell/aztec-code/` | barcode-2d, gf256, reed-solomon |
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+1. **GF(16) arithmetic**: verify the log/antilog tables, multiplication and
+   division for all non-zero elements, and the identity `α^15 = α^0 = 1`.
+
+2. **Mode message encoding (compact)**:
+   - Input: 1 layer, 5 data codewords
+   - Expected mode message: compute manually and verify bit pattern
+   - Verify all 7 nibbles (2 data + 5 ECC) are correct
+
+3. **Mode message encoding (full)**:
+   - Input: 2 layers, 12 data codewords
+   - Verify all 10 nibbles
+
+4. **Bit stuffing**:
+   - Input: `0b00001111_00001111` → verify stuff bits inserted after each
+     run of 4 identical bits
+   - Input: alternating bits → verify no stuffing (no runs of 4)
+   - Input: all zeros (32 bits) → verify every 4th bit has a stuff 1
+
+5. **Layer spiral placement**:
+   - For a compact 1-layer symbol with known data, verify that each module
+     in the data ring is set to the expected bit value at the expected
+     (row, col) position
+
+6. **RS encoding (GF(256) byte mode)**:
+   - Encode a known byte sequence. Verify ECC codewords match MA02 output
+     with the same generator roots and poly 0x12D.
+
+7. **Full encode integration**:
+   - Encode `"A"` → verify it produces a 15×15 compact 1-layer symbol
+   - Verify bullseye is correctly placed (center 3×3 dark, ring 2 light, etc.)
+   - Verify mode message ring modules
+
+### Integration tests
+
+1. **Round-trip test**: encode a string with this encoder, render to PNG,
+   decode with a reference Aztec scanner (e.g., `zxing`), verify decoded
+   string matches input.
+
+2. **Known test vectors** from ISO/IEC 24778:2008 Annex I (sample symbols):
+   - Character string "ISO/IEC 24778:2008" → verify exact module grid
+
+3. **IATA boarding pass encoding**: encode a standard IATA boarding pass
+   data string and verify the symbol is accepted by boarding pass scanners.
+
+### Cross-language verification
+
+All 15 language implementations should produce **identical ModuleGrid outputs**
+for the same input. Run the test corpus against all implementations:
+
+```
+"A"                               -- compact 1 layer, uppercase only
+"Hello World"                     -- binary-shift from Upper
+"https://example.com"             -- URL, mixed case, symbol chars
+"01234567890123456789"             -- digit-heavy
+<64 bytes of 0x00..0x3F>          -- raw binary
+```
+
+---
+
+## Dependency Stack
+
+```
+paint-metal (P2D02)    paint-vm-svg    paint-vm-canvas
+      └──────────────────┬─────────────────┘
+                         │
+                  paint-vm (P2D01)
+                         │
+              paint-instructions (P2D00)
+                         │
+                     barcode-2d          MA02 reed-solomon
+                         │                   │
+                    aztec-code ──────────────┘
+                         │
+                      MA01 gf256
+                         │
+                      MA00 polynomial
+```
+
+`aztec-code` depends on:
+- `barcode-2d` — for the `ModuleGrid` type and `layout()` function
+- `MA02` (reed-solomon) — for GF(256) RS encoding in byte mode (same polynomial
+  as Data Matrix, `0x12D`, b=1 convention — MA02 is a direct drop-in)
+- `MA01` (gf256) — for GF(256) field arithmetic; GF(16) is implemented inline
+  since it is not provided by an existing package
+
+Unlike `qr-code`, which uses a different RS convention (b=0) and cannot call
+MA02 directly, `aztec-code` uses the b=1 convention and calls MA02 directly
+for all GF(256) RS operations. GF(16) arithmetic for the mode message is a
+small self-contained implementation (15-element field, two 15-element tables).
+
+---
+
+## Future Extensions
+
+- **Multi-mode encoding** — optimal segmentation into Digit, Upper, Lower,
+  Mixed, Punct, and Binary regions for minimum symbol size. For typical URL
+  inputs this can reduce the layer count by 1–2 compared to byte-only mode.
+
+- **ECI mode** — Extended Channel Interpretation for signaling non-ASCII
+  character encodings (UTF-8, ISO-8859-n, shift-JIS, etc.) to the decoder.
+
+- **Structured Append** — split a large message across multiple Aztec symbols,
+  each with a sequence number and total count.
+
+- **Decoder** — a separate, more complex spec covering image preprocessing,
+  perspective correction, bullseye detection, mode message extraction,
+  RS decoding with error location, and multi-mode codeword parsing.
+
+- **Animated / multi-layer display** — the `explain()` API with the
+  interactive visualizer showing each layer, mode switch, and RS codeword
+  highlighted in the symbol.
+
+- **Micro Aztec** — sub-compact forms for very short strings on tiny labels
+  (not part of ISO/IEC 24778 but discussed in the Welch Allyn patent history).
+
+- **GF(32) RS** — implement a general GF(32) RS encoder for 5-bit codeword
+  sequences; currently the 8-bit codeword path via GF(256) serves as the
+  universal v0.1.0 fallback.

--- a/code/specs/data-matrix.md
+++ b/code/specs/data-matrix.md
@@ -1,0 +1,1669 @@
+# Data Matrix ECC200
+
+## Overview
+
+This spec defines a **Data Matrix ECC200 encoder** for the coding-adventures
+monorepo.
+
+Data Matrix is a two-dimensional matrix barcode first developed by RVSI Acuity
+CiMatrix (formerly Siemens) in 1989 under the name "DataCode." The ECC200
+variant — introduced in the mid-1990s and standardized as ISO/IEC 16022:2006
+— replaced the older ECC000–ECC140 lineage with Reed-Solomon error correction
+over GF(256). It is now the dominant form worldwide and the only variant this
+spec covers.
+
+Data Matrix is used wherever small, high-density, damage-tolerant marks are
+needed on physical objects:
+
+- **Printed circuit boards**: every PCB carries a Data Matrix etched or printed
+  on the substrate for traceability through automated assembly lines.
+- **Pharmaceuticals**: the US FDA mandates Data Matrix 2D barcodes on unit-dose
+  packaging for drug traceability (DSCSA).
+- **Aerospace**: parts marking on aircraft components — rivets, shims, brackets —
+  requires marks that survive decades of abrasion, heat, and cleaning chemicals.
+  Data Matrix is used because it can be etched (dot-peen, laser, chemical) onto
+  metal, surviving conditions that would destroy ink-printed labels.
+- **US Postal Service**: the USPS 4-State Customer Barcode (Intelligent Mail)
+  embeds routing information in a stacked linear format, but Data Matrix is used
+  on registered mail and customs forms.
+- **Medical devices**: DI (device identification) codes on surgical instruments
+  and implants.
+
+The format's defining characteristics:
+
+1. **No masking** — data is placed directly without the XOR masking step QR
+   requires. The diagonal placement algorithm distributes bits well enough
+   without it.
+2. **L-shaped finder + clock border** — instead of three separate finder
+   patterns, the entire perimeter is used: a solid-dark L on two sides, and
+   alternating dark/light on the other two. This single-pass border is faster
+   to locate than three disjoint finder patterns.
+3. **Diagonal "Utah" placement** — codeword bits spiral diagonally through the
+   grid in a pattern that resembles the outline of the US state of Utah. The
+   diagonal trajectory distributes bits evenly, gives every codeword physical
+   separation from its neighbors, and avoids the need for masking.
+4. **Uses MA02 (b=1) Reed-Solomon directly** — unlike QR, which uses a
+   different generator root convention (b=0), Data Matrix uses exactly the
+   same b=1 convention as the MA02 reed-solomon package in this repo.
+
+Understanding how to build a Data Matrix encoder from scratch teaches:
+
+- how structured borders serve as both finders and timing signals
+- how a diagonal placement algorithm distributes bits without masking
+- how large symbols are subdivided into data regions with interregion alignment
+  borders
+- how multiple interleaved RS blocks improve burst-error resilience
+- how the same GF(256) math underlies different barcode standards
+
+The encoder in this spec produces a **valid, scannable Data Matrix ECC200
+symbol** for any input string that fits within the 144×144 maximum symbol size.
+It does not implement decoding.
+
+---
+
+## Symbol Structure
+
+A Data Matrix ECC200 symbol is a square or rectangular grid of **modules** —
+dark (1) or light (0) square cells. Every module participates in the symbol:
+there are no dedicated "alignment-only" interior patterns separate from the
+data area (unlike QR's alignment patterns, which eat into data capacity).
+
+### The "finder + clock" border
+
+The outermost ring of every Data Matrix symbol forms a fixed perimeter pattern.
+Reading the perimeter clockwise from the bottom-left corner:
+
+```
+  col 0    col 1   ...  col N-1   col N
+row 0:  D   D    D   D   D   D   D   D
+        ^                               ^
+        |  timing (alternating D/L)     |
+        L                               L
+row 1:  D                               D
+        |  ...       data modules ...   |
+        |  (interior)                   |
+        L                               L
+row N:  D   L    D   L   D   L   D   L
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        finder L-bar (all dark, bottom row)
+
+Legend:
+  D = dark module
+  L = light module
+  col 0 = left column (all dark = "L-bar" left leg)
+  row N = bottom row  (all dark = "L-bar" bottom leg)
+  row 0 = top row     (alternating D/L starting with D = timing clock)
+  col N = right column (alternating D/L starting with D = timing clock)
+```
+
+More precisely for a symbol of size R rows × C columns:
+
+```
+Top row    (row 0):       module[0][c] = (c % 2 == 0) ? dark : light
+                          -- alternating, starts dark at col 0
+Right col  (col C-1):     module[r][C-1] = (r % 2 == 0) ? dark : light
+                          -- alternating, starts dark at row 0
+Bottom row (row R-1):     module[R-1][c] = dark  (all dark)
+Left col   (col 0):       module[r][0]   = dark  (all dark)
+```
+
+The L-shaped solid-dark bar (left column + bottom row) is the **finder
+pattern**. It tells a scanner where the symbol is and which way it is
+oriented. The alternating dark/light clock on the top row and right column
+is the **timing pattern**. It tells the scanner the module pitch so it can
+recover from slight distortion.
+
+Together the four sides form the "finder + clock" border:
+
+```
+D D D D D D D D D D   ← timing (col 0 is also the start of the L-finder)
+D . . . . . . . . D   ← right column timing  |
+D . data modules . D   |
+D . (interior)   . D   |
+D . . . . . . . . D   |
+D . . . . . . . . L   ← timing (alternating)
+D D D D D D D D D D   ← L-finder bottom row (all dark)
+↑
+L-finder left col (all dark)
+```
+
+The interior `(R-2) × (C-2)` module area after stripping the perimeter border
+is the "data area." This is where data and ECC codewords are placed by the
+Utah algorithm.
+
+### Quiet zone
+
+A quiet zone of **1 module** on all sides is required around the symbol.
+This is narrower than QR's 4-module quiet zone because the L-finder is itself
+high-contrast and self-delimiting. Many practical applications use 2 modules
+for robustness. The `quiet_zone_modules` default for this package should be 1.
+
+### Visualization of a 10×10 symbol
+
+Below is an annotated map of the smallest Data Matrix symbol (10×10 modules).
+The data area is 8×8 after stripping the border.
+
+```
+  col: 0  1  2  3  4  5  6  7  8  9
+row 0: [D][D][L][D][L][D][L][D][L][D]   ← timing row (top)
+row 1: [D][.][.][.][.][.][.][.][.][D]   ← right col timing
+row 2: [D][.][.][.][.][.][.][.][.][L]
+row 3: [D][.][.][.][.][.][.][.][.][D]
+row 4: [D][.][  data + ECC modules .][D]
+row 5: [D][.][  (placed by Utah   .][L]
+row 6: [D][.][   algorithm)        .][D]
+row 7: [D][.][.][.][.][.][.][.][.][L]
+row 8: [D][.][.][.][.][.][.][.][.][D]
+row 9: [D][D][D][D][D][D][D][D][D][D]   ← L-finder bottom row
+
+Legend:
+  [D] = dark module (fixed, structural)
+  [L] = light module (fixed, structural)
+  [.] = data/ECC module (set by Utah placement)
+```
+
+Note that (row 0, col 0) is dark — it is simultaneously the start of the
+L-finder (left column dark) and the start of the timing row. Both converge
+at the corner.
+
+---
+
+## Symbol Sizes
+
+Data Matrix ECC200 comes in 30 square sizes and 6 rectangular sizes, for a
+total of 36 standardized variants.
+
+### Square symbol sizes
+
+| Symbol | Data regions | Data codewords | ECC codewords | Max chars (ASCII) |
+|--------|-------------|----------------|---------------|-------------------|
+| 10×10  | 1×1         | 3              | 5             | 1                 |
+| 12×12  | 1×1         | 5              | 7             | 3                 |
+| 14×14  | 1×1         | 8              | 10            | 6                 |
+| 16×16  | 1×1         | 12             | 12            | 10                |
+| 18×18  | 1×1         | 18             | 14            | 16                |
+| 20×20  | 1×1         | 22             | 18            | 20                |
+| 22×22  | 1×1         | 30             | 20            | 28                |
+| 24×24  | 1×1         | 36             | 24            | 34                |
+| 26×26  | 1×1         | 44             | 28            | 42                |
+| 32×32  | 2×2         | 62             | 36            | 60                |
+| 36×36  | 2×2         | 86             | 42            | 84                |
+| 40×40  | 2×2         | 114            | 48            | 112               |
+| 44×44  | 2×2         | 144            | 56            | 142               |
+| 48×48  | 2×2         | 174            | 68            | 172               |
+| 52×52  | 2×2         | 204            | 84            | 202               |
+| 64×64  | 4×4         | 280            | 112           | 278               |
+| 72×72  | 4×4         | 368            | 144           | 366               |
+| 80×80  | 4×4         | 456            | 192           | 454               |
+| 88×88  | 4×4         | 576            | 224           | 574               |
+| 96×96  | 4×4         | 696            | 272           | 694               |
+| 104×104 | 4×4        | 816            | 336           | 814               |
+| 120×120 | 6×6        | 1050           | 408           | 1048              |
+| 132×132 | 6×6        | 1304           | 496           | 1302              |
+| 144×144 | 6×6        | 1558           | 620           | 1556              |
+
+Notes:
+
+- "Data regions" = how many subregions the interior is divided into (see
+  below). Small symbols (up to 26×26) have a single data region (1×1).
+- "Max chars (ASCII)" is approximate; digit pairs take half the codeword
+  budget because two-digit sequences are packed into one codeword.
+- The 24 sizes above are the primary 24 square sizes. The ISO standard lists
+  30 total square sizes; the 6 additional "extended" square sizes
+  (52×52 is the first extended) involve row/column interleaving for
+  particularly large blocks — the table above covers all values an
+  implementer needs.
+
+### Rectangular symbol sizes
+
+| Symbol | Data regions | Data codewords | ECC codewords |
+|--------|-------------|----------------|---------------|
+| 8×18   | 1×1         | 5              | 7             |
+| 8×32   | 1×2         | 10             | 11            |
+| 12×26  | 1×1         | 16             | 14            |
+| 12×36  | 1×2         | 22             | 18            |
+| 16×36  | 1×2         | 32             | 24            |
+| 16×48  | 1×2         | 49             | 28            |
+
+Rectangular symbols follow the same encoding algorithm as square symbols.
+Their data regions are always single row (1 row of regions, 1 or 2 region
+columns). The L-finder and timing clock borders are on the same sides (left
+column and bottom row dark; top row and right column alternating).
+
+### Symbol size selection
+
+The encoder must select the **smallest symbol** that can hold the encoded data.
+The selection algorithm:
+
+```
+1. Compute the number of encoded codewords for the input
+   (encoding details in the next section).
+2. Iterate over the symbol sizes in ascending order (10×10, 12×12, 14×14, ...,
+   then rectangular variants 8×18, 8×32, ..., if rectangular mode is enabled).
+3. Select the first symbol whose data_codewords capacity ≥ encoded codeword count.
+4. If none fits, return InputTooLong.
+```
+
+By default, the encoder selects from square symbols only. Rectangular symbols
+are available when `DataMatrixOptions.shape = Rectangular`.
+
+---
+
+## Data Regions
+
+For symbols larger than 26×26, the interior data area is subdivided into
+**data regions** — rectangular subareas separated by "alignment borders."
+Each alignment border is 2 modules wide and consists of a solid-dark bar
+adjacent to an alternating dark/light bar (the same visual language as the
+outer finder + timing border). The alignment borders between regions allow
+a scanner to correct for perspective distortion within large symbols.
+
+The structure is:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  outer finder+timing border (all four sides)                    │
+│  ┌──────────┬──┬──────────┬──┬──────────┐                      │
+│  │ data     │AB│ data     │AB│ data     │                      │
+│  │ region   │  │ region   │  │ region   │                      │
+│  │ (10×10   │  │ (10×10   │  │ (10×10   │                      │
+│  │ interior)│  │ interior)│  │ interior)│                      │
+│  ├──────────┴──┴──────────┴──┴──────────┤                      │
+│  │ alignment border (horizontal)        │                      │
+│  ├──────────┬──┬──────────┬──┬──────────┤                      │
+│  │ data     │AB│ data     │AB│ data     │                      │
+│  │ region   │  │ region   │  │ region   │                      │
+│  └──────────┴──┴──────────┴──┴──────────┘                      │
+│                                                                  │
+│  AB = alignment border column (2 modules wide)                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Alignment border pattern
+
+Horizontal alignment borders (between rows of regions):
+
+```
+row AB+0: D D D D D D D D ...   (all dark)
+row AB+1: D L D L D L D L ...   (alternating, starts dark)
+```
+
+Vertical alignment borders (between columns of regions):
+
+```
+col AB+0: D D D D D D D D ...   (all dark)
+col AB+1: D L D L D L D L ...   (alternating, starts dark)
+```
+
+The alignment border has the same "solid + alternating" structure as the outer
+finder + timing border but embedded within the interior.
+
+### Data region layout table
+
+Selected symbol sizes showing data region dimensions:
+
+| Symbol  | # row × col regions | Region data size (interior) |
+|---------|---------------------|-----------------------------|
+| 10×10   | 1×1                 | 8×8                         |
+| 12×12   | 1×1                 | 10×10                       |
+| 14×14   | 1×1                 | 12×12                        |
+| 16×16   | 1×1                 | 14×14                        |
+| 18×18   | 1×1                 | 16×16                        |
+| 20×20   | 1×1                 | 18×18                        |
+| 22×22   | 1×1                 | 20×20                        |
+| 24×24   | 1×1                 | 22×22                        |
+| 26×26   | 1×1                 | 24×24                        |
+| 32×32   | 2×2                 | 14×14 each                   |
+| 40×40   | 2×2                 | 18×18 each                   |
+| 44×44   | 2×2                 | 20×20 each                   |
+| 48×48   | 2×2                 | 22×22 each                   |
+| 64×64   | 4×4                 | 14×14 each                   |
+| 88×88   | 4×4                 | 20×20 each                   |
+| 104×104 | 4×4                 | 24×24 each                   |
+| 120×120 | 6×6                 | 18×18 each                   |
+| 132×132 | 6×6                 | 20×20 each                   |
+| 144×144 | 6×6                 | 22×22 each                   |
+
+Computing the region interior size from the symbol dimensions:
+
+```
+For a symbol of size R×C with rr×rc data region rows×cols:
+  region_height = (R - 2) / rr - 2    -- subtract outer border, divide, subtract AB
+  region_width  = (C - 2) / rc - 2
+
+More precisely, the "matrix height" (interior excl. outer border) = R - 2,
+and with rr regions and (rr - 1) horizontal alignment borders (each 2 wide):
+  region_data_height = (R - 2 - 2*(rr-1)) / rr
+
+Equivalently, the ISO standard defines the "number of data rows" and
+"number of data columns" per region directly as tabulated constants. Embed
+these as a lookup table rather than recomputing at runtime.
+```
+
+### Importance of data regions for the Utah algorithm
+
+The Utah placement algorithm (described below) operates within the
+**logical data matrix** — the concatenation of all data region interiors,
+treated as a single flat grid. The algorithm knows nothing about the
+structural borders. The implementation must map from logical (row, col) in
+the flat data matrix to physical (row, col) in the full symbol, accounting
+for outer border, alignment borders, and region layout. This mapping is
+performed once when writing the final module grid.
+
+---
+
+## Data Encoding
+
+Data Matrix ECC200 does not use distinct "mode indicators" like QR. Instead
+it uses a **codeword vocabulary** of 256 values, where different ranges of
+codeword values invoke different encoding schemes. The encoding state machine
+starts in ASCII mode and can switch to other modes using latch/shift
+codewords.
+
+### ASCII mode (default)
+
+ASCII mode is the default state. Each codeword encodes one character or two
+digits.
+
+| Input | Codeword value | Range |
+|-------|----------------|-------|
+| ASCII 0–127 (single char) | ASCII_value + 1 | 1–128 |
+| Two consecutive ASCII digits (0x30–0x39) | 130 + (d1×10 + d2) | 130–229 |
+| ASCII 128–255 (extended; uses UPPER_SHIFT first) | 235, then ASCII_value - 127 | — |
+| Pad (fill unused capacity) | 129 | — |
+| Latch to C40 mode | 230 | — |
+| Latch to Text mode | 239 | — |
+| Latch to X12 mode | 238 | — |
+| Latch to EDIFACT mode | 240 | — |
+| Latch to Base256 mode | 231 | — |
+| Return to ASCII from C40/Text/X12 | 254 (Unlatch) | — |
+| Return to ASCII from EDIFACT | 0x1f in EDIFACT stream | — |
+
+The digit-pair optimization is critical for performance:
+
+```
+"12" → codeword 130 + (1×10 + 2) = 142       (1 codeword for 2 chars)
+"1"  → codeword 1 + 0x31 = 50                 (1 codeword for 1 char)
+```
+
+Encoding "12345678":
+```
+"12" → 142   "34" → 174   "56" → 196   "78" → 208
+Total: 4 codewords for 8 digit characters.
+Without digit pairs: 8 codewords. Saving: 50%.
+```
+
+The ASCII encoder should consume digit pairs greedily: whenever the current
+and next character are both ASCII digits (0x30–0x39), emit one codeword for
+the pair and advance two positions. Otherwise, encode the current character
+as a single codeword.
+
+#### Extended ASCII (UPPER_SHIFT)
+
+Characters with ASCII value 128–255 are encoded as two codewords:
+
+```
+UPPER_SHIFT (235), then  ASCII_value - 127
+```
+
+Example: ü (ASCII 252):
+```
+codeword 1: 235   (UPPER_SHIFT)
+codeword 2: 252 - 127 = 125
+```
+
+### C40 mode
+
+C40 is optimized for uppercase alphanumeric text mixed with numbers and
+special characters. It was named for the encoding of 40 characters using
+a base-40 packing scheme.
+
+C40 encodes three character values per two codeword bytes:
+
+```
+Three C40 values c1, c2, c3 → two bytes:
+  word = 1600 × c1 + 40 × c2 + c3 + 1
+  byte_high = word >> 8
+  byte_low  = word & 0xFF
+```
+
+The C40 character set (base values):
+
+| Value | Characters |
+|-------|-----------|
+| 0     | Shift 1 (values 0–31: ASCII control chars) |
+| 1     | Shift 2 (values 33–47, 58–64, 91–95) |
+| 2     | Shift 3 (values 96–127) |
+| 3     | Space (ASCII 32) |
+| 4–13  | Digits 0–9 |
+| 14–39 | Uppercase A–Z |
+
+Shift 1, 2, and 3 are shift prefixes that extend the base-40 vocabulary to
+cover all 128 ASCII characters. A character needing a shift prefix consumes
+two C40 values (shift + character value) instead of one.
+
+To return to ASCII mode from C40: emit the Unlatch codeword (254).
+
+C40 mode is most efficient when the message is dominated by uppercase letters
+and digits — common in alphanumeric part numbers, lot codes, and identifiers
+used in manufacturing and healthcare.
+
+### Text mode
+
+Text mode is structurally identical to C40 but with lowercase letters in the
+base set (values 14–39 map to a–z). Uppercase letters require Shift 3.
+Text mode is efficient when the message is dominated by lowercase ASCII text.
+
+| Value | Characters |
+|-------|-----------|
+| 0     | Shift 1 |
+| 1     | Shift 2 |
+| 2     | Shift 3 |
+| 3     | Space |
+| 4–13  | Digits 0–9 |
+| 14–39 | Lowercase a–z |
+
+### X12 mode
+
+X12 mode encodes the 40-character subset used in ANSI X12 EDI transactions:
+
+```
+Carriage return (CR), asterisk (*), greater-than (>), space ( ),
+digits 0–9, uppercase A–Z
+```
+
+Same packing formula as C40 (three values per two codewords). X12 is used
+almost exclusively for electronic data interchange (EDI) transactions in
+healthcare and supply chain.
+
+### EDIFACT mode
+
+EDIFACT mode packs four 6-bit values into three bytes. Each EDIFACT character
+is an ASCII value in the range 32–94 (printable ASCII excluding DEL and
+most control characters). The 6-bit value is `ASCII_value - 32`.
+
+```
+Four EDIFACT values v1, v2, v3, v4 → three bytes:
+  three_bytes = (v1 << 18) | (v2 << 12) | (v3 << 6) | v4
+  byte_1 = (three_bytes >> 16) & 0xFF
+  byte_2 = (three_bytes >>  8) & 0xFF
+  byte_3 =  three_bytes        & 0xFF
+```
+
+To return to ASCII from EDIFACT: emit the special 6-bit Unlatch value
+`0x1F` (31) as the next EDIFACT character before the normal end-of-mode
+handling.
+
+EDIFACT is used in European and international EDI messaging formats.
+
+### Base256 mode
+
+Base256 mode encodes arbitrary binary data. The length is embedded using a
+length indicator codeword that may be 1 or 2 bytes:
+
+```
+If length ≤ 249: one length codeword = length
+If length > 249:
+  length_byte_1 = (length / 250) + 249
+  length_byte_2 = length mod 250
+```
+
+Data bytes are randomized using a 255-element pseudorandom sequence
+(derived from the position within the symbol) to prevent long runs of the
+same value from creating degenerate placement patterns.
+
+The randomization function for byte at position `k` (1-indexed from start
+of symbol's codeword sequence):
+
+```
+scrambled = (raw_byte + (((149 × k) mod 255) + 1)) mod 256
+```
+
+And to unscramble during decoding:
+
+```
+raw_byte = (scrambled - (((149 × k) mod 255) + 1) + 256) mod 256
+```
+
+### Mode selection (v0.1.0)
+
+For the initial implementation, use ASCII mode for all input. This is correct
+for all printable ASCII text and supports the digit-pair optimization. The
+more efficient C40, Text, X12, EDIFACT, and Base256 modes are v0.2.0
+enhancements.
+
+ASCII mode selection heuristic:
+
+```
+If all characters in the input are ASCII digits (0x30–0x39):
+    Use digit-pair packing exclusively. This halves codeword count.
+Else:
+    Encode each character as a single ASCII codeword (ASCII + 1).
+    Apply digit-pair packing greedily wherever two consecutive digits appear.
+```
+
+### Pad codewords
+
+After encoding the data, the codeword sequence must be padded to exactly
+`data_codewords` bytes (the symbol's capacity). Padding rules:
+
+```
+1. The first pad byte is always 129 (the pad codeword).
+2. Subsequent pad bytes are "scrambled" pads using the same 149×k formula
+   as Base256, applied at the position k of the pad byte within the full
+   codeword stream:
+
+   pad_k = (129 + (((149 × k) mod 253) + 1)) mod 254
+   -- Note: mod 253 and mod 254, not 255/256 — different formula for pad!
+
+   More precisely (ISO/IEC 16022 §5.2.3):
+   scrambled_pad = 129 + (149 × k mod 253) + 1
+   if scrambled_pad > 254: scrambled_pad -= 254
+
+3. Each position k is 1-indexed from the start of the codeword sequence
+   (including data codewords before the pad region — k starts at
+   (data_codewords_used + 1) for the first pad).
+```
+
+The scrambled pad prevents a sequence of "129 129 129 ..." from creating
+a degenerate placement pattern in the unused area of a symbol.
+
+---
+
+## Reed-Solomon Error Correction
+
+Data Matrix ECC200 uses Reed-Solomon over **GF(256)** with the primitive
+polynomial:
+
+```
+x^8 + x^5 + x^4 + x^2 + x + 1   (decimal 301, hex 0x12D)
+```
+
+This is **different from QR Code's polynomial** (0x11D). Both are
+degree-8 irreducible polynomials over GF(2) and therefore define a valid
+GF(256) field, but the fields are non-isomorphic — the primitive element
+α has different additive and multiplicative properties in each.
+
+### Generator polynomial convention
+
+Data Matrix uses the **b=1 convention** — the generator polynomial's roots
+are α^1, α^2, ..., α^n:
+
+```
+g(x) = (x + α^1)(x + α^2)···(x + α^n)
+```
+
+This is exactly the convention used by **MA02 (reed-solomon)** in this repo.
+Data Matrix implementations MUST use MA02 with the 0x12D field polynomial,
+not QR's 0x11D polynomial.
+
+The difference in convention between QR (b=0) and Data Matrix (b=1):
+
+| Format       | Primitive poly | Generator roots | MA02 usable? |
+|--------------|----------------|-----------------|--------------|
+| QR Code      | 0x11D          | α^0 ... α^{n-1} | No (wrong roots) |
+| Data Matrix  | 0x12D          | α^1 ... α^n     | Yes (exact match) |
+| Aztec full   | 0x12D          | α^1 ... α^n     | Yes (exact match) |
+
+### GF(256) with polynomial 0x12D
+
+The GF(256) field for Data Matrix is generated with the reduction rule:
+when a polynomial multiplication produces a degree ≥ 8 term, reduce modulo
+0x12D:
+
+```
+0x12D = 0b100101101
+       = x^8 + x^5 + x^4 + x^2 + x + 1
+
+Reduction: if bit 8 is set in intermediate result r:
+    r = r XOR 0x12D       (because x^8 ≡ x^5+x^4+x^2+x+1 in this field)
+```
+
+The alpha (primitive element) table for 0x12D:
+
+```
+α^0  = 1 (= 0x01)
+α^1  = 2 (= 0x02)
+α^2  = 4 (= 0x04)
+α^3  = 8 (= 0x08)
+α^4  = 16 (= 0x10)
+α^5  = 32 (= 0x20)
+α^6  = 64 (= 0x40)
+α^7  = 128 (= 0x80)
+α^8  = 0x2D  (= 45  — 0x80 << 1, reduced by 0x12D)
+α^9  = 0x5A  (= 90)
+α^10 = 0xB4  (= 180)
+α^11 = 0x6D  (= 109)  -- reduction applied
+α^12 = 0xDA  (= 218)
+...
+α^254 = ??? (compute from recurrence)
+α^255 = 1    (field element order = 255)
+```
+
+Implementations must precompute the full 256-entry exp table and 256-entry
+log table for the 0x12D field. Do not reuse QR's 0x11D tables.
+
+### ECC block structure
+
+For large symbols, the data codeword stream is split across multiple
+interleaved RS blocks. Each block has its own independent RS computation.
+Interleaving distributes burst errors across all blocks, so a physical
+scratch or contamination that destroys a contiguous region of the symbol
+affects at most a few codewords from each block — well within each block's
+correction capacity.
+
+Full ECC block table:
+
+| Symbol  | Data CWs | ECC CWs | Blocks | Data/block     | ECC/block |
+|---------|----------|---------|--------|----------------|-----------|
+| 10×10   | 3        | 5       | 1      | 3              | 5         |
+| 12×12   | 5        | 7       | 1      | 5              | 7         |
+| 14×14   | 8        | 10      | 1      | 8              | 10        |
+| 16×16   | 12       | 12      | 1      | 12             | 12        |
+| 18×18   | 18       | 14      | 1      | 18             | 14        |
+| 20×20   | 22       | 18      | 1      | 22             | 18        |
+| 22×22   | 30       | 20      | 1      | 30             | 20        |
+| 24×24   | 36       | 24      | 1      | 36             | 24        |
+| 26×26   | 44       | 28      | 1      | 44             | 28        |
+| 32×32   | 62       | 36      | 2      | 31             | 18        |
+| 36×36   | 86       | 42      | 2      | 43             | 21        |
+| 40×40   | 114      | 48      | 2      | 57             | 24        |
+| 44×44   | 144      | 56      | 4      | 36             | 14        |
+| 48×48   | 174      | 68      | 4      | 43 + 44 + ...  | 17        |
+| 52×52   | 204      | 84      | 4      | 51             | 21        |
+| 64×64   | 280      | 112     | 4      | 70             | 28        |
+| 72×72   | 368      | 144     | 4      | 92             | 36        |
+| 80×80   | 456      | 192     | 4      | 114            | 48        |
+| 88×88   | 576      | 224     | 4      | 144            | 56        |
+| 96×96   | 696      | 272     | 4      | 174            | 68        |
+| 104×104 | 816      | 336     | 6      | 136            | 56        |
+| 120×120 | 1050     | 408     | 6      | 175            | 68        |
+| 132×132 | 1304     | 496     | 8      | 163            | 62        |
+| 144×144 | 1558     | 620     | 10     | 155 + 156×4+.. | 62        |
+
+For symbols with multiple blocks, split data codewords evenly:
+- If `data_codewords` is divisible by `num_blocks`: each block has
+  `data_codewords / num_blocks` data codewords.
+- If not evenly divisible: the first `data_codewords mod num_blocks` blocks
+  get one extra codeword (rounded up), the rest get the floor. This
+  matches the ISO interleaving convention.
+
+After computing ECC:
+```
+-- Block layout: each block i has data[i] and ecc[i]
+-- Interleave for placement:
+interleaved = []
+for position in 0..max_data_per_block:
+    for block in 0..num_blocks:
+        if position < len(data[block]):
+            interleaved.append(data[block][position])
+for position in 0..ecc_per_block:
+    for block in 0..num_blocks:
+        interleaved.append(ecc[block][position])
+```
+
+### RS encoding algorithm
+
+Each block's ECC codewords are computed as the polynomial remainder:
+
+```
+Given:
+  D(x) = data polynomial (data codewords as coefficients, highest degree first)
+  G(x) = generator polynomial for n_ecc ECC codewords (degree n_ecc)
+
+Compute:
+  R(x) = (D(x) × x^n_ecc) mod G(x)
+
+The n_ecc coefficients of R(x) are the ECC codewords for this block.
+```
+
+Linear-feedback implementation (using the LFSR approach, identical to QR
+but with the 0x12D GF table):
+
+```python
+def rs_encode_block(data: list[int], n_ecc: int, gen_poly: list[int]) -> list[int]:
+    # gen_poly[0] is the leading coefficient (degree n_ecc-1 term)
+    # gen_poly[n_ecc] is the constant term
+    ecc = [0] * n_ecc
+    for byte in data:
+        feedback = byte ^ ecc[0]
+        # Shift register left
+        for i in range(n_ecc - 1):
+            ecc[i] = ecc[i + 1] ^ gf_mul_0x12D(gen_poly[i + 1], feedback)
+        ecc[n_ecc - 1] = gf_mul_0x12D(gen_poly[n_ecc], feedback)
+    return ecc
+```
+
+### Generator polynomials for Data Matrix
+
+These must be embedded as constants. They are computed as
+`g(x) = ∏(x + α^k)` for k = 1 to n_ecc, over GF(256)/0x12D.
+
+Key generator polynomials (hex coefficients, highest degree first, including
+the implicit leading 1):
+
+```
+n_ecc = 5:
+  01 0F 36 78 40 A9  (degree-5 polynomial, 6 coefficients incl. leading 1)
+
+n_ecc = 7:
+  01 4F A0 C3 09 39 F5 82
+
+n_ecc = 10:
+  01 4B C1 E0 26 D6 43 2E 72 B8 A3
+
+n_ecc = 12:
+  01 E3 DB 1C 71 1F C5 D4 2C B0 83 EB 12
+
+n_ecc = 14:
+  01 4D 91 2A E3 EA F3 5D 1B 7B A1 2F 15 15 06
+
+n_ecc = 18:
+  01 8F E1 93 61 BA B1 BD 90 5B A5 F3 0E A6 4A B4 3A B0 3A
+
+n_ecc = 20:
+  01 1D C8 C1 0C A1 29 2D 47 E4 1B E8 6D B1 73 6C 1B 97 EA 3C DB
+
+n_ecc = 24:
+  01 DA 31 32 04 AE B6 D7 E2 21 93 94 D8 29 B8 3B 83 B7 4D 83 9A DA D4 22
+
+n_ecc = 28:
+  01 36 92 5D 52 40 B5 D1 57 A2 E3 CD 28 39 BD 19 C8 A0 FE 87 49 F1 2A 37
+     A7 B9 32 C5 3D
+
+n_ecc = 36:
+  01 DA 9E 89 5B 1E C9 06 77 FD 27 F0 81 C5 60 4D CF E2 B4 3E 3D 8A 51 A9
+     DE DC 5F F3 4F 79 A6 AB 54 4F E3
+
+n_ecc = 42:
+  (see ISO/IEC 16022 Annex A for full tables)
+
+n_ecc = 48:
+  (see ISO/IEC 16022 Annex A)
+
+... (larger block sizes: embed from ISO Annex A)
+```
+
+Implementers should embed all required generator polynomials from ISO
+Annex A as compile-time constants keyed by ECC codeword count.
+
+---
+
+## Module Placement — The Utah Algorithm
+
+The module placement algorithm is the most distinctive part of Data Matrix
+encoding. It is called the **"Utah" algorithm** because the 8-module patterns
+used to place each codeword vaguely resemble the US state of Utah — a
+rectangular shape with a notch cut from the top-right corner.
+
+### Conceptual overview
+
+The placement algorithm works on the **logical data matrix** — a virtual grid
+with rows numbered 0 to (data_rows-1) and columns 0 to (data_cols-1), where
+data_rows and data_cols are the interior dimensions after stripping the outer
+border. For multi-region symbols, this virtual grid spans all data regions
+concatenated.
+
+The algorithm walks a reference position (row, col) through this logical
+grid in a specific diagonal pattern, placing 8 bits of each codeword at
+8 fixed offsets relative to that reference position. After each codeword,
+the reference moves up-right by 2 columns and 2 rows.
+
+### The 8-module "Utah" placement shape
+
+For a codeword with MSB as bit 8 and LSB as bit 1, the 8 modules are placed
+at the following offsets relative to reference position (row, col):
+
+```
+Standard "Utah" placement (the common case for most positions):
+
+    col-2 col-1  col   col+1
+row-2: [bit8]
+row-1: [bit7] [bit6]
+row  : [bit5] [bit4] [bit3]
+                      [bit2] [bit1]  ← (row+1, col+1) and (row, col+1) NOT here
+```
+
+Wait — the actual layout is subtler. The Utah shape is:
+
+```
+Standard "Utah" shape for codeword at reference (row, col):
+
+  Offset    Row      Col
+  ------    ---      ---
+  bit 1:   row-2    col-1
+  bit 2:   row-2    col
+  bit 3:   row-1    col-2
+  bit 4:   row-1    col-1
+  bit 5:   row-1    col
+  bit 6:   row      col-2
+  bit 7:   row      col-1
+  bit 8:   row      col
+```
+
+Visualized as a grid (X = bit placed here, . = empty):
+
+```
+col:   c-2  c-1   c
+row-2:  .   [1]  [2]
+row-1: [3]  [4]  [5]
+row  : [6]  [7]  [8]
+```
+
+This shape looks like the state of Utah — a rectangle (cols c-2 to c,
+rows row-2 to row) with the top-left corner missing (no bit at row-2, col-2).
+
+The numbers [1]–[8] correspond to bits 1–8 of the codeword:
+- bit 8 (MSB) at (row, col)
+- bit 7 at (row, col-1)
+- bit 6 at (row, col-2)
+- bit 5 at (row-1, col)
+- bit 4 at (row-1, col-1)
+- bit 3 at (row-1, col-2)
+- bit 2 at (row-2, col)
+- bit 1 at (row-2, col-1)
+
+### The corner placement patterns
+
+When the standard Utah shape would place bits outside the data area boundary,
+special corner patterns handle wrapping. There are four special corner
+patterns defined in ISO/IEC 16022, Section 10.
+
+#### Corner pattern 1 (top-left wrap)
+
+Triggered when a codeword falls at the top-left corner region.
+
+```
+Offsets for corner pattern 1:
+  bit 8: (0,    nCols-2)    -- top row, near-right column
+  bit 7: (0,    nCols-1)    -- top row, rightmost column
+  bit 6: (1,    0)          -- second row, leftmost column
+  bit 5: (2,    0)          -- third row, leftmost column
+  bit 4: (nRows-2, 0)       -- near-bottom row, leftmost column
+  bit 3: (nRows-1, 0)       -- bottom row, leftmost column
+  bit 2: (nRows-1, 1)       -- bottom row, second column
+  bit 1: (nRows-1, 2)       -- bottom row, third column
+```
+
+#### Corner pattern 2 (top-right wrap)
+
+Triggered when the reference position falls in the top-right corner.
+
+```
+Offsets for corner pattern 2:
+  bit 8: (0,    nCols-2)
+  bit 7: (0,    nCols-1)
+  bit 6: (1,    nCols-1)
+  bit 5: (2,    nCols-1)
+  bit 4: (nRows-1, 0)
+  bit 3: (nRows-1, 1)
+  bit 2: (nRows-1, 2)
+  bit 1: (nRows-1, 3)
+```
+
+#### Corner pattern 3 (bottom-left wrap)
+
+Triggered at the bottom-left corner region.
+
+```
+Offsets for corner pattern 3:
+  bit 8: (0,    nCols-1)
+  bit 7: (1,    0)
+  bit 6: (2,    0)
+  bit 5: (nRows-2, 0)
+  bit 4: (nRows-1, 0)
+  bit 3: (nRows-1, 1)
+  bit 2: (nRows-1, 2)
+  bit 1: (nRows-1, 3)
+```
+
+#### Corner pattern 4 (right-edge wrap for odd-size matrices)
+
+A special-case 4th corner used only in matrices where (nRows mod 2 ≠ 0)
+and (nCols mod 2 ≠ 0) — rectangular symbols and some extended square sizes.
+
+```
+Offsets for corner pattern 4:
+  bit 8: (nRows-3, nCols-1)
+  bit 7: (nRows-2, nCols-1)
+  bit 6: (nRows-1, nCols-3)
+  bit 5: (nRows-1, nCols-2)
+  bit 4: (nRows-1, nCols-1)
+  bit 3: (0,       0)
+  bit 2: (1,       0)
+  bit 1: (2,       0)
+```
+
+### Boundary wrapping
+
+Even in the non-corner cases, the Utah shape may partially extend beyond
+the grid boundaries. When any bit's computed (row, col) is out of bounds,
+apply the following wrap rules:
+
+```
+If row < 0 and col >= 0:
+    row += nRows
+    col -= 4
+
+If col < 0 and row >= 0:
+    col += nCols
+    row -= 4
+
+If row < 0 and col == 0:
+    row = 1
+    col = 3
+
+If row < 0 and col == nCols:
+    row = 0
+    col = col - 2
+```
+
+These rules handle the diagonal scanning when the reference position is near
+the top or left edges.
+
+### The placement algorithm (complete pseudocode)
+
+```
+-- Initialization
+nRows = data_rows    -- logical data matrix height (excl. outer border)
+nCols = data_cols    -- logical data matrix width  (excl. outer border)
+grid  = new bool[nRows][nCols]   -- all false
+used  = new bool[nRows][nCols]   -- tracks assigned modules
+
+-- Precompute: is_assigned(r, c) = grid module already set (for special patterns)
+
+-- Run the Utah algorithm
+codeword_index = 0
+row = 4
+col = 0
+
+while true:
+    -- Special case 1: top-left corner fill for odd-position
+    if row == nRows and col == 0 and (nRows mod 4 == 0 or nCols mod 4 == 0):
+        place_corner1(codewords[codeword_index++], nRows, nCols, grid)
+    
+    -- Special case 2: top-right corner fill
+    if row == (nRows - 2) and col == 0 and nCols mod 4 != 0:
+        place_corner2(codewords[codeword_index++], nRows, nCols, grid)
+    
+    -- Special case 3: top-right corner fill (different condition)
+    if row == (nRows - 2) and col == 0 and nCols mod 8 == 4:
+        place_corner3(codewords[codeword_index++], nRows, nCols, grid)
+    
+    -- Special case 4: bottom-left / odd rectangle
+    if row == (nRows + 4) and col == 2 and nCols mod 8 == 0:
+        place_corner4(codewords[codeword_index++], nRows, nCols, grid)
+    
+    -- Standard diagonal traversal (upward-right)
+    loop:
+        if row >= 0 and col < nCols and not used[row][col]:
+            place_utah(codewords[codeword_index++], row, col, nRows, nCols, grid, used)
+        row -= 2
+        col += 2
+        if row < 0 or col >= nCols: break
+    
+    -- Step to next diagonal start position
+    row += 1
+    col += 3
+    
+    loop:
+        if row < nRows and col >= 0 and not used[row][col]:
+            place_utah(codewords[codeword_index++], row, col, nRows, nCols, grid, used)
+        row += 2
+        col -= 2
+        if row >= nRows or col < 0: break
+    
+    -- Step to next diagonal start position
+    row += 3
+    col += 1
+    
+    -- Termination: all codewords placed
+    if row >= nRows and col >= nCols: break
+    if codeword_index >= total_codewords: break
+
+-- Fill any remaining unset modules with 1 (dark)
+-- (These are the alignment/fill modules at the lower-right corner that
+-- exist in some symbol sizes to complete the grid)
+for r in 0..nRows:
+    for c in 0..nCols:
+        if not used[r][c]:
+            grid[r][c] = (r + c) mod 2 == 1   -- fill pattern: dark at odd positions
+```
+
+The fill pattern at the end (`(r + c) mod 2 == 1`) matches the ISO
+specification's "right and bottom fill" rule for symbols whose data area is
+not evenly divisible by the codeword placement scheme.
+
+### Placing a single codeword (place_utah)
+
+```
+procedure place_utah(codeword: byte, row: int, col: int,
+                     nRows: int, nCols: int,
+                     grid: bool[][], used: bool[][]):
+
+    -- Compute the 8 module positions using the standard Utah offsets
+    positions = [
+        (row,   col   ),   -- bit 8 (MSB)
+        (row,   col-1 ),   -- bit 7
+        (row,   col-2 ),   -- bit 6
+        (row-1, col   ),   -- bit 5
+        (row-1, col-1 ),   -- bit 4
+        (row-1, col-2 ),   -- bit 3
+        (row-2, col   ),   -- bit 2
+        (row-2, col-1 ),   -- bit 1 (LSB)
+    ]
+    
+    bits = [
+        (codeword >> 7) & 1,  -- bit 8
+        (codeword >> 6) & 1,  -- bit 7
+        (codeword >> 5) & 1,  -- bit 6
+        (codeword >> 4) & 1,  -- bit 5
+        (codeword >> 3) & 1,  -- bit 4
+        (codeword >> 2) & 1,  -- bit 3
+        (codeword >> 1) & 1,  -- bit 2
+        (codeword >> 0) & 1,  -- bit 1
+    ]
+    
+    for i in 0..8:
+        (r, c) = apply_boundary_wrap(positions[i], nRows, nCols)
+        if 0 <= r < nRows and 0 <= c < nCols and not used[r][c]:
+            grid[r][c] = bits[i] == 1
+            used[r][c] = true
+```
+
+### Mapping logical to physical coordinates
+
+After the Utah algorithm fills the logical data matrix `grid[nRows][nCols]`,
+map each (r, c) to physical symbol coordinates:
+
+```
+For a symbol with rr × rc data regions, each of size (rh × rw) logical:
+
+physical_row(r, c) =
+    (r / rh) * (rh + 2) + (r mod rh) + 1   -- +1 for outer finder border
+
+physical_col(r, c) =
+    (c / rw) * (rw + 2) + (c mod rw) + 1   -- +1 for outer finder border
+```
+
+The `+2` accounts for the 2-module alignment border between regions.
+The `+1` accounts for the 1-module outer border (finder + timing).
+
+For single-region symbols (1×1), this simplifies to:
+
+```
+physical_row = r + 1
+physical_col = c + 1
+```
+
+### No masking
+
+Data Matrix ECC200 does **not** apply masking after module placement. The
+diagonal Utah placement pattern inherently distributes bits across the symbol
+in a way that avoids degenerate patterns. The encoded data is placed once and
+the symbol is complete. This is in contrast to QR Code, which requires
+evaluating all 8 mask patterns and picking the best one.
+
+---
+
+## Complete Encoding Algorithm
+
+The full pipeline for encoding a given input string into a Data Matrix ECC200
+symbol:
+
+```
+1. ENCODE DATA
+   a. If all input characters are ASCII (0–127), use ASCII mode.
+      For each character:
+        - If current and next characters are both ASCII digits (0x30–0x39):
+          emit codeword 130 + (d1*10 + d2); advance two positions.
+        - Else: emit codeword ASCII_value + 1; advance one position.
+   b. Characters 128–255: emit 235 (UPPER_SHIFT) then (ASCII_value - 127).
+   c. Collect encoded codewords into a list.
+
+2. CHOOSE SYMBOL SIZE
+   a. Count encoded codewords (length of list from step 1).
+   b. Iterate over symbol sizes in ascending order (smallest first).
+   c. Select the first symbol where data_codewords ≥ encoded codeword count.
+   d. If none fits, return DataMatrixError::InputTooLong.
+
+3. PAD TO CAPACITY
+   a. If encoded_count < data_codewords:
+      - Append the pad codeword 129.
+      - For each subsequent position k (1-indexed from start of codeword stream)
+        where padding is needed, compute scrambled_pad and append.
+   b. Result is a list of exactly data_codewords codewords.
+
+4. SPLIT INTO RS BLOCKS
+   a. Look up num_blocks and ecc_per_block for the chosen symbol.
+   b. Split data codewords evenly across blocks (earlier blocks get +1 if uneven).
+   c. Each block: data_block[i] = data[i*block_size .. (i+1)*block_size].
+
+5. COMPUTE ECC PER BLOCK
+   a. For each block, compute RS ECC using the generator polynomial for
+      ecc_per_block, over GF(256)/0x12D.
+   b. ecc_block[i] = rs_encode_block(data_block[i], ecc_per_block, gen_poly).
+
+6. INTERLEAVE BLOCKS
+   a. Interleave data codewords across blocks:
+      for pos in 0..max_data_per_block:
+          for blk in 0..num_blocks:
+              if pos < len(data_block[blk]):
+                  interleaved.append(data_block[blk][pos])
+   b. Interleave ECC codewords across blocks:
+      for pos in 0..ecc_per_block:
+          for blk in 0..num_blocks:
+              interleaved.append(ecc_block[blk][pos])
+   c. interleaved now contains total_codewords = data_codewords + ecc_codewords values.
+
+7. INITIALIZE PHYSICAL MODULE GRID
+   a. Create grid of size symbol_rows × symbol_cols, all light (0).
+   b. Place finder pattern:
+      - Left column (col 0): all modules dark.
+      - Bottom row (row symbol_rows-1): all modules dark.
+   c. Place timing pattern:
+      - Top row (row 0): alternate dark/light starting from col 0 (dark).
+      - Right column (col symbol_cols-1): alternate dark/light starting from row 0 (dark).
+   d. For multi-region symbols, place alignment borders:
+      - For each horizontal alignment border between region rows r and r+1:
+        Rows at position: 1 + r*(region_height+2) + region_height   (the row after last data row of region r)
+        Row AB+0: all dark.
+        Row AB+1: alternating dark/light.
+      - For each vertical alignment border between region cols c and c+1:
+        Cols at position: 1 + c*(region_width+2) + region_width
+        Col AB+0: all dark.
+        Col AB+1: alternating dark/light.
+
+8. RUN UTAH PLACEMENT ALGORITHM
+   a. Compute logical data matrix size:
+      nRows = (symbol_rows - 2 - 2*(rr-1)) = total data area height / rr * rr
+      nCols = (symbol_cols - 2 - 2*(rc-1)) = total data area width  / rc * rc
+      (More precisely: nRows = rr * region_data_height, nCols = rc * region_data_width)
+   b. Run the Utah algorithm on interleaved[], filling logical grid[nRows][nCols].
+   c. Map each logical (r, c) to physical (physical_row, physical_col) and set
+      the corresponding module in the physical grid.
+
+9. OUTPUT
+   a. Return the physical ModuleGrid (symbol_rows × symbol_cols).
+   b. No masking step — the grid is final.
+
+10. LAYOUT + PAINT (optional)
+    Pass the ModuleGrid to barcode-2d::layout(grid, config) → PaintScene.
+    The quiet zone (1 module minimum) is added at this stage by the layout step.
+```
+
+---
+
+## Implementation Notes
+
+### Tables to embed as constants
+
+The following tables must be embedded in each implementation. Do not compute
+them at runtime.
+
+#### 1. Symbol size table
+
+For each of the 30 square and 6 rectangular symbol sizes:
+
+```
+{
+  symbol_rows,        -- total rows including outer border
+  symbol_cols,        -- total cols including outer border
+  region_rows,        -- rr: number of data region rows
+  region_cols,        -- rc: number of data region cols
+  data_region_height, -- interior height of each data region
+  data_region_width,  -- interior width of each data region
+  data_codewords,     -- total data codeword capacity
+  ecc_codewords,      -- total ECC codeword count
+  num_blocks,         -- number of interleaved RS blocks
+  ecc_per_block,      -- ECC codewords per block (same for all blocks)
+}
+```
+
+#### 2. Generator polynomials for all required ECC lengths
+
+All unique ecc_per_block values that appear in the symbol size table must
+have a precomputed generator polynomial embedded. From the table above, the
+required lengths are:
+
+```
+5, 7, 10, 11, 12, 14, 17, 18, 20, 21, 24, 28, 36, 42, 48, 56, 62, 68
+```
+
+Each generator polynomial is a list of `n_ecc + 1` bytes (including the
+implicit leading coefficient 1). Embed from ISO/IEC 16022, Annex A, using
+GF(256)/0x12D.
+
+#### 3. GF(256)/0x12D exp and log tables
+
+```
+gf_exp[256]:  gf_exp[i] = α^i mod 0x12D  (for i = 0..254; gf_exp[255] = gf_exp[0] = 1)
+gf_log[256]:  gf_log[v] = k such that α^k = v  (for v = 1..255; gf_log[0] = undefined)
+```
+
+These two tables (512 bytes total) are the foundation of all GF(256)
+arithmetic. Use them for the RS encoding inner loop.
+
+### Implementing GF multiplication
+
+```
+gf_mul(a: byte, b: byte) -> byte:
+    if a == 0 or b == 0: return 0
+    return gf_exp[(gf_log[a] + gf_log[b]) mod 255]
+```
+
+This log/exp trick turns a field multiplication (which would require
+polynomial reduction) into two table lookups and an addition modulo 255.
+It is the standard implementation for GF(256) multiplication.
+
+### Corner pattern trigger conditions
+
+The four corner patterns in the Utah algorithm are triggered based on
+specific (row, col) reference positions and symbol dimensions. These
+conditions are precise and must be implemented exactly. Incorrect corner
+handling produces an invalid symbol that may encode incorrect data or be
+unreadable by scanners.
+
+The reference implementation in ISO/IEC 16022, Annex F, defines the exact
+conditions in pseudocode. Implementors should verify their Utah algorithm
+against the ISO worked example for the 10×10 symbol (the simplest case
+that exercises most of the algorithm's behavior).
+
+The easiest verification strategy:
+
+1. Encode "A" → should produce a 10×10 symbol.
+2. The expected hexadecimal module grid (row by row, MSB to LSB) for "A"
+   in a 10×10 Data Matrix is published in Annex F of ISO/IEC 16022:2006.
+   Compare module-for-module.
+
+### Module numbering convention
+
+The physical module grid uses the convention:
+- `grid[0][0]` = top-left corner of the symbol (inside quiet zone)
+- Row 0 = topmost row (the timing row)
+- Column 0 = leftmost column (the L-finder column)
+- `grid[R-1][C-1]` = bottom-right corner
+
+This matches the visual orientation when printed: row increases downward,
+column increases rightward.
+
+### Rectangular symbol handling
+
+Rectangular symbols follow all the same rules as square symbols. The Utah
+algorithm operates identically; the only difference is `nRows != nCols`.
+The boundary wrap conditions in the algorithm handle non-square logical
+matrices correctly.
+
+For rectangular symbols with a single data region (8×18, 12×26, 16×36):
+`nRows` and `nCols` differ but both are small (≤ 14 or ≤ 22), making the
+algorithm easy to verify visually.
+
+### Mode selection for v0.1.0
+
+The v0.1.0 implementation uses only ASCII mode. Mode selection for C40,
+Text, EDIFACT, X12, and Base256 is deferred to v0.2.0. The full multi-mode
+optimizer for v0.3.0 would segment the input into runs of different
+character classes and choose the most compact mode for each segment.
+
+---
+
+## Visualization Annotations
+
+The encoder should optionally produce an annotated module grid for the
+visualizer. Each module records its role:
+
+| Color (suggested) | Role |
+|-------------------|------|
+| Deep green        | finder (L-bar: left column + bottom row) |
+| Green-grey        | timing (top row + right column alternating) |
+| Teal              | alignment border (inter-region, multi-region symbols only) |
+| Black/white       | data module |
+| Gold/yellow       | ECC module |
+| Blue              | pad module (scrambled pad codeword bits) |
+
+The visualizer can distinguish which codeword each module belongs to by
+annotating `codeword_index` (0-indexed within the interleaved stream) and
+`bit_index` (0–7, MSB=7) per module.
+
+---
+
+## Error Types
+
+```
+DataMatrixError::InputTooLong
+    -- The encoded codeword count exceeds the 144×144 symbol's data capacity.
+    -- Message should include the encoded codeword count and the maximum (1558).
+
+DataMatrixError::InvalidInput
+    -- Input contains byte values that cannot be encoded in the selected mode.
+    -- In ASCII mode, all byte values 0–255 are technically encodable
+    -- (values ≥ 128 use UPPER_SHIFT), so this error occurs only in
+    -- restricted modes (C40/Text/X12/EDIFACT) with out-of-range characters.
+
+DataMatrixError::SymbolTooSmall
+    -- The caller forced a specific symbol size via DataMatrixOptions.min_size
+    -- but the input is too large for that size.
+    -- (v0.2.0 when forced-size option is implemented)
+```
+
+---
+
+## Public API
+
+```
+encode(input: string | bytes, options?: DataMatrixOptions) → ModuleGrid
+  -- Encode input to a Data Matrix ECC200 module grid.
+  -- Selects the smallest symbol that fits the input.
+  -- Raises DataMatrixError::InputTooLong if input exceeds 144×144 capacity.
+  -- Raises DataMatrixError::InvalidInput if input contains unsupported characters.
+
+layout(grid: ModuleGrid, config?: Barcode2DLayoutConfig) → PaintScene
+  -- Translate a ModuleGrid into a pixel-resolved PaintScene (P2D00).
+  -- Delegates to barcode-2d::layout(). data-matrix does not implement this itself.
+
+encode_and_layout(
+    input: string | bytes,
+    options?: DataMatrixOptions,
+    config?: Barcode2DLayoutConfig
+) → PaintScene
+  -- Convenience: encode + layout in one call.
+
+render_svg(
+    input: string | bytes,
+    options?: DataMatrixOptions,
+    config?: Barcode2DLayoutConfig
+) → string
+  -- Convenience: encode + layout + paint-vm-svg backend → SVG string.
+
+explain(input: string | bytes, options?: DataMatrixOptions) → AnnotatedModuleGrid
+  -- Encode with full per-module role and codeword annotations (for visualizers).
+
+DataMatrixOptions {
+  min_size?: SymbolSize
+    -- Force at least this symbol size. If the encoded data fits in a smaller
+    -- symbol, the encoder will use the forced minimum size and pad to fill.
+    -- If the data does not fit, raise DataMatrixError::SymbolTooSmall.
+
+  shape?: SymbolShape
+    -- "Square" (default): select from square symbol sizes only.
+    -- "Rectangular": prefer rectangular symbol sizes over square.
+    -- "Any": try both and pick the smallest.
+
+  mode?: EncodingMode
+    -- Force encoding mode. Default: ASCII.
+    -- (C40 | Text | X12 | EDIFACT | Base256 are v0.2.0)
+}
+
+SymbolSize =
+  | Square10x10   | Square12x12   | Square14x14   | Square16x16
+  | Square18x18   | Square20x20   | Square22x22   | Square24x24
+  | Square26x26   | Square32x32   | Square36x36   | Square40x40
+  | Square44x44   | Square48x48   | Square52x52   | Square64x64
+  | Square72x72   | Square80x80   | Square88x88   | Square96x96
+  | Square104x104 | Square120x120 | Square132x132 | Square144x144
+  | Rect8x18      | Rect8x32      | Rect12x26
+  | Rect12x36     | Rect16x36     | Rect16x48
+
+SymbolShape = Square | Rectangular | Any
+
+EncodingMode = ASCII | C40 | Text | X12 | EDIFACT | Base256
+```
+
+---
+
+## Package Matrix
+
+| Language   | Directory                                   | Depends on                    |
+|------------|---------------------------------------------|-------------------------------|
+| Rust       | `code/packages/rust/data-matrix/`           | barcode-2d, gf256, reed-solomon |
+| TypeScript | `code/packages/typescript/data-matrix/`     | barcode-2d, gf256, reed-solomon |
+| Python     | `code/packages/python/data-matrix/`         | barcode-2d, gf256, reed-solomon |
+| Go         | `code/packages/go/data-matrix/`             | barcode-2d, gf256, reed-solomon |
+| Ruby       | `code/packages/ruby/data_matrix/`           | barcode-2d, gf256, reed-solomon |
+| Elixir     | `code/packages/elixir/data_matrix/`         | barcode_2d, gf256, reed_solomon |
+| Lua        | `code/packages/lua/data-matrix/`            | barcode-2d, gf256, reed-solomon |
+| Perl       | `code/packages/perl/data-matrix/`           | barcode-2d, gf256, reed-solomon |
+| Swift      | `code/packages/swift/DataMatrix/`           | Barcode2D, GF256, ReedSolomon  |
+| C#         | `code/packages/csharp/DataMatrix/`          | Barcode2D, GF256, ReedSolomon  |
+| F#         | `code/packages/fsharp/DataMatrix/`          | Barcode2D, GF256, ReedSolomon  |
+| Kotlin     | `code/packages/kotlin/data-matrix/`         | barcode-2d, gf256, reed-solomon |
+| Java       | `code/packages/java/data-matrix/`           | barcode-2d, gf256, reed-solomon |
+| Dart       | `code/packages/dart/data_matrix/`           | barcode_2d, gf256, reed_solomon |
+| Haskell    | `code/packages/haskell/data-matrix/`        | barcode-2d, gf256, reed-solomon |
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+#### 1. GF(256)/0x12D arithmetic
+
+Verify the exp and log tables and multiplication for the 0x12D field:
+
+```
+gf_exp[0]   == 1      (α^0)
+gf_exp[1]   == 2      (α^1)
+gf_exp[7]   == 128    (α^7 = 0x80)
+gf_exp[8]   == 0x2D   (α^8 reduced: 0x80<<1 XOR 0x12D = 0x2D)
+gf_exp[254] == ???     (compute and verify against ISO Annex D)
+gf_mul(2, 2)   == 4   (α^1 * α^1 = α^2 = 4)
+gf_mul(0x80, 2) == 0x2D  (α^7 * α^1 = α^8 = 0x2D)
+gf_mul(0, 0xFF) == 0    (zero absorbs multiplication)
+```
+
+#### 2. ASCII encoding
+
+```
+encode_ascii("A")    → [66]          (65 + 1 = 66)
+encode_ascii(" ")    → [33]          (32 + 1 = 33)
+encode_ascii("12")   → [142]         (130 + 12 = 142, digit pair)
+encode_ascii("1234") → [142, 174]    (2 digit pairs)
+encode_ascii("1A")   → [50, 66]      (digit, then letter — no pair)
+encode_ascii("00")   → [130]         (130 + 0 = 130)
+encode_ascii("99")   → [229]         (130 + 99 = 229)
+```
+
+#### 3. Pad codewords
+
+For a 10×10 symbol (data_codewords = 3), encoding "A" produces [66].
+After padding to 3 codewords:
+
+```
+Codeword sequence before padding: [66]
+First pad at position k=2: codeword = 129
+Second pad at position k=3: scrambled_pad = (129 + (149*3 mod 253) + 1) mod 254
+                                           = (129 + (447 mod 253) + 1) mod 254
+                                           = (129 + 194 + 1) mod 254
+                                           = 324 mod 254 = 70
+Final padded sequence: [66, 129, 70]
+```
+
+Verify this against the ISO-16022 worked example.
+
+#### 4. RS encoding
+
+For the 10×10 symbol (ecc_per_block = 5, generator polynomial for n=5):
+Data = [66, 129, 70] (encoded "A" + padding).
+
+Expected ECC bytes: compute using RS over GF(256)/0x12D with the n=5
+generator polynomial. Cross-check against the ISO/IEC 16022 Annex F
+worked example for encoding "A".
+
+#### 5. Module placement (Utah algorithm)
+
+For the 10×10 symbol, the complete module placement of "A" is given in
+ISO/IEC 16022, Annex F. The expected physical module grid (10 rows × 10
+columns) is reproduced there as a binary matrix. Compare module-by-module.
+
+#### 6. Symbol border
+
+For any symbol:
+
+```
+-- Finder L-bar: all left column and bottom row modules are dark
+for r in 0..symbol_rows: assert grid[r][0] == dark
+for c in 0..symbol_cols: assert grid[symbol_rows-1][c] == dark
+
+-- Timing clock: top row alternating, starting dark
+for c in 0..symbol_cols:
+    expected = (c mod 2 == 0) ? dark : light
+    assert grid[0][c] == expected
+
+-- Right column alternating, starting dark
+for r in 0..symbol_rows:
+    expected = (r mod 2 == 0) ? dark : light
+    assert grid[r][symbol_cols-1] == expected
+
+-- Corner (0,0) must be dark (L-bar meets timing)
+assert grid[0][0] == dark
+```
+
+### Integration tests
+
+#### 1. Encode "A" → 10×10 symbol
+
+The smallest possible Data Matrix ECC200 symbol. Full pipeline:
+- Input: single character "A" (ASCII 65)
+- Expected: 10×10 symbol
+- Verify: module grid matches ISO Annex F worked example bit-for-bit
+
+#### 2. Encode "1234" → 10×10 symbol
+
+Digit-pair encoding test:
+- "12" → codeword 142, "34" → codeword 174
+- 2 data codewords; fits in 10×10 (capacity 3)
+- Verify: correct codewords, correct ECC, correct module grid
+
+#### 3. Encode "Hello World" → 16×16 symbol
+
+Mixed case, space:
+- 11 characters → 11 ASCII codewords → needs ≥ 11 data codewords
+- 16×16 has 12 data codewords, so 11 + 1 pad = 12 codewords
+- Verify: symbol is 16×16, correct border, passes scanner test
+
+#### 4. Encode a 44-character string → 26×26 symbol
+
+Maximum single-region square symbol:
+- Verify: data regions = 1×1, no alignment borders in interior
+
+#### 5. Encode a string requiring 32×32 → multi-region
+
+Choose a string requiring 45–62 codewords:
+- Verify: data regions = 2×2, alignment borders present at correct positions
+- Verify: physical module grid has correct alignment border pattern
+
+#### 6. Scanner verification
+
+Render the symbol as SVG. Use `zxing-cpp` or `libdmtx` to decode the SVG.
+Compare decoded string to original input. Run for all test cases.
+
+### Cross-language verification
+
+All 15 language implementations must produce **identical ModuleGrid outputs**
+for the same input. Use a JSON format for the test vectors:
+
+```json
+{
+  "input": "A",
+  "symbol": "10x10",
+  "grid": [
+    [1,1,0,1,0,1,0,1,0,1],
+    [1,...],
+    ...
+  ]
+}
+```
+
+Generate the canonical test vectors from the ISO Annex F worked example and
+from one reference implementation (e.g., libdmtx, which implements ISO/IEC
+16022 faithfully). All 15 implementations must match these vectors exactly.
+
+Suggested cross-language test corpus:
+
+```
+"A"             (10×10 — ISO worked example; minimal)
+"1234"          (10×10 — digit-pair test; same symbol as "A")
+"Hello World"   (16×16 — mixed ASCII)
+"https://coding-adventures.dev"   (32×32 — URL, multi-region)
+"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"  (26×26 — full alphanumeric)
+```
+
+All cross-language outputs must be bit-for-bit identical for each input.
+
+---
+
+## Dependency Stack
+
+```
+paint-metal (P2D02)    paint-vm-svg    paint-vm-canvas
+      └──────────────────┬──────────────────┘
+                         │
+                  paint-vm (P2D01)
+                         │
+              paint-instructions (P2D00)
+                         │
+                     barcode-2d          MA02 reed-solomon (b=1, 0x12D)
+                         │                        │
+                    data-matrix ─────────────────┘
+                                            MA01 gf256 (0x12D)
+```
+
+`data-matrix` depends on:
+
+- `barcode-2d`: for the `ModuleGrid` type and the `layout()` function.
+- `reed-solomon` (MA02): for RS encoding over GF(256)/0x12D. Data Matrix
+  uses the b=1 convention, which matches MA02 exactly. The only required
+  configuration is the field polynomial (0x12D, not QR's 0x11D).
+- `gf256` (MA01): for GF(256)/0x12D field arithmetic tables.
+
+Unlike `qr-code`, which must implement its own RS encoder with a different
+generator root convention, `data-matrix` can call MA02 directly. This is
+a significant simplification.
+
+---
+
+## Future Extensions
+
+- **Decoder** — A separate, considerably more complex spec involving scanner
+  coordinate correction, border detection, perspective transform, and syndrome
+  decoding. Not planned for the near term; a separate spec will cover it.
+
+- **C40 / Text mode encoding** (v0.2.0) — Optimize uppercase-heavy input.
+  The encoder will detect when C40 saves codewords over ASCII and
+  automatically switch to C40 mode.
+
+- **Multi-mode segmentation** (v0.3.0) — Segment input into runs of digits,
+  uppercase, lowercase, binary. Choose the best mode per segment. The
+  optimizer is a dynamic-programming problem over the mode-codeword cost
+  table.
+
+- **Extended Channel Interpretation (ECI)** — Embed a charset identifier
+  (e.g., ECI 26 = UTF-8) before the data for scanners that do not default
+  to UTF-8.
+
+- **Structured Append** — Split a large message across up to 16 Data Matrix
+  symbols, each carrying a segment index and a file identification character.
+  The reader reassembles the segments in order.
+
+- **Rectangular symbol auto-selection** — When `shape = Any`, the encoder
+  finds the smallest symbol across both square and rectangular options. For
+  short strings like lot codes and part numbers, a rectangular symbol often
+  fits the aspect ratio of the print area better.
+
+- **Direct mark / dot-peen rendering** — Physical Data Matrix marks (etched
+  or dot-peened on metal) use circles or dots instead of squares. The render
+  pipeline supports this via a `dot_style: Circular` option in
+  `Barcode2DLayoutConfig`, which switches the PaintRect instructions to
+  PaintEllipse. This is a paint-layer concern; the encoding is unchanged.
+
+- **GS1 Data Matrix** — A standardized use of Data Matrix for product and
+  trade item identification. The input uses Application Identifiers (AIs)
+  from GS1-128. The encoding is standard Data Matrix; the difference is a
+  mandatory `FNC1` character (ASCII 29, Group Separator) at the start of the
+  message. A `gs1_mode: bool` option in `DataMatrixOptions` prepends this
+  character automatically.
+
+- **Visualizer integration** — Interactive drill-down showing which codeword,
+  RS block, and generator polynomial produced each module. Same architecture
+  as the QR visualizer; just different role annotations.

--- a/code/specs/micro-qr.md
+++ b/code/specs/micro-qr.md
@@ -1,0 +1,1434 @@
+# Micro QR Code
+
+## Overview
+
+This spec defines a **Micro QR Code encoder** for the coding-adventures monorepo.
+
+Micro QR Code is a compact variant of QR Code, standardized in ISO/IEC 18004:2015
+Annex E. It was designed for applications where space is extremely limited —
+think surface-mount electronic components, tiny labels on circuit boards, and
+miniature product markings — where even the smallest regular QR Code (21×21 at
+version 1) is too large.
+
+The defining characteristic of Micro QR is the **single finder pattern**: where
+regular QR Code uses three identical corner squares to establish orientation,
+Micro QR uses only one, in the top-left. This saves a dramatic amount of space at
+the cost of some scanner robustness: Micro QR scanners must determine orientation
+by other means (the single-corner placement is unambiguous). The tradeoff is
+deliberate — Micro QR targets controlled scanning environments (factory floors,
+industrial equipment) rather than consumer apps.
+
+Micro QR has four symbol versions: M1 through M4. Each is a square, and the sizes
+are much smaller than regular QR:
+
+```
+M1: 11×11 modules
+M2: 13×13 modules
+M3: 15×15 modules
+M4: 17×17 modules
+```
+
+The formula is `size = 2 × version_number + 9`. So M1 = 2(1)+9 = 11, M4 = 2(4)+9 = 17.
+
+Understanding how to build a Micro QR encoder from scratch teaches:
+
+- how a constrained 2D format packs data into a tiny fixed-size grid
+- how error correction levels trade symbol capacity for damage tolerance
+- how format information encoding differs when you only have a single finder
+- why the quiet zone can be halved (from 4 to 2 modules) without breaking
+  scanner detection
+- how the same Reed-Solomon math used in QR Code scales down to tiny data payloads
+
+The encoder in this spec produces a **valid, scannable Micro QR Code** for any
+input string that fits within M4. It does not implement decoding — that is a
+separate, more complex problem.
+
+---
+
+## Symbol Structure
+
+A Micro QR Code symbol is a square grid of **modules** — dark (1) or light (0)
+square cells. Unlike regular QR where size is `4V+17`, Micro QR uses:
+
+```
+size = 2 × version_number + 9
+```
+
+| Symbol | Version Number | Size |
+|--------|---------------|------|
+| M1     | 1             | 11×11 |
+| M2     | 2             | 13×13 |
+| M3     | 3             | 15×15 |
+| M4     | 4             | 17×17 |
+
+Here is a schematic view of an M4 (17×17) symbol, showing all functional regions:
+
+```
+col:  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16
+     ┌──────────────────────────────────────────────────────
+row0 │ T  T  T  T  T  T  T  T  .  .  .  .  .  .  .  .  .
+row1 │ T  ■  ■  ■  ■  ■  T  S  F  .  .  .  .  .  .  .  .
+row2 │ T  ■  □  □  □  ■  T  S  F  .  .  .  .  .  .  .  .
+row3 │ T  ■  □  ■  □  ■  T  S  F  .  .  .  .  .  .  .  .
+row4 │ T  ■  □  □  □  ■  T  S  F  .  .  .  .  .  .  .  .
+row5 │ T  ■  ■  ■  ■  ■  T  S  F  .  .  .  .  .  .  .  .
+row6 │ T  T  T  T  T  T  T  S  F  .  .  .  .  .  .  .  .
+row7 │ T  S  S  S  S  S  S  S  F  .  .  .  .  .  .  .  .
+row8 │ T  F  F  F  F  F  F  F  .  .  .  .  .  .  .  .  .
+row9 │ .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
+...  │ .  .  .  .  .  .  .  .  .  (data and ECC modules)  .
+row16│ .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
+     └──────────────────────────────────────────────────────
+
+Legend:
+  T = timing pattern module (alternating dark/light)
+  ■ = dark module of finder pattern
+  □ = light module of finder pattern
+  S = separator module (always light)
+  F = format information module
+  . = data or ECC module
+```
+
+Note how the top row (row 0) and left column (col 0) are entirely timing pattern
+modules. This is the opposite of regular QR Code, where timing patterns are on
+row 6 and column 6.
+
+### Finder Pattern
+
+The same 7×7 finder pattern as regular QR Code, but placed in the **top-left
+corner only** (rows 0–6, cols 0–6):
+
+```
+1 1 1 1 1 1 1
+1 0 0 0 0 0 1
+1 0 1 1 1 0 1
+1 0 1 1 1 0 1
+1 0 1 1 1 0 1
+1 0 0 0 0 0 1
+1 1 1 1 1 1 1
+```
+
+This is precisely the same 1:1:3:1:1 dark-light-dark pattern that scanners use
+for detection. Because there is only one finder pattern, a scanner immediately
+knows the top-left corner — so orientation is unambiguous with one pattern (the
+data area is always to the bottom-right of the finder).
+
+### Separators
+
+The finder pattern is bordered on its **bottom and right sides** by a 1-module-wide
+strip of light modules (value 0). The top and left sides of the finder are the
+symbol edge — there is nothing to separate there.
+
+```
+Separator modules:
+  Row 7, cols 0–7  (bottom of finder)
+  Col 7, rows 0–7  (right of finder)
+```
+
+This forms an L-shaped separator (not a full surrounding border as in regular QR,
+which has separators on all four sides of each finder — Micro QR's top-left
+and top-right edges of the finder are literally the edge of the symbol).
+
+### Timing Patterns
+
+Unlike regular QR Code where timing patterns run along row 6 and column 6, Micro
+QR places its timing patterns along the **outer edges** of the finder pattern —
+along row 0 and column 0 — and extends them to the opposite edge of the symbol:
+
+```
+Horizontal timing: row 0, cols 0 through (size-1)
+Vertical timing:   col 0, rows 0 through (size-1)
+```
+
+The timing pattern alternates dark/light starting with dark at (0,0). For an
+11×11 symbol (M1):
+
+```
+Row 0: 1 1 1 1 1 1 1 1 1 1 1   ← NO! They're not all dark.
+```
+
+Wait — let's be precise. The timing pattern rule is: module at position `k` is
+dark if `k` is even, light if `k` is odd. But in Micro QR, the top-left 7×7
+region is the finder pattern. The finder pattern's top row (row 0, cols 0–6) and
+left column (col 0, rows 0–6) are already determined by the finder pattern
+definition, and those modules *are* the timing pattern for those positions. The
+timing pattern extends outward:
+
+```
+Row 0 pattern:
+  Cols 0–6: finder pattern row 0 = [1,1,1,1,1,1,1]  (all dark)
+
+  Hmm — but timing should alternate. Let's look at the standard more carefully.
+```
+
+Actually, the ISO standard places the timing patterns consistently as alternating
+dark/light, and the finder pattern's outer ring happens to satisfy the timing
+pattern at those positions (outer ring of finder is all dark). The timing
+pattern modules that extend beyond the finder (from col 8 onward on row 0, and
+from row 8 onward on col 0) alternate dark/light in the usual way.
+
+The correct specification is:
+
+```
+Timing pattern value at (row=0, col=c): dark if c is even, light if c is odd
+Timing pattern value at (row=r, col=0): dark if r is even, light if r is odd
+```
+
+These definitions are consistent with the finder pattern: the finder's outer
+ring entries on row 0 (cols 0–6) are all dark, and col indices 0,2,4,6 are even
+(dark) while 1,3,5 are odd — but the finder is 1,1,1,1,1,1,1, not alternating.
+
+The resolution is that in Micro QR the **finder pattern overrides** the timing
+pattern for the overlapping modules. The timing pattern is placed first (or the
+overlap is treated as reserved by the finder). In practice: set the finder
+pattern, then place timing starting at col 8 (row 0) and row 8 (col 0).
+The timing value at col 8 (even-numbered if you count from 0) is dark.
+
+Concretely for M4 (17×17):
+
+```
+Row 0 (timing, starting after separator at col 8):
+  col 8: dark (even), col 9: light, col 10: dark, ..., col 16: dark
+
+Col 0 (timing, starting after separator at row 8):
+  row 8: dark (even), row 9: light, row 10: dark, ..., row 16: dark
+```
+
+The timing row and column modules at positions 0–6 are part of the finder
+pattern. Position 7 is part of the separator (always light). Position 8 onward
+is the extended timing pattern.
+
+### No Alignment Patterns
+
+Micro QR has **no alignment patterns**. The symbol is too small to suffer from
+the perspective distortion that alignment patterns correct in larger QR codes.
+Removing them frees up data capacity.
+
+### Quiet Zone
+
+Micro QR requires only a **2-module quiet zone** on all sides (compared to 4
+modules for regular QR). This is safe because the single-finder-corner detection
+is more spatially distinctive and the smaller symbol size means distortion is
+less severe.
+
+```
+Quiet zone layout for M4 (17 + 2 + 2 = 21 total rendering width):
+
+  2 light modules │ 17-module symbol │ 2 light modules
+                  ↕
+              2 light modules
+```
+
+### Format Information
+
+15 bits reserved in a specific location. See the [Format Information](#format-information)
+section for detailed placement.
+
+### Dark Module
+
+Micro QR does **not** have a separate always-dark "dark module" independent of
+the finder pattern (unlike regular QR Code's dark module at position `(4V+9, 8)`).
+All forced-dark modules in Micro QR are part of the finder pattern or timing
+strips.
+
+---
+
+## Versions and Capacity
+
+Micro QR has four symbol versions. The version determines maximum capacity and
+which encoding modes and error correction levels are available.
+
+### ECC Levels by Version
+
+| Symbol | Available ECC Levels |
+|--------|---------------------|
+| M1     | Detection only (no correction) |
+| M2     | L, M |
+| M3     | L, M |
+| M4     | L, M, Q |
+
+No symbol supports level H (High). This is a deliberate tradeoff: the symbols
+are so small that adding 30% redundancy would leave almost no room for data.
+M1 does not even support error *correction* — only error *detection* (one error
+detection codeword, essentially a simple checksum).
+
+Error correction level meanings (same as regular QR):
+
+| Level | Approximate recovery capacity |
+|-------|-------------------------------|
+| L (Low) | ~7% of codewords |
+| M (Medium) | ~15% of codewords |
+| Q (Quartile) | ~25% of codewords |
+
+### Capacity Table
+
+The maximum number of characters per symbol/ECC level combination:
+
+| Symbol | ECC | Numeric | Alphanumeric | Byte (ISO-8859-1) | Kanji |
+|--------|-----|---------|--------------|-------------------|-------|
+| M1     | Det | 5       | —            | —                 | —     |
+| M2     | L   | 10      | 6            | 4                 | —     |
+| M2     | M   | 8       | 5            | 3                 | —     |
+| M3     | L   | 23      | 14           | 9                 | —     |
+| M3     | M   | 18      | 11           | 7                 | —     |
+| M4     | L   | 35      | 21           | 15                | 9     |
+| M4     | M   | 30      | 18           | 13                | 8     |
+| M4     | Q   | 21      | 13           | 9                 | 6     |
+
+These numbers come from the ISO standard. Dashes indicate mode is not available
+for that symbol version.
+
+### Codeword Counts
+
+The exact codeword structure (total codewords, data codewords, ECC codewords) per
+version and ECC level:
+
+| Symbol | ECC | Total CWs | Data CWs | ECC CWs | Blocks |
+|--------|-----|-----------|----------|---------|--------|
+| M1     | Det | 5         | 3        | 2       | 1      |
+| M2     | L   | 10        | 5        | 5       | 1      |
+| M2     | M   | 10        | 4        | 6       | 1      |
+| M3     | L   | 17        | 11       | 6       | 1      |
+| M3     | M   | 17        | 9        | 8       | 1      |
+| M4     | L   | 24        | 16       | 8       | 1      |
+| M4     | M   | 24        | 14       | 10      | 1      |
+| M4     | Q   | 24        | 10       | 14      | 1      |
+
+All Micro QR symbols use a **single block** — there is no interleaving needed.
+The data stream is a single byte sequence; the ECC codewords follow directly.
+
+Note on M1: it uses 3 data codewords but only 3.5 bytes of data (the last
+codeword is 4 bits, not 8). See the special M1 encoding rules in the
+[Data Encoding Modes](#data-encoding-modes) section.
+
+### Module Count and Remainder
+
+| Symbol | Grid modules | Function modules | Data+ECC modules |
+|--------|-------------|-----------------|-----------------|
+| M1     | 121         | 81              | 36 (+ 4 remainder = 40) |
+| M2     | 169         | 97              | 80              |
+| M3     | 225         | 113             | 136 (+ 0 remainder) |
+| M4     | 289         | 129             | 160 (+ 0 remainder) |
+
+The function modules are: finder pattern (49) + separators (row 7 cols 0–7 = 8,
+plus col 7 rows 0–7 = 8, minus corner overlap = 15 total) + timing extensions +
+format information (15).
+
+In practice, just reserve all known functional positions and fill the rest with
+data and ECC bits.
+
+---
+
+## Data Encoding Modes
+
+Micro QR supports the same four encoding modes as regular QR, but availability
+depends on the symbol version. Each mode encodes a specific character set in a
+compact binary format.
+
+### Mode Availability
+
+| Mode | M1 | M2 | M3 | M4 |
+|------|----|----|----|----|
+| Numeric | YES | YES | YES | YES |
+| Alphanumeric | NO | YES | YES | YES |
+| Byte (ISO-8859-1) | NO | NO | YES | YES |
+| Kanji | NO | NO | NO | YES |
+
+### Mode Indicators (Narrower Than Regular QR)
+
+Regular QR uses a 4-bit mode indicator. Micro QR uses **fewer bits**, saving
+precious capacity. The mode indicator is **prefixed** to the character count:
+
+| Symbol | Mode Indicator Width | Mode Codes |
+|--------|---------------------|------------|
+| M1 | 0 bits (implicit numeric) | N/A — only numeric, no indicator |
+| M2 | 1 bit | `0` = numeric, `1` = alphanumeric |
+| M3 | 2 bits | `00` = numeric, `01` = alphanumeric, `10` = byte |
+| M4 | 3 bits | `000` = numeric, `001` = alphanumeric, `010` = byte, `011` = kanji |
+
+M1 has no mode indicator because it only supports one mode. This is analogous to
+a function that has no arguments because it has no choices to make.
+
+### Character Count Indicator Widths
+
+After the mode indicator, the number of characters (not bytes) is encoded in a
+fixed-width field. The width varies by mode and symbol version:
+
+| Mode         | M1 | M2 | M3 | M4 |
+|-------------|----|----|----|----|
+| Numeric     | 3  | 4  | 5  | 6  |
+| Alphanumeric| —  | 3  | 4  | 5  |
+| Byte        | —  | —  | 4  | 5  |
+| Kanji       | —  | —  | —  | 4  |
+
+Compare these to regular QR's character count widths (10–14 bits for numeric,
+9–13 for alphanumeric, 8–16 for byte). Micro QR's counts are dramatically
+smaller because the symbols hold far fewer characters.
+
+### Numeric Mode
+
+Identical to regular QR numeric mode encoding:
+
+- Groups of 3 digits → 10 bits (decimal value 000–999)
+- Remaining pair of 2 digits → 7 bits (decimal value 00–99)
+- Single remaining digit → 4 bits (decimal value 0–9)
+
+Example: `"12345"` → groups `"123"`, `"45"` → bits `0001111011` (123 in 10 bits),
+`0101101` (45 in 7 bits) = 17 bits.
+
+```
+Digit grouping (greedy from left):
+  "12345" → "123" + "45" → 10 bits + 7 bits = 17 bits
+  "1234"  → "123" + "4"  → 10 bits + 4 bits = 14 bits
+  "123"   → "123"        → 10 bits           = 10 bits
+  "12"    → "12"         → 7 bits            = 7 bits
+  "1"     → "1"          → 4 bits            = 4 bits
+```
+
+### Alphanumeric Mode
+
+Identical to regular QR alphanumeric encoding. The 45-character set:
+
+```
+0–9 → indices 0–9
+A–Z → indices 10–35
+SP  → 36
+$   → 37
+%   → 38
+*   → 39
++   → 40
+-   → 41
+.   → 42
+/   → 43
+:   → 44
+```
+
+Pairs of characters are packed into 11 bits: `first_index * 45 + second_index`.
+A trailing single character uses 6 bits.
+
+Example: `"AC-3"` → pair `"AC"` = (10)(12) = 10×45+12 = 462 = `00111001110`
+(11 bits), pair `"-3"` = (41)(3) = 41×45+3 = 1848 = `11100111000` (11 bits).
+
+### Byte Mode
+
+Raw byte encoding. Each character is encoded as its ISO-8859-1 byte value in 8
+bits. UTF-8 strings can be encoded in byte mode by treating each UTF-8 byte as
+a raw byte (scanners supporting UTF-8 will decode correctly; legacy scanners
+will see Latin-1 or garbled text for non-ASCII).
+
+Example: `"Hi!"` → `0x48 0x69 0x21` → `01001000 01101001 00100001` (24 bits).
+
+### Kanji Mode (M4 Only)
+
+Encodes Japanese characters from the Shift-JIS encoding. Characters in the ranges
+0x8140–0x9FFC and 0xE040–0xEBBF are supported. Each character is encoded in 13
+bits using the following transformation:
+
+```
+1. Look up the 2-byte Shift-JIS code point.
+2. Subtract 0x8140 (for range 0x8140–0x9FFC) or 0xC140 (for range 0xE040–0xEBBF).
+3. Multiply the high byte by 0xC0 and add the low byte.
+4. Encode the result in 13 bits.
+```
+
+This packs a character that normally needs 16 bits into 13 bits. Kanji mode is
+only available in M4 — the other symbols are too small to hold meaningful kanji
+content.
+
+### Terminator
+
+After all data segments, a **terminator** is appended (all zero bits). The
+terminator width depends on the symbol version:
+
+| Symbol | Terminator Width |
+|--------|-----------------|
+| M1     | 3 bits (000) |
+| M2     | 5 bits (00000) |
+| M3     | 7 bits (0000000) |
+| M4     | 9 bits (000000000) |
+
+Regular QR uses a 4-bit terminator for all versions. Micro QR uses longer
+terminators to fill more of the final partial codeword, and shorter for M1 to
+save space.
+
+The terminator is truncated if the remaining capacity is less than the full
+terminator width.
+
+### Bit Stream Assembly
+
+The encoder builds a **bit stream** as follows:
+
+```
+[mode indicator (0–3 bits, version-dependent)]
+[character count (width from table above)]
+[encoded data bits]
+[terminator (3/5/7/9 zero bits, or truncated)]
+[zero bits to reach next byte boundary]
+[padding codewords: alternate 0xEC and 0x11 to fill remaining data codewords]
+```
+
+For M1, the bit stream has a special structure. M1 uses 3 data codewords, but
+the last "codeword" is only **4 bits** (not 8). The M1 bit stream format is:
+
+```
+M1 total data bits = 3 × 8 − 4 = 20 bits  (NO — this is wrong)
+M1 actual data capacity = 20 bits total (not 24), because the final nibble
+  is a half-codeword.
+```
+
+Concretely: M1 has 3 data codewords. The first two are full 8-bit codewords
+(16 bits); the third is 4 bits. So total usable data bits = 20. The standard
+treats this as a 3-byte stream where the last byte is only 4 bits wide —
+terminators and padding account for this.
+
+The final bit stream is placed into the module grid after Reed-Solomon encoding
+(see next section).
+
+---
+
+## Reed-Solomon Error Correction
+
+Micro QR uses the same Galois field as regular QR Code:
+
+- **Field**: GF(256)
+- **Primitive polynomial**: `x^8 + x^4 + x^3 + x^2 + 1` (hex 0x11D, decimal 285)
+- **Generator convention**: b=0 (first root is α^0 = 1)
+
+This is identical to regular QR. The `gf256` package (MA01) provides all field
+arithmetic needed.
+
+The generator polynomial of degree `n` is:
+
+```
+g(x) = (x + α^0)(x + α^1)···(x + α^{n-1})
+```
+
+where `n` is the number of ECC codewords.
+
+### Generator Polynomials
+
+Micro QR needs only four distinct ECC codeword counts: 2, 5, 6, 8, 10, 14.
+The generator polynomials (in coefficient form, highest degree first, over GF(256)):
+
+```
+2 ECC codewords (M1 detection):
+  g(x) = x^2 + α^0·x + α^1·x^0... wait, let me derive properly.
+
+  g(x) = (x + α^0)(x + α^1)
+       = x^2 + (α^0 + α^1)x + α^0·α^1
+       = x^2 + (1 + 2)x + 2
+       = x^2 + 3x + 2
+  Coefficients: [01, 03, 02]   (n+1 coefficients for degree n)
+```
+
+Full table of generator polynomials (coefficients in hex, leading 1 omitted,
+highest power first):
+
+| ECC CWs | Generator polynomial coefficients (hex) |
+|---------|----------------------------------------|
+| 2       | 03 02 |
+| 5       | 1f f6 44 d9 68 |
+| 6       | 3f 4e 17 9b 05 37 |
+| 8       | 63 0d 60 6d 5b 10 a2 a3 |
+| 10      | f6 75 a8 d0 c3 e3 36 e1 3c 45 |
+| 14      | f6 9a 60 97 8a f1 a4 a1 8e fc 7a 52 ad ac |
+
+These are the same polynomials used in regular QR for blocks with matching ECC
+codeword counts. Implement as compile-time constants; do not compute at runtime.
+
+### Block Structure
+
+All Micro QR symbols use **a single block** — there are no groups, no interleaving.
+The entire data stream is one block, and the ECC codewords for that one block
+are appended to form the final symbol codeword stream.
+
+This greatly simplifies the encoder: there is no block splitting, no
+per-block RS computation, and no interleaving step.
+
+```
+final_codewords = data_codewords ++ rs_ecc(data_codewords, n_ecc)
+```
+
+### RS Encoding Algorithm
+
+For a single block, RS encoding computes the remainder of polynomial division:
+
+```
+Given: data bytes D[0..k-1] (k = number of data codewords)
+       generator poly G[0..n] (n = number of ECC codewords)
+
+Compute ECC bytes E[0..n-1] by polynomial remainder:
+
+ecc = [0] × n
+for each byte b in data_codewords:
+    feedback = b XOR ecc[0]
+    shift ecc left by one (drop ecc[0], append 0)
+    for i in 0..n-1:
+        ecc[i] = ecc[i] XOR gf_multiply(G[n - i], feedback)
+
+Result: E = ecc
+```
+
+This is identical to the QR Code RS encoder. The `gf_multiply` function is
+GF(256) multiplication using the 0x11D primitive polynomial.
+
+---
+
+## Module Placement
+
+After computing ECC, the final codeword stream is placed into the module grid
+using a **two-column zigzag** scan.
+
+### Reserved Modules
+
+Before placing data, mark all structural modules as reserved:
+
+```
+1. Finder pattern: rows 0–6, cols 0–6  (49 modules)
+2. Separators: row 7 cols 0–7, col 7 rows 0–7
+   (15 unique modules — corner at row 7/col 7 is shared)
+3. Timing row: row 0, cols 8 through (size-1)
+4. Timing col: col 0, rows 8 through (size-1)
+5. Format information strip (see Format Information section)
+```
+
+Note: there are no alignment patterns and no version information in Micro QR.
+
+### Format Information Module Positions
+
+The format information occupies 15 specific modules. These are the only modules
+that need to be reserved before placement but filled in after mask selection:
+
+```
+Row 8, cols 1 through 8  →  8 modules  (format bits f14 down to f7)
+Col 8, rows 1 through 7  →  7 modules  (format bits f6 down to f0)
+```
+
+Total: 15 modules, matching the 15-bit format information word exactly.
+
+Illustrated for M4 (17×17):
+
+```
+  c0 c1 c2 c3 c4 c5 c6 c7 c8 ...
+r0  T  T  T  T  T  T  T  T  T ...   (timing)
+r1  T  ■  ■  ■  ■  ■  T  S [f0]...  (finder + sep + fmt)
+r2  T  ■  □  □  □  ■  T  S [f1]...
+r3  T  ■  □  ■  □  ■  T  S [f2]...
+r4  T  ■  □  □  □  ■  T  S [f3]...
+r5  T  ■  ■  ■  ■  ■  T  S [f4]...
+r6  T  T  T  T  T  T  T  S [f5]...
+r7  T  S  S  S  S  S  S  S [f6]...
+r8  T [f14][f13][f12][f11][f10][f9][f8]  .  ...  (format row)
+r9  T  .  .  .  .  .  .  .  .  ...
+```
+
+Reading order:
+
+- f14 (MSB) at row 8, col 1
+- f13 at row 8, col 2
+- f12 at row 8, col 3
+- f11 at row 8, col 4
+- f10 at row 8, col 5
+- f9  at row 8, col 6
+- f8  at row 8, col 7
+- f7  at row 8, col 8
+- f6  at col 8, row 7
+- f5  at col 8, row 6
+- f4  at col 8, row 5
+- f3  at col 8, row 4
+- f2  at col 8, row 3
+- f1  at col 8, row 2
+- f0 (LSB) at col 8, row 1
+
+The format information strip forms an L-shape: 8 bits going rightward along row
+8, then 7 bits going upward along col 8. (Note the "upward" direction: row 7
+holds f6, row 1 holds f0 — the LSB is nearest the finder corner.)
+
+### Zigzag Data Placement
+
+The data placement algorithm is a **two-column zigzag**, starting from the
+**bottom-right** corner of the symbol, scanning upward, then downward alternately,
+moving left two columns at a time:
+
+```
+size  = symbol side length (11, 13, 15, or 17)
+col   = size - 1        -- start at rightmost column
+dir   = -1              -- -1 = upward, +1 = downward
+bit_index = 0           -- index into final_codewords bit stream
+
+while col >= 1:
+    -- scan this 2-column strip in the current direction
+    if dir == -1:   -- upward
+        rows = range(size-1, -1, -1)    -- size-1 down to 0
+    else:           -- downward
+        rows = range(0, size)           -- 0 up to size-1
+
+    for row in rows:
+        for sub_col in [col, col-1]:
+            if module(row, sub_col) is reserved:
+                skip
+            place bit_stream[bit_index] at module(row, sub_col)
+            bit_index += 1
+
+    -- move left and flip direction
+    dir = -dir
+    col -= 2
+```
+
+Note that unlike regular QR Code, there is **no timing column at col 6** to skip
+around — the timing in Micro QR is at col 0, which is always reserved and thus
+naturally skipped by the reserved-module check.
+
+The zigzag must stop at `col >= 1` (not `col >= 0`) because the leftmost two
+columns (0 and 1) start at col 1 — col 0 is entirely reserved for timing.
+
+Wait — col 0 is the timing column, so when `col = 1`, the two-column strip is
+`col = 1` and `col - 1 = 0`. The col-0 modules are reserved (timing), so the
+bit-placement skips them automatically. This is correct behavior.
+
+After all data+ECC bits are placed, the remaining unreserved modules (if any)
+receive **remainder bits** (zeros). M1 has 4 remainder bits; all others have 0.
+
+---
+
+## Masking
+
+Masking flips data and ECC module values to avoid patterns that could confuse
+scanners. Unlike regular QR which evaluates 8 masks, **Micro QR only uses 4
+mask patterns**.
+
+### The 4 Mask Patterns
+
+| Pattern | Condition (flip module if true) |
+|---------|---------------------------------|
+| 0       | `(row + col) mod 2 == 0` |
+| 1       | `row mod 2 == 0` |
+| 2       | `col mod 3 == 0` |
+| 3       | `(row + col) mod 3 == 0` |
+
+These are the first four of regular QR's eight patterns. The more complex
+patterns (4–7) are absent from Micro QR — the smaller symbol size means the
+simpler patterns are sufficient to break up degenerate sequences.
+
+Masking is applied **only to data and ECC modules**, never to finder pattern,
+separator, timing, or format information modules.
+
+### Penalty Scoring
+
+All four candidate masks are evaluated, and the one with the **lowest penalty
+score** is selected. The same four penalty rules as regular QR Code apply:
+
+**Rule 1 — Adjacent run penalty:**
+
+Scan each row and each column for runs of ≥5 consecutive modules of the same
+color. Add `run_length − 2` to the penalty for each qualifying run.
+
+```
+Run of 5 → +3
+Run of 6 → +4
+Run of 7 → +5
+...etc.
+```
+
+**Rule 2 — 2×2 block penalty:**
+
+For each 2×2 square with all four modules the same color (all dark or all
+light), add 3 to the penalty.
+
+**Rule 3 — Finder-pattern-like sequences:**
+
+Scan all rows and columns for the 11-module sequence `1 0 1 1 1 0 1 0 0 0 0`
+or its reverse `0 0 0 0 1 0 1 1 1 0 1`. Each occurrence adds 40 to the penalty.
+
+These sequences look like a finder pattern to a scanner and must be avoided.
+
+**Rule 4 — Dark-module proportion:**
+
+```
+dark_count = number of dark modules in the entire symbol
+total      = size × size
+dark_pct   = dark_count × 100 / total   (integer percent)
+prev5      = largest multiple of 5 ≤ dark_pct
+next5      = prev5 + 5
+penalty    = min(|prev5 - 50|, |next5 - 50|) / 5 × 10
+```
+
+The penalty is 0 when dark_pct is exactly 50%, increasing as the balance shifts.
+A heavily dark or heavily light symbol is harder for scanners to process.
+
+### Mask Selection
+
+Evaluate all four masks. For each:
+
+1. Apply mask to data/ECC modules.
+2. Compute format information for this mask.
+3. Write format information into the grid.
+4. Compute penalty score.
+5. Record (penalty, mask_index).
+
+Select the mask with the **lowest total penalty**. Break ties by preferring the
+lower-numbered mask pattern.
+
+---
+
+## Format Information
+
+The format information tells a scanner which symbol version+ECC combination it
+is reading, and which mask was applied. Micro QR encodes this differently from
+regular QR.
+
+### Format Information Bits
+
+The 15-bit format string is constructed from:
+
+```
+[symbol_indicator (3 bits)][mask_pattern (2 bits)][BCH remainder (10 bits)]
+```
+
+Total: 3 + 2 + 10 = 15 bits.
+
+**Symbol indicator** encodes both the version (M1–M4) and ECC level in 3 bits:
+
+| Symbol + ECC    | Symbol Indicator |
+|----------------|-----------------|
+| M1 (det. only) | 000 |
+| M2-L           | 001 |
+| M2-M           | 010 |
+| M3-L           | 011 |
+| M3-M           | 100 |
+| M4-L           | 101 |
+| M4-M           | 110 |
+| M4-Q           | 111 |
+
+Eight possible combinations, covered by 3 bits. The symbol indicator is enough
+to completely identify the symbol type — version and ECC level are bound together
+here, unlike regular QR where ECC level and version are independent.
+
+**Mask pattern** is a 2-bit value (00–11), indicating which of the four Micro QR
+mask patterns was selected.
+
+### BCH Code Generation
+
+The 10-bit BCH remainder is computed using the same generator polynomial as
+regular QR format information:
+
+```
+G(x) = x^10 + x^8 + x^5 + x^4 + x^2 + x + 1
+     = 10100110111 in binary
+     = 0x537 (but as a BCH generator: 0b10100110111)
+```
+
+Procedure:
+
+```
+1. Form the 5-bit data string:
+      D = [symbol_indicator (3 bits)] [mask_pattern (2 bits)]
+
+2. Left-shift by 10 positions (multiply by x^10):
+      D_shifted = D << 10   (now a 15-bit integer)
+
+3. Compute remainder:
+      remainder = D_shifted mod G(x)   (polynomial division over GF(2))
+      The result is a 10-bit integer.
+
+4. Append remainder to D:
+      format_15 = D_shifted | remainder   (15-bit integer)
+
+5. XOR with the Micro QR mask value 0x4445:
+      format_final = format_15 XOR 0x4445
+```
+
+Note: Micro QR uses **0x4445** as the XOR mask, **not** regular QR's 0x5412.
+This is a deliberate difference to prevent a Micro QR symbol from being
+misread as a regular QR symbol.
+
+The XOR mask in binary: `100 0100 0100 0101` = 0x4445.
+
+### Example: M2-L, mask pattern 1
+
+```
+symbol_indicator = 001  (M2-L)
+mask_pattern     = 01   (pattern 1)
+5-bit data       = 001 01 = 00101 = 0x05
+
+D_shifted = 0x05 << 10 = 0x1400 = 0001 0100 0000 0000
+
+Divide by G(x) = 10100110111:
+  Polynomial division of 1 0100 0000 0000 0 by 10100110111
+  (work through binary long division)
+  ... remainder R
+
+format_15 = D_shifted | R
+
+format_final = format_15 XOR 0x4445
+```
+
+Implementors should generate a lookup table of all 32 possible format values
+(8 symbol_indicator values × 4 mask patterns) at build time or embed them as a
+constant table.
+
+### Pre-computed Format Information Table
+
+For convenience, here are all 32 format information values (after XOR with
+0x4445), expressed as 15-bit integers. Bit 14 is MSB, bit 0 is LSB:
+
+| Symbol+ECC | Mask 0 | Mask 1 | Mask 2 | Mask 3 |
+|-----------|--------|--------|--------|--------|
+| M1 (000)  | 0x4445 | 0x4172 | 0x4E2B | 0x4B1C |
+| M2-L (001)| 0x5528 | 0x501F | 0x5F46 | 0x5A71 |
+| M2-M (010)| 0x6649 | 0x637E | 0x6C27 | 0x6910 |
+| M3-L (011)| 0x7764 | 0x7253 | 0x7D0A | 0x783D |
+| M3-M (100)| 0x06DE | 0x03E9 | 0x0CB0 | 0x0987 |
+| M4-L (101)| 0x17F3 | 0x12C4 | 0x1D9D | 0x18AA |
+| M4-M (110)| 0x24B2 | 0x2185 | 0x2EDC | 0x2BEB |
+| M4-Q (111)| 0x359F | 0x30A8 | 0x3FF1 | 0x3AC6 |
+
+Note: these values are computed using the procedure above. Verify them against
+the ISO standard worked examples before relying on them in production. Embed the
+final table as a constant to avoid any computation errors.
+
+### Format Information Placement
+
+The 15-bit format value is placed into the symbol with **f14 as the MSB**:
+
+```
+Row 8, col 1  ← f14  (MSB)
+Row 8, col 2  ← f13
+Row 8, col 3  ← f12
+Row 8, col 4  ← f11
+Row 8, col 5  ← f10
+Row 8, col 6  ← f9
+Row 8, col 7  ← f8
+Row 8, col 8  ← f7
+Col 8, row 7  ← f6
+Col 8, row 6  ← f5
+Col 8, row 5  ← f4
+Col 8, row 4  ← f3
+Col 8, row 3  ← f2
+Col 8, row 2  ← f1
+Col 8, row 1  ← f0  (LSB)
+```
+
+There is **only one copy** of the format information in Micro QR (unlike regular
+QR, which places it in two locations). This means Micro QR format information
+offers no redundancy — if those modules are damaged, the symbol cannot be decoded.
+
+---
+
+## Complete Encoding Algorithm
+
+The full encoding pipeline for a given input string, desired symbol version (or
+auto-selection), and ECC level:
+
+```
+1. CHOOSE VERSION
+   If version is not specified, auto-select:
+   For each symbol M1, M2, M3, M4 in order:
+     For the chosen ECC level (or all levels if not specified):
+       Check if the input fits in the data capacity (data_codewords available).
+       Use the smallest symbol+ECC combination that fits.
+   If no symbol fits, raise InputTooLong.
+   Validate that the chosen ECC level is available for the selected symbol
+   (M1 only supports detection; M2/M3 support L and M; M4 supports L, M, Q).
+
+2. ENCODE DATA
+   a. Select encoding mode:
+      - If all characters are digits 0–9 AND the symbol supports numeric: numeric
+      - Else if all chars are in the 45-char alphanumeric set AND symbol supports
+        alphanumeric: alphanumeric
+      - Else if all bytes are in ISO-8859-1 AND symbol supports byte: byte
+      - Else if all characters are valid Shift-JIS kanji AND symbol supports
+        kanji: kanji
+      - Raise InvalidMode if no mode works for this symbol.
+      
+   b. Build the bit stream:
+      - mode indicator (0/1/2/3 bits depending on symbol)
+      - character count (width from the table above)
+      - encoded data bits (mode-specific encoding)
+      - terminator (3/5/7/9 zero bits, truncated if capacity exhausted)
+      - zero bits to reach next byte boundary
+      - pad bytes: alternate 0xEC and 0x11 to fill remaining data codewords
+      
+   Special M1 case: the data capacity is 20 bits (not 24). After encoding,
+   pad with zeros to 20 bits. No 0xEC/0x11 padding for M1 since it uses
+   a non-integer number of full codewords.
+
+3. COMPUTE RS ECC
+   a. Extract the data codeword bytes from the bit stream.
+   b. For M1: the "codewords" are the first 2 full bytes plus 4 bits;
+      use the 3 data bytes (the last nibble sits in the high bits of byte 2
+      with 4 zero low-bits). Feed all 3 bytes to the RS encoder.
+   c. For all others: straightforward byte sequence.
+   d. Compute ECC using the RS algorithm above.
+   e. Append ECC bytes to data bytes → final_codewords.
+
+4. BUILD BIT STREAM FOR PLACEMENT
+   Flatten final_codewords to a bit string (MSB-first per codeword).
+   For M1: the last data codeword contributes only 4 bits (the MSB nibble).
+
+5. INITIALIZE GRID
+   Create a size×size grid of unset modules.
+   Place finder pattern at rows 0–6, cols 0–6.
+   Place separators at row 7 cols 0–7 and col 7 rows 0–7 (all light).
+   Place timing row 0 (cols 8 to size-1): alternating dark/light, dark at
+     col 8 (even index).
+   Place timing col 0 (rows 8 to size-1): alternating dark/light, dark at
+     row 8 (even index).
+   Mark format information modules (row 8 cols 1–8 and col 8 rows 1–7) as
+     reserved (temporarily set to light = 0).
+
+6. PLACE DATA
+   Run the two-column zigzag from bottom-right, placing bits from the
+   flat bit stream into unreserved modules.
+   Set any remaining unreserved modules to remainder bits (0).
+
+7. EVALUATE ALL 4 MASKS
+   For each mask pattern 0–3:
+   a. For each data/ECC module at (row, col) (non-reserved):
+      if mask_condition(row, col): flip the module value.
+   b. Compute format information for this mask.
+   c. Place format information into reserved format modules.
+   d. Compute penalty score (rules 1–4).
+   e. Undo the mask (or work on a copy) and record (penalty, mask_index).
+
+8. SELECT BEST MASK
+   Choose the mask with the lowest penalty score (ties → lower index wins).
+
+9. FINALIZE
+   Apply the selected mask to all data/ECC modules in the grid.
+   Write the final format information into the format modules.
+
+10. LAYOUT + PAINT
+    Pass the final ModuleGrid to barcode-2d's layout(grid, config), which
+    resolves module positions to pixel coordinates and returns a PaintScene
+    (P2D00). Pass to a PaintVM backend: paint-vm-svg for SVG output, or
+    paint-metal for GPU-rendered PNG or native window.
+    Include the 2-module quiet zone in the layout config.
+```
+
+---
+
+## Implementation Notes
+
+### Tables to Embed
+
+The following tables must be embedded as compile-time constants:
+
+1. **Capacity table**: for each of the 8 symbol+ECC combinations:
+   - data codewords
+   - ECC codewords
+   - capacity per mode (numeric, alphanumeric, byte, kanji)
+
+2. **RS generator polynomials**: for ECC codeword counts 2, 5, 6, 8, 10, 14.
+
+3. **Format information lookup table**: all 32 pre-computed format words
+   (8 symbol+ECC × 4 masks), stored as 15-bit integers.
+
+4. **Format module positions**: the 15 (row, col) pairs for format placement.
+   These are fixed and identical regardless of symbol size (always row 8 and
+   col 8 relative to the finder).
+
+### Quiet Zone
+
+The quiet zone (2 modules on all sides) is **not part of the module grid**.
+The grid is exactly `size × size`. The quiet zone is added at the layout/render
+stage. The `layout()` function in barcode-2d accepts a `quiet_zone` parameter;
+pass 2 (not 4) for Micro QR.
+
+### Mode Selection Heuristic
+
+For auto-selection, prefer the most compact mode that covers the full input:
+
+```
+1. All digits 0–9 and symbol supports numeric? → numeric mode
+2. All chars in the 45-char alphanumeric set and symbol supports alphanumeric?
+   → alphanumeric mode
+3. All bytes ≤ 255 and symbol supports byte? → byte mode
+4. All chars are valid Shift-JIS kanji and symbol is M4? → kanji mode
+```
+
+This is a greedy single-mode selection. Multi-mode segments (like QR Code's
+"numeric-then-byte" for a URL with a code) are future work.
+
+### Symbol vs. Version Terminology
+
+The ISO standard refers to the four sizes as "M1", "M2", "M3", "M4" (symbol
+designators), not "versions". In code, use the type name `MicroQRVersion` with
+values `M1 | M2 | M3 | M4`. This avoids confusion with regular QR's integer
+versions.
+
+### Relationship to Regular QR
+
+Micro QR shares:
+- GF(256) field and primitive polynomial (0x11D)
+- RS generator polynomial convention (b=0)
+- Same 4 encoding modes (subset of regular QR's modes)
+- Same finder pattern design
+- Same penalty scoring rules
+- Same format information BCH generator polynomial
+
+Micro QR differs from regular QR in:
+- Single finder pattern instead of three
+- No alignment patterns
+- No version information blocks
+- No dark module
+- Timing patterns at row 0 / col 0 instead of row 6 / col 6
+- Only 4 masks instead of 8
+- Narrower mode indicators (0–3 bits instead of 4)
+- Narrower character count fields
+- Longer terminators (3–9 bits instead of fixed 4)
+- 2-module quiet zone instead of 4
+- Format XOR mask: 0x4445 instead of 0x5412
+- Format info encodes symbol_indicator (version+ECC) instead of ECC-only
+- Format info is placed once (not twice)
+- Single-block RS (no interleaving)
+
+### UTF-8 and Byte Mode
+
+When encoding to byte mode, use UTF-8 byte values for characters outside
+ISO-8859-1. Multi-byte UTF-8 sequences are each treated as individual byte
+values in the character count (so a 3-byte UTF-8 character counts as 3 in the
+character count field and contributes 3 bytes of data, not 1 character).
+
+### M1 Half-Codeword
+
+M1's final codeword is a 4-bit "nibble", not a full byte. This means:
+- The character count field for numeric is only 3 bits (max value 7)
+- After encoding `"12345"` (the maximum), the bit stream must fit in 20 bits
+- Terminate at the 3-bit boundary
+- The RS encoder receives 3 bytes (with the third byte having the data in its
+  upper 4 bits and zeros in the lower 4 bits)
+
+Some implementations treat M1 as having 2 full data bytes plus 4 data bits,
+while others treat it as 3 bytes where the last byte's low nibble is forced to
+zero. Both approaches yield identical symbols.
+
+### Error Detection vs. Error Correction
+
+M1 provides error **detection** only, via its 2-byte "ECC". Strictly speaking,
+these are used only to detect errors, not correct them. A scanner that finds
+the RS check fails on an M1 symbol will report an unreadable symbol rather than
+attempting correction. For M2–M4, the ECC bytes provide genuine error correction.
+
+---
+
+## Visualization Annotations
+
+The encoder should optionally produce an **annotated module grid** where each
+module records its role. This supports interactive learning tools and visualizers.
+
+| Color (suggested) | Role |
+|-------------------|------|
+| Deep blue  | finder pattern module |
+| Blue-grey  | separator module |
+| Grey       | timing pattern module |
+| Purple     | format information module |
+| Black/white | data module |
+| Green/light green | ECC module |
+| Orange     | remainder bits |
+
+There are no alignment, version information, or dark-module roles in Micro QR.
+A visualizer can annotate each module with its codeword index and bit position,
+making it possible to see exactly which character's data occupies which region
+of the symbol.
+
+---
+
+## Error Types
+
+```
+MicroQRError::InputTooLong
+  -- Input does not fit in any M1–M4 symbol at any ECC level.
+  -- Suggest using regular QR Code instead.
+
+MicroQRError::InputTooLongForECC(requested_ecc)
+  -- Input fits at a lower ECC level but not the requested one.
+  -- Include message: "fits at L but not M" or similar.
+
+MicroQRError::InvalidMode(mode, symbol)
+  -- Requested encoding mode not available for this symbol.
+  -- E.g., byte mode requested but only M1 available.
+
+MicroQRError::InvalidCharacter(char, mode)
+  -- Character not encodable in the selected mode.
+  -- E.g., lowercase letter in alphanumeric mode.
+
+MicroQRError::ECCNotAvailable(ecc_level, symbol)
+  -- E.g., ECC level H requested (not supported by any Micro QR symbol).
+  -- E.g., ECC level Q requested for M2 (only L and M available).
+```
+
+---
+
+## Public API
+
+```
+encode(input: string, ecc?: EccLevel) → ModuleGrid
+  -- Encodes input to a Micro QR Code module grid (abstract module units, no
+  -- pixels). Auto-selects the smallest symbol that fits the input at the
+  -- requested ECC level. If ecc is omitted, defaults to M (medium).
+  -- Raises InputTooLong if input exceeds M4 capacity.
+  -- Raises InvalidCharacter if input contains unencodable characters.
+
+encode_at(input: string, version: MicroQRVersion, ecc: EccLevel) → ModuleGrid
+  -- Encodes to a specific symbol version. Raises InputTooLong if the input
+  -- does not fit in the requested version/ECC combination.
+
+layout(grid: ModuleGrid, config?: Barcode2DLayoutConfig) → PaintScene
+  -- Translates a ModuleGrid into a pixel-resolved PaintScene (P2D00).
+  -- Sets quiet_zone=2 automatically unless overridden in config.
+  -- Delegates to barcode-2d::layout() — micro-qr does not implement this.
+
+encode_and_layout(input: string, ecc?: EccLevel, config?: Barcode2DLayoutConfig)
+  → PaintScene
+  -- Convenience: encode + layout in one call.
+
+render_svg(input: string, ecc?: EccLevel, config?: Barcode2DLayoutConfig) → string
+  -- Convenience: encode + layout + paint-vm-svg backend → SVG string.
+
+explain(input: string, ecc?: EccLevel) → AnnotatedModuleGrid
+  -- Encode with full per-module role annotations. Used by visualizers.
+  -- Each module includes its role, codeword index, and bit position.
+
+MicroQRVersion = M1 | M2 | M3 | M4
+
+EccLevel = Detection | L | M | Q
+  -- Detection is M1 only. L/M available for M2–M4. Q only for M4.
+  -- H is not available in Micro QR — raise ECCNotAvailable if requested.
+```
+
+---
+
+## Package Matrix
+
+| Language   | Directory                              | Depends on            |
+|------------|----------------------------------------|-----------------------|
+| Rust       | `code/packages/rust/micro-qr/`         | barcode-2d, gf256     |
+| TypeScript | `code/packages/typescript/micro-qr/`   | barcode-2d, gf256     |
+| Python     | `code/packages/python/micro-qr/`       | barcode-2d, gf256     |
+| Go         | `code/packages/go/micro-qr/`           | barcode-2d, gf256     |
+| Ruby       | `code/packages/ruby/micro_qr/`         | barcode-2d, gf256     |
+| Elixir     | `code/packages/elixir/micro_qr/`       | barcode_2d, gf256     |
+| Lua        | `code/packages/lua/micro-qr/`          | barcode-2d, gf256     |
+| Perl       | `code/packages/perl/micro-qr/`         | barcode-2d, gf256     |
+| Swift      | `code/packages/swift/micro-qr/`        | Barcode2D, GF256      |
+| C#         | `code/packages/csharp/micro-qr/`       | Barcode2D, GF256      |
+| F#         | `code/packages/fsharp/micro-qr/`       | Barcode2D, GF256      |
+| Kotlin     | `code/packages/kotlin/micro-qr/`       | barcode-2d, gf256     |
+| Java       | `code/packages/java/micro-qr/`         | barcode-2d, gf256     |
+| Dart       | `code/packages/dart/micro-qr/`         | barcode-2d, gf256     |
+| Haskell    | `code/packages/haskell/micro-qr/`      | barcode-2d, gf256     |
+
+Each package follows the standard repo layout:
+
+```
+micro-qr/
+  src/           (or lib/ per language conventions)
+  tests/
+  BUILD
+  README.md
+  CHANGELOG.md
+  <build-manifest>  (Cargo.toml / package.json / pyproject.toml / etc.)
+```
+
+The `gf256` dependency is the MA01 package in the same language. The `barcode-2d`
+dependency provides `ModuleGrid`, `Barcode2DLayoutConfig`, and `layout()`.
+
+Note on language-specific naming:
+- Ruby and Elixir conventionally use snake_case module/package names: `micro_qr`
+- Rust, TypeScript, Python, Go, Lua, Perl: `micro-qr` (kebab-case directories)
+- Swift, C#, F#: `MicroQR` or `Micro-QR` depending on toolchain conventions
+- Kotlin, Java: `micro-qr` directory, `com.codingadventures.microqr` Java package
+
+---
+
+## Test Strategy
+
+### Unit Tests
+
+**1. RS Encoder**
+
+For each of the five ECC codeword counts used in Micro QR (2, 5, 6, 8, 10, 14),
+encode a known data sequence and verify the output ECC bytes match hand-computed
+values. At minimum, verify the 2-ECC-codeword case:
+
+```
+data = [0x10, 0x20, 0x0C]   (example M1 data codewords for "123")
+ecc  = rs_encode(data, 2)
+-- expected: compute by hand or derive from standard's example
+```
+
+**2. Format Information**
+
+Verify all 32 format words in the lookup table. Pick several arbitrary entries,
+recompute from the BCH formula, and check against the table:
+
+```
+format_word(symbol_indicator=0b001, mask=0b01)   -- M2-L, mask 1
+format_word(symbol_indicator=0b111, mask=0b11)   -- M4-Q, mask 3
+```
+
+**3. Mode Selection**
+
+- `"12345"` → numeric, M1 (fits in 5 numeric chars)
+- `"HELLO"` → alphanumeric, M2-L
+- `"hello"` → byte, M3-L (lowercase not in alphanumeric set)
+- `"https://a.b"` → byte (colon and slashes are in alphanumeric, but lowercase
+  isn't — must use byte)
+- `"123456"` → numeric, M2-L (6 digits exceeds M1's 5-char limit)
+
+**4. Bit Stream Assembly**
+
+- Verify correct mode indicators for each symbol version
+- Verify correct character count widths
+- Verify terminator length (3/5/7/9 bits)
+- Verify 0xEC/0x11 padding fills to exact data codeword count
+- Verify M1 20-bit data structure
+
+**5. Penalty Scoring**
+
+Create module grids with known degenerate patterns (all-dark row, checkerboard,
+etc.) and verify the four penalty rules produce expected scores.
+
+**6. Masking**
+
+Apply each of the 4 mask patterns to a known grid, verify the XOR is applied
+only to data/ECC modules (not structural modules), and verify the format
+information changes to reflect the new mask.
+
+### Integration Tests
+
+**1. Encode a known M1 symbol: `"1"`**
+
+```
+Input: "1" at M1 (detection only)
+Expected:
+  - Symbol is 11×11
+  - Grid passes scanner validation
+  - Decode via external library confirms output == "1"
+```
+
+**2. Encode at the limit of M1: `"12345"`**
+
+```
+Input: "12345" at M1
+Expected:
+  - Fits exactly (5 numeric chars is M1 capacity)
+  - "123456" should fall through to M2
+```
+
+**3. Alphanumeric in M2: `"HELLO"`**
+
+```
+Input: "HELLO" at M2-L
+Expected:
+  - Symbol is 13×13
+  - Decode confirms "HELLO"
+```
+
+**4. Byte mode URL: `"https://a.b"`**
+
+```
+Input: "https://a.b" at M4-L
+Expected:
+  - Symbol is 17×17
+  - Byte mode selected
+  - Decode confirms "https://a.b"
+```
+
+**5. All ECC levels for M4**
+
+```
+Input: "MICRO QR" at each of M4-L, M4-M, M4-Q
+Expected:
+  - Each produces a valid 17×17 symbol
+  - Different format information bits for each level
+  - All decode correctly
+```
+
+**6. Scanner round-trip**
+
+Use a Python script calling `zxing-cpp` or `zbar` to decode the rendered PNG
+from each language's implementation and compare to the original input. All 15
+implementations should produce scannable symbols.
+
+### Cross-Language Verification
+
+All 15 implementations must produce **bit-for-bit identical `ModuleGrid` outputs**
+for the same input. The test corpus:
+
+```
+"1"              (M1, minimal numeric)
+"12345"          (M1, maximum numeric capacity)
+"HELLO"          (M2-L, alphanumeric)
+"01234567"       (M2-L, numeric, 8 digits)
+"https://a.b"    (M4-L, byte mode URL)
+"MICRO QR TEST"  (M3-L, alphanumeric, typical use)
+```
+
+For each test input, serialize the ModuleGrid to a plain text format (e.g.,
+`"0" and "1"` characters, row by row) and compare across all 15 language outputs.
+A CI job should run this comparison automatically.
+
+---
+
+## Dependency Stack
+
+```
+paint-metal (P2D02)    paint-vm-svg    paint-vm-canvas
+      └──────────────────┬─────────────────┘
+                         │
+                  paint-vm (P2D01)
+                         │
+              paint-instructions (P2D00)
+                         │
+                     barcode-2d          MA01 gf256
+                         │                   │
+                    micro-qr ───────────────┘
+```
+
+`micro-qr` depends on:
+- `barcode-2d` — for `ModuleGrid` type and `layout()` function
+- `gf256` (MA01) — for GF(256) multiplication in the RS encoder
+
+`micro-qr` does **not** depend on:
+- `qr-code` — Micro QR is a sibling package, not a superset or subset
+- MA02 (reed-solomon) — Micro QR uses the same b=0 RS convention as QR Code
+  and handles RS internally (the computation is simple enough)
+- Any alignment table package — Micro QR has no alignment patterns
+
+The relationship between `micro-qr` and `qr-code`:
+- Both encode barcode symbols to `ModuleGrid`
+- Both use the same GF(256) field
+- Neither depends on the other
+- A future `barcode-factory` package might wrap both with a unified API
+
+---
+
+## Future Extensions
+
+- **Decoder** — Micro QR decoding is simpler than regular QR (no perspective
+  correction for three finder patterns) but still requires image preprocessing
+  and RS syndrome decoding. A separate spec.
+
+- **Mixed-mode encoding** — Allow a single symbol to contain both a numeric
+  segment and a byte segment for maximum capacity. For example, a barcode like
+  `"PART-12345"` could encode `"PART-"` in alphanumeric and `"12345"` in
+  numeric. Significant implementation complexity, modest capacity improvement.
+
+- **rMQR (Rectangular Micro QR)** — ISO/IEC 23941:2022 defines a rectangular
+  variant for extremely space-constrained applications. Similar structure to
+  Micro QR but in a rectangular rather than square symbol. A separate spec.
+
+- **QR Code integration** — A `barcode-factory` package that accepts an input
+  string and desired ECC level, and automatically chooses between Micro QR and
+  regular QR based on capacity requirements and size constraints.
+
+- **Visualizer integration** — The `explain()` API returns an `AnnotatedModuleGrid`
+  that a browser-based visualizer can render with per-module color coding,
+  showing exactly which bits encode which characters, which modules are ECC vs.
+  data, and how the format information identifies the symbol type.
+
+- **Japanese Industrial Standard validation** — Verify symbols against the JIS
+  X 0510 standard (the Japanese national standard equivalent of ISO/IEC 18004),
+  which includes additional test vectors.

--- a/code/specs/pdf417.md
+++ b/code/specs/pdf417.md
@@ -1,0 +1,1655 @@
+# PDF417
+
+## Overview
+
+This spec defines a **PDF417 encoder** for the coding-adventures monorepo.
+
+PDF417 (Portable Data File 417) was invented by Ynjiun P. Wang at Symbol
+Technologies in 1991. The name encodes the format's geometry: each codeword is
+exactly **4** bars and **4** spaces (8 elements total), and every codeword
+occupies exactly **17** modules of horizontal space. "417" = 4 elements × 17
+modules.
+
+PDF417 is governed by **ISO/IEC 15438:2015**. Unlike true matrix codes (QR,
+Data Matrix, Aztec), PDF417 is a **stacked linear** barcode. It is essentially
+many rows of a 1D-like encoding stacked vertically. A single linear scanner
+sweeping one horizontal row can read that row independently — the row indicator
+codewords carry enough context to reconstruct the full symbol from any row.
+
+PDF417 is deployed in high-stakes, high-volume contexts:
+
+- **AAMVA** — North American driver's licences and government-issued IDs
+- **IATA BCBP** — airline boarding passes (the barcode on your phone)
+- **USPS** — domestic shipping labels (USPS 4-State Customer Barcode uses
+  PDF417 for metadata)
+- **US immigration** — Form I-94, customs declarations
+- **Healthcare** — patient wristbands, medication labels
+
+Understanding how to build a PDF417 encoder from scratch teaches:
+
+- how a new Galois field GF(929) is constructed over a prime modulus
+- how stacked row encoding works differently from matrix encoding
+- how three distinct compaction modes (text, byte, numeric) are selected
+- how row indicator codewords make each row self-describing
+- how to pack the most information into the fewest codewords
+
+The encoder in this spec produces a **valid, scannable PDF417 symbol** for any
+input data. It does not implement decoding.
+
+---
+
+## Symbol Structure
+
+A PDF417 symbol is a rectangle made of stacked rows. Every row has the same
+width. The number of rows and the number of data columns per row are both
+variable and configurable.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  quiet zone (2+ modules left, right, top, bottom)                   │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ START │ LRI │ d₀ │ d₁ │ ... │ d_{c-1} │ RRI │  STOP  │ row 0 │  │
+│  │ START │ LRI │ d_c│ d_{c+1}...│d_{2c-1} │ RRI │  STOP  │ row 1 │  │
+│  │  ...  │     │    │    │ ... │         │     │  ...   │  ...  │  │
+│  │ START │ LRI │    │    │ ... │         │ RRI │  STOP  │ row R-1│  │
+│  └───────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+
+LRI = Left Row Indicator codeword
+RRI = Right Row Indicator codeword
+d_i = data codeword at position i
+c   = number of data columns (1..30)
+R   = number of rows (3..90)
+```
+
+### Row anatomy (single row)
+
+Each row in the symbol has the following components left to right:
+
+```
+[START] [LRI] [d₀] [d₁] ... [d_{c-1}] [RRI] [STOP]
+   17     17    17   17  ...    17        17     18
+   ← modules →
+```
+
+The widths in modules:
+- **Start pattern**: 17 modules, fixed bit pattern `11111111010101000`
+- **Each codeword** (LRI, data, RRI): 17 modules, 4 bars + 4 spaces
+- **Stop pattern**: 18 modules, fixed bit pattern `111111101000101001`
+
+Total row width in modules:
+```
+row_width = 17           -- start
+          + 17           -- left row indicator
+          + c × 17       -- data codewords
+          + 17           -- right row indicator
+          + 18           -- stop
+          = 17 + 17 + 17c + 17 + 18
+          = 69 + 17c     modules
+```
+
+For example, with c=1 data column: 69 + 17 = 86 modules per row.
+With c=30 data columns: 69 + 510 = 579 modules per row.
+
+### Symbol constraints
+
+| Parameter | Minimum | Maximum |
+|-----------|---------|---------|
+| Rows | 3 | 90 |
+| Data columns | 1 | 30 |
+| Data codewords | 1 | 2710 |
+| ECC codewords | 2 (level 0) | 512 (level 8) |
+
+Quiet zone: minimum 2 modules on left and right, minimum 2 module-rows top
+and bottom. Implementations should default to 2 but allow this to be
+configured.
+
+### Row height
+
+A "row" in the spec means one pass of row-encoded codewords — a strip of
+module height `row_height` pixels (or row_height module-rows in abstract units).
+The minimum recommended row height is 3 modules; the common default in practice
+is 4–8 modules. For scanning reliability, the total symbol height should be at
+least 1/8 of the symbol width (a width:height ratio no wider than 8:1).
+
+The `row_height` parameter controls how many module-rows tall each logical row
+is. It does not affect the encoded codeword content — it is purely a rendering
+decision.
+
+---
+
+## Codeword Clusters
+
+This is the most distinctive structural element of PDF417. Unlike QR Code where
+every codeword has one fixed bar/space pattern, PDF417 uses **three different
+mappings** from codeword value to bar/space pattern, cycling through them
+row by row.
+
+The three mappings are called **clusters** 0, 3, and 6.
+
+```
+Row 0  → cluster 0   (row % 3 == 0)
+Row 1  → cluster 3   (row % 3 == 1)
+Row 2  → cluster 6   (row % 3 == 2)
+Row 3  → cluster 0   (row % 3 == 0)
+Row 4  → cluster 3   (row % 3 == 1)
+...
+```
+
+The cluster number is: `cluster = (row_number % 3) * 3`
+
+**Why three clusters?** A scanner sweeping a single row needs to know it is
+reading a complete PDF417 row and not a spurious horizontal slice through a
+different part of the symbol (or a different barcode entirely). Because cluster
+0, 3, and 6 have different bar/space patterns for the same codeword value, a
+reader that knows which cluster it is in can verify each row independently.
+If you scanned row 1 thinking it was cluster 0, the decoded values would be
+inconsistent with the row indicator codewords — the cluster mismatch is
+detectable.
+
+### Codeword encoding
+
+Each codeword (value 0–928) has a different 17-module bar/space pattern in
+each cluster. A pattern consists of 8 alternating elements: bar, space, bar,
+space, bar, space, bar, space. The first element is always a bar (dark modules).
+The element widths sum to exactly 17.
+
+```
+Codeword pattern structure:
+
+  b₁ s₁ b₂ s₂ b₃ s₃ b₄ s₄
+  ← ← ← ← ← ← ← ← sum = 17 ← ← ← ← ← ← ← →
+
+b_i = width of i-th bar in modules (1..6)
+s_i = width of i-th space in modules (1..6)
+```
+
+The clusters are designed so that every codeword value 0–928 has a unique
+pattern in each cluster. There are 929 valid codeword values (0–928); the
+field GF(929) is prime, and this is not coincidental.
+
+### Cluster tables
+
+The complete cluster tables (all 929 × 3 = 2787 patterns) are defined in
+**ISO/IEC 15438:2015, Annex B**. They are not reproduced here in full because
+2787 entries would dominate the spec.
+
+For implementation, the cluster tables should be embedded as static lookup
+arrays. Each entry maps `(cluster_index, codeword_value)` to a tuple of 8
+element widths `(b1, s1, b2, s2, b3, s3, b4, s4)`.
+
+The tables can be computed algorithmically (the ISO standard provides the
+generation formula) or sourced from a reference implementation and embedded.
+For v0.1.0, embed the tables as constants — do not generate them at runtime.
+
+A compact representation stores each pattern as a 32-bit integer using 4 bits
+per element (each element is 1–6, fits in 3 bits; 8 elements × 3 bits = 24
+bits, or 8 × 4 bits = 32 bits for byte-aligned convenience):
+
+```
+-- 8 elements × 4 bits each = 32 bits per pattern
+-- bits 31..28 = b1, bits 27..24 = s1, ..., bits 3..0 = s4
+pack_pattern(b1, s1, b2, s2, b3, s3, b4, s4) =
+  (b1 << 28) | (s1 << 24) | (b2 << 20) | (s2 << 16)
+  | (b3 << 12) | (s3 << 8) | (b4 << 4) | s4
+```
+
+Three arrays of 929 u32s each = 3 × 929 × 4 bytes = 11,148 bytes total.
+This is acceptable to embed in source as a constant table.
+
+---
+
+## GF(929) — The Prime Field
+
+PDF417 uses Reed-Solomon error correction over **GF(929)**, not GF(256). This
+is the most algorithmically distinct aspect of PDF417 compared to other 2D
+barcodes.
+
+### Why GF(929)?
+
+The codeword alphabet has exactly 929 elements (values 0–928). For Reed-Solomon
+to work, the error correction must be computed in a field whose size equals the
+alphabet size. Since 929 is prime, GF(929) is simply **the integers modulo
+929**, with no need for a primitive polynomial or extension field construction.
+
+```
+929 is prime. Verify: 929 = 929, not divisible by 2, 3, 5, 7, 11, 13,
+17, 19, 23, 29 (29² = 841 < 929 < 961 = 31²). Next prime after 929 is
+937. So 929 is indeed prime.
+```
+
+For GF(p) where p is prime:
+- The field elements are {0, 1, 2, ..., 928}
+- Every non-zero element has a multiplicative inverse
+- The field has characteristic 929 (not 2)
+- There is no notion of XOR — arithmetic is modular integer arithmetic
+
+### Field arithmetic
+
+```
+GF(929) arithmetic:
+
+  add(a, b) = (a + b) mod 929
+  sub(a, b) = (a - b + 929) mod 929    -- +929 to avoid negative
+  mul(a, b) = (a * b) mod 929
+  inv(b)    = b^927 mod 929            -- Fermat's little theorem: b^{p-1} ≡ 1
+  div(a, b) = mul(a, inv(b))
+```
+
+Fermat's little theorem guarantees that for any non-zero b in GF(p):
+b^{p-1} ≡ 1 (mod p), so b^{p-2} ≡ b^{-1} (mod p). For p=929,
+the inverse is b^{927} mod 929.
+
+**Efficiency note**: Computing b^{927} naively requires 926 multiplications.
+Use fast exponentiation (square-and-multiply) instead:
+
+```
+pow_mod(base, exp, mod):
+  result = 1
+  base = base mod mod
+  while exp > 0:
+    if exp is odd: result = (result * base) mod mod
+    exp = exp >> 1
+    base = (base * base) mod mod
+  return result
+
+inv_gf929(b) = pow_mod(b, 927, 929)   -- 10 squarings + ~6 multiplies
+```
+
+For the encoder (which does not need to invert during synthesis), it is more
+efficient to precompute an **inverse table** or use the **extended Euclidean
+algorithm**:
+
+```
+-- Extended Euclidean Algorithm for inverse in GF(p)
+inv_gf929_euclid(b):
+  -- Find x such that b*x ≡ 1 (mod 929)
+  -- Using extended Euclidean: gcd(b, 929) = 929*s + b*t → t = b^{-1} mod 929
+  old_r, r = b, 929
+  old_s, s = 1, 0
+  while r != 0:
+    q = old_r / r
+    old_r, r = r, old_r - q*r
+    old_s, s = s, old_s - q*s
+  -- old_s is the inverse (may be negative)
+  return (old_s + 929) mod 929
+```
+
+### Generator element
+
+The generator (primitive root) of GF(929) is **α = 3**. This means 3 is a
+primitive root modulo 929: the powers 3^0, 3^1, 3^2, ..., 3^{927} cycle
+through all 928 non-zero elements of GF(929) before repeating.
+
+Verify (conceptually):
+```
+3^1    mod 929 = 3
+3^2    mod 929 = 9
+3^3    mod 929 = 27
+...
+3^{928} mod 929 = 1    (Fermat's little theorem)
+3^k    mod 929 ≠ 1    for any 0 < k < 928  (primitivity of 3 mod 929)
+```
+
+The value α = 3 is specified in **ISO/IEC 15438:2015, Annex A.4**.
+
+### Log and antilog tables
+
+For encoding performance, precompute log and antilog tables modulo 929:
+
+```
+-- gf929_exp[i] = 3^i mod 929, for i in 0..927 (then cycles)
+-- gf929_log[v] = discrete log base 3 of v, for v in 1..928
+-- gf929_log[0] = undefined (log of zero is undefined)
+
+Build:
+  gf929_exp = new array[929]
+  gf929_log = new array[929]
+  x = 1
+  for i in 0..927:
+    gf929_exp[i] = x
+    gf929_log[x] = i
+    x = (x * 3) mod 929
+  gf929_exp[928] = gf929_exp[0]   -- wrap for convenience
+
+Fast multiply using tables:
+  mul_gf929(a, b):
+    if a == 0 or b == 0: return 0
+    return gf929_exp[(gf929_log[a] + gf929_log[b]) mod 928]
+```
+
+This reduces each multiplication to two table lookups and an addition modulo
+928 — much faster than a general modular multiply.
+
+### gf929 as a separate package
+
+Because GF(929) is unique to PDF417 (and MicroPDF417) among the formats in
+this repo, it should be implemented as its own package **gf929**, separate
+from the existing gf256 package. The gf929 package provides:
+
+```
+gf929::add(a, b) → u16
+gf929::sub(a, b) → u16
+gf929::mul(a, b) → u16
+gf929::inv(b) → u16        -- panics/errors if b == 0
+gf929::div(a, b) → u16     -- panics/errors if b == 0
+gf929::pow(base, exp) → u16
+gf929::EXP_TABLE: [u16; 929]   -- α^i mod 929
+gf929::LOG_TABLE: [u16; 929]   -- discrete log base α
+```
+
+The type `u16` is sufficient since all values are in 0..928 (10 bits).
+
+---
+
+## Reed-Solomon Error Correction
+
+PDF417 uses **Reed-Solomon over GF(929)** with a fixed generator using the
+**b=3 convention**: the roots of the generator polynomial are
+α^3, α^4, ..., α^{2+k} where k is the number of ECC codewords.
+
+### ECC levels
+
+PDF417 defines 9 ECC levels numbered 0 through 8:
+
+| ECC Level | ECC codewords (k) | Error correction capacity | Erasure capacity |
+|-----------|------------------|--------------------------|-----------------|
+| 0 | 2 | detects 1 error | 2 erasures |
+| 1 | 4 | corrects 1 error | 4 erasures |
+| 2 | 8 | corrects 3 errors | 8 erasures |
+| 3 | 16 | corrects 7 errors | 16 erasures |
+| 4 | 32 | corrects 15 errors | 32 erasures |
+| 5 | 64 | corrects 31 errors | 64 erasures |
+| 6 | 128 | corrects 63 errors | 128 erasures |
+| 7 | 256 | corrects 127 errors | 256 erasures |
+| 8 | 512 | corrects 255 errors | 512 erasures |
+
+ECC codewords = 2^{level+1}. The error correction capacity is floor(k/2)
+errors or k erasures (where an erasure is a known-position error).
+
+Recommended minimum: **level 2** (8 ECC codewords). For production use with
+driver's licences or boarding passes, level 4 or higher is typical.
+
+**Auto-level selection rule** (for the encoder's default behavior):
+
+```
+data_codewords_count → recommended_minimum_level:
+  ≤ 40    → level 2   (8 ECC codewords)
+  ≤ 160   → level 3   (16 ECC codewords)
+  ≤ 320   → level 4   (32 ECC codewords)
+  ≤ 863   → level 5   (64 ECC codewords)
+  otherwise → level 6  (128 ECC codewords)
+```
+
+### Generator polynomial
+
+For ECC level L (k = 2^{L+1} ECC codewords), the generator polynomial is:
+
+```
+g(x) = ∏_{i=3}^{k+2} (x - α^i)   over GF(929)
+     = (x - α^3)(x - α^4)···(x - α^{k+2})
+```
+
+This is the **b=3 convention**: roots start at α^3, not α^0 (QR) or α^1
+(Data Matrix, Aztec, MA02).
+
+For ECC level 0 (k=2):
+```
+g(x) = (x - α^3)(x - α^4)
+     = x² - (α^3 + α^4)x + α^7
+     = x² - (27 + 81)x + 2187 mod 929
+     = x² - 108x + 400        (since 2187 mod 929 = 329... verify below)
+```
+
+Wait — let us compute precisely for reference:
+```
+α = 3
+α^3 = 27
+α^4 = 81
+α^7 = 3^7 = 2187 mod 929:
+  2187 / 929 = 2 remainder 329
+  α^7 mod 929 = 329
+
+g(x) for k=2:
+  = (x - 27)(x - 81)
+  = x² - (27+81)x + (27×81)
+  = x² - 108x + 2187
+  in GF(929): x² + sub(0, 108)x + (2187 mod 929)
+  = x² + 821x + 329    (since -108 mod 929 = 821, 2187 mod 929 = 329)
+```
+
+Note that in GF(929), subtraction wraps: `(a - b) mod 929`.
+
+### Generator polynomial precomputation
+
+For each ECC level, precompute the generator polynomial coefficients once and
+embed them as constants. The generator polynomial for level L has k+1
+coefficients (degree k), stored as g[0..k] where g[0] is the leading (x^k)
+coefficient (which is always 1).
+
+```
+-- Precompute generator polynomial g(x) = ∏_{j=3}^{k+2} (x - α^j)
+-- Start with g = [1]
+-- For each root α^j:
+--   g(x) = g(x) * (x - α^j)
+--        = x*g(x) - α^j * g(x)
+build_generator(k):
+  g = [1]
+  for j in 3..(k+2):
+    root = gf929_exp[j]       -- α^j
+    new_g = [0] * (len(g) + 1)
+    for i in 0..len(g):
+      new_g[i]   = gf929_add(new_g[i], g[i])        -- coefficient of x^{k-i+1}
+      new_g[i+1] = gf929_add(new_g[i+1], gf929_mul(g[i], 929 - root))  -- -root = 929-root
+  return new_g
+```
+
+### RS encoding (computing ECC codewords)
+
+Given data codewords D = [d_0, d_1, ..., d_{n-1}] and generator polynomial
+g(x) of degree k, the ECC codewords are the coefficients of:
+
+```
+R(x) = D(x) × x^k mod g(x)
+```
+
+where D(x) = d_0 × x^{n-1} + d_1 × x^{n-2} + ... + d_{n-1}.
+
+This is computed by the standard shift-register (LFSR) method:
+
+```
+rs_encode_pdf417(data, g):
+  -- data: list of codeword values 0..928
+  -- g: generator polynomial coefficients [g_0=1, g_1, ..., g_k]
+  -- returns: k ECC codewords
+
+  k = len(g) - 1         -- degree of generator = number of ECC codewords
+  ecc = [0] * k
+
+  for d in data:
+    feedback = gf929_add(d, ecc[0])
+    ecc = ecc[1:] + [0]
+    for i in range(k):
+      ecc[i] = gf929_add(ecc[i], gf929_mul(g[k - i], feedback))
+
+  return ecc
+```
+
+The result is appended to the data codewords (data first, ECC last) before
+the symbol layout step.
+
+**No interleaving**: unlike QR Code, PDF417 does NOT split data into multiple
+blocks and interleave them. All data codewords are fed to a single RS encoder
+to produce all ECC codewords in one pass. This simplifies the encoder
+considerably compared to QR.
+
+---
+
+## Three Compaction Modes
+
+PDF417 compresses the input into **codewords** (each 0–928) before error
+correction. There are three compaction modes, each optimized for a different
+type of input. The encoder selects or mixes modes to minimize codeword count.
+
+A PDF417 data stream is a sequence of codewords, where special "latch" and
+"shift" codewords signal mode changes.
+
+### Reserved codeword values
+
+| Value | Meaning |
+|-------|---------|
+| 0–899 | Data codewords (used in text and byte compaction) |
+| 900 | Latch to Text Compaction |
+| 901 | Latch to Byte Compaction (for sequence length divisible by 6) |
+| 902 | Latch to Numeric Compaction |
+| 903–909 | Reserved |
+| 910–912 | Reserved |
+| 913 | Shift to Byte (single byte in text mode) |
+| 914–920 | Reserved |
+| 921–923 | Reserved |
+| 924 | Latch to Byte Compaction (for any length — alternative) |
+| 925 | Macro PDF417 control block begins |
+| 926 | Macro PDF417 optional fields follow |
+| 927 | Macro PDF417 optional field control |
+| 928 | Macro PDF417 segment count |
+
+For v0.1.0, only codewords 900–902, 913, and 924 are relevant.
+
+### Mode 1: Text Compaction
+
+Text compaction encodes characters from the ASCII printable subset,
+packing **2 characters per codeword** in the range 0–899. It uses four
+sub-modes:
+
+```
+Sub-mode name → character set
+  UC (uppercase)  : A–Z, space, and switch characters
+  LC (lowercase)  : a–z, space, and switch characters
+  ML (mixed)      : 0–9, &, CR, HT, comma, !, ", #, $, %, *, +, -, ., /, :, ;, <, =, >, ?, @, [, \, ], ^, _
+  PL (punctuation): tab, newline, CR, FF, |, ~, DEL, and more
+```
+
+Each sub-mode assigns values 0–29 (or 0–28 for PL) to its character set.
+Two consecutive character values a and b (each 0–29) in the same sub-mode
+are packed into a single codeword:
+
+```
+codeword = a * 30 + b      (range: 0..899)
+```
+
+If the last character in a text compaction segment is a lone character (odd
+count), it is encoded as `a * 30 + 29` where 29 is a latch/shift indicator;
+the second character position carries the mode switch value.
+
+#### Sub-mode switch codewords within text compaction
+
+| Value (as character position) | Action |
+|-------------------------------|--------|
+| 27 | Switch to lower case (LC) |
+| 28 | Switch to mixed (ML) |
+| 29 | Switch to punctuation (PL) |
+| 28 then 25 | Switch to upper case (UC) from ML |
+| 28 then 26 | Switch to upper case (UC) from PL (back to UC) |
+
+The full sub-mode character tables are defined in ISO/IEC 15438:2015,
+Table 3 (Text Compaction sub-mode values).
+
+#### Text compaction character tables (values 0–29 per sub-mode)
+
+```
+Index | UC  | LC  | ML  | PL
+------+-----+-----+-----+-------
+ 0    |  A  |  a  |  0  | TAB
+ 1    |  B  |  b  |  1  | LF
+ 2    |  C  |  c  |  2  | ETX (CR in some docs)
+ 3    |  D  |  d  |  3  | FF
+ 4    |  E  |  e  |  4  | (reserved)
+ 5    |  F  |  f  |  5  | !
+ 6    |  G  |  g  |  6  | "
+ 7    |  H  |  h  |  7  | #
+ 8    |  I  |  i  |  8  | $
+ 9    |  J  |  j  |  9  | %
+10    |  K  |  k  |  &  | &
+11    |  L  |  l  |  CR | '
+12    |  M  |  m  |  HT | (
+13    |  N  |  n  |  ,  | )
+14    |  O  |  o  |  !  | *
+15    |  P  |  p  |  "  | +
+16    |  Q  |  q  |  #  | ,
+17    |  R  |  r  |  $  | -
+18    |  S  |  s  |  %  | .
+19    |  T  |  t  |  *  | /
+20    |  U  |  u  |  +  | :
+21    |  V  |  v  |  -  | ;
+22    |  W  |  w  |  .  | <
+23    |  X  |  x  |  /  | =
+24    |  Y  |  y  |  :  | >
+25    |  Z  |  z  |  ;  | ?
+26    |  SP |  SP |  <  | @
+27    | LC  |  UC | UC→ | [
+28    | ML→ | ML→ | ML→ | \
+29    | PL→ | PL→ | PL→ | ]
+-- (PL continues)
+-- Index 27 in PL = ^
+-- Index 28 in PL = _ 
+-- Index 29 in PL = UC→ (return to UC)
+```
+
+(The exact 29/30 entry mapping for PL differs from UC/LC/ML; see ISO Table 3.)
+
+#### Text compaction encoding algorithm
+
+```
+text_compact(chars):
+  values = []           -- integer values 0..29, one per character
+  modes = []            -- sub-mode for each character
+  current_mode = UC
+
+  for each char in chars:
+    find (sub_mode, value) for char in current_mode
+    if sub_mode != current_mode:
+      emit switch codeword to reach sub_mode
+      current_mode = sub_mode
+    emit value
+
+  -- Now pack pairs into codewords
+  codewords = []
+  i = 0
+  while i < len(values):
+    if i + 1 < len(values):
+      codewords.append(values[i] * 30 + values[i+1])
+      i += 2
+    else:
+      -- odd trailing character: pad with 29
+      codewords.append(values[i] * 30 + 29)
+      i += 1
+
+  return codewords
+```
+
+#### Text compaction latch codeword
+
+To enter text compaction from another mode: emit codeword **900**.
+Text compaction is the default mode at the start of the data stream (no
+leading latch codeword required if starting in text mode).
+
+#### Shift to byte (codeword 913)
+
+Within text compaction, a single byte that cannot be represented in text mode
+can be emitted as: codeword **913** followed by codeword **byte_value**
+(0–255). The byte value is a raw codeword (0–255 is a valid codeword value);
+this does not require special treatment. After the shifted byte, text
+compaction resumes.
+
+### Mode 2: Byte Compaction
+
+Byte compaction encodes arbitrary binary data. It operates in two sub-modes
+depending on the length of the byte sequence:
+
+#### Full-group encoding (6 bytes → 5 codewords)
+
+Every group of 6 bytes is converted to 5 codewords by treating the 6 bytes
+as a 48-bit big-endian integer and expressing it in base 900:
+
+```
+Given bytes b₁, b₂, b₃, b₄, b₅, b₆ (each 0..255):
+
+n = b₁ × 256^5
+  + b₂ × 256^4
+  + b₃ × 256^3
+  + b₄ × 256^2
+  + b₅ × 256
+  + b₆
+
+-- Convert n to base 900:
+c₅ = n mod 900;  n = n / 900
+c₄ = n mod 900;  n = n / 900
+c₃ = n mod 900;  n = n / 900
+c₂ = n mod 900;  n = n / 900
+c₁ = n mod 900;  -- n should now be 0
+
+codewords = [c₁, c₂, c₃, c₄, c₅]
+```
+
+The math: 256^6 = 281,474,976,710,656. The maximum value of n is 256^6 - 1.
+900^5 = 590,490,000,000 × 9 ≈ wait — 900^5 = 900^5:
+```
+900^1 = 900
+900^2 = 810,000
+900^3 = 729,000,000
+900^4 = 656,100,000,000
+900^5 = 590,490,000,000,000
+```
+And 256^6 = 281,474,976,710,656 < 590,490,000,000,000 = 900^5. So 6 bytes
+always fit in 5 base-900 codewords. The compression ratio is 6/5 = 1.2
+bytes per codeword, versus 1 byte per codeword in the fallback mode.
+
+**Important**: this computation requires 48-bit integers. Languages without
+native big integers must use arbitrary precision or 64-bit integers. All
+values fit in u64 (256^6 < 2^48 < 2^64).
+
+#### Remainder encoding (1–5 bytes)
+
+If the byte sequence length is not a multiple of 6, the remaining 1 to 5
+bytes are encoded one codeword per byte (direct mapping):
+
+```
+for each remaining byte b:
+  codewords.append(b)   -- range 0..255, directly valid as a codeword value
+```
+
+This is less efficient (1 byte per codeword instead of 6/5) but handles the
+odd-length tail.
+
+#### Byte compaction latch codewords
+
+Two latch codewords enter byte compaction, with slightly different semantics:
+
+- **Codeword 901**: latch to byte compaction. The count of byte data
+  codewords that follow encodes a sequence whose length in bytes is
+  **not** a multiple of 6. Use when: byte count mod 6 ≠ 0. Actually
+  codeword 901 means: the byte compaction group length is not evenly
+  divisible by 6; use direct 1-codeword-per-byte for any remainder.
+
+- **Codeword 924**: latch to byte compaction (alternate). Used when the
+  total byte count is divisible by 6 (all groups are full 6-byte groups).
+  Codeword 924 can also be used for any byte data regardless of length in
+  many implementations.
+
+In practice, **use codeword 924 for all byte compaction sequences** (both
+divisible and non-divisible by 6). The encoding then:
+
+1. Emit codeword 924.
+2. Encode full groups of 6 bytes as 5 codewords each.
+3. Encode remaining 1–5 bytes as 1 codeword each.
+
+This is the simplest and most compatible approach and is what v0.1.0 should
+implement.
+
+### Mode 3: Numeric Compaction
+
+Numeric compaction encodes sequences of decimal digits (0–9). It achieves the
+highest density for numeric data: approximately 2.9 digits per codeword
+(versus 2 characters per codeword in text mode).
+
+The algorithm:
+1. Group digits into chunks of at most 44 digits.
+2. Prepend a '1' to each chunk (making a 45-digit number for a full chunk).
+3. Convert the resulting big decimal integer to base-900.
+4. The result is exactly 15 codewords for a full 44-digit chunk, or fewer
+   for shorter chunks.
+
+```
+Encoding one chunk of digits d₁d₂...d_n (1 ≤ n ≤ 44):
+
+  number = integer_value_of("1" + d₁d₂...d_n)
+         = 10^n + d₁×10^{n-1} + ... + d_n×10^0
+
+  convert number to base 900:
+  codewords = []
+  while number > 0:
+    codewords.prepend(number mod 900)
+    number = number / 900
+
+  -- For n=44: prepending '1' gives a 45-digit number
+  -- 10^44 < 900^15 (check: 900^15 ≈ 2.05 × 10^44, so 15 codewords suffice)
+```
+
+Verify capacity:
+```
+900^1  = 900
+900^2  = 810,000
+...
+log₁₀(900^15) = 15 × log₁₀(900) = 15 × 2.9542 = 44.31
+```
+
+So 900^15 > 10^44, confirming that 15 codewords can hold a 44-digit chunk
+with the prepended '1'.
+
+#### Numeric compaction latch
+
+Emit codeword **902** to latch to numeric compaction. When the numeric
+sequence ends, latch back with **900** (text) or **924** (byte).
+
+#### Numeric compaction encoding algorithm
+
+```
+numeric_compact(digits_string):
+  codewords = []
+  codewords.append(902)    -- latch to numeric
+
+  i = 0
+  while i < len(digits_string):
+    chunk = digits_string[i : i+44]  -- up to 44 digits
+    i += len(chunk)
+
+    -- Prepend '1' and convert to integer
+    n = int("1" + chunk)             -- big integer
+
+    -- Convert to base 900
+    chunk_cwords = []
+    while n > 0:
+      chunk_cwords.prepend(n mod 900)
+      n = n / 900
+
+    codewords.extend(chunk_cwords)
+
+  return codewords
+```
+
+### Mode selection and auto-detect
+
+For a given input, the encoder should analyze the input and choose the most
+compact representation. The general strategy:
+
+```
+Analyze input segments:
+  - Runs of ASCII text characters → text compaction
+  - Runs of digits → numeric compaction (if run ≥ 13 digits, it's more
+    efficient than text)
+  - Binary/non-ASCII bytes → byte compaction
+
+For v0.1.0: use a simplified strategy:
+  - If all bytes are in the text compaction character set → text compaction
+  - If all bytes are decimal digits (0–9) → numeric compaction
+  - Otherwise → byte compaction
+```
+
+The breakeven point for numeric vs. text:
+```
+Text:    2 chars per codeword → 2.0 chars/codeword
+Numeric: 44 digits / 15 codewords ≈ 2.93 digits/codeword
+```
+Numeric compaction is always more efficient than text compaction for digit
+sequences of 13 or more digits. For 1–12 digit sequences, text may be more
+efficient (avoids the overhead of switching modes).
+
+For v0.1.0, use **byte compaction only** for maximum simplicity. This is
+correct and scannable, just not maximally dense. Text and numeric compaction
+are v0.2.0 enhancements.
+
+---
+
+## Symbol Layout Algorithm
+
+Once the data has been compacted to codewords and ECC has been appended, the
+encoder must decide on the symbol dimensions and arrange the codewords into
+rows.
+
+### Step 1: Count codewords
+
+```
+total_data_codewords = 1               -- length descriptor (always first)
+                     + data_cwords     -- compacted data codewords
+                     + ecc_cwords      -- Reed-Solomon ECC codewords
+```
+
+The **length descriptor** (codeword index 0) contains the total number of
+codewords in the data region of the symbol, including itself and the ECC
+codewords but NOT including row indicators. Its value is:
+
+```
+length_descriptor = 1 + len(data_cwords) + len(ecc_cwords)
+```
+
+### Step 2: Choose dimensions
+
+The encoder must choose the number of data columns c (1–30) and the number
+of rows r (3–90) such that:
+
+```
+r × c ≥ total_data_codewords + ecc_codewords
+
+subject to:
+  3 ≤ r ≤ 90
+  1 ≤ c ≤ 30
+```
+
+The symbol must contain at least enough slots for all codewords. If the
+total does not fill the grid exactly, pad with codeword **900** (text
+compaction latch — a neutral padding value).
+
+```
+pad_slots = r × c - (1 + len(data_cwords) + len(ecc_cwords))
+for i in 0..pad_slots:
+  data_cwords.append(900)
+```
+
+**Dimension selection heuristic** for v0.1.0:
+
+Choose the number of data columns c to produce a roughly square or slightly
+wide symbol. A common heuristic:
+
+```
+total = 1 + len(data_cwords) + len(ecc_cwords)
+
+-- Try c from 1 to 30, pick the c that minimizes |r - c * aspect_ratio|
+-- where aspect_ratio ≈ 3 (PDF417 rows are typically ~3× wider than tall due
+--   to the 17-module codeword width vs. ~3 module row height)
+
+for c in 1..30:
+  r = ceil(total / c)
+  if r > 90: continue
+  score = abs(r * row_height - c * 17)  -- aspect ratio fitness
+  keep track of best (c, r) by score
+```
+
+A simpler starting point for v0.1.0: default to **c = ceil(sqrt(total / 3))**,
+clamped to 1..30, then compute r = ceil(total / c), clamped to 3..90.
+
+### Step 3: Assemble the codeword sequence
+
+After padding:
+```
+full_sequence = [length_descriptor]
+              + data_cwords
+              + pad_cwords
+              + ecc_cwords
+```
+
+Length: `r × c` codewords.
+
+### Step 4: Row indicator encoding
+
+Each row r (0-indexed) needs two row indicator codewords:
+
+#### Left Row Indicator (LRI)
+
+The left row indicator encodes row-group metadata. The encoding depends on
+the cluster of the row:
+
+```
+cluster = (r mod 3) * 3   → 0, 3, or 6
+
+row_group = r / 3          -- integer division
+
+-- Left indicator value based on cluster:
+cluster 0:  LRI_value = 30 * row_group + (R - 1) / 3
+            -- where R = total number of rows (1-indexed: R = r_total)
+cluster 3:  LRI_value = 30 * row_group + (ecc_level * 3) + ((C - 1) / 3)
+            -- where C = number of data columns
+cluster 6:  LRI_value = 30 * row_group + ((C - 1) mod 3) * 3 + ...
+```
+
+The precise formulas are defined in **ISO/IEC 15438:2015, Table 2**. They
+encode three quantities — row count (R), column count (C), and ECC level (L)
+— distributed across the three clusters in a way that allows a scanner to
+recover R, C, and L from any three consecutive rows (one of each cluster).
+
+The three quantities use these encodings:
+
+```
+R_info = (R - 1) / 3         -- where R = number of rows, 3..90 → R_info ∈ 0..29
+C_info = C - 1               -- where C = data columns, 1..30 → C_info ∈ 0..29
+L_info = 3 * ECC_level + (R - 1) mod 3   -- encodes both level and row parity
+```
+
+For each row r, the cluster determines which values are packed into the LRI:
+
+```
+Cluster 0: LRI_value = 30 * (r / 3) + R_info
+Cluster 3: LRI_value = 30 * (r / 3) + L_info
+Cluster 6: LRI_value = 30 * (r / 3) + C_info
+```
+
+#### Right Row Indicator (RRI)
+
+```
+Cluster 0: RRI_value = 30 * (r / 3) + L_info
+Cluster 3: RRI_value = 30 * (r / 3) + C_info
+Cluster 6: RRI_value = 30 * (r / 3) + R_info
+```
+
+Note that the LRI and RRI for the same row encode complementary information.
+Given any two adjacent rows (one cluster 0 and one cluster 3, for instance),
+both R, C, and L can be recovered from their row indicators.
+
+The row indicator codeword value is then looked up in the cluster's codeword
+table like any other data codeword, using the cluster of that row.
+
+### Step 5: Assemble each row
+
+For each row r (0-indexed):
+
+```
+row_codewords = []
+row_codewords.append(LRI_value(r))
+for j in 0..c:
+  row_codewords.append(full_sequence[r * c + j])
+row_codewords.append(RRI_value(r))
+```
+
+Each codeword value is then mapped to a 17-module bar/space pattern using
+the cluster table for this row's cluster.
+
+---
+
+## Start and Stop Patterns
+
+Every row in a PDF417 symbol begins with the same start pattern and ends with
+the same stop pattern, regardless of row number or cluster.
+
+### Start pattern
+
+```
+Binary: 11111111 0 1010 1000
+
+As bar/space widths: b=8, s=1, b=1, s=1, b=1, s=3
+That is: bar(8), space(1), bar(1), space(1), bar(1), space(3)
+
+Total: 8+1+1+1+1+3 = 15... wait, let's recount:
+
+The start pattern is 17 modules:
+  11111111 01010 1000
+  = 8 dark, 1 light, 1 dark, 1 light, 1 dark, 1 light, 1 dark, 3 light
+  Wait — 8+1+1+1+1+1+1+3 = 17. Yes.
+
+As a module sequence (1=dark, 0=light):
+  1 1 1 1 1 1 1 1 0 1 0 1 0 1 0 0 0
+
+Element decomposition (bars and spaces, alternating starting with bar):
+  bar(8)   = 8 modules
+  space(1) = 1 module
+  bar(1)   = 1 module
+  space(1) = 1 module
+  bar(1)   = 1 module
+  space(3) = 3 modules
+  Total: 8+1+1+1+1+3 = 15... off by 2.
+
+Correct ISO 15438 start pattern: 11111111010101000
+  Count: 17 modules ✓
+  As bits: 1(×8) 0 1 0 1 0 1 0 0 0
+
+  Hmm: that's 8 ones, then 0,1,0,1,0,1,0,0,0 = 9 more = 17 total ✓
+
+  Bar/space decomposition:
+  bar(8), space(1), bar(1), space(1), bar(1), space(1), bar(1), space(2)
+  8+1+1+1+1+1+1+2 = 16... not 17.
+
+Recount character by character:
+  Position: 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17
+  Module:   1  1  1  1  1  1  1  1  0  1  0  1  0  1  0  0  0
+  Count:    8 dark (pos 1-8), 1 light (9), 1 dark (10), 1 light (11),
+            1 dark (12), 1 light (13), 1 dark (14), 2 light (15-16)...
+  Wait: pos 14=1 (dark), pos 15=0, pos 16=0, pos 17=?
+
+The pattern is given in the standard as 17 modules.
+Let's go bit-by-bit:
+  11111111010101000
+  Position 1-17:
+    1,1,1,1,1,1,1,1,0,1,0,1,0,1,0,0,0
+
+  Runs: 8×dark, 1×light, 1×dark, 1×light, 1×dark, 1×light, 1×dark, 3×light
+  Sum: 8+1+1+1+1+1+1+3 = 17 ✓
+
+  Bars: 8, 1, 1, 1  (four bars)
+  Spaces: 1, 1, 1, 3 (four spaces)
+  8+1+1+1 = 11 modules in bars
+  1+1+1+3 = 6 modules in spaces
+  Total: 17 ✓
+```
+
+The start pattern as a bit string of 17 modules:
+```
+11111111010101000
+└──8───┘└┘└┘└┘└─3─┘
+```
+
+### Stop pattern
+
+The stop pattern is 18 modules:
+
+```
+Module sequence: 111111101000101001
+Position 1-18:
+  1,1,1,1,1,1,1,0,1,0,0,0,1,0,1,0,0,1
+
+Runs: 7×dark, 1×light, 1×dark, 3×light, 1×dark, 1×light, 1×dark, 2×light, 1×dark
+  7+1+1+3+1+1+1+2+1 = 18 ✓
+
+Bars: 7, 1, 1, 1, 1 (five bars — stop has an extra bar to terminate the row)
+Spaces: 1, 3, 1, 2 (four spaces)
+```
+
+The stop pattern has 5 bars and 4 spaces (9 elements), making it asymmetric
+and thus distinguishable from all codewords (which always have 4 bars and
+4 spaces = 8 elements).
+
+```
+ASCII diagram of one complete PDF417 row:
+
+  ║████████░█░█░█░░░║  ← start pattern (17 modules)
+  ║ codeword  (LRI)  ║  ← 17 modules per codeword
+  ║   codeword 0     ║  ← 17 modules
+  ║   codeword 1     ║  ← 17 modules
+  ║      ...         ║
+  ║ codeword c-1     ║  ← 17 modules
+  ║ codeword  (RRI)  ║  ← 17 modules
+  ║███████░█░░░█░█░░█║  ← stop pattern (18 modules)
+```
+
+---
+
+## Rasterization to ModuleGrid
+
+After assembling all rows as sequences of bar/space widths, rasterize to a
+`ModuleGrid`.
+
+### ModuleGrid dimensions for PDF417
+
+```
+total_cols = 17                   -- start pattern
+           + 17                   -- left row indicator
+           + c × 17               -- data columns
+           + 17                   -- right row indicator
+           + 18                   -- stop pattern
+           = 69 + 17c
+
+total_rows = R × row_height       -- each logical row repeated row_height times
+```
+
+where `row_height` is the number of module-rows per logical PDF417 row
+(configurable, default: 3).
+
+### Rasterization algorithm
+
+```
+rasterize(rows, c, row_height):
+  total_module_cols = 69 + 17 * c
+  total_module_rows = R * row_height
+  grid = ModuleGrid(cols=total_module_cols, rows=total_module_rows)
+
+  for r in 0..R:
+    cluster = (r mod 3) * 3
+    module_row_base = r * row_height
+
+    -- Assemble the module sequence for this row
+    modules = []
+
+    -- Start pattern (fixed, 17 modules)
+    modules.extend(pattern_to_modules("11111111010101000"))
+
+    -- Left row indicator codeword
+    lri = LRI_value(r, R, c, ecc_level)
+    modules.extend(codeword_to_modules(lri, cluster))
+
+    -- Data codewords
+    for j in 0..c:
+      cw = full_sequence[r * c + j]
+      modules.extend(codeword_to_modules(cw, cluster))
+
+    -- Right row indicator codeword
+    rri = RRI_value(r, R, c, ecc_level)
+    modules.extend(codeword_to_modules(rri, cluster))
+
+    -- Stop pattern (fixed, 18 modules)
+    modules.extend(pattern_to_modules("111111101000101001"))
+
+    -- Assert: len(modules) == total_module_cols
+    assert len(modules) == total_module_cols
+
+    -- Write this row into the grid, repeated row_height times
+    for h in 0..row_height:
+      grid.row[module_row_base + h] = modules
+
+  return grid
+
+-- Helper: convert a codeword value and cluster to 17 modules
+codeword_to_modules(value, cluster):
+  (b1,s1,b2,s2,b3,s3,b4,s4) = CLUSTER_TABLE[cluster][value]
+  modules = []
+  modules.extend([1] * b1)
+  modules.extend([0] * s1)
+  modules.extend([1] * b2)
+  modules.extend([0] * s2)
+  modules.extend([1] * b3)
+  modules.extend([0] * s3)
+  modules.extend([1] * b4)
+  modules.extend([0] * s4)
+  assert len(modules) == 17
+  return modules
+```
+
+---
+
+## Complete Encoding Algorithm
+
+The full pipeline, from raw input to a scannable `ModuleGrid`:
+
+```
+Step 1: COMPACT INPUT
+  Analyze input:
+    - v0.1.0: always use byte compaction (codeword 924 latch)
+    - v0.2.0: auto-detect runs of text/digits/binary and mix modes
+
+  Produce data_cwords list (each value 0..928).
+
+Step 2: CHOOSE ECC LEVEL
+  If options.ecc_level is specified, use it.
+  Otherwise use auto-level based on len(data_cwords):
+    ≤ 40 → level 2, ≤ 160 → level 3, ≤ 320 → level 4,
+    ≤ 863 → level 5, else → level 6.
+
+  ecc_count = 2^(ecc_level + 1)
+
+Step 3: COMPUTE LENGTH DESCRIPTOR
+  length_descriptor = 1 + len(data_cwords) + ecc_count
+  -- Prepend to data: full_data = [length_descriptor] + data_cwords
+
+Step 4: COMPUTE RS ECC
+  ecc_cwords = rs_encode_pdf417(full_data, generator[ecc_level])
+  -- full_data has len(data_cwords) + 1 codewords; ecc_cwords has ecc_count.
+
+Step 5: CHOOSE DIMENSIONS
+  total_codewords = 1 + len(data_cwords) + ecc_count
+  Choose c (data columns) and r (rows) such that r × c ≥ total_codewords,
+  3 ≤ r ≤ 90, 1 ≤ c ≤ 30.
+
+Step 6: PAD
+  pad_count = r × c - total_codewords
+  Append pad_count copies of codeword 900 to full_data.
+  Note: padding goes BETWEEN data and ECC in the final arrangement.
+  full_sequence = full_data_padded + ecc_cwords
+    where full_data_padded = [length_descriptor] + data_cwords + [900×pad_count]
+
+Step 7: COMPUTE ROW INDICATORS
+  For each row r (0..R-1):
+    R_info = (R - 1) / 3            -- integer division
+    C_info = C - 1
+    L_info = 3 * ecc_level + (R - 1) mod 3
+
+    cluster = (r mod 3) * 3
+    row_group = r / 3
+
+    LRI values by cluster:
+      cluster 0: 30 * row_group + R_info
+      cluster 3: 30 * row_group + L_info
+      cluster 6: 30 * row_group + C_info
+
+    RRI values by cluster:
+      cluster 0: 30 * row_group + L_info
+      cluster 3: 30 * row_group + C_info
+      cluster 6: 30 * row_group + R_info
+
+Step 8: RASTERIZE
+  For each row r (0..R-1):
+    Emit start pattern as 17 dark/light modules.
+    Emit LRI codeword (17 modules) using cluster table.
+    Emit each data codeword j (17 modules each) using cluster table.
+    Emit RRI codeword (17 modules) using cluster table.
+    Emit stop pattern as 18 dark/light modules.
+    Repeat this module row row_height times.
+
+  Collect into ModuleGrid(cols = 69 + 17c, rows = R × row_height).
+
+Step 9: ADD QUIET ZONE
+  The quiet zone is applied at the layout stage (barcode-2d::layout),
+  not during rasterization. The ModuleGrid contains only the active symbol
+  area.
+
+Step 10: LAYOUT + PAINT
+  Pass the ModuleGrid to barcode-2d::layout(grid, config) to produce a
+  PaintScene (P2D00). Pass the PaintScene to a PaintVM backend.
+```
+
+---
+
+## Implementation Notes
+
+### v0.1.0 simplifications
+
+1. **Byte compaction only** — implement only byte compaction (codeword 924).
+   All inputs are treated as raw bytes regardless of content. This means:
+   - ASCII text input is byte-compacted, not text-compacted
+   - All-digit input is byte-compacted, not numeric-compacted
+   - Any byte sequence works correctly
+   - The symbol will be valid and scannable; it will just be less compact
+     than a fully-optimized encoder for pure text or numeric inputs
+
+2. **Single-mode only** — no mixed-mode segments. v0.2.0 adds auto-detection
+   of runs and mode switching.
+
+3. **Auto ECC level** — use the auto-level formula based on data length.
+   Expose `ecc_level` as an option to allow override.
+
+4. **Auto dimensions** — use the simple heuristic to choose c and r.
+   Expose `columns` as an option to allow override.
+
+5. **Embed cluster tables** — the cluster tables (CLUSTER_TABLE[0..2][0..928])
+   must be embedded as static constants. Generate them once using a reference
+   implementation or the ISO formula, write them to source code as a constant
+   array, and verify against known test vectors.
+
+6. **No Macro PDF417** — codewords 925–928 (Macro PDF417 for multi-symbol
+   sequences) are not implemented.
+
+### Cluster table generation
+
+The ISO standard provides formulas for generating the cluster tables
+algorithmically. The generation process is complex and error-prone to
+implement from scratch. Recommended approach:
+
+1. Find a reference implementation (there are several in the public domain,
+   including in Zint and ZXing).
+2. Extract the table data.
+3. Verify a sample of entries against the ISO standard's test examples.
+4. Embed the tables as static arrays in the implementation.
+
+The tables are deterministic constants and will never change. Generating them
+at runtime adds startup cost with no benefit.
+
+### Big integer arithmetic for byte compaction
+
+The 6-bytes-to-5-codewords conversion requires arithmetic on 48-bit integers.
+Use native u64 (unsigned 64-bit) where available:
+
+```
+-- u64 can hold up to ~1.8 × 10^19; 256^6 ≈ 2.81 × 10^14. Safe.
+n: u64 = 0
+for b in [b1, b2, b3, b4, b5, b6]:
+  n = n * 256 + b
+
+c5 = n mod 900;  n = n / 900
+c4 = n mod 900;  n = n / 900
+c3 = n mod 900;  n = n / 900
+c2 = n mod 900;  n = n / 900
+c1 = n as u64
+```
+
+For numeric compaction with 44-digit groups, the number can exceed u64.
+Use a big integer library or multi-word arithmetic. For v0.1.0 (byte
+compaction only), u64 arithmetic is sufficient.
+
+### Padding codeword
+
+The padding codeword **900** is the latch-to-text codeword. It is neutral:
+if a scanner encounters it after the data region, it switches to text mode
+(which produces no output until actual character codewords follow). This
+makes it a safe padding value.
+
+### ECC codeword placement
+
+The RS ECC codewords are appended **after** all data codewords (including
+padding) in the full_sequence. When laid out into the r×c grid:
+
+```
+full_sequence[0] = length_descriptor
+full_sequence[1..n-ecc-1] = data codewords
+full_sequence[n-ecc..n-1] = ECC codewords (appended last)
+```
+
+This means the ECC codewords occupy the last rows (partially or fully) of
+the symbol. A scanner that reads from the top can begin processing data
+codewords before reading the ECC.
+
+---
+
+## GF(929) Package Note
+
+The `gf929` package is a new package in the dependency stack, unique to
+PDF417. It should be created as a sibling to `gf256` in each language's
+package hierarchy.
+
+```
+code/packages/rust/gf929/
+code/packages/typescript/gf929/
+code/packages/python/gf929/
+code/packages/go/gf929/
+code/packages/ruby/gf929/
+...
+```
+
+The gf929 package is intentionally minimal: it provides field arithmetic
+(add, sub, mul, inv, pow) and the precomputed exp/log tables for GF(929).
+No polynomial arithmetic is needed in gf929 itself — polynomial operations
+over GF(929) belong in the pdf417 package.
+
+The name `gf929` follows the same naming convention as `gf256`. The two
+packages are parallel but distinct: GF(929) uses modular integer arithmetic
+(prime characteristic), while GF(256) uses binary polynomial arithmetic
+(characteristic 2). They share no implementation.
+
+---
+
+## Error Types
+
+```
+PDF417Error::InputTooLong
+  -- The input data, after compaction, produces more codewords than the
+  -- maximum symbol capacity (90 rows × 30 columns = 2700 data slots,
+  -- minus ECC slots).
+
+PDF417Error::InvalidDimensions
+  -- The user specified rows/columns that cannot fit all codewords, or
+  -- that are outside the 3–90 rows, 1–30 columns limits.
+
+PDF417Error::InvalidECCLevel
+  -- The specified ECC level is not in the range 0–8.
+
+PDF417Error::InvalidClusterTable
+  -- Internal error: cluster table lookup failed (value out of range 0–928).
+  -- Should never occur in correct usage; indicates a programming error.
+
+PDF417Error::ArithmeticOverflow
+  -- Big integer computation exceeded available precision.
+  -- (Should not occur in v0.1.0 with byte-only compaction.)
+```
+
+---
+
+## Public API
+
+```
+encode(input: string | bytes, options?: PDF417Options) → ModuleGrid
+  -- Encode input to a PDF417 ModuleGrid.
+  -- input can be a string (encoded as UTF-8 bytes) or raw bytes.
+  -- Returns the ModuleGrid in abstract module units (no pixels).
+  -- Raises PDF417Error::InputTooLong if input exceeds symbol capacity.
+
+layout(grid: ModuleGrid, config?: Barcode2DLayoutConfig) → PaintScene
+  -- Translate a ModuleGrid into a pixel-resolved PaintScene (P2D00).
+  -- Delegates to barcode-2d::layout().
+  -- Does NOT belong to pdf417 — this is barcode-2d's responsibility.
+
+encode_and_layout(
+  input: string | bytes,
+  options?: PDF417Options,
+  config?: Barcode2DLayoutConfig
+) → PaintScene
+  -- Convenience: encode + layout in one call.
+
+render_svg(
+  input: string | bytes,
+  options?: PDF417Options,
+  config?: Barcode2DLayoutConfig
+) → string
+  -- Convenience: encode + layout + paint-vm-svg → SVG string.
+  -- Useful for tests and server-side rendering.
+
+explain(input: string | bytes, options?: PDF417Options) → AnnotatedModuleGrid
+  -- Encode with full per-module role annotations (for visualizers).
+  -- Each module records: cluster, row_number, codeword_index,
+  --   codeword_type (LRI/data/RRI/start/stop/padding/ecc).
+
+PDF417Options {
+  ecc_level?: 0..8
+    -- ECC level (0–8). Default: auto-select based on data length.
+
+  columns?: 1..30
+    -- Number of data columns. Default: auto-select for roughly square symbol.
+
+  row_height?: 2..10
+    -- Number of module-rows per logical PDF417 row. Default: 3.
+    -- Larger values produce taller symbols; improve scan reliability
+    -- on low-resolution printing.
+
+  compaction?: 'text' | 'byte' | 'numeric' | 'auto'
+    -- Compaction mode. Default: 'byte' in v0.1.0, 'auto' in v0.2.0.
+}
+```
+
+---
+
+## Package Matrix
+
+| Language | Directory | Depends on |
+|----------|-----------|------------|
+| Rust | `code/packages/rust/pdf417/` | barcode-2d, gf929 |
+| TypeScript | `code/packages/typescript/pdf417/` | barcode-2d, gf929 |
+| Python | `code/packages/python/pdf417/` | barcode-2d, gf929 |
+| Go | `code/packages/go/pdf417/` | barcode-2d, gf929 |
+| Ruby | `code/packages/ruby/pdf417/` | barcode-2d, gf929 |
+| Elixir | `code/packages/elixir/pdf417/` | barcode_2d, gf929 |
+| Lua | `code/packages/lua/pdf417/` | barcode-2d, gf929 |
+| Perl | `code/packages/perl/pdf417/` | barcode-2d, gf929 |
+| Swift | `code/packages/swift/pdf417/` | Barcode2D, GF929 |
+| C# | `code/packages/csharp/pdf417/` | barcode-2d, gf929 |
+| F# | `code/packages/fsharp/pdf417/` | barcode-2d, gf929 |
+| Kotlin | `code/packages/kotlin/pdf417/` | barcode-2d, gf929 |
+| Java | `code/packages/java/pdf417/` | barcode-2d, gf929 |
+| Dart | `code/packages/dart/pdf417/` | barcode-2d, gf929 |
+| Haskell | `code/packages/haskell/pdf417/` | barcode-2d, gf929 |
+
+The `gf929` package must be implemented before `pdf417` in every language.
+The `gf929` package depends on nothing (pure arithmetic).
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+1. **GF(929) arithmetic**
+   - `add(100, 900)` → `(100 + 900) mod 929 = 71`
+   - `sub(5, 10)` → `(5 - 10 + 929) mod 929 = 924`
+   - `mul(3, 3)` → `9`; `mul(400, 400)` → `(160000 mod 929)` = verify
+   - `inv(3)` → the inverse of 3 mod 929:
+     `3 × x ≡ 1 (mod 929)` → x = 310 (verify: 3 × 310 = 930 ≡ 1 mod 929 ✓)
+   - `pow(3, 928)` → `1` (Fermat's little theorem)
+   - Log/antilog table round-trip: `gf929_exp[gf929_log[v]] == v` for all v in 1..928
+
+2. **RS ECC encoding**
+   - For ECC level 0 (k=2), encode a known sequence and verify the 2 ECC
+     codewords match a reference computation.
+   - For ECC level 2 (k=8), encode "test" as byte-compacted data and verify
+     the 8 ECC codewords.
+
+3. **Byte compaction**
+   - 6 bytes `[0x41, 0x42, 0x43, 0x44, 0x45, 0x46]` = "ABCDEF"
+     → n = 0x414243444546 = 71,362,640,895,814... wait:
+     Actually: 0x41=65, 0x42=66, ..., 0x46=70.
+     n = 65×256^5 + 66×256^4 + 67×256^3 + 68×256^2 + 69×256 + 70
+       = 65×1,099,511,627,776 + 66×4,294,967,296 + 67×16,777,216
+         + 68×65,536 + 69×256 + 70
+       = compute and verify 5 base-900 codewords.
+   - Single byte `[0xFF]` → codeword `[255]` (direct mapping).
+   - Odd-length sequence `[0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]`
+     → 5 codewords from the 6-byte group + codeword `71` for the last byte.
+
+4. **Row indicator computation**
+   - For a 10-row, 3-column, ECC level 2 symbol:
+     - R=10, C=3, L=2
+     - R_info = (10-1)/3 = 3
+     - C_info = 3-1 = 2
+     - L_info = 3×2 + (10-1) mod 3 = 6 + 0 = 6
+     - Row 0 (cluster 0): LRI = 30×0 + 3 = 3, RRI = 30×0 + 6 = 6
+     - Row 1 (cluster 3): LRI = 30×0 + 6 = 6, RRI = 30×0 + 2 = 2
+     - Row 2 (cluster 6): LRI = 30×0 + 2 = 2, RRI = 30×0 + 3 = 3
+     - Row 3 (cluster 0): LRI = 30×1 + 3 = 33, RRI = 30×1 + 6 = 36
+
+5. **Symbol dimensions**
+   - Input of 10 bytes → byte-compact → 924 latch + 2 codewords (6 bytes
+     as 5) + 4 bytes as 4 codewords = 1 + 5 + 4 = 10 data codewords.
+     With length descriptor: 11. With ECC level 2 (8 ECC): total = 19.
+     Minimum symbol: r×c ≥ 19, c ≥ 1, r ≥ 3. One solution: c=3, r=7.
+
+### Integration tests
+
+1. **Encode minimal input**
+   - Encode `"A"` (1 byte).
+   - Verify: ModuleGrid dimensions match expected (r × row_height rows,
+     (69 + 17c) cols).
+   - Verify start pattern in every row: first 17 modules match
+     `11111111010101000`.
+   - Verify stop pattern in every row: last 18 modules match
+     `111111101000101001`.
+
+2. **Encode "HELLO WORLD"** (11 bytes in v0.1.0 byte mode)
+   - Verify ECC level auto-selected as level 2.
+   - Verify length descriptor = total codewords in symbol.
+   - Scan the rendered symbol with a reference decoder (ZXing, Zint) and
+     verify the decoded text equals "HELLO WORLD".
+
+3. **Encode "1234567890"** (10 bytes / digits)
+   - In v0.1.0: byte compaction.
+   - In v0.2.0: should switch to numeric compaction.
+
+4. **Encode binary data** — 256 bytes `[0, 1, 2, ..., 255]`
+   - Verify all 256 bytes survive the encode→decode round trip.
+   - Verify length descriptor, ECC codewords are correct.
+
+5. **Encode maximum capacity** — fill a 90×30 symbol minus ECC overhead.
+
+### Cross-language verification
+
+All 15 language implementations must produce **identical `ModuleGrid` outputs**
+for the same input and options. Run the test corpus against all implementations
+and compare module grids bit-by-bit.
+
+Suggested test corpus:
+```
+"A"                          (minimal, 1 byte)
+"HELLO WORLD"                (11 bytes, v0.1.0 byte mode)
+"1234567890"                 (digits — byte in v0.1.0, numeric in v0.2.0)
+bytes [0x00..0xFF]           (all 256 byte values, boundary test)
+256 bytes of 0xFF            (repetitive high bytes)
+```
+
+---
+
+## Dependency Stack
+
+```
+paint-metal (P2D02)    paint-vm-svg    paint-vm-canvas
+      └──────────────────┬─────────────────┘
+                         │
+                  paint-vm (P2D01)
+                         │
+              paint-instructions (P2D00)
+                         │
+              ┌──────────┴──────────┐
+          barcode-2d              gf929 (new)
+              │                     │
+           pdf417 ──────────────────┘
+```
+
+`pdf417` depends on:
+- `barcode-2d` for the `ModuleGrid` type and the `layout()` function
+- `gf929` for GF(929) field arithmetic in the Reed-Solomon encoder
+
+`pdf417` does **not** depend on `gf256` or `reed-solomon` (MA02), because
+those operate over GF(256) and use the b=1 or b=0 convention. PDF417's
+GF(929) RS uses b=3.
+
+`gf929` depends on nothing.
+
+---
+
+## Visualization Annotations
+
+The `explain()` API should produce an annotated module grid where each module
+records its semantic role. Suggested annotation schema:
+
+| Role | Color (suggested) | Description |
+|------|--------------------|-------------|
+| start | dark blue | Start pattern module |
+| stop | dark teal | Stop pattern module |
+| lri | purple | Left row indicator codeword module |
+| rri | indigo | Right row indicator codeword module |
+| data | black/white | Data codeword module |
+| ecc | green/light green | ECC codeword module |
+| pad | yellow | Padding codeword module (codeword 900) |
+| quiet | white | Quiet zone |
+
+Additionally, annotate per-codeword metadata:
+- `codeword_index`: position in full_sequence
+- `codeword_value`: the integer value 0–928
+- `cluster`: 0, 3, or 6
+- `row_number`: which logical row (0..R-1)
+- `compaction_mode`: 'byte' / 'text' / 'numeric' / 'indicator'
+
+A visualizer built on this annotation can interactively show what each group
+of bars/spaces encodes, which codeword it belongs to, and how the row
+indicator reconstructs the symbol metadata.
+
+---
+
+## Future Extensions
+
+- **Text compaction** (v0.2.0) — implement the UC/LC/ML/PL sub-mode tables
+  and auto-detection of text segments.
+- **Numeric compaction** (v0.2.0) — implement 44-digit chunk encoding and
+  digit run detection.
+- **Mixed-mode encoding** (v0.2.0) — segment the input into text/byte/numeric
+  regions and emit mode-latch codewords between segments.
+- **Macro PDF417** — multi-symbol sequences using codewords 925–928. Allows
+  a large payload to be split across multiple PDF417 symbols (e.g., multi-page
+  documents). Requires a segment count and a Macro PDF417 control block.
+- **MicroPDF417** — a compact variant of PDF417 with a smaller fixed structure.
+  Uses the same GF(929) RS and the same cluster tables. Separate spec.
+- **AAMVA driver's licence parsing** — the AAMVA standard defines a specific
+  PDF417 data format for driver's licences (header fields, subfile designators,
+  field codes). A higher-level AAMVA parser built on top of this pdf417 encoder
+  can generate standards-compliant licences.
+- **IATA BCBP** — the IATA Boarding Card Bar Code Project defines a PDF417
+  payload format for boarding passes. A higher-level IATA parser can generate
+  compliant boarding passes.
+- **Decoder** — decoding is a separate and much more complex problem involving
+  image binarization, row detection, start/stop pattern matching, cluster
+  identification, and RS syndrome decoding over GF(929).
+- **Truncated PDF417** — a compact variant where the right row indicator and
+  stop pattern are simplified. Reduces symbol width for space-constrained
+  labels at the cost of reduced damage resilience.
+- **Visualizer integration** — interactive drill-down showing which compaction
+  mode produced each codeword, which RS codeword covers which data codeword,
+  and how the row indicator encodes R, C, and L.


### PR DESCRIPTION
## Summary

- Ports the TypeScript `barcode-2d` abstraction layer to Elixir as `code/packages/elixir/barcode_2d/`
- Implements `ModuleGrid` struct, `Barcode2DLayoutConfig` struct, `make_module_grid/3`, `set_module/4`, and `layout/2` — matching the TypeScript API idiomatically in Elixir
- Supports both `:square` modules (QR Code, Data Matrix, Aztec, PDF417) and `:hex` modules (MaxiCode flat-top hexagons with odd-row offset)

## Test plan

- [ ] 61 ExUnit tests pass locally, 0 failures
- [ ] 100% coverage across all three modules (`CodingAdventures.Barcode2D`, `ModuleGrid`, `Barcode2DLayoutConfig`)
- [ ] Covers: `make_module_grid` happy paths and edge cases, `set_module` immutability + all out-of-bounds error branches, `layout` square pixel math, `layout` hex geometry (path commands, odd-row offset, sqrt(3) height), all validation error branches
- [ ] No Elixir reserved words used as variables (`after`, `rescue`, `catch`, `else`, `end`)
- [ ] `.gitignore` prevents `cover/` and `_build/` artifacts from being committed
- [ ] `BUILD` file: `mix deps.get --quiet && mix test --cover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)