### PR TITLE
feat(foundation): add Kotlin gf256, polynomial, reed-solomon

### DIFF
--- a/code/packages/kotlin/gf256/.gitignore
+++ b/code/packages/kotlin/gf256/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/gf256/BUILD
+++ b/code/packages/kotlin/gf256/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/gf256/BUILD_windows
+++ b/code/packages/kotlin/gf256/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/gf256/CHANGELOG.md
+++ b/code/packages/kotlin/gf256/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog — gf256 (Kotlin)
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- `GF256` singleton object with `PRIMITIVE_POLY = 0x11D`
+- Precomputed `EXP[512]` and `LOG[256]` tables built at object initialisation
+- `add(a, b)` — bitwise XOR (characteristic-2 addition)
+- `sub(a, b)` — bitwise XOR (identical to add in GF(2^n))
+- `mul(a, b)` — multiplication via log/exp table lookup, O(1)
+- `div(a, b)` — division using log tables; throws `ArithmeticException` on b=0
+- `pow(base, n)` — exponentiation with modular group arithmetic; 0^0 = 1 by convention
+- `inv(a)` — multiplicative inverse via `EXP[255 − LOG[a]]`; throws on a=0
+- 37 unit tests covering field axioms, all operations, error cases, and spot-check vectors
+- `VERSION = "0.1.0"` constant
+
+### Notes
+
+- Primitive polynomial `0x11D` = `x^8 + x^4 + x^3 + x^2 + 1` (Reed-Solomon standard)
+- `EXP` table is 512 entries (doubled) to allow `LOG[a] + LOG[b]` without modular wrap
+  in the hot-path `mul` implementation
+- Matches TypeScript reference implementation `@coding-adventures/gf256` v0.1.0

--- a/code/packages/kotlin/gf256/README.md
+++ b/code/packages/kotlin/gf256/README.md
@@ -1,0 +1,64 @@
+# gf256 — Kotlin
+
+Galois Field GF(2^8) arithmetic over the Reed-Solomon primitive polynomial
+`x^8 + x^4 + x^3 + x^2 + 1` (= `0x11D`).
+
+## What is GF(256)?
+
+GF(256) is a finite field with exactly 256 elements (the integers 0..255).
+Its arithmetic powers:
+
+- **Reed-Solomon error correction** — QR codes, CDs, DVDs, RAID-6
+- **AES encryption** — SubBytes (S-box) and MixColumns steps
+
+## Key insight: Add = XOR = Subtract
+
+In a characteristic-2 field, 1 + 1 = 0. Every element is its own additive
+inverse. So addition and subtraction are both bitwise XOR — no carry, no
+overflow.
+
+## Multiplication via log tables
+
+The element `g = 2` generates all 255 non-zero elements. We precompute:
+
+```
+EXP[i] = 2^i mod p(x)
+LOG[x] = i such that 2^i = x
+```
+
+Then `a × b = EXP[LOG[a] + LOG[b]]` — O(1) with two table lookups.
+
+## Usage
+
+```kotlin
+import com.codingadventures.gf256.GF256
+
+val product = GF256.mul(0x53, 0x8C)   // → 1   (inverse pair under 0x11D)
+val sum     = GF256.add(0x53, 0xCA)   // → 0x99
+val inverse = GF256.inv(0x53)          // → 0x8C
+```
+
+## API
+
+| Function | Description |
+|----------|-------------|
+| `add(a, b)` | XOR (addition = subtraction in GF(2^n)) |
+| `sub(a, b)` | XOR (same as add) |
+| `mul(a, b)` | Multiplication via log/exp tables |
+| `div(a, b)` | Division; throws `ArithmeticException` when b = 0 |
+| `pow(base, n)` | Exponentiation; 0^0 = 1 by convention |
+| `inv(a)` | Multiplicative inverse; throws when a = 0 |
+
+Constants: `PRIMITIVE_POLY = 0x11D`, `EXP[512]`, `LOG[256]`
+
+## Build
+
+```
+gradle test
+```
+
+Requires JDK 21 on PATH. Uses JUnit Jupiter 5.11.4.
+
+## Spec
+
+`code/specs/MA01-gf256.md`

--- a/code/packages/kotlin/gf256/build.gradle.kts
+++ b/code/packages/kotlin/gf256/build.gradle.kts
@@ -1,0 +1,37 @@
+// Gradle's default output directory is "build/", which conflicts with our BUILD file
+// on case-insensitive filesystems (macOS, Windows). Redirect to "gradle-build/" instead.
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/gf256/settings.gradle.kts
+++ b/code/packages/kotlin/gf256/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gf256"

--- a/code/packages/kotlin/gf256/src/main/kotlin/com/codingadventures/gf256/GF256.kt
+++ b/code/packages/kotlin/gf256/src/main/kotlin/com/codingadventures/gf256/GF256.kt
@@ -1,0 +1,247 @@
+/**
+ * GF(2^8) — Galois Field arithmetic over 256 elements.
+ *
+ * GF(256) is the finite field whose elements are the integers 0..255.
+ * It is the mathematical backbone of Reed-Solomon error correction (QR codes,
+ * CDs, hard drives, deep-space probes) and AES encryption.
+ *
+ * ## Why a finite field?
+ *
+ * Error-correction codes need to do polynomial arithmetic over the data bytes.
+ * Ordinary integer arithmetic does not close neatly: multiplying two bytes can
+ * produce values larger than 255. A finite field keeps everything in range and
+ * ensures every non-zero element has a multiplicative inverse — properties
+ * critical for the decoding algorithms.
+ *
+ * ## The primitive polynomial
+ *
+ * Elements of GF(2^8) are polynomials over GF(2) of degree ≤ 7:
+ *
+ *   a₇x⁷ + a₆x⁶ + … + a₁x + a₀   where each aᵢ ∈ {0, 1}
+ *
+ * When multiplication would exceed degree 7 (byte overflow), we reduce modulo
+ * an irreducible polynomial of degree 8.  This implementation uses:
+ *
+ *   p(x) = x^8 + x^4 + x^3 + x^2 + 1  =  0x11D  =  285
+ *
+ * This polynomial is both irreducible (cannot be factored) and primitive (the
+ * element g=2 generates the entire multiplicative group of order 255).
+ *
+ * ## Add = XOR = Subtract
+ *
+ * In any characteristic-2 field, 1 + 1 = 0.  So −1 = 1, meaning subtraction
+ * and addition are the same operation: bitwise XOR.  No carries, no overflow.
+ *
+ * ## Multiplication via logarithms
+ *
+ * Because g=2 generates all 255 non-zero elements, we precompute:
+ *
+ *   EXP[i] = g^i mod p(x)           — the antilogarithm ("exp") table
+ *   LOG[x] = i such that g^i = x    — the logarithm table
+ *
+ * Then: a × b = EXP[(LOG[a] + LOG[b]) mod 255]
+ *
+ * Two table lookups and one addition replace a complex bit-level polynomial
+ * multiplication.  O(1) per operation.
+ *
+ * Spec: MA01-gf256.md
+ */
+package com.codingadventures.gf256
+
+/** Version of this package. */
+const val VERSION = "0.1.0"
+
+/**
+ * GF256 contains all GF(2^8) arithmetic operations over the Reed-Solomon
+ * primitive polynomial 0x11D.
+ *
+ * All values passed to and returned from these functions are bytes in 0..255.
+ * Kotlin uses Int for clarity and to avoid signed-byte confusion.
+ *
+ * Design: a Kotlin object (singleton) holding precomputed tables and functions,
+ * matching the typical module-level function style of the TypeScript reference
+ * implementation but using Kotlin idioms.
+ */
+object GF256 {
+
+    /**
+     * The primitive (irreducible, primitive) polynomial used for reduction.
+     *
+     *   p(x) = x^8 + x^4 + x^3 + x^2 + 1
+     *
+     * Binary representation:
+     *   bit 8 → x^8 = 256
+     *   bit 4 → x^4 = 16
+     *   bit 3 → x^3 = 8
+     *   bit 2 → x^2 = 4
+     *   bit 0 → 1
+     *
+     *   256 + 16 + 8 + 4 + 1 = 285 = 0x11D
+     *
+     * Why primitive?  Because g=2 (the polynomial "x") satisfies g^255 = 1
+     * and all of g^0, g^1, …, g^254 are distinct — i.e., g generates the
+     * complete multiplicative group.  This is what makes logarithm tables
+     * possible.
+     */
+    const val PRIMITIVE_POLY: Int = 0x11D
+
+    // =========================================================================
+    // Log / Antilog (Exp) Tables
+    // =========================================================================
+    //
+    // We precompute two 256-element arrays at object initialisation.
+    //
+    // EXP[i] = 2^i mod p(x)  for i in 0..510
+    //   (doubled to 512 so we can use LOG[a] + LOG[b] without modular wrap
+    //    in the hot-path multiply — some implementations do this for speed.
+    //    We keep the standard 512-entry version from the TypeScript source.)
+    //
+    // LOG[x] = i such that 2^i = x  for x in 1..255
+    // LOG[0] = -1  (0 has no logarithm; there is no power of 2 that equals 0)
+    //
+    // Construction:
+    //   Start with val = 1.
+    //   Each iteration: val = val * 2 in GF(256)
+    //     = (val shl 1) XOR 0x11D   when bit 8 is set after the shift
+    //     = (val shl 1)              otherwise
+    //   Record EXP[i] = val, LOG[val] = i.
+    //   Duplicate EXP[0..254] into EXP[255..509] to allow LOG[a]+LOG[b] without mod.
+
+    /** Antilogarithm (exp) table of size 512 for multiplication without modular wrap. */
+    val EXP: IntArray = IntArray(512)
+
+    /** Logarithm table. LOG[0] = -1 (undefined). LOG[x] for x in 1..255 = i where 2^i = x. */
+    val LOG: IntArray = IntArray(256)
+
+    init {
+        // Fill EXP[0..254] and LOG[1..255].
+        var x = 1
+        for (i in 0 until 255) {
+            EXP[i] = x
+            LOG[x] = i
+            // Multiply x by 2 (left-shift by 1).
+            x = x shl 1
+            // If bit 8 is set, reduce modulo the primitive polynomial.
+            if (x and 0x100 != 0) {
+                x = x xor PRIMITIVE_POLY
+            }
+        }
+        // EXP[255] through EXP[511]: duplicate the first 255 entries so that
+        //   LOG[a] + LOG[b] can range up to 508 without overflow in mul().
+        for (i in 255 until 512) {
+            EXP[i] = EXP[i - 255]
+        }
+        // LOG[0] is explicitly -1 (no logarithm exists for 0).
+        LOG[0] = -1
+    }
+
+    // =========================================================================
+    // Fundamental Operations
+    // =========================================================================
+
+    /**
+     * Add two GF(256) elements.
+     *
+     * In characteristic-2 arithmetic, addition is bitwise XOR.  Each bit
+     * represents a coefficient in GF(2), and 1 + 1 = 0 mod 2.
+     *
+     * Truth table for a single bit:
+     *   0 + 0 = 0
+     *   0 + 1 = 1
+     *   1 + 0 = 1
+     *   1 + 1 = 0  ← this is the "characteristic 2" property
+     *
+     * Examples:
+     *   add(0x53, 0xCA) = 0x53 XOR 0xCA = 0x99
+     *   add(x, x)       = 0 for all x  (every element is its own inverse)
+     */
+    fun add(a: Int, b: Int): Int = a xor b
+
+    /**
+     * Subtract two GF(256) elements.
+     *
+     * In characteristic-2 fields, −1 = 1, so subtraction equals addition: XOR.
+     * This simplifies error-correction algorithms: a "syndrome" computed via
+     * subtraction uses identical hardware/logic to addition.
+     */
+    fun sub(a: Int, b: Int): Int = a xor b
+
+    /**
+     * Multiply two GF(256) elements using logarithm/antilogarithm tables.
+     *
+     * Identity: a × b = g^(LOG[a] + LOG[b])  = EXP[LOG[a] + LOG[b]]
+     *
+     * The extended EXP table (size 512) avoids the modulo-255 wrap in the hot
+     * path: LOG[a] + LOG[b] can be at most 254 + 254 = 508, which is within
+     * bounds.  The duplication ensures EXP[k] = EXP[k mod 255] for k ≥ 255.
+     *
+     * Special case: 0 × anything = 0.  (Zero has no logarithm, so this must
+     * be handled explicitly.)
+     *
+     * Time complexity: O(1) — two table lookups and one addition.
+     */
+    fun mul(a: Int, b: Int): Int {
+        if (a == 0 || b == 0) return 0
+        return EXP[LOG[a] + LOG[b]]
+    }
+
+    /**
+     * Divide a by b in GF(256).
+     *
+     * a / b = g^(LOG[a] − LOG[b])
+     *
+     * The +255 before the mod ensures a non-negative result when LOG[a] < LOG[b].
+     * (Kotlin's % operator can return negative values for negative operands.)
+     *
+     * Special case: 0 / b = 0.
+     *
+     * @throws ArithmeticException if b = 0 (division by zero is undefined)
+     */
+    fun div(a: Int, b: Int): Int {
+        if (b == 0) throw ArithmeticException("GF256: division by zero")
+        if (a == 0) return 0
+        return EXP[(LOG[a] - LOG[b] + 255) % 255]
+    }
+
+    /**
+     * Raise a GF(256) element to a non-negative integer power.
+     *
+     * base^exp = EXP[(LOG[base] * exp) mod 255]
+     *
+     * The modulo 255 reflects the order of the multiplicative group: by
+     * Fermat's little theorem for finite fields, every non-zero element
+     * satisfies a^255 = 1.
+     *
+     * Special cases:
+     *   0^0 = 1 by convention (consistent with the spec and most libraries)
+     *   0^n = 0 for n > 0
+     *
+     * @throws IllegalArgumentException if exp is negative
+     */
+    fun pow(base: Int, n: Int): Int {
+        require(n >= 0) { "GF256: exponent must be non-negative, got $n" }
+        if (n == 0) return 1
+        if (base == 0) return 0
+        return EXP[(LOG[base].toLong() * n % 255).toInt().let { if (it < 0) it + 255 else it }]
+    }
+
+    /**
+     * Compute the multiplicative inverse of a GF(256) element.
+     *
+     * The inverse of a satisfies: a × inv(a) = 1.
+     *
+     * Derivation:
+     *   a × a^(−1) = 1 = g^0 = g^255
+     *   LOG[a] + LOG[a^(−1)] ≡ 0 (mod 255)
+     *   LOG[a^(−1)] = 255 − LOG[a]
+     *   a^(−1) = EXP[255 − LOG[a]]
+     *
+     * This is used in Reed-Solomon decoding (Forney algorithm) and AES SubBytes.
+     *
+     * @throws ArithmeticException if a = 0 (zero has no multiplicative inverse)
+     */
+    fun inv(a: Int): Int {
+        if (a == 0) throw ArithmeticException("GF256: zero has no multiplicative inverse")
+        return EXP[255 - LOG[a]]
+    }
+}

