### PR TITLE
feat(parity): add fenwick tree packages

### DIFF
--- a/code/packages/elixir/fenwick_tree/BUILD
+++ b/code/packages/elixir/fenwick_tree/BUILD
@@ -1,0 +1,1 @@
+mix deps.get && mix test --cover

--- a/code/packages/elixir/fenwick_tree/BUILD_windows
+++ b/code/packages/elixir/fenwick_tree/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get && mix test --cover

--- a/code/packages/elixir/fenwick_tree/CHANGELOG.md
+++ b/code/packages/elixir/fenwick_tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Elixir Fenwick tree package with prefix sums, range sums, point
+  updates, point queries, order-statistic lookup, and validation helpers.

--- a/code/packages/elixir/fenwick_tree/README.md
+++ b/code/packages/elixir/fenwick_tree/README.md
@@ -1,0 +1,8 @@
+# CodingAdventures.FenwickTree
+
+An immutable Binary Indexed Tree for prefix sums and point updates.
+
+```elixir
+tree = CodingAdventures.FenwickTree.from_list([3, 2, 1, 7, 4])
+CodingAdventures.FenwickTree.range_sum(tree, 2, 4)
+```

--- a/code/packages/elixir/fenwick_tree/lib/coding_adventures/fenwick_tree.ex
+++ b/code/packages/elixir/fenwick_tree/lib/coding_adventures/fenwick_tree.ex
@@ -1,0 +1,134 @@
+defmodule CodingAdventures.FenwickTree do
+  @moduledoc """
+  Immutable Binary Indexed Tree for prefix sums and point updates.
+  """
+
+  import Bitwise
+
+  defstruct length: 0, bit: {0.0}
+
+  @type t :: %__MODULE__{length: non_neg_integer(), bit: tuple()}
+
+  def new(length) when is_integer(length) and length >= 0 do
+    %__MODULE__{length: length, bit: List.to_tuple(List.duplicate(0.0, length + 1))}
+  end
+
+  def new(length),
+    do: raise(ArgumentError, "size must be a non-negative integer, got #{inspect(length)}")
+
+  def from_list(values) when is_list(values) do
+    length = length(values)
+
+    bit =
+      Enum.reduce(1..length//1, List.to_tuple([0.0 | values]), fn index, bit ->
+        parent = index + lowbit(index)
+
+        if parent <= length do
+          put_elem(bit, parent, elem(bit, parent) + elem(bit, index))
+        else
+          bit
+        end
+      end)
+
+    %__MODULE__{length: length, bit: bit}
+  end
+
+  def update(%__MODULE__{} = tree, index, delta) do
+    check_index!(tree, index)
+
+    bit =
+      Stream.iterate(index, &(&1 + lowbit(&1)))
+      |> Enum.take_while(&(&1 <= tree.length))
+      |> Enum.reduce(tree.bit, fn current, bit ->
+        put_elem(bit, current, elem(bit, current) + delta)
+      end)
+
+    %{tree | bit: bit}
+  end
+
+  def prefix_sum(%__MODULE__{} = tree, index) do
+    unless is_integer(index) and index >= 0 and index <= tree.length do
+      raise ArgumentError, "prefix_sum index #{inspect(index)} out of range [0, #{tree.length}]"
+    end
+
+    Stream.iterate(index, &(&1 - lowbit(&1)))
+    |> Enum.take_while(&(&1 > 0))
+    |> Enum.reduce(0.0, fn current, total -> total + elem(tree.bit, current) end)
+  end
+
+  def range_sum(%__MODULE__{} = tree, left, right) do
+    if left > right do
+      raise ArgumentError, "left (#{left}) must be <= right (#{right})"
+    end
+
+    check_index!(tree, left)
+    check_index!(tree, right)
+
+    if left == 1 do
+      prefix_sum(tree, right)
+    else
+      prefix_sum(tree, right) - prefix_sum(tree, left - 1)
+    end
+  end
+
+  def point_query(%__MODULE__{} = tree, index) do
+    check_index!(tree, index)
+    range_sum(tree, index, index)
+  end
+
+  def find_kth(%__MODULE__{length: 0}, _target) do
+    raise ArgumentError, "find_kth called on empty tree"
+  end
+
+  def find_kth(%__MODULE__{}, target) when target <= 0 do
+    raise ArgumentError, "k must be positive, got #{inspect(target)}"
+  end
+
+  def find_kth(%__MODULE__{} = tree, target) do
+    total = prefix_sum(tree, tree.length)
+
+    if target > total do
+      raise ArgumentError, "k exceeds total sum of the tree"
+    end
+
+    {index, _target} =
+      Stream.iterate(highest_power_of_two_at_most(tree.length), &div(&1, 2))
+      |> Enum.take_while(&(&1 > 0))
+      |> Enum.reduce({0, target}, fn step, {index, remaining} ->
+        next = index + step
+
+        if next <= tree.length and elem(tree.bit, next) < remaining do
+          {next, remaining - elem(tree.bit, next)}
+        else
+          {index, remaining}
+        end
+      end)
+
+    index + 1
+  end
+
+  def empty?(%__MODULE__{length: 0}), do: true
+  def empty?(%__MODULE__{}), do: false
+
+  def bit_array(%__MODULE__{} = tree) do
+    tree.bit
+    |> Tuple.to_list()
+    |> tl()
+  end
+
+  defp check_index!(%__MODULE__{} = tree, index) do
+    unless is_integer(index) and index >= 1 and index <= tree.length do
+      raise ArgumentError, "Index #{inspect(index)} out of range [1, #{tree.length}]"
+    end
+  end
+
+  defp lowbit(index), do: index &&& -index
+
+  defp highest_power_of_two_at_most(0), do: 0
+
+  defp highest_power_of_two_at_most(number) do
+    Stream.iterate(1, &(&1 * 2))
+    |> Enum.take_while(&(&1 <= number))
+    |> List.last()
+  end
+end

