### PR TITLE
feat(parity): add hash function packages

### DIFF
--- a/code/packages/elixir/hash_functions/BUILD
+++ b/code/packages/elixir/hash_functions/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/hash_functions/BUILD_windows
+++ b/code/packages/elixir/hash_functions/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/hash_functions/CHANGELOG.md
+++ b/code/packages/elixir/hash_functions/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Elixir hash-functions package.
+- FNV-1a 32-bit and 64-bit implementations.
+- DJB2, polynomial rolling hash, and MurmurHash3 32-bit implementations.
+- Deterministic avalanche and bucket-distribution analysis helpers.
+- Unit tests covering source-of-truth vectors and edge cases.

--- a/code/packages/elixir/hash_functions/README.md
+++ b/code/packages/elixir/hash_functions/README.md
@@ -1,0 +1,23 @@
+# hash_functions
+
+Pure non-cryptographic hash functions implemented from scratch in Elixir.
+
+The package includes FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and
+small deterministic analysis helpers. These hashes are useful for teaching and
+data structures, not password storage or signatures.
+
+## Usage
+
+```elixir
+CodingAdventures.HashFunctions.fnv1a32("hello")
+# => 1335831723
+
+CodingAdventures.HashFunctions.murmur3_32("abc")
+# => 3017643002
+```
+
+## Development
+
+```bash
+mix deps.get && mix test --cover
+```

