### PR TITLE
feat(parity): add go register vm package

### DIFF
--- a/code/packages/go/register-vm/BUILD
+++ b/code/packages/go/register-vm/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/register-vm/BUILD_windows
+++ b/code/packages/go/register-vm/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/register-vm/CHANGELOG.md
+++ b/code/packages/go/register-vm/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added a Go register VM package with the shared opcode surface used by the Rust, Python, TypeScript, Ruby, and Elixir implementations.
+- Implemented accumulator loads, register moves, globals, context slots, arithmetic and bitwise operations, comparisons, relative jumps, object and array literals, property access, deletion, trace capture, and halt/return execution.
+- Added inline-cache feedback helpers and lexical context helpers for parity with the complete implementations.

--- a/code/packages/go/register-vm/README.md
+++ b/code/packages/go/register-vm/README.md
@@ -1,0 +1,25 @@
+# Register VM (Go)
+
+A register-based bytecode interpreter modeled after the V8 Ignition-style VM used by the other language packages in this repository.
+
+The Go package currently focuses on the portable core: opcodes, bytecode data structures, inline-cache feedback, lexical contexts, property/object helpers, trace capture, and deterministic execution for arithmetic, control-flow, globals, context slots, and object operations. More advanced closure, spread call, generator, and native-extension behavior can be layered on top in later parity batches where Go can either host native implementations or call into Rust-backed packages.
+
+## Example
+
+```go
+code := registervm.CodeObject{
+	Instructions: []registervm.RegisterInstruction{
+		{Opcode: registervm.LdaConstant, Operands: []int{0}},
+		{Opcode: registervm.Star, Operands: []int{0}},
+		{Opcode: registervm.LdaConstant, Operands: []int{1}},
+		{Opcode: registervm.Add, Operands: []int{0, 0}},
+		{Opcode: registervm.Halt},
+	},
+	Constants:         []registervm.VMValue{40, 2},
+	RegisterCount:     1,
+	FeedbackSlotCount: 1,
+}
+
+result, err := registervm.NewRegisterVM().Execute(code)
+// result.Value == 42
+```

--- a/code/packages/go/register-vm/feedback.go
+++ b/code/packages/go/register-vm/feedback.go
@@ -1,0 +1,134 @@
+package registervm
+
+import "fmt"
+
+// FeedbackKind is the inline-cache state for one feedback slot.
+type FeedbackKind string
+
+const (
+	FeedbackUninitialized FeedbackKind = "uninitialized"
+	FeedbackMonomorphic   FeedbackKind = "monomorphic"
+	FeedbackPolymorphic   FeedbackKind = "polymorphic"
+	FeedbackMegamorphic   FeedbackKind = "megamorphic"
+)
+
+// TypePair records the pair of observed operand types at an inline-cache site.
+type TypePair struct {
+	Left  string
+	Right string
+}
+
+// FeedbackSlot stores the current state of one inline-cache slot.
+type FeedbackSlot struct {
+	Kind  FeedbackKind
+	Types []TypePair
+}
+
+var nextHiddenClassID int
+
+// NewHiddenClassID returns a process-local shape id for VMObject instances.
+func NewHiddenClassID() int {
+	id := nextHiddenClassID
+	nextHiddenClassID++
+	return id
+}
+
+// NewVector creates a feedback vector initialized to uninitialized slots.
+func NewVector(size int) []FeedbackSlot {
+	if size <= 0 {
+		return []FeedbackSlot{}
+	}
+	vector := make([]FeedbackSlot, size)
+	for i := range vector {
+		vector[i] = FeedbackSlot{Kind: FeedbackUninitialized}
+	}
+	return vector
+}
+
+// ValueType returns a JavaScript-style type name for a VM value.
+func ValueType(v VMValue) string {
+	switch v.(type) {
+	case bool:
+		return "boolean"
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return "number"
+	case string:
+		return "string"
+	case undefinedValue:
+		return "undefined"
+	case *VMObject, VMObject:
+		return "object"
+	case []VMValue, []any:
+		return "array"
+	case *VMFunction, VMFunction, NativeFunction:
+		return "function"
+	case nil:
+		return "null"
+	default:
+		return "unknown"
+	}
+}
+
+// RecordBinaryOp records the operand types for a binary operation.
+func RecordBinaryOp(vector []FeedbackSlot, slot int, left VMValue, right VMValue) {
+	if slot < 0 || slot >= len(vector) {
+		return
+	}
+	vector[slot] = updateSlot(vector[slot], TypePair{Left: ValueType(left), Right: ValueType(right)})
+}
+
+// RecordPropertyLoad records object shape feedback for a property access.
+func RecordPropertyLoad(vector []FeedbackSlot, slot int, hiddenClassID int) {
+	if slot < 0 || slot >= len(vector) {
+		return
+	}
+	pair := TypePair{Left: fmt.Sprintf("object_%d", hiddenClassID), Right: "property"}
+	vector[slot] = updateSlot(vector[slot], pair)
+}
+
+// RecordCallSite records callee feedback for a call site.
+func RecordCallSite(vector []FeedbackSlot, slot int, calleeType string) {
+	if slot < 0 || slot >= len(vector) {
+		return
+	}
+	vector[slot] = updateSlot(vector[slot], TypePair{Left: calleeType, Right: "call"})
+}
+
+func updateSlot(current FeedbackSlot, pair TypePair) FeedbackSlot {
+	switch current.Kind {
+	case "", FeedbackUninitialized:
+		return FeedbackSlot{Kind: FeedbackMonomorphic, Types: []TypePair{pair}}
+	case FeedbackMonomorphic:
+		if hasPair(current.Types, pair) {
+			return current
+		}
+		return FeedbackSlot{Kind: FeedbackPolymorphic, Types: append(copyPairs(current.Types), pair)}
+	case FeedbackPolymorphic:
+		if hasPair(current.Types, pair) {
+			return current
+		}
+		if len(current.Types) >= 4 {
+			return FeedbackSlot{Kind: FeedbackMegamorphic}
+		}
+		return FeedbackSlot{Kind: FeedbackPolymorphic, Types: append(copyPairs(current.Types), pair)}
+	case FeedbackMegamorphic:
+		return current
+	default:
+		return FeedbackSlot{Kind: FeedbackMonomorphic, Types: []TypePair{pair}}
+	}
+}
+
+func hasPair(pairs []TypePair, pair TypePair) bool {
+	for _, existing := range pairs {
+		if existing == pair {
+			return true
+		}
+	}
+	return false
+}
+
+func copyPairs(pairs []TypePair) []TypePair {
+	copied := make([]TypePair, len(pairs))
+	copy(copied, pairs)
+	return copied
+}

--- a/code/packages/go/register-vm/go.mod
+++ b/code/packages/go/register-vm/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/register-vm
+
+go 1.23