--- a/code/packages/elixir/fenwick_tree/mix.exs
+++ b/code/packages/elixir/fenwick_tree/mix.exs
@@ -1,0 +1,16 @@
+defmodule CodingAdventures.FenwickTree.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_fenwick_tree,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: [],
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application, do: [extra_applications: [:logger]]
+end

--- a/code/packages/elixir/fenwick_tree/required_capabilities.json
+++ b/code/packages/elixir/fenwick_tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/fenwick_tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/fenwick_tree/test/fenwick_tree_test.exs
+++ b/code/packages/elixir/fenwick_tree/test/fenwick_tree_test.exs
@@ -1,0 +1,67 @@
+defmodule CodingAdventures.FenwickTreeTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.FenwickTree
+
+  test "new and from_list build prefix sums" do
+    tree = FenwickTree.from_list([3, 2, 1, 7, 4])
+    assert tree.length == 5
+    refute FenwickTree.empty?(tree)
+
+    Enum.each(Enum.with_index([3, 5, 6, 13, 17], 1), fn {expected, index} ->
+      assert FenwickTree.prefix_sum(tree, index) == expected
+    end)
+
+    assert FenwickTree.empty?(FenwickTree.new(0))
+    assert_raise ArgumentError, fn -> FenwickTree.new(-1) end
+  end
+
+  test "prefix range point and update operations" do
+    tree = FenwickTree.from_list([3, 2, 1, 7, 4])
+    assert FenwickTree.prefix_sum(tree, 0) == 0.0
+    assert FenwickTree.range_sum(tree, 2, 4) == 10
+    assert FenwickTree.point_query(tree, 4) == 7
+
+    tree = FenwickTree.update(tree, 3, 5)
+    assert FenwickTree.point_query(tree, 3) == 6
+    assert FenwickTree.prefix_sum(tree, 3) == 11
+  end
+
+  test "find_kth examples" do
+    tree = FenwickTree.from_list([1, 2, 3, 4, 5])
+    assert FenwickTree.find_kth(tree, 1) == 1
+    assert FenwickTree.find_kth(tree, 2) == 2
+    assert FenwickTree.find_kth(tree, 3) == 2
+    assert FenwickTree.find_kth(tree, 4) == 3
+    assert FenwickTree.find_kth(tree, 10) == 4
+  end
+
+  test "find_kth errors" do
+    assert_raise ArgumentError, fn -> FenwickTree.find_kth(FenwickTree.new(0), 1) end
+
+    tree = FenwickTree.from_list([1, 2, 3])
+    assert_raise ArgumentError, fn -> FenwickTree.find_kth(tree, 0) end
+    assert_raise ArgumentError, fn -> FenwickTree.find_kth(tree, 100) end
+  end
+
+  test "invalid indices and ranges" do
+    tree = FenwickTree.from_list([1, 2, 3])
+    assert_raise ArgumentError, fn -> FenwickTree.prefix_sum(tree, 4) end
+    assert_raise ArgumentError, fn -> FenwickTree.update(tree, 0, 1) end
+    assert_raise ArgumentError, fn -> FenwickTree.range_sum(tree, 3, 1) end
+    assert_raise ArgumentError, fn -> FenwickTree.range_sum(tree, 0, 3) end
+  end
+
+  test "brute force prefix sums and bit array" do
+    values = [5, -2, 7, 1.5, 4.5]
+    tree = FenwickTree.from_list(values)
+
+    values
+    |> Enum.with_index(1)
+    |> Enum.each(fn {_value, index} ->
+      assert FenwickTree.prefix_sum(tree, index) == values |> Enum.take(index) |> Enum.sum()
+    end)
+
+    assert length(FenwickTree.bit_array(tree)) == length(values)
+  end
+end

