### PR TITLE
Add ALGOL label parameter support

### DIFF
--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -39,9 +39,9 @@ failure propagation from callees back to the by-name formal read. Stores through
 read-only expression thunks still raise targeted `CompileError` diagnostics
 until Phase 5 grows full store-helper coverage. The supported integer by-name
 surface is covered by the WASM acceptance suite, including typed whole-array
-formals passed as descriptor pointers. Full ALGOL forms such as non-integer
-formals, procedure-valued actuals, procedure-crossing gotos, nonlocal switch
-selections, and escaping thunk descriptors remain future work.
+formals passed as descriptor pointers and label formals passed as pending-goto
+targets. Full ALGOL forms such as switch/procedure-valued formals and escaping
+thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -214,6 +214,7 @@ class AlgolIrCompiler:
         self.procedure_calls: dict[tuple[int, str], ResolvedProcedureCall] = {}
         self.array_accesses: dict[tuple[int, str], ResolvedArrayAccess] = {}
         self.labels: dict[int, LabelDescriptor] = {}
+        self.labels_by_symbol: dict[int, LabelDescriptor] = {}
         self.labels_by_block_name: dict[tuple[int, str], LabelDescriptor] = {}
         self.gotos: dict[int, ResolvedGoto] = {}
         self.gotos_by_designational: dict[int, ResolvedGoto] = {}
@@ -288,6 +289,9 @@ class AlgolIrCompiler:
         self.labels_by_id = {
             label.label_id: label for label in type_result.semantic.labels
         }
+        self.labels_by_symbol = {
+            label.symbol_id: label for label in type_result.semantic.labels
+        }
         self.labels_by_block_name = {
             (label.declaring_block_id, label.name): label
             for label in type_result.semantic.labels
@@ -338,7 +342,8 @@ class AlgolIrCompiler:
                     _INTEGER_TYPE,
                     *(
                         _INTEGER_TYPE
-                        if parameter.mode == _NAME_MODE or parameter.kind == "array"
+                        if parameter.mode == _NAME_MODE
+                        or parameter.kind in {"array", "label"}
                         else parameter.type_name
                         for parameter in procedure.parameters
                     ),
@@ -967,9 +972,14 @@ class AlgolIrCompiler:
         direct = _direct_label_from_simple_designational(node)
         if direct is not None:
             label = self._resolve_label_in_scope_chain(direct.value, scope)
-            if label is None:
-                raise CompileError(f"goto target {direct.value!r} was not resolved")
-            self._emit_goto_label(label, execution_scope)
+            if label is not None:
+                self._emit_goto_label(label, execution_scope)
+                return
+            label_value = self._compile_label_parameter_target(direct, scope)
+            if label_value is not None:
+                self._emit_pending_goto_return_reg(execution_scope, label_value)
+                return
+            raise CompileError(f"goto target {direct.value!r} was not resolved")
             return
 
         if any(token.value == "[" for token in _direct_tokens(node)):
@@ -1010,6 +1020,31 @@ class AlgolIrCompiler:
                 return label
             current = current.goto_parent
         return None
+
+    def _compile_label_parameter_target(
+        self,
+        token: Token,
+        scope: _FrameScope,
+    ) -> int | None:
+        resolved = self._resolve_symbol_in_scope_chain(token.value, scope)
+        if resolved is None:
+            return None
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind != "label" or symbol.parameter_mode is None:
+            return None
+        if symbol.slot_offset is None:
+            raise CompileError(
+                f"label parameter {token.value!r} has no planned frame slot"
+            )
+        frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+        value_reg = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(value_reg),
+            IrRegister(frame_reg),
+            IrRegister(self._const_reg(symbol.slot_offset)),
+        )
+        return value_reg
 
     def _emit_goto_label(
         self,
@@ -2169,7 +2204,7 @@ class AlgolIrCompiler:
             for index, (argument, parameter) in enumerate(
                 zip(actuals, procedure.parameters, strict=True)
             )
-            if parameter.kind != "array"
+            if parameter.kind not in {"array", "label"}
             and parameter.mode == _NAME_MODE
             and self._requires_by_name_thunk_descriptor(argument)
         ]
