### PR TITLE
feat(parity): add elixir ruby and css parsers

### DIFF
--- a/code/packages/elixir/css_parser/BUILD
+++ b/code/packages/elixir/css_parser/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/css_parser/CHANGELOG.md
+++ b/code/packages/elixir/css_parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Elixir CSS parser wrapper over the shared grammar-driven parser.
+- Added tests for empty stylesheets, qualified rules, selector lists, at-rules, parser creation, lexer error propagation, and malformed parse errors.

--- a/code/packages/elixir/css_parser/README.md
+++ b/code/packages/elixir/css_parser/README.md
@@ -1,0 +1,9 @@
+# CSS Parser (Elixir)
+
+Grammar-driven CSS parser for Elixir.
+
+This package tokenizes source with `CodingAdventures.CssLexer`, loads `code/grammars/css.grammar`, and delegates parsing to `CodingAdventures.Parser.GrammarParser`.
+
+```elixir
+{:ok, ast} = CodingAdventures.CssParser.parse("h1 { color: red; }")
+```

--- a/code/packages/elixir/css_parser/lib/css_parser.ex
+++ b/code/packages/elixir/css_parser/lib/css_parser.ex
@@ -1,0 +1,44 @@
+defmodule CodingAdventures.CssParser do
+  @moduledoc """
+  CSS parser backed by the shared grammar-driven parser engine.
+
+  The parser reads `css.grammar` from `code/grammars/`, tokenizes source with
+  `CodingAdventures.CssLexer`, and delegates AST construction to
+  `CodingAdventures.Parser.GrammarParser`.
+  """
+
+  alias CodingAdventures.CssLexer
+  alias CodingAdventures.GrammarTools.ParserGrammar
+  alias CodingAdventures.Parser.{ASTNode, GrammarParser}
+
+  @grammars_dir Path.join([__DIR__, "..", "..", "..", "..", "grammars"])
+                |> Path.expand()
+
+  @doc """
+  Parse CSS source code and return `{:ok, ast}` or `{:error, message}`.
+  """
+  @spec parse(String.t()) :: {:ok, ASTNode.t()} | {:error, String.t()}
+  def parse(source) when is_binary(source) do
+    case CssLexer.tokenize(source) do
+      {:ok, tokens} -> GrammarParser.parse(tokens, create_parser())
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc """
+  Parse and return the cached CSS `ParserGrammar`.
+  """
+  @spec create_parser() :: ParserGrammar.t()
+  def create_parser do
+    case :persistent_term.get({__MODULE__, :grammar}, nil) do
+      nil ->
+        grammar_path = Path.join(@grammars_dir, "css.grammar")
+        {:ok, grammar} = ParserGrammar.parse(File.read!(grammar_path))
+        :persistent_term.put({__MODULE__, :grammar}, grammar)
+        grammar
+
+      grammar ->
+        grammar
+    end
+  end
+end

--- a/code/packages/elixir/css_parser/mix.exs
+++ b/code/packages/elixir/css_parser/mix.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.CssParser.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_css_parser,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_parser, path: "../parser"},
+      {:coding_adventures_css_lexer, path: "../css_lexer"}
+    ]
+  end
+end

--- a/code/packages/elixir/css_parser/required_capabilities.json
+++ b/code/packages/elixir/css_parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/css_parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the shared CSS parser grammar file from code/grammars/ to configure the parser."
+    }
+  ],
+  "justification": "Reads the shared CSS parser grammar file at runtime."
+}

--- a/code/packages/elixir/css_parser/test/css_parser_test.exs
+++ b/code/packages/elixir/css_parser/test/css_parser_test.exs
@@ -1,0 +1,54 @@
+defmodule CodingAdventures.CssParserTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.CssParser
+  alias CodingAdventures.Parser.ASTNode
+
+  defp find_nodes(%ASTNode{} = node, rule_name) do
+    current = if node.rule_name == rule_name, do: [node], else: []
+
+    Enum.reduce(node.children, current, fn
+      %ASTNode{} = child, acc -> acc ++ find_nodes(child, rule_name)
+      _child, acc -> acc
+    end)
+  end
+
+  test "parses an empty stylesheet" do
+    {:ok, ast} = CssParser.parse("")
+    assert ast.rule_name == "stylesheet"
+    assert ast.children == []
+  end
+
+  test "parses a qualified rule with a declaration" do
+    {:ok, ast} = CssParser.parse("h1 { color: red; }")
+    assert ast.rule_name == "stylesheet"
+    assert length(find_nodes(ast, "rule")) == 1
+    assert length(find_nodes(ast, "declaration")) == 1
+  end
+
+  test "parses selector lists" do
+    {:ok, ast} = CssParser.parse("h1, h2, h3 { font-weight: bold; }")
+    assert length(find_nodes(ast, "complex_selector")) == 3
+  end
+
+  test "parses at-rules" do
+    {:ok, ast} = CssParser.parse(~s(@import "theme.css";))
+    assert length(find_nodes(ast, "at_rule")) == 1
+  end
+
+  test "create_parser returns the parsed grammar" do
+    grammar = CssParser.create_parser()
+    assert is_map(grammar)
+    assert hd(grammar.rules).name == "stylesheet"
+  end
+
+  test "lexer errors are returned" do
+    assert {:error, message} = CssParser.parse("`")
+    assert message =~ "Unexpected character"
+  end
+
+  test "malformed CSS returns a parser error" do
+    assert {:error, message} = CssParser.parse("h1 { color: red")
+    assert message =~ "Expected"
+  end
+end