--- a/code/packages/elixir/fenwick_tree/test/test_helper.exs
+++ b/code/packages/elixir/fenwick_tree/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/go/fenwick-tree/BUILD
+++ b/code/packages/go/fenwick-tree/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -coverprofile=coverage.out

--- a/code/packages/go/fenwick-tree/BUILD_windows
+++ b/code/packages/go/fenwick-tree/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -coverprofile=coverage.out

--- a/code/packages/go/fenwick-tree/CHANGELOG.md
+++ b/code/packages/go/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Go Fenwick tree package with prefix sums, range sums, point updates,
+  point queries, order-statistic lookup, and validation helpers.

--- a/code/packages/go/fenwick-tree/README.md
+++ b/code/packages/go/fenwick-tree/README.md
@@ -1,0 +1,10 @@
+# Go Fenwick tree
+
+A Binary Indexed Tree for O(log n) prefix sums and point updates over numeric
+values.
+
+```go
+tree := fenwicktree.FromSlice([]float64{3, 2, 1, 7, 4})
+sum, _ := tree.RangeSum(2, 4) // 10
+tree.Update(3, 5)
+```

--- a/code/packages/go/fenwick-tree/fenwicktree.go
+++ b/code/packages/go/fenwick-tree/fenwicktree.go
@@ -1,0 +1,175 @@
+package fenwicktree
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrInvalidSize       = errors.New("size must be a non-negative integer")
+	ErrIndexOutOfRange   = errors.New("index out of range")
+	ErrInvalidRange      = errors.New("left must be <= right")
+	ErrEmptyTree         = errors.New("find kth called on empty tree")
+	ErrNonPositiveTarget = errors.New("target must be positive")
+	ErrTargetExceedsSum  = errors.New("target exceeds total sum")
+)
+
+type FenwickTree struct {
+	n   int
+	bit []float64
+}
+
+func New(n int) (*FenwickTree, error) {
+	if n < 0 {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidSize, n)
+	}
+	return &FenwickTree{n: n, bit: make([]float64, n+1)}, nil
+}
+
+func MustNew(n int) *FenwickTree {
+	tree, err := New(n)
+	if err != nil {
+		panic(err)
+	}
+	return tree
+}
+
+func FromSlice(values []float64) *FenwickTree {
+	tree := MustNew(len(values))
+	for index := 1; index <= tree.n; index++ {
+		tree.bit[index] += values[index-1]
+		parent := index + lowbit(index)
+		if parent <= tree.n {
+			tree.bit[parent] += tree.bit[index]
+		}
+	}
+	return tree
+}
+
+func FromValues(values ...float64) *FenwickTree {
+	return FromSlice(values)
+}
+
+func (t *FenwickTree) Update(index int, delta float64) error {
+	if err := t.checkIndex(index); err != nil {
+		return err
+	}
+
+	for current := index; current <= t.n; current += lowbit(current) {
+		t.bit[current] += delta
+	}
+	return nil
+}
+
+func (t *FenwickTree) PrefixSum(index int) (float64, error) {
+	if index < 0 || index > t.n {
+		return 0, fmt.Errorf("%w: prefix index %d out of range [0, %d]", ErrIndexOutOfRange, index, t.n)
+	}
+
+	total := 0.0
+	for current := index; current > 0; current -= lowbit(current) {
+		total += t.bit[current]
+	}
+	return total, nil
+}
+
+func (t *FenwickTree) RangeSum(left int, right int) (float64, error) {
+	if left > right {
+		return 0, fmt.Errorf("%w: left=%d right=%d", ErrInvalidRange, left, right)
+	}
+	if err := t.checkIndex(left); err != nil {
+		return 0, err
+	}
+	if err := t.checkIndex(right); err != nil {
+		return 0, err
+	}
+	if left == 1 {
+		return t.PrefixSum(right)
+	}
+
+	rightSum, err := t.PrefixSum(right)
+	if err != nil {
+		return 0, err
+	}
+	beforeLeft, err := t.PrefixSum(left - 1)
+	if err != nil {
+		return 0, err
+	}
+	return rightSum - beforeLeft, nil
+}
+
+func (t *FenwickTree) PointQuery(index int) (float64, error) {
+	if err := t.checkIndex(index); err != nil {
+		return 0, err
+	}
+	return t.RangeSum(index, index)
+}
+
+func (t *FenwickTree) FindKth(target float64) (int, error) {
+	if t.n == 0 {
+		return 0, ErrEmptyTree
+	}
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: %v", ErrNonPositiveTarget, target)
+	}
+
+	total, err := t.PrefixSum(t.n)
+	if err != nil {
+		return 0, err
+	}
+	if target > total {
+		return 0, fmt.Errorf("%w: target=%v total=%v", ErrTargetExceedsSum, target, total)
+	}
+
+	index := 0
+	step := highestPowerOfTwoAtMost(t.n)
+	for step > 0 {
+		next := index + step
+		if next <= t.n && t.bit[next] < target {
+			index = next
+			target -= t.bit[index]
+		}
+		step >>= 1
+	}
+	return index + 1, nil
+}
+
+func (t *FenwickTree) Len() int {
+	return t.n
+}
+
+func (t *FenwickTree) IsEmpty() bool {
+	return t.n == 0
+}
+
+func (t *FenwickTree) BitArray() []float64 {
+	out := make([]float64, t.n)
+	copy(out, t.bit[1:])
+	return out
+}
+
+func (t *FenwickTree) String() string {
+	return fmt.Sprintf("FenwickTree(n=%d, bit=%v)", t.n, t.BitArray())
+}
+
+func (t *FenwickTree) checkIndex(index int) error {
+	if index >= 1 && index <= t.n {
+		return nil
+	}
+	return fmt.Errorf("%w: index %d out of range [1, %d]", ErrIndexOutOfRange, index, t.n)
+}
+
+func lowbit(index int) int {
+	return index & -index
+}
+
+func highestPowerOfTwoAtMost(n int) int {
+	if n == 0 {
+		return 0
+	}
+	power := 1
+	for power<<1 <= n {
+		power <<= 1
+	}
+	return power
+}