--- a/code/packages/go/register-vm/opcodes.go
+++ b/code/packages/go/register-vm/opcodes.go
@@ -1,0 +1,168 @@
+package registervm
+
+// Opcode identifies one bytecode operation in the register VM.
+type Opcode int
+
+const (
+	// Accumulator loads.
+	LdaConstant  Opcode = 0x00
+	LdaZero      Opcode = 0x01
+	LdaSmi       Opcode = 0x02
+	LdaUndefined Opcode = 0x03
+	LdaNull      Opcode = 0x04
+	LdaTrue      Opcode = 0x05
+	LdaFalse     Opcode = 0x06
+
+	// Register moves.
+	Ldar Opcode = 0x10
+	Star Opcode = 0x11
+	Mov  Opcode = 0x12
+
+	// Variable and context access.
+	LdaGlobal             Opcode = 0x20
+	StaGlobal             Opcode = 0x21
+	LdaLocal              Opcode = 0x22
+	StaLocal              Opcode = 0x23
+	LdaContextSlot        Opcode = 0x24
+	StaContextSlot        Opcode = 0x25
+	LdaCurrentContextSlot Opcode = 0x26
+	StaCurrentContextSlot Opcode = 0x27
+
+	// Arithmetic and bitwise operations.
+	Add               Opcode = 0x30
+	Sub               Opcode = 0x31
+	Mul               Opcode = 0x32
+	Div               Opcode = 0x33
+	Mod               Opcode = 0x34
+	Pow               Opcode = 0x35
+	AddSmi            Opcode = 0x36
+	SubSmi            Opcode = 0x37
+	BitwiseAnd        Opcode = 0x38
+	BitwiseOr         Opcode = 0x39
+	BitwiseXor        Opcode = 0x3A
+	BitwiseNot        Opcode = 0x3B
+	ShiftLeft         Opcode = 0x3C
+	ShiftRight        Opcode = 0x3D
+	ShiftRightLogical Opcode = 0x3E
+	Negate            Opcode = 0x3F
+
+	// Comparisons and type tests.
+	TestEqual              Opcode = 0x40
+	TestNotEqual           Opcode = 0x41
+	TestStrictEqual        Opcode = 0x42
+	TestStrictNotEqual     Opcode = 0x43
+	TestLessThan           Opcode = 0x44
+	TestGreaterThan        Opcode = 0x45
+	TestLessThanOrEqual    Opcode = 0x46
+	TestGreaterThanOrEqual Opcode = 0x47
+	TestIn                 Opcode = 0x48
+	TestInstanceof         Opcode = 0x49
+	TestUndetectable       Opcode = 0x4A
+	LogicalNot             Opcode = 0x4B
+	Typeof                 Opcode = 0x4C
+
+	// Control flow.
+	Jump                  Opcode = 0x50
+	JumpIfTrue            Opcode = 0x51
+	JumpIfFalse           Opcode = 0x52
+	JumpIfNull            Opcode = 0x53
+	JumpIfUndefined       Opcode = 0x54
+	JumpIfNullOrUndefined Opcode = 0x55
+	JumpIfToBooleanTrue   Opcode = 0x56
+	JumpIfToBooleanFalse  Opcode = 0x57
+	JumpLoop              Opcode = 0x58
+
+	// Calls and function control.
+	CallAnyReceiver       Opcode = 0x60
+	CallProperty          Opcode = 0x61
+	CallUndefinedReceiver Opcode = 0x62
+	Construct             Opcode = 0x63
+	ConstructWithSpread   Opcode = 0x64
+	CallWithSpread        Opcode = 0x65
+	Return                Opcode = 0x66
+	SuspendGenerator      Opcode = 0x67
+	ResumeGenerator       Opcode = 0x68
+
+	// Property access.
+	LdaNamedProperty           Opcode = 0x70
+	StaNamedProperty           Opcode = 0x71
+	LdaKeyedProperty           Opcode = 0x72
+	StaKeyedProperty           Opcode = 0x73
+	LdaNamedPropertyNoFeedback Opcode = 0x74
+	StaNamedPropertyNoFeedback Opcode = 0x75
+	DeletePropertyStrict       Opcode = 0x76
+	DeletePropertySloppy       Opcode = 0x77
+
+	// Object and closure creation.
+	CreateObjectLiteral Opcode = 0x80
+	CreateArrayLiteral  Opcode = 0x81
+	CreateRegexpLiteral Opcode = 0x82
+	CreateClosure       Opcode = 0x83
+	CreateContext       Opcode = 0x84
+	CloneObject         Opcode = 0x85
+
+	// Iteration.
+	GetIterator      Opcode = 0x90
+	CallIteratorStep Opcode = 0x91
+	GetIteratorDone  Opcode = 0x92
+	GetIteratorValue Opcode = 0x93
+
+	// Exceptions.
+	Throw   Opcode = 0xA0
+	Rethrow Opcode = 0xA1
+
+	// Context and module variable access.
+	PushContext       Opcode = 0xB0
+	PopContext        Opcode = 0xB1
+	LdaModuleVariable Opcode = 0xB4
+	StaModuleVariable Opcode = 0xB5
+
+	// VM meta instructions.
+	StackCheck Opcode = 0xF0
+	Debugger   Opcode = 0xF1
+	Halt       Opcode = 0xFF
+)
+
+var opcodeNames = map[Opcode]string{
+	LdaConstant: "LDA_CONSTANT", LdaZero: "LDA_ZERO", LdaSmi: "LDA_SMI", LdaUndefined: "LDA_UNDEFINED",
+	LdaNull: "LDA_NULL", LdaTrue: "LDA_TRUE", LdaFalse: "LDA_FALSE", Ldar: "LDAR", Star: "STAR", Mov: "MOV",
+	LdaGlobal: "LDA_GLOBAL", StaGlobal: "STA_GLOBAL", LdaLocal: "LDA_LOCAL", StaLocal: "STA_LOCAL",
+	LdaContextSlot: "LDA_CONTEXT_SLOT", StaContextSlot: "STA_CONTEXT_SLOT",
+	LdaCurrentContextSlot: "LDA_CURRENT_CONTEXT_SLOT", StaCurrentContextSlot: "STA_CURRENT_CONTEXT_SLOT",
+	Add: "ADD", Sub: "SUB", Mul: "MUL", Div: "DIV", Mod: "MOD", Pow: "POW", AddSmi: "ADD_SMI", SubSmi: "SUB_SMI",
+	BitwiseAnd: "BITWISE_AND", BitwiseOr: "BITWISE_OR", BitwiseXor: "BITWISE_XOR", BitwiseNot: "BITWISE_NOT",
+	ShiftLeft: "SHIFT_LEFT", ShiftRight: "SHIFT_RIGHT", ShiftRightLogical: "SHIFT_RIGHT_LOGICAL", Negate: "NEGATE",
+	TestEqual: "TEST_EQUAL", TestNotEqual: "TEST_NOT_EQUAL", TestStrictEqual: "TEST_STRICT_EQUAL",
+	TestStrictNotEqual: "TEST_STRICT_NOT_EQUAL", TestLessThan: "TEST_LESS_THAN", TestGreaterThan: "TEST_GREATER_THAN",
+	TestLessThanOrEqual: "TEST_LESS_THAN_OR_EQUAL", TestGreaterThanOrEqual: "TEST_GREATER_THAN_OR_EQUAL",
+	TestIn: "TEST_IN", TestInstanceof: "TEST_INSTANCEOF", TestUndetectable: "TEST_UNDETECTABLE",
+	LogicalNot: "LOGICAL_NOT", Typeof: "TYPEOF", Jump: "JUMP", JumpIfTrue: "JUMP_IF_TRUE",
+	JumpIfFalse: "JUMP_IF_FALSE", JumpIfNull: "JUMP_IF_NULL", JumpIfUndefined: "JUMP_IF_UNDEFINED",
+	JumpIfNullOrUndefined: "JUMP_IF_NULL_OR_UNDEFINED", JumpIfToBooleanTrue: "JUMP_IF_TO_BOOLEAN_TRUE",
+	JumpIfToBooleanFalse: "JUMP_IF_TO_BOOLEAN_FALSE", JumpLoop: "JUMP_LOOP", CallAnyReceiver: "CALL_ANY_RECEIVER",
+	CallProperty: "CALL_PROPERTY", CallUndefinedReceiver: "CALL_UNDEFINED_RECEIVER", Construct: "CONSTRUCT",
+	ConstructWithSpread: "CONSTRUCT_WITH_SPREAD", CallWithSpread: "CALL_WITH_SPREAD", Return: "RETURN",
+	SuspendGenerator: "SUSPEND_GENERATOR", ResumeGenerator: "RESUME_GENERATOR", LdaNamedProperty: "LDA_NAMED_PROPERTY",
+	StaNamedProperty: "STA_NAMED_PROPERTY", LdaKeyedProperty: "LDA_KEYED_PROPERTY", StaKeyedProperty: "STA_KEYED_PROPERTY",
+	LdaNamedPropertyNoFeedback: "LDA_NAMED_PROPERTY_NO_FEEDBACK",
+	StaNamedPropertyNoFeedback: "STA_NAMED_PROPERTY_NO_FEEDBACK", DeletePropertyStrict: "DELETE_PROPERTY_STRICT",
+	DeletePropertySloppy: "DELETE_PROPERTY_SLOPPY", CreateObjectLiteral: "CREATE_OBJECT_LITERAL",
+	CreateArrayLiteral: "CREATE_ARRAY_LITERAL", CreateRegexpLiteral: "CREATE_REGEXP_LITERAL", CreateClosure: "CREATE_CLOSURE",
+	CreateContext: "CREATE_CONTEXT", CloneObject: "CLONE_OBJECT", GetIterator: "GET_ITERATOR",
+	CallIteratorStep: "CALL_ITERATOR_STEP", GetIteratorDone: "GET_ITERATOR_DONE", GetIteratorValue: "GET_ITERATOR_VALUE",
+	Throw: "THROW", Rethrow: "RETHROW", PushContext: "PUSH_CONTEXT", PopContext: "POP_CONTEXT",
+	LdaModuleVariable: "LDA_MODULE_VARIABLE", StaModuleVariable: "STA_MODULE_VARIABLE", StackCheck: "STACK_CHECK",
+	Debugger: "DEBUGGER", Halt: "HALT",
+}
+
+// OpcodeName returns a stable human-readable name for an opcode.
+func OpcodeName(op Opcode) string {
+	if name, ok := opcodeNames[op]; ok {
+		return name
+	}
+	return "UNKNOWN"
+}
+
+func (op Opcode) String() string {
+	return OpcodeName(op)
+}