@@ -2192,6 +2227,9 @@ class AlgolIrCompiler:
                     raise CompileError(
                         f"value array parameter {parameter.name!r} is not supported yet"
                     )
+                continue
+            if parameter.kind == "label":
+                arguments[index] = self._compile_label_actual_value(argument, scope)
                 continue
             if parameter.mode == _VALUE_MODE:
                 value = self._compile_expr(argument, scope)
@@ -2226,6 +2264,9 @@ class AlgolIrCompiler:
         ):
             if parameter.kind == "array":
                 arguments[index] = self._compile_array_actual_pointer(argument, scope)
+                continue
+            if parameter.kind == "label":
+                arguments[index] = self._compile_label_actual_value(argument, scope)
                 continue
             if parameter.mode != _NAME_MODE:
                 continue
@@ -2796,6 +2837,44 @@ class AlgolIrCompiler:
             raise CompileError("array parameter actual is missing a name")
         access = self._require_array_access(name, "actual")
         return self._emit_load_array_descriptor(access, scope)
+
+    def _compile_label_actual_value(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            raise CompileError("label parameter actual must be a direct label")
+        name = _variable_name(variable)
+        if name is None:
+            raise CompileError("label parameter actual is missing a name")
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            raise CompileError(f"label actual {name.value!r} was not resolved")
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind != "label":
+            raise CompileError(
+                f"label parameter actual {name.value!r} is not a label"
+            )
+        if symbol.parameter_mode is not None:
+            if symbol.slot_offset is None:
+                raise CompileError(
+                    f"label parameter actual {name.value!r} has no planned frame slot"
+                )
+            frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+            value_reg = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(value_reg),
+                IrRegister(frame_reg),
+                IrRegister(self._const_reg(symbol.slot_offset)),
+            )
+            return value_reg
+        label = self.labels_by_symbol.get(symbol.symbol_id)
+        if label is None:
+            raise CompileError(f"label actual {name.value!r} has no descriptor")
+        return self._const_reg(label.label_id)
 
     def _compile_eval_thunk_actual(
         self,
@@ -3465,7 +3544,11 @@ class AlgolIrCompiler:
 
     def _is_by_name_reference(self, reference: ResolvedReference) -> bool:
         parameter = self.parameters_by_symbol.get(reference.symbol_id)
-        return parameter is not None and parameter.mode == _NAME_MODE
+        return (
+            parameter is not None
+            and parameter.mode == _NAME_MODE
+            and parameter.kind == "scalar"
+        )
 
     def _emit_store_reference(
         self,
@@ -3554,8 +3637,15 @@ class AlgolIrCompiler:
                 f"reference {reference.name!r} was resolved for block "
                 f"{reference.use_block_id}, but codegen is in block {scope.block_id}"
             )
+        return self._emit_frame_for_lexical_depth(scope, reference.lexical_depth_delta)
+
+    def _emit_frame_for_lexical_depth(
+        self,
+        scope: _FrameScope,
+        lexical_depth_delta: int,
+    ) -> int:
         frame_reg = scope.frame_base_reg
-        for _ in range(reference.lexical_depth_delta):
+        for _ in range(lexical_depth_delta):
             next_frame = self._fresh_reg()
             offset_reg = self._const_reg(_STATIC_LINK_OFFSET)
             self._emit(
@@ -3566,6 +3656,17 @@ class AlgolIrCompiler:
             )
             frame_reg = next_frame
         return frame_reg
+
+    def _resolve_symbol_in_scope_chain(
+        self,
+        name: str,
+        scope: _FrameScope,
+    ) -> tuple[Symbol, int] | None:
+        resolved = scope.semantic_block.scope.resolve_with_scope(name)
+        if resolved is None:
+            return None
+        symbol, _, lexical_depth_delta = resolved
+        return symbol, lexical_depth_delta
 
     def _emit_load_array_descriptor(
         self,
@@ -3937,9 +4038,16 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         label_id: int,
     ) -> None:
+        self._emit_pending_goto_return_reg(scope, self._const_reg(label_id))
+
+    def _emit_pending_goto_return_reg(
+        self,
+        scope: _FrameScope,
+        label_reg: int,
+    ) -> None:
         self._store_runtime_state(
             _RUNTIME_PENDING_GOTO_LABEL_OFFSET,
-            self._const_reg(label_id),
+            label_reg,
         )
         self._emit_zero_result_reg()
         if not scope.helper_failure:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -871,6 +871,26 @@ class TestAlgolIrCompiler:
             instruction.opcode == IrOp.CMP_NE for instruction in probe_window
         )
 