--- a/code/packages/go/fenwick-tree/fenwicktree_test.go
+++ b/code/packages/go/fenwick-tree/fenwicktree_test.go
@@ -1,0 +1,149 @@
+package fenwicktree
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+func assertClose(t *testing.T, actual float64, expected float64) {
+	t.Helper()
+	if math.Abs(actual-expected) > 1e-9 {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestNewAndFromSlice(t *testing.T) {
+	tree := FromSlice([]float64{3, 2, 1, 7, 4})
+	if tree.Len() != 5 || tree.IsEmpty() {
+		t.Fatalf("tree size state is wrong")
+	}
+	expected := []float64{3, 5, 6, 13, 17}
+	for i, want := range expected {
+		got, err := tree.PrefixSum(i + 1)
+		if err != nil {
+			t.Fatalf("PrefixSum returned error: %v", err)
+		}
+		assertClose(t, got, want)
+	}
+
+	empty := MustNew(0)
+	if !empty.IsEmpty() {
+		t.Fatalf("empty tree should report empty")
+	}
+	if _, err := New(-1); !errors.Is(err, ErrInvalidSize) {
+		t.Fatalf("expected invalid size error, got %v", err)
+	}
+}
+
+func TestPrefixRangePointAndUpdate(t *testing.T) {
+	tree := FromValues(3, 2, 1, 7, 4)
+	sum, err := tree.PrefixSum(0)
+	if err != nil {
+		t.Fatalf("PrefixSum(0) errored: %v", err)
+	}
+	assertClose(t, sum, 0)
+
+	sum, err = tree.RangeSum(2, 4)
+	if err != nil {
+		t.Fatalf("RangeSum returned error: %v", err)
+	}
+	assertClose(t, sum, 10)
+	sum, err = tree.RangeSum(1, 5)
+	if err != nil {
+		t.Fatalf("full RangeSum returned error: %v", err)
+	}
+	assertClose(t, sum, 17)
+
+	point, err := tree.PointQuery(4)
+	if err != nil {
+		t.Fatalf("PointQuery returned error: %v", err)
+	}
+	assertClose(t, point, 7)
+
+	if err := tree.Update(3, 5); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	point, _ = tree.PointQuery(3)
+	assertClose(t, point, 6)
+	sum, _ = tree.PrefixSum(3)
+	assertClose(t, sum, 11)
+}
+
+func TestFindKth(t *testing.T) {
+	tree := FromValues(1, 2, 3, 4, 5)
+	cases := map[float64]int{1: 1, 2: 2, 3: 2, 4: 3, 10: 4}
+	for target, want := range cases {
+		got, err := tree.FindKth(target)
+		if err != nil {
+			t.Fatalf("FindKth(%v) errored: %v", target, err)
+		}
+		if got != want {
+			t.Fatalf("FindKth(%v) = %d", target, got)
+		}
+	}
+}
+
+func TestFindKthErrors(t *testing.T) {
+	if _, err := MustNew(0).FindKth(1); !errors.Is(err, ErrEmptyTree) {
+		t.Fatalf("expected empty tree error, got %v", err)
+	}
+	tree := FromValues(1, 2, 3)
+	if _, err := tree.FindKth(0); !errors.Is(err, ErrNonPositiveTarget) {
+		t.Fatalf("expected non-positive target error, got %v", err)
+	}
+	if _, err := tree.FindKth(100); !errors.Is(err, ErrTargetExceedsSum) {
+		t.Fatalf("expected target-exceeds-total error, got %v", err)
+	}
+}
+
+func TestInvalidIndicesAndRanges(t *testing.T) {
+	tree := FromValues(1, 2, 3)
+	if _, err := tree.PrefixSum(4); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("expected prefix range error, got %v", err)
+	}
+	if err := tree.Update(0, 1); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("expected update range error, got %v", err)
+	}
+	if _, err := tree.RangeSum(3, 1); !errors.Is(err, ErrInvalidRange) {
+		t.Fatalf("expected invalid range error, got %v", err)
+	}
+	if _, err := tree.RangeSum(0, 3); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("expected range index error, got %v", err)
+	}
+	if _, err := tree.RangeSum(1, 4); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("expected right range index error, got %v", err)
+	}
+	if _, err := tree.PointQuery(0); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("expected point query index error, got %v", err)
+	}
+}
+
+func TestMustNewPanicsOnInvalidSize(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("MustNew should panic for invalid size")
+		}
+	}()
+	_ = MustNew(-1)
+}
+
+func TestBruteForceAndRendering(t *testing.T) {
+	values := []float64{5, -2, 7, 1.5, 4.5}
+	tree := FromSlice(values)
+	for index := 1; index <= len(values); index++ {
+		prefix := 0.0
+		for i := 0; i < index; i++ {
+			prefix += values[i]
+		}
+		got, _ := tree.PrefixSum(index)
+		assertClose(t, got, prefix)
+	}
+	if got := tree.BitArray(); len(got) != len(values) {
+		t.Fatalf("BitArray length = %d", len(got))
+	}
+	if !strings.Contains(tree.String(), "FenwickTree") {
+		t.Fatalf("String should identify the tree")
+	}
+}

