### PR TITLE
Add ALGOL whole-array parameter support

### DIFF
--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -38,10 +38,10 @@ thunks are supported, including nested by-name descriptor allocation and runtime
 failure propagation from callees back to the by-name formal read. Stores through
 read-only expression thunks still raise targeted `CompileError` diagnostics
 until Phase 5 grows full store-helper coverage. The supported integer by-name
-surface is covered by the WASM acceptance suite, while full ALGOL forms such as
-non-integer formals, whole-array by-name values, procedure-valued actuals,
-procedure-crossing gotos, nonlocal switch selections, and escaping thunk
-descriptors remain future work.
+surface is covered by the WASM acceptance suite, including typed whole-array
+formals passed as descriptor pointers. Full ALGOL forms such as non-integer
+formals, procedure-valued actuals, procedure-crossing gotos, nonlocal switch
+selections, and escaping thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -65,6 +65,7 @@ _FIRST_GENERAL_REG = 32
 _ARRAY_DESCRIPTOR_SIZE = 24
 _ARRAY_ELEMENT_TYPE_INTEGER = 1
 _ARRAY_ELEMENT_TYPE_REAL = 2
+_ARRAY_DIMENSION_COUNT_OFFSET = 4
 _ARRAY_DIMENSION_ENTRY_SIZE = 12
 _ARRAY_DIM_LOWER_OFFSET = 0
 _ARRAY_DIM_UPPER_OFFSET = 4
@@ -325,7 +326,11 @@ class AlgolIrCompiler:
         }
         self.arrays_by_block = {}
         for array in type_result.semantic.arrays:
