### PR TITLE
feat(parity): add go haskell lexer and parser

### DIFF
--- a/code/packages/go/haskell-lexer/BUILD
+++ b/code/packages/go/haskell-lexer/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/haskell-lexer/BUILD_windows
+++ b/code/packages/go/haskell-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/haskell-lexer/CHANGELOG.md
+++ b/code/packages/go/haskell-lexer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Go Haskell lexer wrapper over the shared grammar-driven lexer.
+- Added routing for the repository's Haskell 1.0, 1.1, 1.2, 1.3, 1.4, Haskell 98, and Haskell 2010 token grammars.
+- Added tests for default tokenization, layout tokens, version routing, lexer creation, and invalid versions.

--- a/code/packages/go/haskell-lexer/README.md
+++ b/code/packages/go/haskell-lexer/README.md
@@ -1,0 +1,11 @@
+# Haskell Lexer (Go)
+
+Grammar-driven Haskell lexer for Go.
+
+This package loads one of the repository's `code/grammars/haskell/haskell*.tokens` files and delegates tokenization to the shared Go `lexer` package. It matches the public surface used by the Python and TypeScript Haskell lexer packages:
+
+- `CreateHaskellLexer(source, version)` returns a configured grammar lexer.
+- `TokenizeHaskell(source, version)` returns the complete token stream.
+- `DefaultVersion` is `2010`.
+
+Pass an empty version string to use Haskell 2010. Supported versions are `1.0`, `1.1`, `1.2`, `1.3`, `1.4`, `98`, and `2010`.

--- a/code/packages/go/haskell-lexer/go.mod
+++ b/code/packages/go/haskell-lexer/go.mod
@@ -1,0 +1,21 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/haskell-lexer
+
+go 1.23
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph

--- a/code/packages/go/haskell-lexer/haskell_lexer_test.go
+++ b/code/packages/go/haskell-lexer/haskell_lexer_test.go
@@ -1,0 +1,69 @@
+package haskelllexer
+
+import (
+	"testing"
+
+	"github.com/adhithyan15/coding-adventures/code/packages/go/lexer"
+)
+
+func TestTokenizeHaskellDefaultVersion(t *testing.T) {
+	tokens, err := TokenizeHaskell("x", "")
+	if err != nil {
+		t.Fatalf("tokenize failed: %v", err)
+	}
+	if len(tokens) < 2 {
+		t.Fatalf("expected name and EOF tokens, got %#v", tokens)
+	}
+	if tokens[0].TypeName != "NAME" || tokens[0].Value != "x" {
+		t.Fatalf("expected NAME x, got %#v", tokens[0])
+	}
+	if tokens[len(tokens)-1].Type != lexer.TokenEOF {
+		t.Fatalf("expected EOF token, got %#v", tokens[len(tokens)-1])
+	}
+}
+
+func TestTokenizeHaskellEmitsLayoutTokens(t *testing.T) {
+	tokens, err := TokenizeHaskell("let\n  x = y\nin x", "")
+	if err != nil {
+		t.Fatalf("tokenize failed: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, token := range tokens {
+		seen[token.TypeName] = true
+	}
+	if !seen["VIRTUAL_LBRACE"] || !seen["VIRTUAL_RBRACE"] {
+		t.Fatalf("expected virtual layout braces, saw %#v", seen)
+	}
+}
+
+func TestTokenizeHaskellVersions(t *testing.T) {
+	for _, version := range ValidVersions() {
+		t.Run(version, func(t *testing.T) {
+			tokens, err := TokenizeHaskell("x", version)
+			if err != nil {
+				t.Fatalf("tokenize %s failed: %v", version, err)
+			}
+			if tokens[0].TypeName != "NAME" {
+				t.Fatalf("expected NAME for %s, got %#v", version, tokens[0])
+			}
+		})
+	}
+}
+
+func TestCreateHaskellLexer(t *testing.T) {
+	haskellLexer, err := CreateHaskellLexer("x", "2010")
+	if err != nil {
+		t.Fatalf("create lexer failed: %v", err)
+	}
+	if haskellLexer == nil {
+		t.Fatal("expected non-nil lexer")
+	}
+}
+
+func TestTokenizeHaskellUnknownVersion(t *testing.T) {
+	_, err := TokenizeHaskell("x", "2020")
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+}

--- a/code/packages/go/haskell-lexer/lexer.go
+++ b/code/packages/go/haskell-lexer/lexer.go
@@ -1,0 +1,85 @@
+package haskelllexer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	grammartools "github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/lexer"
+)
+
+// DefaultVersion is used when callers pass version="".
+const DefaultVersion = "2010"
+
+var validVersions = map[string]bool{
+	"1.0":  true,
+	"1.1":  true,
+	"1.2":  true,
+	"1.3":  true,
+	"1.4":  true,
+	"98":   true,
+	"2010": true,
+}
+
+// ValidVersions returns the supported Haskell grammar versions in stable order.
+func ValidVersions() []string {
+	versions := make([]string, 0, len(validVersions))
+	for version := range validVersions {
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func normalizeVersion(version string) (string, error) {
+	if version == "" {
+		return DefaultVersion, nil
+	}
+	if validVersions[version] {
+		return version, nil
+	}
+	return "", fmt.Errorf("unknown Haskell version %q: valid versions are %s", version, strings.Join(ValidVersions(), ", "))
+}
+
+func grammarRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "grammars")
+}
+
+func getTokensPath(version string) (string, error) {
+	effectiveVersion, err := normalizeVersion(version)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(grammarRoot(), "haskell", "haskell"+effectiveVersion+".tokens"), nil
+}
+
+// CreateHaskellLexer constructs a shared GrammarLexer for the selected Haskell version.
+func CreateHaskellLexer(source string, version string) (*lexer.GrammarLexer, error) {
+	tokensPath, err := getTokensPath(version)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := os.ReadFile(tokensPath)
+	if err != nil {
+		return nil, err
+	}
+	grammar, err := grammartools.ParseTokenGrammar(string(bytes))
+	if err != nil {
+		return nil, err
+	}
+	return lexer.NewGrammarLexer(source, grammar), nil
+}
+
+// TokenizeHaskell tokenizes source with the selected Haskell grammar.
+func TokenizeHaskell(source string, version string) ([]lexer.Token, error) {
+	haskellLexer, err := CreateHaskellLexer(source, version)
+	if err != nil {
+		return nil, err
+	}
+	return haskellLexer.Tokenize(), nil
+}

