### PR TITLE
feat(parity): add elixir lisp lexer and parser

### DIFF
--- a/code/packages/elixir/lisp_lexer/BUILD
+++ b/code/packages/elixir/lisp_lexer/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/lisp_lexer/CHANGELOG.md
+++ b/code/packages/elixir/lisp_lexer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Elixir Lisp lexer wrapper over the shared grammar-driven lexer.
+- Added tests for basic lists, operator symbols, comments, quoted dotted pairs, grammar creation, and invalid input errors.

--- a/code/packages/elixir/lisp_lexer/README.md
+++ b/code/packages/elixir/lisp_lexer/README.md
@@ -1,0 +1,9 @@
+# Lisp Lexer (Elixir)
+
+Grammar-driven Lisp lexer for Elixir.
+
+This package loads `code/grammars/lisp.tokens` and delegates tokenization to `CodingAdventures.Lexer.GrammarLexer`.
+
+```elixir
+{:ok, tokens} = CodingAdventures.LispLexer.tokenize("(define x 42)")
+```

--- a/code/packages/elixir/lisp_lexer/lib/coding_adventures/lisp_lexer.ex
+++ b/code/packages/elixir/lisp_lexer/lib/coding_adventures/lisp_lexer.ex
@@ -1,0 +1,41 @@
+defmodule CodingAdventures.LispLexer do
+  @moduledoc """
+  Lisp lexer backed by the shared grammar-driven lexer engine.
+
+  The lexer reads `lisp.tokens` from `code/grammars/`, parses the file into a
+  `TokenGrammar`, caches it in `:persistent_term`, and delegates tokenization
+  to `CodingAdventures.Lexer.GrammarLexer`.
+  """
+
+  alias CodingAdventures.GrammarTools.TokenGrammar
+  alias CodingAdventures.Lexer.GrammarLexer
+
+  @grammars_dir Path.join([__DIR__, "..", "..", "..", "..", "..", "grammars"])
+                |> Path.expand()
+
+  @doc """
+  Tokenize Lisp source code and return `{:ok, tokens}` or `{:error, message}`.
+  """
+  @spec tokenize(String.t()) ::
+          {:ok, [CodingAdventures.Lexer.Token.t()]} | {:error, String.t()}
+  def tokenize(source) when is_binary(source) do
+    GrammarLexer.tokenize(source, create_lexer())
+  end
+
+  @doc """
+  Parse and return the cached Lisp `TokenGrammar`.
+  """
+  @spec create_lexer() :: TokenGrammar.t()
+  def create_lexer do
+    case :persistent_term.get({__MODULE__, :grammar}, nil) do
+      nil ->
+        tokens_path = Path.join(@grammars_dir, "lisp.tokens")
+        {:ok, grammar} = TokenGrammar.parse(File.read!(tokens_path))
+        :persistent_term.put({__MODULE__, :grammar}, grammar)
+        grammar
+
+      grammar ->
+        grammar
+    end
+  end
+end

--- a/code/packages/elixir/lisp_lexer/mix.exs
+++ b/code/packages/elixir/lisp_lexer/mix.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.LispLexer.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_lisp_lexer,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_grammar_tools, path: "../grammar_tools"},
+      {:coding_adventures_lexer, path: "../lexer"}
+    ]
+  end
+end

--- a/code/packages/elixir/lisp_lexer/required_capabilities.json
+++ b/code/packages/elixir/lisp_lexer/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/lisp_lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the shared Lisp token grammar file from code/grammars/ to configure the lexer."
+    }
+  ],
+  "justification": "Reads the shared Lisp token grammar file at runtime."
+}

--- a/code/packages/elixir/lisp_lexer/test/lisp_lexer_test.exs
+++ b/code/packages/elixir/lisp_lexer/test/lisp_lexer_test.exs
@@ -1,0 +1,54 @@
+defmodule CodingAdventures.LispLexerTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.LispLexer
+
+  test "tokenizes a basic definition" do
+    {:ok, tokens} = LispLexer.tokenize("(define x 42)")
+
+    assert Enum.map(tokens, & &1.type) == [
+             "LPAREN",
+             "SYMBOL",
+             "SYMBOL",
+             "NUMBER",
+             "RPAREN",
+             "EOF"
+           ]
+
+    assert Enum.map(tokens, & &1.value) == ["(", "define", "x", "42", ")", ""]
+  end
+
+  test "keeps operator names as symbols and negative numbers as numbers" do
+    {:ok, tokens} = LispLexer.tokenize("(+ -42 (* x 2))")
+    assert Enum.at(tokens, 1).type == "SYMBOL"
+    assert Enum.at(tokens, 1).value == "+"
+    assert Enum.at(tokens, 2).type == "NUMBER"
+    assert Enum.at(tokens, 2).value == "-42"
+    assert Enum.at(tokens, 4).value == "*"
+  end
+
+  test "skips comments and tokenizes quoted dotted pairs" do
+    {:ok, tokens} = LispLexer.tokenize("; ignore\n'(a . b)")
+
+    assert Enum.map(tokens, & &1.type) == [
+             "QUOTE",
+             "LPAREN",
+             "SYMBOL",
+             "DOT",
+             "SYMBOL",
+             "RPAREN",
+             "EOF"
+           ]
+  end
+
+  test "create_lexer returns the parsed token grammar" do
+    grammar = LispLexer.create_lexer()
+    assert is_map(grammar)
+    assert Enum.any?(grammar.definitions, &(&1.name == "SYMBOL"))
+  end
+
+  test "invalid characters return a lexer error" do
+    assert {:error, message} = LispLexer.tokenize("@")
+    assert message =~ "Unexpected character"
+  end
+end