-            self.arrays_by_block.setdefault(array.declaring_block_id, []).append(array)
+            if array.storage_class in {"frame", "static"}:
+                self.arrays_by_block.setdefault(
+                    array.declaring_block_id,
+                    [],
+                ).append(array)
         self.procedure_signatures = {
             procedure.label: ProcedureSignaturePlan(
                 param_types=(
@@ -333,7 +338,7 @@ class AlgolIrCompiler:
                     _INTEGER_TYPE,
                     *(
                         _INTEGER_TYPE
-                        if parameter.mode == _NAME_MODE
+                        if parameter.mode == _NAME_MODE or parameter.kind == "array"
                         else parameter.type_name
                         for parameter in procedure.parameters
                     ),
@@ -767,7 +772,11 @@ class AlgolIrCompiler:
                 else _ARRAY_ELEMENT_TYPE_INTEGER
             ),
         )
-        self._store_word_const(heap_pointer, 4, len(array.dimensions))
+        self._store_word_const(
+            heap_pointer,
+            _ARRAY_DIMENSION_COUNT_OFFSET,
+            len(array.dimensions),
+        )
         self._store_word_reg(
             value_reg=total_reg,
             base_reg=heap_pointer,
@@ -2160,7 +2169,8 @@ class AlgolIrCompiler:
             for index, (argument, parameter) in enumerate(
                 zip(actuals, procedure.parameters, strict=True)
             )
-            if parameter.mode == _NAME_MODE
+            if parameter.kind != "array"
+            and parameter.mode == _NAME_MODE
             and self._requires_by_name_thunk_descriptor(argument)
         ]
         for _, argument, parameter in thunk_actuals:
@@ -2177,6 +2187,12 @@ class AlgolIrCompiler:
         for index, (argument, parameter) in enumerate(
             zip(actuals, procedure.parameters, strict=True)
         ):
+            if parameter.kind == "array":
+                if parameter.mode == _VALUE_MODE:
+                    raise CompileError(
+                        f"value array parameter {parameter.name!r} is not supported yet"
+                    )
+                continue
             if parameter.mode == _VALUE_MODE:
                 value = self._compile_expr(argument, scope)
                 arguments[index] = self._coerce_reg_to_type(
@@ -2208,6 +2224,9 @@ class AlgolIrCompiler:
         for index, (argument, parameter) in enumerate(
             zip(actuals, procedure.parameters, strict=True)
         ):
+            if parameter.kind == "array":
+                arguments[index] = self._compile_array_actual_pointer(argument, scope)
+                continue
             if parameter.mode != _NAME_MODE:
                 continue
             descriptor = None
@@ -2764,6 +2783,20 @@ class AlgolIrCompiler:
         reference = self._require_reference(name, "read")
         return self._emit_reference_pointer(reference, scope)
 
+    def _compile_array_actual_pointer(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            raise CompileError("array parameter actual must be a whole-array variable")
+        name = _variable_name(variable)
+        if name is None:
+            raise CompileError("array parameter actual is missing a name")
+        access = self._require_array_access(name, "actual")
+        return self._emit_load_array_descriptor(access, scope)
+
     def _compile_eval_thunk_actual(
         self,
         argument: ASTNode,
@@ -3110,7 +3143,7 @@ class AlgolIrCompiler:
         )
         self._initialize_scalar_slots(scope)
         for index, parameter in enumerate(procedure.parameters):
-            if parameter.mode == _NAME_MODE:
+            if parameter.kind == "array" or parameter.mode == _NAME_MODE:
                 self._store_word_reg(
                     value_reg=_VALUE_PARAM_BASE_REG + index,
                     base_reg=scope.frame_base_reg,
@@ -3221,8 +3254,27 @@ class AlgolIrCompiler:
             IrRegister(bounds_offset),
         )
 
-        element_index = self._const_reg(0)
         subscripts = _variable_subscripts(variable)
+        dimension_count = self._fresh_reg()
+        dimension_mismatch = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(dimension_count),
+            IrRegister(descriptor_pointer),
+            IrRegister(self._const_reg(_ARRAY_DIMENSION_COUNT_OFFSET)),
+        )
+        self._emit(
+            IrOp.CMP_NE,
+            IrRegister(dimension_mismatch),
+            IrRegister(dimension_count),
+            IrRegister(self._const_reg(len(subscripts))),
+        )
+        if helper_failure:
+            self._emit_helper_runtime_failure_guard(dimension_mismatch, scope)
+        else:
+            self._emit_runtime_failure_guard(dimension_mismatch, scope)
+
+        element_index = self._const_reg(0)
         for index, subscript in enumerate(subscripts):
             subscript_reg = self._compile_expr(subscript, scope)
             lower = self._fresh_reg()

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -830,6 +830,47 @@ class TestAlgolIrCompiler:
         assert signature.param_types == ("integer", "integer", "string")
         assert signature.return_type == "string"
 
+    def test_compiles_integer_array_parameter_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer array xs[1:2]; integer result; "
+                "procedure setfirst(a); integer a; array a; begin a[1] := 9 end; "
+                "xs[1] := 4; setfirst(xs); result := xs[1] "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        signature = result.procedure_signatures[calls[0].operands[0].name]
+
+        assert signature.param_count == 3
+        assert signature.param_types == ("integer", "integer", "integer")
+
+    def test_compiles_array_parameter_dimension_guard(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer array xs[1:2]; integer result; "
+                "procedure probe(a); integer a; array a; begin result := a[1, 1] end; "
+                "probe(xs); result := 1 "
+                "end"
+            )
+        )
+        instructions = result.program.instructions
+        probe_index = next(
+            index
+            for index, instruction in enumerate(instructions)
+            if instruction.opcode == IrOp.LABEL
+            and instruction.operands[0].name == "_fn_algol_0_probe"
+        )
+        probe_window = instructions[probe_index : probe_index + 80]
+
+        assert any(
+            instruction.opcode == IrOp.CMP_NE for instruction in probe_window
+        )
+
     def test_compiles_integer_actual_promoted_for_real_value_parameter(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -36,16 +36,15 @@ switch selections and nonlocal conditional/switch designational branches remain
 guarded with targeted diagnostics. Switch entries that recursively select
 another switch are also guarded until the later dispatch-lowering phase.
 
-Unsupported ALGOL 60 features, including real/Boolean/string arrays, array
-parameters, procedure-valued parameters, nonlocal switches, and nonlocal
-procedure-crossing `goto`, are reported as diagnostics instead of being
-silently accepted by the compiled pipeline. By-name parameters are accepted in
-the semantic model, while later lowering packages now implement the integer
-call-by-name subset. The checker keeps guarding the remaining full-ALGOL gaps,
-including non-assignable actuals passed to written by-name formals,
-non-integer by-name types, whole-array parameters, procedure-valued parameters,
-conditional designational expressions that cross frame boundaries, and `goto`
-forms that escape a called procedure.
+Unsupported ALGOL 60 features, including procedure-valued parameters, nonlocal
+switches, and nonlocal procedure-crossing `goto`, are reported as diagnostics
+instead of being silently accepted by the compiled pipeline. By-name parameters
+are accepted in the semantic model, while later lowering packages now implement
+scalar call-by-name plus typed whole-array formals. The checker keeps guarding
+the remaining full-ALGOL gaps, including non-assignable actuals passed to
+written by-name formals, non-integer by-name types, value array parameters,
+procedure-valued parameters, conditional designational expressions that cross
+frame boundaries, and `goto` forms that escape a called procedure.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -21,6 +21,7 @@ ARRAY = "array"
 LABEL = "label"
 SWITCH = "switch"
 STATIC = "static"
+PARAMETER_STORAGE = "parameter"
 MAX_ARRAY_DIMENSIONS = 4
 
 
@@ -192,8 +193,17 @@ class ProcedureParameter:
     mode: str
     symbol_id: int
     slot_offset: int
+    kind: str = "scalar"
     may_write: bool = False
     write_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _ParameterSpec:
+    """Combined kind/type information for one formal parameter."""
+
+    kind: str = "scalar"
+    type_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -752,7 +762,7 @@ class AlgolTypeChecker:
 
         formal_names = _formal_parameter_names(node)
         value_names = _value_parameter_names(node)
-        spec_types = _parameter_spec_types(node)
+        parameter_specs = _parameter_specs(node)
         body = _first_direct_node(node, "proc_body")
         body_inner = _first_ast_child(body) if body is not None else None
         known_procedures = _unique_procedure_names(self.semantic_procedures)
@@ -765,8 +775,24 @@ class AlgolTypeChecker:
         )
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
-            parameter_type = spec_types.get(formal.value)
-            if mode == NAME and parameter_type not in {
+            parameter_spec = parameter_specs.get(formal.value, _ParameterSpec())
+            parameter_kind = parameter_spec.kind
+            parameter_type = parameter_spec.type_name
+            if parameter_kind == ARRAY:
+                if mode == VALUE:
+                    self._error(
+                        formal,
+                        f"value parameter {formal.value!r} cannot be an array in "
+                        "this phase",
+                    )
+                if parameter_type is None:
+                    parameter_type = REAL
+            elif parameter_kind in {LABEL, SWITCH, "procedure"}:
+                self._error(
+                    formal,
+                    f"{parameter_kind} parameter {formal.value!r} is not supported yet",
+                )
+            elif mode == NAME and parameter_type not in {
                 INTEGER,
                 BOOLEAN,
                 REAL,
@@ -842,7 +868,14 @@ class AlgolTypeChecker:
 
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
-            parameter_type = spec_types.get(formal.value)
+            parameter_spec = parameter_specs.get(formal.value, _ParameterSpec())
+            parameter_kind = parameter_spec.kind
+            parameter_type = parameter_spec.type_name
+            if parameter_kind == ARRAY:
+                if parameter_type is None:
+                    parameter_type = REAL
+            elif parameter_kind in {LABEL, SWITCH, "procedure"}:
+                parameter_kind = "scalar"
             param_symbol = Symbol(
                 name=formal.value,
                 type_name=(
@@ -853,9 +886,15 @@ class AlgolTypeChecker:
                 line=formal.line,
                 column=formal.column,
                 symbol_id=self._next_symbol_id,
-                kind="parameter",
+                kind=ARRAY if parameter_kind == ARRAY else "parameter",
+                storage_class=(
+                    PARAMETER_STORAGE if parameter_kind == ARRAY else "frame"
+                ),
                 declaring_block_id=proc_scope.block_id,
                 procedure_id=procedure_id,
+                array_id=(
+                    self._next_array_id if parameter_kind == ARRAY else None
+                ),
                 parameter_mode=mode,
             )
             if not proc_scope.declare(param_symbol):
@@ -865,9 +904,32 @@ class AlgolTypeChecker:
                 )
                 continue
             self._next_symbol_id += 1
-            if proc_scope.frame_layout is not None:
+            if parameter_kind == ARRAY:
+                self._next_array_id += 1
+                if proc_scope.frame_layout is not None:
+                    proc_scope.frame_layout.allocate_descriptor(param_symbol)
+            elif proc_scope.frame_layout is not None:
                 proc_scope.frame_layout.allocate_scalar(param_symbol)
             self.semantic_symbols.append(param_symbol)
+            if (
+                parameter_kind == ARRAY
+                and param_symbol.slot_offset is not None
+                and param_symbol.array_id is not None
+            ):
+                self.semantic_arrays.append(
+                    ArrayDescriptor(
+                        array_id=param_symbol.array_id,
+                        name=formal.value,
+                        element_type=param_symbol.type_name,
+                        storage_class=PARAMETER_STORAGE,
+                        declaring_block_id=proc_scope.block_id,
+                        dimensions=tuple(),
+                        symbol_id=param_symbol.symbol_id,
+                        slot_offset=param_symbol.slot_offset,
+                        line=formal.line,
+                        column=formal.column,
+                    )
+                )
             if param_symbol.slot_offset is not None:
                 parameters.append(
                     ProcedureParameter(
@@ -876,8 +938,17 @@ class AlgolTypeChecker:
                         mode=mode,
                         symbol_id=param_symbol.symbol_id,
                         slot_offset=param_symbol.slot_offset,
-                        may_write=formal.value in write_reasons,
-                        write_reason=write_reasons.get(formal.value),
+                        kind=parameter_kind,
+                        may_write=(
+                            formal.value in write_reasons
+                            if parameter_kind != ARRAY
+                            else False
+                        ),
+                        write_reason=(
+                            write_reasons.get(formal.value)
+                            if parameter_kind != ARRAY
+                            else None
+                        ),
                     )
                 )
 
@@ -1525,6 +1596,7 @@ class AlgolTypeChecker:
         scope: Scope,
         *,
         role: str,
+        allow_whole: bool = False,
     ) -> ResolvedArrayAccess | None:
         name_token = _variable_head_name(variable)
         if name_token is None:
@@ -1567,7 +1639,11 @@ class AlgolTypeChecker:
             return None
 
         subscripts = _variable_subscripts(variable)
-        if len(subscripts) != len(descriptor.dimensions):
+        if (
+            descriptor.storage_class != PARAMETER_STORAGE
+            and not allow_whole
+            and len(subscripts) != len(descriptor.dimensions)
+        ):
             self._error(
                 name_token,
                 f"array {name_token.value!r} expects "
@@ -1632,6 +1708,9 @@ class AlgolTypeChecker:
                 f"{len(descriptor.parameters)} argument(s), got {len(arguments)}",
             )
         for argument, parameter in zip(arguments, descriptor.parameters, strict=False):
+            if parameter.kind == ARRAY:
+                self._check_array_parameter_actual(argument, scope, parameter)
+                continue
             actual_type = self._infer_expr(argument, scope)
             if descriptor.procedure_id == -1:
                 if actual_type != ERROR and actual_type not in {
@@ -1699,6 +1778,47 @@ class AlgolTypeChecker:
         )
         self.resolved_procedure_calls.append(call)
         return call
+
+    def _check_array_parameter_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        parameter: ProcedureParameter,
+    ) -> ResolvedArrayAccess | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            self._error(
+                argument,
+                f"array parameter {parameter.name!r} expects a whole-array actual",
+            )
+            return None
+        access = self._check_array_access(
+            variable,
+            scope,
+            role="actual",
+            allow_whole=True,
+        )
+        if access is None:
+            return None
+        descriptor = next(
+            (
+                array
+                for array in self.semantic_arrays
+                if array.array_id == access.array_id
+            ),
+            None,
+        )
+        if (
+            descriptor is not None
+            and descriptor.element_type != ERROR
+            and descriptor.element_type != parameter.type_name
+        ):
+            self._error(
+                argument,
+                f"array parameter {parameter.name!r} expects "
+                f"{parameter.type_name} elements, got {descriptor.element_type}",
+            )
+        return access
 
     def _resolve_builtin_procedure(
         self,
@@ -2066,16 +2186,26 @@ def _value_parameter_names(node: ASTNode) -> set[str]:
     }
 
 
-def _parameter_spec_types(node: ASTNode) -> dict[str, str]:
-    spec_types: dict[str, str] = {}
+def _parameter_specs(node: ASTNode) -> dict[str, _ParameterSpec]:
+    specs: dict[str, _ParameterSpec] = {}
     for spec_part in _direct_nodes(node, "spec_part"):
         specifier = _first_direct_node(spec_part, "specifier")
-        type_name = _first_keyword_value(specifier) or ""
+        specifier_name = _first_keyword_value(specifier) or ""
         ident_list = _first_direct_node(spec_part, "ident_list")
         for token in _tokens(ident_list):
             if token.type_name == "NAME":
-                spec_types[token.value] = type_name
-    return spec_types
+                current = specs.get(token.value, _ParameterSpec())
+                if specifier_name in {INTEGER, BOOLEAN, REAL, STRING}:
+                    specs[token.value] = _ParameterSpec(
+                        kind=current.kind,
+                        type_name=specifier_name,
+                    )
+                elif specifier_name in {ARRAY, LABEL, SWITCH, "procedure"}:
+                    specs[token.value] = _ParameterSpec(
+                        kind=specifier_name,
+                        type_name=current.type_name,
+                    )
+    return specs
 
 
 def _label_token(node: ASTNode) -> Token | None:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -648,6 +648,34 @@ class TestAlgolTypeChecker:
         assert parameter.mode == "name"
         assert parameter.may_write
 
+    def test_accepts_integer_array_parameter_and_whole_array_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer array xs[1:2]; integer result; "
+            "procedure setfirst(a); integer a; array a; begin a[1] := 9 end; "
+            "xs[1] := 4; setfirst(xs); result := xs[1] "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "array"
+        assert parameter.type_name == "integer"
+        assert any(access.role == "actual" for access in result.semantic.array_accesses)
+
+    def test_rejects_value_array_parameter_in_this_phase(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure probe(a); value a; integer a; array a; begin end; "
+            "result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "cannot be an array in this phase" in result.diagnostics[0].message
+
     def test_accepts_integer_array_descriptor_and_accesses(self) -> None:
         ast = parse_algol(
             "begin integer result, lo, hi; "

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -17,7 +17,8 @@ already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
-- value and by-name parameters, including Jensen-style expression thunks
+- value and by-name parameters, including Jensen-style expression thunks and
+  typed whole-array formals
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   non-recursive switch entries

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -654,6 +654,24 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [8]
         assert "".join(captured) == "OK"
 
+    def test_integer_array_parameter_writes_back_through_descriptor(self) -> None:
+        result = compile_source(
+            "begin integer array xs[1:2]; integer result; "
+            "procedure setfirst(a); integer a; array a; begin a[1] := 9 end; "
+            "xs[1] := 4; setfirst(xs); result := xs[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
+    def test_array_parameter_runtime_dimension_mismatch_returns_from_callee(self) -> None:
+        result = compile_source(
+            "begin integer array xs[1:2]; integer result; "
+            "procedure probe(a); integer a; array a; begin result := a[1, 1] end; "
+            "probe(xs); result := 1 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
     def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- add typed whole-array formal parameter support in the ALGOL type checker
- lower array actuals as descriptor pointers through the IR and WASM pipeline
- add runtime dimension-count checks for array-formal accesses plus focused checker/IR/WASM coverage

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k 'not array_failure_in_procedure_unwinds_before_caller_continues' -q`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-type-checker/README.md code/packages/python/algol-ir-compiler/README.md code/packages/python/algol-wasm-compiler/README.md code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Notes
- the pre-existing WASM stress test `test_array_failure_in_procedure_unwinds_before_caller_continues` still times out locally after 30 seconds in this checkout; this batch does not change that baseline behavior