--- a/code/packages/go/haskell-lexer/required_capabilities.json
+++ b/code/packages/go/haskell-lexer/required_capabilities.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/haskell-lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.0.tokens",
+      "justification": "Haskell 1.0 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.1.tokens",
+      "justification": "Haskell 1.1 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.2.tokens",
+      "justification": "Haskell 1.2 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.3.tokens",
+      "justification": "Haskell 1.3 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.4.tokens",
+      "justification": "Haskell 1.4 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell98.tokens",
+      "justification": "Haskell 98 token grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell2010.tokens",
+      "justification": "Haskell 2010 token grammar."
+    }
+  ],
+  "justification": "Reads grammar definition files for the selected Haskell version. No write, network, or process access needed."
+}

--- a/code/packages/go/haskell-parser/BUILD
+++ b/code/packages/go/haskell-parser/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/haskell-parser/BUILD_windows
+++ b/code/packages/go/haskell-parser/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/haskell-parser/CHANGELOG.md
+++ b/code/packages/go/haskell-parser/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Go Haskell parser wrapper over the shared grammar-driven parser.
+- Added version routing for Haskell 1.0, 1.1, 1.2, 1.3, 1.4, Haskell 98, and Haskell 2010 parser grammars.
+- Added tests for parsing default/versioned sources, parser construction, and invalid versions.

--- a/code/packages/go/haskell-parser/README.md
+++ b/code/packages/go/haskell-parser/README.md
@@ -1,0 +1,11 @@
+# Haskell Parser (Go)
+
+Grammar-driven Haskell parser for Go.
+
+This package tokenizes Haskell source with `go/haskell-lexer`, loads the matching `code/grammars/haskell/haskell*.grammar` file, and delegates parsing to the shared Go `parser` package.
+
+- `CreateHaskellParser(source, version)` returns a configured grammar parser.
+- `ParseHaskell(source, version)` returns the parse tree root.
+- `DefaultVersion` is `2010`.
+
+Supported versions are `1.0`, `1.1`, `1.2`, `1.3`, `1.4`, `98`, and `2010`.

--- a/code/packages/go/haskell-parser/go.mod
+++ b/code/packages/go/haskell-parser/go.mod
@@ -1,0 +1,27 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/haskell-parser
+
+go 1.23
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/haskell-lexer v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/haskell-lexer => ../haskell-lexer
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph

--- a/code/packages/go/haskell-parser/haskell_parser_test.go
+++ b/code/packages/go/haskell-parser/haskell_parser_test.go
@@ -1,0 +1,58 @@
+package haskellparser
+
+import "testing"
+
+func TestParseHaskellDefaultVersion(t *testing.T) {
+	ast, err := ParseHaskell("x", "")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if ast.RuleName != "file" {
+		t.Fatalf("expected file root, got %s", ast.RuleName)
+	}
+}
+
+func TestParseHaskellExplicitLayout(t *testing.T) {
+	parser, err := CreateHaskellParser("let { x = y } in x", "2010")
+	if err != nil {
+		t.Fatalf("create parser failed: %v", err)
+	}
+	ast, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if ast.RuleName != "file" {
+		t.Fatalf("expected file root, got %s", ast.RuleName)
+	}
+}
+
+func TestParseHaskellVersions(t *testing.T) {
+	for _, version := range ValidVersions() {
+		t.Run(version, func(t *testing.T) {
+			ast, err := ParseHaskell("x", version)
+			if err != nil {
+				t.Fatalf("parse %s failed: %v", version, err)
+			}
+			if ast.RuleName != "file" {
+				t.Fatalf("expected file root for %s, got %s", version, ast.RuleName)
+			}
+		})
+	}
+}
+
+func TestCreateHaskellParser(t *testing.T) {
+	parser, err := CreateHaskellParser("x", "98")
+	if err != nil {
+		t.Fatalf("create parser failed: %v", err)
+	}
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+}
+
+func TestParseHaskellUnknownVersion(t *testing.T) {
+	_, err := ParseHaskell("x", "2020")
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+}

--- a/code/packages/go/haskell-parser/parser.go
+++ b/code/packages/go/haskell-parser/parser.go
@@ -1,0 +1,90 @@
+package haskellparser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	grammartools "github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools"
+	haskelllexer "github.com/adhithyan15/coding-adventures/code/packages/go/haskell-lexer"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/parser"
+)
+
+// DefaultVersion is used when callers pass version="".
+const DefaultVersion = "2010"
+
+var validVersions = map[string]bool{
+	"1.0":  true,
+	"1.1":  true,
+	"1.2":  true,
+	"1.3":  true,
+	"1.4":  true,
+	"98":   true,
+	"2010": true,
+}
+
+// ValidVersions returns the supported Haskell grammar versions in stable order.
+func ValidVersions() []string {
+	versions := make([]string, 0, len(validVersions))
+	for version := range validVersions {
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func normalizeVersion(version string) (string, error) {
+	if version == "" {
+		return DefaultVersion, nil
+	}
+	if validVersions[version] {
+		return version, nil
+	}
+	return "", fmt.Errorf("unknown Haskell version %q: valid versions are %s", version, strings.Join(ValidVersions(), ", "))
+}
+
+func grammarRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "grammars")
+}
+
+func getGrammarPath(version string) (string, error) {
+	effectiveVersion, err := normalizeVersion(version)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(grammarRoot(), "haskell", "haskell"+effectiveVersion+".grammar"), nil
+}
+
+// CreateHaskellParser constructs a shared GrammarParser for the selected Haskell version.
+func CreateHaskellParser(source string, version string) (*parser.GrammarParser, error) {
+	tokens, err := haskelllexer.TokenizeHaskell(source, version)
+	if err != nil {
+		return nil, err
+	}
+	grammarPath, err := getGrammarPath(version)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := os.ReadFile(grammarPath)
+	if err != nil {
+		return nil, err
+	}
+	grammar, err := grammartools.ParseParserGrammar(string(bytes))
+	if err != nil {
+		return nil, err
+	}
+	return parser.NewGrammarParser(tokens, grammar), nil
+}
+
+// ParseHaskell parses source with the selected Haskell grammar.
+func ParseHaskell(source string, version string) (*parser.ASTNode, error) {
+	haskellParser, err := CreateHaskellParser(source, version)
+	if err != nil {
+		return nil, err
+	}
+	return haskellParser.Parse()
+}

--- a/code/packages/go/haskell-parser/required_capabilities.json
+++ b/code/packages/go/haskell-parser/required_capabilities.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/haskell-parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.0.grammar",
+      "justification": "Haskell 1.0 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.1.grammar",
+      "justification": "Haskell 1.1 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.2.grammar",
+      "justification": "Haskell 1.2 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.3.grammar",
+      "justification": "Haskell 1.3 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell1.4.grammar",
+      "justification": "Haskell 1.4 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell98.grammar",
+      "justification": "Haskell 98 parser grammar."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../grammars/haskell/haskell2010.grammar",
+      "justification": "Haskell 2010 parser grammar."
+    }
+  ],
+  "justification": "Reads grammar definition files for the selected Haskell version. No write, network, or process access needed."
+}


### PR DESCRIPTION
## Summary
- add Go Haskell lexer and parser packages to close the Go gap for the Haskell grammar family
- route the lexer/parser to the repository Haskell 1.0, 1.1, 1.2, 1.3, 1.4, 98, and 2010 grammars
- include required capability manifests for grammar reads and focused tests for default/versioned parsing, layout tokens, and invalid versions

## Verification
- go test ./... -cover (go/haskell-lexer: 93.3%)
- go test ./... -cover (go/haskell-parser: 84.8%)
- required_capabilities.json parses with ConvertFrom-Json