--- a/code/packages/go/register-vm/registervm_test.go
+++ b/code/packages/go/register-vm/registervm_test.go
@@ -1,0 +1,654 @@
+package registervm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLoadsArithmeticAndFeedback(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Add, Operands: []int{0, 0}},
+			{Opcode: Halt},
+		},
+		Constants:         []VMValue{40, 2},
+		RegisterCount:     1,
+		FeedbackSlotCount: 1,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != 42 {
+		t.Fatalf("expected 42, got %#v", result.Value)
+	}
+	if result.FeedbackVector[0].Kind != FeedbackMonomorphic {
+		t.Fatalf("expected monomorphic feedback, got %#v", result.FeedbackVector[0])
+	}
+}
+
+func TestRegisterMovesAndSmallIntegers(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaSmi, Operands: []int{10}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: Mov, Operands: []int{0, 1}},
+			{Opcode: Ldar, Operands: []int{1}},
+			{Opcode: AddSmi, Operands: []int{5}},
+			{Opcode: SubSmi, Operands: []int{3}},
+			{Opcode: Halt},
+		},
+		RegisterCount: 2,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != 12 {
+		t.Fatalf("expected 12, got %#v", result.Value)
+	}
+}
+
+func TestStringConcatenationAndTypeof(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Add, Operands: []int{0}},
+			{Opcode: Typeof},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{"world", "hello "},
+		RegisterCount: 1,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != "string" {
+		t.Fatalf("expected typeof string, got %#v", result.Value)
+	}
+}
+
+func TestControlFlow(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaFalse},
+			{Opcode: JumpIfFalse, Operands: []int{2}},
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Jump, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{"wrong", "right"},
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != "right" {
+		t.Fatalf("expected right branch, got %#v", result.Value)
+	}
+}
+
+func TestGlobalsAndModuleVariables(t *testing.T) {
+	vm := NewRegisterVM()
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: StaGlobal, Operands: []int{0}},
+			{Opcode: LdaGlobal, Operands: []int{0}},
+			{Opcode: StaModuleVariable, Operands: []int{1}},
+			{Opcode: LdaModuleVariable, Operands: []int{1}},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{99},
+		Names:     []string{"answer", "exportedAnswer"},
+	}
+
+	result, err := vm.Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != 99 || result.Globals["answer"] != 99 || result.Globals["exportedAnswer"] != 99 {
+		t.Fatalf("unexpected globals/result: %#v %#v", result.Value, result.Globals)
+	}
+}
+
+func TestContextSlots(t *testing.T) {
+	vm := NewRegisterVM()
+	vm.Context = NewContext(nil, 2)
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: StaCurrentContextSlot, Operands: []int{1}},
+			{Opcode: LdaCurrentContextSlot, Operands: []int{1}},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{"closed"},
+	}
+
+	result, err := vm.Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != "closed" {
+		t.Fatalf("expected closed-over value, got %#v", result.Value)
+	}
+}
+
+func TestNamedAndKeyedProperties(t *testing.T) {
+	obj := NewObject()
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: StaNamedProperty, Operands: []int{0, 0, 0}},
+			{Opcode: LdaNamedProperty, Operands: []int{0, 0, 0}},
+			{Opcode: Star, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{2}},
+			{Opcode: Star, Operands: []int{2}},
+			{Opcode: LdaConstant, Operands: []int{3}},
+			{Opcode: StaKeyedProperty, Operands: []int{0, 2}},
+			{Opcode: LdaKeyedProperty, Operands: []int{0, 2}},
+			{Opcode: Halt},
+		},
+		Constants:         []VMValue{obj, 42, "dynamic", "value"},
+		Names:             []string{"answer"},
+		RegisterCount:     3,
+		FeedbackSlotCount: 1,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != "value" || obj.Properties["answer"] != 42 {
+		t.Fatalf("unexpected object properties: %#v", obj.Properties)
+	}
+	if result.FeedbackVector[0].Kind != FeedbackMonomorphic {
+		t.Fatalf("expected property feedback, got %#v", result.FeedbackVector[0])
+	}
+}
+
+func TestArrayLengthAndDelete(t *testing.T) {
+	obj := NewObject()
+	obj.Properties["gone"] = true
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Star, Operands: []int{1}},
+			{Opcode: DeletePropertySloppy, Operands: []int{0, 1}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{obj, "gone"},
+		RegisterCount: 2,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != true {
+		t.Fatalf("expected delete success, got %#v", result.Value)
+	}
+	if _, ok := obj.Properties["gone"]; ok {
+		t.Fatal("expected property to be deleted")
+	}
+
+	arrayCode := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaNamedPropertyNoFeedback, Operands: []int{0, 0}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{[]VMValue{1, 2, 3}},
+		Names:         []string{"length"},
+		RegisterCount: 1,
+	}
+	arrayResult, err := NewRegisterVM().Execute(arrayCode)
+	if err != nil {
+		t.Fatalf("array execute failed: %v", err)
+	}
+	if arrayResult.Value != 3 {
+		t.Fatalf("expected length 3, got %#v", arrayResult.Value)
+	}
+}
+
+func TestComparisonsBitwiseAndLogicalNot(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: TestGreaterThan, Operands: []int{0}},
+			{Opcode: LogicalNot},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{5, 10},
+		RegisterCount: 1,
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != false {
+		t.Fatalf("expected logical negation of true, got %#v", result.Value)
+	}
+
+	bitwise := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: BitwiseOr, Operands: []int{0}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{2, 4},
+		RegisterCount: 1,
+	}
+	bitwiseResult, err := NewRegisterVM().Execute(bitwise)
+	if err != nil {
+		t.Fatalf("bitwise execute failed: %v", err)
+	}
+	if bitwiseResult.Value != 6 {
+		t.Fatalf("expected 6, got %#v", bitwiseResult.Value)
+	}
+}
+
+func TestArithmeticVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		opcode   Opcode
+		right    VMValue
+		left     VMValue
+		expected VMValue
+	}{
+		{name: "sub", opcode: Sub, right: 2, left: 10, expected: 8},
+		{name: "mul", opcode: Mul, right: 6, left: 7, expected: 42},
+		{name: "div", opcode: Div, right: 2, left: 9, expected: 4.5},
+		{name: "mod", opcode: Mod, right: 3, left: 10, expected: 1},
+		{name: "pow", opcode: Pow, right: 3, left: 2, expected: 8},
+		{name: "and", opcode: BitwiseAnd, right: 0b0110, left: 0b1010, expected: 0b0010},
+		{name: "xor", opcode: BitwiseXor, right: 0b0110, left: 0b1010, expected: 0b1100},
+		{name: "shift left", opcode: ShiftLeft, right: 2, left: 3, expected: 12},
+		{name: "shift right", opcode: ShiftRight, right: 1, left: 8, expected: 4},
+		{name: "logical shift right", opcode: ShiftRightLogical, right: 1, left: -2, expected: 2147483647},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NewRegisterVM().Execute(CodeObject{
+				Instructions: []RegisterInstruction{
+					{Opcode: LdaConstant, Operands: []int{0}},
+					{Opcode: Star, Operands: []int{0}},
+					{Opcode: LdaConstant, Operands: []int{1}},
+					{Opcode: test.opcode, Operands: []int{0}},
+					{Opcode: Halt},
+				},
+				Constants:     []VMValue{test.right, test.left},
+				RegisterCount: 1,
+			})
+			if err != nil {
+				t.Fatalf("execute failed: %v", err)
+			}
+			if result.Value != test.expected {
+				t.Fatalf("expected %#v, got %#v", test.expected, result.Value)
+			}
+		})
+	}
+
+	unary := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: BitwiseNot},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Negate},
+			{Opcode: Add, Operands: []int{0}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{0, 5},
+		RegisterCount: 1,
+	}
+	result, err := NewRegisterVM().Execute(unary)
+	if err != nil {
+		t.Fatalf("unary execute failed: %v", err)
+	}
+	if result.Value != -6 {
+		t.Fatalf("expected -6, got %#v", result.Value)
+	}
+}
+
+func TestComparisonAndMembershipVariants(t *testing.T) {
+	obj := NewObject()
+	obj.Properties["answer"] = 42
+
+	tests := []struct {
+		name     string
+		opcode   Opcode
+		right    VMValue
+		left     VMValue
+		expected VMValue
+	}{
+		{name: "loose equal", opcode: TestEqual, right: 7, left: "7", expected: true},
+		{name: "not equal", opcode: TestNotEqual, right: 7, left: 8, expected: true},
+		{name: "strict equal", opcode: TestStrictEqual, right: 7, left: 7, expected: true},
+		{name: "strict not equal", opcode: TestStrictNotEqual, right: 7, left: "7", expected: true},
+		{name: "less than", opcode: TestLessThan, right: 10, left: 5, expected: true},
+		{name: "less than or equal", opcode: TestLessThanOrEqual, right: 5, left: 5, expected: true},
+		{name: "greater than or equal", opcode: TestGreaterThanOrEqual, right: 5, left: 6, expected: true},
+		{name: "in object", opcode: TestIn, right: obj, left: "answer", expected: true},
+		{name: "in string", opcode: TestIn, right: "abcdef", left: "bcd", expected: true},
+		{name: "instanceof", opcode: TestInstanceof, right: obj, left: NewObject(), expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NewRegisterVM().Execute(CodeObject{
+				Instructions: []RegisterInstruction{
+					{Opcode: LdaConstant, Operands: []int{0}},
+					{Opcode: Star, Operands: []int{0}},
+					{Opcode: LdaConstant, Operands: []int{1}},
+					{Opcode: test.opcode, Operands: []int{0}},
+					{Opcode: Halt},
+				},
+				Constants:     []VMValue{test.right, test.left},
+				RegisterCount: 1,
+			})
+			if err != nil {
+				t.Fatalf("execute failed: %v", err)
+			}
+			if result.Value != test.expected {
+				t.Fatalf("expected %#v, got %#v", test.expected, result.Value)
+			}
+		})
+	}
+
+	result, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaUndefined},
+			{Opcode: TestUndetectable},
+			{Opcode: Halt},
+		},
+	})
+	if err != nil {
+		t.Fatalf("undetectable execute failed: %v", err)
+	}
+	if result.Value != true {
+		t.Fatalf("expected undefined to be undetectable, got %#v", result.Value)
+	}
+}
+
+func TestJumpVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		load   Opcode
+		jump   Opcode
+		offset int
+	}{
+		{name: "true", load: LdaTrue, jump: JumpIfTrue, offset: 1},
+		{name: "to boolean true", load: LdaTrue, jump: JumpIfToBooleanTrue, offset: 1},
+		{name: "to boolean false", load: LdaZero, jump: JumpIfToBooleanFalse, offset: 1},
+		{name: "null", load: LdaNull, jump: JumpIfNull, offset: 1},
+		{name: "undefined", load: LdaUndefined, jump: JumpIfUndefined, offset: 1},
+		{name: "null or undefined", load: LdaNull, jump: JumpIfNullOrUndefined, offset: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NewRegisterVM().Execute(CodeObject{
+				Instructions: []RegisterInstruction{
+					{Opcode: test.load},
+					{Opcode: test.jump, Operands: []int{test.offset}},
+					{Opcode: LdaConstant, Operands: []int{0}},
+					{Opcode: LdaConstant, Operands: []int{1}},
+					{Opcode: Halt},
+				},
+				Constants: []VMValue{"wrong", "right"},
+			})
+			if err != nil {
+				t.Fatalf("execute failed: %v", err)
+			}
+			if result.Value != "right" {
+				t.Fatalf("expected jump to right branch, got %#v", result.Value)
+			}
+		})
+	}
+}
+
+func TestContextDepthAndCreationOpcodes(t *testing.T) {
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: CreateContext, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: StaCurrentContextSlot, Operands: []int{0}},
+			{Opcode: PushContext, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: StaCurrentContextSlot, Operands: []int{0}},
+			{Opcode: LdaContextSlot, Operands: []int{1, 0}},
+			{Opcode: PopContext},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{"outer", "inner"},
+	}
+
+	result, err := NewRegisterVM().Execute(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != "outer" {
+		t.Fatalf("expected outer context value, got %#v", result.Value)
+	}
+}
+
+func TestCreationCloneRegexpAndArrayKeyedStore(t *testing.T) {
+	obj := NewObject()
+	obj.Properties["answer"] = 42
+
+	cloneResult, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: CloneObject},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaNamedPropertyNoFeedback, Operands: []int{0, 0}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{obj},
+		Names:         []string{"answer"},
+		RegisterCount: 1,
+	})
+	if err != nil {
+		t.Fatalf("clone execute failed: %v", err)
+	}
+	if cloneResult.Value != 42 {
+		t.Fatalf("expected cloned property, got %#v", cloneResult.Value)
+	}
+
+	arrayResult, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: CreateArrayLiteral},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaSmi, Operands: []int{2}},
+			{Opcode: Star, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: StaKeyedProperty, Operands: []int{0, 1}},
+			{Opcode: LdaNamedPropertyNoFeedback, Operands: []int{0, 0}},
+			{Opcode: Halt},
+		},
+		Constants:     []VMValue{"third"},
+		Names:         []string{"length"},
+		RegisterCount: 2,
+	})
+	if err != nil {
+		t.Fatalf("array execute failed: %v", err)
+	}
+	if arrayResult.Value != 3 {
+		t.Fatalf("expected extended array length, got %#v", arrayResult.Value)
+	}
+
+	regexpResult, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: CreateRegexpLiteral, Operands: []int{0}},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{"[a-z]+"},
+	})
+	if err != nil {
+		t.Fatalf("regexp execute failed: %v", err)
+	}
+	if regexpResult.Value != "[a-z]+" {
+		t.Fatalf("expected regexp placeholder, got %#v", regexpResult.Value)
+	}
+
+	closureResult, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: CreateClosure, Operands: []int{0}},
+			{Opcode: Typeof},
+			{Opcode: Halt},
+		},
+		Constants: []VMValue{CodeObject{Name: "inner"}},
+	})
+	if err != nil {
+		t.Fatalf("closure execute failed: %v", err)
+	}
+	if closureResult.Value != "function" {
+		t.Fatalf("expected closure typeof function, got %#v", closureResult.Value)
+	}
+}
+
+func TestNativeCallAndTrace(t *testing.T) {
+	native := NativeFunction(func(args []VMValue) (VMValue, error) {
+		if len(args) != 2 {
+			return nil, errors.New("expected two args")
+		}
+		return args[0].(int) + args[1].(int), nil
+	})
+	code := CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Star, Operands: []int{0}},
+			{Opcode: LdaConstant, Operands: []int{1}},
+			{Opcode: Star, Operands: []int{1}},
+			{Opcode: LdaConstant, Operands: []int{2}},
+			{Opcode: Star, Operands: []int{2}},
+			{Opcode: CallUndefinedReceiver, Operands: []int{0, 1, 2, 0}},
+			{Opcode: Halt},
+		},
+		Constants:         []VMValue{native, 20, 22},
+		RegisterCount:     3,
+		FeedbackSlotCount: 1,
+	}
+
+	result, err := NewRegisterVM().ExecuteWithTrace(code)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.Value != 42 {
+		t.Fatalf("expected native call result, got %#v", result.Value)
+	}
+	if len(result.Trace) != len(code.Instructions) {
+		t.Fatalf("expected trace for every instruction, got %d", len(result.Trace))
+	}
+	if result.FeedbackVector[0].Kind != FeedbackMonomorphic {
+		t.Fatalf("expected call feedback, got %#v", result.FeedbackVector[0])
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	if OpcodeName(Add) != "ADD" || OpcodeName(Opcode(0xDE)) != "UNKNOWN" || Add.String() != "ADD" {
+		t.Fatalf("unexpected opcode names")
+	}
+	if (RegisterInstruction{Opcode: Add, Operands: []int{0}}).String() != "ADD [0]" {
+		t.Fatalf("unexpected instruction string")
+	}
+	if Undefined.(undefinedValue).String() != "undefined" {
+		t.Fatalf("unexpected undefined string")
+	}
+	if (&VMError{Message: "bad", InstructionIndex: 3, Opcode: Add}).Error() != "bad at instruction 3 (ADD)" {
+		t.Fatalf("unexpected VMError string")
+	}
+
+	ctx := NewContext(nil, 1)
+	if err := SetSlot(ctx, 0, 0, "value"); err != nil {
+		t.Fatalf("set slot failed: %v", err)
+	}
+	got, err := GetSlot(ctx, 0, 0)
+	if err != nil {
+		t.Fatalf("get slot failed: %v", err)
+	}
+	if got != "value" {
+		t.Fatalf("unexpected slot value %#v", got)
+	}
+
+	vector := NewVector(1)
+	RecordBinaryOp(vector, 0, 1, 2)
+	RecordBinaryOp(vector, 0, "a", "b")
+	RecordBinaryOp(vector, 0, true, false)
+	RecordBinaryOp(vector, 0, nil, Undefined)
+	RecordBinaryOp(vector, 0, NewObject(), NewObject())
+	if vector[0].Kind != FeedbackMegamorphic {
+		t.Fatalf("expected megamorphic feedback, got %#v", vector[0])
+	}
+
+	empty := NewVector(0)
+	RecordBinaryOp(empty, 0, 1, 2)
+	RecordPropertyLoad(empty, 0, 1)
+	RecordCallSite(empty, 0, "function")
+}
+
+func TestErrors(t *testing.T) {
+	_, err := NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{{Opcode: Opcode(0xEE)}},
+	})
+	if err == nil {
+		t.Fatal("expected unknown opcode error")
+	}
+
+	_, err = NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: LdaConstant, Operands: []int{0}},
+			{Opcode: Throw},
+		},
+		Constants: []VMValue{"boom"},
+	})
+	if err == nil {
+		t.Fatal("expected throw error")
+	}
+
+	_, err = (&RegisterVM{MaxSteps: 3}).Execute(CodeObject{
+		Instructions: []RegisterInstruction{
+			{Opcode: JumpLoop, Operands: []int{-1}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected max steps error")
+	}
+
+	_, err = NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{{Opcode: LdaConstant, Operands: []int{99}}},
+	})
+	if err == nil {
+		t.Fatal("expected constant bounds error")
+	}
+
+	_, err = NewRegisterVM().Execute(CodeObject{
+		Instructions: []RegisterInstruction{{Opcode: CallWithSpread}},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported opcode error")
+	}
+}

--- a/code/packages/go/register-vm/required_capabilities.json
+++ b/code/packages/go/register-vm/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/register-vm",
+  "capabilities": [],
+  "justification": "Pure in-memory bytecode execution. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/register-vm/scope.go
+++ b/code/packages/go/register-vm/scope.go
@@ -1,0 +1,57 @@
+package registervm
+
+import "fmt"
+
+// NewContext creates a lexical context with slot_count undefined slots.
+func NewContext(parent *Context, slotCount int) *Context {
+	if slotCount < 0 {
+		slotCount = 0
+	}
+	slots := make([]VMValue, slotCount)
+	for i := range slots {
+		slots[i] = Undefined
+	}
+	return &Context{Slots: slots, Parent: parent}
+}
+
+// GetSlot reads a value from a context at depth/index.
+func GetSlot(ctx *Context, depth int, index int) (VMValue, error) {
+	target, err := walkContext(ctx, depth)
+	if err != nil {
+		return nil, err
+	}
+	if index < 0 || index >= len(target.Slots) {
+		return nil, fmt.Errorf("context slot index %d out of range", index)
+	}
+	return target.Slots[index], nil
+}
+
+// SetSlot writes a value into a context at depth/index.
+func SetSlot(ctx *Context, depth int, index int, value VMValue) error {
+	target, err := walkContext(ctx, depth)
+	if err != nil {
+		return err
+	}
+	if index < 0 || index >= len(target.Slots) {
+		return fmt.Errorf("context slot index %d out of range", index)
+	}
+	target.Slots[index] = value
+	return nil
+}
+
+func walkContext(ctx *Context, depth int) (*Context, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+	if depth < 0 {
+		return nil, fmt.Errorf("context depth %d out of range", depth)
+	}
+	current := ctx
+	for i := 0; i < depth; i++ {
+		if current.Parent == nil {
+			return nil, fmt.Errorf("context chain shorter than depth %d", depth)
+		}
+		current = current.Parent
+	}
+	return current, nil
+}

--- a/code/packages/go/register-vm/types.go
+++ b/code/packages/go/register-vm/types.go
@@ -1,0 +1,116 @@
+package registervm
+
+import "fmt"
+
+// VMValue is the dynamic value type carried by registers and the accumulator.
+type VMValue any
+
+type undefinedValue struct{}
+
+// Undefined represents JavaScript's undefined sentinel, distinct from nil/null.
+var Undefined VMValue = undefinedValue{}
+
+// IsUndefined reports whether v is the VM undefined sentinel.
+func IsUndefined(v VMValue) bool {
+	_, ok := v.(undefinedValue)
+	return ok
+}
+
+func (undefinedValue) String() string {
+	return "undefined"
+}
+
+// VMObject is a heap object with a shape identifier and string-keyed storage.
+type VMObject struct {
+	HiddenClassID int
+	Properties    map[string]VMValue
+}
+
+// NewObject creates an object with a fresh hidden class id.
+func NewObject() *VMObject {
+	return ObjectWithHiddenClass(NewHiddenClassID())
+}
+
+// ObjectWithHiddenClass creates an object using an explicit hidden class id.
+func ObjectWithHiddenClass(id int) *VMObject {
+	return &VMObject{HiddenClassID: id, Properties: map[string]VMValue{}}
+}
+
+// NativeFunction is a host function callable by the VM's simple call opcodes.
+type NativeFunction func(args []VMValue) (VMValue, error)
+
+// VMFunction is a closure value made from bytecode plus a captured context.
+type VMFunction struct {
+	Code    CodeObject
+	Context *Context
+	Native  NativeFunction
+}
+
+// CodeObject is one compiled bytecode unit.
+type CodeObject struct {
+	Instructions      []RegisterInstruction
+	Constants         []VMValue
+	Names             []string
+	RegisterCount     int
+	FeedbackSlotCount int
+	ParameterCount    int
+	Name              string
+}
+
+// RegisterInstruction is one opcode plus integer operands.
+type RegisterInstruction struct {
+	Opcode          Opcode
+	Operands        []int
+	FeedbackSlot    int
+	HasFeedbackSlot bool
+}
+
+func (i RegisterInstruction) String() string {
+	if len(i.Operands) == 0 {
+		return OpcodeName(i.Opcode)
+	}
+	return fmt.Sprintf("%s %v", OpcodeName(i.Opcode), i.Operands)
+}
+
+// Context stores lexical closure slots and a parent link.
+type Context struct {
+	Slots  []VMValue
+	Parent *Context
+}
+
+// TraceStep captures the state transition for one executed instruction.
+type TraceStep struct {
+	IP                int
+	Instruction       RegisterInstruction
+	AccumulatorBefore VMValue
+	AccumulatorAfter  VMValue
+	RegistersBefore   []VMValue
+	RegistersAfter    []VMValue
+	FeedbackBefore    []FeedbackSlot
+	FeedbackAfter     []FeedbackSlot
+}
+
+// VMResult is returned after successful execution.
+type VMResult struct {
+	Value          VMValue
+	Globals        map[string]VMValue
+	FeedbackVector []FeedbackSlot
+	Trace          []TraceStep
+}
+
+// VMError describes a bytecode execution failure.
+type VMError struct {
+	Message          string
+	InstructionIndex int
+	Opcode           Opcode
+}
+
+func (e *VMError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Opcode != 0 || e.InstructionIndex >= 0 {
+		return fmt.Sprintf("%s at instruction %d (%s)", e.Message, e.InstructionIndex, OpcodeName(e.Opcode))
+	}
+	return e.Message
+}

--- a/code/packages/go/register-vm/vm.go
+++ b/code/packages/go/register-vm/vm.go
@@ -1,0 +1,1015 @@
+package registervm
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+const defaultMaxSteps = 100000
+
+// RegisterVM executes register bytecode.
+type RegisterVM struct {
+	Globals  map[string]VMValue
+	Context  *Context
+	MaxSteps int
+}
+
+// NewRegisterVM creates a VM with an empty global scope.
+func NewRegisterVM() *RegisterVM {
+	return &RegisterVM{
+		Globals:  map[string]VMValue{},
+		MaxSteps: defaultMaxSteps,
+	}
+}
+
+// Execute runs bytecode and returns the final accumulator value.
+func (vm *RegisterVM) Execute(code CodeObject) (VMResult, error) {
+	return vm.execute(code, false)
+}
+
+// ExecuteWithTrace runs bytecode and records one TraceStep per instruction.
+func (vm *RegisterVM) ExecuteWithTrace(code CodeObject) (VMResult, error) {
+	return vm.execute(code, true)
+}
+
+func (vm *RegisterVM) execute(code CodeObject, wantTrace bool) (VMResult, error) {
+	if vm.Globals == nil {
+		vm.Globals = map[string]VMValue{}
+	}
+	maxSteps := vm.MaxSteps
+	if maxSteps <= 0 {
+		maxSteps = defaultMaxSteps
+	}
+
+	registers := make([]VMValue, code.RegisterCount)
+	for i := range registers {
+		registers[i] = Undefined
+	}
+	feedback := NewVector(code.FeedbackSlotCount)
+	context := vm.Context
+	accumulator := Undefined
+	ip := 0
+	steps := 0
+	trace := []TraceStep{}
+
+	for ip >= 0 && ip < len(code.Instructions) {
+		if steps >= maxSteps {
+			return VMResult{}, &VMError{Message: "maximum instruction count exceeded", InstructionIndex: ip, Opcode: code.Instructions[ip].Opcode}
+		}
+		steps++
+
+		instr := code.Instructions[ip]
+		currentIP := ip
+		accBefore := accumulator
+		regsBefore := cloneValues(registers)
+		feedbackBefore := cloneFeedback(feedback)
+		ip++
+
+		if err := vm.step(code, instr, currentIP, &ip, &accumulator, registers, feedback, &context); err != nil {
+			if vmErr, ok := err.(*VMError); ok {
+				return VMResult{}, vmErr
+			}
+			return VMResult{}, &VMError{Message: err.Error(), InstructionIndex: currentIP, Opcode: instr.Opcode}
+		}
+
+		if wantTrace {
+			trace = append(trace, TraceStep{
+				IP:                currentIP,
+				Instruction:       instr,
+				AccumulatorBefore: accBefore,
+				AccumulatorAfter:  accumulator,
+				RegistersBefore:   regsBefore,
+				RegistersAfter:    cloneValues(registers),
+				FeedbackBefore:    feedbackBefore,
+				FeedbackAfter:     cloneFeedback(feedback),
+			})
+		}
+
+		if instr.Opcode == Halt || instr.Opcode == Return {
+			vm.Context = context
+			return VMResult{Value: accumulator, Globals: cloneGlobals(vm.Globals), FeedbackVector: cloneFeedback(feedback), Trace: trace}, nil
+		}
+	}
+
+	vm.Context = context
+	return VMResult{Value: accumulator, Globals: cloneGlobals(vm.Globals), FeedbackVector: cloneFeedback(feedback), Trace: trace}, nil
+}
+
+func (vm *RegisterVM) step(code CodeObject, instr RegisterInstruction, currentIP int, ip *int, accumulator *VMValue, registers []VMValue, feedback []FeedbackSlot, context **Context) error {
+	operands := instr.Operands
+	op := instr.Opcode
+
+	switch op {
+	case LdaConstant:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := constantAt(code, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case LdaZero:
+		*accumulator = 0
+	case LdaSmi:
+		value, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case LdaUndefined:
+		*accumulator = Undefined
+	case LdaNull:
+		*accumulator = nil
+	case LdaTrue:
+		*accumulator = true
+	case LdaFalse:
+		*accumulator = false
+	case Ldar, LdaLocal:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := registerAt(registers, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case Star, StaLocal:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if err := setRegister(registers, idx, *accumulator); err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+	case Mov:
+		src, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		dst, err := operand(operands, 1)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := registerAt(registers, src)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if err := setRegister(registers, dst, value); err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+	case LdaGlobal, LdaModuleVariable:
+		name, err := nameAt(code, operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, ok := vm.Globals[name]
+		if !ok {
+			if op == LdaModuleVariable {
+				*accumulator = Undefined
+				return nil
+			}
+			return vmError(fmt.Sprintf("global %q is not defined", name), currentIP, op)
+		}
+		*accumulator = value
+	case StaGlobal, StaModuleVariable:
+		name, err := nameAt(code, operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		vm.Globals[name] = *accumulator
+	case LdaContextSlot:
+		depth, idx, err := depthIndex(operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := GetSlot(*context, depth, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case StaContextSlot:
+		depth, idx, err := depthIndex(operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if err := SetSlot(*context, depth, idx, *accumulator); err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+	case LdaCurrentContextSlot:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := GetSlot(*context, 0, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case StaCurrentContextSlot:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if err := SetSlot(*context, 0, idx, *accumulator); err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+	case Add, Sub, Mul, Div, Mod, Pow, BitwiseAnd, BitwiseOr, BitwiseXor, ShiftLeft, ShiftRight, ShiftRightLogical:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		right, err := registerAt(registers, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		fbSlot := feedbackIndex(instr, 1)
+		RecordBinaryOp(feedback, fbSlot, *accumulator, right)
+		result, err := binaryOp(op, *accumulator, right)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = result
+	case AddSmi, SubSmi:
+		value, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		right := VMValue(value)
+		RecordBinaryOp(feedback, feedbackIndex(instr, 1), *accumulator, right)
+		if op == AddSmi {
+			result, err := binaryOp(Add, *accumulator, right)
+			if err != nil {
+				return vmError(err.Error(), currentIP, op)
+			}
+			*accumulator = result
+		} else {
+			result, err := binaryOp(Sub, *accumulator, right)
+			if err != nil {
+				return vmError(err.Error(), currentIP, op)
+			}
+			*accumulator = result
+		}
+	case BitwiseNot:
+		value, ok := toInt(*accumulator)
+		if !ok {
+			return vmError("bitwise not requires an integer", currentIP, op)
+		}
+		*accumulator = ^value
+	case Negate:
+		value, ok := toNumber(*accumulator)
+		if !ok {
+			return vmError("negate requires a number", currentIP, op)
+		}
+		if integral, ok := toInt(*accumulator); ok {
+			*accumulator = -integral
+		} else {
+			*accumulator = -value
+		}
+	case TestEqual, TestNotEqual, TestStrictEqual, TestStrictNotEqual, TestLessThan, TestGreaterThan, TestLessThanOrEqual, TestGreaterThanOrEqual, TestIn, TestInstanceof:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		right, err := registerAt(registers, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		result, err := compareOp(op, *accumulator, right)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = result
+	case TestUndetectable:
+		*accumulator = *accumulator == nil || IsUndefined(*accumulator)
+	case LogicalNot:
+		*accumulator = !truthy(*accumulator)
+	case Typeof:
+		*accumulator = ValueType(*accumulator)
+	case Jump, JumpLoop:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*ip += offset
+	case JumpIfTrue, JumpIfToBooleanTrue:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if truthy(*accumulator) {
+			*ip += offset
+		}
+	case JumpIfFalse, JumpIfToBooleanFalse:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if !truthy(*accumulator) {
+			*ip += offset
+		}
+	case JumpIfNull:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if *accumulator == nil {
+			*ip += offset
+		}
+	case JumpIfUndefined:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if IsUndefined(*accumulator) {
+			*ip += offset
+		}
+	case JumpIfNullOrUndefined:
+		offset, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if *accumulator == nil || IsUndefined(*accumulator) {
+			*ip += offset
+		}
+	case CallAnyReceiver, CallUndefinedReceiver:
+		if err := vm.callNative(code, instr, currentIP, accumulator, registers, feedback); err != nil {
+			return err
+		}
+	case Return:
+		return nil
+	case LdaNamedProperty, LdaNamedPropertyNoFeedback:
+		obj, name, err := objectAndName(code, registers, operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if op == LdaNamedProperty {
+			if receiver, ok := obj.(*VMObject); ok {
+				RecordPropertyLoad(feedback, feedbackIndex(instr, 2), receiver.HiddenClassID)
+			}
+		}
+		value, err := loadNamedProperty(obj, name)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case StaNamedProperty, StaNamedPropertyNoFeedback:
+		obj, name, err := objectAndName(code, registers, operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if op == StaNamedProperty {
+			if receiver, ok := obj.(*VMObject); ok {
+				RecordPropertyLoad(feedback, feedbackIndex(instr, 2), receiver.HiddenClassID)
+			}
+		}
+		if err := storeNamedProperty(obj, name, *accumulator); err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+	case LdaKeyedProperty:
+		obj, key, err := objectAndKey(registers, operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := loadKeyedProperty(obj, key)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case StaKeyedProperty:
+		objReg, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		obj, key, err := objectAndKey(registers, operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		updated, err := storeKeyedProperty(obj, key, *accumulator)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		if updated != nil {
+			registers[objReg] = updated
+		}
+	case DeletePropertyStrict, DeletePropertySloppy:
+		obj, key, err := objectAndKey(registers, operands)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = deleteProperty(obj, key)
+	case CreateObjectLiteral:
+		*accumulator = NewObject()
+	case CreateArrayLiteral:
+		*accumulator = []VMValue{}
+	case CreateRegexpLiteral:
+		if len(operands) == 0 {
+			*accumulator = ""
+			return nil
+		}
+		value, err := constantAt(code, operands[0])
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		*accumulator = value
+	case CreateClosure:
+		idx, err := operand(operands, 0)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		value, err := constantAt(code, idx)
+		if err != nil {
+			return vmError(err.Error(), currentIP, op)
+		}
+		inner, ok := value.(CodeObject)
+		if !ok {
+			return vmError("CREATE_CLOSURE constant is not a CodeObject", currentIP, op)
+		}
+		*accumulator = &VMFunction{Code: inner, Context: *context}
+	case CreateContext, PushContext:
+		slotCount := 0
+		if len(operands) > 0 {
+			slotCount = operands[0]
+		}
+		*context = NewContext(*context, slotCount)
+	case CloneObject:
+		*accumulator = cloneValue(*accumulator)
+	case PopContext:
+		if *context != nil && (*context).Parent != nil {
+			*context = (*context).Parent
+		}
+	case Throw:
+		return vmError(fmt.Sprint(*accumulator), currentIP, op)
+	case Rethrow:
+		return vmError("RETHROW is not implemented", currentIP, op)
+	case StackCheck, Debugger, Halt:
+		return nil
+	case CallProperty, Construct, ConstructWithSpread, CallWithSpread, SuspendGenerator, ResumeGenerator, GetIterator, CallIteratorStep, GetIteratorDone, GetIteratorValue:
+		return vmError(fmt.Sprintf("%s is not implemented in the Go core VM yet", OpcodeName(op)), currentIP, op)
+	default:
+		return vmError(fmt.Sprintf("unknown opcode 0x%02X", int(op)), currentIP, op)
+	}
+	return nil
+}
+
+func (vm *RegisterVM) callNative(code CodeObject, instr RegisterInstruction, currentIP int, accumulator *VMValue, registers []VMValue, feedback []FeedbackSlot) error {
+	calleeReg, err := operand(instr.Operands, 0)
+	if err != nil {
+		return vmError(err.Error(), currentIP, instr.Opcode)
+	}
+	argStart := 1
+	argCount := 0
+	if len(instr.Operands) > 1 {
+		argStart = instr.Operands[1]
+	}
+	if len(instr.Operands) > 2 {
+		argCount = instr.Operands[2]
+	}
+	callee, err := registerAt(registers, calleeReg)
+	if err != nil {
+		return vmError(err.Error(), currentIP, instr.Opcode)
+	}
+	args := make([]VMValue, argCount)
+	for i := range args {
+		args[i], err = registerAt(registers, argStart+i)
+		if err != nil {
+			return vmError(err.Error(), currentIP, instr.Opcode)
+		}
+	}
+
+	var native NativeFunction
+	switch fn := callee.(type) {
+	case NativeFunction:
+		native = fn
+	case *VMFunction:
+		native = fn.Native
+	case VMFunction:
+		native = fn.Native
+	default:
+		return vmError(fmt.Sprintf("cannot call %s", ValueType(callee)), currentIP, instr.Opcode)
+	}
+	if native == nil {
+		return vmError("bytecode function calls are not implemented in the Go core VM yet", currentIP, instr.Opcode)
+	}
+	RecordCallSite(feedback, feedbackIndex(instr, 3), ValueType(callee))
+	result, err := native(args)
+	if err != nil {
+		return vmError(err.Error(), currentIP, instr.Opcode)
+	}
+	*accumulator = result
+	_ = code
+	return nil
+}
+
+func operand(operands []int, idx int) (int, error) {
+	if idx < 0 || idx >= len(operands) {
+		return 0, fmt.Errorf("missing operand %d", idx)
+	}
+	return operands[idx], nil
+}
+
+func depthIndex(operands []int) (int, int, error) {
+	depth, err := operand(operands, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	idx, err := operand(operands, 1)
+	return depth, idx, err
+}
+
+func constantAt(code CodeObject, idx int) (VMValue, error) {
+	if idx < 0 || idx >= len(code.Constants) {
+		return nil, fmt.Errorf("constant index %d out of range", idx)
+	}
+	return code.Constants[idx], nil
+}
+
+func nameAt(code CodeObject, operands []int, operandIndex int) (string, error) {
+	idx, err := operand(operands, operandIndex)
+	if err != nil {
+		return "", err
+	}
+	if idx < 0 || idx >= len(code.Names) {
+		return "", fmt.Errorf("name index %d out of range", idx)
+	}
+	return code.Names[idx], nil
+}
+
+func registerAt(registers []VMValue, idx int) (VMValue, error) {
+	if idx < 0 || idx >= len(registers) {
+		return nil, fmt.Errorf("register index %d out of range", idx)
+	}
+	return registers[idx], nil
+}
+
+func setRegister(registers []VMValue, idx int, value VMValue) error {
+	if idx < 0 || idx >= len(registers) {
+		return fmt.Errorf("register index %d out of range", idx)
+	}
+	registers[idx] = value
+	return nil
+}
+
+func feedbackIndex(instr RegisterInstruction, operandIndex int) int {
+	if instr.HasFeedbackSlot {
+		return instr.FeedbackSlot
+	}
+	if operandIndex >= 0 && operandIndex < len(instr.Operands) {
+		return instr.Operands[operandIndex]
+	}
+	return -1
+}
+
+func binaryOp(op Opcode, left VMValue, right VMValue) (VMValue, error) {
+	if op == Add {
+		if _, ok := left.(string); ok {
+			return stringify(left) + stringify(right), nil
+		}
+		if _, ok := right.(string); ok {
+			return stringify(left) + stringify(right), nil
+		}
+	}
+
+	leftInt, leftIsInt := toInt(left)
+	rightInt, rightIsInt := toInt(right)
+	leftNum, leftIsNum := toNumber(left)
+	rightNum, rightIsNum := toNumber(right)
+	if !leftIsNum || !rightIsNum {
+		return nil, fmt.Errorf("%s requires numeric operands", OpcodeName(op))
+	}
+
+	switch op {
+	case Add:
+		if leftIsInt && rightIsInt {
+			return leftInt + rightInt, nil
+		}
+		return leftNum + rightNum, nil
+	case Sub:
+		if leftIsInt && rightIsInt {
+			return leftInt - rightInt, nil
+		}
+		return leftNum - rightNum, nil
+	case Mul:
+		if leftIsInt && rightIsInt {
+			return leftInt * rightInt, nil
+		}
+		return leftNum * rightNum, nil
+	case Div:
+		if rightNum == 0 {
+			return nil, fmt.Errorf("division by zero")
+		}
+		return leftNum / rightNum, nil
+	case Mod:
+		if rightNum == 0 {
+			return nil, fmt.Errorf("modulo by zero")
+		}
+		if leftIsInt && rightIsInt {
+			return leftInt % rightInt, nil
+		}
+		return math.Mod(leftNum, rightNum), nil
+	case Pow:
+		result := math.Pow(leftNum, rightNum)
+		if leftIsInt && rightIsInt && result == math.Trunc(result) {
+			return int(result), nil
+		}
+		return result, nil
+	case BitwiseAnd:
+		return leftInt & rightInt, nil
+	case BitwiseOr:
+		return leftInt | rightInt, nil
+	case BitwiseXor:
+		return leftInt ^ rightInt, nil
+	case ShiftLeft:
+		return leftInt << rightInt, nil
+	case ShiftRight:
+		return leftInt >> rightInt, nil
+	case ShiftRightLogical:
+		return int(uint32(leftInt) >> uint(rightInt)), nil
+	default:
+		return nil, fmt.Errorf("unsupported binary operation %s", OpcodeName(op))
+	}
+}
+
+func compareOp(op Opcode, left VMValue, right VMValue) (bool, error) {
+	switch op {
+	case TestEqual:
+		return looseEqual(left, right), nil
+	case TestNotEqual:
+		return !looseEqual(left, right), nil
+	case TestStrictEqual:
+		return strictEqual(left, right), nil
+	case TestStrictNotEqual:
+		return !strictEqual(left, right), nil
+	case TestLessThan, TestGreaterThan, TestLessThanOrEqual, TestGreaterThanOrEqual:
+		leftNum, lok := toNumber(left)
+		rightNum, rok := toNumber(right)
+		if lok && rok {
+			switch op {
+			case TestLessThan:
+				return leftNum < rightNum, nil
+			case TestGreaterThan:
+				return leftNum > rightNum, nil
+			case TestLessThanOrEqual:
+				return leftNum <= rightNum, nil
+			case TestGreaterThanOrEqual:
+				return leftNum >= rightNum, nil
+			}
+		}
+		leftStr, lok := left.(string)
+		rightStr, rok := right.(string)
+		if lok && rok {
+			switch op {
+			case TestLessThan:
+				return leftStr < rightStr, nil
+			case TestGreaterThan:
+				return leftStr > rightStr, nil
+			case TestLessThanOrEqual:
+				return leftStr <= rightStr, nil
+			case TestGreaterThanOrEqual:
+				return leftStr >= rightStr, nil
+			}
+		}
+		return false, fmt.Errorf("%s requires comparable operands", OpcodeName(op))
+	case TestIn:
+		key := stringify(left)
+		switch obj := right.(type) {
+		case *VMObject:
+			_, ok := obj.Properties[key]
+			return ok, nil
+		case VMObject:
+			_, ok := obj.Properties[key]
+			return ok, nil
+		case []VMValue:
+			idx, err := strconv.Atoi(key)
+			return err == nil && idx >= 0 && idx < len(obj), nil
+		case string:
+			return contains(obj, key), nil
+		default:
+			return false, fmt.Errorf("right operand is not searchable")
+		}
+	case TestInstanceof:
+		if right == nil || left == nil {
+			return false, nil
+		}
+		return reflect.TypeOf(left) == reflect.TypeOf(right), nil
+	default:
+		return false, fmt.Errorf("unsupported comparison %s", OpcodeName(op))
+	}
+}
+
+func looseEqual(left VMValue, right VMValue) bool {
+	if strictEqual(left, right) {
+		return true
+	}
+	leftNum, lok := toNumber(left)
+	rightNum, rok := toNumber(right)
+	if lok && rok {
+		return leftNum == rightNum
+	}
+	return stringify(left) == stringify(right)
+}
+
+func strictEqual(left VMValue, right VMValue) bool {
+	if IsUndefined(left) || IsUndefined(right) {
+		return IsUndefined(left) && IsUndefined(right)
+	}
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	if reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func toNumber(value VMValue) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func toInt(value VMValue) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int8:
+		return int(v), true
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func truthy(value VMValue) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case undefinedValue:
+		return false
+	case bool:
+		return v
+	case int:
+		return v != 0
+	case int8:
+		return v != 0
+	case int16:
+		return v != 0
+	case int32:
+		return v != 0
+	case int64:
+		return v != 0
+	case uint:
+		return v != 0
+	case uint8:
+		return v != 0
+	case uint16:
+		return v != 0
+	case uint32:
+		return v != 0
+	case uint64:
+		return v != 0
+	case float32:
+		return v != 0
+	case float64:
+		return v != 0
+	case string:
+		return v != ""
+	default:
+		return true
+	}
+}
+
+func stringify(value VMValue) string {
+	if IsUndefined(value) {
+		return "undefined"
+	}
+	if value == nil {
+		return "null"
+	}
+	return fmt.Sprint(value)
+}
+
+func objectAndName(code CodeObject, registers []VMValue, operands []int) (VMValue, string, error) {
+	objReg, err := operand(operands, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	obj, err := registerAt(registers, objReg)
+	if err != nil {
+		return nil, "", err
+	}
+	name, err := nameAt(code, operands, 1)
+	return obj, name, err
+}
+
+func objectAndKey(registers []VMValue, operands []int) (VMValue, VMValue, error) {
+	objReg, err := operand(operands, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyReg, err := operand(operands, 1)
+	if err != nil {
+		return nil, nil, err
+	}
+	obj, err := registerAt(registers, objReg)
+	if err != nil {
+		return nil, nil, err
+	}
+	key, err := registerAt(registers, keyReg)
+	return obj, key, err
+}
+
+func loadNamedProperty(obj VMValue, name string) (VMValue, error) {
+	switch receiver := obj.(type) {
+	case *VMObject:
+		if value, ok := receiver.Properties[name]; ok {
+			return value, nil
+		}
+		return Undefined, nil
+	case VMObject:
+		if value, ok := receiver.Properties[name]; ok {
+			return value, nil
+		}
+		return Undefined, nil
+	case []VMValue:
+		if name == "length" {
+			return len(receiver), nil
+		}
+	}
+	return nil, fmt.Errorf("cannot load property %q from %s", name, ValueType(obj))
+}
+
+func storeNamedProperty(obj VMValue, name string, value VMValue) error {
+	switch receiver := obj.(type) {
+	case *VMObject:
+		receiver.Properties[name] = value
+		return nil
+	case VMObject:
+		receiver.Properties[name] = value
+		return nil
+	default:
+		return fmt.Errorf("cannot store property %q on %s", name, ValueType(obj))
+	}
+}
+
+func loadKeyedProperty(obj VMValue, key VMValue) (VMValue, error) {
+	switch receiver := obj.(type) {
+	case *VMObject:
+		if value, ok := receiver.Properties[stringify(key)]; ok {
+			return value, nil
+		}
+		return Undefined, nil
+	case VMObject:
+		if value, ok := receiver.Properties[stringify(key)]; ok {
+			return value, nil
+		}
+		return Undefined, nil
+	case []VMValue:
+		idx, ok := toInt(key)
+		if ok && idx >= 0 && idx < len(receiver) {
+			return receiver[idx], nil
+		}
+		return Undefined, nil
+	default:
+		return nil, fmt.Errorf("cannot keyed-load from %s", ValueType(obj))
+	}
+}
+
+func storeKeyedProperty(obj VMValue, key VMValue, value VMValue) (VMValue, error) {
+	switch receiver := obj.(type) {
+	case *VMObject:
+		receiver.Properties[stringify(key)] = value
+		return nil, nil
+	case VMObject:
+		receiver.Properties[stringify(key)] = value
+		return receiver, nil
+	case []VMValue:
+		idx, ok := toInt(key)
+		if !ok || idx < 0 {
+			return nil, fmt.Errorf("array key must be a non-negative integer")
+		}
+		for len(receiver) <= idx {
+			receiver = append(receiver, Undefined)
+		}
+		receiver[idx] = value
+		return receiver, nil
+	default:
+		return nil, fmt.Errorf("cannot keyed-store on %s", ValueType(obj))
+	}
+}
+
+func deleteProperty(obj VMValue, key VMValue) bool {
+	switch receiver := obj.(type) {
+	case *VMObject:
+		delete(receiver.Properties, stringify(key))
+		return true
+	case VMObject:
+		delete(receiver.Properties, stringify(key))
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneValue(value VMValue) VMValue {
+	switch v := value.(type) {
+	case *VMObject:
+		cloned := NewObject()
+		for key, prop := range v.Properties {
+			cloned.Properties[key] = prop
+		}
+		return cloned
+	case VMObject:
+		cloned := NewObject()
+		for key, prop := range v.Properties {
+			cloned.Properties[key] = prop
+		}
+		return cloned
+	case []VMValue:
+		return cloneValues(v)
+	default:
+		return value
+	}
+}
+
+func cloneValues(values []VMValue) []VMValue {
+	copied := make([]VMValue, len(values))
+	copy(copied, values)
+	return copied
+}
+
+func cloneFeedback(slots []FeedbackSlot) []FeedbackSlot {
+	copied := make([]FeedbackSlot, len(slots))
+	for i, slot := range slots {
+		copied[i] = FeedbackSlot{Kind: slot.Kind, Types: copyPairs(slot.Types)}
+	}
+	return copied
+}
+
+func cloneGlobals(globals map[string]VMValue) map[string]VMValue {
+	copied := make(map[string]VMValue, len(globals))
+	for key, value := range globals {
+		copied[key] = value
+	}
+	return copied
+}
+
+func contains(haystack string, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func vmError(message string, instructionIndex int, opcode Opcode) *VMError {
+	return &VMError{Message: message, InstructionIndex: instructionIndex, Opcode: opcode}
+}


### PR DESCRIPTION
## Summary
- add a Go register-vm package to close the missing language gap for the register VM family
- include the shared opcode surface, VM data types, inline-cache feedback helpers, lexical context helpers, and object helpers
- implement the portable VM core for loads, register moves, globals/modules, context slots, arithmetic, comparisons, jumps, native calls, properties, creation, trace capture, halt/return, and structured VM errors

## Verification
- go test ./... -cover
- required_capabilities.json parses with ConvertFrom-Json