--- a/code/packages/go/fenwick-tree/go.mod
+++ b/code/packages/go/fenwick-tree/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/fenwick-tree
+
+go 1.23

--- a/code/packages/go/fenwick-tree/required_capabilities.json
+++ b/code/packages/go/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/fenwick_tree/BUILD
+++ b/code/packages/ruby/fenwick_tree/BUILD
@@ -1,0 +1,2 @@
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/fenwick_tree/BUILD_windows
+++ b/code/packages/ruby/fenwick_tree/BUILD_windows
@@ -1,0 +1,2 @@
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/fenwick_tree/CHANGELOG.md
+++ b/code/packages/ruby/fenwick_tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Ruby Fenwick tree package with prefix sums, range sums, point updates,
+  point queries, order-statistic lookup, and validation helpers.

--- a/code/packages/ruby/fenwick_tree/Gemfile
+++ b/code/packages/ruby/fenwick_tree/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/fenwick_tree/README.md
+++ b/code/packages/ruby/fenwick_tree/README.md
@@ -1,0 +1,9 @@
+# coding_adventures_fenwick_tree
+
+A Ruby Binary Indexed Tree for prefix sums and point updates.
+
+```ruby
+tree = CodingAdventures::FenwickTree::FenwickTree.from_list([3, 2, 1, 7, 4])
+tree.range_sum(2, 4) #=> 10
+tree.update(3, 5)
+```