--- a/code/packages/elixir/lisp_lexer/test/test_helper.exs
+++ b/code/packages/elixir/lisp_lexer/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/lisp_parser/BUILD
+++ b/code/packages/elixir/lisp_parser/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/lisp_parser/CHANGELOG.md
+++ b/code/packages/elixir/lisp_parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Elixir Lisp parser wrapper over the shared grammar-driven parser.
+- Added tests for lists, quoted forms, dotted pairs, parser creation, invalid input propagation, and malformed list errors.

--- a/code/packages/elixir/lisp_parser/README.md
+++ b/code/packages/elixir/lisp_parser/README.md
@@ -1,0 +1,9 @@
+# Lisp Parser (Elixir)
+
+Grammar-driven Lisp parser for Elixir.
+
+This package tokenizes source with `CodingAdventures.LispLexer`, loads `code/grammars/lisp.grammar`, and delegates parsing to `CodingAdventures.Parser.GrammarParser`.
+
+```elixir
+{:ok, ast} = CodingAdventures.LispParser.parse("(+ 1 2)")
+```

--- a/code/packages/elixir/lisp_parser/lib/coding_adventures/lisp_parser.ex
+++ b/code/packages/elixir/lisp_parser/lib/coding_adventures/lisp_parser.ex
@@ -1,0 +1,44 @@
+defmodule CodingAdventures.LispParser do
+  @moduledoc """
+  Lisp parser backed by the shared grammar-driven parser engine.
+
+  The parser reads `lisp.grammar` from `code/grammars/`, tokenizes source with
+  `CodingAdventures.LispLexer`, and delegates AST construction to
+  `CodingAdventures.Parser.GrammarParser`.
+  """
+
+  alias CodingAdventures.GrammarTools.ParserGrammar
+  alias CodingAdventures.LispLexer
+  alias CodingAdventures.Parser.{ASTNode, GrammarParser}
+
+  @grammars_dir Path.join([__DIR__, "..", "..", "..", "..", "..", "grammars"])
+                |> Path.expand()
+
+  @doc """
+  Parse Lisp source code and return `{:ok, ast}` or `{:error, message}`.
+  """
+  @spec parse(String.t()) :: {:ok, ASTNode.t()} | {:error, String.t()}
+  def parse(source) when is_binary(source) do
+    case LispLexer.tokenize(source) do
+      {:ok, tokens} -> GrammarParser.parse(tokens, create_parser())
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc """
+  Parse and return the cached Lisp `ParserGrammar`.
+  """
+  @spec create_parser() :: ParserGrammar.t()
+  def create_parser do
+    case :persistent_term.get({__MODULE__, :grammar}, nil) do
+      nil ->
+        grammar_path = Path.join(@grammars_dir, "lisp.grammar")
+        {:ok, grammar} = ParserGrammar.parse(File.read!(grammar_path))
+        :persistent_term.put({__MODULE__, :grammar}, grammar)
+        grammar
+
+      grammar ->
+        grammar
+    end
+  end
+end

--- a/code/packages/elixir/lisp_parser/mix.exs
+++ b/code/packages/elixir/lisp_parser/mix.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.LispParser.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_lisp_parser,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_parser, path: "../parser"},
+      {:coding_adventures_lisp_lexer, path: "../lisp_lexer"}
+    ]
+  end
+end

--- a/code/packages/elixir/lisp_parser/required_capabilities.json
+++ b/code/packages/elixir/lisp_parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/lisp_parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the shared Lisp parser grammar file from code/grammars/ to configure the parser."
+    }
+  ],
+  "justification": "Reads the shared Lisp parser grammar file at runtime."
+}

--- a/code/packages/elixir/lisp_parser/test/lisp_parser_test.exs
+++ b/code/packages/elixir/lisp_parser/test/lisp_parser_test.exs
@@ -1,0 +1,37 @@
+defmodule CodingAdventures.LispParserTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.LispParser
+
+  test "parses a basic definition" do
+    {:ok, ast} = LispParser.parse("(define x 42)")
+    assert ast.rule_name == "program"
+    assert ast.children != []
+  end
+
+  test "parses quoted forms" do
+    {:ok, ast} = LispParser.parse("'(a b c)")
+    assert ast.rule_name == "program"
+  end
+
+  test "parses dotted pairs" do
+    {:ok, ast} = LispParser.parse("(a . b)")
+    assert ast.rule_name == "program"
+  end
+
+  test "create_parser returns the parsed grammar" do
+    grammar = LispParser.create_parser()
+    assert is_map(grammar)
+    assert hd(grammar.rules).name == "program"
+  end
+
+  test "invalid lexer input is returned as an error" do
+    assert {:error, message} = LispParser.parse("@")
+    assert message =~ "Unexpected character"
+  end
+
+  test "malformed lists return a parser error" do
+    assert {:error, message} = LispParser.parse("(a b")
+    assert message =~ "Expected"
+  end
+end

--- a/code/packages/elixir/lisp_parser/test/test_helper.exs
+++ b/code/packages/elixir/lisp_parser/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add Elixir Lisp lexer and parser packages using the shared grammar-driven engines
- load lisp.tokens and lisp.grammar with capability manifests and persistent-term grammar caching
- cover lists, operator symbols, comments, quoted forms, dotted pairs, invalid lexer input, malformed parser input, and grammar creation

## Verification
- mix deps.get --quiet && mix test --cover (elixir/lisp_lexer: 100%)
- mix deps.get --quiet && mix test --cover (elixir/lisp_parser: 100%)
- required_capabilities.json parses with ConvertFrom-Json