### PR TITLE
Add ALGOL switch parameter support

### DIFF
--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -39,9 +39,10 @@ failure propagation from callees back to the by-name formal read. Stores through
 read-only expression thunks still raise targeted `CompileError` diagnostics
 until Phase 5 grows full store-helper coverage. The supported integer by-name
 surface is covered by the WASM acceptance suite, including typed whole-array
-formals passed as descriptor pointers and label formals passed as pending-goto
-targets. Full ALGOL forms such as switch/procedure-valued formals and escaping
-thunk descriptors remain future work.
+formals passed as descriptor pointers, label formals passed as pending-goto
+targets, and switch formals passed as descriptor closures that re-evaluate in
+the caller's declaring scope. Full ALGOL forms such as procedure-valued
+formals and escaping thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -83,12 +83,16 @@ _THUNK_EVAL_LABEL = "_fn_algol_eval_thunk"
 _THUNK_STORE_LABEL = "_fn_algol_store_thunk"
 _THUNK_EVAL_REAL_LABEL = "_fn_algol_eval_real_thunk"
 _THUNK_STORE_REAL_LABEL = "_fn_algol_store_real_thunk"
+_SWITCH_EVAL_LABEL = "_fn_algol_eval_switch"
 _THUNK_DESCRIPTOR_SIZE = 12
 _THUNK_CODE_ID_OFFSET = 0
 _THUNK_CALLER_FRAME_OFFSET = 4
 _THUNK_FLAGS_OFFSET = 8
 _THUNK_DESCRIPTOR_TAG = 1
 _THUNK_FLAG_STORE = 1
+_SWITCH_DESCRIPTOR_SIZE = 8
+_SWITCH_DESCRIPTOR_ID_OFFSET = 0
+_SWITCH_DESCRIPTOR_CALLER_FRAME_OFFSET = 4
 _MAX_EVAL_THUNKS = 256
 _INTEGER_TYPE = "integer"
 _BOOLEAN_TYPE = "boolean"
@@ -232,6 +236,7 @@ class AlgolIrCompiler:
         self.current_function_return_type: str | None = _INTEGER_TYPE
         self.eval_thunks: list[_EvalThunk] = []
         self.has_by_name_parameters = False
+        self.has_switch_parameters = False
         self.string_literal_offsets: dict[str, int] = {}
 
     def compile(self, typed: TypeCheckResult | ASTNode) -> CompileResult:
@@ -260,6 +265,7 @@ class AlgolIrCompiler:
         self.heap_limit_reg = -1
         self.eval_thunks = []
         self.has_by_name_parameters = False
+        self.has_switch_parameters = False
         self.string_literal_offsets = {}
         self.semantic_blocks = list(type_result.semantic.blocks)
         self.semantic_blocks_by_ast = {
@@ -325,6 +331,11 @@ class AlgolIrCompiler:
             for procedure in type_result.semantic.procedures
             for parameter in procedure.parameters
         )
+        self.has_switch_parameters = any(
+            parameter.kind == "switch"
+            for procedure in type_result.semantic.procedures
+            for parameter in procedure.parameters
+        )
         self.arrays = {
             array.array_id: array for array in type_result.semantic.arrays
         }
@@ -343,7 +354,7 @@ class AlgolIrCompiler:
                     *(
                         _INTEGER_TYPE
                         if parameter.mode == _NAME_MODE
-                        or parameter.kind in {"array", "label"}
+                        or parameter.kind in {"array", "label", "switch"}
                         else parameter.type_name
                         for parameter in procedure.parameters
                     ),
@@ -372,6 +383,11 @@ class AlgolIrCompiler:
                     param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _REAL_TYPE),
                     return_type=_INTEGER_TYPE,
                 )
+            )
+        if self.has_switch_parameters:
+            self.procedure_signatures[_SWITCH_EVAL_LABEL] = ProcedureSignaturePlan(
+                param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
+                return_type=_INTEGER_TYPE,
             )
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
         self.variable_slots = self._collect_variable_slots(self.semantic_blocks)
@@ -480,6 +496,8 @@ class AlgolIrCompiler:
                 label=_THUNK_STORE_REAL_LABEL,
                 thunk_kind=_REAL_TYPE,
             )