--- a/code/packages/elixir/hash_functions/lib/coding_adventures/hash_functions.ex
+++ b/code/packages/elixir/hash_functions/lib/coding_adventures/hash_functions.ex
@@ -1,0 +1,197 @@
+defmodule CodingAdventures.HashFunctions do
+  @moduledoc """
+  Non-cryptographic hash functions implemented from scratch.
+
+  The module provides FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and
+  deterministic analysis helpers for avalanche and bucket distribution.
+  """
+
+  import Bitwise
+
+  @fnv32_offset_basis 0x811C9DC5
+  @fnv32_prime 0x01000193
+  @fnv64_offset_basis 0xCBF29CE484222325
+  @fnv64_prime 0x00000100000001B3
+  @polynomial_rolling_default_base 31
+  @polynomial_rolling_default_modulus (1 <<< 61) - 1
+  @mask32 0xFFFFFFFF
+  @mask64 0xFFFFFFFFFFFFFFFF
+  @murmur3_c1 0xCC9E2D51
+  @murmur3_c2 0x1B873593
+
+  def fnv1a32(data) when is_binary(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.reduce(@fnv32_offset_basis, fn byte, hash ->
+      hash
+      |> bxor(byte)
+      |> then(&band(&1 * @fnv32_prime, @mask32))
+    end)
+  end
+
+  def fnv1a64(data) when is_binary(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.reduce(@fnv64_offset_basis, fn byte, hash ->
+      hash
+      |> bxor(byte)
+      |> then(&band(&1 * @fnv64_prime, @mask64))
+    end)
+  end
+
+  def djb2(data) when is_binary(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.reduce(5381, fn byte, hash ->
+      band((hash <<< 5) + hash + byte, @mask64)
+    end)
+  end
+
+  def polynomial_rolling(
+        data,
+        base \\ @polynomial_rolling_default_base,
+        modulus \\ @polynomial_rolling_default_modulus
+      )
+
+  def polynomial_rolling(_data, _base, modulus) when modulus <= 0 do
+    raise ArgumentError, "modulus must be positive"
+  end
+
+  def polynomial_rolling(data, base, modulus) when is_binary(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.reduce(0, fn byte, hash ->
+      rem(hash * base + byte, modulus)
+    end)
+  end
+
+  def murmur3_32(data, seed \\ 0) when is_binary(data) do
+    length = byte_size(data)
+    block_count = div(length, 4)
+
+    block_indexes = if block_count == 0, do: [], else: 0..(block_count - 1)//1
+
+    hash =
+      block_indexes
+      |> Enum.reduce(band(seed, @mask32), fn block_index, hash ->
+        offset = block_index * 4
+        <<k0::little-32>> = binary_part(data, offset, 4)
+
+        k =
+          k0
+          |> then(&band(&1 * @murmur3_c1, @mask32))
+          |> rotl32(15)
+          |> then(&band(&1 * @murmur3_c2, @mask32))
+
+        hash
+        |> bxor(k)
+        |> rotl32(13)
+        |> then(&band(&1 * 5 + 0xE6546B64, @mask32))
+      end)
+
+    tail_offset = block_count * 4
+    tail = binary_part(data, tail_offset, length - tail_offset)
+
+    k =
+      tail
+      |> :binary.bin_to_list()
+      |> Enum.with_index()
+      |> Enum.reduce(0, fn {byte, index}, acc -> bxor(acc, byte <<< (index * 8)) end)
+
+    hash =
+      if byte_size(tail) > 0 do
+        mixed_tail =
+          k
+          |> then(&band(&1 * @murmur3_c1, @mask32))
+          |> rotl32(15)
+          |> then(&band(&1 * @murmur3_c2, @mask32))
+
+        bxor(hash, mixed_tail)
+      else
+        hash
+      end
+
+    hash
+    |> bxor(length)
+    |> fmix32()
+  end
+
+  def avalanche_score(hash_fn, output_bits, sample_size \\ 100) do
+    if output_bits <= 0 or output_bits > 64,
+      do: raise(ArgumentError, "output_bits must be in 1..64")
+
+    if sample_size <= 0, do: raise(ArgumentError, "sample_size must be positive")
+
+    {total_bit_flips, total_trials} =
+      0..(sample_size - 1)//1
+      |> Enum.reduce({0, 0}, fn sample_index, {flip_acc, trial_acc} ->
+        input = deterministic_bytes(sample_index)
+        original = hash_fn.(input)
+
+        0..(byte_size(input) * 8 - 1)//1
+        |> Enum.reduce({flip_acc, trial_acc}, fn bit_position,
+                                                 {inner_flip_acc, inner_trial_acc} ->
+          byte_index = div(bit_position, 8)
+          bit_mask = 1 <<< rem(bit_position, 8)
+          <<prefix::binary-size(byte_index), byte, suffix::binary>> = input
+          flipped = <<prefix::binary, bxor(byte, bit_mask), suffix::binary>>
+          diff = bxor(original, hash_fn.(flipped))
+          {inner_flip_acc + popcount(diff), inner_trial_acc + output_bits}
+        end)
+      end)
+
+    total_bit_flips / total_trials
+  end
+
+  def distribution_test(hash_fn, inputs, num_buckets) do
+    if num_buckets <= 0, do: raise(ArgumentError, "num_buckets must be positive")
+    if inputs == [], do: raise(ArgumentError, "inputs must not be empty")
+
+    counts =
+      Enum.reduce(inputs, List.duplicate(0, num_buckets), fn input, counts ->
+        bucket = rem(hash_fn.(input), num_buckets)
+        List.update_at(counts, bucket, &(&1 + 1))
+      end)
+
+    expected = length(inputs) / num_buckets
+
+    Enum.reduce(counts, 0.0, fn observed, sum ->
+      delta = observed - expected
+      sum + delta * delta / expected
+    end)
+  end
+
+  defp rotl32(value, count) do
+    band(value <<< count ||| value >>> (32 - count), @mask32)
+  end
+
+  defp fmix32(hash) do
+    hash
+    |> then(&bxor(&1, &1 >>> 16))
+    |> then(&band(&1 * 0x85EBCA6B, @mask32))
+    |> then(&bxor(&1, &1 >>> 13))
+    |> then(&band(&1 * 0xC2B2AE35, @mask32))
+    |> then(&bxor(&1, &1 >>> 16))
+    |> band(@mask32)
+  end
+
+  defp popcount(value) do
+    Stream.unfold(value, fn
+      0 -> nil
+      current -> {band(current, 1), current >>> 1}
+    end)
+    |> Enum.sum()
+  end
+
+  defp deterministic_bytes(sample_index) do
+    {_state, bytes} =
+      Enum.reduce(0..7, {bxor(0x9E3779B9, sample_index), []}, fn _index, {state, bytes} ->
+        next_state = band(state * 1_664_525 + 1_013_904_223, @mask32)
+        {next_state, [band(next_state, 0xFF) | bytes]}
+      end)
+
+    bytes
+    |> Enum.reverse()
+    |> :binary.list_to_bin()
+  end
+end

--- a/code/packages/elixir/hash_functions/mix.exs
+++ b/code/packages/elixir/hash_functions/mix.exs
@@ -1,0 +1,26 @@
+defmodule CodingAdventures.HashFunctions.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_hash_functions,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/code/packages/elixir/hash_functions/required_capabilities.json
+++ b/code/packages/elixir/hash_functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/hash_functions",
+  "capabilities": [],
+  "justification": "Pure in-memory computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/hash_functions/test/hash_functions_test.exs
+++ b/code/packages/elixir/hash_functions/test/hash_functions_test.exs
@@ -1,0 +1,76 @@
+defmodule CodingAdventures.HashFunctionsTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.HashFunctions
+
+  test "FNV-1a matches source-of-truth vectors" do
+    assert HashFunctions.fnv1a32("") == 2_166_136_261
+    assert HashFunctions.fnv1a32("a") == 3_826_002_220
+    assert HashFunctions.fnv1a32("abc") == 440_920_331
+    assert HashFunctions.fnv1a32("hello") == 1_335_831_723
+    assert HashFunctions.fnv1a32("foobar") == 3_214_735_720
+
+    assert HashFunctions.fnv1a64("") == 14_695_981_039_346_656_037
+    assert HashFunctions.fnv1a64("a") == 12_638_187_200_555_641_996
+    assert HashFunctions.fnv1a64("abc") == 16_654_208_175_385_433_931
+    assert HashFunctions.fnv1a64("hello") == 11_831_194_018_420_276_491
+  end
+
+  test "DJB2 matches known vectors" do
+    assert HashFunctions.djb2("") == 5381
+    assert HashFunctions.djb2("a") == 177_670
+    assert HashFunctions.djb2("abc") == 193_485_963
+    assert HashFunctions.djb2("hello") == 210_714_636_441
+  end
+
+  test "polynomial rolling hash matches manual computations" do
+    assert HashFunctions.polynomial_rolling("") == 0
+    assert HashFunctions.polynomial_rolling("a") == 97
+    assert HashFunctions.polynomial_rolling("ab") == 3105
+    assert HashFunctions.polynomial_rolling("abc") == 96_354
+    assert HashFunctions.polynomial_rolling("hello world", 31, 100) < 100
+    assert_raise ArgumentError, fn -> HashFunctions.polynomial_rolling("x", 31, 0) end
+  end
+
+  test "MurmurHash3 matches source-of-truth vectors" do
+    assert HashFunctions.murmur3_32("", 0) == 0
+    assert HashFunctions.murmur3_32("", 1) == 0x514E28B7
+    assert HashFunctions.murmur3_32("a") == 0x3C2569B2
+    assert HashFunctions.murmur3_32("abc") == 0xB3DD93FA
+  end
+
+  test "MurmurHash3 covers tail paths and seeds" do
+    for input <- ["abcd", "abcde", "abcdef", "abcdefg"] do
+      assert is_integer(HashFunctions.murmur3_32(input))
+    end
+
+    refute HashFunctions.murmur3_32("hello", 0) == HashFunctions.murmur3_32("hello", 1)
+  end
+
+  test "analysis helpers return bounded values" do
+    score = HashFunctions.avalanche_score(&HashFunctions.fnv1a32/1, 32, 8)
+    assert score >= 0.0
+    assert score <= 1.0
+
+    chi2 = HashFunctions.distribution_test(fn _data -> 0 end, ["a", "b", "c", "d"], 4)
+    assert chi2 == 12.0
+  end
+
+  test "analysis helpers reject invalid inputs" do
+    assert_raise ArgumentError, fn ->
+      HashFunctions.avalanche_score(&HashFunctions.fnv1a32/1, 0, 1)
+    end
+
+    assert_raise ArgumentError, fn ->
+      HashFunctions.avalanche_score(&HashFunctions.fnv1a32/1, 32, 0)
+    end
+
+    assert_raise ArgumentError, fn ->
+      HashFunctions.distribution_test(&HashFunctions.fnv1a32/1, [], 4)
+    end
+
+    assert_raise ArgumentError, fn ->
+      HashFunctions.distribution_test(&HashFunctions.fnv1a32/1, ["x"], 0)
+    end
+  end
+end

--- a/code/packages/elixir/hash_functions/test/test_helper.exs
+++ b/code/packages/elixir/hash_functions/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/go/hash-functions/BUILD
+++ b/code/packages/go/hash-functions/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-functions/BUILD_windows
+++ b/code/packages/go/hash-functions/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-functions/CHANGELOG.md
+++ b/code/packages/go/hash-functions/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Go hash-functions package.
+- FNV-1a 32-bit and 64-bit implementations.
+- DJB2, polynomial rolling hash, and MurmurHash3 32-bit implementations.
+- Deterministic avalanche and bucket-distribution analysis helpers.
+- Unit tests covering source-of-truth vectors and edge cases.

--- a/code/packages/go/hash-functions/README.md
+++ b/code/packages/go/hash-functions/README.md
@@ -1,0 +1,27 @@
+# hash-functions
+
+Pure non-cryptographic hash functions implemented from scratch in Go.
+
+The package provides FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and
+small deterministic analysis helpers. These hashes are useful for learning,
+hash tables, Bloom filters, and other data structures. They are not password
+hashes and should not be treated as cryptographic primitives.
+
+## Usage
+
+```go
+package main
+
+import hashfunctions "github.com/adhithyan15/coding-adventures/code/packages/go/hash-functions"
+
+func main() {
+    _ = hashfunctions.Fnv1a32([]byte("hello"))
+    _ = hashfunctions.Murmur3_32([]byte("abc"))
+}
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/go/hash-functions/go.mod
+++ b/code/packages/go/hash-functions/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/hash-functions
+
+go 1.26

--- a/code/packages/go/hash-functions/hash_functions.go
+++ b/code/packages/go/hash-functions/hash_functions.go
@@ -1,0 +1,198 @@
+// Package hashfunctions implements non-cryptographic hash functions from
+// scratch. The algorithms here are building blocks for hash tables, Bloom
+// filters, sketches, and parser/runtime experiments.
+package hashfunctions
+
+import (
+	"math/big"
+	"math/bits"
+)
+
+const (
+	Djb2OffsetBasis                 uint64 = 5381
+	Fnv32OffsetBasis                uint32 = 0x811c9dc5
+	Fnv32Prime                      uint32 = 0x01000193
+	Fnv64OffsetBasis                uint64 = 0xcbf29ce484222325
+	Fnv64Prime                      uint64 = 0x00000100000001b3
+	PolynomialRollingDefaultBase    uint64 = 31
+	PolynomialRollingDefaultModulus uint64 = (1 << 61) - 1
+)
+
+const (
+	murmur3C1 uint32 = 0xcc9e2d51
+	murmur3C2 uint32 = 0x1b873593
+)
+
+// Fnv1a32 computes the 32-bit Fowler-Noll-Vo FNV-1a hash.
+func Fnv1a32(data []byte) uint32 {
+	hash := Fnv32OffsetBasis
+	for _, b := range data {
+		hash ^= uint32(b)
+		hash *= Fnv32Prime
+	}
+	return hash
+}
+
+// Fnv1a64 computes the 64-bit Fowler-Noll-Vo FNV-1a hash.
+func Fnv1a64(data []byte) uint64 {
+	hash := Fnv64OffsetBasis
+	for _, b := range data {
+		hash ^= uint64(b)
+		hash *= Fnv64Prime
+	}
+	return hash
+}
+
+// Djb2 computes Dan Bernstein's shift-and-add hash, bounded to 64 bits.
+func Djb2(data []byte) uint64 {
+	hash := Djb2OffsetBasis
+	for _, b := range data {
+		hash = (hash << 5) + hash + uint64(b)
+	}
+	return hash
+}
+
+// PolynomialRolling computes the default polynomial rolling hash.
+func PolynomialRolling(data []byte) uint64 {
+	return PolynomialRollingWithParams(
+		data,
+		PolynomialRollingDefaultBase,
+		PolynomialRollingDefaultModulus,
+	)
+}
+
+// PolynomialRollingWithParams evaluates the byte polynomial modulo modulus.
+func PolynomialRollingWithParams(data []byte, base uint64, modulus uint64) uint64 {
+	if modulus == 0 {
+		panic("modulus must be positive")
+	}
+
+	hash := big.NewInt(0)
+	baseInt := new(big.Int).SetUint64(base)
+	modulusInt := new(big.Int).SetUint64(modulus)
+	byteInt := new(big.Int)
+
+	for _, b := range data {
+		hash.Mul(hash, baseInt)
+		hash.Add(hash, byteInt.SetUint64(uint64(b)))
+		hash.Mod(hash, modulusInt)
+	}
+
+	return hash.Uint64()
+}
+
+// Murmur3_32 computes Austin Appleby's MurmurHash3 32-bit variant.
+func Murmur3_32(data []byte) uint32 {
+	return Murmur3_32WithSeed(data, 0)
+}
+
+// Murmur3_32WithSeed computes MurmurHash3 with an explicit 32-bit seed.
+func Murmur3_32WithSeed(data []byte, seed uint32) uint32 {
+	hash := seed
+	blockCount := len(data) / 4
+
+	for blockIndex := 0; blockIndex < blockCount; blockIndex++ {
+		offset := blockIndex * 4
+		k := uint32(data[offset]) |
+			uint32(data[offset+1])<<8 |
+			uint32(data[offset+2])<<16 |
+			uint32(data[offset+3])<<24
+
+		k *= murmur3C1
+		k = bits.RotateLeft32(k, 15)
+		k *= murmur3C2
+
+		hash ^= k
+		hash = bits.RotateLeft32(hash, 13)
+		hash = hash*5 + 0xe6546b64
+	}
+
+	tailOffset := blockCount * 4
+	var k uint32
+	switch len(data) & 3 {
+	case 3:
+		k ^= uint32(data[tailOffset+2]) << 16
+		fallthrough
+	case 2:
+		k ^= uint32(data[tailOffset+1]) << 8
+		fallthrough
+	case 1:
+		k ^= uint32(data[tailOffset])
+		k *= murmur3C1
+		k = bits.RotateLeft32(k, 15)
+		k *= murmur3C2
+		hash ^= k
+	}
+
+	hash ^= uint32(len(data))
+	return fmix32(hash)
+}
+
+// AvalancheScore estimates the fraction of output bits that flip after a
+// one-bit input change. A strong mixing function should land near 0.5.
+func AvalancheScore(hashFn func([]byte) uint64, outputBits int, sampleSize int) float64 {
+	if outputBits <= 0 || outputBits > 64 {
+		panic("outputBits must be in 1..64")
+	}
+	if sampleSize <= 0 {
+		panic("sampleSize must be positive")
+	}
+
+	var totalBitFlips uint64
+	var totalTrials uint64
+	for sampleIndex := 0; sampleIndex < sampleSize; sampleIndex++ {
+		input := deterministicBytes(sampleIndex)
+		original := hashFn(input)
+		for bitPosition := 0; bitPosition < len(input)*8; bitPosition++ {
+			flipped := append([]byte(nil), input...)
+			flipped[bitPosition/8] ^= 1 << (bitPosition % 8)
+			totalBitFlips += uint64(bits.OnesCount64(original ^ hashFn(flipped)))
+			totalTrials += uint64(outputBits)
+		}
+	}
+
+	return float64(totalBitFlips) / float64(totalTrials)
+}
+
+// DistributionTest returns the chi-squared statistic for bucket distribution.
+func DistributionTest(hashFn func([]byte) uint64, inputs [][]byte, numBuckets int) float64 {
+	if numBuckets <= 0 {
+		panic("numBuckets must be positive")
+	}
+	if len(inputs) == 0 {
+		panic("inputs must not be empty")
+	}
+
+	counts := make([]uint64, numBuckets)
+	for _, input := range inputs {
+		bucket := hashFn(input) % uint64(numBuckets)
+		counts[bucket]++
+	}
+
+	expected := float64(len(inputs)) / float64(numBuckets)
+	var chi2 float64
+	for _, observed := range counts {
+		delta := float64(observed) - expected
+		chi2 += delta * delta / expected
+	}
+	return chi2
+}
+
+func fmix32(hash uint32) uint32 {
+	hash ^= hash >> 16
+	hash *= 0x85ebca6b
+	hash ^= hash >> 13
+	hash *= 0xc2b2ae35
+	hash ^= hash >> 16
+	return hash
+}
+
+func deterministicBytes(sampleIndex int) []byte {
+	state := uint32(0x9e3779b9) ^ uint32(sampleIndex)
+	result := make([]byte, 8)
+	for index := range result {
+		state = state*1664525 + 1013904223
+		result[index] = byte(state)
+	}
+	return result
+}

--- a/code/packages/go/hash-functions/hash_functions_test.go
+++ b/code/packages/go/hash-functions/hash_functions_test.go
@@ -1,0 +1,110 @@
+package hashfunctions
+
+import "testing"
+
+func TestFnv1aVectors(t *testing.T) {
+	tests32 := map[string]uint32{
+		"":       2166136261,
+		"a":      3826002220,
+		"abc":    440920331,
+		"hello":  1335831723,
+		"foobar": 3214735720,
+	}
+	for input, want := range tests32 {
+		if got := Fnv1a32([]byte(input)); got != want {
+			t.Fatalf("Fnv1a32(%q) = %d, want %d", input, got, want)
+		}
+	}
+
+	tests64 := map[string]uint64{
+		"":      14695981039346656037,
+		"a":     12638187200555641996,
+		"abc":   16654208175385433931,
+		"hello": 11831194018420276491,
+	}
+	for input, want := range tests64 {
+		if got := Fnv1a64([]byte(input)); got != want {
+			t.Fatalf("Fnv1a64(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestDjb2Vectors(t *testing.T) {
+	tests := map[string]uint64{
+		"":      5381,
+		"a":     177670,
+		"abc":   193485963,
+		"hello": 210714636441,
+	}
+	for input, want := range tests {
+		if got := Djb2([]byte(input)); got != want {
+			t.Fatalf("Djb2(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestPolynomialRolling(t *testing.T) {
+	if got := PolynomialRolling([]byte("")); got != 0 {
+		t.Fatalf("PolynomialRolling(empty) = %d, want 0", got)
+	}
+	if got := PolynomialRolling([]byte("a")); got != 97 {
+		t.Fatalf("PolynomialRolling(a) = %d, want 97", got)
+	}
+	if got := PolynomialRolling([]byte("ab")); got != 3105 {
+		t.Fatalf("PolynomialRolling(ab) = %d, want 3105", got)
+	}
+	if got := PolynomialRolling([]byte("abc")); got != 96354 {
+		t.Fatalf("PolynomialRolling(abc) = %d, want 96354", got)
+	}
+	if got := PolynomialRollingWithParams([]byte("hello world"), 31, 100); got >= 100 {
+		t.Fatalf("custom modulus was not respected: %d", got)
+	}
+}
+
+func TestPolynomialRollingPanicsOnZeroModulus(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	PolynomialRollingWithParams([]byte("x"), 31, 0)
+}
+
+func TestMurmur3Vectors(t *testing.T) {
+	if got := Murmur3_32WithSeed([]byte(""), 0); got != 0 {
+		t.Fatalf("Murmur3 empty seed 0 = %d", got)
+	}
+	if got := Murmur3_32WithSeed([]byte(""), 1); got != 0x514e28b7 {
+		t.Fatalf("Murmur3 empty seed 1 = %#x", got)
+	}
+	if got := Murmur3_32([]byte("a")); got != 0x3c2569b2 {
+		t.Fatalf("Murmur3 a = %#x", got)
+	}
+	if got := Murmur3_32([]byte("abc")); got != 0xb3dd93fa {
+		t.Fatalf("Murmur3 abc = %#x", got)
+	}
+}
+
+func TestMurmur3TailPathsAndSeeds(t *testing.T) {
+	inputs := []string{"abcd", "abcde", "abcdef", "abcdefg"}
+	for _, input := range inputs {
+		_ = Murmur3_32([]byte(input))
+	}
+	if Murmur3_32WithSeed([]byte("hello"), 0) == Murmur3_32WithSeed([]byte("hello"), 1) {
+		t.Fatal("seed should change output")
+	}
+}
+
+func TestAnalysisHelpers(t *testing.T) {
+	score := AvalancheScore(func(data []byte) uint64 { return uint64(Fnv1a32(data)) }, 32, 8)
+	if score < 0 || score > 1 {
+		t.Fatalf("score out of range: %f", score)
+	}
+
+	chi2 := DistributionTest(func([]byte) uint64 { return 0 }, [][]byte{
+		[]byte("a"), []byte("b"), []byte("c"), []byte("d"),
+	}, 4)
+	if chi2 != 12 {
+		t.Fatalf("chi2 = %f, want 12", chi2)
+	}
+}

--- a/code/packages/go/hash-functions/required_capabilities.json
+++ b/code/packages/go/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/hash-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/hash_functions/BUILD
+++ b/code/packages/ruby/hash_functions/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/hash_functions/BUILD_windows
+++ b/code/packages/ruby/hash_functions/BUILD_windows
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/hash_functions/CHANGELOG.md
+++ b/code/packages/ruby/hash_functions/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Ruby hash-functions package.
+- FNV-1a 32-bit and 64-bit implementations.
+- DJB2, polynomial rolling hash, and MurmurHash3 32-bit implementations.
+- Deterministic avalanche and bucket-distribution analysis helpers.
+- Unit tests covering source-of-truth vectors and edge cases.

--- a/code/packages/ruby/hash_functions/Gemfile
+++ b/code/packages/ruby/hash_functions/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec

--- a/code/packages/ruby/hash_functions/README.md
+++ b/code/packages/ruby/hash_functions/README.md
@@ -1,0 +1,25 @@
+# coding_adventures_hash_functions
+
+Pure non-cryptographic hash functions implemented from scratch in Ruby.
+
+The package includes FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and
+small deterministic analysis helpers. These functions are teaching and data
+structure utilities, not cryptographic password hashes.
+
+## Usage
+
+```ruby
+require "coding_adventures_hash_functions"
+
+CodingAdventures::HashFunctions.fnv1a32("hello")
+# => 1335831723
+
+CodingAdventures::HashFunctions.murmur3_32("abc")
+# => 3017643002
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/ruby/hash_functions/Rakefile
+++ b/code/packages/ruby/hash_functions/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/hash_functions/coding_adventures_hash_functions.gemspec
+++ b/code/packages/ruby/hash_functions/coding_adventures_hash_functions.gemspec
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/hash_functions/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_hash_functions"
+  spec.version       = CodingAdventures::HashFunctions::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Non-cryptographic hash functions implemented from scratch"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/hash_functions/lib/coding_adventures/hash_functions/version.rb
+++ b/code/packages/ruby/hash_functions/lib/coding_adventures/hash_functions/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module HashFunctions
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/hash_functions/lib/coding_adventures_hash_functions.rb
+++ b/code/packages/ruby/hash_functions/lib/coding_adventures_hash_functions.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/hash_functions/version"
+
+module CodingAdventures
+  module HashFunctions
+    FNV32_OFFSET_BASIS = 0x811C9DC5
+    FNV32_PRIME = 0x01000193
+    FNV64_OFFSET_BASIS = 0xCBF29CE484222325
+    FNV64_PRIME = 0x00000100000001B3
+    POLYNOMIAL_ROLLING_DEFAULT_BASE = 31
+    POLYNOMIAL_ROLLING_DEFAULT_MODULUS = (1 << 61) - 1
+
+    MASK32 = 0xFFFFFFFF
+    MASK64 = 0xFFFFFFFFFFFFFFFF
+    MURMUR3_C1 = 0xCC9E2D51
+    MURMUR3_C2 = 0x1B873593
+
+    module_function
+
+    def fnv1a32(data)
+      hash = FNV32_OFFSET_BASIS
+      bytes_for(data).each do |byte|
+        hash ^= byte
+        hash = (hash * FNV32_PRIME) & MASK32
+      end
+      hash
+    end
+
+    def fnv1a64(data)
+      hash = FNV64_OFFSET_BASIS
+      bytes_for(data).each do |byte|
+        hash ^= byte
+        hash = (hash * FNV64_PRIME) & MASK64
+      end
+      hash
+    end
+
+    def djb2(data)
+      hash = 5381
+      bytes_for(data).each do |byte|
+        hash = (((hash << 5) + hash) + byte) & MASK64
+      end
+      hash
+    end
+
+    def polynomial_rolling(
+      data,
+      base: POLYNOMIAL_ROLLING_DEFAULT_BASE,
+      modulus: POLYNOMIAL_ROLLING_DEFAULT_MODULUS
+    )
+      raise ArgumentError, "modulus must be positive" unless modulus.positive?
+
+      hash = 0
+      bytes_for(data).each do |byte|
+        hash = (hash * base + byte) % modulus
+      end
+      hash
+    end
+
+    def murmur3_32(data, seed: 0)
+      raw = bytes_for(data)
+      hash = seed & MASK32
+      block_count = raw.length / 4
+
+      block_count.times do |block_index|
+        offset = block_index * 4
+        k = raw[offset] | (raw[offset + 1] << 8) | (raw[offset + 2] << 16) | (raw[offset + 3] << 24)
+        k = (k * MURMUR3_C1) & MASK32
+        k = rotl32(k, 15)
+        k = (k * MURMUR3_C2) & MASK32
+
+        hash ^= k
+        hash = rotl32(hash, 13)
+        hash = (hash * 5 + 0xE6546B64) & MASK32
+      end
+
+      tail_offset = block_count * 4
+      k = 0
+      remaining = raw.length & 3
+      k ^= raw[tail_offset + 2] << 16 if remaining >= 3
+      k ^= raw[tail_offset + 1] << 8 if remaining >= 2
+      if remaining >= 1
+        k ^= raw[tail_offset]
+        k = (k * MURMUR3_C1) & MASK32
+        k = rotl32(k, 15)
+        k = (k * MURMUR3_C2) & MASK32
+        hash ^= k
+      end
+
+      fmix32(hash ^ raw.length)
+    end
+
+    def avalanche_score(hash_fn, output_bits:, sample_size: 100)
+      raise ArgumentError, "output_bits must be in 1..64" unless (1..64).cover?(output_bits)
+      raise ArgumentError, "sample_size must be positive" unless sample_size.positive?
+
+      total_bit_flips = 0
+      total_trials = 0
+      sample_size.times do |sample_index|
+        input = deterministic_bytes(sample_index)
+        original = hash_fn.call(input)
+
+        (input.length * 8).times do |bit_position|
+          flipped = input.dup
+          byte_index = bit_position / 8
+          flipped.setbyte(byte_index, flipped.getbyte(byte_index) ^ (1 << (bit_position & 7)))
+          diff = original ^ hash_fn.call(flipped)
+          total_bit_flips += diff.bit_length.downto(0).count { |bit| (diff & (1 << bit)) != 0 }
+          total_trials += output_bits
+        end
+      end
+
+      total_bit_flips.to_f / total_trials
+    end
+
+    def distribution_test(hash_fn, inputs, num_buckets:)
+      raise ArgumentError, "num_buckets must be positive" unless num_buckets.positive?
+      raise ArgumentError, "inputs must not be empty" if inputs.empty?
+
+      counts = Array.new(num_buckets, 0)
+      inputs.each do |input|
+        counts[hash_fn.call(input) % num_buckets] += 1
+      end
+
+      expected = inputs.length.to_f / num_buckets
+      counts.sum do |observed|
+        delta = observed - expected
+        delta * delta / expected
+      end
+    end
+
+    def bytes_for(data)
+      data.b.bytes
+    end
+    private_class_method :bytes_for
+
+    def rotl32(value, count)
+      ((value << count) | (value >> (32 - count))) & MASK32
+    end
+    private_class_method :rotl32
+
+    def fmix32(hash)
+      mixed = hash & MASK32
+      mixed ^= mixed >> 16
+      mixed = (mixed * 0x85EBCA6B) & MASK32
+      mixed ^= mixed >> 13
+      mixed = (mixed * 0xC2B2AE35) & MASK32
+      mixed ^= mixed >> 16
+      mixed & MASK32
+    end
+    private_class_method :fmix32
+
+    def deterministic_bytes(sample_index)
+      state = 0x9E3779B9 ^ sample_index
+      bytes = +""
+      8.times do
+        state = (state * 1_664_525 + 1_013_904_223) & MASK32
+        bytes << (state & 0xFF)
+      end
+      bytes
+    end
+    private_class_method :deterministic_bytes
+  end
+end

--- a/code/packages/ruby/hash_functions/required_capabilities.json
+++ b/code/packages/ruby/hash_functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/hash_functions",
+  "capabilities": [],
+  "justification": "Pure in-memory computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/hash_functions/test/test_hash_functions.rb
+++ b/code/packages/ruby/hash_functions/test/test_hash_functions.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_hash_functions"
+
+class HashFunctionsTest < Minitest::Test
+  HF = CodingAdventures::HashFunctions
+
+  def test_fnv1a_vectors
+    assert_equal 2_166_136_261, HF.fnv1a32("")
+    assert_equal 3_826_002_220, HF.fnv1a32("a")
+    assert_equal 440_920_331, HF.fnv1a32("abc")
+    assert_equal 1_335_831_723, HF.fnv1a32("hello")
+    assert_equal 3_214_735_720, HF.fnv1a32("foobar")
+
+    assert_equal 14_695_981_039_346_656_037, HF.fnv1a64("")
+    assert_equal 12_638_187_200_555_641_996, HF.fnv1a64("a")
+    assert_equal 16_654_208_175_385_433_931, HF.fnv1a64("abc")
+    assert_equal 11_831_194_018_420_276_491, HF.fnv1a64("hello")
+  end
+
+  def test_djb2_vectors
+    assert_equal 5381, HF.djb2("")
+    assert_equal 177_670, HF.djb2("a")
+    assert_equal 193_485_963, HF.djb2("abc")
+    assert_equal 210_714_636_441, HF.djb2("hello")
+  end
+
+  def test_polynomial_rolling
+    assert_equal 0, HF.polynomial_rolling("")
+    assert_equal 97, HF.polynomial_rolling("a")
+    assert_equal 3105, HF.polynomial_rolling("ab")
+    assert_equal 96_354, HF.polynomial_rolling("abc")
+    assert_operator HF.polynomial_rolling("hello world", modulus: 100), :<, 100
+    assert_raises(ArgumentError) { HF.polynomial_rolling("x", modulus: 0) }
+  end
+
+  def test_murmur3_vectors
+    assert_equal 0, HF.murmur3_32("", seed: 0)
+    assert_equal 0x514E28B7, HF.murmur3_32("", seed: 1)
+    assert_equal 0x3C2569B2, HF.murmur3_32("a")
+    assert_equal 0xB3DD93FA, HF.murmur3_32("abc")
+  end
+
+  def test_murmur3_tail_paths_and_seed
+    %w[abcd abcde abcdef abcdefg].each { |input| assert_kind_of Integer, HF.murmur3_32(input) }
+    refute_equal HF.murmur3_32("hello", seed: 0), HF.murmur3_32("hello", seed: 1)
+  end
+
+  def test_analysis_helpers
+    score = HF.avalanche_score(->(data) { HF.fnv1a32(data) }, output_bits: 32, sample_size: 8)
+    assert_operator score, :>=, 0.0
+    assert_operator score, :<=, 1.0
+
+    chi2 = HF.distribution_test(->(_data) { 0 }, %w[a b c d], num_buckets: 4)
+    assert_equal 12.0, chi2
+  end
+
+  def test_analysis_rejects_invalid_inputs
+    fnv = ->(data) { HF.fnv1a32(data) }
+
+    assert_raises(ArgumentError) { HF.avalanche_score(fnv, output_bits: 0) }
+    assert_raises(ArgumentError) { HF.avalanche_score(fnv, output_bits: 32, sample_size: 0) }
+    assert_raises(ArgumentError) { HF.distribution_test(fnv, [], num_buckets: 4) }
+    assert_raises(ArgumentError) { HF.distribution_test(fnv, ["x"], num_buckets: 0) }
+  end
+end

--- a/code/packages/typescript/hash-functions/BUILD
+++ b/code/packages/typescript/hash-functions/BUILD
@@ -1,0 +1,2 @@
+npm install --silent
+npx vitest run --coverage

--- a/code/packages/typescript/hash-functions/BUILD_windows
+++ b/code/packages/typescript/hash-functions/BUILD_windows
@@ -1,0 +1,2 @@
+npm install --silent
+npx vitest run --coverage

--- a/code/packages/typescript/hash-functions/CHANGELOG.md
+++ b/code/packages/typescript/hash-functions/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial TypeScript hash-functions package.
+- FNV-1a 32-bit and 64-bit implementations.
+- DJB2, polynomial rolling hash, and MurmurHash3 32-bit implementations.
+- Deterministic avalanche and bucket-distribution analysis helpers.
+- Unit tests covering source-of-truth vectors and edge cases.

--- a/code/packages/typescript/hash-functions/README.md
+++ b/code/packages/typescript/hash-functions/README.md
@@ -1,0 +1,23 @@
+# hash-functions
+
+Pure non-cryptographic hash functions implemented from scratch in TypeScript.
+
+This package covers the same educational surface as the Python and Rust
+`hash-functions` packages: FNV-1a, DJB2, polynomial rolling hash, MurmurHash3,
+and small analysis helpers for avalanche and bucket distribution.
+
+## Usage
+
+```ts
+import { fnv1a32, fnv1a64, murmur3_32 } from "@coding-adventures/hash-functions";
+
+fnv1a32("hello");       // 1335831723
+fnv1a64("hello");       // 11831194018420276491n
+murmur3_32("abc");      // 3017643002
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/typescript/hash-functions/package-lock.json
+++ b/code/packages/typescript/hash-functions/package-lock.json
@@ -1,0 +1,2503 @@
+{
+  "name": "@coding-adventures/hash-functions",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/hash-functions",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/hash-functions/package.json
+++ b/code/packages/typescript/hash-functions/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@coding-adventures/hash-functions",
+  "version": "0.1.0",
+  "description": "Non-cryptographic hash functions implemented from scratch",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/hash-functions/required_capabilities.json
+++ b/code/packages/typescript/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/hash-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/typescript/hash-functions/src/index.ts
+++ b/code/packages/typescript/hash-functions/src/index.ts
@@ -1,0 +1,197 @@
+export type HashInput = string | Uint8Array;
+export type HashValue = number | bigint;
+
+export const FNV32_OFFSET_BASIS = 0x811c9dc5;
+export const FNV32_PRIME = 0x01000193;
+export const FNV64_OFFSET_BASIS = 0xcbf29ce484222325n;
+export const FNV64_PRIME = 0x00000100000001b3n;
+export const POLYNOMIAL_ROLLING_DEFAULT_BASE = 31n;
+export const POLYNOMIAL_ROLLING_DEFAULT_MODULUS = (1n << 61n) - 1n;
+
+const MASK32 = 0xffffffff;
+const MASK64 = 0xffffffffffffffffn;
+const MURMUR3_C1 = 0xcc9e2d51;
+const MURMUR3_C2 = 0x1b873593;
+const textEncoder = new TextEncoder();
+
+function toBytes(data: HashInput): Uint8Array {
+  return typeof data === "string" ? textEncoder.encode(data) : data;
+}
+
+function rotl32(value: number, count: number): number {
+  return ((value << count) | (value >>> (32 - count))) >>> 0;
+}
+
+function fmix32(value: number): number {
+  let hash = value >>> 0;
+  hash ^= hash >>> 16;
+  hash = Math.imul(hash, 0x85ebca6b) >>> 0;
+  hash ^= hash >>> 13;
+  hash = Math.imul(hash, 0xc2b2ae35) >>> 0;
+  hash ^= hash >>> 16;
+  return hash >>> 0;
+}
+
+function asBigInt(value: HashValue): bigint {
+  return typeof value === "bigint" ? value : BigInt(value >>> 0);
+}
+
+function popcount(value: bigint): number {
+  let remaining = value;
+  let count = 0;
+  while (remaining > 0n) {
+    count += Number(remaining & 1n);
+    remaining >>= 1n;
+  }
+  return count;
+}
+
+function deterministicBytes(sampleIndex: number): Uint8Array {
+  let state = (0x9e3779b9 ^ sampleIndex) >>> 0;
+  const bytes = new Uint8Array(8);
+  for (let index = 0; index < bytes.length; index += 1) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    bytes[index] = state & 0xff;
+  }
+  return bytes;
+}
+
+export function fnv1a32(data: HashInput): number {
+  let hash = FNV32_OFFSET_BASIS >>> 0;
+  for (const byte of toBytes(data)) {
+    hash ^= byte;
+    hash = Math.imul(hash, FNV32_PRIME) >>> 0;
+  }
+  return hash;
+}
+
+export function fnv1a64(data: HashInput): bigint {
+  let hash = FNV64_OFFSET_BASIS;
+  for (const byte of toBytes(data)) {
+    hash ^= BigInt(byte);
+    hash = (hash * FNV64_PRIME) & MASK64;
+  }
+  return hash;
+}
+
+export function djb2(data: HashInput): bigint {
+  let hash = 5381n;
+  for (const byte of toBytes(data)) {
+    hash = (((hash << 5n) + hash) + BigInt(byte)) & MASK64;
+  }
+  return hash;
+}
+
+export function polynomialRolling(
+  data: HashInput,
+  base: bigint = POLYNOMIAL_ROLLING_DEFAULT_BASE,
+  modulus: bigint = POLYNOMIAL_ROLLING_DEFAULT_MODULUS,
+): bigint {
+  if (modulus <= 0n) {
+    throw new RangeError("modulus must be positive");
+  }
+
+  let hash = 0n;
+  for (const byte of toBytes(data)) {
+    hash = (hash * base + BigInt(byte)) % modulus;
+  }
+  return hash;
+}
+
+export function murmur3_32(data: HashInput, seed = 0): number {
+  const raw = toBytes(data);
+  const length = raw.length;
+  let hash = seed >>> 0;
+  const blockCount = length >>> 2;
+
+  for (let blockIndex = 0; blockIndex < blockCount; blockIndex += 1) {
+    const offset = blockIndex * 4;
+    let k =
+      raw[offset] |
+      (raw[offset + 1] << 8) |
+      (raw[offset + 2] << 16) |
+      (raw[offset + 3] << 24);
+
+    k = Math.imul(k, MURMUR3_C1) >>> 0;
+    k = rotl32(k, 15);
+    k = Math.imul(k, MURMUR3_C2) >>> 0;
+
+    hash ^= k;
+    hash = rotl32(hash, 13);
+    hash = (Math.imul(hash, 5) + 0xe6546b64) >>> 0;
+  }
+
+  const tailOffset = blockCount * 4;
+  let k = 0;
+  switch (length & 3) {
+    case 3:
+      k ^= raw[tailOffset + 2] << 16;
+    // fall through
+    case 2:
+      k ^= raw[tailOffset + 1] << 8;
+    // fall through
+    case 1:
+      k ^= raw[tailOffset];
+      k = Math.imul(k, MURMUR3_C1) >>> 0;
+      k = rotl32(k, 15);
+      k = Math.imul(k, MURMUR3_C2) >>> 0;
+      hash ^= k;
+  }
+
+  hash ^= length;
+  return fmix32(hash);
+}
+
+export function avalancheScore(
+  hashFn: (data: Uint8Array) => HashValue,
+  outputBits: number,
+  sampleSize = 100,
+): number {
+  if (outputBits <= 0 || outputBits > 64) {
+    throw new RangeError("outputBits must be in 1..64");
+  }
+  if (sampleSize <= 0) {
+    throw new RangeError("sampleSize must be positive");
+  }
+
+  let totalBitFlips = 0;
+  let totalTrials = 0;
+  for (let sampleIndex = 0; sampleIndex < sampleSize; sampleIndex += 1) {
+    const input = deterministicBytes(sampleIndex);
+    const original = asBigInt(hashFn(input));
+
+    for (let bitPosition = 0; bitPosition < input.length * 8; bitPosition += 1) {
+      const flipped = new Uint8Array(input);
+      flipped[bitPosition >>> 3] ^= 1 << (bitPosition & 7);
+      totalBitFlips += popcount(original ^ asBigInt(hashFn(flipped)));
+      totalTrials += outputBits;
+    }
+  }
+
+  return totalBitFlips / totalTrials;
+}
+
+export function distributionTest(
+  hashFn: (data: Uint8Array) => HashValue,
+  inputs: HashInput[],
+  numBuckets: number,
+): number {
+  if (numBuckets <= 0) {
+    throw new RangeError("numBuckets must be positive");
+  }
+  if (inputs.length === 0) {
+    throw new RangeError("inputs must not be empty");
+  }
+
+  const counts = new Array<number>(numBuckets).fill(0);
+  for (const input of inputs) {
+    const bucket = Number(asBigInt(hashFn(toBytes(input))) % BigInt(numBuckets));
+    counts[bucket] += 1;
+  }
+
+  const expected = inputs.length / numBuckets;
+  return counts.reduce((sum, observed) => {
+    const delta = observed - expected;
+    return sum + (delta * delta) / expected;
+  }, 0);
+}

--- a/code/packages/typescript/hash-functions/tests/index.test.ts
+++ b/code/packages/typescript/hash-functions/tests/index.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  avalancheScore,
+  distributionTest,
+  djb2,
+  fnv1a32,
+  fnv1a64,
+  murmur3_32,
+  polynomialRolling,
+} from "../src/index";
+
+describe("FNV-1a", () => {
+  it("matches 32-bit vectors", () => {
+    expect(fnv1a32("")).toBe(2166136261);
+    expect(fnv1a32("a")).toBe(3826002220);
+    expect(fnv1a32("abc")).toBe(440920331);
+    expect(fnv1a32("hello")).toBe(1335831723);
+    expect(fnv1a32("foobar")).toBe(3214735720);
+  });
+
+  it("matches 64-bit vectors", () => {
+    expect(fnv1a64("")).toBe(14695981039346656037n);
+    expect(fnv1a64("a")).toBe(12638187200555641996n);
+    expect(fnv1a64("abc")).toBe(16654208175385433931n);
+    expect(fnv1a64("hello")).toBe(11831194018420276491n);
+  });
+
+  it("treats strings as UTF-8 bytes", () => {
+    expect(fnv1a32("cafe")).toBe(fnv1a32(new TextEncoder().encode("cafe")));
+  });
+});
+
+describe("DJB2", () => {
+  it("matches known vectors", () => {
+    expect(djb2("")).toBe(5381n);
+    expect(djb2("a")).toBe(177670n);
+    expect(djb2("abc")).toBe(193485963n);
+    expect(djb2("hello")).toBe(210714636441n);
+  });
+});
+
+describe("polynomialRolling", () => {
+  it("matches manual computations", () => {
+    expect(polynomialRolling("")).toBe(0n);
+    expect(polynomialRolling("a")).toBe(97n);
+    expect(polynomialRolling("ab")).toBe(3105n);
+    expect(polynomialRolling("abc")).toBe(96354n);
+  });
+
+  it("honors custom parameters", () => {
+    expect(polynomialRolling("hello", 37n)).not.toBe(polynomialRolling("hello"));
+    expect(polynomialRolling("hello world", 31n, 100n)).toBeLessThan(100n);
+    expect(() => polynomialRolling("x", 31n, 0n)).toThrow(RangeError);
+  });
+});
+
+describe("murmur3_32", () => {
+  it("matches source-of-truth vectors", () => {
+    expect(murmur3_32("", 0)).toBe(0);
+    expect(murmur3_32("", 1)).toBe(0x514e28b7);
+    expect(murmur3_32("a", 0)).toBe(0x3c2569b2);
+    expect(murmur3_32("abc", 0)).toBe(0xb3dd93fa);
+  });
+
+  it("covers all tail paths and seed variation", () => {
+    expect(murmur3_32("abcd")).not.toBe(murmur3_32("abce"));
+    expect(murmur3_32("abcde")).toBeGreaterThanOrEqual(0);
+    expect(murmur3_32("abcdef")).toBeGreaterThanOrEqual(0);
+    expect(murmur3_32("abcdefg")).toBeGreaterThanOrEqual(0);
+    expect(murmur3_32("hello", 0)).not.toBe(murmur3_32("hello", 1));
+  });
+});
+
+describe("analysis helpers", () => {
+  it("computes bounded avalanche scores", () => {
+    const score = avalancheScore(fnv1a32, 32, 8);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it("computes exact chi-squared values", () => {
+    const chi2 = distributionTest(() => 0, ["a", "b", "c", "d"], 4);
+    expect(chi2).toBe(12);
+  });
+
+  it("rejects invalid analysis inputs", () => {
+    expect(() => avalancheScore(fnv1a32, 0, 1)).toThrow(RangeError);
+    expect(() => avalancheScore(fnv1a32, 32, 0)).toThrow(RangeError);
+    expect(() => distributionTest(fnv1a32, [], 10)).toThrow(RangeError);
+    expect(() => distributionTest(fnv1a32, ["x"], 0)).toThrow(RangeError);
+  });
+});

--- a/code/packages/typescript/hash-functions/tsconfig.json
+++ b/code/packages/typescript/hash-functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/hash-functions/vitest.config.ts
+++ b/code/packages/typescript/hash-functions/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -1,0 +1,287 @@
+# Package Parity Roadmap
+
+## Goal
+
+Close package gaps intelligently across language buckets without pretending
+that directory equality is the same as useful parity.
+
+The repo should aim for portable API parity where a package is naturally
+language-agnostic, and for honest native or web specialization where the
+package is tied to a runtime, operating system, browser API, or FFI boundary.
+
+## Current Baseline
+
+The most useful baseline today is not "everything everywhere." It is:
+
+- **Portable core:** packages present in both Rust and Python.
+- **Native source of truth:** Rust packages that expose platform, FFI, graphics,
+  runtime, or C ABI behavior.
+- **Python prototyping/runtime lane:** Python packages that carry language
+  runtime experiments, compiler tracks, and native-wrapper facades.
+- **Web lane:** TypeScript and WASM packages that depend on browser, DOM,
+  Canvas, IndexedDB, Vite, or Web Audio behavior.
+
+After normalizing folder naming conventions, the current inventory is:
+
+| Baseline | Count |
+|---|---:|
+| All normalized package names, excluding Starlark | 540 |
+| Rust/Python union | 493 |
+| Rust/Python shared core | 261 |
+| Rust packages | 377 |
+| Python packages | 377 |
+| Rust-only packages | 116 |
+| Python-only packages | 116 |
+| Packages outside Rust/Python | 47 |
+
+Core parity coverage against the Rust/Python shared core:
+
+| Language | Missing Core | Coverage |
+|---|---:|---:|
+| TypeScript | 19 | 92.7% |
+| Go | 23 | 91.2% |
+| Ruby | 23 | 91.2% |
+| Elixir | 32 | 87.7% |
+| Perl | 56 | 78.5% |
+| Lua | 57 | 78.2% |
+| Swift | 136 | 47.9% |
+| Haskell | 138 | 47.1% |
+| Java | 192 | 26.4% |
+| Kotlin | 193 | 26.1% |
+| WASM | 200 | 23.4% |
+| F# | 209 | 19.9% |
+| C# | 210 | 19.5% |
+| Dart | 228 | 12.6% |
+
+Regenerate the numbers with:
+
+```sh
+python scripts/package_parity_report.py --format markdown
+```
+
+## Parity Rules
+
+### Portable Packages Should Converge
+
+Packages should converge across all serious implementation languages when they
+are pure algorithms, data structures, grammar frontends, codecs, IR models,
+validators, encoders, simulators, or deterministic transforms.
+
+Examples:
+
+- `hash-functions`
+- `trie`
+- `bloom-filter`
+- `lexer`
+- `parser`
+- `wasm-module-encoder`
+- `json-value`
+- `zip`
+
+### Native Packages Should Not Be Reimplemented Blindly
+
+Rust should remain the implementation source of truth for packages that are
+really platform or ABI surfaces. Other languages should usually receive thin,
+tested wrappers instead of independent reimplementations.
+
+Examples:
+
+- `python-bridge`, `ruby-bridge`, `node-bridge`, `lua-bridge`
+- `epoll`, `kqueue`, `iocp`
+- `audio-device-coreaudio`
+- `paint-vm-direct2d`, `paint-vm-gdi`, `paint-metal`
+- `cuda-compute`, `metal-compute`
+- `*-c`, `*-native`, and runtime extension packages
+
+### Web Packages Stay Web-First
+
+Browser and app-shell packages should not become parity blockers for backend
+languages.
+
+Examples:
+
+- `indexeddb`
+- `ui-components`
+- `vite-plugin-lattice`
+- `paint-vm-canvas`
+- `window-canvas`
+- `web-audio-sink`
+- `browser-extension-toolkit`
+
+### Runtime-Specific Compiler Backends Need Dependency Readiness
+
+Compiler and VM packages should be ported in dependency waves, not one package
+at a time. A backend package is only ready when its local lexer, parser, IR,
+validator, encoder, and runtime dependencies are already present or included in
+the same wave.
+
+## Optimal Implementation Order
+
+### Phase 0: Keep the Map Fresh
+
+Status: started by this roadmap and `scripts/package_parity_report.py`.
+
+- Keep `scripts/package_parity_report.py` as the canonical quick inventory.
+- Use the Rust/Python shared core as the portable parity target.
+- Classify every apparent gap before implementing it.
+- Do not count Starlark as an implementation language; it is a build/config
+  rule lane.
+
+### Phase 1: Close Near-Parity Languages First
+
+Target languages:
+
+- TypeScript
+- Go
+- Ruby
+- Elixir
+
+These buckets are already above 87% core coverage. Closing them first gives the
+repo fast wins and creates templates for Lua, Perl, Swift, and Haskell.
+
+Recommended first wave:
+
+| Package | Languages | Why first |
+|---|---|---|
+| `hash-functions` | TypeScript, Go, Ruby, Elixir | Leaf-like utility used by later structures |
+| `trie` | TypeScript, Go, Ruby, Elixir | Pure data structure with clear tests |
+| `bloom-filter` | TypeScript, Go, Ruby, Elixir | Depends naturally on hash behavior |
+
+The `hash-functions` row is implemented in this branch. The next best cut is
+`trie`, followed by `bloom-filter`.
+
+Recommended second wave:
+
+| Package | Languages | Why second |
+|---|---|---|
+| `css-lexer` | TypeScript, Go | Grammar-generated and browser-relevant |
+| `css-parser` | TypeScript, Go, Elixir | Completes the CSS frontend pair |
+| `haskell-lexer` | Go, Perl | Follow existing grammar-generated package pattern |
+| `haskell-parser` | Go, Perl | Follows lexer support |
+
+Hold for classification:
+
+- `audio-device-sink`: likely portable facade plus native backends.
+- `tcp-server`: portable contract, but runtime behavior must be shaped per
+  language.
+- `ml-framework-*`: probably educational facades; confirm desired depth before
+  porting.
+- `jit-compiler`, `lisp-*`, `starlark-compiler`: port as compiler waves after
+  dependency checks.
+
+### Phase 2: Bring Lua and Perl to Near-Parity
+
+Lua and Perl are around 78% core coverage and share many missing packages. Use
+the Phase 1 implementations as templates after they pass in TypeScript, Go,
+Ruby, and Elixir.
+
+Prioritize:
+
+- `hash-functions`
+- `bloom-filter`
+- `fenwick-tree`
+- `hash-map`
+- `hyperloglog`
+- `radix-tree`
+- `skip-list`
+- `tree-set`
+- `trie`
+- `resp-protocol`
+- `tcp-server`
+
+Then continue with compiler/runtime packages from the existing convergence
+specs.
+
+### Phase 3: Treat Haskell and Swift as Medium Catch-Up Tracks
+
+Haskell and Swift sit near 47% core coverage, so their next work should be
+dependency-shaped rather than gap-count-shaped.
+
+Haskell:
+
+- Refresh `haskell-catch-up-survey.md` with the new merged baseline.
+- Prioritize tooling/core packages that make future Haskell package creation
+  cheaper.
+- Continue the Brainfuck/Nib/WASM convergence wave in
+  `04n-haskell-wasm-convergence.md`.
+- Be strict about `cabal.project` transitive local dependencies.
+
+Swift:
+
+- Add a Swift catch-up survey similar to the Haskell one.
+- Prioritize portable algorithm/data-structure packages before native app
+  surfaces.
+- Port grammar frontends only after package scaffolding and build support are
+  predictable.
+
+### Phase 4: Work in Paired Ecosystems
+
+Java and Kotlin should move together. C# and F# should move together.
+
+The best initial paired waves are:
+
+- generated lexer/parser packages
+- data structures
+- crypto and compression primitives
+- WASM encoder/runtime slices
+- existing Brainfuck/Nib convergence specs
+
+Avoid one-off ports that make Java diverge from Kotlin or C# diverge from F#.
+
+### Phase 5: Keep Dart and WASM Selective
+
+Dart has low coverage but should not blindly mirror systems packages. Favor
+portable packages that fit the Dart ecosystem:
+
+- data structures
+- codecs
+- QR/barcode work
+- grammar frontends
+- document and paint transforms
+
+WASM packages should stay focused on wrappers, runtime targets, and browser or
+portable execution units. They do not need to mirror every source-language
+package.
+
+## First Implementation Tranche
+
+Start with 12 packages:
+
+- `code/packages/typescript/hash-functions` - done in this branch
+- `code/packages/go/hash-functions` - done in this branch
+- `code/packages/ruby/hash_functions` - done in this branch
+- `code/packages/elixir/hash_functions` - done in this branch
+- `code/packages/typescript/trie`
+- `code/packages/go/trie`
+- `code/packages/ruby/trie`
+- `code/packages/elixir/trie`
+- `code/packages/typescript/bloom-filter`
+- `code/packages/go/bloom-filter`
+- `code/packages/ruby/bloom_filter`
+- `code/packages/elixir/bloom_filter`
+
+Build order:
+
+1. `hash-functions`
+2. `trie`
+3. `bloom-filter`
+
+Validation rules:
+
+- Each package needs `BUILD`, README, CHANGELOG, package metadata, and tests.
+- BUILD files must install transitive local dependencies in leaf-to-root order.
+- Ruby requires dependency `require` ordering before local modules.
+- Elixir implementations must avoid reserved words as variables.
+- Go packages must run `go mod tidy` after adding local module dependencies.
+- TypeScript packages must avoid committing generated `.js`, `.d.ts`, or source
+  map outputs.
+
+## Completion Definition
+
+This roadmap is working when:
+
+- the parity report can be regenerated after every major merge;
+- near-parity language gaps shrink in coherent waves;
+- native and web-only packages are classified instead of treated as failures;
+- new implementations follow existing package conventions;
+- specs, READMEs, CHANGELOGs, and tests move together.

--- a/scripts/package_parity_report.py
+++ b/scripts/package_parity_report.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Report package parity across language buckets.
+
+The report intentionally normalizes only folder-name conventions. It does not
+try to decide that every package should exist in every language. That judgment
+belongs in the roadmap/spec layer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+NORMALIZATION_OVERRIDES = {
+    "barcode1d": "barcode-1d",
+    "barcode2d": "barcode-2d",
+    "barcodelayout1d": "barcode-layout-1d",
+    "ean13": "ean-13",
+    "imagecodecbmp": "image-codec-bmp",
+    "imagecodecppm": "image-codec-ppm",
+    "imagecodecqoi": "image-codec-qoi",
+    "imagegeometrictransforms": "image-geometric-transforms",
+    "imagepointops": "image-point-ops",
+    "paintcodecpngnative": "paint-codec-png-native",
+    "paintinstructions": "paint-instructions",
+    "paintvmdirect2dnative": "paint-vm-direct2d-native",
+    "paintvmmetalnative": "paint-vm-metal-native",
+    "pixelcontainer": "pixel-container",
+    "upca": "upc-a",
+}
+
+IGNORED_PACKAGE_DIRS = {
+    ".cargo",
+}
+
+IGNORED_LANGUAGE_BUCKETS = {
+    "starlark",
+}
+
+
+def normalize_package_name(name: str) -> str | None:
+    if name in IGNORED_PACKAGE_DIRS:
+        return None
+    normalized = name.lower().replace("_", "-")
+    return NORMALIZATION_OVERRIDES.get(normalized, normalized)
+
+
+def discover_packages(root: Path) -> dict[str, set[str]]:
+    package_root = root / "code" / "packages"
+    language_packages: dict[str, set[str]] = {}
+
+    for language_dir in sorted(package_root.iterdir()):
+        if not language_dir.is_dir() or language_dir.name in IGNORED_LANGUAGE_BUCKETS:
+            continue
+
+        packages: set[str] = set()
+        for package_dir in sorted(language_dir.iterdir()):
+            if not package_dir.is_dir():
+                continue
+            normalized = normalize_package_name(package_dir.name)
+            if normalized:
+                packages.add(normalized)
+
+        language_packages[language_dir.name] = packages
+
+    return language_packages
+
+
+def sorted_list(values: Iterable[str]) -> list[str]:
+    return sorted(values)
+
+
+def build_report(root: Path) -> dict[str, object]:
+    language_packages = discover_packages(root)
+    if "rust" not in language_packages or "python" not in language_packages:
+        raise SystemExit("package parity report requires rust and python buckets")
+
+    all_packages: set[str] = set()
+    for packages in language_packages.values():
+        all_packages.update(packages)
+
+    rust_packages = language_packages["rust"]
+    python_packages = language_packages["python"]
+    rust_python_core = rust_packages & python_packages
+    rust_python_union = rust_packages | python_packages
+
+    coverage = []
+    for language, packages in sorted(language_packages.items()):
+        missing_core = rust_python_core - packages
+        present_core = len(rust_python_core) - len(missing_core)
+        coverage.append(
+            {
+                "language": language,
+                "present": len(packages),
+                "missing_core": len(missing_core),
+                "core_coverage": present_core / len(rust_python_core),
+                "missing_core_packages": sorted_list(missing_core),
+            }
+        )
+
+    package_frequency = []
+    for package in sorted(all_packages):
+        languages = [
+            language
+            for language, packages in sorted(language_packages.items())
+            if package in packages
+        ]
+        package_frequency.append(
+            {
+                "package": package,
+                "language_count": len(languages),
+                "languages": languages,
+            }
+        )
+
+    return {
+        "package_count": {
+            "all_languages_union": len(all_packages),
+            "rust_python_union": len(rust_python_union),
+            "rust_python_core": len(rust_python_core),
+            "rust": len(rust_packages),
+            "python": len(python_packages),
+        },
+        "rust_only": sorted_list(rust_packages - python_packages),
+        "python_only": sorted_list(python_packages - rust_packages),
+        "outside_rust_python": sorted_list(all_packages - rust_python_union),
+        "coverage": sorted(coverage, key=lambda row: (row["missing_core"], row["language"])),
+        "package_frequency": package_frequency,
+    }
+
+
+def render_markdown(report: dict[str, object]) -> str:
+    counts = report["package_count"]
+    assert isinstance(counts, dict)
+    lines = [
+        "# Package Parity Report",
+        "",
+        "## Summary",
+        "",
+        "| Baseline | Count |",
+        "|---|---:|",
+        f"| All normalized package names | {counts['all_languages_union']} |",
+        f"| Rust/Python union | {counts['rust_python_union']} |",
+        f"| Rust/Python shared core | {counts['rust_python_core']} |",
+        f"| Rust packages | {counts['rust']} |",
+        f"| Python packages | {counts['python']} |",
+        "",
+        "## Core Coverage",
+        "",
+        "| Language | Present | Missing Core | Core Coverage |",
+        "|---|---:|---:|---:|",
+    ]
+
+    coverage = report["coverage"]
+    assert isinstance(coverage, list)
+    for row in coverage:
+        assert isinstance(row, dict)
+        lines.append(
+            "| {language} | {present} | {missing_core} | {core_coverage:.1%} |".format(
+                **row
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Rust Only",
+            "",
+            ", ".join(report["rust_only"]),  # type: ignore[arg-type]
+            "",
+            "## Python Only",
+            "",
+            ", ".join(report["python_only"]),  # type: ignore[arg-type]
+            "",
+            "## Outside Rust/Python",
+            "",
+            ", ".join(report["outside_rust_python"]),  # type: ignore[arg-type]
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="output format",
+    )
+    args = parser.parse_args()
+
+    report = build_report(args.root)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
- Add package parity roadmap and reusable parity report script.
- Add hash-functions packages for TypeScript, Go, Ruby, and Elixir.
- Cover FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and analysis helpers.

Verification
- python scripts/package_parity_report.py --format json
- python -m py_compile scripts/package_parity_report.py
- TypeScript: npm install; npm run build --silent; npx vitest run --coverage
- Go: go test ./... -cover
- Ruby: bundle exec rake test
- Elixir: mix test --cover

Security review
- Pure in-memory computation only.
- Capability manifests declare no filesystem, network, process, or environment access.
- Manual scan found no dynamic execution or OS access in package code.