### PR TITLE
refactor(tetrad-runtime): inline 4004 codegen; drop tetrad-vm + tetrad-jit deps

### DIFF
--- a/code/packages/python/tetrad-runtime/BUILD
+++ b/code/packages/python/tetrad-runtime/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../register-vm -e ../virtual-machine -e ../simulator-protocol -e ../tetrad-lexer -e ../tetrad-parser -e ../tetrad-type-checker -e ../tetrad-compiler -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ../intel4004-simulator -e ../tetrad-vm -e ../tetrad-jit -e ".[dev]" --quiet
+uv pip install -e ../tetrad-lexer -e ../tetrad-parser -e ../tetrad-type-checker -e ../tetrad-compiler -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ../intel4004-simulator -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/tetrad-runtime/BUILD
+++ b/code/packages/python/tetrad-runtime/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../tetrad-lexer -e ../tetrad-parser -e ../tetrad-type-checker -e ../tetrad-compiler -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ../intel4004-simulator -e ".[dev]" --quiet
+uv pip install -e ../simulator-protocol -e ../virtual-machine -e ../tetrad-lexer -e ../tetrad-parser -e ../tetrad-type-checker -e ../tetrad-compiler -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ../intel4004-simulator -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/tetrad-runtime/CHANGELOG.md
+++ b/code/packages/python/tetrad-runtime/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `tetrad-runtime` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — inline the Intel 4004 codegen, drop legacy package deps
+
+The bytecode → 4004 codegen and the SSA-by-name `IRInstr` it consumes
+moved in-tree under `tetrad_runtime._intel4004_codegen` (subpackage,
+underscore-prefixed to mark it internal).  Originally these lived in
+the now-retired `tetrad-jit` package; the only consumer was
+`Intel4004Backend`, so co-locating them with their sole user
+simplifies the dependency graph and unblocks deletion of `tetrad-jit`.
+
+- `tetrad_runtime._intel4004_codegen.ir` — `IRInstr`, `evaluate_op`
+- `tetrad_runtime._intel4004_codegen.codegen` — `codegen`,
+  `run_on_4004`, `DeoptimizerError`
+- `Intel4004Backend.compile` / `.run` now import from the in-tree
+  module instead of `tetrad_jit`; the deprecated import-fallback
+  branch was removed.
+- The 13 `evaluate_op` tests and 20 `codegen` tests from
+  `tetrad-jit/tests/test_tetrad_jit.py` (the `TestEvaluateOp` and
+  `TestCodegen` classes) moved here as `tests/test_intel4004_codegen.py`.
+
+### Removed
+
+- `coding-adventures-tetrad-vm` and `coding-adventures-tetrad-jit`
+  removed from `pyproject.toml` `dependencies` and from `BUILD`.
+  `intel4004-simulator` remains (still needed for `run_on_4004`).
+
 ### Added — LANG17 PR4: legacy ``TetradVM`` API parity
 
 Adds re-projection wrappers on `TetradRuntime` so callers can switch