--- a/code/packages/kotlin/gf256/src/test/kotlin/com/codingadventures/gf256/GF256Test.kt
+++ b/code/packages/kotlin/gf256/src/test/kotlin/com/codingadventures/gf256/GF256Test.kt
@@ -1,0 +1,330 @@
+package com.codingadventures.gf256
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Tests for GF(256) arithmetic with primitive polynomial 0x11D.
+ *
+ * Test vectors derived from the MA01 specification and cross-checked against
+ * the TypeScript reference implementation.
+ */
+class GF256Test {
+
+    // =========================================================================
+    // Table sanity
+    // =========================================================================
+
+    @Test
+    fun `EXP table first entry is 1 (generator to the power 0)`() {
+        // g^0 = 1 in any multiplicative group
+        assertEquals(1, GF256.EXP[0])
+    }
+
+    @Test
+    fun `EXP table second entry is 2 (the generator itself)`() {
+        // g = 2 is our primitive element
+        assertEquals(2, GF256.EXP[1])
+    }
+
+    @Test
+    fun `EXP table entry 8 is 29 (first reduction step)`() {
+        // 2^8 = 256; 256 XOR 0x11D = 29.  The first time we overflow a byte.
+        assertEquals(29, GF256.EXP[8])
+    }
+
+    @Test
+    fun `generator has order 255 - EXP 255 equals EXP 0`() {
+        // g^255 wraps back to 1 (the multiplicative group has order 255).
+        assertEquals(GF256.EXP[0], GF256.EXP[255])
+    }
+
+    @Test
+    fun `LOG of 0 is -1 (undefined)`() {
+        assertEquals(-1, GF256.LOG[0])
+    }
+
+    @Test
+    fun `LOG and EXP are inverses for all non-zero elements`() {
+        // For every x in 1..255: EXP[LOG[x]] == x
+        for (x in 1..255) {
+            assertEquals(x, GF256.EXP[GF256.LOG[x]],
+                "EXP[LOG[$x]] should equal $x")
+        }
+    }
+
+    @Test
+    fun `all 255 non-zero elements appear exactly once in EXP 0 through 254`() {
+        // The primitive element generates all non-zero field elements.
+        val seen = mutableSetOf<Int>()
+        for (i in 0 until 255) {
+            val v = GF256.EXP[i]
+            assert(v in 1..255) { "EXP[$i] = $v is out of range" }
+            assert(seen.add(v)) { "EXP[$i] = $v appeared more than once" }
+        }
+        assertEquals(255, seen.size)
+    }
+
+    // =========================================================================
+    // Addition
+    // =========================================================================
+
+    @Test
+    fun `add is XOR`() {
+        assertEquals(0x53 xor 0xCA, GF256.add(0x53, 0xCA))
+    }
+
+    @Test
+    fun `add is its own inverse - add(x, x) equals 0 for all x`() {
+        // In characteristic-2, every element is its own additive inverse.
+        for (x in 0..255) {
+            assertEquals(0, GF256.add(x, x), "add($x, $x) should be 0")
+        }
+    }
+
+    @Test
+    fun `add is commutative`() {
+        assertEquals(GF256.add(0x53, 0xCA), GF256.add(0xCA, 0x53))
+    }
+
+    @Test
+    fun `add with zero is identity`() {
+        for (x in 0..255) {
+            assertEquals(x, GF256.add(x, 0), "add($x, 0) should be $x")
+        }
+    }
+
+    // =========================================================================
+    // Subtraction
+    // =========================================================================
+
+    @Test
+    fun `sub equals add in GF(256)`() {
+        // Subtraction and addition are identical in characteristic-2 fields.
+        for (a in 0..15) {
+            for (b in 0..15) {
+                assertEquals(GF256.add(a, b), GF256.sub(a, b))
+            }
+        }
+    }
+
+    // =========================================================================
+    // Multiplication
+    // =========================================================================
+
+    @Test
+    fun `mul of zero with anything is zero`() {
+        for (x in 0..255) {
+            assertEquals(0, GF256.mul(0, x))
+            assertEquals(0, GF256.mul(x, 0))
+        }
+    }
+
+    @Test
+    fun `mul by one is identity`() {
+        for (x in 0..255) {
+            assertEquals(x, GF256.mul(x, 1), "mul($x, 1) should be $x")
+        }
+    }
+
+    @Test
+    fun `mul is commutative`() {
+        for (a in 0..15) {
+            for (b in 0..15) {
+                assertEquals(GF256.mul(a, b), GF256.mul(b, a))
+            }
+        }
+    }
+
+    @Test
+    fun `mul spot check - 3 times 7 equals 9`() {
+        // Known value from GF(256) with 0x11D:
+        // LOG[3] = 25, LOG[7] = 198 (verify: EXP[25+198 mod 255] = EXP[223] = 9? wait,
+        // let's just test the actual value since the TS impl agrees with 9)
+        // The precise value depends on the table; cross-checked with TypeScript.
+        assertEquals(9, GF256.mul(3, 7))
+    }
+
+    @Test
+    fun `mul spot check - known inverse pair`() {
+        // Under 0x11D polynomial: 0x53 × 0x8C = 1
+        // (This is the Reed-Solomon inverse pair; different from AES 0x11B pair.)
+        assertEquals(1, GF256.mul(0x53, 0x8C))
+    }
+
+    @Test
+    fun `mul is distributive over add`() {
+        // a × (b + c) = (a × b) + (a × c)
+        for (a in listOf(2, 3, 7, 0x53)) {
+            for (b in listOf(1, 5, 0xCA, 0xFF)) {
+                for (c in listOf(0, 3, 0xAB)) {
+                    val lhs = GF256.mul(a, GF256.add(b, c))
+                    val rhs = GF256.add(GF256.mul(a, b), GF256.mul(a, c))
+                    assertEquals(lhs, rhs)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Division
+    // =========================================================================
+
+    @Test
+    fun `div by zero throws ArithmeticException`() {
+        assertThrows<ArithmeticException> { GF256.div(1, 0) }
+        assertThrows<ArithmeticException> { GF256.div(0, 0) }
+    }
+
+    @Test
+    fun `div zero by anything non-zero is zero`() {
+        for (b in 1..255) {
+            assertEquals(0, GF256.div(0, b))
+        }
+    }
+
+    @Test
+    fun `div is inverse of mul`() {
+        // For all a in 1..255, b in 1..255: div(mul(a, b), b) == a
+        for (a in listOf(1, 2, 3, 0x53, 0xFF)) {
+            for (b in listOf(1, 2, 7, 0x8C, 0xFE)) {
+                val product = GF256.mul(a, b)
+                assertEquals(a, GF256.div(product, b),
+                    "div(mul($a, $b), $b) should equal $a")
+            }
+        }
+    }
+
+    @Test
+    fun `div x by x is 1 for all non-zero x`() {
+        for (x in 1..255) {
+            assertEquals(1, GF256.div(x, x), "div($x, $x) should be 1")
+        }
+    }
+
+    // =========================================================================
+    // Power
+    // =========================================================================
+
+    @Test
+    fun `pow 0 to the 0 is 1 by convention`() {
+        assertEquals(1, GF256.pow(0, 0))
+    }
+
+    @Test
+    fun `pow 0 to any positive exponent is 0`() {
+        for (n in 1..10) {
+            assertEquals(0, GF256.pow(0, n))
+        }
+    }
+
+    @Test
+    fun `pow anything to the 0 is 1`() {
+        for (x in 0..255) {
+            assertEquals(1, GF256.pow(x, 0), "pow($x, 0) should be 1")
+        }
+    }
+
+    @Test
+    fun `pow anything to the 1 is itself`() {
+        for (x in 0..255) {
+            assertEquals(x, GF256.pow(x, 1), "pow($x, 1) should be $x")
+        }
+    }
+
+    @Test
+    fun `pow generator to 255 is 1 (field order)`() {
+        // g^255 = 1 because the multiplicative group has order 255.
+        assertEquals(1, GF256.pow(2, 255))
+    }
+
+    @Test
+    fun `pow negative exponent throws`() {
+        assertThrows<IllegalArgumentException> { GF256.pow(2, -1) }
+    }
+
+    @Test
+    fun `pow agrees with repeated mul`() {
+        // pow(3, 5) should match mul(mul(mul(mul(3, 3), 3), 3), 3)
+        var manual = 1
+        for (i in 0 until 5) manual = GF256.mul(manual, 3)
+        assertEquals(manual, GF256.pow(3, 5))
+    }
+
+    @Test
+    fun `pow large exponent uses modular arithmetic`() {
+        // g^255 = 1, so g^256 = g^1 = 2, g^510 = g^0 = 1
+        assertEquals(2, GF256.pow(2, 256))
+        assertEquals(1, GF256.pow(2, 510))
+    }
+
+    // =========================================================================
+    // Inverse
+    // =========================================================================
+
+    @Test
+    fun `inv of zero throws ArithmeticException`() {
+        assertThrows<ArithmeticException> { GF256.inv(0) }
+    }
+
+    @Test
+    fun `inv of 1 is 1 (multiplicative identity)`() {
+        assertEquals(1, GF256.inv(1))
+    }
+
+    @Test
+    fun `a times inv(a) equals 1 for all non-zero a`() {
+        for (a in 1..255) {
+            assertEquals(1, GF256.mul(a, GF256.inv(a)),
+                "mul($a, inv($a)) should be 1")
+        }
+    }
+
+    @Test
+    fun `inv of inv is original element`() {
+        for (a in 1..255) {
+            assertEquals(a, GF256.inv(GF256.inv(a)),
+                "inv(inv($a)) should be $a")
+        }
+    }
+
+    @Test
+    fun `inv spot check - 0x53 inverts to 0x8C under 0x11D`() {
+        assertEquals(0x8C, GF256.inv(0x53))
+    }
+
+    // =========================================================================
+    // Field axioms (comprehensive)
+    // =========================================================================
+
+    @Test
+    fun `mul is associative`() {
+        // (a × b) × c = a × (b × c)
+        for (a in listOf(2, 3, 0x53)) {
+            for (b in listOf(5, 7, 0xCA)) {
+                for (c in listOf(11, 0x8C, 0xFF)) {
+                    val lhs = GF256.mul(GF256.mul(a, b), c)
+                    val rhs = GF256.mul(a, GF256.mul(b, c))
+                    assertEquals(lhs, rhs,
+                        "Associativity failed for mul($a, $b, $c)")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `add is associative`() {
+        for (a in 0..15) {
+            for (b in 0..15) {
+                for (c in 0..15) {
+                    assertEquals(
+                        GF256.add(GF256.add(a, b), c),
+                        GF256.add(a, GF256.add(b, c))
+                    )
+                }
+            }
+        }
+    }
+}

--- a/code/packages/kotlin/polynomial/.gitignore
+++ b/code/packages/kotlin/polynomial/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/polynomial/BUILD
+++ b/code/packages/kotlin/polynomial/BUILD
@@ -1,0 +1,1 @@
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/kotlin-foundation.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 test; status=$?; rmdir ../../../../.build-locks/kotlin-foundation.lock; exit $status

--- a/code/packages/kotlin/polynomial/BUILD_windows
+++ b/code/packages/kotlin/polynomial/BUILD_windows
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 test

--- a/code/packages/kotlin/polynomial/CHANGELOG.md
+++ b/code/packages/kotlin/polynomial/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog — polynomial (Kotlin)
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- `normalize(p)` — strips trailing zero coefficients
+- `degree(p)` — returns index of highest non-zero coefficient; -1 for zero polynomial
+- `zero()` / `one()` — additive and multiplicative identity helpers
+- `poly(vararg)` — convenience constructor with normalisation
+- `add(a, b)` — coefficient-wise XOR (GF(256) addition)
+- `sub(a, b)` — identical to add (subtraction = addition in characteristic-2 fields)
+- `mul(a, b)` — polynomial convolution over GF(256) using `GF256.mul`
+- `divmod(a, b)` — polynomial long division over GF(256); returns (quotient, remainder)
+- `divide(a, b)` — quotient from divmod
+- `mod(a, b)` — remainder from divmod (used by RS encoder)
+- `eval(p, x)` — Horner's method evaluation at GF(256) element x (used by RS syndrome computation)
+- `gcd(a, b)` — Euclidean GCD of two GF(256) polynomials
+- 41 unit tests covering all operations, field axioms, RS generator verification, error cases
+- `VERSION = "0.1.0"` constant
+
+### Notes
+
+- Coefficients are all GF(256) elements (0..255); arithmetic defers to `com.codingadventures.gf256.GF256`
+- Dependency on `gf256` resolved as a local Gradle composite build via `includeBuild("../gf256")`
+- Divergence from TypeScript MA00 `polynomial`: TypeScript MA00 uses real-number (f64) coefficients
+  for a general polynomial library; this Kotlin package uses GF(256) coefficients to directly
+  support MA02 Reed-Solomon (matching what Ruby/Python/Go implementations do)

--- a/code/packages/kotlin/polynomial/README.md
+++ b/code/packages/kotlin/polynomial/README.md
@@ -1,0 +1,79 @@
+# polynomial — Kotlin
+
+Polynomial arithmetic over GF(2^8) (Galois Field with 256 elements).
+
+## What are GF(256) polynomials?
+
+These are polynomials whose coefficients are GF(256) elements (bytes 0..255).
+All arithmetic — addition, subtraction, multiplication, division — uses GF(256)
+field operations rather than ordinary integer math.
+
+This is the mathematical layer between raw byte arithmetic (gf256) and
+Reed-Solomon error correction (reed-solomon).
+
+## Representation
+
+Polynomials are little-endian `IntArray`s: index `i` holds the coefficient
+of `x^i`.
+
+```
+[3, 0, 2]  →  3 + 0·x + 2·x²
+[1]        →  constant 1
+[]         →  zero polynomial
+```
+
+## Key differences from real-number polynomials
+
+| Operation     | Real polynomials | GF(256) polynomials       |
+|---------------|-----------------|---------------------------|
+| Add coeff     | a + b           | a XOR b                   |
+| Sub coeff     | a − b           | a XOR b  (same as add!)   |
+| Mul coeff     | a × b           | `GF256.mul(a, b)`         |
+| Div coeff     | a / b           | `GF256.div(a, b)`         |
+
+## Usage
+
+```kotlin
+import com.codingadventures.polynomial.*
+
+val p = poly(3, 0, 2)       // 3 + 2x²
+val q = poly(1, 1)          // 1 + x
+
+val sum  = add(p, q)        // coefficient-wise XOR
+val prod = mul(p, q)        // polynomial convolution in GF(256)
+val (quotient, rem) = divmod(prod, q)
+
+val root = eval(prod, 4)    // Horner evaluation at x=4 in GF(256)
+```
+
+## API
+
+| Function | Description |
+|----------|-------------|
+| `normalize(p)` | Strip trailing zero coefficients |
+| `degree(p)` | Degree of p; -1 for zero polynomial |
+| `zero()` | The zero polynomial `[]` |
+| `one()` | The identity polynomial `[1]` |
+| `poly(vararg)` | Construct and normalise a polynomial |
+| `add(a, b)` | XOR each coefficient |
+| `sub(a, b)` | Same as add in GF(256) |
+| `mul(a, b)` | Polynomial convolution using GF(256) mul |
+| `divmod(a, b)` | Long division → (quotient, remainder) |
+| `divide(a, b)` | Quotient of divmod |
+| `mod(a, b)` | Remainder of divmod |
+| `eval(p, x)` | Horner evaluation at GF(256) point x |
+| `gcd(a, b)` | GCD via Euclidean algorithm |
+
+## Dependencies
+
+- `gf256` — GF(2^8) field operations (resolved as a local composite build)
+
+## Build
+
+```
+gradle test
+```
+
+## Spec
+
+`code/specs/MA00-polynomial.md`

--- a/code/packages/kotlin/polynomial/build.gradle.kts
+++ b/code/packages/kotlin/polynomial/build.gradle.kts
@@ -1,0 +1,40 @@
+// Gradle's default output directory is "build/", which conflicts with our BUILD file
+// on case-insensitive filesystems (macOS, Windows). Redirect to "gradle-build/" instead.
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    // Local composite build — resolved via includeBuild("../gf256") in settings.gradle.kts.
+    // This gives us GF256 field operations for coefficient arithmetic.
+    api("com.codingadventures:gf256")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/polynomial/settings.gradle.kts
+++ b/code/packages/kotlin/polynomial/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "polynomial"
+
+// Include the local gf256 build so Gradle can resolve com.codingadventures:gf256
+// without publishing to a Maven repository.  This is the same pattern used by
+// kotlin/directed-graph → kotlin/graph.
+includeBuild("../gf256")

--- a/code/packages/kotlin/polynomial/src/main/kotlin/com/codingadventures/polynomial/Polynomial.kt
+++ b/code/packages/kotlin/polynomial/src/main/kotlin/com/codingadventures/polynomial/Polynomial.kt
@@ -1,0 +1,342 @@
+/**
+ * Polynomial arithmetic over GF(2^8).
+ *
+ * This package implements polynomials whose coefficients are elements of the
+ * finite field GF(256) — the integers 0..255 under XOR-addition and
+ * log/exp-table multiplication.
+ *
+ * ## Representation
+ *
+ * A polynomial is a little-endian IntArray:
+ *
+ *   index i  =  coefficient of x^i
+ *
+ *   [3, 0, 2]  →  3 + 0·x + 2·x²  =  3 + 2x²
+ *   [1, 2, 3]  →  1 + 2x + 3x²
+ *   []         →  the zero polynomial
+ *
+ * "Little-endian" keeps addition trivially position-aligned and makes Horner's
+ * method natural (iterate from high index to 0).
+ *
+ * All functions return normalised polynomials: trailing zeros are stripped.
+ * [1, 0, 0] and [1] both represent the constant polynomial 1.
+ *
+ * ## Why GF(256) coefficients?
+ *
+ * Reed-Solomon encoding and decoding require polynomial arithmetic over the
+ * same field as the data bytes.  Real-number polynomials accumulate rounding
+ * errors and cannot represent byte values exactly.  GF(256) arithmetic is
+ * exact, closed, and fast.
+ *
+ * ## Key differences from real-number polynomials (MA00)
+ *
+ * | Operation | Real polynomials | GF(256) polynomials |
+ * |-----------|-----------------|---------------------|
+ * | add coeff | a + b           | a XOR b             |
+ * | sub coeff | a − b           | a XOR b  (same!)    |
+ * | mul coeff | a × b           | GF256.mul(a, b)     |
+ * | div coeff | a / b           | GF256.div(a, b)     |
+ *
+ * Spec: MA00-polynomial.md (GF(256) variant used by MA02 reed-solomon)
+ */
+package com.codingadventures.polynomial
+
+import com.codingadventures.gf256.GF256
+
+/** Version of this package. */
+const val VERSION = "0.1.0"
+
+// =============================================================================
+// Type alias
+// =============================================================================
+
+/**
+ * A polynomial over GF(256), represented as a little-endian IntArray.
+ * Index i holds the coefficient of x^i.  All coefficients must be in 0..255.
+ * The zero polynomial is an empty array.
+ */
+typealias Poly = IntArray
+
+// =============================================================================
+// Fundamentals
+// =============================================================================
+
+/**
+ * Return a normalised copy of [p], with all trailing zero coefficients removed.
+ *
+ * Trailing zeros represent zero-coefficient high-degree terms. They do not
+ * change the polynomial's value but do affect degree comparisons and the loop
+ * termination condition in polynomial long division.
+ *
+ * Examples:
+ *   normalize([1, 0, 0]) → [1]   (constant polynomial 1)
+ *   normalize([0])       → []    (zero polynomial)
+ *   normalize([1, 2, 3]) → [1, 2, 3]  (already normalised)
+ */
+fun normalize(p: Poly): Poly {
+    var len = p.size
+    // Walk backward until we reach a non-zero coefficient.
+    while (len > 0 && p[len - 1] == 0) len--
+    return p.copyOfRange(0, len)
+}
+
+/**
+ * Return the degree of polynomial [p].
+ *
+ * The degree is the index of the highest non-zero coefficient.
+ * By convention, the zero polynomial has degree −1. This sentinel lets
+ * polynomial long division terminate cleanly: the loop condition
+ * `degree(remainder) >= degree(divisor)` is false when the remainder is zero.
+ *
+ * Examples:
+ *   degree([3, 0, 2]) → 2
+ *   degree([7])       → 0
+ *   degree([])        → -1   (zero polynomial)
+ *   degree([0, 0])    → -1   (normalises to []; same as zero polynomial)
+ */
+fun degree(p: Poly): Int = normalize(p).size - 1
+
+/** The zero polynomial — the additive identity. */
+fun zero(): Poly = IntArray(0)
+
+/** The multiplicative identity polynomial [1]. */
+fun one(): Poly = intArrayOf(1)
+
+// =============================================================================
+// Addition and Subtraction
+// =============================================================================
+
+/**
+ * Add two GF(256) polynomials coefficient-by-coefficient.
+ *
+ * In GF(256), addition is XOR for each coefficient.  The shorter polynomial
+ * is extended with implicit zero coefficients.
+ *
+ * Visual example (in GF(256)):
+ *   [1, 2, 3]   =  1 + 2x + 3x²
+ * + [4, 5]      =  4 + 5x
+ * ────────────────────────────────
+ *   [1⊕4, 2⊕5, 3]  =  [5, 7, 3]   (XOR of each position)
+ */
+fun add(a: Poly, b: Poly): Poly {
+    val len = maxOf(a.size, b.size)
+    val result = IntArray(len)
+    for (i in 0 until len) {
+        val ai = if (i < a.size) a[i] else 0
+        val bi = if (i < b.size) b[i] else 0
+        result[i] = GF256.add(ai, bi)  // XOR
+    }
+    return normalize(result)
+}
+
+/**
+ * Subtract polynomial [b] from [a] coefficient-by-coefficient.
+ *
+ * In GF(256), subtraction equals addition (XOR), because −1 = 1 in
+ * characteristic-2 fields.  This function is provided for clarity/symmetry
+ * with the MA00 polynomial interface.
+ */
+fun sub(a: Poly, b: Poly): Poly = add(a, b)  // sub == add in GF(2^n)
+
+// =============================================================================
+// Multiplication
+// =============================================================================
+
+/**
+ * Multiply two GF(256) polynomials by polynomial convolution.
+ *
+ * Each term a[i]·x^i of [a] multiplies each term b[j]·x^j of [b],
+ * contributing GF256.mul(a[i], b[j]) to result[i+j] via XOR accumulation.
+ *
+ * If [a] has degree m and [b] has degree n, the result has degree m + n.
+ *
+ * Visual example (in GF(256)):
+ *   [1, 2]  =  1 + 2x
+ * × [3, 4]  =  3 + 4x
+ * ────────────────────────────────────────
+ *   i=0,j=0: result[0] ^= mul(1,3) = 3
+ *   i=0,j=1: result[1] ^= mul(1,4) = 4
+ *   i=1,j=0: result[1] ^= mul(2,3) = 6  → result[1] = 4^6 = 2
+ *   i=1,j=1: result[2] ^= mul(2,4) = 8? let's just note it's GF multiplication
+ *
+ * Result: [mul(1,3), mul(1,4)^mul(2,3), mul(2,4)]
+ */
+fun mul(a: Poly, b: Poly): Poly {
+    if (a.isEmpty() || b.isEmpty()) return zero()
+    val resultLen = a.size + b.size - 1
+    val result = IntArray(resultLen)
+    for (i in a.indices) {
+        for (j in b.indices) {
+            result[i + j] = GF256.add(result[i + j], GF256.mul(a[i], b[j]))
+        }
+    }
+    return normalize(result)
+}
+
+// =============================================================================
+// Division
+// =============================================================================
+
+/**
+ * Perform GF(256) polynomial long division, returning [quotient, remainder].
+ *
+ * Finds q and r such that:
+ *   a = b × q + r   and   degree(r) < degree(b)
+ *
+ * The algorithm is the polynomial analog of long division:
+ * 1. Find the leading term of the current remainder.
+ * 2. Divide it by the leading term of [b] (using GF256.div) to get the next
+ *    quotient term.
+ * 3. Subtract (quotient term) × b from the remainder (XOR, because GF add=sub).
+ * 4. Repeat until degree(remainder) < degree(b).
+ *
+ * This is the core operation used in:
+ * - RS encoding: compute M(x)·x^nCheck mod g(x) to get parity bytes
+ * - RS decoding: extended Euclidean algorithm for error-locator polynomials
+ *
+ * @throws ArithmeticException if [b] is the zero polynomial
+ */
+fun divmod(a: Poly, b: Poly): Pair<Poly, Poly> {
+    val nb = normalize(b)
+    if (nb.isEmpty()) throw ArithmeticException("polynomial division by zero")
+
+    val na = normalize(a)
+    val degA = na.size - 1
+    val degB = nb.size - 1
+
+    // If degree(a) < degree(b), quotient is 0, remainder is a.
+    if (degA < degB) return Pair(zero(), na)
+
+    // Work on a mutable copy of the remainder.
+    val rem = na.copyOf()
+    // Allocate the quotient array with the correct degree.
+    val quot = IntArray(degA - degB + 1)
+
+    // Leading coefficient of the divisor — used to normalise each quotient term.
+    val leadB = nb[degB]
+
+    // Current logical degree of the remainder (walks downward).
+    var degRem = degA
+
+    while (degRem >= degB) {
+        val leadRem = rem[degRem]
+        if (leadRem == 0) {
+            degRem--
+            continue
+        }
+        // Quotient coefficient: leadRem / leadB in GF(256).
+        val coeff = GF256.div(leadRem, leadB)
+        val power = degRem - degB
+        quot[power] = coeff
+
+        // Subtract coeff·x^power·b from rem (XOR-based subtraction).
+        for (j in 0..degB) {
+            rem[power + j] = GF256.add(rem[power + j], GF256.mul(coeff, nb[j]))
+        }
+
+        // The leading term is now zero by construction.  Decrement, skipping new
+        // trailing zeros.
+        degRem--
+        while (degRem >= 0 && rem[degRem] == 0) degRem--
+    }
+
+    return Pair(normalize(quot), normalize(rem))
+}
+
+/**
+ * Return the quotient of [divmod].
+ *
+ * @throws ArithmeticException if [b] is the zero polynomial
+ */
+fun divide(a: Poly, b: Poly): Poly = divmod(a, b).first
+
+/**
+ * Return the remainder of [divmod].
+ *
+ * This is the GF(256) polynomial "modulo" operation.  Reed-Solomon encoding
+ * reduces the shifted message polynomial modulo the generator polynomial using
+ * this function.
+ *
+ * @throws ArithmeticException if [b] is the zero polynomial
+ */
+fun mod(a: Poly, b: Poly): Poly = divmod(a, b).second
+
+// =============================================================================
+// Evaluation
+// =============================================================================
+
+/**
+ * Evaluate a GF(256) polynomial at [x] using Horner's method.
+ *
+ * Horner's method rewrites the polynomial in nested form to minimise
+ * multiplications:
+ *
+ *   a₀ + x(a₁ + x(a₂ + … + x·aₙ))
+ *
+ * Algorithm (iterating coefficients from high degree to low):
+ *   acc = 0
+ *   for i from n downto 0:
+ *       acc = GF256.add(GF256.mul(acc, x), p[i])
+ *   return acc
+ *
+ * This requires exactly n GF(256) multiplications and n additions (XORs).
+ *
+ * Used in Reed-Solomon syndrome computation:
+ *   S_j = codeword(α^j)   for j = 1, …, nCheck
+ *
+ * @param p  polynomial to evaluate (little-endian GF(256) coefficients)
+ * @param x  the field element at which to evaluate (0..255)
+ * @return   the GF(256) value p(x)
+ */
+fun eval(p: Poly, x: Int): Int {
+    val n = normalize(p)
+    if (n.isEmpty()) return 0
+    var acc = 0
+    for (i in n.size - 1 downTo 0) {
+        acc = GF256.add(GF256.mul(acc, x), n[i])
+    }
+    return acc
+}
+
+// =============================================================================
+// Greatest Common Divisor
+// =============================================================================
+
+/**
+ * Compute the GCD of two GF(256) polynomials using the Euclidean algorithm.
+ *
+ * Repeatedly replaces (a, b) with (b, a mod b) until b is the zero polynomial.
+ * The last non-zero remainder is the GCD.
+ *
+ * Pseudocode:
+ *   while b ≠ zero:
+ *       a, b = b, a mod b
+ *   return normalize(a)
+ *
+ * This is identical to the integer GCD algorithm, with polynomial mod in place
+ * of integer mod.
+ *
+ * Use case: Reed-Solomon decoding uses the extended Euclidean algorithm on
+ * polynomials to find the error-locator and error-evaluator polynomials.
+ */
+fun gcd(a: Poly, b: Poly): Poly {
+    var u = normalize(a)
+    var v = normalize(b)
+    while (v.isNotEmpty()) {
+        val r = mod(u, v)
+        u = v
+        v = r
+    }
+    return normalize(u)
+}
+
+// =============================================================================
+// Convenience constructors
+// =============================================================================
+
+/**
+ * Create a polynomial from a vararg list of GF(256) coefficients (little-endian).
+ *
+ * Example: `poly(3, 0, 2)` → 3 + 0·x + 2·x² in GF(256)
+ */
+fun poly(vararg coeffs: Int): Poly = normalize(IntArray(coeffs.size) { coeffs[it] })

--- a/code/packages/kotlin/polynomial/src/test/kotlin/com/codingadventures/polynomial/PolynomialTest.kt
+++ b/code/packages/kotlin/polynomial/src/test/kotlin/com/codingadventures/polynomial/PolynomialTest.kt
@@ -1,0 +1,366 @@
+package com.codingadventures.polynomial
+
+import com.codingadventures.gf256.GF256
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Tests for GF(256) polynomial arithmetic.
+ *
+ * All arithmetic is over GF(2^8) with primitive polynomial 0x11D.
+ * Test vectors are cross-checked against the TypeScript reference
+ * implementation and the MA00/MA01 specifications.
+ */
+class PolynomialTest {
+
+    // =========================================================================
+    // normalize
+    // =========================================================================
+
+    @Test
+    fun `normalize removes trailing zeros`() {
+        assertContentEquals(intArrayOf(1), normalize(intArrayOf(1, 0, 0)))
+    }
+
+    @Test
+    fun `normalize of all-zeros is empty`() {
+        assertContentEquals(intArrayOf(), normalize(intArrayOf(0)))
+        assertContentEquals(intArrayOf(), normalize(intArrayOf(0, 0, 0)))
+    }
+
+    @Test
+    fun `normalize preserves already-normalised polynomial`() {
+        assertContentEquals(intArrayOf(1, 2, 3), normalize(intArrayOf(1, 2, 3)))
+    }
+
+    @Test
+    fun `normalize of empty is empty`() {
+        assertContentEquals(intArrayOf(), normalize(intArrayOf()))
+    }
+
+    // =========================================================================
+    // degree
+    // =========================================================================
+
+    @Test
+    fun `degree of zero polynomial is -1`() {
+        assertEquals(-1, degree(intArrayOf()))
+        assertEquals(-1, degree(intArrayOf(0)))
+    }
+
+    @Test
+    fun `degree of constant polynomial is 0`() {
+        assertEquals(0, degree(intArrayOf(7)))
+    }
+
+    @Test
+    fun `degree of x-squared term is 2`() {
+        assertEquals(2, degree(intArrayOf(3, 0, 2)))
+    }
+
+    // =========================================================================
+    // add / sub
+    // =========================================================================
+
+    @Test
+    fun `add is XOR of each coefficient`() {
+        // [1, 2, 3] + [4, 5] = [1^4, 2^5, 3] = [5, 7, 3]
+        assertContentEquals(
+            intArrayOf(5, 7, 3),
+            add(intArrayOf(1, 2, 3), intArrayOf(4, 5))
+        )
+    }
+
+    @Test
+    fun `add with zero polynomial is identity`() {
+        val p = intArrayOf(1, 2, 3)
+        assertContentEquals(p, add(p, intArrayOf()))
+        assertContentEquals(p, add(intArrayOf(), p))
+    }
+
+    @Test
+    fun `add a polynomial to itself gives zero`() {
+        // In GF(256), p + p = 0 for any polynomial p.
+        val p = intArrayOf(1, 2, 3, 255)
+        assertContentEquals(intArrayOf(), add(p, p))
+    }
+
+    @Test
+    fun `sub equals add in GF(256)`() {
+        val a = intArrayOf(3, 7, 0x53)
+        val b = intArrayOf(0xCA, 1)
+        assertContentEquals(add(a, b), sub(a, b))
+    }
+
+    @Test
+    fun `add is commutative`() {
+        val a = intArrayOf(1, 2, 3)
+        val b = intArrayOf(4, 5, 6)
+        assertContentEquals(add(a, b), add(b, a))
+    }
+
+    // =========================================================================
+    // mul
+    // =========================================================================
+
+    @Test
+    fun `mul by zero polynomial gives zero`() {
+        val p = intArrayOf(1, 2, 3)
+        assertContentEquals(intArrayOf(), mul(p, intArrayOf()))
+        assertContentEquals(intArrayOf(), mul(intArrayOf(), p))
+    }
+
+    @Test
+    fun `mul by one polynomial is identity`() {
+        val p = intArrayOf(3, 7, 0x53)
+        assertContentEquals(p, mul(p, intArrayOf(1)))
+        assertContentEquals(p, mul(intArrayOf(1), p))
+    }
+
+    @Test
+    fun `mul by scalar scales every coefficient`() {
+        // [1, 2, 3] × [c] = [mul(1,c), mul(2,c), mul(3,c)]
+        val c = 3
+        val p = intArrayOf(1, 2, 3)
+        val expected = IntArray(p.size) { GF256.mul(p[it], c) }
+        assertContentEquals(expected, mul(p, intArrayOf(c)))
+    }
+
+    @Test
+    fun `mul degree is sum of degrees`() {
+        val a = intArrayOf(1, 0, 1)  // degree 2
+        val b = intArrayOf(1, 1)     // degree 1
+        val product = mul(a, b)
+        assertEquals(degree(a) + degree(b), degree(product))
+    }
+
+    @Test
+    fun `mul is commutative`() {
+        val a = intArrayOf(1, 2, 3)
+        val b = intArrayOf(4, 5)
+        assertContentEquals(mul(a, b), mul(b, a))
+    }
+
+    @Test
+    fun `mul is distributive over add`() {
+        // a × (b + c) = a×b + a×c
+        val a = intArrayOf(1, 2)
+        val b = intArrayOf(3, 4, 5)
+        val c = intArrayOf(6, 7)
+        assertContentEquals(
+            mul(a, add(b, c)),
+            add(mul(a, b), mul(a, c))
+        )
+    }
+
+    @Test
+    fun `mul known RS generator - 2 check bytes`() {
+        // buildGenerator(2) in RS gives [8, 6, 1] (little-endian)
+        // Manually: start with [1], multiply by [2, 1] (x + alpha^1 = x + 2):
+        //   [1] × [2, 1] = [2, 1]
+        // then multiply by [4, 1] (x + alpha^2 = x + 4):
+        //   [2, 1] × [4, 1] = [mul(2,4)^0, mul(2,1)^mul(1,4), 1]
+        //                   = [8, 2^4, 1] = [8, 6, 1]
+        val factor1 = intArrayOf(2, 1)   // (x + alpha^1)
+        val factor2 = intArrayOf(4, 1)   // (x + alpha^2)
+        val gen = mul(factor1, factor2)
+        assertContentEquals(intArrayOf(8, 6, 1), gen)
+    }
+
+    // =========================================================================
+    // divmod
+    // =========================================================================
+
+    @Test
+    fun `divmod by zero throws`() {
+        assertThrows<ArithmeticException> {
+            divmod(intArrayOf(1, 2, 3), intArrayOf())
+        }
+    }
+
+    @Test
+    fun `divmod when dividend degree less than divisor`() {
+        // x / (x^2 + 1) = quotient 0, remainder x
+        val (q, r) = divmod(intArrayOf(0, 1), intArrayOf(1, 0, 1))
+        assertContentEquals(intArrayOf(), q)
+        assertContentEquals(intArrayOf(0, 1), r)
+    }
+
+    @Test
+    fun `divmod basic case - exact division`() {
+        // [2, 1] × [4, 1] = [8, 6, 1], so [8, 6, 1] / [2, 1] = [4, 1], rem 0
+        val product = mul(intArrayOf(2, 1), intArrayOf(4, 1))
+        val (q, r) = divmod(product, intArrayOf(2, 1))
+        assertContentEquals(intArrayOf(4, 1), q)
+        assertContentEquals(intArrayOf(), r)
+    }
+
+    @Test
+    fun `divmod remainder has lower degree than divisor`() {
+        val a = intArrayOf(1, 2, 3, 4)   // degree 3
+        val b = intArrayOf(1, 1, 1)      // degree 2
+        val (q, r) = divmod(a, b)
+        assert(degree(r) < degree(b)) {
+            "Remainder degree ${degree(r)} should be < divisor degree ${degree(b)}"
+        }
+    }
+
+    @Test
+    fun `divmod satisfies a equals b times q plus r`() {
+        // The fundamental division identity: a = b*q + r
+        val a = intArrayOf(3, 1, 4, 1, 5)
+        val b = intArrayOf(1, 2, 1)
+        val (q, r) = divmod(a, b)
+        val reconstructed = add(mul(b, q), r)
+        assertContentEquals(normalize(a), reconstructed)
+    }
+
+    @Test
+    fun `divmod single byte divisor`() {
+        // [6, 4, 2] / [2] = [div(6,2), div(4,2), div(2,2)] = [3, 2, 1]
+        val (q, r) = divmod(intArrayOf(6, 4, 2), intArrayOf(2))
+        assertContentEquals(intArrayOf(), r)
+        // Verify b * q = a
+        assertContentEquals(normalize(intArrayOf(6, 4, 2)), mul(intArrayOf(2), q))
+    }
+
+    // =========================================================================
+    // eval
+    // =========================================================================
+
+    @Test
+    fun `eval of zero polynomial at any point is 0`() {
+        for (x in 0..255) {
+            assertEquals(0, eval(intArrayOf(), x))
+        }
+    }
+
+    @Test
+    fun `eval of constant polynomial is that constant`() {
+        assertEquals(7, eval(intArrayOf(7), 0))
+        assertEquals(7, eval(intArrayOf(7), 5))
+        assertEquals(7, eval(intArrayOf(7), 255))
+    }
+
+    @Test
+    fun `eval of polynomial at 0 is constant term`() {
+        // p(0) = p[0] (only the constant term survives when x = 0)
+        val p = intArrayOf(42, 7, 3, 1)
+        assertEquals(42, eval(p, 0))
+    }
+
+    @Test
+    fun `eval linear polynomial`() {
+        // p(x) = 3 + 5x  →  p(2) = 3 XOR mul(5, 2)
+        val p = intArrayOf(3, 5)
+        val expected = GF256.add(3, GF256.mul(5, 2))
+        assertEquals(expected, eval(p, 2))
+    }
+
+    @Test
+    fun `eval agrees with direct computation`() {
+        // p(x) = 1 + 2x + 3x^2; evaluate at x = 7
+        // = 1 XOR mul(2,7) XOR mul(3, mul(7,7))
+        val p = intArrayOf(1, 2, 3)
+        val x = 7
+        val manual = GF256.add(
+            GF256.add(1, GF256.mul(2, x)),
+            GF256.mul(3, GF256.mul(x, x))
+        )
+        assertEquals(manual, eval(p, x))
+    }
+
+    @Test
+    fun `eval generator roots are zero - RS property`() {
+        // The RS generator polynomial g = [8, 6, 1] has roots alpha^1=2, alpha^2=4.
+        val gen = intArrayOf(8, 6, 1)
+        assertEquals(0, eval(gen, 2),  "g(alpha^1) should be 0")
+        assertEquals(0, eval(gen, 4),  "g(alpha^2) should be 0")
+    }
+
+    // =========================================================================
+    // gcd
+    // =========================================================================
+
+    @Test
+    fun `gcd of polynomial with itself is normalised self`() {
+        val p = intArrayOf(1, 2, 3)
+        val g = gcd(p, p)
+        // GCD is defined up to a scalar; the leading coefficient may differ.
+        // The key property: g divides p with zero remainder.
+        val (_, r) = divmod(p, g)
+        assertContentEquals(intArrayOf(), r)
+    }
+
+    @Test
+    fun `gcd of polynomial with zero is that polynomial`() {
+        val p = intArrayOf(1, 2, 3)
+        val g = gcd(p, intArrayOf())
+        assertContentEquals(normalize(p), g)
+    }
+
+    @Test
+    fun `gcd of coprime polynomials is constant`() {
+        // p = (x + 2)(x + 4) = [8, 6, 1]; q = (x + 3) = [3, 1]
+        // These share no common root, so GCD should be degree 0.
+        val p = mul(intArrayOf(2, 1), intArrayOf(4, 1))  // [8, 6, 1]
+        val q = intArrayOf(3, 1)
+        val g = gcd(p, q)
+        assertEquals(0, degree(g))
+    }
+
+    @Test
+    fun `gcd divides both inputs`() {
+        val a = mul(intArrayOf(2, 1), intArrayOf(4, 1))  // (x+2)(x+4)
+        val b = mul(intArrayOf(2, 1), intArrayOf(3, 1))  // (x+2)(x+3)
+        val g = gcd(a, b)
+        // g must divide both a and b
+        val (_, ra) = divmod(a, g)
+        val (_, rb) = divmod(b, g)
+        assertContentEquals(intArrayOf(), ra)
+        assertContentEquals(intArrayOf(), rb)
+    }
+
+    // =========================================================================
+    // poly helper
+    // =========================================================================
+
+    @Test
+    fun `poly vararg constructor normalises`() {
+        assertContentEquals(intArrayOf(1), poly(1, 0, 0))
+        assertContentEquals(intArrayOf(), poly(0))
+    }
+
+    @Test
+    fun `poly with multiple non-zero coefficients`() {
+        assertContentEquals(intArrayOf(3, 0, 2), poly(3, 0, 2))
+    }
+
+    // =========================================================================
+    // zero and one helpers
+    // =========================================================================
+
+    @Test
+    fun `zero polynomial is empty`() {
+        assertContentEquals(intArrayOf(), zero())
+    }
+
+    @Test
+    fun `one polynomial is the constant 1`() {
+        assertContentEquals(intArrayOf(1), one())
+    }
+
+    @Test
+    fun `add with zero is identity via zero helper`() {
+        val p = poly(3, 7, 0x53)
+        assertContentEquals(p, add(p, zero()))
+    }
+
+    @Test
+    fun `mul with one is identity via one helper`() {
+        val p = poly(3, 7, 0x53)
+        assertContentEquals(p, mul(p, one()))
+    }
+}

--- a/code/packages/kotlin/reed-solomon/.gitignore
+++ b/code/packages/kotlin/reed-solomon/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/reed-solomon/BUILD
+++ b/code/packages/kotlin/reed-solomon/BUILD
@@ -1,0 +1,1 @@
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/kotlin-foundation.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 test; status=$?; rmdir ../../../../.build-locks/kotlin-foundation.lock; exit $status

--- a/code/packages/kotlin/reed-solomon/BUILD_windows
+++ b/code/packages/kotlin/reed-solomon/BUILD_windows
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 test

--- a/code/packages/kotlin/reed-solomon/CHANGELOG.md
+++ b/code/packages/kotlin/reed-solomon/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — reed-solomon (Kotlin)
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- `buildGenerator(nCheck)` — builds the monic RS generator polynomial `g(x) = (x+α)(x+α²)…(x+α^nCheck)` in little-endian form
+- `encode(message, nCheck)` — systematic RS encoding via `M(x)·x^{nCheck} mod g(x)`; output is `message || parity`
+- `syndromes(received, nCheck)` — evaluates codeword at α^1…α^{nCheck} (big-endian Horner)
+- `decode(received, nCheck)` — full Berlekamp-Massey / Chien / Forney pipeline; corrects up to `t = nCheck/2` errors
+- `errorLocator(synds)` — exposes Berlekamp-Massey result for diagnostics/QR decoders
+- `TooManyErrorsException` — thrown when codeword has more than `t` errors
+- `InvalidInputException` — thrown for bad parameters (nCheck=0/odd, total length >255, etc.)
+- `VERSION = "0.1.0"` constant
+- 35 unit tests covering: generator construction, syndrome computation, encoding/decoding with 0/1/2/4 errors,
+  single-byte round-trips for all 256 values, too-many-errors case, parameter validation
+
+### Implementation notes
+
+- Uses b=1 convention: generator roots are α^1, α^2, …, α^{nCheck} (α=2)
+- Codeword bytes treated as big-endian polynomial: `codeword[0]·x^{n-1} + … + codeword[n-1]`
+- `polynomial` package dependency is declared but internal helpers use direct GF256 operations
+  for big-endian byte arrays (avoiding LE/BE conversion overhead in the hot path)
+- Dependencies on `gf256` and `polynomial` resolved via Gradle composite builds (`includeBuild`)
+- BUILD uses a shared mutex lock (`kotlin-foundation.lock`) to prevent CI race conditions
+  when building alongside the `polynomial` package which includes the same `gf256` composite build

--- a/code/packages/kotlin/reed-solomon/README.md
+++ b/code/packages/kotlin/reed-solomon/README.md
@@ -1,0 +1,93 @@
+# reed-solomon — Kotlin
+
+Reed-Solomon error-correcting codes over GF(256).
+
+## What is Reed-Solomon?
+
+Reed-Solomon (RS) is a block error-correcting code. You add `nCheck`
+redundancy bytes to a message; the decoder can recover the original data
+even if up to `t = nCheck / 2` bytes are corrupted anywhere in the codeword.
+
+## Where RS is used
+
+| System           | How RS helps                                        |
+|------------------|-----------------------------------------------------|
+| QR codes         | Up to 30% of a QR symbol can be destroyed/scratched |
+| CDs / DVDs       | CIRC two-level RS corrects scratches and defects    |
+| Hard drives      | Firmware sector-level error correction              |
+| Voyager probes   | Transmit images across 20+ billion km               |
+| RAID-6           | Two parity drives = (n, n-2) RS code                |
+
+## Building blocks
+
+```
+gf256        — GF(2^8) field arithmetic
+polynomial   — GF(256) polynomial arithmetic
+reed-solomon ← this package
+```
+
+## Usage
+
+```kotlin
+import com.codingadventures.reedsolomon.*
+
+val message = intArrayOf(72, 101, 108, 108, 111)  // "Hello"
+val nCheck = 8  // t = 4 errors correctable
+
+val codeword = encode(message, nCheck)
+// codeword[0..4] == message (systematic)
+
+// Corrupt up to t=4 bytes — still recoverable
+val corrupted = codeword.copyOf()
+corrupted[0] = corrupted[0] xor 0xFF
+corrupted[2] = corrupted[2] xor 0xAA
+
+val recovered = decode(corrupted, nCheck)
+// recovered deep-equals message
+```
+
+## API
+
+| Function | Description |
+|----------|-------------|
+| `buildGenerator(nCheck)` | Build the RS generator polynomial `g(x)` |
+| `encode(message, nCheck)` | Systematic encoding — appends `nCheck` parity bytes |
+| `decode(received, nCheck)` | Decode and correct up to `t = nCheck/2` errors |
+| `syndromes(received, nCheck)` | Compute the `nCheck` syndrome values |
+| `errorLocator(synds)` | Run Berlekamp-Massey to find the error locator polynomial |
+
+### Exceptions
+
+| Class | When thrown |
+|-------|-------------|
+| `InvalidInputException` | Bad parameters (nCheck=0/odd, length>255, etc.) |
+| `TooManyErrorsException` | More than `t` errors — codeword is unrecoverable |
+
+## Decoding pipeline
+
+```
+received
+  ↓ Step 1: syndromes — all zero? return message unchanged
+  ↓ Step 2: Berlekamp-Massey → error locator polynomial Λ(x)
+  ↓ Step 3: Chien search → error positions {p₁…pᵥ}
+  ↓ Step 4: Forney algorithm → error magnitudes {e₁…eᵥ}
+  ↓ Step 5: Apply corrections: codeword[pₖ] ^= eₖ
+  ↓ Return first k bytes
+```
+
+## Dependencies
+
+- `gf256` — GF(2^8) field operations
+- `polynomial` — GF(256) polynomial arithmetic
+
+Both are resolved as local Gradle composite builds.
+
+## Build
+
+```
+gradle test
+```
+
+## Spec
+
+`code/specs/MA02-reed-solomon.md`

--- a/code/packages/kotlin/reed-solomon/build.gradle.kts
+++ b/code/packages/kotlin/reed-solomon/build.gradle.kts
@@ -1,0 +1,40 @@
+// Gradle's default output directory is "build/", which conflicts with our BUILD file
+// on case-insensitive filesystems (macOS, Windows). Redirect to "gradle-build/" instead.
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    // Local composite builds — resolved via includeBuild() in settings.gradle.kts.
+    api("com.codingadventures:gf256")
+    api("com.codingadventures:polynomial")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/reed-solomon/settings.gradle.kts
+++ b/code/packages/kotlin/reed-solomon/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "reed-solomon"
+
+// Include both local builds for composite dependency resolution.
+// gf256 must be listed even though polynomial already includes it —
+// Gradle composite builds do not transitively expose sub-includes.
+includeBuild("../gf256")
+includeBuild("../polynomial")

--- a/code/packages/kotlin/reed-solomon/src/main/kotlin/com/codingadventures/reedsolomon/ReedSolomon.kt
+++ b/code/packages/kotlin/reed-solomon/src/main/kotlin/com/codingadventures/reedsolomon/ReedSolomon.kt
@@ -1,0 +1,568 @@
+/**
+ * Reed-Solomon error-correcting codes over GF(256).
+ *
+ * Reed-Solomon (RS) is a block error-correcting code. You add `nCheck`
+ * redundancy bytes to a message, and the decoder can recover the original
+ * message even if up to `t = nCheck / 2` bytes are corrupted anywhere in
+ * the codeword.
+ *
+ * ## Where RS is used
+ *
+ * | System           | How RS helps                                        |
+ * |------------------|-----------------------------------------------------|
+ * | QR codes         | Up to 30% of a QR symbol can be destroyed/scratched |
+ * | CDs / DVDs       | CIRC two-level RS corrects scratches and defects    |
+ * | Hard drives      | Firmware sector-level error correction              |
+ * | Voyager probes   | Transmit images across 20+ billion km               |
+ * | RAID-6           | Two parity drives are exactly an (n, n-2) RS code   |
+ *
+ * ## Building blocks
+ *
+ * ```
+ * MA01  gf256        — GF(2^8) field: add=XOR, mul=table lookup
+ * MA00  polynomial   — GF(256) polynomial arithmetic (convolution, divmod, eval)
+ * MA02  reed-solomon ← THIS PACKAGE
+ * ```
+ *
+ * ## Polynomial conventions
+ *
+ * Codeword bytes are interpreted as a **big-endian** polynomial:
+ *
+ *   codeword[0]·x^{n-1} + codeword[1]·x^{n-2} + … + codeword[n-1]
+ *
+ * Systematic codeword layout:
+ *
+ *   [ message[0] … message[k-1] | check[0] … check[nCheck-1] ]
+ *     degree n-1 … degree nCheck    degree nCheck-1 … degree 0
+ *
+ * The generator polynomial roots use the `b=1` convention: α^1, α^2, …, α^nCheck,
+ * where α = 2 is the primitive element of GF(256).
+ *
+ * Spec: MA02-reed-solomon.md
+ */
+package com.codingadventures.reedsolomon
+
+import com.codingadventures.gf256.GF256
+
+/** Version of this package. */
+const val VERSION = "0.1.0"
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/**
+ * Thrown when a received codeword has more errors than the correction capacity
+ * `t = nCheck / 2`.
+ *
+ * The codeword is unrecoverable. The caller should request a retransmission or
+ * report a permanent error.
+ */
+class TooManyErrorsException(message: String = "reed-solomon: too many errors — codeword is unrecoverable") :
+    Exception(message)
+
+/**
+ * Thrown when encode or decode receive invalid parameters.
+ *
+ * Common causes:
+ * - nCheck is 0 or odd
+ * - Total codeword length exceeds 255 (GF(256) block size limit)
+ * - Received codeword is shorter than nCheck
+ */
+class InvalidInputException(message: String) :
+    Exception("reed-solomon: invalid input — $message")
+
+// =============================================================================
+// Generator Polynomial
+// =============================================================================
+
+/**
+ * Build the RS generator polynomial for [nCheck] check bytes.
+ *
+ * The generator is the product of `nCheck` linear factors:
+ *
+ *   g(x) = (x + α^1)(x + α^2)…(x + α^{nCheck})
+ *
+ * where α = 2 is the primitive element of GF(256).
+ *
+ * ## Algorithm
+ *
+ * Start with `g = [1]` (little-endian: constant 1).
+ * At each step i from 1 to nCheck, multiply by `(x + α^i)`:
+ *
+ *   new_g[j] = GF256.mul(α^i, g[j]) XOR g[j-1]
+ *
+ * The resulting polynomial has nCheck+1 coefficients, with leading coefficient 1 (monic).
+ *
+ * ## Example: nCheck = 2
+ *
+ * ```
+ * Start: g = [1]
+ * i=1:   g = [mul(1, alpha^1)=2, 1] = [2, 1]        → (x + 2)
+ * i=2:   new_g[0] = mul(4, 2) = 8
+ *        new_g[1] = mul(4, 1) XOR 2 = 4 XOR 2 = 6
+ *        new_g[2] = 1
+ *        g = [8, 6, 1]
+ * ```
+ *
+ * Verify root α^1=2: g(2) = 8 XOR mul(6,2) XOR mul(1,4) = 8 XOR 12 XOR 4 = 0 ✓
+ * Verify root α^2=4: g(4) = 8 XOR mul(6,4) XOR mul(1,16) = 8 XOR 24 XOR 16 = 0 ✓
+ *
+ * @throws InvalidInputException if nCheck is 0 or odd
+ */
+fun buildGenerator(nCheck: Int): IntArray {
+    if (nCheck == 0 || nCheck % 2 != 0) {
+        throw InvalidInputException("nCheck must be a positive even number, got $nCheck")
+    }
+
+    var g = IntArray(1) { 1 }  // start: [1]
+
+    for (i in 1..nCheck) {
+        val alphaI = GF256.pow(2, i)
+        val newG = IntArray(g.size + 1)
+        for (j in g.indices) {
+            newG[j] = GF256.add(newG[j], GF256.mul(g[j], alphaI))
+            newG[j + 1] = GF256.add(newG[j + 1], g[j])
+        }
+        g = newG
+    }
+
+    return g  // little-endian, length nCheck+1, monic (last coeff = 1)
+}
+
+// =============================================================================
+// Internal Polynomial Helpers
+// =============================================================================
+
+/**
+ * Evaluate a **big-endian** GF(256) polynomial at [x] using Horner's method.
+ *
+ * `p[0]` is the coefficient of the highest-degree term.
+ * Horner left-to-right: `acc = acc·x XOR b` for each byte b in p.
+ *
+ * Used for syndrome computation: `S_j = polyEvalBE(codeword, α^j)`.
+ */
+private fun polyEvalBE(p: IntArray, x: Int): Int {
+    var acc = 0
+    for (b in p) {
+        acc = GF256.add(GF256.mul(acc, x), b)
+    }
+    return acc
+}
+
+/**
+ * Evaluate a **little-endian** GF(256) polynomial at [x] using Horner's method.
+ *
+ * `p[i]` is the coefficient of `x^i`. Iterate from high degree downto 0.
+ *
+ * Used for Chien search (evaluating the error-locator polynomial) and Forney
+ * (evaluating the error-evaluator polynomial).
+ */
+private fun polyEvalLE(p: IntArray, x: Int): Int {
+    var acc = 0
+    for (i in p.size - 1 downTo 0) {
+        acc = GF256.add(GF256.mul(acc, x), p[i])
+    }
+    return acc
+}
+
+/**
+ * Multiply two **little-endian** GF(256) polynomials.
+ *
+ * `result[i+j] ^= a[i] · b[j]`
+ */
+private fun polyMulLE(a: IntArray, b: IntArray): IntArray {
+    if (a.isEmpty() || b.isEmpty()) return IntArray(0)
+    val result = IntArray(a.size + b.size - 1)
+    for (i in a.indices) {
+        for (j in b.indices) {
+            result[i + j] = GF256.add(result[i + j], GF256.mul(a[i], b[j]))
+        }
+    }
+    return result
+}
+
+/**
+ * Compute the remainder of **big-endian** polynomial division in GF(256).
+ *
+ * Both [dividend] and [divisor] are big-endian (first byte = highest degree).
+ * The divisor must be **monic** (leading coefficient = 1).
+ *
+ * ## Algorithm
+ *
+ * At each step, eliminate the current leading term by XOR-ing a scaled copy
+ * of the divisor:
+ *
+ * ```
+ * for i in 0..(dividend.length - divisor.length):
+ *   coeff = dividend[i]          (since divisor is monic: coeff = dividend[i] / 1)
+ *   for j in 0..divisor.length:
+ *     dividend[i+j] ^= mul(coeff, divisor[j])
+ * ```
+ *
+ * The last `(divisor.length - 1)` bytes are the remainder.
+ *
+ * Used in RS encoding to compute `M(x)·x^{nCheck} mod g(x)`.
+ */
+private fun polyModBE(dividend: IntArray, divisor: IntArray): IntArray {
+    val rem = dividend.copyOf()
+    val divLen = divisor.size
+
+    if (rem.size < divLen) return rem
+
+    val steps = rem.size - divLen + 1
+    for (i in 0 until steps) {
+        val coeff = rem[i]
+        if (coeff == 0) continue
+        for (j in 0 until divLen) {
+            rem[i + j] = GF256.add(rem[i + j], GF256.mul(coeff, divisor[j]))
+        }
+    }
+
+    return rem.copyOfRange(rem.size - (divLen - 1), rem.size)
+}
+
+/**
+ * Compute the inverse locator `X_p⁻¹` for byte position [p] in a codeword
+ * of length [n].
+ *
+ * In big-endian convention, position `p` has degree `n-1-p`.
+ * The locator is `X_p = α^{n-1-p}`, so `X_p⁻¹ = α^{(p + 256 - n) mod 255}`.
+ *
+ * Special cases:
+ * - `p = n-1` (last byte): `X_p⁻¹ = α^{255 mod 255} = α^0 = 1`
+ * - `p = 0` (first byte): `X_p⁻¹ = α^{(256 - n) mod 255}`
+ *
+ * Internally used by Chien search and Forney algorithm.
+ */
+private fun invLocator(p: Int, n: Int): Int {
+    val exp = (p + 256 - n) % 255
+    return GF256.pow(2, exp)
+}
+
+// =============================================================================
+// Encoding
+// =============================================================================
+
+/**
+ * Encode a message with Reed-Solomon, producing a systematic codeword.
+ *
+ * **Systematic** means the original message bytes are unchanged in the output:
+ *
+ * ```
+ * output = [ message bytes | check bytes ]
+ *            message[0..k-1]  check[0..nCheck-1]
+ * ```
+ *
+ * ## Algorithm
+ *
+ * 1. Build generator `g` (little-endian), then reverse to big-endian `gBE`.
+ * 2. Append `nCheck` zero bytes: `shifted = message || 000…0`
+ *    (this represents `M(x)·x^{nCheck}` in big-endian).
+ * 3. Compute remainder `R = shifted mod gBE`.
+ * 4. Output `message || R` (padded to exactly `nCheck` bytes).
+ *
+ * ## Why it works
+ *
+ * `C(x) = M(x)·x^{nCheck} + R(x) = Q(x)·g(x)` (by the division algorithm).
+ * Therefore `C(α^i) = Q(α^i)·g(α^i) = 0` for i = 1…nCheck,
+ * which is the defining property of a valid RS codeword.
+ *
+ * @param message  raw data bytes as IntArray (values 0..255)
+ * @param nCheck   number of check bytes to add (must be even ≥ 2)
+ * @return systematic codeword of length `message.size + nCheck`
+ * @throws InvalidInputException if nCheck is invalid or total length > 255
+ */
+fun encode(message: IntArray, nCheck: Int): IntArray {
+    if (nCheck == 0 || nCheck % 2 != 0) {
+        throw InvalidInputException("nCheck must be a positive even number, got $nCheck")
+    }
+    val n = message.size + nCheck
+    if (n > 255) {
+        throw InvalidInputException(
+            "total codeword length $n exceeds GF(256) block size limit of 255"
+        )
+    }
+
+    val gLE = buildGenerator(nCheck)
+    // Reverse to big-endian for division: gLE[last]=1 becomes gBE[0]=1 (monic head).
+    val gBE = gLE.reversedArray()
+
+    // shifted = message || zeros  (big-endian representation of M(x)·x^{nCheck})
+    val shifted = IntArray(n)
+    for (i in message.indices) shifted[i] = message[i]
+    // trailing nCheck slots remain 0
+
+    val remainder = polyModBE(shifted, gBE)
+
+    // Codeword = message || check bytes (padded to exactly nCheck bytes if remainder is shorter)
+    val codeword = IntArray(n)
+    for (i in message.indices) codeword[i] = message[i]
+    val pad = nCheck - remainder.size
+    for (i in remainder.indices) codeword[message.size + pad + i] = remainder[i]
+
+    return codeword
+}
+
+// =============================================================================
+// Decoding
+// =============================================================================
+
+/**
+ * Compute the [nCheck] syndrome values of a received codeword.
+ *
+ * `S_j = received(α^j)` for `j = 1, …, nCheck`.
+ *
+ * If all syndromes are zero, the codeword has no errors. Any non-zero syndrome
+ * reveals corruption.
+ *
+ * The codeword is evaluated as a **big-endian** polynomial. An error at position
+ * `p` contributes `e · (α^j)^{n-1-p} = e · X_p^j` where `X_p = α^{n-1-p}`.
+ *
+ * @param received  received codeword bytes (possibly corrupted)
+ * @param nCheck    number of check bytes in the codeword
+ * @return IntArray of nCheck syndrome values
+ */
+fun syndromes(received: IntArray, nCheck: Int): IntArray {
+    return IntArray(nCheck) { i -> polyEvalBE(received, GF256.pow(2, i + 1)) }
+}
+
+/**
+ * Berlekamp-Massey algorithm: find the shortest LFSR generating the syndrome
+ * sequence.
+ *
+ * Returns `(Λ, L)` where Λ is the **error locator polynomial** (little-endian,
+ * Λ[0] = 1) and L is the number of errors.
+ *
+ * The LFSR connection polynomial satisfies:
+ *
+ *   Λ(x) = ∏_{k=1}^{v} (1 - X_k · x)
+ *
+ * where X_k are the error locator numbers.  The roots of Λ are X_k⁻¹, found
+ * by Chien search.
+ *
+ * ## Algorithm
+ *
+ * ```
+ * C = [1], B = [1], L = 0, xShift = 1, b = 1
+ *
+ * for n = 0 to 2t-1:
+ *   d = S[n] XOR ∑_{j=1}^{L} C[j]·S[n-j]   ← discrepancy
+ *
+ *   if d == 0:
+ *     xShift++
+ *   elif 2L ≤ n:
+ *     T = C.clone()
+ *     C = C XOR (d/b)·x^{xShift}·B
+ *     L = n+1-L;  B = T;  b = d;  xShift = 1
+ *   else:
+ *     C = C XOR (d/b)·x^{xShift}·B
+ *     xShift++
+ * ```
+ */
+private fun berlekampMassey(synds: IntArray): Pair<IntArray, Int> {
+    val twoT = synds.size
+
+    var c = IntArray(1) { 1 }   // connection polynomial Λ(x), LE, starts as [1]
+    var b = IntArray(1) { 1 }   // previous connection polynomial
+    var bigL = 0
+    var xShift = 1
+    var bScale = 1
+
+    for (n in 0 until twoT) {
+        // Compute discrepancy: d = S[n] XOR ∑_{j=1}^{L} C[j]·S[n-j]
+        var d = synds[n]
+        for (j in 1..bigL) {
+            if (j < c.size && n >= j) {
+                d = GF256.add(d, GF256.mul(c[j], synds[n - j]))
+            }
+        }
+
+        if (d == 0) {
+            xShift++
+        } else if (2 * bigL <= n) {
+            val tSave = c.copyOf()
+            val scale = GF256.div(d, bScale)
+            val shiftedLen = xShift + b.size
+            if (c.size < shiftedLen) {
+                val cNew = IntArray(shiftedLen)
+                c.copyInto(cNew)
+                c = cNew
+            }
+            for (k in b.indices) {
+                c[xShift + k] = GF256.add(c[xShift + k], GF256.mul(scale, b[k]))
+            }
+            bigL = n + 1 - bigL
+            b = tSave
+            bScale = d
+            xShift = 1
+        } else {
+            val scale = GF256.div(d, bScale)
+            val shiftedLen = xShift + b.size
+            if (c.size < shiftedLen) {
+                val cNew = IntArray(shiftedLen)
+                c.copyInto(cNew)
+                c = cNew
+            }
+            for (k in b.indices) {
+                c[xShift + k] = GF256.add(c[xShift + k], GF256.mul(scale, b[k]))
+            }
+            xShift++
+        }
+    }
+
+    return Pair(c, bigL)
+}
+
+/**
+ * Chien Search: find which byte positions are error locations.
+ *
+ * Position `p` is an error location if `Λ(X_p⁻¹) = 0`, where
+ * `X_p⁻¹ = α^{(p+256-n) mod 255}` for a codeword of length `n`.
+ *
+ * Named after Robert Chien who described this exhaustive search in 1964.
+ *
+ * @return sorted list of error positions (0-indexed, big-endian)
+ */
+private fun chienSearch(lambda: IntArray, n: Int): List<Int> {
+    val positions = mutableListOf<Int>()
+    for (p in 0 until n) {
+        val xiInv = invLocator(p, n)
+        if (polyEvalLE(lambda, xiInv) == 0) {
+            positions.add(p)
+        }
+    }
+    return positions
+}
+
+/**
+ * Forney Algorithm: compute error magnitudes from positions.
+ *
+ * For each error at position `p`:
+ *
+ *   e_p = Ω(X_p⁻¹) / Λ'(X_p⁻¹)
+ *
+ * where:
+ * - Ω(x) = (S(x) · Λ(x)) mod x^{2t}  — error evaluator polynomial
+ * - S(x) = S₁ + S₂x + … + S_{2t}x^{2t-1}  — syndrome polynomial (LE)
+ * - Λ'(x) — formal derivative of Λ in GF(2^8)
+ *
+ * ## Formal derivative in characteristic 2
+ *
+ * Only odd-indexed coefficients survive (even terms vanish because 2 = 0):
+ *
+ *   Λ'(x) = Λ₁ + Λ₃x² + Λ₅x⁴ + …
+ *
+ * @throws TooManyErrorsException if the denominator evaluates to zero
+ */
+private fun forney(
+    lambda: IntArray,
+    synds: IntArray,
+    positions: List<Int>,
+    n: Int
+): List<Int> {
+    val twoT = synds.size
+
+    // Ω = S(x) · Λ(x) mod x^{2t}: truncate to first 2t terms
+    val omegaFull = polyMulLE(synds, lambda)
+    val omega = omegaFull.copyOf(minOf(twoT, omegaFull.size))
+
+    // Formal derivative Λ'(x): only odd-indexed Λ terms contribute
+    // Λ'[k] = Λ[k+1] if (k+1) is odd (i.e., k is even), else 0
+    val lambdaPrimeSize = maxOf(0, lambda.size - 1)
+    val lambdaPrime = IntArray(lambdaPrimeSize)
+    for (j in 1 until lambda.size) {
+        if (j % 2 == 1) {
+            lambdaPrime[j - 1] = GF256.add(lambdaPrime[j - 1], lambda[j])
+        }
+    }
+
+    return positions.map { pos ->
+        val xiInv = invLocator(pos, n)
+        val omegaVal = polyEvalLE(omega, xiInv)
+        val lpVal = polyEvalLE(lambdaPrime, xiInv)
+        if (lpVal == 0) throw TooManyErrorsException()
+        GF256.div(omegaVal, lpVal)
+    }
+}
+
+/**
+ * Decode a received Reed-Solomon codeword, correcting up to `t = nCheck/2` errors.
+ *
+ * ## Pipeline
+ *
+ * ```
+ * received
+ *   │
+ *   ▼ Step 1: Compute syndromes S₁…S_{nCheck}
+ *   │         All zero? → no errors, return message directly
+ *   │
+ *   ▼ Step 2: Berlekamp-Massey → Λ(x), error count L
+ *   │         L > t? → TooManyErrorsException
+ *   │
+ *   ▼ Step 3: Chien search → error positions {p₁…pᵥ}
+ *   │         |positions| ≠ L? → TooManyErrorsException
+ *   │
+ *   ▼ Step 4: Forney → error magnitudes {e₁…eᵥ}
+ *   │
+ *   ▼ Step 5: Correct: received[pₖ] XOR= eₖ
+ *   │
+ *   ▼ Return first k = received.size - nCheck bytes
+ * ```
+ *
+ * @param received  received codeword bytes (possibly corrupted)
+ * @param nCheck    number of check bytes (must be even ≥ 2)
+ * @return recovered message bytes (length = received.size - nCheck)
+ * @throws InvalidInputException   if nCheck is invalid or received is too short
+ * @throws TooManyErrorsException  if more than t errors are present
+ */
+fun decode(received: IntArray, nCheck: Int): IntArray {
+    if (nCheck == 0 || nCheck % 2 != 0) {
+        throw InvalidInputException("nCheck must be a positive even number, got $nCheck")
+    }
+    if (received.size < nCheck) {
+        throw InvalidInputException("received length ${received.size} < nCheck $nCheck")
+    }
+
+    val t = nCheck / 2
+    val n = received.size
+    val k = n - nCheck
+
+    // Step 1: Syndromes
+    val synds = syndromes(received, nCheck)
+    if (synds.all { it == 0 }) {
+        return received.copyOf(k)  // no errors
+    }
+
+    // Step 2: Berlekamp-Massey
+    val (lambda, numErrors) = berlekampMassey(synds)
+    if (numErrors > t) throw TooManyErrorsException()
+
+    // Step 3: Chien Search
+    val positions = chienSearch(lambda, n)
+    if (positions.size != numErrors) throw TooManyErrorsException()
+
+    // Step 4: Forney
+    val magnitudes = forney(lambda, synds, positions, n)
+
+    // Step 5: Apply corrections (XOR the error magnitude into each error position)
+    val corrected = received.copyOf()
+    for (i in positions.indices) {
+        corrected[positions[i]] = GF256.add(corrected[positions[i]], magnitudes[i])
+    }
+
+    return corrected.copyOf(k)
+}
+
+/**
+ * Compute the error locator polynomial from a syndrome array.
+ *
+ * Exposed for advanced use (QR decoders, diagnostics).
+ * Returns Λ(x) in **little-endian** form with Λ[0] = 1.
+ *
+ * @param synds syndrome array (length = nCheck)
+ */
+fun errorLocator(synds: IntArray): IntArray {
+    val (lambda, _) = berlekampMassey(synds)
+    return lambda
+}

--- a/code/packages/kotlin/reed-solomon/src/test/kotlin/com/codingadventures/reedsolomon/ReedSolomonTest.kt
+++ b/code/packages/kotlin/reed-solomon/src/test/kotlin/com/codingadventures/reedsolomon/ReedSolomonTest.kt
@@ -1,0 +1,393 @@
+package com.codingadventures.reedsolomon
+
+import com.codingadventures.gf256.GF256
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for Reed-Solomon encode/decode over GF(256) with primitive polynomial 0x11D.
+ *
+ * Test vectors cross-checked against the TypeScript reference implementation
+ * and the MA02 specification.
+ */
+class ReedSolomonTest {
+
+    // =========================================================================
+    // buildGenerator
+    // =========================================================================
+
+    @Test
+    fun `buildGenerator nCheck 0 throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { buildGenerator(0) }
+    }
+
+    @Test
+    fun `buildGenerator odd nCheck throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { buildGenerator(3) }
+        assertThrows<InvalidInputException> { buildGenerator(5) }
+    }
+
+    @Test
+    fun `buildGenerator nCheck 2 produces degree-2 monic polynomial`() {
+        val g = buildGenerator(2)
+        // Should have length nCheck+1 = 3
+        assertEquals(3, g.size)
+        // Monic: leading coefficient (last in LE) = 1
+        assertEquals(1, g.last())
+    }
+
+    @Test
+    fun `buildGenerator nCheck 2 known value`() {
+        // g = (x + alpha^1)(x + alpha^2) = (x+2)(x+4) = [8, 6, 1] LE
+        val g = buildGenerator(2)
+        assertContentEquals(intArrayOf(8, 6, 1), g)
+    }
+
+    @Test
+    fun `buildGenerator nCheck 4 has degree 4 and is monic`() {
+        val g = buildGenerator(4)
+        assertEquals(5, g.size)
+        assertEquals(1, g.last())
+    }
+
+    @Test
+    fun `buildGenerator roots are alpha powers 1 through nCheck`() {
+        // For nCheck=4, the roots of g are alpha^1, alpha^2, alpha^3, alpha^4
+        val nCheck = 4
+        val g = buildGenerator(nCheck)
+        // Evaluate g at each expected root; should get 0
+        for (i in 1..nCheck) {
+            val alphaI = GF256.pow(2, i)
+            // Evaluate big-endian (reverse g for BE evaluation)
+            val gBE = g.reversedArray()
+            var acc = 0
+            for (b in gBE) {
+                acc = GF256.add(GF256.mul(acc, alphaI), b)
+            }
+            assertEquals(0, acc, "g(alpha^$i) should be 0 for nCheck=$nCheck")
+        }
+    }
+
+    // =========================================================================
+    // syndromes
+    // =========================================================================
+
+    @Test
+    fun `syndromes of valid codeword are all zero`() {
+        val msg = intArrayOf(72, 101, 108, 108, 111)  // "Hello"
+        val nCheck = 8
+        val codeword = encode(msg, nCheck)
+        val synds = syndromes(codeword, nCheck)
+        assertTrue(synds.all { it == 0 }, "All syndromes of a valid codeword should be 0")
+    }
+
+    @Test
+    fun `syndromes of corrupted codeword are non-zero`() {
+        val msg = intArrayOf(1, 2, 3, 4)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[0] = corrupted[0] xor 0xFF  // flip all bits in first byte
+        val synds = syndromes(corrupted, nCheck)
+        assertTrue(synds.any { it != 0 }, "At least one syndrome should be non-zero after corruption")
+    }
+
+    // =========================================================================
+    // encode
+    // =========================================================================
+
+    @Test
+    fun `encode nCheck 0 throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { encode(intArrayOf(1, 2, 3), 0) }
+    }
+
+    @Test
+    fun `encode odd nCheck throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { encode(intArrayOf(1, 2, 3), 3) }
+    }
+
+    @Test
+    fun `encode total length over 255 throws InvalidInputException`() {
+        val bigMsg = IntArray(250) { it }
+        assertThrows<InvalidInputException> { encode(bigMsg, 10) }
+    }
+
+    @Test
+    fun `encode is systematic - message bytes unchanged in codeword prefix`() {
+        val msg = intArrayOf(72, 101, 108, 108, 111)  // "Hello"
+        val nCheck = 8
+        val codeword = encode(msg, nCheck)
+        assertEquals(msg.size + nCheck, codeword.size)
+        // First msg.size bytes should be the original message
+        for (i in msg.indices) {
+            assertEquals(msg[i], codeword[i], "codeword[$i] should equal message[$i]")
+        }
+    }
+
+    @Test
+    fun `encode produces codeword with zero syndromes`() {
+        val msg = intArrayOf(1, 2, 3, 4, 5)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val synds = syndromes(codeword, nCheck)
+        assertTrue(synds.all { it == 0 })
+    }
+
+    @Test
+    fun `encode nCheck 2 known parity bytes`() {
+        // Short message [4, 8] with nCheck=2: manually verify via polyModBE
+        // g = [8, 6, 1], gBE = [1, 6, 8]
+        // shifted = [4, 8, 0, 0], then compute shifted mod gBE
+        val msg = intArrayOf(4, 8)
+        val nCheck = 2
+        val codeword = encode(msg, nCheck)
+        assertEquals(4, codeword.size)
+        // Verify the codeword is valid (zero syndromes)
+        val synds = syndromes(codeword, nCheck)
+        assertTrue(synds.all { it == 0 })
+    }
+
+    @Test
+    fun `encode single byte message`() {
+        val msg = intArrayOf(42)
+        val nCheck = 2
+        val codeword = encode(msg, nCheck)
+        assertEquals(3, codeword.size)
+        assertEquals(42, codeword[0])
+        assertTrue(syndromes(codeword, nCheck).all { it == 0 })
+    }
+
+    @Test
+    fun `encode empty message`() {
+        val msg = intArrayOf()
+        val nCheck = 2
+        val codeword = encode(msg, nCheck)
+        // All-zero message → all-zero codeword (including parity)
+        assertEquals(nCheck, codeword.size)
+        assertTrue(syndromes(codeword, nCheck).all { it == 0 })
+    }
+
+    // =========================================================================
+    // decode — no errors
+    // =========================================================================
+
+    @Test
+    fun `decode with no errors recovers original message`() {
+        val msg = intArrayOf(72, 101, 108, 108, 111)
+        val nCheck = 8
+        val codeword = encode(msg, nCheck)
+        val recovered = decode(codeword, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `decode nCheck 0 throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { decode(intArrayOf(1, 2, 3), 0) }
+    }
+
+    @Test
+    fun `decode odd nCheck throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { decode(intArrayOf(1, 2, 3, 4), 3) }
+    }
+
+    @Test
+    fun `decode received shorter than nCheck throws InvalidInputException`() {
+        assertThrows<InvalidInputException> { decode(intArrayOf(1, 2), 4) }
+    }
+
+    // =========================================================================
+    // decode — single error
+    // =========================================================================
+
+    @Test
+    fun `decode corrects single error in message area`() {
+        val msg = intArrayOf(1, 2, 3, 4, 5)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[2] = corrupted[2] xor 0x55  // corrupt byte at position 2
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `decode corrects single error in check area`() {
+        val msg = intArrayOf(10, 20, 30)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[msg.size + 1] = corrupted[msg.size + 1] xor 0xAA  // corrupt a parity byte
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `decode corrects single error at position 0`() {
+        val msg = intArrayOf(0xDE, 0xAD, 0xBE, 0xEF)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[0] = corrupted[0] xor 0xFF
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `decode corrects single error at last position`() {
+        val msg = intArrayOf(10, 20, 30, 40)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[codeword.size - 1] = corrupted[codeword.size - 1] xor 0x7F
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    // =========================================================================
+    // decode — two errors (nCheck=4 supports t=2)
+    // =========================================================================
+
+    @Test
+    fun `decode corrects two errors with nCheck 4`() {
+        val msg = intArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[0] = corrupted[0] xor 0xFF
+        corrupted[3] = corrupted[3] xor 0xAA
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `decode corrects two errors at any positions`() {
+        val msg = IntArray(10) { it + 1 }
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[1] = corrupted[1] xor 0x5A
+        corrupted[codeword.size - 2] = corrupted[codeword.size - 2] xor 0xA5
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    // =========================================================================
+    // decode — four errors (nCheck=8 supports t=4)
+    // =========================================================================
+
+    @Test
+    fun `decode corrects four errors with nCheck 8`() {
+        val msg = intArrayOf(72, 101, 108, 108, 111)  // "Hello"
+        val nCheck = 8
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        // Corrupt exactly t=4 bytes
+        corrupted[0] = corrupted[0] xor 0xFF
+        corrupted[2] = corrupted[2] xor 0xAA
+        corrupted[4] = corrupted[4] xor 0x55
+        corrupted[6] = corrupted[6] xor 0x11
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    // =========================================================================
+    // decode — too many errors
+    // =========================================================================
+
+    @Test
+    fun `decode throws TooManyErrorsException when more than t errors`() {
+        val msg = intArrayOf(1, 2, 3, 4, 5)
+        val nCheck = 4  // t = 2
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        // Corrupt 3 bytes (t+1 = 3 > t = 2)
+        corrupted[0] = corrupted[0] xor 0xFF
+        corrupted[1] = corrupted[1] xor 0xAA
+        corrupted[2] = corrupted[2] xor 0x55
+        assertThrows<TooManyErrorsException> { decode(corrupted, nCheck) }
+    }
+
+    // =========================================================================
+    // errorLocator
+    // =========================================================================
+
+    @Test
+    fun `errorLocator returns polynomial with leading term 1`() {
+        val msg = intArrayOf(1, 2, 3, 4)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[0] = corrupted[0] xor 0x12
+        val synds = syndromes(corrupted, nCheck)
+        val lambda = errorLocator(synds)
+        assertEquals(1, lambda[0], "Λ[0] should always be 1")
+    }
+
+    @Test
+    fun `errorLocator for no errors is the unit polynomial`() {
+        val msg = intArrayOf(1, 2, 3, 4)
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val synds = syndromes(codeword, nCheck)
+        val lambda = errorLocator(synds)
+        assertContentEquals(intArrayOf(1), lambda)
+    }
+
+    // =========================================================================
+    // Round-trip tests (various parameters)
+    // =========================================================================
+
+    @Test
+    fun `round trip nCheck 2 no errors`() {
+        val msg = IntArray(20) { it + 1 }
+        val codeword = encode(msg, 2)
+        val recovered = decode(codeword, 2)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `round trip nCheck 8 with 4 scattered errors`() {
+        val msg = IntArray(30) { 255 - it }
+        val nCheck = 8
+        val codeword = encode(msg, nCheck)
+        val corrupted = codeword.copyOf()
+        corrupted[5]  = corrupted[5]  xor 0x01
+        corrupted[15] = corrupted[15] xor 0x80
+        corrupted[25] = corrupted[25] xor 0xFF
+        corrupted[29] = corrupted[29] xor 0x42
+        val recovered = decode(corrupted, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `round trip all-zeros message`() {
+        val msg = IntArray(5) { 0 }
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val recovered = decode(codeword, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `round trip all-255 message`() {
+        val msg = IntArray(10) { 255 }
+        val nCheck = 4
+        val codeword = encode(msg, nCheck)
+        val recovered = decode(codeword, nCheck)
+        assertContentEquals(msg, recovered)
+    }
+
+    @Test
+    fun `round trip single byte with nCheck 2`() {
+        for (b in 0..255) {
+            val msg = intArrayOf(b)
+            val codeword = encode(msg, 2)
+            val recovered = decode(codeword, 2)
+            assertContentEquals(msg, recovered, "Failed for byte $b")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **gf256** - GF(2^8) arithmetic over the Reed-Solomon primitive polynomial 0x11D. Implements add, sub, mul, div, pow, inv using precomputed EXP/LOG tables. 37 tests.
- **polynomial** - Polynomial arithmetic over GF(256). Implements normalize, degree, add, sub, mul, divmod, eval (Horner), gcd. 41 tests.
- **reed-solomon** - Systematic RS encoding and decoding. Full Berlekamp-Massey/Chien/Forney pipeline. Corrects up to t = nCheck/2 errors. 35 tests.

## Test plan

- [ ] CI passes for all three Kotlin packages (gradle test in each)
- [ ] gf256: 37 tests pass including field axioms and spot check 0x53 times 0x8C = 1
- [ ] polynomial: 41 tests pass including RS generator roots verification
- [ ] reed-solomon: 35 tests pass including 0/1/2/4 error correction and all-256 single-byte round-trips

## Notes

- All packages use layout.buildDirectory = file("gradle-build") to avoid BUILD/build collision on case-insensitive filesystems
- polynomial and reed-solomon declare gf256 as local Gradle composite builds via includeBuild (same pattern as directed-graph to graph)
- polynomial and reed-solomon BUILD scripts share a kotlin-foundation.lock mutex to prevent CI race conditions
- Security review passed: pure mathematical computation, no I/O, no unsafe operations

Generated with Claude Code