--- a/code/packages/elixir/css_parser/test/test_helper.exs
+++ b/code/packages/elixir/css_parser/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/ruby_parser/BUILD
+++ b/code/packages/elixir/ruby_parser/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/ruby_parser/CHANGELOG.md
+++ b/code/packages/elixir/ruby_parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Elixir Ruby parser wrapper over the shared grammar-driven parser.
+- Added tests for assignments, arithmetic precedence, method calls, parser creation, lexer error propagation, and malformed parse errors.

--- a/code/packages/elixir/ruby_parser/README.md
+++ b/code/packages/elixir/ruby_parser/README.md
@@ -1,0 +1,9 @@
+# Ruby Parser (Elixir)
+
+Grammar-driven Ruby parser for Elixir.
+
+This package tokenizes source with `CodingAdventures.RubyLexer`, loads `code/grammars/ruby.grammar`, and delegates parsing to `CodingAdventures.Parser.GrammarParser`.
+
+```elixir
+{:ok, ast} = CodingAdventures.RubyParser.parse("x = 1 + 2")
+```

--- a/code/packages/elixir/ruby_parser/lib/ruby_parser.ex
+++ b/code/packages/elixir/ruby_parser/lib/ruby_parser.ex
@@ -1,0 +1,44 @@
+defmodule CodingAdventures.RubyParser do
+  @moduledoc """
+  Ruby parser backed by the shared grammar-driven parser engine.
+
+  The parser reads `ruby.grammar` from `code/grammars/`, tokenizes source with
+  `CodingAdventures.RubyLexer`, and delegates AST construction to
+  `CodingAdventures.Parser.GrammarParser`.
+  """
+
+  alias CodingAdventures.GrammarTools.ParserGrammar
+  alias CodingAdventures.Parser.{ASTNode, GrammarParser}
+  alias CodingAdventures.RubyLexer
+
+  @grammars_dir Path.join([__DIR__, "..", "..", "..", "..", "grammars"])
+                |> Path.expand()
+
+  @doc """
+  Parse Ruby source code and return `{:ok, ast}` or `{:error, message}`.
+  """
+  @spec parse(String.t()) :: {:ok, ASTNode.t()} | {:error, String.t()}
+  def parse(source) when is_binary(source) do
+    case RubyLexer.tokenize(source) do
+      {:ok, tokens} -> GrammarParser.parse(tokens, create_parser())
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc """
+  Parse and return the cached Ruby `ParserGrammar`.
+  """
+  @spec create_parser() :: ParserGrammar.t()
+  def create_parser do
+    case :persistent_term.get({__MODULE__, :grammar}, nil) do
+      nil ->
+        grammar_path = Path.join(@grammars_dir, "ruby.grammar")
+        {:ok, grammar} = ParserGrammar.parse(File.read!(grammar_path))
+        :persistent_term.put({__MODULE__, :grammar}, grammar)
+        grammar
+
+      grammar ->
+        grammar
+    end
+  end
+end

--- a/code/packages/elixir/ruby_parser/mix.exs
+++ b/code/packages/elixir/ruby_parser/mix.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.RubyParser.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_ruby_parser,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_parser, path: "../parser"},
+      {:coding_adventures_ruby_lexer, path: "../ruby_lexer"}
+    ]
+  end
+end

--- a/code/packages/elixir/ruby_parser/required_capabilities.json
+++ b/code/packages/elixir/ruby_parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/ruby_parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the shared Ruby parser grammar file from code/grammars/ to configure the parser."
+    }
+  ],
+  "justification": "Reads the shared Ruby parser grammar file at runtime."
+}

--- a/code/packages/elixir/ruby_parser/test/ruby_parser_test.exs
+++ b/code/packages/elixir/ruby_parser/test/ruby_parser_test.exs
@@ -1,0 +1,50 @@
+defmodule CodingAdventures.RubyParserTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.Parser.ASTNode
+  alias CodingAdventures.RubyParser
+
+  defp find_nodes(%ASTNode{} = node, rule_name) do
+    current = if node.rule_name == rule_name, do: [node], else: []
+
+    Enum.reduce(node.children, current, fn
+      %ASTNode{} = child, acc -> acc ++ find_nodes(child, rule_name)
+      _child, acc -> acc
+    end)
+  end
+
+  test "parses assignment statements" do
+    {:ok, ast} = RubyParser.parse("x = 1 + 2")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "assignment")) == 1
+    assert length(find_nodes(ast, "expression")) >= 1
+  end
+
+  test "parses arithmetic precedence through term nesting" do
+    {:ok, ast} = RubyParser.parse("x = 1 + 2 * 3")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "term")) >= 2
+  end
+
+  test "parses method calls" do
+    {:ok, ast} = RubyParser.parse("puts(\"hello\")")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "method_call")) == 1
+  end
+
+  test "create_parser returns the parsed grammar" do
+    grammar = RubyParser.create_parser()
+    assert is_map(grammar)
+    assert hd(grammar.rules).name == "program"
+  end
+
+  test "lexer errors are returned" do
+    assert {:error, message} = RubyParser.parse("@")
+    assert message =~ "Unexpected character"
+  end
+
+  test "malformed Ruby returns a parser error" do
+    assert {:error, message} = RubyParser.parse("x = (1 + 2")
+    assert message =~ "Expected"
+  end
+end

--- a/code/packages/elixir/ruby_parser/test/test_helper.exs
+++ b/code/packages/elixir/ruby_parser/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add Elixir Ruby and CSS parser packages using the shared grammar-driven parser
- wire them to existing Ruby/CSS lexer packages and shared grammar files
- include capability manifests and focused parser tests for happy paths plus lexer/parser errors

## Verification
- mix deps.get --quiet && mix test --cover (elixir/ruby_parser: 100%)
- mix deps.get --quiet && mix test --cover (elixir/css_parser: 100%)
- required_capabilities.json parses with ConvertFrom-Json