+    def test_compiles_label_parameter_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure jump(target); label target; begin goto target end; "
+                "jump(done); "
+                "done: result := 7 "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        signature = result.procedure_signatures[calls[0].operands[0].name]
+
+        assert signature.param_count == 3
+        assert signature.param_types == ("integer", "integer", "integer")
+
     def test_compiles_integer_actual_promoted_for_real_value_parameter(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -36,15 +36,14 @@ switch selections and nonlocal conditional/switch designational branches remain
 guarded with targeted diagnostics. Switch entries that recursively select
 another switch are also guarded until the later dispatch-lowering phase.
 
-Unsupported ALGOL 60 features, including procedure-valued parameters, nonlocal
-switches, and nonlocal procedure-crossing `goto`, are reported as diagnostics
-instead of being silently accepted by the compiled pipeline. By-name parameters
-are accepted in the semantic model, while later lowering packages now implement
-scalar call-by-name plus typed whole-array formals. The checker keeps guarding
-the remaining full-ALGOL gaps, including non-assignable actuals passed to
-written by-name formals, non-integer by-name types, value array parameters,
-procedure-valued parameters, conditional designational expressions that cross
-frame boundaries, and `goto` forms that escape a called procedure.
+Unsupported ALGOL 60 features, including switch- and procedure-valued
+parameters, are reported as diagnostics instead of being silently accepted by
+the compiled pipeline. By-name parameters are accepted in the semantic model,
+while later lowering packages now implement scalar call-by-name, typed
+whole-array formals, and label formals. The checker keeps guarding the
+remaining full-ALGOL gaps, including non-assignable actuals passed to written
+by-name formals, non-integer by-name types, value array/label parameters,
+procedure-valued parameters, and switch-valued parameters.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -787,7 +787,15 @@ class AlgolTypeChecker:
                     )
                 if parameter_type is None:
                     parameter_type = REAL