+        if self.has_switch_parameters:
+            self._compile_switch_eval_dispatcher()
 
         return CompileResult(
             program=self.program,
@@ -1046,6 +1064,31 @@ class AlgolIrCompiler:
         )
         return value_reg
 
+    def _compile_switch_parameter_pointer(
+        self,
+        name: str,
+        scope: _FrameScope,
+    ) -> int | None:
+        resolved = self._resolve_symbol_in_scope_chain(name, scope)
+        if resolved is None:
+            return None
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind != "switch" or symbol.parameter_mode is None:
+            return None
+        if symbol.slot_offset is None:
+            raise CompileError(
+                f"switch parameter {name!r} has no planned frame slot"
+            )
+        frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+        descriptor_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(descriptor_pointer),
+            IrRegister(frame_reg),
+            IrRegister(self._const_reg(symbol.slot_offset)),
+        )
+        return descriptor_pointer
+
     def _emit_goto_label(
         self,
         label: LabelDescriptor,
@@ -1081,15 +1124,31 @@ class AlgolIrCompiler:
         selection = self.switch_selections.get(id(node))
         if selection is None:
             raise CompileError("switch selection was not resolved")
-        descriptor = self.switches.get(selection.switch_id)
-        if descriptor is None:
-            raise CompileError(f"switch {selection.name!r} has no descriptor")
         if execution_scope is None:
             execution_scope = scope
         indexes = _direct_nodes(node, "arith_expr")
         if len(indexes) != 1:
             raise CompileError("switch selection requires exactly one index")
         index_value = self._compile_expr(indexes[0], scope)
+        if selection.switch_id < 0:
+            descriptor_pointer = self._compile_switch_parameter_pointer(
+                selection.name,
+                scope,
+            )
+            if descriptor_pointer is None:
+                raise CompileError(
+                    f"switch parameter {selection.name!r} was not resolved"
+                )
+            label_value = self._emit_call_switch_eval(
+                descriptor_pointer,
+                index_value,
+                scope,
+            )
+            self._emit_pending_goto_return_reg(execution_scope, label_value)
+            return
+        descriptor = self.switches.get(selection.switch_id)
+        if descriptor is None:
+            raise CompileError(f"switch {selection.name!r} has no descriptor")
         entry_scope = self._active_scope_for_block(selection.declaration_block_id, scope)
         dispatch_index = self.switch_count
         self.switch_count += 1
@@ -1117,6 +1176,154 @@ class AlgolIrCompiler:
             self._label(next_label)
         failed = self._const_reg(1)
         self._emit_runtime_failure_guard(failed, execution_scope)
+
+    def _compile_designational_value(
+        self,
+        node: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        if any(token.value == "if" for token in _direct_tokens(node)):
+            index = self.if_count
+            self.if_count += 1
+            else_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
+            result = self._fresh_reg()
+            bool_expr = _first_direct_node(node, "bool_expr")
+            if bool_expr is None:
+                raise CompileError("conditional designational is missing a condition")
+            condition = self._compile_expr(bool_expr, scope)
+            self._emit(IrOp.BRANCH_Z, IrRegister(condition), IrLabel(else_label))
+            then_desig = _first_direct_node(node, "simple_desig")
+            if then_desig is None:
+                raise CompileError("conditional designational is missing then target")
+            then_value = self._compile_simple_designational_value(then_desig, scope)
+            self._copy_reg(dst=result, src=then_value)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            else_desig = _first_direct_node(node, "desig_expr")
+            if else_desig is None:
+                raise CompileError("conditional designational is missing else target")
+            else_value = self._compile_designational_value(else_desig, scope)
+            self._copy_reg(dst=result, src=else_value)
+            self._label(end_label)
+            return result
+
+        simple = _first_direct_node(node, "simple_desig")
+        if simple is None:
+            raise CompileError("unsupported designational expression")
+        return self._compile_simple_designational_value(simple, scope)
+
+    def _compile_simple_designational_value(
+        self,
+        node: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        direct = _direct_label_from_simple_designational(node)
+        if direct is not None:
+            label = self._resolve_label_in_scope_chain(direct.value, scope)
+            if label is not None:
+                return self._const_reg(label.label_id)
+            label_value = self._compile_label_parameter_target(direct, scope)
+            if label_value is not None:
+                return label_value
+            raise CompileError(f"goto target {direct.value!r} was not resolved")
+
+        if any(token.value == "[" for token in _direct_tokens(node)):
+            return self._compile_switch_selection_value(node, scope)
+
+        nested = _first_direct_node(node, "desig_expr")
+        if nested is not None:
+            return self._compile_designational_value(nested, scope)
+        raise CompileError("unsupported designational expression")
+
+    def _compile_switch_selection_value(
+        self,
+        node: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        selection = self.switch_selections.get(id(node))
+        if selection is None:
+            raise CompileError("switch selection was not resolved")
+        indexes = _direct_nodes(node, "arith_expr")
+        if len(indexes) != 1:
+            raise CompileError("switch selection requires exactly one index")
+        index_value = self._compile_expr(indexes[0], scope)
+        if selection.switch_id < 0:
+            descriptor_pointer = self._compile_switch_parameter_pointer(
+                selection.name,
+                scope,
+            )
+            if descriptor_pointer is None:
+                raise CompileError(
+                    f"switch parameter {selection.name!r} was not resolved"
+                )
+            return self._emit_call_switch_eval(descriptor_pointer, index_value, scope)
+
+        descriptor = self.switches.get(selection.switch_id)
+        if descriptor is None:
+            raise CompileError(f"switch {selection.name!r} has no descriptor")
+        entry_scope = self._rebase_scope_for_selection(scope, selection)
+        return self._compile_switch_entries_value(
+            descriptor,
+            selection,
+            index_value,
+            entry_scope,
+        )
+
+    def _compile_switch_entries_value(
+        self,
+        descriptor: SwitchDescriptor,
+        selection: ResolvedSwitchSelection,
+        index_value: int,
+        entry_scope: _FrameScope,
+    ) -> int:
+        dispatch_index = self.switch_count
+        self.switch_count += 1
+        result = self._const_reg(0)
+        end_label = f"switch_value_{dispatch_index}_end"
+        for entry_index, entry_node_id in enumerate(descriptor.entry_node_ids, start=1):
+            next_label = f"switch_value_{dispatch_index}_{entry_index}_next"
+            expected = self._const_reg(entry_index)
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(index_value),
+                IrRegister(expected),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(next_label))
+            entry = self._find_ast_by_id(entry_node_id)
+            if entry is None:
+                raise CompileError(
+                    f"switch {selection.name!r} entry {entry_index} is missing"
+                )
+            result = self._compile_designational_value(entry, entry_scope)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(next_label)
+        failed = self._const_reg(1)
+        self._emit_runtime_failure_guard(failed, entry_scope)
+        self._label(end_label)
+        return result
+
+    def _rebase_scope_for_selection(
+        self,
+        scope: _FrameScope,
+        selection: ResolvedSwitchSelection,
+    ) -> _FrameScope:
+        frame_base_reg = self._emit_frame_for_lexical_depth(
+            scope,
+            selection.lexical_depth_delta,
+        )
+        return _FrameScope(
+            semantic_block=self.semantic_blocks_by_id[selection.declaration_block_id],
+            frame_base_reg=frame_base_reg,
+            heap_mark_reg=scope.heap_mark_reg,
+            parent=None,
+            goto_parent=None,
+            function_owner_procedure_id=scope.function_owner_procedure_id,
+            active_thunk_heap_mark_reg=scope.active_thunk_heap_mark_reg,
+            helper_failure=scope.helper_failure,
+        )
 
     def _compile_assignment(self, assign: ASTNode, scope: _FrameScope) -> None:
         left_part = _first_direct_node(assign, "left_part")
@@ -2204,9 +2411,16 @@ class AlgolIrCompiler:
             for index, (argument, parameter) in enumerate(
                 zip(actuals, procedure.parameters, strict=True)
             )
-            if parameter.kind not in {"array", "label"}
+            if parameter.kind not in {"array", "label", "switch"}
             and parameter.mode == _NAME_MODE
             and self._requires_by_name_thunk_descriptor(argument)
+        ]
+        switch_actuals = [
+            (index, argument, parameter)
+            for index, (argument, parameter) in enumerate(
+                zip(actuals, procedure.parameters, strict=True)
+            )
+            if parameter.kind == "switch"
         ]
         for _, argument, parameter in thunk_actuals:
             variable = _single_variable_expr(argument)
@@ -2231,6 +2445,8 @@ class AlgolIrCompiler:
             if parameter.kind == "label":
                 arguments[index] = self._compile_label_actual_value(argument, scope)
                 continue
+            if parameter.kind == "switch":
+                continue
             if parameter.mode == _VALUE_MODE:
                 value = self._compile_expr(argument, scope)
                 arguments[index] = self._coerce_reg_to_type(
@@ -2239,9 +2455,13 @@ class AlgolIrCompiler:
                     expected_type=parameter.type_name,
                 )
 
+        temp_descriptor_bytes = (
+            len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+            + len(switch_actuals) * _SWITCH_DESCRIPTOR_SIZE
+        )
         descriptor_heap_mark = (
-            self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
-            if thunk_actuals
+            self._emit_reserve_temp_descriptor_space(temp_descriptor_bytes, scope)
+            if temp_descriptor_bytes
             else None
         )
         active_thunk_heap_mark = (
@@ -2259,6 +2479,15 @@ class AlgolIrCompiler:
                 thunk_actuals
             )
         }
+        switch_descriptor_offsets = {
+            argument_index: (
+                len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+                + descriptor_index * _SWITCH_DESCRIPTOR_SIZE
+            )
+            for descriptor_index, (argument_index, _, _) in enumerate(
+                switch_actuals
+            )
+        }
         for index, (argument, parameter) in enumerate(
             zip(actuals, procedure.parameters, strict=True)
         ):
@@ -2267,6 +2496,19 @@ class AlgolIrCompiler:
                 continue
             if parameter.kind == "label":
                 arguments[index] = self._compile_label_actual_value(argument, scope)
+                continue
+            if parameter.kind == "switch":
+                descriptor = None
+                if descriptor_heap_mark is not None and index in switch_descriptor_offsets:
+                    descriptor = self._emit_descriptor_at(
+                        descriptor_heap_mark,
+                        switch_descriptor_offsets[index],
+                    )
+                arguments[index] = self._compile_switch_actual_pointer(
+                    argument,
+                    scope,
+                    descriptor,
+                )
                 continue
             if parameter.mode != _NAME_MODE:
                 continue
@@ -2838,6 +3080,54 @@ class AlgolIrCompiler:
         access = self._require_array_access(name, "actual")
         return self._emit_load_array_descriptor(access, scope)
 
+    def _compile_switch_actual_pointer(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+        descriptor: int | None,
+    ) -> int:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            raise CompileError("switch parameter actual must be a direct switch")
+        name = _variable_name(variable)
+        if name is None:
+            raise CompileError("switch parameter actual is missing a name")
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            raise CompileError(f"switch actual {name.value!r} was not resolved")
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind != "switch":
+            raise CompileError(
+                f"switch parameter actual {name.value!r} is not a switch"
+            )
+        if symbol.parameter_mode is not None:
+            if symbol.slot_offset is None:
+                raise CompileError(
+                    f"switch parameter actual {name.value!r} has no planned frame slot"
+                )
+            frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+            pointer = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(pointer),
+                IrRegister(frame_reg),
+                IrRegister(self._const_reg(symbol.slot_offset)),
+            )
+            return pointer
+        if symbol.switch_id is None:
+            raise CompileError(f"switch actual {name.value!r} has no descriptor")
+        if descriptor is None:
+            raise CompileError(
+                f"missing reserved descriptor for switch actual {name.value!r}"
+            )
+        caller_frame = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+        self._emit_write_switch_descriptor(
+            descriptor,
+            symbol.switch_id,
+            caller_frame,
+        )
+        return descriptor
+
     def _compile_label_actual_value(
         self,
         argument: ASTNode,
@@ -2875,6 +3165,29 @@ class AlgolIrCompiler:
         if label is None:
             raise CompileError(f"label actual {name.value!r} has no descriptor")
         return self._const_reg(label.label_id)
+
+    def _emit_call_switch_eval(
+        self,
+        descriptor_pointer: int,
+        index_value: int,
+        scope: _FrameScope,
+    ) -> int:
+        active_thunk_heap_mark = (
+            scope.active_thunk_heap_mark_reg
+            if scope.active_thunk_heap_mark_reg is not None
+            else self._const_reg(0)
+        )
+        self._emit(
+            IrOp.CALL,
+            IrLabel(_SWITCH_EVAL_LABEL),
+            IrRegister(descriptor_pointer),
+            IrRegister(active_thunk_heap_mark),
+            IrRegister(index_value),
+        )
+        self._emit_propagate_thunk_failure(scope)
+        result = self._fresh_reg()
+        self._copy_reg(dst=result, src=_RESULT_REG)
+        return result
 
     def _compile_eval_thunk_actual(
         self,
@@ -2960,6 +3273,16 @@ class AlgolIrCompiler:
         count: int,
         scope: _FrameScope,
     ) -> int:
+        return self._emit_reserve_temp_descriptor_space(
+            count * _THUNK_DESCRIPTOR_SIZE,
+            scope,
+        )
+
+    def _emit_reserve_temp_descriptor_space(
+        self,
+        byte_count: int,
+        scope: _FrameScope,
+    ) -> int:
         descriptor_base = self._fresh_reg()
         heap_limit = self._fresh_reg()
         self._load_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, descriptor_base)
