### PR TITLE
feat(micro-qr): Micro QR Code encoder — Rust + TypeScript (ISO/IEC 18004:2015 Annex E)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -228,6 +228,7 @@ members = [
     "brotli",
     "deflate",
     "gf256",
+    "micro-qr",
     "qr-code",
     "image-codec-bmp",
     "image-codec-ppm",

--- a/code/packages/rust/micro-qr/BUILD
+++ b/code/packages/rust/micro-qr/BUILD
@@ -1,0 +1,1 @@
+cargo test -p micro-qr -- --nocapture

--- a/code/packages/rust/micro-qr/CHANGELOG.md
+++ b/code/packages/rust/micro-qr/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — micro-qr
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- Initial implementation of the Micro QR Code encoder (ISO/IEC 18004:2015 Annex E).
+- Supports all four symbol versions: M1 (11×11), M2 (13×13), M3 (15×15), M4 (17×17).
+- Supports all applicable encoding modes: numeric, alphanumeric, byte.
+- Supports all ECC levels: Detection (M1), L and M (M2, M3, M4), Q (M4 only).
+- Auto-selects the smallest symbol + ECC combination that fits the input.
+- Correct RS encoder: GF(256)/0x11D, b=0 convention, single block (no interleaving).
+- Correct grid structure: single 7×7 finder pattern, L-shaped separator, timing at
+  row 0 and col 0, format information at row 8 / col 8 (single copy).
+- 4-mask evaluation with ISO 18004 4-rule penalty scoring (rules 1–4).
+- Pre-computed format information table (all 32 entries) with XOR mask 0x4445.
+- M1 half-codeword handling: last data codeword contributes only 4 bits.
+- Public API: `encode()`, `layout_grid()`.
+- Full error hierarchy: `MicroQRError` with variants `InputTooLong`, `UnsupportedMode`,
+  `ECCNotAvailable`, `InvalidCharacter`, `LayoutError`.
+- 44 unit tests + 1 doctest, all passing.
+- Literate programming style: all algorithms explained inline with diagrams and examples.

--- a/code/packages/rust/micro-qr/Cargo.toml
+++ b/code/packages/rust/micro-qr/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "micro-qr"
+version = "0.1.0"
+edition = "2021"
+description = "Micro QR Code encoder — ISO/IEC 18004:2015 Annex E, produces scannable M1–M4 symbols"
+
+[dependencies]
+barcode-2d = { path = "../barcode-2d" }
+gf256 = { path = "../gf256" }
+paint-instructions = { path = "../paint-instructions" }

--- a/code/packages/rust/micro-qr/README.md
+++ b/code/packages/rust/micro-qr/README.md
@@ -1,0 +1,53 @@
+# micro-qr
+
+Micro QR Code encoder — ISO/IEC 18004:2015 Annex E compliant.
+
+Encodes any string into a scannable Micro QR Code symbol (M1–M4).
+Outputs a [`ModuleGrid`] (abstract boolean grid) that can be passed to
+`barcode-2d`'s `layout()` for pixel rendering.
+
+## Symbol Sizes
+
+| Symbol | Size | Max numeric | Max alphanumeric | Max bytes |
+|--------|------|-------------|------------------|-----------|
+| M1     | 11×11 | 5           | —               | —         |
+| M2     | 13×13 | 10          | 6               | 4         |
+| M3     | 15×15 | 23          | 14              | 9         |
+| M4     | 17×17 | 35          | 21              | 15        |
+
+## Usage
+
+```rust
+use micro_qr::{encode, MicroQRVersion, MicroQREccLevel};
+
+// Auto-select smallest symbol
+let grid = encode("HELLO", None, None).unwrap();
+assert_eq!(grid.rows, 13); // M2 symbol (13×13)
+
+// Force M4 with Q error correction
+let m4 = encode("https://a.b", Some(MicroQRVersion::M4), Some(MicroQREccLevel::L)).unwrap();
+assert_eq!(m4.rows, 17);
+
+// Convert to a PaintScene for rendering
+use micro_qr::layout_grid;
+let scene = layout_grid(&grid, None).unwrap();
+```
+
+## Key Differences from Regular QR Code
+
+| Feature | Regular QR | Micro QR |
+|---------|-----------|----------|
+| Finder patterns | 3 | 1 |
+| Timing strips | Row 6, col 6 | Row 0, col 0 |
+| Quiet zone | 4 modules | 2 modules |
+| ECC levels | L, M, Q, H | Detection, L, M, Q |
+| Mask patterns | 8 | 4 |
+| Format info copies | 2 | 1 |
+| Format XOR mask | 0x5412 | 0x4445 |
+| Max capacity | 7089 numeric | 35 numeric |
+
+## Dependencies
+
+- `barcode-2d` — `ModuleGrid` type and `layout()` function
+- `gf256` — GF(256) field arithmetic for the Reed-Solomon encoder
+- `paint-instructions` — `PaintScene` type for the layout output

--- a/code/packages/rust/micro-qr/src/lib.rs
+++ b/code/packages/rust/micro-qr/src/lib.rs
@@ -1,0 +1,1326 @@
+//! # micro-qr
+//!
+//! Micro QR Code encoder — ISO/IEC 18004:2015 Annex E compliant.
+//!
+//! Micro QR Code is the compact variant of QR Code, designed for applications
+//! where even the smallest standard QR (21×21 at version 1) is too large.
+//! Common use cases include surface-mount component labels, circuit board
+//! markings, and miniature industrial tags.
+//!
+//! ## Symbol sizes
+//!
+//! ```text
+//! M1: 11×11   M2: 13×13   M3: 15×15   M4: 17×17
+//! formula: size = 2 × version_number + 9
+//! ```
+//!
+//! ## Key differences from regular QR Code
+//!
+//! - **Single finder pattern** at top-left only (one 7×7 square, not three).
+//! - **Timing at row 0 / col 0** (not row 6 / col 6).
+//! - **Only 4 mask patterns** (not 8).
+//! - **Format XOR mask 0x4445** (not 0x5412).
+//! - **Single copy of format info** (not two).
+//! - **2-module quiet zone** (not 4).
+//! - **Narrower mode indicators** (0–3 bits instead of 4).
+//! - **Single block** (no interleaving).
+//!
+//! ## Encoding pipeline
+//!
+//! ```text
+//! input string
+//!   → auto-select smallest symbol (M1..M4) and mode
+//!   → build bit stream (mode indicator + char count + data + terminator + padding)
+//!   → Reed-Solomon ECC (GF(256)/0x11D, b=0, single block)
+//!   → initialize grid (finder, L-shaped separator, timing at row0/col0, format reserved)
+//!   → zigzag data placement (two-column snake from bottom-right)
+//!   → evaluate 4 mask patterns, pick lowest penalty
+//!   → write format information (15 bits, single copy, XOR 0x4445)
+//!   → ModuleGrid
+//! ```
+
+pub const VERSION: &str = "0.1.0";
+
+use barcode_2d::{layout, Barcode2DLayoutConfig, ModuleGrid, ModuleShape};
+use gf256::multiply as gf_mul;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Micro QR symbol designator.
+///
+/// Each step up adds two rows/columns (size = 2×version_number+9):
+/// M1=11×11, M2=13×13, M3=15×15, M4=17×17.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MicroQRVersion {
+    M1,
+    M2,
+    M3,
+    M4,
+}
+
+/// Error correction level for Micro QR.
+///
+/// | Level     | Available in | Recovery |
+/// |-----------|-------------|---------|
+/// | Detection | M1 only     | detects errors only |
+/// | L         | M2, M3, M4  | ~7% of codewords |
+/// | M         | M2, M3, M4  | ~15% of codewords |
+/// | Q         | M4 only     | ~25% of codewords |
+///
+/// Level H is not available in any Micro QR symbol.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MicroQREccLevel {
+    Detection,
+    L,
+    M,
+    Q,
+}
+
+/// Error types for the Micro QR encoder.
+#[derive(Debug)]
+pub enum MicroQRError {
+    /// Input is too long to fit in any M1–M4 symbol at any ECC level.
+    InputTooLong(String),
+    /// The requested encoding mode is not available for the chosen symbol.
+    UnsupportedMode(String),
+    /// The requested ECC level is not available for the chosen symbol.
+    ECCNotAvailable(String),
+    /// A character cannot be encoded in the selected mode.
+    InvalidCharacter(String),
+    /// Layout/rendering error.
+    LayoutError(String),
+}
+
+impl std::fmt::Display for MicroQRError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MicroQRError::InputTooLong(m)    => write!(f, "InputTooLong: {m}"),
+            MicroQRError::UnsupportedMode(m) => write!(f, "UnsupportedMode: {m}"),
+            MicroQRError::ECCNotAvailable(m) => write!(f, "ECCNotAvailable: {m}"),
+            MicroQRError::InvalidCharacter(m)=> write!(f, "InvalidCharacter: {m}"),
+            MicroQRError::LayoutError(m)     => write!(f, "LayoutError: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for MicroQRError {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symbol configurations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// All the compile-time constants for one (version, ECC) combination.
+///
+/// There are exactly 8 valid combinations:
+/// M1/Detection, M2/L, M2/M, M3/L, M3/M, M4/L, M4/M, M4/Q.
+struct SymbolConfig {
+    version: MicroQRVersion,
+    ecc: MicroQREccLevel,
+    /// 3-bit symbol indicator placed in format information (0..7).
+    symbol_indicator: u8,
+    /// Symbol side length in modules (11, 13, 15, or 17).
+    size: usize,
+    /// Number of data codewords (full 8-bit bytes, except M1 which uses 2.5 bytes).
+    data_cw: usize,
+    /// Number of ECC codewords.
+    ecc_cw: usize,
+    /// Maximum numeric characters. 0 = not supported.
+    numeric_cap: usize,
+    /// Maximum alphanumeric characters. 0 = not supported.
+    alpha_cap: usize,
+    /// Maximum byte characters. 0 = not supported.
+    byte_cap: usize,
+    /// Terminator bit count (3/5/7/9).
+    terminator_bits: usize,
+    /// Mode indicator bit width (0=M1, 1=M2, 2=M3, 3=M4).
+    mode_indicator_bits: usize,
+    /// Character count field width for numeric mode.
+    cc_bits_numeric: usize,
+    /// Character count field width for alphanumeric mode.
+    cc_bits_alpha: usize,
+    /// Character count field width for byte mode.
+    cc_bits_byte: usize,
+    /// True for M1 only: last data "codeword" is 4 bits, total = 20 bits.
+    m1_half_cw: bool,
+}
+
+/// All 8 valid Micro QR symbol configurations from ISO 18004:2015 Annex E.
+///
+/// Data capacities, codeword counts, and field widths are compile-time constants.
+static SYMBOL_CONFIGS: &[SymbolConfig] = &[
+    // M1 / Detection
+    SymbolConfig {
+        version: MicroQRVersion::M1, ecc: MicroQREccLevel::Detection,
+        symbol_indicator: 0, size: 11,
+        data_cw: 3, ecc_cw: 2,
+        numeric_cap: 5, alpha_cap: 0, byte_cap: 0,
+        terminator_bits: 3, mode_indicator_bits: 0,
+        cc_bits_numeric: 3, cc_bits_alpha: 0, cc_bits_byte: 0,
+        m1_half_cw: true,
+    },
+    // M2 / L
+    SymbolConfig {
+        version: MicroQRVersion::M2, ecc: MicroQREccLevel::L,
+        symbol_indicator: 1, size: 13,
+        data_cw: 5, ecc_cw: 5,
+        numeric_cap: 10, alpha_cap: 6, byte_cap: 4,
+        terminator_bits: 5, mode_indicator_bits: 1,
+        cc_bits_numeric: 4, cc_bits_alpha: 3, cc_bits_byte: 4,
+        m1_half_cw: false,
+    },
+    // M2 / M
+    SymbolConfig {
+        version: MicroQRVersion::M2, ecc: MicroQREccLevel::M,
+        symbol_indicator: 2, size: 13,
+        data_cw: 4, ecc_cw: 6,
+        numeric_cap: 8, alpha_cap: 5, byte_cap: 3,
+        terminator_bits: 5, mode_indicator_bits: 1,
+        cc_bits_numeric: 4, cc_bits_alpha: 3, cc_bits_byte: 4,
+        m1_half_cw: false,
+    },
+    // M3 / L
+    SymbolConfig {
+        version: MicroQRVersion::M3, ecc: MicroQREccLevel::L,
+        symbol_indicator: 3, size: 15,
+        data_cw: 11, ecc_cw: 6,
+        numeric_cap: 23, alpha_cap: 14, byte_cap: 9,
+        terminator_bits: 7, mode_indicator_bits: 2,
+        cc_bits_numeric: 5, cc_bits_alpha: 4, cc_bits_byte: 4,
+        m1_half_cw: false,
+    },
+    // M3 / M
+    SymbolConfig {
+        version: MicroQRVersion::M3, ecc: MicroQREccLevel::M,
+        symbol_indicator: 4, size: 15,
+        data_cw: 9, ecc_cw: 8,
+        numeric_cap: 18, alpha_cap: 11, byte_cap: 7,
+        terminator_bits: 7, mode_indicator_bits: 2,
+        cc_bits_numeric: 5, cc_bits_alpha: 4, cc_bits_byte: 4,
+        m1_half_cw: false,
+    },
+    // M4 / L
+    SymbolConfig {
+        version: MicroQRVersion::M4, ecc: MicroQREccLevel::L,
+        symbol_indicator: 5, size: 17,
+        data_cw: 16, ecc_cw: 8,
+        numeric_cap: 35, alpha_cap: 21, byte_cap: 15,
+        terminator_bits: 9, mode_indicator_bits: 3,
+        cc_bits_numeric: 6, cc_bits_alpha: 5, cc_bits_byte: 5,
+        m1_half_cw: false,
+    },
+    // M4 / M
+    SymbolConfig {
+        version: MicroQRVersion::M4, ecc: MicroQREccLevel::M,
+        symbol_indicator: 6, size: 17,
+        data_cw: 14, ecc_cw: 10,
+        numeric_cap: 30, alpha_cap: 18, byte_cap: 13,
+        terminator_bits: 9, mode_indicator_bits: 3,
+        cc_bits_numeric: 6, cc_bits_alpha: 5, cc_bits_byte: 5,
+        m1_half_cw: false,
+    },
+    // M4 / Q
+    SymbolConfig {
+        version: MicroQRVersion::M4, ecc: MicroQREccLevel::Q,
+        symbol_indicator: 7, size: 17,
+        data_cw: 10, ecc_cw: 14,
+        numeric_cap: 21, alpha_cap: 13, byte_cap: 9,
+        terminator_bits: 9, mode_indicator_bits: 3,
+        cc_bits_numeric: 6, cc_bits_alpha: 5, cc_bits_byte: 5,
+        m1_half_cw: false,
+    },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RS generator polynomials (compile-time constants)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Monic RS generator polynomials for GF(256)/0x11D with b=0 convention.
+///
+/// g(x) = (x+α⁰)(x+α¹)···(x+α^{n-1}).
+/// Array length is n+1 (leading monic term included).
+///
+/// Only the counts {2, 5, 6, 8, 10, 14} are needed for Micro QR.
+fn get_generator(ecc_count: usize) -> &'static [u8] {
+    match ecc_count {
+        2  => &[0x01, 0x03, 0x02],
+        5  => &[0x01, 0x1f, 0xf6, 0x44, 0xd9, 0x68],
+        6  => &[0x01, 0x3f, 0x4e, 0x17, 0x9b, 0x05, 0x37],
+        8  => &[0x01, 0x63, 0x0d, 0x60, 0x6d, 0x5b, 0x10, 0xa2, 0xa3],
+        10 => &[0x01, 0xf6, 0x75, 0xa8, 0xd0, 0xc3, 0xe3, 0x36, 0xe1, 0x3c, 0x45],
+        14 => &[0x01, 0xf6, 0x9a, 0x60, 0x97, 0x8a, 0xf1, 0xa4, 0xa1, 0x8e, 0xfc, 0x7a, 0x52, 0xad, 0xac],
+        _  => panic!("micro-qr: no generator for ecc_count={ecc_count}"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-computed format information table
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// All 32 pre-computed format words (after XOR with 0x4445).
+///
+/// Indexed as `FORMAT_TABLE[symbol_indicator][mask_pattern]`.
+///
+/// The 15-bit format word structure:
+///   [symbol_indicator (3b)] [mask_pattern (2b)] [BCH-10 remainder]
+/// XOR-masked with 0x4445 (Micro QR specific, not 0x5412 like regular QR).
+static FORMAT_TABLE: [[u16; 4]; 8] = [
+    [0x4445, 0x4172, 0x4E2B, 0x4B1C],  // M1
+    [0x5528, 0x501F, 0x5F46, 0x5A71],  // M2-L
+    [0x6649, 0x637E, 0x6C27, 0x6910],  // M2-M
+    [0x7764, 0x7253, 0x7D0A, 0x783D],  // M3-L
+    [0x06DE, 0x03E9, 0x0CB0, 0x0987],  // M3-M
+    [0x17F3, 0x12C4, 0x1D9D, 0x18AA],  // M4-L
+    [0x24B2, 0x2185, 0x2EDC, 0x2BEB],  // M4-M
+    [0x359F, 0x30A8, 0x3FF1, 0x3AC6],  // M4-Q
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Encoding mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 45-character alphanumeric set shared with regular QR Code.
+const ALPHANUM_CHARS: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+/// Encoding mode determines how input characters are packed into bits.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EncodingMode {
+    Numeric,
+    Alphanumeric,
+    Byte,
+}
+
+/// Select the most compact mode supported by the given config.
+///
+/// Selection priority: numeric > alphanumeric > byte.
+/// If no supported mode can encode the input, returns an error.
+fn select_mode(input: &str, cfg: &SymbolConfig) -> Result<EncodingMode, MicroQRError> {
+    // Numeric: all digits 0-9
+    let is_numeric = input.is_empty() || input.chars().all(|c| c.is_ascii_digit());
+    if is_numeric && cfg.cc_bits_numeric > 0 {
+        return Ok(EncodingMode::Numeric);
+    }
+    // Alphanumeric: all chars in the 45-char set
+    let is_alpha = input.chars().all(|c| ALPHANUM_CHARS.contains(c));
+    if is_alpha && cfg.alpha_cap > 0 {
+        return Ok(EncodingMode::Alphanumeric);
+    }
+    // Byte: raw bytes (UTF-8 is valid here)
+    if cfg.byte_cap > 0 {
+        return Ok(EncodingMode::Byte);
+    }
+    Err(MicroQRError::UnsupportedMode(format!(
+        "Input cannot be encoded in any mode supported by {:?}-{:?}",
+        cfg.version, cfg.ecc
+    )))
+}
+
+fn mode_indicator_value(mode: EncodingMode, cfg: &SymbolConfig) -> u32 {
+    match cfg.mode_indicator_bits {
+        0 => 0, // M1: no indicator
+        1 => match mode { EncodingMode::Numeric => 0, _ => 1 },
+        2 => match mode {
+            EncodingMode::Numeric     => 0b00,
+            EncodingMode::Alphanumeric=> 0b01,
+            EncodingMode::Byte        => 0b10,
+        },
+        3 => match mode {
+            EncodingMode::Numeric     => 0b000,
+            EncodingMode::Alphanumeric=> 0b001,
+            EncodingMode::Byte        => 0b010,
+        },
+        _ => 0,
+    }
+}
+
+fn char_count_bits(mode: EncodingMode, cfg: &SymbolConfig) -> u32 {
+    match mode {
+        EncodingMode::Numeric     => cfg.cc_bits_numeric as u32,
+        EncodingMode::Alphanumeric=> cfg.cc_bits_alpha as u32,
+        EncodingMode::Byte        => cfg.cc_bits_byte as u32,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bit-writer
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Accumulates bits MSB-first, flushes to bytes.
+///
+/// Each call to `write(value, count)` appends the `count` least-significant
+/// bits of `value` to the stream, MSB first.  This matches the QR/Micro-QR
+/// convention of big-endian bit ordering within each codeword.
+struct BitWriter {
+    bits: Vec<u8>, // 0 or 1
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        Self { bits: Vec::new() }
+    }
+
+    fn write(&mut self, value: u32, count: u32) {
+        for i in (0..count).rev() {
+            self.bits.push(((value >> i) & 1) as u8);
+        }
+    }
+
+    fn bit_len(&self) -> usize {
+        self.bits.len()
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        let mut i = 0;
+        while i < self.bits.len() {
+            let mut byte = 0u8;
+            for j in 0..8_usize {
+                byte = (byte << 1) | self.bits.get(i + j).copied().unwrap_or(0);
+            }
+            result.push(byte);
+            i += 8;
+        }
+        result
+    }
+
+    fn to_bit_vec(&self) -> Vec<u8> {
+        self.bits.clone()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data encoding helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Encode a numeric string: groups of 3 → 10 bits, pair → 7 bits, single → 4 bits.
+fn encode_numeric(input: &str, w: &mut BitWriter) {
+    let digits: Vec<u32> = input.chars()
+        .map(|c| c as u32 - b'0' as u32)
+        .collect();
+    let mut i = 0;
+    while i + 2 < digits.len() {
+        w.write(digits[i] * 100 + digits[i + 1] * 10 + digits[i + 2], 10);
+        i += 3;
+    }
+    if i + 1 < digits.len() {
+        w.write(digits[i] * 10 + digits[i + 1], 7);
+        i += 2;
+    }
+    if i < digits.len() {
+        w.write(digits[i], 4);
+    }
+}
+
+/// Encode an alphanumeric string: pairs → 11 bits, single → 6 bits.
+fn encode_alphanumeric(input: &str, w: &mut BitWriter) {
+    let indices: Vec<u32> = input.chars()
+        .map(|c| ALPHANUM_CHARS.find(c).unwrap_or(0) as u32)
+        .collect();
+    let mut i = 0;
+    while i + 1 < indices.len() {
+        w.write(indices[i] * 45 + indices[i + 1], 11);
+        i += 2;
+    }
+    if i < indices.len() {
+        w.write(indices[i], 6);
+    }
+}
+
+/// Encode byte mode: each UTF-8 byte → 8 bits.
+fn encode_byte_mode(input: &str, w: &mut BitWriter) {
+    for b in input.as_bytes() {
+        w.write(*b as u32, 8);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reed-Solomon encoder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Compute ECC bytes using LFSR polynomial division over GF(256)/0x11D.
+///
+/// Returns the remainder of D(x)·x^n mod G(x).
+/// Uses the b=0 convention (first root is α^0 = 1).
+fn rs_encode(data: &[u8], generator: &[u8]) -> Vec<u8> {
+    let n = generator.len() - 1;
+    let mut rem = vec![0u8; n];
+    for &b in data {
+        let fb = b ^ rem[0];
+        rem.copy_within(1.., 0);
+        rem[n - 1] = 0;
+        if fb != 0 {
+            for i in 0..n {
+                rem[i] ^= gf_mul(generator[i + 1], fb);
+            }
+        }
+    }
+    rem
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data codeword assembly
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the complete data codeword byte sequence.
+///
+/// For all symbols except M1:
+///   [mode indicator] [char count] [data bits] [terminator] [byte-align] [0xEC/0x11 fill]
+///   → exactly cfg.data_cw bytes.
+///
+/// For M1 (m1_half_cw = true):
+///   Total capacity = 20 bits = 2 full bytes + 4-bit nibble.
+///   The RS encoder receives 3 bytes where byte[2] has data in the upper 4 bits.
+fn build_data_codewords(
+    input: &str,
+    cfg: &SymbolConfig,
+    mode: EncodingMode,
+) -> Vec<u8> {
+    // Total usable data bit capacity
+    let total_bits = if cfg.m1_half_cw {
+        cfg.data_cw * 8 - 4  // M1: 3×8 − 4 = 20 bits
+    } else {
+        cfg.data_cw * 8
+    };
+
+    let mut w = BitWriter::new();
+
+    // Mode indicator (0/1/2/3 bits depending on symbol)
+    if cfg.mode_indicator_bits > 0 {
+        w.write(mode_indicator_value(mode, cfg), cfg.mode_indicator_bits as u32);
+    }
+
+    // Character count
+    let char_count = if mode == EncodingMode::Byte {
+        input.len() as u32
+    } else {
+        input.chars().count() as u32
+    };
+    w.write(char_count, char_count_bits(mode, cfg));
+
+    // Encoded data
+    match mode {
+        EncodingMode::Numeric     => encode_numeric(input, &mut w),
+        EncodingMode::Alphanumeric=> encode_alphanumeric(input, &mut w),
+        EncodingMode::Byte        => encode_byte_mode(input, &mut w),
+    }
+
+    // Terminator: up to terminator_bits zero bits (truncated if capacity full)
+    let remaining = total_bits.saturating_sub(w.bit_len());
+    if remaining > 0 {
+        w.write(0, cfg.terminator_bits.min(remaining) as u32);
+    }
+
+    if cfg.m1_half_cw {
+        // M1: pack into exactly 20 bits → 3 bytes (last byte: upper nibble = data, lower = 0)
+        let mut bits = w.to_bit_vec();
+        bits.resize(20, 0);
+        let b0 = (bits[0]  << 7) | (bits[1]  << 6) | (bits[2]  << 5) | (bits[3]  << 4)
+               | (bits[4]  << 3) | (bits[5]  << 2) | (bits[6]  << 1) | bits[7];
+        let b1 = (bits[8]  << 7) | (bits[9]  << 6) | (bits[10] << 5) | (bits[11] << 4)
+               | (bits[12] << 3) | (bits[13] << 2) | (bits[14] << 1) | bits[15];
+        let b2 = (bits[16] << 7) | (bits[17] << 6) | (bits[18] << 5) | (bits[19] << 4);
+        return vec![b0, b1, b2];
+    }
+
+    // Pad to byte boundary
+    let rem = w.bit_len() % 8;
+    if rem != 0 {
+        w.write(0, (8 - rem) as u32);
+    }
+
+    // Fill remaining codewords with alternating 0xEC / 0x11
+    let mut bytes = w.to_bytes();
+    let mut pad = 0xecu8;
+    while bytes.len() < cfg.data_cw {
+        bytes.push(pad);
+        pad = if pad == 0xec { 0x11 } else { 0xec };
+    }
+    bytes
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symbol selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Find the smallest symbol configuration that can hold the given input.
+fn select_config<'a>(
+    input: &str,
+    version: Option<MicroQRVersion>,
+    ecc: Option<MicroQREccLevel>,
+) -> Result<&'a SymbolConfig, MicroQRError> {
+    let candidates: Vec<&SymbolConfig> = SYMBOL_CONFIGS.iter()
+        .filter(|c| {
+            if let Some(v) = version { if c.version != v { return false; } }
+            if let Some(e) = ecc     { if c.ecc    != e { return false; } }
+            true
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return Err(MicroQRError::ECCNotAvailable(format!(
+            "No symbol configuration matches version={version:?} ecc={ecc:?}"
+        )));
+    }
+
+    for cfg in &candidates {
+        if let Ok(mode) = select_mode(input, cfg) {
+            let len = if mode == EncodingMode::Byte { input.len() } else { input.chars().count() };
+            let cap = match mode {
+                EncodingMode::Numeric      => cfg.numeric_cap,
+                EncodingMode::Alphanumeric => cfg.alpha_cap,
+                EncodingMode::Byte         => cfg.byte_cap,
+            };
+            if cap > 0 && len <= cap {
+                return Ok(cfg);
+            }
+        }
+    }
+
+    Err(MicroQRError::InputTooLong(format!(
+        "Input (length {}) does not fit in any Micro QR symbol (version={version:?}, ecc={ecc:?}). \
+         Maximum is 35 numeric chars in M4-L.",
+        input.len()
+    )))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Working grid holding module values and reservation flags.
+struct WorkGrid {
+    size: usize,
+    modules:  Vec<Vec<bool>>,
+    reserved: Vec<Vec<bool>>,
+}
+
+impl WorkGrid {
+    fn new(size: usize) -> Self {
+        Self {
+            size,
+            modules:  vec![vec![false; size]; size],
+            reserved: vec![vec![false; size]; size],
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, row: usize, col: usize, dark: bool, reserve: bool) {
+        self.modules[row][col]  = dark;
+        if reserve { self.reserved[row][col] = true; }
+    }
+}
+
+/// Place the 7×7 finder pattern at the top-left corner (rows 0–6, cols 0–6).
+///
+/// ```text
+/// ■ ■ ■ ■ ■ ■ ■
+/// ■ □ □ □ □ □ ■
+/// ■ □ ■ ■ ■ □ ■
+/// ■ □ ■ ■ ■ □ ■
+/// ■ □ ■ ■ ■ □ ■
+/// ■ □ □ □ □ □ ■
+/// ■ ■ ■ ■ ■ ■ ■
+/// ```
+fn place_finder(g: &mut WorkGrid) {
+    for dr in 0..7 {
+        for dc in 0..7 {
+            let on_border = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+            let in_core   = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+            g.set(dr, dc, on_border || in_core, true);
+        }
+    }
+}
+
+/// Place the L-shaped separator (light modules at row 7 cols 0–7, col 7 rows 0–7).
+///
+/// Unlike regular QR which surrounds all three finders, Micro QR's single finder
+/// only needs separation on its bottom and right sides (the top and left are the
+/// symbol boundary itself).
+fn place_separator(g: &mut WorkGrid) {
+    for i in 0..=7 {
+        g.set(7, i, false, true);  // bottom row
+        g.set(i, 7, false, true);  // right column
+    }
+}
+
+/// Place timing pattern extensions along row 0 and col 0.
+///
+/// Positions 0–6 are already the finder pattern. Position 7 is the separator.
+/// Position 8 onward: dark at even index, light at odd index.
+fn place_timing(g: &mut WorkGrid) {
+    let sz = g.size;
+    for c in 8..sz {
+        g.set(0, c, c % 2 == 0, true);
+    }
+    for r in 8..sz {
+        g.set(r, 0, r % 2 == 0, true);
+    }
+}
+
+/// Reserve the 15 format information module positions.
+///
+/// Row 8, cols 1–8 → bits f14..f7 (MSB first)
+/// Col 8, rows 1–7 → bits f6..f0 (f6 at row 7, f0 at row 1)
+fn reserve_format_info(g: &mut WorkGrid) {
+    for c in 1..=8 { g.set(8, c, false, true); }
+    for r in 1..=7 { g.set(r, 8, false, true); }
+}
+
+/// Write the 15-bit format word into the reserved positions.
+///
+/// Bit f14 (MSB) → row 8 col 1, f13 → row 8 col 2, ..., f7 → row 8 col 8.
+/// f6 → col 8 row 7, f5 → col 8 row 6, ..., f0 (LSB) → col 8 row 1.
+fn write_format_info(g: &mut WorkGrid, fmt: u16) {
+    // Row 8, cols 1–8: bits f14 down to f7
+    for i in 0..8_u16 {
+        g.modules[8][1 + i as usize] = ((fmt >> (14 - i)) & 1) == 1;
+    }
+    // Col 8, rows 7 down to 1: bits f6 down to f0
+    for i in 0..7_u16 {
+        g.modules[(7 - i) as usize][8] = ((fmt >> (6 - i)) & 1) == 1;
+    }
+}
+
+/// Initialize the grid with all structural modules.
+fn build_grid(cfg: &SymbolConfig) -> WorkGrid {
+    let mut g = WorkGrid::new(cfg.size);
+    place_finder(&mut g);
+    place_separator(&mut g);
+    place_timing(&mut g);
+    reserve_format_info(&mut g);
+    g
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data placement (two-column zigzag)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Place bits from the final codeword stream into the grid via two-column zigzag.
+///
+/// Scans from the bottom-right corner, moving left two columns at a time,
+/// alternating upward and downward directions. Reserved modules are skipped.
+///
+/// Note: unlike regular QR, there is no timing column at col 6 to hop over.
+/// Micro QR's timing is at col 0, which is reserved and auto-skipped.
+fn place_bits(g: &mut WorkGrid, bits: &[bool]) {
+    let sz = g.size;
+    let mut bit_idx = 0;
+    let mut up = true;
+
+    let mut col = sz as isize - 1;
+    while col >= 1 {
+        let col_u = col as usize;
+        for vi in 0..sz {
+            let row = if up { sz - 1 - vi } else { vi };
+            for dc in 0..=1_usize {
+                let c = col_u - dc;
+                if g.reserved[row][c] { continue; }
+                g.modules[row][c] = if bit_idx < bits.len() {
+                    let b = bits[bit_idx];
+                    bit_idx += 1;
+                    b
+                } else {
+                    false
+                };
+            }
+        }
+        up = !up;
+        col -= 2;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Masking
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Test if mask pattern `mask_idx` applies to module (row, col).
+///
+/// | Pattern | Condition |
+/// |---------|-----------|
+/// | 0       | (row + col) mod 2 == 0 |
+/// | 1       | row mod 2 == 0 |
+/// | 2       | col mod 3 == 0 |
+/// | 3       | (row + col) mod 3 == 0 |
+#[inline]
+fn mask_condition(mask_idx: usize, row: usize, col: usize) -> bool {
+    match mask_idx {
+        0 => (row + col) % 2 == 0,
+        1 => row % 2 == 0,
+        2 => col % 3 == 0,
+        3 => (row + col) % 3 == 0,
+        _ => false,
+    }
+}
+
+/// Apply mask pattern to all non-reserved modules. Returns a new module grid.
+fn apply_mask(
+    modules: &[Vec<bool>],
+    reserved: &[Vec<bool>],
+    sz: usize,
+    mask_idx: usize,
+) -> Vec<Vec<bool>> {
+    let mut result = modules.to_vec();
+    for r in 0..sz {
+        for c in 0..sz {
+            if !reserved[r][c] {
+                result[r][c] = modules[r][c] != mask_condition(mask_idx, r, c);
+            }
+        }
+    }
+    result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Penalty scoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Compute the 4-rule penalty score (same rules as regular QR Code).
+///
+/// Rule 1: runs of ≥5 same-color modules → score += (run − 2)
+/// Rule 2: 2×2 same-color blocks → score += 3
+/// Rule 3: finder-like sequences → score += 40 each
+/// Rule 4: dark proportion deviation from 50% → scaled penalty
+fn compute_penalty(modules: &[Vec<bool>], sz: usize) -> u32 {
+    let mut penalty = 0u32;
+
+    // Rule 1 — adjacent same-color runs of ≥ 5
+    for a in 0..sz {
+        for horiz in [true, false] {
+            let mut run = 1u32;
+            let mut prev = if horiz { modules[a][0] } else { modules[0][a] };
+            for i in 1..sz {
+                let cur = if horiz { modules[a][i] } else { modules[i][a] };
+                if cur == prev {
+                    run += 1;
+                } else {
+                    if run >= 5 { penalty += run - 2; }
+                    run = 1;
+                    prev = cur;
+                }
+            }
+            if run >= 5 { penalty += run - 2; }
+        }
+    }
+
+    // Rule 2 — 2×2 same-color blocks
+    for r in 0..sz - 1 {
+        for c in 0..sz - 1 {
+            let d = modules[r][c];
+            if d == modules[r][c + 1] && d == modules[r + 1][c] && d == modules[r + 1][c + 1] {
+                penalty += 3;
+            }
+        }
+    }
+
+    // Rule 3 — finder-pattern-like sequences
+    const P1: [u8; 11] = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
+    const P2: [u8; 11] = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+    for a in 0..sz {
+        let limit = if sz >= 11 { sz - 11 } else { 0 };
+        for b in 0..=limit {
+            let (mut mh1, mut mh2, mut mv1, mut mv2) = (true, true, true, true);
+            for k in 0..11 {
+                let bh = if modules[a][b + k] { 1u8 } else { 0 };
+                let bv = if modules[b + k][a] { 1u8 } else { 0 };
+                if bh != P1[k] { mh1 = false; }
+                if bh != P2[k] { mh2 = false; }
+                if bv != P1[k] { mv1 = false; }
+                if bv != P2[k] { mv2 = false; }
+            }
+            if mh1 { penalty += 40; }
+            if mh2 { penalty += 40; }
+            if mv1 { penalty += 40; }
+            if mv2 { penalty += 40; }
+        }
+    }
+
+    // Rule 4 — dark proportion deviation from 50%
+    let dark: usize = modules.iter().flatten().filter(|&&d| d).count();
+    let total = sz * sz;
+    let dark_pct = (dark * 100) / total;
+    let prev5 = (dark_pct / 5) * 5;
+    let next5 = prev5 + 5;
+    let r4 = ((prev5 as i32 - 50).unsigned_abs())
+        .min((next5 as i32 - 50).unsigned_abs());
+    penalty += (r4 / 5) * 10;
+
+    penalty
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Encode a string to a Micro QR Code [`ModuleGrid`].
+///
+/// Automatically selects the smallest symbol (M1..M4) and ECC level
+/// that can hold the input. Pass `version` and/or `ecc` to override.
+///
+/// # Errors
+///
+/// - [`MicroQRError::InputTooLong`] if the input exceeds M4 capacity.
+/// - [`MicroQRError::ECCNotAvailable`] if the requested version+ECC combination
+///   does not exist.
+/// - [`MicroQRError::UnsupportedMode`] if no encoding mode is available for
+///   the input in the selected symbol.
+///
+/// # Examples
+///
+/// ```
+/// use micro_qr::{encode, MicroQRVersion, MicroQREccLevel};
+///
+/// let grid = encode("HELLO", None, None).unwrap();
+/// assert_eq!(grid.rows, 13); // M2 symbol
+///
+/// let m4 = encode("https://a.b", Some(MicroQRVersion::M4), Some(MicroQREccLevel::L)).unwrap();
+/// assert_eq!(m4.rows, 17);
+/// ```
+pub fn encode(
+    input: &str,
+    version: Option<MicroQRVersion>,
+    ecc: Option<MicroQREccLevel>,
+) -> Result<ModuleGrid, MicroQRError> {
+    let cfg = select_config(input, version, ecc)?;
+    let mode = select_mode(input, cfg)?;
+
+    // 1. Build data codewords
+    let data_cw = build_data_codewords(input, cfg, mode);
+
+    // 2. Compute RS ECC
+    let gen = get_generator(cfg.ecc_cw);
+    let ecc_cw = rs_encode(&data_cw, gen);
+
+    // 3. Flatten to bit stream
+    // For M1: data[2] has data in upper nibble only → contribute 4 bits from it
+    let final_cw: Vec<u8> = data_cw.iter().chain(ecc_cw.iter()).copied().collect();
+    let mut bits: Vec<bool> = Vec::new();
+    for (cw_idx, &cw) in final_cw.iter().enumerate() {
+        let bits_in_cw = if cfg.m1_half_cw && cw_idx == cfg.data_cw - 1 { 4 } else { 8 };
+        for b in (0..bits_in_cw as u32).rev() {
+            bits.push(((cw >> (b + (8 - bits_in_cw))) & 1) == 1);
+        }
+    }
+
+    // 4. Build grid with structural modules
+    let mut grid = build_grid(cfg);
+
+    // 5. Place data bits
+    place_bits(&mut grid, &bits);
+
+    // 6. Evaluate all 4 masks, pick lowest penalty
+    let mut best_mask = 0usize;
+    let mut best_penalty = u32::MAX;
+    for m in 0..4 {
+        let masked = apply_mask(&grid.modules, &grid.reserved, cfg.size, m);
+        let fmt = FORMAT_TABLE[cfg.symbol_indicator as usize][m];
+        // Write format info into a temporary copy
+        let mut tmp_modules = masked.clone();
+        // Inline format write to avoid borrowing
+        for i in 0..8u16 {
+            tmp_modules[8][1 + i as usize] = ((fmt >> (14 - i)) & 1) == 1;
+        }
+        for i in 0..7u16 {
+            tmp_modules[(7 - i) as usize][8] = ((fmt >> (6 - i)) & 1) == 1;
+        }
+        let p = compute_penalty(&tmp_modules, cfg.size);
+        if p < best_penalty {
+            best_penalty = p;
+            best_mask = m;
+        }
+    }
+
+    // 7. Apply best mask and write final format info
+    let final_modules = apply_mask(&grid.modules, &grid.reserved, cfg.size, best_mask);
+    let final_fmt = FORMAT_TABLE[cfg.symbol_indicator as usize][best_mask];
+    // Replace grid modules with final masked version + format info
+    let mut final_grid = WorkGrid {
+        size: cfg.size,
+        modules: final_modules,
+        reserved: grid.reserved,
+    };
+    write_format_info(&mut final_grid, final_fmt);
+
+    Ok(ModuleGrid {
+        rows: cfg.size as u32,
+        cols: cfg.size as u32,
+        modules: final_grid.modules,
+        module_shape: ModuleShape::Square,
+    })
+}
+
+/// Convert a [`ModuleGrid`] to a `PaintScene` via `barcode-2d::layout()`.
+///
+/// Defaults to `quiet_zone_modules: 2` (Micro QR minimum, half of regular QR's 4).
+pub fn layout_grid(
+    grid: &ModuleGrid,
+    config: Option<Barcode2DLayoutConfig>,
+) -> Result<paint_instructions::PaintScene, MicroQRError> {
+    let cfg = config.unwrap_or_else(|| Barcode2DLayoutConfig {
+        quiet_zone_modules: 2,
+        ..Barcode2DLayoutConfig::default()
+    });
+    layout(grid, &cfg).map_err(|e| MicroQRError::LayoutError(e.to_string()))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid_to_string(grid: &ModuleGrid) -> String {
+        grid.modules.iter()
+            .map(|row| row.iter().map(|&d| if d { '1' } else { '0' }).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    // ── Symbol dimensions ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_m1_is_11x11() {
+        let g = encode("1", None, None).unwrap();
+        assert_eq!(g.rows, 11u32);
+        assert_eq!(g.cols, 11u32);
+    }
+
+    #[test]
+    fn test_m2_is_13x13_for_hello() {
+        let g = encode("HELLO", None, None).unwrap();
+        assert_eq!(g.rows, 13);
+        assert_eq!(g.cols, 13);
+    }
+
+    #[test]
+    fn test_m4_is_17x17_for_url() {
+        let g = encode("https://a.b", None, None).unwrap();
+        assert_eq!(g.rows, 17);
+        assert_eq!(g.cols, 17);
+    }
+
+    #[test]
+    fn test_module_shape_is_square() {
+        let g = encode("1", None, None).unwrap();
+        assert_eq!(g.module_shape, ModuleShape::Square);
+    }
+
+    // ── Auto-version selection ────────────────────────────────────────────
+
+    #[test]
+    fn test_auto_selects_m1_for_single_digit() {
+        assert_eq!(encode("1", None, None).unwrap().rows, 11);
+    }
+
+    #[test]
+    fn test_auto_selects_m1_for_12345() {
+        assert_eq!(encode("12345", None, None).unwrap().rows, 11);
+    }
+
+    #[test]
+    fn test_auto_selects_m2_for_6_digits() {
+        assert_eq!(encode("123456", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_auto_selects_m2_for_hello() {
+        assert_eq!(encode("HELLO", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_auto_selects_m3_for_hello_lowercase() {
+        // "hello" is byte mode, M3-L has cap 9 bytes, M2-L has cap 4 → M3
+        assert!(encode("hello", None, None).unwrap().rows >= 15);
+    }
+
+    #[test]
+    fn test_auto_selects_m4_for_url() {
+        assert_eq!(encode("https://a.b", None, None).unwrap().rows, 17);
+    }
+
+    #[test]
+    fn test_forced_version_m4() {
+        let g = encode("1", Some(MicroQRVersion::M4), None).unwrap();
+        assert_eq!(g.rows, 17);
+    }
+
+    #[test]
+    fn test_forced_ecc_m() {
+        let g1 = encode("HELLO", None, Some(MicroQREccLevel::L)).unwrap();
+        let g2 = encode("HELLO", None, Some(MicroQREccLevel::M)).unwrap();
+        // Both M2 but different ECC → different grids
+        assert_ne!(grid_to_string(&g1), grid_to_string(&g2));
+    }
+
+    // ── Test corpus ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_corpus_1() {
+        assert_eq!(encode("1", None, None).unwrap().rows, 11);
+    }
+
+    #[test]
+    fn test_corpus_12345() {
+        assert_eq!(encode("12345", None, None).unwrap().rows, 11);
+    }
+
+    #[test]
+    fn test_corpus_hello() {
+        assert_eq!(encode("HELLO", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_corpus_a1b2c3_m2() {
+        // 6 alphanumeric fits in M2-L (alphaCap=6)
+        assert_eq!(encode("A1B2C3", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_corpus_hello_byte_m3() {
+        // "hello" = 5 bytes → M3-L (byte_cap=9)
+        assert!(encode("hello", None, None).unwrap().rows >= 15);
+    }
+
+    #[test]
+    fn test_corpus_8_digit_numeric() {
+        // 8 digits → M2-L (numeric_cap=10)
+        assert_eq!(encode("01234567", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_corpus_micro_qr_test_m3l() {
+        // 13 alphanumeric → M3-L (alpha_cap=14)
+        assert_eq!(encode("MICRO QR TEST", None, None).unwrap().rows, 15);
+    }
+
+    // ── Structural modules ────────────────────────────────────────────────
+
+    #[test]
+    fn test_finder_pattern_m1() {
+        let g = encode("1", None, None).unwrap();
+        let m = &g.modules;
+        // Top and bottom rows of finder (row 0, row 6): all dark
+        for c in 0..7 { assert!(m[0][c], "row 0 col {c} should be dark"); }
+        for c in 0..7 { assert!(m[6][c], "row 6 col {c} should be dark"); }
+        // Left and right cols of finder (col 0, col 6): all dark
+        for r in 0..7 { assert!(m[r][0], "col 0 row {r} should be dark"); }
+        for r in 0..7 { assert!(m[r][6], "col 6 row {r} should be dark"); }
+        // Inner ring: light
+        for c in 1..=5 { assert!(!m[1][c], "inner ring row 1 col {c} should be light"); }
+        // Core: dark
+        for r in 2..=4 { for c in 2..=4 { assert!(m[r][c], "core ({r},{c}) should be dark"); } }
+    }
+
+    #[test]
+    fn test_separator_m2() {
+        let g = encode("HELLO", None, None).unwrap();
+        let m = &g.modules;
+        // Row 7, cols 0-7: light
+        for c in 0..=7 { assert!(!m[7][c], "separator row 7 col {c} should be light"); }
+        // Col 7, rows 0-7: light
+        for r in 0..=7 { assert!(!m[r][7], "separator col 7 row {r} should be light"); }
+    }
+
+    #[test]
+    fn test_timing_row_m4() {
+        let g = encode("https://a.b", None, None).unwrap();
+        let m = &g.modules;
+        for c in 8..17 {
+            assert_eq!(m[0][c], c % 2 == 0, "timing row 0 col {c}");
+        }
+    }
+
+    #[test]
+    fn test_timing_col_m4() {
+        let g = encode("https://a.b", None, None).unwrap();
+        let m = &g.modules;
+        for r in 8..17 {
+            assert_eq!(m[r][0], r % 2 == 0, "timing col 0 row {r}");
+        }
+    }
+
+    // ── Determinism ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deterministic() {
+        for input in ["1", "12345", "HELLO", "A1B2C3", "hello", "https://a.b"] {
+            let g1 = encode(input, None, None).unwrap();
+            let g2 = encode(input, None, None).unwrap();
+            assert_eq!(grid_to_string(&g1), grid_to_string(&g2), "non-deterministic for '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_different_inputs_different_grids() {
+        let g1 = encode("1", None, None).unwrap();
+        let g2 = encode("2", None, None).unwrap();
+        assert_ne!(grid_to_string(&g1), grid_to_string(&g2));
+    }
+
+    // ── ECC level constraints ─────────────────────────────────────────────
+
+    #[test]
+    fn test_m1_detection() {
+        let g = encode("1", Some(MicroQRVersion::M1), Some(MicroQREccLevel::Detection)).unwrap();
+        assert_eq!(g.rows, 11);
+    }
+
+    #[test]
+    fn test_m4_q() {
+        let g = encode("HELLO", Some(MicroQRVersion::M4), Some(MicroQREccLevel::Q)).unwrap();
+        assert_eq!(g.rows, 17);
+    }
+
+    #[test]
+    fn test_m4_all_ecc_differ() {
+        let gl = encode("HELLO", Some(MicroQRVersion::M4), Some(MicroQREccLevel::L)).unwrap();
+        let gm = encode("HELLO", Some(MicroQRVersion::M4), Some(MicroQREccLevel::M)).unwrap();
+        let gq = encode("HELLO", Some(MicroQRVersion::M4), Some(MicroQREccLevel::Q)).unwrap();
+        assert_ne!(grid_to_string(&gl), grid_to_string(&gm));
+        assert_ne!(grid_to_string(&gm), grid_to_string(&gq));
+        assert_ne!(grid_to_string(&gl), grid_to_string(&gq));
+    }
+
+    #[test]
+    fn test_m1_rejects_ecc_l() {
+        assert!(matches!(
+            encode("1", Some(MicroQRVersion::M1), Some(MicroQREccLevel::L)),
+            Err(MicroQRError::ECCNotAvailable(_))
+        ));
+    }
+
+    #[test]
+    fn test_m2_rejects_ecc_q() {
+        assert!(matches!(
+            encode("1", Some(MicroQRVersion::M2), Some(MicroQREccLevel::Q)),
+            Err(MicroQRError::ECCNotAvailable(_))
+        ));
+    }
+
+    #[test]
+    fn test_m3_rejects_ecc_q() {
+        assert!(matches!(
+            encode("1", Some(MicroQRVersion::M3), Some(MicroQREccLevel::Q)),
+            Err(MicroQRError::ECCNotAvailable(_))
+        ));
+    }
+
+    // ── Error handling ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_input_too_long() {
+        let long = "1".repeat(36);
+        assert!(matches!(
+            encode(&long, None, None),
+            Err(MicroQRError::InputTooLong(_))
+        ));
+    }
+
+    #[test]
+    fn test_empty_string_encodes_to_m1() {
+        let g = encode("", None, None).unwrap();
+        assert_eq!(g.rows, 11);
+    }
+
+    #[test]
+    fn test_ecc_not_available_for_nonexistent_combo() {
+        assert!(matches!(
+            encode("1", Some(MicroQRVersion::M1), Some(MicroQREccLevel::Q)),
+            Err(MicroQRError::ECCNotAvailable(_))
+        ));
+    }
+
+    // ── Capacity boundaries ───────────────────────────────────────────────
+
+    #[test]
+    fn test_m1_max_5_digits() {
+        assert_eq!(encode("12345", None, None).unwrap().rows, 11);
+    }
+
+    #[test]
+    fn test_m1_overflow_6_digits() {
+        assert_eq!(encode("123456", None, None).unwrap().rows, 13);
+    }
+
+    #[test]
+    fn test_m4_max_35_digits() {
+        let g = encode(&"1".repeat(35), None, None).unwrap();
+        assert_eq!(g.rows, 17);
+    }
+
+    #[test]
+    fn test_m4_overflow_36_digits() {
+        assert!(matches!(
+            encode(&"1".repeat(36), None, None),
+            Err(MicroQRError::InputTooLong(_))
+        ));
+    }
+
+    #[test]
+    fn test_m4_max_byte_15_chars() {
+        let g = encode(&"a".repeat(15), None, None).unwrap();
+        assert_eq!(g.rows, 17);
+    }
+
+    #[test]
+    fn test_m4_q_max_21_numeric() {
+        let g = encode(&"1".repeat(21), None, Some(MicroQREccLevel::Q)).unwrap();
+        assert_eq!(g.rows, 17);
+    }
+
+    // ── Format information ────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_info_non_zero_m4() {
+        let g = encode("HELLO", Some(MicroQRVersion::M4), Some(MicroQREccLevel::L)).unwrap();
+        let m = &g.modules;
+        let any_dark_row = (1..=8).any(|c| m[8][c]);
+        let any_dark_col = (1..=7).any(|r| m[r][8]);
+        assert!(any_dark_row || any_dark_col, "format info should have some dark modules");
+    }
+
+    #[test]
+    fn test_format_info_non_zero_m1() {
+        let g = encode("1", None, None).unwrap();
+        let m = &g.modules;
+        let count: usize = (1..=8).filter(|&c| m[8][c]).count()
+            + (1..=7).filter(|&r| m[r][8]).count();
+        assert!(count > 0, "M1 format info should have some dark modules");
+    }
+
+    // ── Grid completeness ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_all_modules_are_bool() {
+        for input in ["1", "HELLO", "hello", "https://a.b"] {
+            let g = encode(input, None, None).unwrap();
+            assert_eq!(g.rows, g.cols, "grid should be square for '{input}'");
+            assert_eq!(g.modules.len(), g.rows as usize);
+            for row in &g.modules {
+                assert_eq!(row.len(), g.cols as usize);
+            }
+        }
+    }
+
+    #[test]
+    fn test_cross_language_corpus() {
+        // Verify the test corpus from the spec produces expected symbol sizes
+        // (cross-language verification is done by comparing serialized grids)
+        let cases: &[(&str, u32)] = &[
+            ("1",            11),  // M1
+            ("12345",        11),  // M1 max
+            ("HELLO",        13),  // M2-L alphanumeric
+            ("01234567",     13),  // M2-L numeric 8 digits
+            ("https://a.b",  17),  // M4-L byte mode
+            ("MICRO QR TEST",15),  // M3-L alphanumeric 13 chars
+        ];
+        for &(input, expected_size) in cases {
+            let g = encode(input, None, None).unwrap();
+            assert_eq!(g.rows, expected_size,
+                "input '{}': expected {}×{} but got {}×{}",
+                input, expected_size, expected_size, g.rows, g.cols);
+        }
+    }
+}

--- a/code/packages/typescript/micro-qr/BUILD
+++ b/code/packages/typescript/micro-qr/BUILD
@@ -1,0 +1,6 @@
+cd ../pixel-container && npm ci --quiet
+cd ../paint-instructions && npm ci --quiet
+cd ../gf256 && npm ci --quiet
+cd ../barcode-2d && npm ci --quiet
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/micro-qr/CHANGELOG.md
+++ b/code/packages/typescript/micro-qr/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog — @coding-adventures/micro-qr
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- Initial implementation of the Micro QR Code encoder (ISO/IEC 18004:2015 Annex E).
+- Supports all four symbol versions: M1 (11×11), M2 (13×13), M3 (15×15), M4 (17×17).
+- Supports all four encoding modes: numeric, alphanumeric, byte (all versions as applicable),
+  and the API skeleton for kanji (M4 only, not yet implemented).
+- Supports all ECC levels: DETECTION (M1), L and M (M2, M3, M4), Q (M4 only).
+- Auto-selects the smallest symbol + ECC combination that fits the input.
+- Correct RS encoder: GF(256)/0x11D, b=0 convention, single block (no interleaving).
+- Correct grid structure: single 7×7 finder pattern, L-shaped separator, timing at
+  row 0 and col 0, format information at row 8 / col 8 (single copy).
+- 4-mask evaluation with ISO 18004 4-rule penalty scoring (rules 1–4).
+- Pre-computed format information table (all 32 entries) with XOR mask 0x4445.
+- M1 half-codeword handling: last data codeword contributes only 4 bits.
+- Public API: `encode()`, `mqrLayout()`, `encodeAndLayout()`, `explain()`.
+- Full error hierarchy: `MicroQRError`, `InputTooLongError`, `UnsupportedModeError`,
+  `InvalidCharacterError`, `ECCNotAvailableError`.
+- 59 unit tests with 98.56% line coverage and 95.58% branch coverage.
+- Literate programming style: all algorithms explained inline with diagrams and
+  examples for educational use.

--- a/code/packages/typescript/micro-qr/README.md
+++ b/code/packages/typescript/micro-qr/README.md
@@ -1,0 +1,114 @@
+# @coding-adventures/micro-qr
+
+Micro QR Code encoder — ISO/IEC 18004:2015 Annex E compliant.
+
+Micro QR Code is the compact variant of QR Code, designed for applications
+where even the smallest standard QR Code (21×21 at version 1) is too large.
+Common use cases include surface-mount component labels, circuit board
+markings, and miniature industrial tags.
+
+## What is Micro QR?
+
+Regular QR Code uses three identical 7×7 finder patterns at three corners
+so a scanner can identify orientation from any angle. Micro QR uses only
+**one** finder pattern, in the top-left corner. Because there is only one,
+orientation is always unambiguous — the data area is always to the bottom-right
+of the single finder. This saves enormous space, making symbols 50–75% smaller
+than equivalent QR Codes.
+
+## Symbol Sizes
+
+| Symbol | Size | Max numeric | Max alphanumeric | Max bytes |
+|--------|------|-------------|------------------|-----------|
+| M1     | 11×11 | 5           | —               | —         |
+| M2     | 13×13 | 10          | 6               | 4         |
+| M3     | 15×15 | 23          | 14              | 9         |
+| M4     | 17×17 | 35          | 21              | 15        |
+
+## Installation
+
+```bash
+npm install @coding-adventures/micro-qr
+```
+
+## Usage
+
+```typescript
+import { encode, mqrLayout, encodeAndLayout } from "@coding-adventures/micro-qr";
+
+// Encode to a ModuleGrid (abstract boolean grid)
+const grid = encode("HELLO");
+// grid.rows === 13, grid.cols === 13 (M2 symbol)
+
+// Encode with explicit version and ECC level
+const m4Grid = encode("https://example.com", { version: "M4", ecc: "L" });
+
+// Convert to a PaintScene for rendering
+const scene = mqrLayout(grid);
+
+// Encode + layout in one step
+const scene2 = encodeAndLayout("HELLO", { version: "M4", ecc: "M" });
+```
+
+## API
+
+### `encode(input, options?)`
+
+Encodes a string to a Micro QR Code `ModuleGrid`.
+
+- `options.version?: "M1" | "M2" | "M3" | "M4"` — force a specific symbol size.
+  If omitted, the smallest symbol that fits the input is chosen.
+- `options.ecc?: "DETECTION" | "L" | "M" | "Q"` — error correction level.
+  If omitted, the encoder tries L, M, Q in order.
+
+Returns a `ModuleGrid` with `moduleShape: "square"`.
+
+### `mqrLayout(grid, config?)`
+
+Converts a `ModuleGrid` to a `PaintScene` using `barcode-2d`'s `layout()`.
+Defaults to `quietZoneModules: 2` (the Micro QR minimum, half of regular QR's 4).
+
+### `encodeAndLayout(input, options?, config?)`
+
+Convenience: `encode` + `mqrLayout` in one call.
+
+### `explain(input, options?)`
+
+Returns an `AnnotatedModuleGrid` for visualizer use (v0.1.0: annotations are null).
+
+## Error Handling
+
+```typescript
+import {
+  MicroQRError,
+  InputTooLongError,
+  UnsupportedModeError,
+  ECCNotAvailableError,
+} from "@coding-adventures/micro-qr";
+
+try {
+  encode("a".repeat(20)); // exceeds M3-L byte capacity (9)
+} catch (e) {
+  if (e instanceof InputTooLongError) {
+    // Input too long for any Micro QR symbol at any ECC level
+  }
+}
+```
+
+## Key Differences from Regular QR Code
+
+| Feature | Regular QR | Micro QR |
+|---------|-----------|----------|
+| Finder patterns | 3 | 1 |
+| Timing strips | Row 6, col 6 | Row 0, col 0 |
+| Quiet zone | 4 modules | 2 modules |
+| ECC levels | L, M, Q, H | DETECTION, L, M, Q |
+| Mask patterns | 8 | 4 |
+| Format info copies | 2 | 1 |
+| Format XOR mask | 0x5412 | 0x4445 |
+| Max capacity | 7089 numeric | 35 numeric |
+
+## Dependencies
+
+- `@coding-adventures/barcode-2d` — `ModuleGrid` type and `layout()` function
+- `@coding-adventures/gf256` — GF(256) multiplication for the Reed-Solomon encoder

--- a/code/packages/typescript/micro-qr/package-lock.json
+++ b/code/packages/typescript/micro-qr/package-lock.json
@@ -1,0 +1,2538 @@
+{
+  "name": "@coding-adventures/micro-qr",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/micro-qr",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/barcode-2d": "file:../barcode-2d",
+        "@coding-adventures/gf256": "file:../gf256"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../barcode-2d": {
+      "name": "@coding-adventures/barcode-2d",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../gf256": {
+      "name": "@coding-adventures/gf256",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/barcode-2d": {
+      "resolved": "../barcode-2d",
+      "link": true
+    },
+    "node_modules/@coding-adventures/gf256": {
+      "resolved": "../gf256",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/micro-qr/package.json
+++ b/code/packages/typescript/micro-qr/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/micro-qr",
+  "version": "0.1.0",
+  "description": "Micro QR Code encoder — ISO/IEC 18004:2015 Annex E, produces scannable M1–M4 symbols",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/barcode-2d": "file:../barcode-2d",
+    "@coding-adventures/gf256": "file:../gf256"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/micro-qr/src/index.ts
+++ b/code/packages/typescript/micro-qr/src/index.ts
@@ -1,0 +1,1155 @@
+/**
+ * @module micro-qr
+ *
+ * Micro QR Code encoder — ISO/IEC 18004:2015 Annex E compliant.
+ *
+ * Micro QR Code is the compact variant of QR Code, designed for applications
+ * where even the smallest standard QR (21×21) is too large. Think
+ * surface-mount component labels, circuit board markings, and miniature
+ * industrial tags.
+ *
+ * ## What makes Micro QR different from regular QR?
+ *
+ * Regular QR Code uses three identical 7×7 finder patterns (squares at
+ * top-left, top-right, and bottom-left corners) so a scanner can identify
+ * orientation from any angle. Micro QR uses only **one** finder, in the
+ * top-left. Because there is only one, orientation is always unambiguous —
+ * the data area is always to the bottom-right of the single finder. This
+ * saves enormous space at the cost of needing a controlled scanning
+ * environment.
+ *
+ * ## Symbol sizes
+ *
+ * ```
+ * M1: 11×11   M2: 13×13   M3: 15×15   M4: 17×17
+ * formula: size = 2 × version_number + 9
+ * ```
+ *
+ * ## Encoding pipeline
+ *
+ * ```
+ * input string
+ *   → auto-select smallest symbol (M1..M4) and mode (numeric/alphanumeric/byte)
+ *   → build bit stream (mode indicator + char count + data + terminator + padding)
+ *   → Reed-Solomon ECC (GF(256)/0x11D, b=0, single block)
+ *   → initialize grid (finder, L-shaped separator, timing at row0/col0, format reserved)
+ *   → zigzag data placement (two-column snake from bottom-right)
+ *   → evaluate 4 mask patterns, pick lowest penalty
+ *   → write format information (15 bits, single copy, XOR 0x4445)
+ *   → ModuleGrid
+ * ```
+ */
+
+import {
+  type ModuleGrid,
+  type Barcode2DLayoutConfig,
+  type PaintScene,
+  type AnnotatedModuleGrid,
+  layout,
+} from "@coding-adventures/barcode-2d";
+
+import { multiply as gfMul, ALOG } from "@coding-adventures/gf256";
+
+export type { ModuleGrid, Barcode2DLayoutConfig, PaintScene, AnnotatedModuleGrid };
+
+export const VERSION = "0.1.0";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Micro QR symbol designator (M1 through M4).
+ *
+ * Each step up adds two rows/columns (size = 2×version+9), increasing
+ * data capacity. M1 is the smallest (11×11) and supports only numeric mode
+ * with no real error correction. M4 (17×17) supports all four modes and
+ * reaches 35 numeric digits at ECC-L.
+ */
+export type MicroQRVersion = "M1" | "M2" | "M3" | "M4";
+
+/**
+ * Error correction level.
+ *
+ * Unlike regular QR which has L/M/Q/H, Micro QR has a reduced set:
+ *
+ * | Level     | Available in | Recovery |
+ * |-----------|-------------|---------|
+ * | DETECTION | M1 only     | detects errors only (no correction) |
+ * | L         | M2, M3, M4  | ~7% of codewords |
+ * | M         | M2, M3, M4  | ~15% of codewords |
+ * | Q         | M4 only     | ~25% of codewords |
+ *
+ * Level H (30%) is not available in any Micro QR symbol — the symbols
+ * are too small to afford that much redundancy.
+ */
+export type MicroQREccLevel = "DETECTION" | "L" | "M" | "Q";
+
+/**
+ * Error hierarchy for the Micro QR encoder.
+ *
+ * All errors extend MicroQRError so callers can catch the whole family
+ * with a single `instanceof MicroQRError` guard.
+ */
+export class MicroQRError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MicroQRError";
+  }
+}
+
+/** Input is too long for any M1–M4 symbol at any ECC level. */
+export class InputTooLongError extends MicroQRError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InputTooLongError";
+  }
+}
+
+/** The requested encoding mode is not available for the chosen symbol. */
+export class UnsupportedModeError extends MicroQRError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedModeError";
+  }
+}
+
+/** A character cannot be encoded in the selected mode. */
+export class InvalidCharacterError extends MicroQRError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidCharacterError";
+  }
+}
+
+/** The requested ECC level is not available for the chosen symbol. */
+export class ECCNotAvailableError extends MicroQRError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ECCNotAvailableError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Capacity and codeword tables
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Symbol+ECC configuration.
+ *
+ * There are exactly 8 valid (version, ECC) combinations in Micro QR.
+ * We use a tuple index 0..7 derived from the symbol_indicator field
+ * in the format information (the standard's own numbering).
+ *
+ * symbol_indicator → version+ECC:
+ *   0 = M1/DETECTION   4 = M3/M
+ *   1 = M2/L           5 = M4/L
+ *   2 = M2/M           6 = M4/M
+ *   3 = M3/L           7 = M4/Q
+ */
+interface SymbolConfig {
+  version: MicroQRVersion;
+  ecc: MicroQREccLevel;
+  symbolIndicator: number;    // 0..7, used in format information
+  size: number;               // symbol side length in modules
+  dataCW: number;             // data codewords (full bytes)
+  eccCW: number;              // ECC codewords
+  numericCap: number;         // max numeric characters
+  alphaCap: number;           // max alphanumeric chars (-1 = not supported)
+  byteCap: number;            // max byte chars (-1 = not supported)
+  kanjiCap: number;           // max kanji chars (-1 = not supported)
+  terminatorBits: number;     // 3/5/7/9 zero bits appended after data
+  modeIndicatorBits: number;  // 0/1/2/3 bits for the mode indicator field
+  charCountBitsNumeric: number;    // char-count field width for numeric
+  charCountBitsAlpha: number;      // char-count field width for alphanumeric
+  charCountBitsByte: number;       // char-count field width for byte
+  charCountBitsKanji: number;      // char-count field width for kanji
+  m1HalfCW: boolean;          // true for M1: last data "codeword" is 4 bits
+}
+
+/**
+ * All 8 valid Micro QR symbol configurations from ISO 18004:2015 Annex E.
+ *
+ * The data capacities, codeword counts, and field widths are mandatory
+ * compile-time constants — do not compute them at runtime.
+ */
+const SYMBOL_CONFIGS: SymbolConfig[] = [
+  // M1 / DETECTION
+  {
+    version: "M1", ecc: "DETECTION", symbolIndicator: 0, size: 11,
+    dataCW: 3, eccCW: 2,
+    numericCap: 5, alphaCap: -1, byteCap: -1, kanjiCap: -1,
+    terminatorBits: 3, modeIndicatorBits: 0,
+    charCountBitsNumeric: 3, charCountBitsAlpha: 0, charCountBitsByte: 0, charCountBitsKanji: 0,
+    m1HalfCW: true,
+  },
+  // M2 / L
+  {
+    version: "M2", ecc: "L", symbolIndicator: 1, size: 13,
+    dataCW: 5, eccCW: 5,
+    numericCap: 10, alphaCap: 6, byteCap: 4, kanjiCap: -1,
+    terminatorBits: 5, modeIndicatorBits: 1,
+    charCountBitsNumeric: 4, charCountBitsAlpha: 3, charCountBitsByte: 4, charCountBitsKanji: 0,
+    m1HalfCW: false,
+  },
+  // M2 / M
+  {
+    version: "M2", ecc: "M", symbolIndicator: 2, size: 13,
+    dataCW: 4, eccCW: 6,
+    numericCap: 8, alphaCap: 5, byteCap: 3, kanjiCap: -1,
+    terminatorBits: 5, modeIndicatorBits: 1,
+    charCountBitsNumeric: 4, charCountBitsAlpha: 3, charCountBitsByte: 4, charCountBitsKanji: 0,
+    m1HalfCW: false,
+  },
+  // M3 / L
+  {
+    version: "M3", ecc: "L", symbolIndicator: 3, size: 15,
+    dataCW: 11, eccCW: 6,
+    numericCap: 23, alphaCap: 14, byteCap: 9, kanjiCap: -1,
+    terminatorBits: 7, modeIndicatorBits: 2,
+    charCountBitsNumeric: 5, charCountBitsAlpha: 4, charCountBitsByte: 4, charCountBitsKanji: 0,
+    m1HalfCW: false,
+  },
+  // M3 / M
+  {
+    version: "M3", ecc: "M", symbolIndicator: 4, size: 15,
+    dataCW: 9, eccCW: 8,
+    numericCap: 18, alphaCap: 11, byteCap: 7, kanjiCap: -1,
+    terminatorBits: 7, modeIndicatorBits: 2,
+    charCountBitsNumeric: 5, charCountBitsAlpha: 4, charCountBitsByte: 4, charCountBitsKanji: 0,
+    m1HalfCW: false,
+  },
+  // M4 / L
+  {
+    version: "M4", ecc: "L", symbolIndicator: 5, size: 17,
+    dataCW: 16, eccCW: 8,
+    numericCap: 35, alphaCap: 21, byteCap: 15, kanjiCap: 9,
+    terminatorBits: 9, modeIndicatorBits: 3,
+    charCountBitsNumeric: 6, charCountBitsAlpha: 5, charCountBitsByte: 5, charCountBitsKanji: 4,
+    m1HalfCW: false,
+  },
+  // M4 / M
+  {
+    version: "M4", ecc: "M", symbolIndicator: 6, size: 17,
+    dataCW: 14, eccCW: 10,
+    numericCap: 30, alphaCap: 18, byteCap: 13, kanjiCap: 8,
+    terminatorBits: 9, modeIndicatorBits: 3,
+    charCountBitsNumeric: 6, charCountBitsAlpha: 5, charCountBitsByte: 5, charCountBitsKanji: 4,
+    m1HalfCW: false,
+  },
+  // M4 / Q
+  {
+    version: "M4", ecc: "Q", symbolIndicator: 7, size: 17,
+    dataCW: 10, eccCW: 14,
+    numericCap: 21, alphaCap: 13, byteCap: 9, kanjiCap: 6,
+    terminatorBits: 9, modeIndicatorBits: 3,
+    charCountBitsNumeric: 6, charCountBitsAlpha: 5, charCountBitsByte: 5, charCountBitsKanji: 4,
+    m1HalfCW: false,
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RS generator polynomials (compile-time constants)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Monic RS generator polynomials over GF(256)/0x11D, b=0 convention.
+ *
+ * These are the polynomials g(x) = (x+α⁰)(x+α¹)···(x+α^{n-1}).
+ * Coefficients listed highest-degree first; leading monic term (1) included
+ * so the array has n+1 entries.
+ *
+ * We only need counts {2, 5, 6, 8, 10, 14} for Micro QR.
+ */
+const RS_GENERATORS: ReadonlyMap<number, ReadonlyArray<number>> = new Map([
+  // 2 ECC codewords (M1 detection)
+  // g(x) = (x+1)(x+α) = x² + 3x + 2
+  [2, [0x01, 0x03, 0x02]],
+
+  // 5 ECC codewords (M2-L)
+  [5, [0x01, 0x1f, 0xf6, 0x44, 0xd9, 0x68]],
+
+  // 6 ECC codewords (M2-M, M3-L)
+  [6, [0x01, 0x3f, 0x4e, 0x17, 0x9b, 0x05, 0x37]],
+
+  // 8 ECC codewords (M3-M, M4-L)
+  [8, [0x01, 0x63, 0x0d, 0x60, 0x6d, 0x5b, 0x10, 0xa2, 0xa3]],
+
+  // 10 ECC codewords (M4-M)
+  [10, [0x01, 0xf6, 0x75, 0xa8, 0xd0, 0xc3, 0xe3, 0x36, 0xe1, 0x3c, 0x45]],
+
+  // 14 ECC codewords (M4-Q)
+  [14, [0x01, 0xf6, 0x9a, 0x60, 0x97, 0x8a, 0xf1, 0xa4, 0xa1, 0x8e, 0xfc, 0x7a, 0x52, 0xad, 0xac]],
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-computed format information table
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * All 32 pre-computed format information words (after XOR with 0x4445).
+ *
+ * Indexed as FORMAT_TABLE[symbolIndicator][maskPattern].
+ *
+ * The 15-bit format word encodes:
+ *   [symbol_indicator (3 bits)] [mask_pattern (2 bits)] [BCH-10 remainder]
+ * then XOR-masked with 0x4445 (not 0x5412 like regular QR).
+ *
+ * Source: computed via the BCH(15,5) procedure with G(x)=0x537.
+ *
+ * | Symbol+ECC | Mask 0 | Mask 1 | Mask 2 | Mask 3 |
+ * |-----------|--------|--------|--------|--------|
+ * | M1 (000)  | 0x4445 | 0x4172 | 0x4E2B | 0x4B1C |
+ * | M2-L(001) | 0x5528 | 0x501F | 0x5F46 | 0x5A71 |
+ * | M2-M(010) | 0x6649 | 0x637E | 0x6C27 | 0x6910 |
+ * | M3-L(011) | 0x7764 | 0x7253 | 0x7D0A | 0x783D |
+ * | M3-M(100) | 0x06DE | 0x03E9 | 0x0CB0 | 0x0987 |
+ * | M4-L(101) | 0x17F3 | 0x12C4 | 0x1D9D | 0x18AA |
+ * | M4-M(110) | 0x24B2 | 0x2185 | 0x2EDC | 0x2BEB |
+ * | M4-Q(111) | 0x359F | 0x30A8 | 0x3FF1 | 0x3AC6 |
+ */
+const FORMAT_TABLE: ReadonlyArray<ReadonlyArray<number>> = [
+  [0x4445, 0x4172, 0x4E2B, 0x4B1C],  // M1
+  [0x5528, 0x501F, 0x5F46, 0x5A71],  // M2-L
+  [0x6649, 0x637E, 0x6C27, 0x6910],  // M2-M
+  [0x7764, 0x7253, 0x7D0A, 0x783D],  // M3-L
+  [0x06DE, 0x03E9, 0x0CB0, 0x0987],  // M3-M
+  [0x17F3, 0x12C4, 0x1D9D, 0x18AA],  // M4-L
+  [0x24B2, 0x2185, 0x2EDC, 0x2BEB],  // M4-M
+  [0x359F, 0x30A8, 0x3FF1, 0x3AC6],  // M4-Q
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Encoding mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The 45-character alphanumeric set used in QR and Micro QR.
+ *
+ * Pairs pack into 11 bits: (first×45 + second).
+ * A trailing single character uses 6 bits.
+ */
+const ALPHANUM_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+type EncodingMode = "numeric" | "alphanumeric" | "byte";
+
+/**
+ * Mode indicator values, keyed by (mode, symbol version).
+ *
+ * M1: no indicator (0 bits — only numeric mode exists)
+ * M2: 1 bit  — 0=numeric, 1=alphanumeric
+ * M3: 2 bits — 00=numeric, 01=alphanumeric, 10=byte
+ * M4: 3 bits — 000=numeric, 001=alphanumeric, 010=byte, 011=kanji
+ *
+ * The fact that mode indicator widths grow with version is deliberate:
+ * larger symbols can fit more modes, so they need more bits to distinguish them.
+ */
+function modeIndicatorValue(mode: EncodingMode, cfg: SymbolConfig): number {
+  if (cfg.modeIndicatorBits === 0) return 0; // M1, no indicator
+  if (cfg.modeIndicatorBits === 1) return mode === "numeric" ? 0 : 1;
+  if (cfg.modeIndicatorBits === 2) {
+    if (mode === "numeric") return 0b00;
+    if (mode === "alphanumeric") return 0b01;
+    return 0b10; // byte
+  }
+  // 3 bits (M4)
+  if (mode === "numeric") return 0b000;
+  if (mode === "alphanumeric") return 0b001;
+  return 0b010; // byte (kanji = 0b011 but handled separately)
+}
+
+function charCountBits(mode: EncodingMode, cfg: SymbolConfig): number {
+  if (mode === "numeric") return cfg.charCountBitsNumeric;
+  if (mode === "alphanumeric") return cfg.charCountBitsAlpha;
+  return cfg.charCountBitsByte;
+}
+
+/**
+ * Determine the most compact encoding mode that covers the full input
+ * and is supported by the given symbol configuration.
+ *
+ * Selection order (most compact to least):
+ *   1. numeric   — all chars are 0–9
+ *   2. alphanumeric — all chars in the 45-char set
+ *   3. byte      — raw UTF-8 bytes
+ *
+ * Kanji mode is handled separately (future extension).
+ */
+function selectMode(input: string, cfg: SymbolConfig): EncodingMode {
+  const isNumeric = input === "" || /^\d+$/.test(input);
+  if (isNumeric && cfg.charCountBitsNumeric > 0) return "numeric";
+
+  const isAlpha = [...input].every((c) => ALPHANUM_CHARS.includes(c));
+  if (isAlpha && cfg.alphaCap > 0) return "alphanumeric";
+
+  if (cfg.byteCap > 0) return "byte";
+
+  throw new UnsupportedModeError(
+    `Input cannot be encoded in any mode supported by ${cfg.version}-${cfg.ecc}. ` +
+    `Use a higher version or switch to byte mode.`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bit-writer utility
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Accumulates individual bits, then flushes them as a byte array.
+ *
+ * The bit stream for Micro QR is MSB-first within each codeword:
+ * the first bit written ends up as the most-significant bit of byte 0.
+ *
+ * This mirrors a serial data bus where the most significant bit is
+ * transmitted first ("big-endian bit order").
+ */
+class BitWriter {
+  private readonly _bits: number[] = [];
+
+  /** Append `count` bits from `value`, MSB first. */
+  write(value: number, count: number): void {
+    for (let i = count - 1; i >= 0; i--) {
+      this._bits.push((value >> i) & 1);
+    }
+  }
+
+  get bitLength(): number { return this._bits.length; }
+
+  /**
+   * Return all accumulated bits as a packed byte array.
+   * If the bit count is not a multiple of 8, the last byte is
+   * zero-padded on the right (least-significant bits are 0).
+   */
+  toBytes(): number[] {
+    const bytes: number[] = [];
+    for (let i = 0; i < this._bits.length; i += 8) {
+      let b = 0;
+      for (let j = 0; j < 8; j++) b = (b << 1) | (this._bits[i + j] ?? 0);
+      bytes.push(b);
+    }
+    return bytes;
+  }
+
+  toBits(): number[] { return [...this._bits]; }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data encoding helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Encode a numeric string into the bit writer.
+ *
+ * Groups of three digits map to 10 bits (values 0–999).
+ * A remaining pair maps to 7 bits (0–99).
+ * A single trailing digit maps to 4 bits (0–9).
+ *
+ * Example: "12345" → "123" (10b=0001111011) + "45" (7b=0101101) = 17 bits.
+ */
+function encodeNumeric(input: string, w: BitWriter): void {
+  let i = 0;
+  while (i + 2 < input.length) {
+    w.write(parseInt(input.slice(i, i + 3), 10), 10);
+    i += 3;
+  }
+  if (i + 1 < input.length) {
+    w.write(parseInt(input.slice(i, i + 2), 10), 7);
+    i += 2;
+  }
+  if (i < input.length) {
+    w.write(parseInt(input[i]!, 10), 4);
+  }
+}
+
+/**
+ * Encode an alphanumeric string into the bit writer.
+ *
+ * Pairs encode as (firstIndex × 45 + secondIndex) in 11 bits.
+ * A trailing single character uses 6 bits.
+ */
+function encodeAlphanumeric(input: string, w: BitWriter): void {
+  let i = 0;
+  while (i + 1 < input.length) {
+    const a = ALPHANUM_CHARS.indexOf(input[i]!);
+    const b = ALPHANUM_CHARS.indexOf(input[i + 1]!);
+    if (a < 0 || b < 0) throw new InvalidCharacterError(
+      `Character not in alphanumeric set: '${a < 0 ? input[i] : input[i + 1]}'`
+    );
+    w.write(a * 45 + b, 11);
+    i += 2;
+  }
+  if (i < input.length) {
+    const a = ALPHANUM_CHARS.indexOf(input[i]!);
+    if (a < 0) throw new InvalidCharacterError(
+      `Character not in alphanumeric set: '${input[i]}'`
+    );
+    w.write(a, 6);
+  }
+}
+
+/**
+ * Encode a byte-mode string by writing each UTF-8 byte as 8 bits.
+ *
+ * For ASCII / ISO-8859-1 inputs this is identical to the raw byte values.
+ * For multi-byte UTF-8 characters, each byte of the UTF-8 encoding is
+ * written individually — so a 3-byte UTF-8 code point uses 3 byte-count
+ * units and 24 bits. Scanners that understand UTF-8 will reconstruct the
+ * original character; older scanners see the raw bytes.
+ */
+function encodeByte(input: string, w: BitWriter): void {
+  const bytes = new TextEncoder().encode(input);
+  for (const b of bytes) w.write(b, 8);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reed-Solomon encoder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute n ECC bytes using GF(256)/0x11D polynomial division.
+ *
+ * This is the LFSR (Linear Feedback Shift Register) implementation
+ * of polynomial remainder division:
+ *
+ * ```
+ * ecc = [0] × n
+ * for each data byte b:
+ *   feedback = b XOR ecc[0]
+ *   shift ecc left (drop ecc[0], append 0)
+ *   for i in 0..n-1:
+ *     ecc[i] ^= G[i+1] × feedback   (GF multiplication)
+ * ```
+ *
+ * The resulting `ecc` array is the remainder of D(x)·x^n mod G(x).
+ * For b=0 convention, the first root of G is α^0 = 1, so the standard
+ * syndrome check S_j = R(α^j) for j=0..n-1 should yield all zeros for
+ * a valid codeword.
+ */
+function rsEncode(data: number[], eccCount: number): number[] {
+  const gen = RS_GENERATORS.get(eccCount);
+  if (!gen) throw new MicroQRError(`No generator polynomial for eccCount=${eccCount}`);
+  const n = eccCount;
+  const rem: number[] = new Array(n).fill(0);
+  for (const b of data) {
+    const fb = b ^ rem[0]!;
+    for (let i = 0; i < n - 1; i++) rem[i] = rem[i + 1]!;
+    rem[n - 1] = 0;
+    if (fb !== 0) {
+      for (let i = 0; i < n; i++) rem[i]! != null && (rem[i] ^= gfMul(gen[i + 1] as number, fb));
+    }
+  }
+  return rem;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data codeword assembly
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the complete data codeword byte sequence for the given input and config.
+ *
+ * For all symbols except M1:
+ *   [mode indicator] [char count] [data bits] [terminator] [byte-align pad] [0xEC/0x11 fill]
+ *   Total: exactly cfg.dataCW bytes.
+ *
+ * For M1 (m1HalfCW = true):
+ *   Total data capacity is 20 bits (2 full bytes + 4-bit nibble).
+ *   The RS encoder receives 3 bytes where byte[2] has data in the upper 4 bits
+ *   and 0000 in the lower 4 bits.
+ *   No 0xEC/0x11 padding is used for M1.
+ *
+ * The terminator is `terminatorBits` zero bits, truncated if capacity is full.
+ */
+function buildDataCodewords(input: string, cfg: SymbolConfig): number[] {
+  const mode = selectMode(input, cfg);
+
+  // Total capacity in bits
+  const totalBits = cfg.m1HalfCW
+    ? cfg.dataCW * 8 - 4     // M1: 3×8 − 4 = 20 usable bits
+    : cfg.dataCW * 8;
+
+  const w = new BitWriter();
+
+  // Mode indicator (0 bits for M1, otherwise 1/2/3 bits)
+  if (cfg.modeIndicatorBits > 0) {
+    w.write(modeIndicatorValue(mode, cfg), cfg.modeIndicatorBits);
+  }
+
+  // Character count
+  const ccBits = charCountBits(mode, cfg);
+  const byteInput = new TextEncoder().encode(input);
+  const charCount = mode === "byte" ? byteInput.length : input.length;
+  w.write(charCount, ccBits);
+
+  // Encoded data
+  if (mode === "numeric")      encodeNumeric(input, w);
+  else if (mode === "alphanumeric") encodeAlphanumeric(input, w);
+  else                         encodeByte(input, w);
+
+  // Terminator: up to terminatorBits zero bits (truncated if capacity exhausted)
+  const remaining = totalBits - w.bitLength;
+  if (remaining > 0) w.write(0, Math.min(cfg.terminatorBits, remaining));
+
+  if (cfg.m1HalfCW) {
+    // M1: pad to exactly 20 bits with zeros, then pack into 3 bytes
+    // (the last byte has data in the upper 4 bits, lower 4 bits = 0000)
+    const bits = w.toBits();
+    while (bits.length < 20) bits.push(0);
+    // Truncate to 20 bits (terminator might overshoot in theory but shouldn't)
+    bits.splice(20);
+    // Pack into 3 bytes: byte0 = bits[0..7], byte1 = bits[8..15],
+    // byte2 = bits[16..19] << 4 (upper nibble only)
+    const b0 = (bits[0]! << 7) | (bits[1]! << 6) | (bits[2]! << 5) | (bits[3]! << 4) |
+               (bits[4]! << 3) | (bits[5]! << 2) | (bits[6]! << 1) | bits[7]!;
+    const b1 = (bits[8]! << 7) | (bits[9]! << 6) | (bits[10]! << 5) | (bits[11]! << 4) |
+               (bits[12]! << 3) | (bits[13]! << 2) | (bits[14]! << 1) | bits[15]!;
+    const b2 = (bits[16]! << 7) | (bits[17]! << 6) | (bits[18]! << 5) | (bits[19]! << 4);
+    return [b0, b1, b2];
+  }
+
+  // Pad to byte boundary
+  const rem = w.bitLength % 8;
+  if (rem !== 0) w.write(0, 8 - rem);
+
+  // Fill remaining data codewords with alternating 0xEC / 0x11
+  const bytes = w.toBytes();
+  let padByte = 0xec;
+  while (bytes.length < cfg.dataCW) {
+    bytes.push(padByte);
+    padByte = padByte === 0xec ? 0x11 : 0xec;
+  }
+  return bytes;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symbol / version selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the smallest symbol configuration that can hold the given input.
+ *
+ * The auto-selection algorithm:
+ *   For each config in SYMBOL_CONFIGS (M1→M4-Q order):
+ *     If the requested ECC level matches (or is "any"):
+ *       Determine the encoding mode for this symbol.
+ *       If the character count fits within the symbol's capacity:
+ *         Return this config.
+ *
+ * The capacity check uses the pre-computed character limits (numericCap,
+ * alphaCap, byteCap) rather than re-computing from bit counts. This
+ * matches the standard's own capacity tables exactly.
+ */
+function selectConfig(
+  input: string,
+  version?: MicroQRVersion,
+  ecc?: MicroQREccLevel,
+): SymbolConfig {
+  const candidates = SYMBOL_CONFIGS.filter((c) => {
+    if (version && c.version !== version) return false;
+    if (ecc && c.ecc !== ecc) return false;
+    return true;
+  });
+
+  if (candidates.length === 0) {
+    throw new ECCNotAvailableError(
+      `No symbol configuration matches version=${version ?? "any"} ecc=${ecc ?? "any"}.`
+    );
+  }
+
+  for (const cfg of candidates) {
+    try {
+      const mode = selectMode(input, cfg);
+      const byteLen = new TextEncoder().encode(input).length;
+      const len = mode === "byte" ? byteLen : input.length;
+      const cap = mode === "numeric" ? cfg.numericCap :
+                  mode === "alphanumeric" ? cfg.alphaCap :
+                  cfg.byteCap;
+      if (cap >= 0 && len <= cap) return cfg;
+    } catch {
+      // Mode not supported or input doesn't fit — try next config
+    }
+  }
+
+  throw new InputTooLongError(
+    `Input "${input.length > 20 ? input.slice(0, 20) + "…" : input}" ` +
+    `(length ${input.length}) does not fit in any Micro QR symbol ` +
+    `(version=${version ?? "any"}, ecc=${ecc ?? "any"}). ` +
+    `Maximum is 35 numeric characters in M4-L.`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Internal working grid — tracks both module values (dark/light) and
+ * which positions are "reserved" (structural) so the data placement
+ * and masking steps know which modules to skip.
+ */
+interface WorkGrid {
+  size: number;
+  modules: boolean[][];   // true = dark
+  reserved: boolean[][];  // true = structural (finder/separator/timing/format)
+}
+
+function makeWorkGrid(size: number): WorkGrid {
+  return {
+    size,
+    modules: Array.from({ length: size }, () => new Array<boolean>(size).fill(false)),
+    reserved: Array.from({ length: size }, () => new Array<boolean>(size).fill(false)),
+  };
+}
+
+function setMod(g: WorkGrid, r: number, c: number, dark: boolean, reserve = false): void {
+  g.modules[r]![c] = dark;
+  if (reserve) g.reserved[r]![c] = true;
+}
+
+/**
+ * Place the 7×7 finder pattern at the top-left corner (rows 0–6, cols 0–6).
+ *
+ * The pattern:
+ * ```
+ * ■ ■ ■ ■ ■ ■ ■
+ * ■ □ □ □ □ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ ■ ■ ■ □ ■
+ * ■ □ □ □ □ □ ■
+ * ■ ■ ■ ■ ■ ■ ■
+ * ```
+ *
+ * Dark modules form the outer border and a 3×3 inner core.
+ * This 1:1:3:1:1 dark:light ratio is what scanners look for.
+ */
+function placeFinder(g: WorkGrid): void {
+  for (let dr = 0; dr < 7; dr++) {
+    for (let dc = 0; dc < 7; dc++) {
+      const onBorder = dr === 0 || dr === 6 || dc === 0 || dc === 6;
+      const inCore   = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+      setMod(g, dr, dc, onBorder || inCore, true);
+    }
+  }
+}
+
+/**
+ * Place the L-shaped separator (light modules bordering the finder on its
+ * bottom and right sides).
+ *
+ * In regular QR, each of the three finder patterns is surrounded on all
+ * four sides by light separators. In Micro QR, the finder is in the
+ * top-left corner, so the top and left edges are the symbol boundary —
+ * only the bottom and right need separators:
+ *
+ * ```
+ * Row 7, cols 0–7  (bottom of finder + corner)
+ * Col 7, rows 0–7  (right of finder + corner)
+ * ```
+ */
+function placeSeparator(g: WorkGrid): void {
+  for (let i = 0; i <= 7; i++) {
+    setMod(g, 7, i, false, true);  // bottom row
+    setMod(g, i, 7, false, true);  // right column
+  }
+}
+
+/**
+ * Place the timing pattern extensions.
+ *
+ * The timing pattern in Micro QR runs along row 0 and col 0. The first
+ * 7 positions (0–6) are already covered by the finder pattern. Position 7
+ * is the separator (always light). Positions 8 onward alternate dark/light:
+ *
+ * ```
+ * Dark at even col index: col 8, 10, 12, ...
+ * Dark at even row index: row 8, 10, 12, ...
+ * ```
+ *
+ * Unlike regular QR, there is no "hop over col 6" because the timing
+ * column is col 0, not col 6.
+ */
+function placeTiming(g: WorkGrid): void {
+  const sz = g.size;
+  // Row 0: timing from col 8 to sz-1
+  for (let c = 8; c < sz; c++) setMod(g, 0, c, c % 2 === 0, true);
+  // Col 0: timing from row 8 to sz-1
+  for (let r = 8; r < sz; r++) setMod(g, r, 0, r % 2 === 0, true);
+}
+
+/**
+ * Reserve format information module positions.
+ *
+ * The 15 format modules form an L-shape:
+ *   Row 8, cols 1–8  → 8 modules (hold bits f14..f7, MSB first)
+ *   Col 8, rows 1–7  → 7 modules (hold bits f6..f0, where f0 is at row 1)
+ *
+ * These are temporarily set to light (false) and marked reserved.
+ * Actual format bits are written after mask selection.
+ *
+ * Note: unlike regular QR which has TWO copies of format info, Micro QR
+ * has only ONE. This means a scanner cannot recover from damage to
+ * these modules — but the small symbol size means they're a smaller
+ * fraction of the total and less likely to be hit.
+ */
+function reserveFormatInfo(g: WorkGrid): void {
+  // Row 8, cols 1–8 (f14..f7)
+  for (let c = 1; c <= 8; c++) { g.modules[8]![c] = false; g.reserved[8]![c] = true; }
+  // Col 8, rows 1–7 (f6..f0)
+  for (let r = 1; r <= 7; r++) { g.modules[r]![8] = false; g.reserved[r]![8] = true; }
+}
+
+/**
+ * Write format information bits into the reserved positions.
+ *
+ * Placement (f14 = MSB):
+ *   Row 8, col 1  ← f14
+ *   Row 8, col 2  ← f13
+ *   ...
+ *   Row 8, col 8  ← f7
+ *   Col 8, row 7  ← f6
+ *   Col 8, row 6  ← f5
+ *   ...
+ *   Col 8, row 1  ← f0  (LSB)
+ *
+ * The row-8 strip goes left-to-right (MSB first).
+ * The col-8 strip goes upward (row 7 → row 1), so the LSB is nearest
+ * the finder corner.
+ */
+function writeFormatInfo(g: WorkGrid, fmtBits: number): void {
+  // Row 8, cols 1–8: bits f14 down to f7
+  for (let i = 0; i < 8; i++) {
+    g.modules[8]![1 + i] = ((fmtBits >> (14 - i)) & 1) === 1;
+  }
+  // Col 8, rows 7 down to 1: bits f6 down to f0
+  for (let i = 0; i < 7; i++) {
+    g.modules[7 - i]![8] = ((fmtBits >> (6 - i)) & 1) === 1;
+  }
+}
+
+/**
+ * Initialize the grid with all structural modules.
+ *
+ * Order matters: each function assumes earlier ones have run.
+ * reserved[][] is the authoritative mask for data placement.
+ */
+function buildGrid(cfg: SymbolConfig): WorkGrid {
+  const g = makeWorkGrid(cfg.size);
+  placeFinder(g);
+  placeSeparator(g);
+  placeTiming(g);
+  reserveFormatInfo(g);
+  return g;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data placement (two-column zigzag)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Place the final codeword stream into the grid using the two-column zigzag.
+ *
+ * The zigzag scans from the bottom-right corner, moving left two columns
+ * at a time, alternating upward and downward direction:
+ *
+ * ```
+ * col = size-1, dir = up
+ *   scan (size-1, col), (size-1, col-1)   ← rightmost cell of current row
+ *   scan (size-2, col), (size-2, col-1)
+ *   ...
+ *   scan (0, col),      (0, col-1)
+ * flip direction, col -= 2
+ * col = size-3, dir = down
+ *   scan (0, col), ...
+ * ```
+ *
+ * Reserved modules (finder/separator/timing/format) are skipped.
+ * Remaining unset modules after all bits are placed receive 0 (remainder bits).
+ *
+ * Key difference from regular QR: no timing column skip at col 6.
+ * Micro QR's timing is at col 0, which is already reserved everywhere,
+ * so the skip happens automatically through the reserved check.
+ */
+function placeBits(g: WorkGrid, bits: boolean[]): void {
+  const sz = g.size;
+  let bitIdx = 0;
+  let up = true;
+
+  for (let col = sz - 1; col >= 1; col -= 2) {
+    const rows = up
+      ? Array.from({ length: sz }, (_, i) => sz - 1 - i)  // sz-1 down to 0
+      : Array.from({ length: sz }, (_, i) => i);           // 0 up to sz-1
+
+    for (const row of rows) {
+      for (const dc of [0, 1]) {
+        const c = col - dc;
+        if (g.reserved[row]![c]) continue;
+        g.modules[row]![c] = bitIdx < bits.length ? bits[bitIdx++]! : false;
+      }
+    }
+    up = !up;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Masking
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The 4 mask conditions for Micro QR (patterns 0–3).
+ *
+ * These are the same as the first four patterns in regular QR's set of 8.
+ * If the condition is true for a data/ECC module, that module is flipped.
+ *
+ * | Pattern | Condition |
+ * |---------|-----------|
+ * | 0       | (row + col) mod 2 == 0 |
+ * | 1       | row mod 2 == 0 |
+ * | 2       | col mod 3 == 0 |
+ * | 3       | (row + col) mod 3 == 0 |
+ */
+const MASK_CONDITIONS: ReadonlyArray<(r: number, c: number) => boolean> = [
+  (r, c) => (r + c) % 2 === 0,
+  (r, _c) => r % 2 === 0,
+  (_r, c) => c % 3 === 0,
+  (r, c) => (r + c) % 3 === 0,
+];
+
+/**
+ * Apply mask pattern `maskIdx` to all non-reserved modules.
+ *
+ * Returns a new module array; the original is not modified (important
+ * because we evaluate all 4 masks to pick the best one).
+ */
+function applyMask(
+  modules: boolean[][], reserved: boolean[][], sz: number, maskIdx: number,
+): boolean[][] {
+  const cond = MASK_CONDITIONS[maskIdx]!;
+  return modules.map((row, r) =>
+    row.map((dark, c) => reserved[r]![c] ? dark : dark !== cond(r, c))
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Penalty scoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the 4-rule penalty score for a module grid.
+ *
+ * The four rules (same as regular QR):
+ *
+ * **Rule 1** — Adjacent same-color runs of 5+ modules in any row or column.
+ *   Score += (run_length - 2) for each run of length ≥ 5.
+ *   A run of 5 scores 3, a run of 7 scores 5, etc.
+ *
+ * **Rule 2** — 2×2 all-same-color blocks.
+ *   Score += 3 for each 2×2 square where all four modules share a color.
+ *   Overlapping blocks each count separately.
+ *
+ * **Rule 3** — Finder-pattern-like sequences.
+ *   Score += 40 for each occurrence of:
+ *     1 0 1 1 1 0 1 0 0 0 0   (looks like a finder in one scan direction)
+ *   or its reverse:
+ *     0 0 0 0 1 0 1 1 1 0 1
+ *   in any row or column. These sequences can confuse scanners trying to
+ *   locate the finder pattern.
+ *
+ * **Rule 4** — Dark/light proportion.
+ *   score += min(|prev5 - 50|, |next5 - 50|) / 5 × 10
+ *   where prev5 = largest multiple of 5 ≤ dark_percent,
+ *         next5 = prev5 + 5.
+ *   This penalizes symbols that are significantly darker or lighter than 50%.
+ */
+function computePenalty(modules: boolean[][], sz: number): number {
+  let penalty = 0;
+
+  // Rule 1 — adjacent same-color runs of ≥ 5
+  for (let a = 0; a < sz; a++) {
+    for (const horiz of [true, false]) {
+      let run = 1;
+      let prev = horiz ? modules[a]![0]! : modules[0]![a]!;
+      for (let i = 1; i < sz; i++) {
+        const cur = horiz ? modules[a]![i]! : modules[i]![a]!;
+        if (cur === prev) {
+          run++;
+        } else {
+          if (run >= 5) penalty += run - 2;
+          run = 1;
+          prev = cur;
+        }
+      }
+      if (run >= 5) penalty += run - 2;
+    }
+  }
+
+  // Rule 2 — 2×2 same-color blocks
+  for (let r = 0; r < sz - 1; r++) {
+    for (let c = 0; c < sz - 1; c++) {
+      const d = modules[r]![c]!;
+      if (d === modules[r]![c + 1]! && d === modules[r + 1]![c]! && d === modules[r + 1]![c + 1]!) {
+        penalty += 3;
+      }
+    }
+  }
+
+  // Rule 3 — finder-like sequences
+  const P1 = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
+  const P2 = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+  for (let a = 0; a < sz; a++) {
+    for (let b = 0; b <= sz - 11; b++) {
+      let mH1 = true, mH2 = true, mV1 = true, mV2 = true;
+      for (let k = 0; k < 11; k++) {
+        const bH = modules[a]![b + k]! ? 1 : 0;
+        const bV = modules[b + k]![a]! ? 1 : 0;
+        if (bH !== P1[k]) mH1 = false;
+        if (bH !== P2[k]) mH2 = false;
+        if (bV !== P1[k]) mV1 = false;
+        if (bV !== P2[k]) mV2 = false;
+      }
+      if (mH1) penalty += 40;
+      if (mH2) penalty += 40;
+      if (mV1) penalty += 40;
+      if (mV2) penalty += 40;
+    }
+  }
+
+  // Rule 4 — dark proportion deviation
+  let dark = 0;
+  for (let r = 0; r < sz; r++) for (let c = 0; c < sz; c++) if (modules[r]![c]!) dark++;
+  const darkPct = (dark / (sz * sz)) * 100;
+  const prev5 = Math.floor(darkPct / 5) * 5;
+  penalty += Math.min(Math.abs(prev5 - 50), Math.abs(prev5 + 5 - 50)) / 5 * 10;
+
+  return penalty;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full encode pipeline
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Encode an input string to a Micro QR Code ModuleGrid.
+ *
+ * The auto-selection logic (when version/ecc are omitted) picks the
+ * smallest symbol+ECC combination that fits the input. This means:
+ *
+ * - "1" → M1 (11×11, detection only)
+ * - "12345" → M1 (exactly fills 5-digit numeric capacity)
+ * - "HELLO" → M2-L (5 alphanumeric chars)
+ * - "hello" → M3-L (5 bytes, lowercase not in alphanumeric set)
+ * - "https://a.b" → M4-L (11 bytes)
+ *
+ * The returned grid is ready for `layout()` or `renderSvg()`.
+ */
+export function encode(input: string, options?: {
+  version?: MicroQRVersion;
+  ecc?: MicroQREccLevel;
+}): ModuleGrid {
+  const cfg = selectConfig(input, options?.version, options?.ecc);
+
+  // 1. Build data codewords
+  const dataCW = buildDataCodewords(input, cfg);
+
+  // 2. Compute RS ECC
+  const eccCW = rsEncode(dataCW, cfg.eccCW);
+
+  // 3. Flatten to bit stream
+  // For M1: data bytes are [b0, b1, b2] where b2 has data only in upper nibble.
+  // We emit 7.5 bytes = 60 bits but only the first 20 data bits matter;
+  // the remaining bits are ECC.
+  const finalCW = [...dataCW, ...eccCW];
+  const bits: boolean[] = [];
+  for (let cwIdx = 0; cwIdx < finalCW.length; cwIdx++) {
+    const cw = finalCW[cwIdx]!;
+    // For M1: last data codeword (index 2) contributes only 4 bits
+    const bitsInCW = cfg.m1HalfCW && cwIdx === cfg.dataCW - 1 ? 4 : 8;
+    for (let b = bitsInCW - 1; b >= 0; b--) {
+      bits.push(((cw >> (b + (8 - bitsInCW))) & 1) === 1);
+    }
+  }
+
+  // 4. Build grid
+  const grid = buildGrid(cfg);
+
+  // 5. Place bits
+  placeBits(grid, bits);
+
+  // 6. Evaluate all 4 masks, pick lowest penalty
+  let bestMask = 0;
+  let bestPenalty = Infinity;
+  for (let m = 0; m < 4; m++) {
+    const masked = applyMask(grid.modules, grid.reserved, cfg.size, m);
+    const fmtBits = FORMAT_TABLE[cfg.symbolIndicator]![m]!;
+    // Write format info into a temporary copy for penalty evaluation
+    const tmpModules = masked.map((row) => [...row]);
+    const tmpGrid: WorkGrid = { size: cfg.size, modules: tmpModules, reserved: grid.reserved };
+    writeFormatInfo(tmpGrid, fmtBits);
+    const p = computePenalty(tmpGrid.modules, cfg.size);
+    if (p < bestPenalty) {
+      bestPenalty = p;
+      bestMask = m;
+    }
+  }
+
+  // 7. Apply best mask and write final format info
+  const finalModules = applyMask(grid.modules, grid.reserved, cfg.size, bestMask);
+  const finalGrid: WorkGrid = { size: cfg.size, modules: finalModules, reserved: grid.reserved };
+  writeFormatInfo(finalGrid, FORMAT_TABLE[cfg.symbolIndicator]![bestMask]!);
+
+  return {
+    rows: cfg.size,
+    cols: cfg.size,
+    modules: finalModules,
+    moduleShape: "square",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Layout and rendering helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a ModuleGrid to a pixel-resolved PaintScene.
+ *
+ * Delegates to `barcode-2d`'s `layout()`. The quiet zone defaults to 2
+ * modules (half of regular QR's 4-module quiet zone) because Micro QR
+ * only requires 2 modules on all sides.
+ *
+ * Override with `config.quietZone` if needed.
+ */
+export function mqrLayout(
+  grid: ModuleGrid,
+  config?: Partial<Barcode2DLayoutConfig>,
+): PaintScene {
+  return layout(grid, { quietZoneModules: 2, ...config });
+}
+
+/**
+ * Encode a string and immediately convert to a PaintScene.
+ *
+ * Convenience wrapper for the common case of encoding and then rendering.
+ */
+export function encodeAndLayout(
+  input: string,
+  options?: { version?: MicroQRVersion; ecc?: MicroQREccLevel },
+  config?: Partial<Barcode2DLayoutConfig>,
+): PaintScene {
+  return mqrLayout(encode(input, options), config);
+}
+
+/**
+ * Encode with per-module role annotations (for interactive visualizers).
+ *
+ * v0.1.0: returns the encoded grid with null annotations.
+ */
+export function explain(
+  input: string,
+  options?: { version?: MicroQRVersion; ecc?: MicroQREccLevel },
+): AnnotatedModuleGrid {
+  const grid = encode(input, options);
+  return {
+    ...grid,
+    annotations: Array.from({ length: grid.rows }, () => new Array(grid.cols).fill(null)),
+  };
+}

--- a/code/packages/typescript/micro-qr/tests/micro-qr.test.ts
+++ b/code/packages/typescript/micro-qr/tests/micro-qr.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Comprehensive tests for the Micro QR Code encoder.
+ *
+ * Test strategy:
+ *   1. RS encoder — verify ECC bytes for known inputs
+ *   2. Format information — verify pre-computed table entries
+ *   3. Mode/version selection — auto-selection logic
+ *   4. Bit stream assembly — mode indicators, char counts, padding
+ *   5. Penalty scoring — known-degenerate grids
+ *   6. Integration — encode round-trip producing correct grid dimensions
+ *      and valid structural module placement
+ *   7. Error handling — InputTooLong, UnsupportedMode, ECCNotAvailable
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  encode,
+  mqrLayout,
+  encodeAndLayout,
+  explain,
+  MicroQRError,
+  InputTooLongError,
+  UnsupportedModeError,
+  ECCNotAvailableError,
+  VERSION,
+} from "../src/index";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: serialize a ModuleGrid to a string for snapshot comparisons
+// ─────────────────────────────────────────────────────────────────────────────
+
+function gridToString(modules: boolean[][]): string {
+  return modules.map((row) => row.map((d) => (d ? "1" : "0")).join("")).join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Version constant
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("version", () => {
+  it("exports VERSION constant", () => {
+    expect(VERSION).toBe("0.1.0");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Symbol dimensions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("symbol dimensions", () => {
+  it("M1 produces an 11×11 grid for single digit", () => {
+    const grid = encode("1");
+    expect(grid.rows).toBe(11);
+    expect(grid.cols).toBe(11);
+    expect(grid.modules.length).toBe(11);
+    expect(grid.modules[0]!.length).toBe(11);
+  });
+
+  it("M2 produces a 13×13 grid for HELLO", () => {
+    const grid = encode("HELLO");
+    expect(grid.rows).toBe(13);
+    expect(grid.cols).toBe(13);
+  });
+
+  it("M2 produces a 13×13 grid for A1B2C3 (6 alphanumeric fits in M2-L)", () => {
+    // M2-L has alphaCap=6, so 6 chars fits
+    const grid = encode("A1B2C3");
+    expect(grid.rows).toBe(13);
+    expect(grid.cols).toBe(13);
+  });
+
+  it("M4 produces a 17×17 grid for https://a.b", () => {
+    const grid = encode("https://a.b");
+    expect(grid.rows).toBe(17);
+    expect(grid.cols).toBe(17);
+  });
+
+  it("moduleShape is square", () => {
+    const grid = encode("1");
+    expect(grid.moduleShape).toBe("square");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Auto-version selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("auto-version selection", () => {
+  it("selects M1 for single digit '1'", () => {
+    const grid = encode("1");
+    expect(grid.rows).toBe(11); // M1 = 11×11
+  });
+
+  it("selects M1 for '12345' (5 numeric, M1 max)", () => {
+    const grid = encode("12345");
+    expect(grid.rows).toBe(11);
+  });
+
+  it("selects M2 for '123456' (6 digits exceeds M1, fits M2)", () => {
+    const grid = encode("123456");
+    expect(grid.rows).toBe(13); // M2 = 13×13
+  });
+
+  it("selects M2 for 'HELLO' (5 uppercase alphanumeric)", () => {
+    const grid = encode("HELLO");
+    expect(grid.rows).toBe(13);
+  });
+
+  it("selects M3+ for 'hello' (byte mode, lowercase not in alphanumeric set)", () => {
+    const grid = encode("hello");
+    expect(grid.rows).toBeGreaterThanOrEqual(15);
+  });
+
+  it("selects M4 for 'https://a.b' (11 byte chars)", () => {
+    const grid = encode("https://a.b");
+    expect(grid.rows).toBe(17);
+  });
+
+  it("selects M4 for long alphanumeric near M4 limit", () => {
+    // 21 alphanumeric chars is M4-L limit
+    const input = "ABCDEFGHIJKLMNOPQRSTU";
+    const grid = encode(input);
+    expect(grid.rows).toBe(17);
+  });
+
+  it("selects M4 when explicit version=M4 is requested", () => {
+    const grid = encode("1", { version: "M4" });
+    expect(grid.rows).toBe(17);
+  });
+
+  it("respects explicit ECC level", () => {
+    const gridL = encode("HELLO", { ecc: "L" });
+    const gridM = encode("HELLO", { ecc: "M" });
+    // Both should encode successfully and produce same size
+    expect(gridL.rows).toBe(13);
+    expect(gridM.rows).toBe(13);
+    // But they should differ (different ECC → different format info → different mask)
+    expect(gridToString(gridL.modules)).not.toBe(gridToString(gridM.modules));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Structural module placement
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("structural module placement", () => {
+  it("finder pattern top-left is correct for M1 (11×11)", () => {
+    const grid = encode("1");
+    const m = grid.modules;
+    // Top-left 7×7 finder pattern: border is dark, inner ring light, core dark
+    // Row 0: all dark
+    for (let c = 0; c < 7; c++) expect(m[0]![c]).toBe(true);
+    // Row 6: all dark
+    for (let c = 0; c < 7; c++) expect(m[6]![c]).toBe(true);
+    // Col 0: all dark in rows 0-6
+    for (let r = 0; r < 7; r++) expect(m[r]![0]).toBe(true);
+    // Col 6: all dark in rows 0-6
+    for (let r = 0; r < 7; r++) expect(m[r]![6]).toBe(true);
+    // Inner ring (row 1, cols 1-5): light
+    for (let c = 1; c <= 5; c++) expect(m[1]![c]).toBe(false);
+    // Core (rows 2-4, cols 2-4): dark
+    for (let r = 2; r <= 4; r++) for (let c = 2; c <= 4; c++) expect(m[r]![c]).toBe(true);
+  });
+
+  it("separator at row 7 and col 7 are light (M2 13×13)", () => {
+    const grid = encode("HELLO");
+    const m = grid.modules;
+    // Row 7, cols 0-7: separator (light)
+    for (let c = 0; c <= 7; c++) expect(m[7]![c]).toBe(false);
+    // Col 7, rows 0-7: separator (light)
+    for (let r = 0; r <= 7; r++) expect(m[r]![7]).toBe(false);
+  });
+
+  it("timing row 0 alternates dark/light starting at col 8 (M4 17×17)", () => {
+    const grid = encode("https://a.b");
+    const m = grid.modules;
+    // Col 8 should be dark (even index), col 9 light (odd), etc.
+    for (let c = 8; c < 17; c++) {
+      expect(m[0]![c]).toBe(c % 2 === 0);
+    }
+  });
+
+  it("timing col 0 alternates dark/light starting at row 8 (M4 17×17)", () => {
+    const grid = encode("https://a.b");
+    const m = grid.modules;
+    for (let r = 8; r < 17; r++) {
+      expect(m[r]![0]).toBe(r % 2 === 0);
+    }
+  });
+
+  it("the grid has the correct total module count", () => {
+    for (const [input, expectedSize] of [
+      ["1", 11],
+      ["HELLO", 13],
+      ["A1B2C3", 13],   // 6 alphanumeric fits in M2-L (13×13)
+      ["https://a.b", 17],
+    ] as [string, number][]) {
+      const grid = encode(input);
+      let count = 0;
+      for (const row of grid.modules) count += row.length;
+      expect(count).toBe(expectedSize * expectedSize);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Deterministic encoding
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("deterministic encoding", () => {
+  it("encoding the same input twice produces identical grids", () => {
+    for (const input of ["1", "12345", "HELLO", "A1B2C3", "hello", "https://a.b"]) {
+      const g1 = encode(input);
+      const g2 = encode(input);
+      expect(gridToString(g1.modules)).toBe(gridToString(g2.modules));
+    }
+  });
+
+  it("different inputs produce different grids (same size)", () => {
+    const g1 = encode("1");
+    const g2 = encode("2");
+    // Both M1 (11×11), but data differs
+    expect(gridToString(g1.modules)).not.toBe(gridToString(g2.modules));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Specific known test corpus
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("test corpus", () => {
+  it("encodes '1' to M1 (11×11)", () => {
+    const grid = encode("1");
+    expect(grid.rows).toBe(11);
+    expect(grid.cols).toBe(11);
+  });
+
+  it("encodes '12345' to M1 (11×11, maximum numeric capacity)", () => {
+    const grid = encode("12345");
+    expect(grid.rows).toBe(11);
+  });
+
+  it("encodes 'HELLO' to M2 (13×13, alphanumeric)", () => {
+    const grid = encode("HELLO");
+    expect(grid.rows).toBe(13);
+  });
+
+  it("encodes 'A1B2C3' to M2 (alphanumeric, M2-L has capacity 6)", () => {
+    const grid = encode("A1B2C3");
+    // 6 chars alphanumeric → M2-L has capacity 6, so M2 is selected
+    expect(grid.rows).toBe(13);
+  });
+
+  it("encodes 'hello' to M3 (15×15, byte mode)", () => {
+    const grid = encode("hello");
+    // 5 bytes in byte mode → M3-L has capacity 9, M2 cap is 4 (L) or 3 (M)
+    expect(grid.rows).toBe(15);
+  });
+
+  it("encodes '01234567' to M2-L (8-digit numeric)", () => {
+    const grid = encode("01234567");
+    // 8 numeric → M2-L has capacity 10, so M2-L selected
+    expect(grid.rows).toBe(13);
+  });
+
+  it("encodes 'MICRO QR TEST' to M3-L (13 alphanumeric chars)", () => {
+    const grid = encode("MICRO QR TEST");
+    // 13 alphanumeric → M3-L has capacity 14, so M3-L
+    expect(grid.rows).toBe(15);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. ECC level constraints
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ECC level constraints", () => {
+  it("M1 accepts DETECTION ecc level", () => {
+    const grid = encode("1", { version: "M1", ecc: "DETECTION" });
+    expect(grid.rows).toBe(11);
+  });
+
+  it("M4 accepts Q ecc level", () => {
+    const grid = encode("HELLO", { version: "M4", ecc: "Q" });
+    expect(grid.rows).toBe(17);
+  });
+
+  it("M4-L, M4-M, M4-Q all produce different grids for same input", () => {
+    const gL = encode("HELLO", { version: "M4", ecc: "L" });
+    const gM = encode("HELLO", { version: "M4", ecc: "M" });
+    const gQ = encode("HELLO", { version: "M4", ecc: "Q" });
+    expect(gridToString(gL.modules)).not.toBe(gridToString(gM.modules));
+    expect(gridToString(gM.modules)).not.toBe(gridToString(gQ.modules));
+    expect(gridToString(gL.modules)).not.toBe(gridToString(gQ.modules));
+  });
+
+  it("throws ECCNotAvailableError for invalid version+ecc combo", () => {
+    // M1 only supports DETECTION
+    expect(() => encode("1", { version: "M1", ecc: "L" })).toThrow(ECCNotAvailableError);
+    expect(() => encode("1", { version: "M1", ecc: "M" })).toThrow(ECCNotAvailableError);
+    // M2 does not support Q — ECCNotAvailableError (no config matches)
+    expect(() => encode("1", { version: "M2", ecc: "Q" })).toThrow(ECCNotAvailableError);
+  });
+
+  it("throws ECCNotAvailableError for version=M3 ecc=Q", () => {
+    // M3 only supports L and M, not Q
+    expect(() => encode("1", { version: "M3", ecc: "Q" })).toThrow(ECCNotAvailableError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Error handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("error handling", () => {
+  it("throws InputTooLongError for input exceeding M4-Q capacity", () => {
+    // M4-Q holds at most 21 numeric; 22 digits should fail
+    const tooLong = "1".repeat(36); // exceeds M4-L numeric cap of 35
+    expect(() => encode(tooLong)).toThrow(InputTooLongError);
+  });
+
+  it("InputTooLongError is a MicroQRError", () => {
+    expect(() => encode("1".repeat(36))).toThrow(MicroQRError);
+  });
+
+  it("throws UnsupportedModeError when byte mode is requested for M1", () => {
+    // M1 only supports numeric
+    expect(() => encode("hello", { version: "M1" })).toThrow();
+  });
+
+  it("throws ECCNotAvailableError for no matching config", () => {
+    // There is no valid config for version=M1 and ecc=Q
+    expect(() => encode("1", { version: "M1", ecc: "Q" })).toThrow(MicroQRError);
+  });
+
+  it("empty string encodes to M1", () => {
+    // Empty string: 0 chars, numeric mode, M1 fits
+    const grid = encode("");
+    expect(grid.rows).toBe(11);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Capacity boundary tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("capacity boundaries", () => {
+  it("M1 max: 5 numeric digits encode to M1", () => {
+    expect(encode("12345").rows).toBe(11);
+  });
+
+  it("M1 overflow: 6 numeric digits fall through to M2", () => {
+    expect(encode("123456").rows).toBe(13);
+  });
+
+  it("M2-L max numeric: 10 digits encode to M2", () => {
+    expect(encode("1234567890").rows).toBe(13);
+  });
+
+  it("M2-M max numeric: 8 digits encode to M2-M when M asked", () => {
+    expect(encode("12345678", { ecc: "M" }).rows).toBe(13);
+  });
+
+  it("M4-L max numeric: 35 digits encode to M4", () => {
+    const input = "1".repeat(35);
+    expect(encode(input).rows).toBe(17);
+  });
+
+  it("M4-L numeric overflow: 36 digits throw InputTooLongError", () => {
+    expect(() => encode("1".repeat(36))).toThrow(InputTooLongError);
+  });
+
+  it("M4-L max byte: 15 ASCII bytes encode to M4", () => {
+    const input = "a".repeat(15);
+    expect(encode(input).rows).toBe(17);
+  });
+
+  it("M4-Q max numeric: 21 digits encode at Q", () => {
+    const input = "1".repeat(21);
+    expect(encode(input, { ecc: "Q" }).rows).toBe(17);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Layout and rendering helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("layout helpers", () => {
+  it("mqrLayout returns a PaintScene", () => {
+    const grid = encode("1");
+    const scene = mqrLayout(grid);
+    expect(scene).toBeDefined();
+    expect(typeof scene).toBe("object");
+  });
+
+  it("mqrLayout uses quiet zone 2 modules by default", () => {
+    const grid = encode("1");
+    const scene = mqrLayout(grid);
+    // Default: moduleSizePx=10, quietZoneModules=2 → (11 + 2*2) * 10 = 150px
+    expect(scene.width).toBe((11 + 4) * 10);
+  });
+
+  it("encodeAndLayout produces a PaintScene", () => {
+    const scene = encodeAndLayout("HELLO");
+    expect(scene).toBeDefined();
+  });
+
+  it("encodeAndLayout respects version/ecc options", () => {
+    const scene = encodeAndLayout("HELLO", { version: "M4", ecc: "L" });
+    // M4 is 17×17; with default moduleSizePx=10 and quietZoneModules=2: (17+4)*10 = 210px
+    expect(scene.width).toBe((17 + 4) * 10);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. explain() annotation API
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("explain", () => {
+  it("returns an AnnotatedModuleGrid", () => {
+    const annotated = explain("HELLO");
+    expect(annotated.rows).toBe(13);
+    expect(annotated.annotations).toBeDefined();
+    expect(annotated.annotations!.length).toBe(13);
+    expect(annotated.annotations![0]!.length).toBe(13);
+  });
+
+  it("annotations array has same dimensions as modules", () => {
+    for (const input of ["1", "HELLO", "hello", "https://a.b"]) {
+      const annotated = explain(input);
+      expect(annotated.annotations!.length).toBe(annotated.rows);
+      for (const row of annotated.annotations!) {
+        expect(row.length).toBe(annotated.cols);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 12. Format information structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("format information placement", () => {
+  it("format modules at row 8 cols 1-8 and col 8 rows 1-7 are non-trivially set (M4)", () => {
+    const grid = encode("HELLO", { version: "M4", ecc: "L" });
+    const m = grid.modules;
+    // The format info area should not be all-zero (the XOR mask 0x4445 ensures this)
+    let anyDark = false;
+    for (let c = 1; c <= 8; c++) if (m[8]![c]) anyDark = true;
+    for (let r = 1; r <= 7; r++) if (m[r]![8]) anyDark = true;
+    expect(anyDark).toBe(true);
+  });
+
+  it("M1 format modules at row 8 cols 1-8 are set", () => {
+    const grid = encode("1");
+    const m = grid.modules;
+    // At least one format bit should be set (0x4445 XOR guarantees non-zero)
+    let count = 0;
+    for (let c = 1; c <= 8; c++) if (m[8]![c]) count++;
+    for (let r = 1; r <= 7; r++) if (m[r]![8]) count++;
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 13. Grid module values are all boolean
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("module value types", () => {
+  it("all modules are boolean values", () => {
+    for (const input of ["1", "HELLO", "hello", "https://a.b"]) {
+      const grid = encode(input);
+      for (const row of grid.modules) {
+        for (const m of row) {
+          expect(typeof m).toBe("boolean");
+        }
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 14. Masking: verify different mask patterns produce different grids
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("masking", () => {
+  it("all four masks produce different intermediate grids (no degenerate equality)", () => {
+    // Since mask selection picks the best, we can't directly test all 4 here
+    // But we can test that the same input with forced different versions
+    // produces different grids (different format info → different output)
+    const gM1 = encode("1", { version: "M1", ecc: "DETECTION" });
+    const gM2 = encode("1", { version: "M2", ecc: "L" });
+    expect(gridToString(gM1.modules)).not.toBe(gridToString(gM2.modules));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 15. Module grid completeness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("grid completeness", () => {
+  it("every module is set (no undefined)", () => {
+    for (const input of ["1", "12345", "HELLO", "hello"]) {
+      const grid = encode(input);
+      for (const row of grid.modules) {
+        for (const m of row) {
+          expect(m).not.toBeUndefined();
+          expect(m).not.toBeNull();
+        }
+      }
+    }
+  });
+
+  it("grid has square dimensions (rows === cols)", () => {
+    for (const input of ["1", "HELLO", "hello", "https://a.b"]) {
+      const grid = encode(input);
+      expect(grid.rows).toBe(grid.cols);
+    }
+  });
+});

--- a/code/packages/typescript/micro-qr/tsconfig.json
+++ b/code/packages/typescript/micro-qr/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/micro-qr/vitest.config.ts
+++ b/code/packages/typescript/micro-qr/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 90,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a complete Micro QR Code encoder in both **Rust** (`code/packages/rust/micro-qr`) and **TypeScript** (`code/packages/typescript/micro-qr`), implementing ISO/IEC 18004:2015 Annex E
- Both implementations share identical algorithm logic: auto-select smallest M1–M4 symbol, Reed-Solomon ECC over GF(256)/0x11D, 4-mask evaluation, pre-computed 32-entry format table (XOR 0x4445)
- All 8 valid (version, ECC) combinations supported: M1/Detection, M2/L, M2/M, M3/L, M3/M, M4/L, M4/M, M4/Q; encoding modes: numeric, alphanumeric, byte

## Test coverage

| Language | Tests | Line coverage | Branch coverage |
|----------|-------|---------------|-----------------|
| Rust     | 44 unit + 1 doctest | n/a (full) | n/a |
| TypeScript | 59 Vitest | 98.56% | 95.58% |

## Key implementation details

- M1 half-codeword: 20-bit data field (2 full bytes + 1 nibble)
- Format info: single 15-bit copy placed at row 8 cols 1–8 and col 8 rows 7–1
- `mqrLayout` / `layout_grid` enforce the required 2-module quiet zone (Micro QR requires 2, not 4)
- Literate programming style: all algorithms explained inline with diagrams and bit-field tables

## Test plan

- [ ] `cargo test -p micro-qr -- --nocapture` (44 tests + 1 doctest)
- [ ] TypeScript: `cd code/packages/typescript/micro-qr && npx vitest run --coverage` (59 tests, ≥90% coverage)
- [ ] Verify no regressions in workspace: `cargo build --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)