--- a/code/packages/ruby/fenwick_tree/Rakefile
+++ b/code/packages/ruby/fenwick_tree/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/fenwick_tree/coding_adventures_fenwick_tree.gemspec
+++ b/code/packages/ruby/fenwick_tree/coding_adventures_fenwick_tree.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "coding_adventures_fenwick_tree"
+  spec.version = "0.1.0"
+  spec.authors = ["Adhithya Rajasekaran"]
+  spec.summary = "A Binary Indexed Tree for prefix sums"
+  spec.description = "A Ruby Fenwick tree with point updates, range sums, and order-statistic lookup."
+  spec.homepage = "https://github.com/adhithyan15/coding-adventures"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.0.0"
+  spec.files = Dir["lib/**/*.rb", "test/**/*.rb"]
+  spec.require_paths = ["lib"]
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/fenwick_tree/lib/coding_adventures/fenwick_tree.rb
+++ b/code/packages/ruby/fenwick_tree/lib/coding_adventures/fenwick_tree.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module FenwickTree
+    class FenwickError < StandardError; end
+    class IndexOutOfRangeError < FenwickError; end
+    class EmptyTreeError < FenwickError; end
+
+    class FenwickTree
+      attr_reader :length
+
+      def initialize(length)
+        raise FenwickError, "size must be a non-negative integer" unless length.is_a?(Integer) && length >= 0
+
+        @length = length
+        @bit = Array.new(length + 1, 0.0)
+      end
+
+      def self.from_list(values)
+        tree = new(values.length)
+        (1..tree.length).each do |index|
+          tree.instance_variable_get(:@bit)[index] += values.fetch(index - 1)
+          parent = index + lowbit(index)
+          tree.instance_variable_get(:@bit)[parent] += tree.instance_variable_get(:@bit)[index] if parent <= tree.length
+        end
+        tree
+      end
+
+      def update(index, delta)
+        check_index!(index)
+        current = index
+        while current <= @length
+          @bit[current] += delta
+          current += self.class.lowbit(current)
+        end
+        nil
+      end
+
+      def prefix_sum(index)
+        unless index.is_a?(Integer) && index >= 0 && index <= @length
+          raise IndexOutOfRangeError, "prefix_sum index #{index} out of range [0, #{@length}]"
+        end
+
+        total = 0.0
+        current = index
+        while current.positive?
+          total += @bit[current]
+          current -= self.class.lowbit(current)
+        end
+        total
+      end
+
+      def range_sum(left, right)
+        raise FenwickError, "left (#{left}) must be <= right (#{right})" if left > right
+
+        check_index!(left)
+        check_index!(right)
+        left == 1 ? prefix_sum(right) : prefix_sum(right) - prefix_sum(left - 1)
+      end
+
+      def point_query(index)
+        check_index!(index)
+        range_sum(index, index)
+      end
+
+      def find_kth(target)
+        raise EmptyTreeError, "find_kth called on empty tree" if @length.zero?
+        raise FenwickError, "k must be positive, got #{target}" if target <= 0
+
+        total = prefix_sum(@length)
+        raise FenwickError, "k exceeds total sum of the tree" if target > total
+
+        index = 0
+        step = highest_power_of_two_at_most(@length)
+        while step.positive?
+          next_index = index + step
+          if next_index <= @length && @bit[next_index] < target
+            index = next_index
+            target -= @bit[index]
+          end
+          step >>= 1
+        end
+        index + 1
+      end
+
+      def empty?
+        @length.zero?
+      end
+
+      def bit_array
+        @bit[1..] || []
+      end
+
+      def inspect
+        "FenwickTree(n=#{@length}, bit=#{bit_array.inspect})"
+      end
+
+      alias to_s inspect
+
+      def self.lowbit(index)
+        index & -index
+      end
+
+      private
+
+      def check_index!(index)
+        return if index.is_a?(Integer) && index >= 1 && index <= @length
+
+        raise IndexOutOfRangeError, "Index #{index} out of range [1, #{@length}]"
+      end
+
+      def highest_power_of_two_at_most(number)
+        return 0 if number.zero?
+
+        power = 1
+        power <<= 1 while (power << 1) <= number
+        power
+      end
+    end
+  end
+end