--- a/code/packages/python/tetrad-runtime/pyproject.toml
+++ b/code/packages/python/tetrad-runtime/pyproject.toml
@@ -16,9 +16,10 @@ dependencies = [
     "coding-adventures-interpreter-ir",
     "coding-adventures-vm-core",
     "coding-adventures-jit-core",
-    # Intel4004Backend bridges to the legacy tetrad-jit codegen and the
-    # intel4004-simulator runner, so both are direct runtime dependencies.
-    "coding-adventures-tetrad-jit",
+    # Intel4004Backend's run() executes 4004 binaries on the simulator.
+    # The codegen + IRInstr that the bridge uses now live in-tree under
+    # tetrad_runtime._intel4004_codegen (moved out of the retired
+    # tetrad-jit package), so simulator is the only external 4004 dep.
     "coding-adventures-intel4004-simulator",
 ]
 classifiers = [

--- a/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/__init__.py
+++ b/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/__init__.py
@@ -1,0 +1,38 @@
+"""Internal Intel 4004 codegen — adopted from the legacy ``tetrad-jit``.
+
+This subpackage is the bytecode → 4004-abstract-assembly → binary
+pipeline that ``Intel4004Backend`` uses.  It moved here as part of
+deprecating ``tetrad-jit`` (and ``tetrad-vm``) — the only consumer of
+the codegen was ``Intel4004Backend``, so co-locating the code with its
+sole user simplifies the dependency graph and lets the legacy package
+be deleted.
+
+The leading underscore marks this as **internal**.  External callers
+should go through ``tetrad_runtime.Intel4004Backend``; the codegen
+shape is not a stable public API.
+
+Modules
+-------
+
+- :mod:`ir` — ``IRInstr`` dataclass, the SSA-by-name shape that
+  ``Intel4004Backend`` re-projects ``CIRInstr`` into.
+- :mod:`codegen` — ``codegen(ir)`` translates an ``IRInstr`` list to a
+  4004 binary; ``run_on_4004(binary, args)`` executes that binary on
+  the ``intel4004-simulator``.
+
+When the day comes for a CIR-native 4004 backend (the planned
+``intel4004-backend`` package), this whole subpackage gets retired.
+For now it bridges CIR back to the original codegen so we don't lose
+the working Tetrad → 4004 pipeline.
+"""
+
+from __future__ import annotations
+
+from tetrad_runtime._intel4004_codegen.codegen import (
+    DeoptimizerError,
+    codegen,
+    run_on_4004,
+)
+from tetrad_runtime._intel4004_codegen.ir import IRInstr
+
+__all__ = ["DeoptimizerError", "IRInstr", "codegen", "run_on_4004"]

--- a/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/codegen.py
+++ b/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/codegen.py
@@ -1,0 +1,729 @@
+"""Intel 4004 code generator for the Tetrad JIT (TET05).
+
+Translates optimized JIT IR (``list[IRInstr]``) to Intel 4004 machine code
+(``bytes``) that can be loaded directly into ``Intel4004Simulator``.
+
+=== Register pair convention ===
+
+The 4004 has 16 × 4-bit registers, organized as 8 pairs (P0–P7):
+
+    P0 (R0:R1)   — argument 0 / return value
+    P1 (R2:R3)   — argument 1
+    P2 (R4:R5)   — local virtual variable 0
+    P3 (R6:R7)   — local virtual variable 1
+    P4 (R8:R9)   — local virtual variable 2
+    P5 (R10:R11) — local virtual variable 3
+    P6 (R12:R13) — RAM address register (reserved for load_var / store_var)
+    P7 (R14:R15) — scratch / immediate temp (reserved)
+
+Each Tetrad u8 value is stored hi-nibble in R(2p), lo-nibble in R(2p+1).
+``FIM Pp, d8`` loads both nibbles in one 2-byte instruction.
+
+=== RAM variable layout ===
+
+Tetrad local variables (``store_var`` / ``load_var``) are kept in
+4004 RAM bank 0, register 0.  Variable i occupies character slots 2i (hi)
+and 2i+1 (lo).  P6 is used as the SRC address pair.  Maximum 8 variables.
+
+=== Deopt ===
+
+Operations without a 4004 encoding (mul, div, mod, bitwise, io, call)
+cause ``codegen(ir)`` to return ``None``.  The JIT then falls back to the
+interpreter.
+
+=== Two-pass assembler ===
+
+Abstract instructions are tuples, e.g. ``("LD", 3)``, ``("JUN", "lbl_0")``.
+A label marker ``("LABEL", "lbl_0")`` contributes zero bytes.
+
+Pass 1 — compute byte offset of every instruction and build label → address.
+Pass 2 — encode each instruction, resolving label names to ROM addresses.
+"""
+
+from __future__ import annotations
+
+from tetrad_runtime._intel4004_codegen.ir import IRInstr
+
+__all__ = ["codegen", "run_on_4004", "DeoptimizerError"]
+
+
+class DeoptimizerError(Exception):
+    """Raised when an IR operation cannot be compiled to 4004 binary."""
+
+
+# ---------------------------------------------------------------------------
+# Supported / unsupported IR ops
+# ---------------------------------------------------------------------------
+
+_DEOPT_OPS = frozenset({
+    "mul", "div", "mod", "and", "or", "xor", "not",
+    "shl", "shr", "logical_not", "io_in", "io_out", "call", "deopt",
+})
+
+_MAX_VARS = 6    # P0–P5 (P6 and P7 are reserved)
+_MAX_PARAMS = 2  # only P0 and P1 can hold arguments
+
+
+# ---------------------------------------------------------------------------
+# Register pair layout helpers
+# ---------------------------------------------------------------------------
+
+def _hi(pair: int) -> int:
+    """Return the index of the high-nibble register in a pair."""
+    return pair * 2
+
+
+def _lo(pair: int) -> int:
+    """Return the index of the low-nibble register in a pair."""
+    return pair * 2 + 1
+
+
+# ---------------------------------------------------------------------------
+# Abstract instruction size table (for the two-pass assembler)
+# ---------------------------------------------------------------------------
+
+_TWO_BYTE_MNEMS = frozenset({"FIM", "JUN", "JMS", "JCN", "ISZ"})
+
+
+def _asm_size(instr: tuple) -> int:
+    """Return the byte size of an abstract 4004 instruction."""
+    return 0 if instr[0] == "LABEL" else (2 if instr[0] in _TWO_BYTE_MNEMS else 1)
+
+
+# ---------------------------------------------------------------------------
+# Abstract instruction encoder (pass 2)
+# ---------------------------------------------------------------------------
+
+def _resolve(operand: str | int, labels: dict[str, int]) -> int:
+    return labels[operand] if isinstance(operand, str) else operand
+
+
+def _encode(instr: tuple, labels: dict[str, int], current_addr: int) -> bytes:
+    """Encode one abstract instruction to 4004 bytes."""
+    m = instr[0]
+
+    if m == "LABEL":
+        return b""
+    if m == "NOP":
+        return bytes([0x00])
+    if m == "HLT":
+        return bytes([0x01])            # simulator-only halt
+    if m == "CLB":
+        return bytes([0xF0])
+    if m == "CLC":
+        return bytes([0xF1])
+    if m == "IAC":
+        return bytes([0xF2])
+    if m == "CMC":
+        return bytes([0xF3])
+    if m == "CMA":
+        return bytes([0xF4])
+    if m == "RAL":
+        return bytes([0xF5])
+    if m == "RAR":
+        return bytes([0xF6])
+    if m == "TCC":
+        return bytes([0xF7])
+    if m == "DAC":
+        return bytes([0xF8])
+    if m == "TCS":
+        return bytes([0xF9])
+    if m == "STC":
+        return bytes([0xFA])
+    if m == "DAA":
+        return bytes([0xFB])
+    if m == "WRM":
+        return bytes([0xE0])
+    if m == "WMP":
+        return bytes([0xE1])
+    if m == "RDM":
+        return bytes([0xE9])
+    if m == "LD":
+        return bytes([0xA0 | (instr[1] & 0xF)])
+    if m == "XCH":
+        return bytes([0xB0 | (instr[1] & 0xF)])
+    if m == "ADD":
+        return bytes([0x80 | (instr[1] & 0xF)])
+    if m == "SUB":
+        return bytes([0x90 | (instr[1] & 0xF)])
+    if m == "INC":
+        return bytes([0x60 | (instr[1] & 0xF)])
+    if m == "LDM":
+        return bytes([0xD0 | (instr[1] & 0xF)])
+    if m == "BBL":
+        return bytes([0xC0 | (instr[1] & 0xF)])
+    if m == "SRC":
+        pair = instr[1]
+        return bytes([0x20 | (pair * 2 + 1)])
+    if m == "FIM":
+        pair, data = instr[1], instr[2] & 0xFF
+        return bytes([0x20 | (pair * 2), data])
+    if m == "JUN":
+        target = _resolve(instr[1], labels)
+        return bytes([0x40 | ((target >> 8) & 0xF), target & 0xFF])
+    if m == "JMS":
+        target = _resolve(instr[1], labels)
+        return bytes([0x50 | ((target >> 8) & 0xF), target & 0xFF])
+    if m == "JCN":
+        cond, label = instr[1], instr[2]
+        target = _resolve(label, labels)
+        page_rel = target & 0xFF
+        return bytes([0x10 | (cond & 0xF), page_rel])
+    if m == "ISZ":
+        reg, label = instr[1], instr[2]
+        target = _resolve(label, labels)
+        page_rel = target & 0xFF
+        return bytes([0x70 | (reg & 0xF), page_rel])
+    raise ValueError(f"unknown abstract mnemonic: {m!r}")
+
+
+# ---------------------------------------------------------------------------
+# Two-pass assembler
+# ---------------------------------------------------------------------------
+
+def _assemble(asm: list[tuple]) -> bytes:
+    """Two-pass assembler: abstract instructions → Intel 4004 binary."""
+    # Pass 1: compute byte addresses for each label.
+    labels: dict[str, int] = {}
+    addr = 0
+    for instr in asm:
+        if instr[0] == "LABEL":
+            labels[instr[1]] = addr
+        else:
+            addr += _asm_size(instr)
+
+    # Pass 2: encode every instruction.
+    result = bytearray()
+    addr = 0
+    for instr in asm:
+        b = _encode(instr, labels, addr)
+        result.extend(b)
+        addr += len(b)
+
+    return bytes(result)
+
+
+# ---------------------------------------------------------------------------
+# Code generator
+# ---------------------------------------------------------------------------
+
+class _Codegen:
+    """Stateful code generator: tracks variable → register pair allocation."""
+
+    # Pair 6 (R12:R13) is the RAM address register.
+    # Pair 7 (R14:R15) is the scratch temp for immediates.
+    _RAM_ADDR_PAIR = 6
+    _TEMP_PAIR = 7
+
+    def __init__(self) -> None:
+        self._asm: list[tuple] = []
+        self._var_pair: dict[str, int] = {}
+        self._next_pair = 0           # next allocatable pair (0=P0, 1=P1, …, 5=P5)
+        self._ft_ctr = 0             # fall-through label counter (for comparisons)
+        self._last_use: dict[str, int] = {}   # var → last IR index where it appears as src
+        self._instr_idx: int = 0              # current IR instruction index
+
+    # ------------------------------------------------------------------
+    # Pair allocation
+    # ------------------------------------------------------------------
+
+    def _alloc_param(self, var: str, param_idx: int) -> None:
+        """Bind a param variable to its fixed pair (P0 or P1)."""
+        if param_idx >= _MAX_PARAMS:
+            raise DeoptimizerError(
+                f"too many params: only {_MAX_PARAMS} supported, got param {param_idx}"
+            )
+        self._var_pair[var] = param_idx
+        # Ensure _next_pair is after all param slots.
+        if self._next_pair <= param_idx:
+            self._next_pair = param_idx + 1
+
+    def _pair_of(self, var: str) -> int:
+        """Return the pair index for *var*, allocating or recycling as needed.
+
+        Liveness-based recycling: before allocating a fresh pair, scan for an
+        existing variable whose last use is strictly before the current IR
+        index (i.e., it is dead). P0 and P1 are param slots and never recycled.
+        Lowest-numbered dead pair is chosen to keep allocation deterministic.
+        """
+        if var in self._var_pair:
+            return self._var_pair[var]
+        # Try to recycle the lowest-indexed dead pair (skip P0/P1 param slots).
+        dead_candidate: tuple[int, str] | None = None  # (pair, dead_var)
+        for dead_var, pair in self._var_pair.items():
+            if (
+                pair >= 2
+                and self._last_use.get(dead_var, -1) < self._instr_idx
+                and (dead_candidate is None or pair < dead_candidate[0])
+            ):
+                dead_candidate = (pair, dead_var)
+        if dead_candidate is not None:
+            recycled_pair, dead_var = dead_candidate
+            del self._var_pair[dead_var]
+            self._var_pair[var] = recycled_pair
+            return recycled_pair
+        # No recyclable pair; allocate fresh.
+        if self._next_pair >= _MAX_VARS:
+            raise DeoptimizerError(
+                f"too many virtual variables: limit is {_MAX_VARS}"
+            )
+        self._var_pair[var] = self._next_pair
+        self._next_pair += 1
+        return self._var_pair[var]
+
+    def _pair_src(self, src: str | int) -> int:
+        """Return the pair holding *src* (variable or immediate).
+
+        Immediates are loaded into the scratch pair P7.
+        """
+        if isinstance(src, int):
+            # Load immediate into P7.
+            self._asm.append(("FIM", self._TEMP_PAIR, src & 0xFF))
+            return self._TEMP_PAIR
+        return self._pair_of(src)
+
+    # ------------------------------------------------------------------
+    # Abstract instruction emitters
+    # ------------------------------------------------------------------
+
+    def _emit(self, *args: object) -> None:
+        self._asm.append(tuple(args))
+
+    def _new_ft_label(self) -> str:
+        lbl = f"_ft_{self._ft_ctr}"
+        self._ft_ctr += 1
+        return lbl
+
+    # ------------------------------------------------------------------
+    # 8-bit operations on register pairs
+    # ------------------------------------------------------------------
+
+    def _emit_add(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: u8 add  Pa + Pb → Pv  (carry-propagating nibble add)."""
+        self._emit("CLC")
+        self._emit("LD",  _lo(pa))
+        self._emit("ADD", _lo(pb))
+        self._emit("XCH", _lo(pv))
+        self._emit("LD",  _hi(pa))
+        self._emit("ADD", _hi(pb))
+        self._emit("XCH", _hi(pv))
+
+    def _emit_sub(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: u8 sub  Pa - Pb → Pv.
+
+        The simulator's SUB Rn computes A = A + ~Rn + (1 - CY), so to obtain
+        A - B (no initial borrow) we start with CY=0 (borrow_in = 1).
+
+        After the lo nibble: CY=1 means no borrow, CY=0 means borrow.
+        We CMC before the hi nibble to flip the carry so the hi nibble uses
+        the correct borrow-in: if lo had no borrow (CY=1→flipped→CY=0,
+        borrow_in=1), hi gets A+~B+1 = A-B ✓; if lo had borrow (CY=0→
+        flipped→CY=1, borrow_in=0), hi gets A+~B = A-B-1 ✓.
+        """
+        self._emit("CLC")
+        self._emit("LD",  _lo(pa))
+        self._emit("SUB", _lo(pb))
+        self._emit("XCH", _lo(pv))
+        self._emit("CMC")          # flip carry so hi uses correct borrow-in
+        self._emit("LD",  _hi(pa))
+        self._emit("SUB", _hi(pb))
+        self._emit("XCH", _hi(pv))
+
+    def _emit_copy(self, psrc: int, pdst: int) -> None:
+        """Copy register pair Psrc → Pdst (4 instructions)."""
+        if psrc == pdst:
+            return
+        self._emit("LD",  _hi(psrc))
+        self._emit("XCH", _hi(pdst))
+        self._emit("LD",  _lo(psrc))
+        self._emit("XCH", _lo(pdst))
+
+    def _emit_load_ram_var(self, var_idx: int, pdst: int) -> None:
+        """Load 8-bit variable *var_idx* from RAM into register pair Pdst.
+
+        RAM layout: var i → character 2i (hi nibble), character 2i+1 (lo nibble)
+        in bank 0, register 0.  P6 is used as the SRC address pair.
+        """
+        hi_char = var_idx * 2
+        lo_char = var_idx * 2 + 1
+        rp = self._RAM_ADDR_PAIR
+        # Load hi nibble.
+        self._emit("FIM", rp, hi_char & 0xFF)
+        self._emit("SRC", rp)
+        self._emit("RDM")
+        self._emit("XCH", _hi(pdst))
+        # Load lo nibble.
+        self._emit("FIM", rp, lo_char & 0xFF)
+        self._emit("SRC", rp)
+        self._emit("RDM")
+        self._emit("XCH", _lo(pdst))
+
+    def _emit_store_ram_var(self, var_idx: int, psrc: int) -> None:
+        """Store 8-bit register pair Psrc into RAM variable *var_idx*."""
+        hi_char = var_idx * 2
+        lo_char = var_idx * 2 + 1
+        rp = self._RAM_ADDR_PAIR
+        # Store hi nibble.
+        self._emit("FIM", rp, hi_char & 0xFF)
+        self._emit("SRC", rp)
+        self._emit("LD",  _hi(psrc))
+        self._emit("WRM")
+        # Store lo nibble.
+        self._emit("FIM", rp, lo_char & 0xFF)
+        self._emit("SRC", rp)
+        self._emit("LD",  _lo(psrc))
+        self._emit("WRM")
+
+    def _emit_cmp_lt(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa < Pb else 0.
+
+        Compute Pa − Pb using CLC + CMC (same borrow-chain as _emit_sub but
+        discarding the result nibbles).  After the hi nibble:
+          CY=1 → Pa >= Pb (no borrow),  CY=0 → Pa < Pb (borrow).
+        CMC gives CY=1 iff Pa < Pb; TCC materialises the boolean.
+        """
+        self._emit("CLC")
+        self._emit("LD",  _lo(pa))
+        self._emit("SUB", _lo(pb))          # lo subtract; result discarded
+        self._emit("CMC")                   # flip for hi borrow-in
+        self._emit("LD",  _hi(pa))
+        self._emit("SUB", _hi(pb))          # hi subtract; CY=1 iff Pa>=Pb
+        self._emit("CMC")                   # CY=1 iff Pa < Pb
+        self._emit("TCC")                   # A = 1 if Pa<Pb, 0 otherwise
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+
+    def _emit_cmp_le(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa <= Pb else 0.
+
+        Compute Pb − Pa (reversed operands).  After the hi nibble:
+          CY=1 → Pb >= Pa (no borrow) → Pa <= Pb.
+        TCC gives the result directly.
+        """
+        self._emit("CLC")
+        self._emit("LD",  _lo(pb))
+        self._emit("SUB", _lo(pa))
+        self._emit("CMC")
+        self._emit("LD",  _hi(pb))
+        self._emit("SUB", _hi(pa))          # CY=1 iff Pb >= Pa (Pa <= Pb)
+        self._emit("TCC")                   # A = 1 if Pa<=Pb
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+
+    def _emit_cmp_gt(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa > Pb else 0  (= Pb < Pa)."""
+        self._emit_cmp_lt(pb, pa, pv)
+
+    def _emit_cmp_ge(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa >= Pb else 0  (= Pb <= Pa)."""
+        self._emit_cmp_le(pb, pa, pv)
+
+    def _emit_cmp_eq(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa == Pb else 0.
+
+        CLC + SUB gives A=0 when both nibbles are equal (A + ~B + 1 = 16
+        mod 16 = 0 when A==B).  JCN 0xC jumps when A != 0.
+        """
+        ineq = self._new_ft_label()
+        done = self._new_ft_label()
+
+        # Check hi nibbles.
+        self._emit("CLC")
+        self._emit("LD",  _hi(pa))
+        self._emit("SUB", _hi(pb))         # A=0 if equal
+        self._emit("JCN", 0xC, ineq)      # jump if A != 0
+
+        # Hi equal → check lo nibbles.
+        self._emit("CLC")
+        self._emit("LD",  _lo(pa))
+        self._emit("SUB", _lo(pb))
+        self._emit("JCN", 0xC, ineq)
+
+        # Both equal: Pv = 1.
+        self._emit("LDM", 1)
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+        self._emit("JUN", done)
+
+        # Not equal: Pv = 0.
+        self._emit("LABEL", ineq)
+        self._emit("LDM", 0)
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+
+        self._emit("LABEL", done)
+
+    def _emit_cmp_ne(self, pa: int, pb: int, pv: int) -> None:
+        """Emit: Pv = 1 if Pa != Pb else 0.
+
+        Same nibble-equality check as _emit_cmp_eq, with result inverted.
+        """
+        neq = self._new_ft_label()
+        done = self._new_ft_label()
+
+        # Check hi nibbles.
+        self._emit("CLC")
+        self._emit("LD",  _hi(pa))
+        self._emit("SUB", _hi(pb))
+        self._emit("JCN", 0xC, neq)   # hi differ → not equal → result=1
+
+        # Hi equal → check lo.
+        self._emit("CLC")
+        self._emit("LD",  _lo(pa))
+        self._emit("SUB", _lo(pb))
+        self._emit("JCN", 0xC, neq)   # lo differ
+
+        # Both equal: Pv = 0.
+        self._emit("LDM", 0)
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+        self._emit("JUN", done)
+
+        # Not equal: Pv = 1.
+        self._emit("LABEL", neq)
+        self._emit("LDM", 1)
+        self._emit("XCH", _lo(pv))
+        self._emit("LDM", 0)
+        self._emit("XCH", _hi(pv))
+
+        self._emit("LABEL", done)
+
+    def _emit_jz(self, ptest: int, lbl: str) -> None:
+        """Jump to *lbl* if register pair Ptest == 0.
+
+        The 4004 can only test a 4-bit nibble at a time.  We check hi first:
+        if hi ≠ 0 the pair is definitely nonzero.  If hi == 0 we then check lo.
+        """
+        ft = self._new_ft_label()
+        # If hi != 0: not zero, fall through.
+        self._emit("LD", _hi(ptest))
+        self._emit("JCN", 0xC, ft)     # jump if A != 0 → skip the JUN lbl
+        # hi == 0: check lo.
+        self._emit("LD", _lo(ptest))
+        self._emit("JCN", 0xC, ft)     # jump if lo != 0 → skip
+        # Both zero: take the jump.
+        self._emit("JUN", lbl)
+        self._emit("LABEL", ft)
+
+    def _emit_jnz(self, ptest: int, lbl: str) -> None:
+        """Jump to *lbl* if register pair Ptest != 0."""
+        # If hi != 0: jump immediately.
+        self._emit("LD", _hi(ptest))
+        self._emit("JCN", 0xC, lbl)
+        # hi == 0: check lo.
+        self._emit("LD", _lo(ptest))
+        self._emit("JCN", 0xC, lbl)
+        # Both zero: don't jump (fall through).
+
+    # ------------------------------------------------------------------
+    # Liveness pre-scan
+    # ------------------------------------------------------------------
+
+    def _compute_last_use(self, ir: list[IRInstr]) -> None:
+        """Record the last IR index at which each variable appears as a source.
+
+        This enables _pair_of() to recycle register pairs whose variable is
+        dead at the current instruction, keeping peak pair usage low.
+        """
+        for idx, instr in enumerate(ir):
+            for src in instr.srcs:
+                if isinstance(src, str):
+                    self._last_use[src] = idx
+
+    # ------------------------------------------------------------------
+    # Main IR → abstract-assembly translation
+    # ------------------------------------------------------------------
+
+    def generate(self, ir: list[IRInstr]) -> None:
+        """Translate IR to abstract 4004 instructions stored in self._asm."""
+        self._compute_last_use(ir)
+        for idx, instr in enumerate(ir):
+            self._instr_idx = idx
+            op = instr.op
+
+            if op in _DEOPT_OPS:
+                raise DeoptimizerError(f"unsupported IR op: {op!r}")
+
+            elif op == "param":
+                self._alloc_param(instr.dst, instr.srcs[0])  # type: ignore[arg-type]
+
+            elif op == "const":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                imm = instr.srcs[0]
+                assert isinstance(imm, int)
+                self._emit("FIM", pv, imm & 0xFF)
+
+            elif op == "load_var":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                var_idx = instr.srcs[0]
+                assert isinstance(var_idx, int)
+                if var_idx * 2 + 1 > 15:
+                    raise DeoptimizerError(
+                        f"load_var: variable index {var_idx} exceeds RAM capacity"
+                    )
+                self._emit_load_ram_var(var_idx, pv)
+
+            elif op == "store_var":
+                var_idx = instr.srcs[0]
+                src_var = instr.srcs[1]
+                assert isinstance(var_idx, int)
+                if var_idx * 2 + 1 > 15:
+                    raise DeoptimizerError(
+                        f"store_var: variable index {var_idx} exceeds RAM capacity"
+                    )
+                psrc = self._pair_src(src_var)  # type: ignore[arg-type]
+                self._emit_store_ram_var(var_idx, psrc)
+
+            elif op == "add":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_add(pa, pb, pv)
+
+            elif op == "sub":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_sub(pa, pb, pv)
+
+            elif op == "cmp_lt":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_lt(pa, pb, pv)
+
+            elif op == "cmp_le":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_le(pa, pb, pv)
+
+            elif op == "cmp_gt":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_gt(pa, pb, pv)
+
+            elif op == "cmp_ge":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_ge(pa, pb, pv)
+
+            elif op == "cmp_eq":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_eq(pa, pb, pv)
+
+            elif op == "cmp_ne":
+                assert instr.dst is not None
+                pv = self._pair_of(instr.dst)
+                pa = self._pair_src(instr.srcs[0])  # type: ignore[arg-type]
+                pb = self._pair_src(instr.srcs[1])  # type: ignore[arg-type]
+                self._emit_cmp_ne(pa, pb, pv)
+
+            elif op == "jmp":
+                lbl = instr.srcs[0]
+                assert isinstance(lbl, str)
+                self._emit("JUN", lbl)
+
+            elif op == "jz":
+                ptest = self._pair_of(instr.srcs[0])  # type: ignore[arg-type]
+                lbl = instr.srcs[1]
+                assert isinstance(lbl, str)
+                self._emit_jz(ptest, lbl)
+
+            elif op == "jnz":
+                ptest = self._pair_of(instr.srcs[0])  # type: ignore[arg-type]
+                lbl = instr.srcs[1]
+                assert isinstance(lbl, str)
+                self._emit_jnz(ptest, lbl)
+
+            elif op == "label":
+                lbl = instr.srcs[0]
+                assert isinstance(lbl, str)
+                self._emit("LABEL", lbl)
+
+            elif op == "ret":
+                src = instr.srcs[0]
+                assert isinstance(src, str)
+                presult = self._pair_of(src)
+                # Move result to P0 (the return pair) if it is not already there.
+                if presult != 0:
+                    self._emit_copy(presult, 0)
+                self._emit("HLT")
+
+            else:
+                raise DeoptimizerError(f"unhandled IR op: {op!r}")
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def codegen(ir: list[IRInstr]) -> bytes | None:
+    """Compile IR to Intel 4004 machine code.
+
+    Returns ``None`` if any IR instruction cannot be encoded (deopt path).
+    """
+    gen = _Codegen()
+    try:
+        gen.generate(ir)
+    except DeoptimizerError:
+        return None
+
+    try:
+        binary = _assemble(gen._asm)
+    except Exception:
+        return None
+
+    # Guard: every compiled program must fit in one 4004 ROM page (256 bytes).
+    if len(binary) > 256:
+        return None
+
+    return binary
+
+
+def run_on_4004(binary: bytes, args: list[int]) -> int:
+    """Load *binary* into a fresh ``Intel4004Simulator``, set arguments,
+    run until HLT, and return the u8 result from P0 (R0:R1).
+
+    The simulator's ``reset()`` zeroes all registers.  We then call
+    ``_write_pair`` directly before execution to inject the argument values.
+    """
+    from intel4004_simulator import Intel4004Simulator  # noqa: PLC0415
+
+    sim = Intel4004Simulator()
+    sim.reset()
+    sim.load_program(binary)
+    sim._prepare_execution()  # noqa: SLF001
+
+    if len(args) >= 1:
+        sim._write_pair(0, args[0] & 0xFF)  # noqa: SLF001
+    if len(args) >= 2:
+        sim._write_pair(1, args[1] & 0xFF)  # noqa: SLF001
+
+    for _ in range(100_000):
+        if sim.halted:
+            break
+        if sim._code is None or sim._vm.pc >= len(sim._code.instructions):  # noqa: SLF001
+            break
+        sim.step()
+
+    return sim._read_pair(0) & 0xFF  # noqa: SLF001

--- a/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/ir.py
+++ b/code/packages/python/tetrad-runtime/src/tetrad_runtime/_intel4004_codegen/ir.py
@@ -1,0 +1,192 @@
+"""Tetrad JIT intermediate representation (SSA-like IR).
+
+Between bytecode and x86-64, the JIT uses a simple SSA-based IR.  Each IR
+instruction operates on **virtual variables** (e.g. ``v0``, ``v1``) rather
+than the accumulator and explicit registers.  This makes optimization passes
+easier to implement: constant folding only needs to track a values dict;
+dead-code elimination only needs a liveness set.
+
+IR instruction set
+------------------
+
++------------------+----------------------------------------------+
+| Op               | Semantics                                    |
++==================+==============================================+
+| ``const``        | dst = srcs[0] (integer literal)              |
++------------------+----------------------------------------------+
+| ``param``        | dst = Nth argument (src[0] = N)              |
++------------------+----------------------------------------------+
+| ``load_var``     | dst = locals[srcs[0]] (or globals)           |
++------------------+----------------------------------------------+
+| ``store_var``    | locals[srcs[0]] = srcs[1]                    |
++------------------+----------------------------------------------+
+| ``add``          | dst = (srcs[0] + srcs[1]) % 256             |
++------------------+----------------------------------------------+
+| ``sub``          | dst = (srcs[0] - srcs[1]) % 256             |
++------------------+----------------------------------------------+
+| ``mul``          | dst = (srcs[0] * srcs[1]) % 256             |
++------------------+----------------------------------------------+
+| ``div``          | dst = srcs[0] // srcs[1]                    |
++------------------+----------------------------------------------+
+| ``mod``          | dst = srcs[0] % srcs[1]                     |
++------------------+----------------------------------------------+
+| ``and``          | dst = srcs[0] & srcs[1]                     |
++------------------+----------------------------------------------+
+| ``or``           | dst = srcs[0] | srcs[1]                     |
++------------------+----------------------------------------------+
+| ``xor``          | dst = srcs[0] ^ srcs[1]                     |
++------------------+----------------------------------------------+
+| ``not``          | dst = ~srcs[0] & 0xFF                       |
++------------------+----------------------------------------------+
+| ``shl``          | dst = (srcs[0] << srcs[1]) & 0xFF           |
++------------------+----------------------------------------------+
+| ``shr``          | dst = srcs[0] >> srcs[1]                    |
++------------------+----------------------------------------------+
+| ``cmp_eq``       | dst = 1 if srcs[0] == srcs[1] else 0        |
++------------------+----------------------------------------------+
+| ``cmp_ne``       | dst = 1 if srcs[0] != srcs[1] else 0        |
++------------------+----------------------------------------------+
+| ``cmp_lt``       | dst = 1 if srcs[0] < srcs[1] else 0         |
++------------------+----------------------------------------------+
+| ``cmp_le``       | dst = 1 if srcs[0] <= srcs[1] else 0        |
++------------------+----------------------------------------------+
+| ``cmp_gt``       | dst = 1 if srcs[0] > srcs[1] else 0         |
++------------------+----------------------------------------------+
+| ``cmp_ge``       | dst = 1 if srcs[0] >= srcs[1] else 0        |
++------------------+----------------------------------------------+
+| ``logical_not``  | dst = 0 if srcs[0] != 0 else 1              |
++------------------+----------------------------------------------+
+| ``jmp``          | unconditional jump to label srcs[0]          |
++------------------+----------------------------------------------+
+| ``jz``           | if srcs[0]==0 jump to label srcs[1]          |
++------------------+----------------------------------------------+
+| ``jnz``          | if srcs[0]!=0 jump to label srcs[1]          |
++------------------+----------------------------------------------+
+| ``label``        | branch target; srcs[0] is the label name     |
++------------------+----------------------------------------------+
+| ``ret``          | return srcs[0]                              |
++------------------+----------------------------------------------+
+| ``io_in``        | dst = read_io()                             |
++------------------+----------------------------------------------+
+| ``io_out``       | write srcs[0] to io                         |
++------------------+----------------------------------------------+
+| ``deopt``        | bail to interpreter                         |
++------------------+----------------------------------------------+
+| ``call``         | dst = call func_idx(srcs[1..])              |
++------------------+----------------------------------------------+
+
+``srcs`` entries can be:
+- ``str``: a virtual variable name (``"v0"``)
+- ``int``: an integer constant
+- ``str`` starting with ``"lbl_"``: a label for jumps
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "ARITHMETIC_OPS",
+    "BINARY_OPS",
+    "CMP_OPS",
+    "SIDE_EFFECT_OPS",
+    "IRInstr",
+    "evaluate_op",
+]
+
+# ---------------------------------------------------------------------------
+# Instruction categories
+# ---------------------------------------------------------------------------
+
+ARITHMETIC_OPS: frozenset[str] = frozenset({
+    "add", "sub", "mul", "div", "mod",
+    "and", "or", "xor", "shl", "shr",
+})
+
+CMP_OPS: frozenset[str] = frozenset({
+    "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
+})
+
+BINARY_OPS: frozenset[str] = ARITHMETIC_OPS | CMP_OPS
+
+SIDE_EFFECT_OPS: frozenset[str] = frozenset({
+    "store_var", "io_out", "jmp", "jz", "jnz", "ret", "deopt", "call",
+})
+
+
+# ---------------------------------------------------------------------------
+# IR instruction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IRInstr:
+    """One instruction in the Tetrad JIT IR.
+
+    ``op``      — operation name (see table above).
+    ``dst``     — destination virtual variable name, or ``None`` for ops with
+                  side effects only (``store_var``, ``io_out``, ``ret``, …).
+    ``srcs``    — list of source virtual variable names or integer literals.
+    ``ty``      — type annotation: ``"u8"`` (concrete) or ``"unknown"``.
+    ``comment`` — optional debug comment appended to the IR dump.
+    """
+
+    op: str
+    dst: str | None
+    srcs: list[str | int]
+    ty: str
+    comment: str = field(default="")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        lhs = f"{self.dst} = " if self.dst else ""
+        srcs = ", ".join(str(s) for s in self.srcs)
+        cmt = f"  # {self.comment}" if self.comment else ""
+        return f"{lhs}{self.op} {srcs}  [{self.ty}]{cmt}"
+
+
+# ---------------------------------------------------------------------------
+# Constant evaluator (used by the constant-folding pass)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_op(op: str, a: int, b: int) -> int:  # noqa: PLR0911
+    """Evaluate a binary arithmetic or comparison operation on two constants.
+
+    All arithmetic results are taken mod 256 (u8 wrap).
+    Division and modulo by zero return 0 (deopt not needed for constants).
+    """
+    match op:
+        case "add":
+            return (a + b) % 256
+        case "sub":
+            return (a - b) % 256
+        case "mul":
+            return (a * b) % 256
+        case "div":
+            return a // b if b != 0 else 0
+        case "mod":
+            return a % b if b != 0 else 0
+        case "and":
+            return a & b
+        case "or":
+            return a | b
+        case "xor":
+            return a ^ b
+        case "shl":
+            return (a << b) & 0xFF
+        case "shr":
+            return a >> b
+        case "cmp_eq":
+            return 1 if a == b else 0
+        case "cmp_ne":
+            return 1 if a != b else 0
+        case "cmp_lt":
+            return 1 if a < b else 0
+        case "cmp_le":
+            return 1 if a <= b else 0
+        case "cmp_gt":
+            return 1 if a > b else 0
+        case "cmp_ge":
+            return 1 if a >= b else 0
+        case _:
+            return 0

--- a/code/packages/python/tetrad-runtime/src/tetrad_runtime/intel4004_backend.py
+++ b/code/packages/python/tetrad-runtime/src/tetrad_runtime/intel4004_backend.py
@@ -1,33 +1,27 @@
 """``Intel4004Backend`` — ``BackendProtocol`` adapter for the 4004 simulator.
 
-The legacy ``tetrad-jit`` package contains a working bytecode → 4004
-abstract-assembly → binary pipeline (``codegen_4004.py``) and a runner
-(``run_on_4004``).  Re-implementing that from scratch against jit-core's
-``CIRInstr`` shape is a substantial follow-up project; for the migration
-PR we adopt a **hybrid strategy**:
+Implements ``jit_core.backend.BackendProtocol``: takes a ``list[CIRInstr]``
+from jit-core's specialise / optimise passes, translates it through a
+small SSA-by-name re-projection (``_cir_to_legacy_ir``), runs it through
+the 4004 codegen, and executes the resulting binary on
+``intel4004-simulator``.
 
-1.  Translate the post-specialise / post-optimise ``list[CIRInstr]`` into
-    the legacy ``tetrad_jit.ir.IRInstr`` shape (a small re-projection — both
-    are flat SSA-by-name lists).
-2.  Hand the IRInstr list to the existing ``codegen()`` function, which
-    returns either ``bytes`` or ``None`` (None = the function uses an
-    opcode the 4004 codegen does not yet support — jit-core treats this
-    as deopt and falls back to the interpreter).
-3.  ``run`` defers to ``tetrad_jit.codegen_4004.run_on_4004`` which feeds
-    the binary into ``Intel4004Simulator`` and returns the u8 result.
+The codegen / IR types live in :mod:`tetrad_runtime._intel4004_codegen` —
+they were originally part of ``tetrad-jit``'s public surface but moved
+in-tree when ``tetrad-jit`` was retired.  See that subpackage's module
+docstring for the deprecation history.
 
-This is a deliberate **bridge**.  When the 4004 backend is rewritten to
-consume CIR directly (a future package, ``intel4004-backend``), this
-module becomes a one-line forwarder.  Until then, this is the path that
-gets a working JIT through the LANG pipeline today.
+This module is still a deliberate **bridge**: the codegen consumes a
+non-CIR shape and ``Intel4004Backend`` re-projects to fit.  When a
+CIR-native 4004 backend lands (planned ``intel4004-backend`` package),
+this module becomes a one-line forwarder and the
+``_intel4004_codegen`` subpackage retires.
 
 Why a bridge instead of "wait for the rewrite"
 ----------------------------------------------
-The point of the migration is to prove Tetrad runs on LANG.  Forcing a
-rewrite of the codegen as a prerequisite would block that proof on weeks
-of unrelated work.  A bridge lets us exercise jit-core, the backend
-protocol, the deopt path, and the JIT cache *today*, with the clear
-signal that the codegen replacement is what's left.
+The bridge lets us exercise jit-core, the backend protocol, the deopt
+path, and the JIT cache *today*.  It defers the codegen rewrite as
+follow-up work without blocking the LANG migration on it.
 """
 
 from __future__ import annotations
@@ -36,11 +30,17 @@ from typing import Any
 
 from jit_core.cir import CIRInstr
 
+from tetrad_runtime._intel4004_codegen import (
+    IRInstr,
+    codegen,
+    run_on_4004,
+)
+
 __all__ = ["Intel4004Backend"]
 
 
 class Intel4004Backend:
-    """Backend that compiles CIR → Intel 4004 binary via the legacy codegen.
+    """Backend that compiles CIR → Intel 4004 binary via the in-tree codegen.
 
     Implements the ``jit_core.backend.BackendProtocol`` structural protocol.
     """
@@ -50,16 +50,10 @@ class Intel4004Backend:
     def compile(self, cir: list[CIRInstr]) -> bytes | None:
         """Translate CIR to a 4004 binary.
 
-        Returns ``None`` for any CIR list that contains an instruction the
-        legacy codegen does not yet support — jit-core's deopt machinery
+        Returns ``None`` for any CIR list that contains an instruction
+        the codegen does not yet support — jit-core's deopt machinery
         will then keep the function on the interpreted path.
         """
-        try:
-            from tetrad_jit.codegen_4004 import codegen
-            from tetrad_jit.ir import IRInstr
-        except ImportError:
-            return None
-
         ir = _cir_to_legacy_ir(cir, IRInstr)
         if ir is None:
             return None
@@ -70,14 +64,13 @@ class Intel4004Backend:
 
     def run(self, binary: bytes, args: list[Any]) -> Any:
         """Execute a previously-compiled 4004 binary on the simulator."""
-        from tetrad_jit.codegen_4004 import run_on_4004
         # The simulator expects ints; coerce.
         int_args = [int(a) & 0xFF for a in args]
         return run_on_4004(binary, int_args)
 
 
 # ---------------------------------------------------------------------------
-# CIR → legacy IRInstr re-projection
+# CIR → in-tree IRInstr re-projection
 # ---------------------------------------------------------------------------
 #
 # jit-core's CIRInstr carries:
@@ -86,20 +79,21 @@ class Intel4004Backend:
 #   srcs — operands (variable names or literals)
 #   type — concrete IIR type ("u8" mostly for Tetrad)
 #
-# Legacy tetrad-jit IRInstr (per tetrad_jit.ir module — discovered at
-# runtime to avoid an import cycle when tetrad-jit is not installed) has:
+# In-tree IRInstr (in :mod:`._intel4004_codegen.ir`) has:
 #   op   — bare mnemonic ("add", "cmp_lt", "const", ...)
-#   dest — SSA destination
+#   dst  — SSA destination
 #   srcs — operands
+#   ty   — "u8" | "unknown"
 #
-# The re-projection drops the type suffix from ``op`` and otherwise copies
-# fields verbatim.  Returns None if any op cannot be mapped (e.g.,
-# ``call_runtime`` — the 4004 codegen has no notion of runtime calls).
+# The re-projection drops the type suffix from ``op`` and otherwise
+# copies fields verbatim.  Returns None if any op cannot be mapped
+# (e.g. ``call_runtime`` — the 4004 codegen has no notion of runtime
+# calls).
 # ---------------------------------------------------------------------------
 
 
 def _cir_to_legacy_ir(cir: list[CIRInstr], IRInstrCls: type) -> list | None:  # type: ignore[type-arg]
-    """Re-project a CIR list to the legacy tetrad-jit IRInstr shape."""
+    """Re-project a CIR list to the in-tree IRInstr shape."""
     out: list = []
     for instr in cir:
         op = instr.op
@@ -119,7 +113,7 @@ def _cir_to_legacy_ir(cir: list[CIRInstr], IRInstrCls: type) -> list | None:  # 
             return None
         if instr.is_generic():
             return None
-        # Map the CIR concrete type onto the legacy IR's two-state field:
+        # Map the CIR concrete type onto the in-tree IR's two-state field:
         # "u8" stays "u8"; anything else is treated as "unknown" (which the
         # codegen handles as a deopt in most cases).
         ty = "u8" if instr.type == "u8" else "unknown"

--- a/code/packages/python/tetrad-runtime/tests/test_intel4004_codegen.py
+++ b/code/packages/python/tetrad-runtime/tests/test_intel4004_codegen.py
@@ -1,0 +1,360 @@
+"""Tests for the in-tree Intel 4004 codegen (``_intel4004_codegen``).
+
+These tests were originally in ``tetrad-jit/tests/test_tetrad_jit.py``
+under the ``TestEvaluateOp`` and ``TestCodegen`` classes.  They moved
+here when the codegen modules moved out of ``tetrad-jit`` (which has
+been retired) and into ``tetrad_runtime._intel4004_codegen``.
+
+The tests exercise:
+
+- ``ir.evaluate_op`` — the abstract-evaluation helper used by the
+  constant-folding optimiser.
+- ``codegen.codegen`` — the IRInstr → 4004 abstract-assembly →
+  binary pipeline.
+- ``codegen.run_on_4004`` — the runner that loads the binary into
+  ``intel4004-simulator`` and returns the u8 accumulator.
+
+End-to-end: ``codegen(ir)`` → ``run_on_4004(binary, args)`` should
+produce the value the IR represents.
+"""
+
+from __future__ import annotations
+
+from tetrad_runtime._intel4004_codegen import (
+    IRInstr,
+    codegen,
+    run_on_4004,
+)
+from tetrad_runtime._intel4004_codegen.ir import evaluate_op
+
+# ---------------------------------------------------------------------------
+# evaluate_op — abstract-eval helper for constant folding
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateOp:
+    def test_add_wrap(self) -> None:
+        assert evaluate_op("add", 200, 100) == 44
+
+    def test_sub_wrap(self) -> None:
+        assert evaluate_op("sub", 3, 10) == 249
+
+    def test_mul_wrap(self) -> None:
+        assert evaluate_op("mul", 20, 20) == 144
+
+    def test_div_zero(self) -> None:
+        assert evaluate_op("div", 10, 0) == 0
+
+    def test_mod_zero(self) -> None:
+        assert evaluate_op("mod", 10, 0) == 0
+
+    def test_and(self) -> None:
+        assert evaluate_op("and", 0xF0, 0x0F) == 0x00
+
+    def test_or(self) -> None:
+        assert evaluate_op("or", 0xF0, 0x0F) == 0xFF
+
+    def test_xor(self) -> None:
+        assert evaluate_op("xor", 0xFF, 0x0F) == 0xF0
+
+    def test_shl_wrap(self) -> None:
+        assert evaluate_op("shl", 0xFF, 1) == 0xFE
+
+    def test_shr(self) -> None:
+        assert evaluate_op("shr", 0xFF, 4) == 0x0F
+
+    def test_cmp_eq_true(self) -> None:
+        assert evaluate_op("cmp_eq", 5, 5) == 1
+
+    def test_cmp_eq_false(self) -> None:
+        assert evaluate_op("cmp_eq", 5, 6) == 0
+
+    def test_unknown_op(self) -> None:
+        assert evaluate_op("bogus", 1, 2) == 0
+
+
+# ---------------------------------------------------------------------------
+# codegen — IRInstr → 4004 binary, end-to-end via the simulator
+# ---------------------------------------------------------------------------
+
+
+class TestCodegen:
+    @staticmethod
+    def _ir_const_ret(n: int) -> list[IRInstr]:
+        return [
+            IRInstr("const", "v0", [n], "u8"),
+            IRInstr("ret",   None, ["v0"], "u8"),
+        ]
+
+    def test_const_return_zero(self) -> None:
+        binary = codegen(self._ir_const_ret(0))
+        assert binary is not None
+        assert run_on_4004(binary, []) == 0
+
+    def test_const_return_42(self) -> None:
+        binary = codegen(self._ir_const_ret(42))
+        assert binary is not None
+        assert run_on_4004(binary, []) == 42
+
+    def test_const_return_255(self) -> None:
+        binary = codegen(self._ir_const_ret(255))
+        assert binary is not None
+        assert run_on_4004(binary, []) == 255
+
+    def test_add_two_args(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("param", "v1", [1], "u8"),
+            IRInstr("add",   "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [3, 4]) == 7
+        assert run_on_4004(binary, [0, 0]) == 0
+        assert run_on_4004(binary, [200, 100]) == 44   # u8 wrap
+
+    def test_sub_two_args(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("param", "v1", [1], "u8"),
+            IRInstr("sub",   "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [10, 3]) == 7
+        assert run_on_4004(binary, [3, 10]) == 249
+
+    def test_add_immediate(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("add",   "v1", ["v0", 5], "u8"),
+            IRInstr("ret",   None, ["v1"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [10]) == 15
+        assert run_on_4004(binary, [255]) == 4   # (255+5)%256 = 4
+
+    def test_cmp_lt(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_lt", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [3, 10]) == 1
+        assert run_on_4004(binary, [10, 3]) == 0
+        assert run_on_4004(binary, [5, 5]) == 0
+
+    def test_cmp_le(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_le", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [3, 10]) == 1
+        assert run_on_4004(binary, [5, 5]) == 1
+        assert run_on_4004(binary, [10, 3]) == 0
+
+    def test_cmp_gt(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_gt", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [10, 3]) == 1
+        assert run_on_4004(binary, [3, 10]) == 0
+        assert run_on_4004(binary, [5, 5]) == 0
+
+    def test_cmp_ge(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_ge", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [10, 3]) == 1
+        assert run_on_4004(binary, [5, 5]) == 1
+        assert run_on_4004(binary, [3, 10]) == 0
+
+    def test_cmp_eq(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_eq", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [5, 5]) == 1
+        assert run_on_4004(binary, [5, 6]) == 0
+        assert run_on_4004(binary, [0, 0]) == 1
+        assert run_on_4004(binary, [255, 255]) == 1
+        assert run_on_4004(binary, [255, 254]) == 0
+
+    def test_cmp_ne(self) -> None:
+        ir = [
+            IRInstr("param",  "v0", [0], "u8"),
+            IRInstr("param",  "v1", [1], "u8"),
+            IRInstr("cmp_ne", "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",    None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [5, 5]) == 0
+        assert run_on_4004(binary, [5, 6]) == 1
+
+    def test_store_and_load_var(self) -> None:
+        ir = [
+            IRInstr("param",     "v0", [0], "u8"),
+            IRInstr("store_var", None, [0, "v0"], "u8"),
+            IRInstr("load_var",  "v1", [0], "u8"),
+            IRInstr("ret",       None, ["v1"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [77]) == 77
+        assert run_on_4004(binary, [0]) == 0
+
+    def test_jmp_unconditional(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [1], "u8"),
+            IRInstr("jmp",   None, ["done"], ""),
+            IRInstr("const", "v0", [99], "u8"),   # unreachable
+            IRInstr("label", None, ["done"], ""),
+            IRInstr("ret",   None, ["v0"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, []) == 1
+
+    def test_jz_taken(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [0], "u8"),
+            IRInstr("jz",    None, ["v0", "zero_branch"], ""),
+            IRInstr("const", "v1", [99], "u8"),
+            IRInstr("ret",   None, ["v1"], "u8"),
+            IRInstr("label", None, ["zero_branch"], ""),
+            IRInstr("const", "v2", [7], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, []) == 7
+
+    def test_jz_not_taken(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [1], "u8"),
+            IRInstr("jz",    None, ["v0", "zero_branch"], ""),
+            IRInstr("const", "v1", [99], "u8"),
+            IRInstr("ret",   None, ["v1"], "u8"),
+            IRInstr("label", None, ["zero_branch"], ""),
+            IRInstr("const", "v2", [7], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, []) == 99
+
+    def test_jnz_taken(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [3], "u8"),
+            IRInstr("jnz",   None, ["v0", "nonzero"], ""),
+            IRInstr("const", "v1", [0], "u8"),
+            IRInstr("ret",   None, ["v1"], "u8"),
+            IRInstr("label", None, ["nonzero"], ""),
+            IRInstr("const", "v2", [42], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, []) == 42
+
+    def test_jnz_not_taken(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [0], "u8"),
+            IRInstr("jnz",   None, ["v0", "nonzero"], ""),
+            IRInstr("const", "v1", [55], "u8"),
+            IRInstr("ret",   None, ["v1"], "u8"),
+            IRInstr("label", None, ["nonzero"], ""),
+            IRInstr("const", "v2", [42], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, []) == 55
+
+    def test_result_already_in_p0(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("ret",   None, ["v0"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert run_on_4004(binary, [123]) == 123
+
+    def test_binary_is_bytes(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [1], "u8"),
+            IRInstr("ret",   None, ["v0"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert isinstance(binary, bytes)
+        assert len(binary) > 0
+
+    def test_fits_in_one_page(self) -> None:
+        ir = [
+            IRInstr("const", "v0", [1], "u8"),
+            IRInstr("ret",   None, ["v0"], "u8"),
+        ]
+        binary = codegen(ir)
+        assert binary is not None
+        assert len(binary) <= 256
+
+
+# ---------------------------------------------------------------------------
+# Deopt — codegen returns None for ops it does not yet support
+# ---------------------------------------------------------------------------
+
+
+class TestCodegenDeopt:
+    """Operations the 4004 codegen explicitly does not support trigger
+    a graceful deopt — ``codegen()`` returns ``None`` instead of raising.
+    The Intel4004Backend then lets jit-core fall back to interpretation."""
+
+    def test_mul_deopts(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("param", "v1", [1], "u8"),
+            IRInstr("mul",   "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        assert codegen(ir) is None
+
+    def test_div_deopts(self) -> None:
+        ir = [
+            IRInstr("param", "v0", [0], "u8"),
+            IRInstr("param", "v1", [1], "u8"),
+            IRInstr("div",   "v2", ["v0", "v1"], "u8"),
+            IRInstr("ret",   None, ["v2"], "u8"),
+        ]
+        assert codegen(ir) is None
+
+    def test_call_deopts(self) -> None:
+        ir = [
+            IRInstr("call", "v0", ["other"], "u8"),
+            IRInstr("ret",  None, ["v0"], "u8"),
+        ]
+        assert codegen(ir) is None

--- a/code/packages/python/tetrad-runtime/tests/test_legacy_api_parity.py
+++ b/code/packages/python/tetrad-runtime/tests/test_legacy_api_parity.py
@@ -1,41 +1,21 @@
-"""LANG17 PR4 — TetradRuntime legacy-shape API parity tests.
+"""LANG17 PR4 — TetradRuntime legacy-shape API tests.
 
 These tests verify that ``TetradRuntime`` exposes every metric API the
-legacy ``TetradVM`` exposed, with the **same return-type signatures**.
-A caller can switch from ``TetradVM`` → ``TetradRuntime`` without
-rewriting metric-reading code.
+legacy ``TetradVM`` used to expose, with the **same return-type
+signatures**.  ``tetrad-vm`` and ``tetrad-jit`` have since been retired;
+this file is the contract for the migration's metric surface.
 
-Why we don't compare values directly with TetradVM
---------------------------------------------------
-
-The two runtimes execute Tetrad programs *differently*:
-
-- ``TetradVM.execute(code)`` runs the top-level CodeObject only (a
-  HALT for most programs); the user's ``fn main()`` is a sibling
-  CodeObject that is never auto-called.  ``TetradJIT.execute_with_jit``
-  is what wraps main into the executed flow.
-- ``TetradRuntime.run(source)`` always wraps the user's ``fn main()``
-  in a synthetic ``__entry__`` function that runs globals and calls
-  main, so main and its callees are always in the call counts.
-
-These different execution scopes mean per-call-count values will
-naturally differ.  What MUST match is the API shape — return types,
-empty-default semantics, and the existence of every legacy method.
-The shape tests below pin that down; the integration test suite in
-``test_runtime.py`` already verifies that ``TetradRuntime`` produces
-the same *result* as semantic Tetrad.
-
-We use the legacy ``TetradVM`` import as a smoke check that both
-runtimes can run the same program without crashing — if a program
-that runs on legacy fails on TetradRuntime (or vice versa), the
-parity contract is broken.
+Originally these tests imported ``tetrad_vm.TetradVM`` for a smoke
+check that the same source ran on both runtimes.  When the legacy
+packages were deleted that import was dropped; the metric-shape
+assertions below remain — they're the parts that mattered for
+guaranteeing call sites can switch from ``TetradVM`` → ``TetradRuntime``
+without rewriting metric-reading code.
 """
 
 from __future__ import annotations
 
 from interpreter_ir import SlotKind
-from tetrad_compiler import compile_program
-from tetrad_vm import TetradVM
 
 from tetrad_runtime import TetradRuntime
 
@@ -100,16 +80,6 @@ def test_hot_functions_threshold_filters_correctly() -> None:
     assert "helper" not in runtime.hot_functions(threshold=10)
     # Threshold of 5 includes it (5 >= 5).
     assert "helper" in runtime.hot_functions(threshold=5)
-
-
-def test_legacy_runtime_imports_for_smoke() -> None:
-    """Importing TetradVM and running a Tetrad program does not crash —
-    a smoke check that the legacy runtime is still functional alongside
-    TetradRuntime."""
-    legacy = TetradVM()
-    code = compile_program(_HOT_PROGRAM)
-    # Legacy execute runs the top-level (HALT) — does not raise.
-    legacy.execute(code)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cleanup PR1 of 2 for retiring the legacy `tetrad-vm` and `tetrad-jit` packages. After this lands, **nothing depends on either**, and PR2 can delete them outright.

## What moved

- `tetrad_jit.ir` → `tetrad_runtime._intel4004_codegen.ir`
- `tetrad_jit.codegen_4004` → `tetrad_runtime._intel4004_codegen.codegen`

The leading underscore marks the subpackage as internal. External callers should keep going through `tetrad_runtime.Intel4004Backend`. When a CIR-native 4004 backend lands (planned `intel4004-backend` package), this whole subpackage retires and `Intel4004Backend` becomes a forwarder.

## Code changes

- `Intel4004Backend.compile`/`run` import from the in-tree module. The deprecated `try/except ImportError` fallback (which silently disabled JIT when `tetrad-jit` wasn't installed) is gone — the dependency is direct now.
- Removed `coding-adventures-tetrad-vm` and `coding-adventures-tetrad-jit` from `pyproject.toml` `dependencies` and from `BUILD`. `intel4004-simulator` remains (needed for `run_on_4004`).
- `tests/test_legacy_api_parity.py`: dropped the `from tetrad_vm import TetradVM` import and the `test_legacy_runtime_imports_for_smoke` test it powered. The rest of the parity tests stay — they're shape assertions over `TetradRuntime` and don't depend on the legacy runtime.

## Tests migrated

The 13 `TestEvaluateOp` and 20 `TestCodegen` tests from `tetrad-jit/tests/test_tetrad_jit.py` moved to `tetrad-runtime/tests/test_intel4004_codegen.py`, imports updated. Plus a small `TestCodegenDeopt` class verifying ops the codegen doesn't support (`mul`, `div`, `call`) return `None` rather than raising — the bridge contract.

## Results

- **104 tests pass** (was 67 + 37 migrated)
- **93% line coverage** (vs. 71% raw without the migrated tests)
- `ruff check` clean

## Test plan

- [x] tetrad-runtime: 104 tests, 93% coverage, ruff clean
- [x] No remaining imports of `tetrad_vm` or `tetrad_jit` in tetrad-runtime
- [x] BUILD installs only the LANG packages + simulator (no legacy)
- [ ] CI green
- [ ] Follow-up PR2 deletes the `tetrad-vm` and `tetrad-jit` directories and updates TET04/TET05 specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)