@@ -2969,7 +3292,7 @@ class AlgolIrCompiler:
             IrOp.ADD_IMM,
             IrRegister(next_heap_pointer),
             IrRegister(descriptor_base),
-            IrImmediate(count * _THUNK_DESCRIPTOR_SIZE),
+            IrImmediate(byte_count),
         )
         exhausted = self._fresh_reg()
         self._emit(
@@ -3014,6 +3337,23 @@ class AlgolIrCompiler:
             descriptor,
             _THUNK_FLAGS_OFFSET,
             _THUNK_FLAG_STORE if thunk.store_capable else 0,
+        )
+
+    def _emit_write_switch_descriptor(
+        self,
+        descriptor: int,
+        switch_id: int,
+        caller_frame_reg: int,
+    ) -> None:
+        self._store_word_const(
+            descriptor,
+            _SWITCH_DESCRIPTOR_ID_OFFSET,
+            switch_id,
+        )
+        self._store_word_reg(
+            value_reg=caller_frame_reg,
+            base_reg=descriptor,
+            offset=_SWITCH_DESCRIPTOR_CALLER_FRAME_OFFSET,
         )
 
     def _compile_procedures(
@@ -3165,6 +3505,80 @@ class AlgolIrCompiler:
             self._label(end_label)
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit(IrOp.RET)
+        self.current_function_return_type = previous_return_type
+
+    def _compile_switch_eval_dispatcher(self) -> None:
+        previous_return_type = self.current_function_return_type
+        self.current_function_return_type = _INTEGER_TYPE
+        self._label(_SWITCH_EVAL_LABEL)
+        descriptor = _STATIC_LINK_PARAM_REG
+        active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
+        index_value = _VALUE_PARAM_BASE_REG
+        switch_id = self._fresh_reg()
+        caller_frame = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(switch_id),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_SWITCH_DESCRIPTOR_ID_OFFSET)),
+        )
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(caller_frame),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_SWITCH_DESCRIPTOR_CALLER_FRAME_OFFSET)),
+        )
+        for switch in self.switches.values():
+            index = self.if_count
+            self.if_count += 1
+            else_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(switch_id),
+                IrRegister(self._const_reg(switch.switch_id)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            self._emit_enter_thunk_helper()
+            switch_scope = _FrameScope(
+                semantic_block=self.semantic_blocks_by_id[switch.declaring_block_id],
+                frame_base_reg=caller_frame,
+                heap_mark_reg=None,
+                parent=None,
+                goto_parent=None,
+                function_owner_procedure_id=None,
+                active_thunk_heap_mark_reg=active_thunk_heap_mark,
+                helper_failure=True,
+            )
+            selection = ResolvedSwitchSelection(
+                node_id=-1,
+                token_id=-1,
+                name=switch.name,
+                switch_id=switch.switch_id,
+                use_block_id=switch.declaring_block_id,
+                declaration_block_id=switch.declaring_block_id,
+                lexical_depth_delta=0,
+                index_node_id=-1,
+                line=switch.line,
+                column=switch.column,
+            )
+            label_value = self._compile_switch_entries_value(
+                switch,
+                selection,
+                index_value,
+                switch_scope,
+            )
+            self._copy_reg(dst=_RESULT_REG, src=label_value)
+            self._emit_leave_thunk_helper()
+            self._emit(IrOp.RET)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            self._label(end_label)
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
+        self._emit_zero_result_reg()
         self._emit(IrOp.RET)
         self.current_function_return_type = previous_return_type
 

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -722,6 +722,37 @@ class TestAlgolIrCompiler:
         assert IrOp.LOAD_WORD in opcodes
         assert IrOp.SYSCALL in opcodes
 
+    def test_compiles_switch_parameter_call_and_helper_dispatch(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, flag; "
+                "procedure escape(sw); switch sw; begin goto sw[1] end; "
+                "switch s := if flag = 0 then left else right; "
+                "flag := 1; escape(s); result := 0; "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert result.procedure_signatures["_fn_algol_eval_switch"].param_count == 3
+        assert "_fn_algol_eval_switch" in labels
+        assert any(
+            instruction.operands[0].name == "_fn_algol_eval_switch"
+            for instruction in calls
+        )
+
     def test_compiles_dynamic_multidimensional_array_bounds(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -40,10 +40,10 @@ Unsupported ALGOL 60 features, including switch- and procedure-valued
 parameters, are reported as diagnostics instead of being silently accepted by
 the compiled pipeline. By-name parameters are accepted in the semantic model,
 while later lowering packages now implement scalar call-by-name, typed
-whole-array formals, and label formals. The checker keeps guarding the
-remaining full-ALGOL gaps, including non-assignable actuals passed to written
-by-name formals, non-integer by-name types, value array/label parameters,
-procedure-valued parameters, and switch-valued parameters.
+whole-array formals, label formals, and switch formals. The checker keeps
+guarding the remaining full-ALGOL gaps, including non-assignable actuals
+passed to written by-name formals, non-integer by-name types, value
+array/label/switch parameters, and procedure-valued parameters.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -795,7 +795,15 @@ class AlgolTypeChecker:
                         "this phase",
                     )
                 parameter_type = LABEL
-            elif parameter_kind in {SWITCH, "procedure"}:
+            elif parameter_kind == SWITCH:
+                if mode == VALUE:
+                    self._error(
+                        formal,
+                        f"value parameter {formal.value!r} cannot be a switch in "
+                        "this phase",
+                    )
+                parameter_type = SWITCH
+            elif parameter_kind == "procedure":
                 self._error(
                     formal,
                     f"{parameter_kind} parameter {formal.value!r} is not supported yet",
@@ -884,13 +892,16 @@ class AlgolTypeChecker:
                     parameter_type = REAL
             elif parameter_kind == LABEL:
                 parameter_type = LABEL
-            elif parameter_kind in {SWITCH, "procedure"}:
+            elif parameter_kind == SWITCH:
+                parameter_type = SWITCH
+            elif parameter_kind == "procedure":
                 parameter_kind = "scalar"
             param_symbol = Symbol(
                 name=formal.value,
                 type_name=(
                     parameter_type
-                    if parameter_type in {INTEGER, BOOLEAN, REAL, STRING, LABEL}
+                    if parameter_type
+                    in {INTEGER, BOOLEAN, REAL, STRING, LABEL, SWITCH}
                     else INTEGER
                 ),
                 line=formal.line,
@@ -898,7 +909,7 @@ class AlgolTypeChecker:
                 symbol_id=self._next_symbol_id,
                 kind=(
                     parameter_kind
-                    if parameter_kind in {ARRAY, LABEL}
+                    if parameter_kind in {ARRAY, LABEL, SWITCH}
                     else "parameter"
                 ),
                 storage_class=(
@@ -955,12 +966,12 @@ class AlgolTypeChecker:
                         kind=parameter_kind,
                         may_write=(
                             formal.value in write_reasons
-                            if parameter_kind != ARRAY
+                            if parameter_kind == "scalar"
                             else False
                         ),
                         write_reason=(
                             write_reasons.get(formal.value)
-                            if parameter_kind != ARRAY
+                            if parameter_kind == "scalar"
                             else None
                         ),
                     )
@@ -1292,9 +1303,6 @@ class AlgolTypeChecker:
                 f"switch {name_token.value!r} cannot select itself recursively",
             )
             return
-        if symbol.switch_id is None:
-            self._error(name_token, f"switch {name_token.value!r} has no descriptor")
-            return
 
         indexes = _direct_nodes(node, "arith_expr")
         if len(indexes) != 1:
@@ -1304,12 +1312,20 @@ class AlgolTypeChecker:
         if index_type != ERROR and index_type != INTEGER:
             self._error(indexes[0], "switch index must be integer")
 
+        if symbol.parameter_mode is not None and symbol.slot_offset is not None:
+            switch_id = -1
+        elif symbol.switch_id is None:
+            self._error(name_token, f"switch {name_token.value!r} has no descriptor")
+            return
+        else:
+            switch_id = symbol.switch_id
+
         self.resolved_switch_selections.append(
             ResolvedSwitchSelection(
                 node_id=id(node),
                 token_id=id(name_token),
                 name=name_token.value,
-                switch_id=symbol.switch_id,
+                switch_id=switch_id,
                 use_block_id=scope.block_id,
                 declaration_block_id=declaring_scope.block_id,
                 lexical_depth_delta=lexical_depth_delta,
@@ -1744,6 +1760,9 @@ class AlgolTypeChecker:
             if parameter.kind == LABEL:
                 self._check_label_parameter_actual(argument, scope, parameter)
                 continue
+            if parameter.kind == SWITCH:
+                self._check_switch_parameter_actual(argument, scope, parameter)
+                continue
             actual_type = self._infer_expr(argument, scope)
             if descriptor.procedure_id == -1:
                 if actual_type != ERROR and actual_type not in {
@@ -1883,6 +1902,40 @@ class AlgolTypeChecker:
             self._error(
                 name,
                 f"label parameter {parameter.name!r} expects a label actual",
+            )
+            return None
+        return symbol
+
+    def _check_switch_parameter_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        parameter: ProcedureParameter,
+    ) -> Symbol | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            self._error(
+                argument,
+                f"switch parameter {parameter.name!r} expects a direct switch actual",
+            )
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            self._error(argument, "switch actual is missing a name")
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            self._error(
+                name,
+                f"{name.value!r} is not declared in block {scope.block_id} "
+                "or its lexical parents",
+            )
+            return None
+        symbol, _, _ = resolved
+        if symbol.kind != SWITCH:
+            self._error(
+                name,
+                f"switch parameter {parameter.name!r} expects a switch actual",
             )
             return None
         return symbol

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -704,6 +704,41 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "cannot be a label in this phase" in result.diagnostics[0].message
 
+    def test_accepts_switch_parameter_and_direct_switch_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result, flag; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "switch s := if flag = 0 then left else right; "
+            "flag := 1; escape(s); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "switch"
+        assert parameter.type_name == "switch"
+        assert any(
+            selection.name == "sw" and selection.switch_id == -1
+            for selection in result.semantic.switch_selections
+        )
+
+    def test_rejects_value_switch_parameter_in_this_phase(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure escape(sw); value sw; switch sw; begin end; "
+            "result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "cannot be a switch in this phase" in result.diagnostics[0].message
+
     def test_accepts_integer_array_descriptor_and_accesses(self) -> None:
         ast = parse_algol(
             "begin integer result, lo, hi; "

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,7 @@ already supports a substantial ALGOL 60 surface:
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
 - value and by-name parameters, including Jensen-style expression thunks and
-  typed whole-array and label formals
+  typed whole-array, label, and switch formals
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   non-recursive switch entries

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -517,6 +517,35 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_switch_parameter_designational_goto_uses_caller_switch_scope(self) -> None:
+        result = compile_source(
+            "begin integer result, flag; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "switch s := if flag = 0 then left else right; "
+            "flag := 1; escape(s); result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_forwarded_switch_parameter_propagates_descriptor_through_calls(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "procedure relay(sw); switch sw; begin escape(sw) end; "
+            "switch s := second; "
+            "relay(s); result := 0; "
+            "first: result := 1; goto done; "
+            "second: result := 8; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
     def test_repeated_switch_designational_gotos_use_distinct_dispatch(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- add checker support for `switch` procedure formals and direct switch actual validation
- lower switch formals through IR/WASM as descriptor-passed closures evaluated in the caller's declaring scope
- add checker, IR, and WASM coverage for direct and forwarded switch-formal gotos

## Testing
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k 'not array_failure_in_procedure_unwinds_before_caller_continues' -q`
- `ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-type-checker/README.md code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-ir-compiler/README.md code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/README.md`
- `git diff --check`