--- a/code/packages/ruby/fenwick_tree/lib/coding_adventures_fenwick_tree.rb
+++ b/code/packages/ruby/fenwick_tree/lib/coding_adventures_fenwick_tree.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/fenwick_tree"

--- a/code/packages/ruby/fenwick_tree/required_capabilities.json
+++ b/code/packages/ruby/fenwick_tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/fenwick_tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/fenwick_tree/test/test_fenwick_tree.rb
+++ b/code/packages/ruby/fenwick_tree/test/test_fenwick_tree.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class FenwickTreeTest < Minitest::Test
+  FenwickTree = CodingAdventures::FenwickTree::FenwickTree
+  FenwickError = CodingAdventures::FenwickTree::FenwickError
+  IndexOutOfRangeError = CodingAdventures::FenwickTree::IndexOutOfRangeError
+  EmptyTreeError = CodingAdventures::FenwickTree::EmptyTreeError
+
+  def assert_close(expected, actual)
+    assert_in_delta expected, actual, 1e-9
+  end
+
+  def test_new_and_from_list
+    tree = FenwickTree.from_list([3, 2, 1, 7, 4])
+    assert_equal 5, tree.length
+    refute tree.empty?
+    [3, 5, 6, 13, 17].each_with_index do |expected, index|
+      assert_close expected, tree.prefix_sum(index + 1)
+    end
+
+    assert FenwickTree.new(0).empty?
+    assert_raises(FenwickError) { FenwickTree.new(-1) }
+  end
+
+  def test_prefix_range_point_and_update
+    tree = FenwickTree.from_list([3, 2, 1, 7, 4])
+    assert_close 0, tree.prefix_sum(0)
+    assert_close 10, tree.range_sum(2, 4)
+    assert_close 7, tree.point_query(4)
+
+    tree.update(3, 5)
+    assert_close 6, tree.point_query(3)
+    assert_close 11, tree.prefix_sum(3)
+  end
+
+  def test_find_kth
+    tree = FenwickTree.from_list([1, 2, 3, 4, 5])
+    assert_equal 1, tree.find_kth(1)
+    assert_equal 2, tree.find_kth(2)
+    assert_equal 2, tree.find_kth(3)
+    assert_equal 3, tree.find_kth(4)
+    assert_equal 4, tree.find_kth(10)
+  end
+
+  def test_find_kth_errors
+    assert_raises(EmptyTreeError) { FenwickTree.new(0).find_kth(1) }
+    tree = FenwickTree.from_list([1, 2, 3])
+    assert_raises(FenwickError) { tree.find_kth(0) }
+    assert_raises(FenwickError) { tree.find_kth(100) }
+  end
+
+  def test_invalid_indices_and_ranges
+    tree = FenwickTree.from_list([1, 2, 3])
+    assert_raises(IndexOutOfRangeError) { tree.prefix_sum(4) }
+    assert_raises(IndexOutOfRangeError) { tree.update(0, 1) }
+    assert_raises(FenwickError) { tree.range_sum(3, 1) }
+    assert_raises(IndexOutOfRangeError) { tree.range_sum(0, 3) }
+  end
+
+  def test_brute_force_and_rendering
+    values = [5, -2, 7, 1.5, 4.5]
+    tree = FenwickTree.from_list(values)
+    values.each_index do |index|
+      assert_close values[0..index].sum, tree.prefix_sum(index + 1)
+    end
+    assert_equal values.length, tree.bit_array.length
+    assert_match(/FenwickTree/, tree.to_s)
+  end
+end

--- a/code/packages/ruby/fenwick_tree/test/test_helper.rb
+++ b/code/packages/ruby/fenwick_tree/test/test_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 95
+end
+
+require "minitest/autorun"
+require_relative "../lib/coding_adventures_fenwick_tree"


### PR DESCRIPTION
## Summary
- Adds Fenwick tree packages for Go, Ruby, and Elixir, closing the gap where Rust/Python/TypeScript already had coverage.
- Supports 1-indexed point updates, prefix sums, range sums, point queries, `find_kth`, empty-tree handling, bounds validation, and BIT-array inspection.
- Declares empty capabilities for all three packages; implementations are pure in-memory data structures.

## Verification
- Go: `go test ./... -cover` (94.9%)
- Ruby: `bundle config set path vendor/bundle`, `bundle install --quiet --full-index`, `bundle exec rake test` (100% line coverage)
- Elixir: `mix deps.get --quiet`, `mix test --cover` (96.23%)
- Manual capability scan found no runtime filesystem, network, process, or environment access beyond required_capabilities justification text.