-            elif parameter_kind in {LABEL, SWITCH, "procedure"}:
+            elif parameter_kind == LABEL:
+                if mode == VALUE:
+                    self._error(
+                        formal,
+                        f"value parameter {formal.value!r} cannot be a label in "
+                        "this phase",
+                    )
+                parameter_type = LABEL
+            elif parameter_kind in {SWITCH, "procedure"}:
                 self._error(
                     formal,
                     f"{parameter_kind} parameter {formal.value!r} is not supported yet",
@@ -874,19 +882,25 @@ class AlgolTypeChecker:
             if parameter_kind == ARRAY:
                 if parameter_type is None:
                     parameter_type = REAL
-            elif parameter_kind in {LABEL, SWITCH, "procedure"}:
+            elif parameter_kind == LABEL:
+                parameter_type = LABEL
+            elif parameter_kind in {SWITCH, "procedure"}:
                 parameter_kind = "scalar"
             param_symbol = Symbol(
                 name=formal.value,
                 type_name=(
                     parameter_type
-                    if parameter_type in {INTEGER, BOOLEAN, REAL, STRING}
+                    if parameter_type in {INTEGER, BOOLEAN, REAL, STRING, LABEL}
                     else INTEGER
                 ),
                 line=formal.line,
                 column=formal.column,
                 symbol_id=self._next_symbol_id,
-                kind=ARRAY if parameter_kind == ARRAY else "parameter",
+                kind=(
+                    parameter_kind
+                    if parameter_kind in {ARRAY, LABEL}
+                    else "parameter"
+                ),
                 storage_class=(
                     PARAMETER_STORAGE if parameter_kind == ARRAY else "frame"
                 ),
@@ -1205,6 +1219,19 @@ class AlgolTypeChecker:
         if symbol.kind != LABEL:
             self._error(target_token, f"{target_token.value!r} is not a label")
             return
+        if symbol.parameter_mode is not None and symbol.slot_offset is not None:
+            return ResolvedGoto(
+                token_id=id(target_token),
+                label_id=-1,
+                target_name=target_token.value,
+                ir_label="",
+                source_block_id=scope.block_id,
+                target_block_id=declaring_scope.block_id,
+                lexical_depth_delta=lexical_depth_delta,
+                line=target_token.line,
+                column=target_token.column,
+                designational_node_id=id(outer_node),
+            )
         if lexical_depth_delta != 0 and not allow_nonlocal_label:
             self._error(
                 target_token,
@@ -1326,6 +1353,9 @@ class AlgolTypeChecker:
             symbol = self._resolve_name(name, scope, role="write")
             if symbol is not None and symbol.kind == ARRAY:
                 self._error(name, f"array {name.value!r} requires subscripts")
+                target_type = ERROR
+            elif symbol is not None and symbol.kind == LABEL:
+                self._error(name, f"label {name.value!r} is not assignable")
                 target_type = ERROR
             else:
                 target_type = ERROR if symbol is None else symbol.type_name
@@ -1711,6 +1741,9 @@ class AlgolTypeChecker:
             if parameter.kind == ARRAY:
                 self._check_array_parameter_actual(argument, scope, parameter)
                 continue
+            if parameter.kind == LABEL:
+                self._check_label_parameter_actual(argument, scope, parameter)
+                continue
             actual_type = self._infer_expr(argument, scope)
             if descriptor.procedure_id == -1:
                 if actual_type != ERROR and actual_type not in {
@@ -1819,6 +1852,40 @@ class AlgolTypeChecker:
                 f"{parameter.type_name} elements, got {descriptor.element_type}",
             )
         return access
+
+    def _check_label_parameter_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        parameter: ProcedureParameter,
+    ) -> Symbol | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            self._error(
+                argument,
+                f"label parameter {parameter.name!r} expects a direct label actual",
+            )
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            self._error(argument, "label actual is missing a name")
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            self._error(
+                name,
+                f"{name.value!r} is not declared in block {scope.block_id} "
+                "or its lexical parents",
+            )
+            return None
+        symbol, _, _ = resolved
+        if symbol.kind != LABEL:
+            self._error(
+                name,
+                f"label parameter {parameter.name!r} expects a label actual",
+            )
+            return None
+        return symbol
 
     def _resolve_builtin_procedure(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -676,6 +676,34 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "cannot be an array in this phase" in result.diagnostics[0].message
 
+    def test_accepts_label_parameter_and_direct_label_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure jump(target); label target; begin goto target end; "
+            "jump(done); "
+            "done: result := 7 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "label"
+        assert parameter.type_name == "label"
+
+    def test_rejects_value_label_parameter_in_this_phase(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure jump(target); value target; label target; begin end; "
+            "result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "cannot be a label in this phase" in result.diagnostics[0].message
+
     def test_accepts_integer_array_descriptor_and_accesses(self) -> None:
         ast = parse_algol(
             "begin integer result, lo, hi; "

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,7 @@ already supports a substantial ALGOL 60 surface:
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
 - value and by-name parameters, including Jensen-style expression thunks and
-  typed whole-array formals
+  typed whole-array and label formals
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   non-recursive switch entries

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -672,6 +672,29 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
 
+    def test_label_parameter_jumps_to_caller_label(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure jump(target); label target; begin goto target end; "
+            "jump(done); result := 1; "
+            "done: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_forwarded_label_parameter_propagates_through_intermediate_procedure(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure jump(target); label target; begin goto target end; "
+            "procedure relay(target); label target; begin jump(target) end; "
+            "relay(done); result := 1; "
+            "done: result := 8 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
     def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- add type-checker support for `label` procedure parameters and direct label actuals
- lower label formals through the IR/WASM pipeline as word-sized pending-goto targets
- cover direct and forwarded label-parameter jumps in checker, IR, and WASM tests

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k 'not array_failure_in_procedure_unwinds_before_caller_continues' -q`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-type-checker/README.md code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-ir-compiler/README.md code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/README.md`
- `git diff --check`