### PR TITLE
feat(parity): add elixir ir optimizer

### DIFF
--- a/code/packages/elixir/ir_optimizer/BUILD
+++ b/code/packages/elixir/ir_optimizer/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/ir_optimizer/BUILD_windows
+++ b/code/packages/elixir/ir_optimizer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/ir_optimizer/CHANGELOG.md
+++ b/code/packages/elixir/ir_optimizer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added an Elixir IR optimizer package with dead-code elimination, constant folding, and peephole optimization passes.
+- Added optimizer result metadata, default/no-op pipelines, custom pass support, and parity tests against the existing compiler IR package.

--- a/code/packages/elixir/ir_optimizer/README.md
+++ b/code/packages/elixir/ir_optimizer/README.md
@@ -1,0 +1,29 @@
+# IR Optimizer (Elixir)
+
+Optimization passes for the `compiler_ir` package.
+
+The package mirrors the Python, Rust, TypeScript, and Go IR optimizer surface with an Elixir-flavored API: pass modules expose `name/0` and `run/1`, and `CodingAdventures.IrOptimizer` threads an immutable `IrProgram` through the configured pipeline.
+
+## Example
+
+```elixir
+alias CodingAdventures.CompilerIr.{IrImmediate, IrInstruction, IrProgram, IrRegister}
+alias CodingAdventures.IrOptimizer
+
+program =
+  IrProgram.new("_start")
+  |> IrProgram.add_instruction(%IrInstruction{
+    opcode: :load_imm,
+    operands: [%IrRegister{index: 1}, %IrImmediate{value: 5}],
+    id: 1
+  })
+  |> IrProgram.add_instruction(%IrInstruction{
+    opcode: :add_imm,
+    operands: [%IrRegister{index: 1}, %IrRegister{index: 1}, %IrImmediate{value: 3}],
+    id: 2
+  })
+
+result = IrOptimizer.optimize(program)
+length(result.program.instructions)
+# 1
+```

--- a/code/packages/elixir/ir_optimizer/lib/coding_adventures/ir_optimizer.ex
+++ b/code/packages/elixir/ir_optimizer/lib/coding_adventures/ir_optimizer.ex
@@ -1,0 +1,378 @@
+defmodule CodingAdventures.IrOptimizer.Pass do
+  @moduledoc """
+  Behaviour implemented by IR optimization passes.
+  """
+
+  alias CodingAdventures.CompilerIr.IrProgram
+
+  @callback name() :: String.t()
+  @callback run(IrProgram.t()) :: IrProgram.t()
+end
+
+defmodule CodingAdventures.IrOptimizer.OptimizationResult do
+  @moduledoc """
+  Result metadata returned by an optimizer run.
+  """
+
+  alias CodingAdventures.CompilerIr.IrProgram
+
+  defstruct program: nil,
+            passes_run: [],
+            instructions_before: 0,
+            instructions_after: 0,
+            instructions_eliminated: 0
+
+  @type t :: %__MODULE__{
+          program: IrProgram.t(),
+          passes_run: [String.t()],
+          instructions_before: non_neg_integer(),
+          instructions_after: non_neg_integer(),
+          instructions_eliminated: integer()
+        }
+end
+
+defmodule CodingAdventures.IrOptimizer do
+  @moduledoc """
+  Pipeline runner for compiler IR optimization passes.
+  """
+
+  alias CodingAdventures.CompilerIr.{IrInstruction, IrProgram}
+  alias __MODULE__.{ConstantFolder, DeadCodeEliminator, OptimizationResult, PeepholeOptimizer}
+
+  defstruct passes: []
+
+  @type pass :: module()
+  @type t :: %__MODULE__{passes: [pass()]}
+
+  @doc "Create an optimizer with the given pass modules."
+  @spec new([pass()]) :: t()
+  def new(passes \\ []), do: %__MODULE__{passes: passes}
+
+  @doc "Create the default optimization pipeline."
+  @spec default_passes() :: t()
+  def default_passes do
+    new([DeadCodeEliminator, ConstantFolder, PeepholeOptimizer])
+  end
+
+  @doc "Create an optimizer that runs no passes."
+  @spec no_op() :: t()
+  def no_op, do: new([])
+
+  @doc "Optimize a program with the default pipeline."
+  @spec optimize(IrProgram.t()) :: OptimizationResult.t()
+  def optimize(%IrProgram{} = program), do: optimize(default_passes(), program)
+
+  @doc "Optimize a program with an explicit pass list or configured optimizer."
+  @spec optimize(IrProgram.t(), [pass()]) :: OptimizationResult.t()
+  @spec optimize(t(), IrProgram.t()) :: OptimizationResult.t()
+  def optimize(%IrProgram{} = program, passes) when is_list(passes) do
+    optimize(new(passes), program)
+  end
+
+  def optimize(%__MODULE__{passes: passes}, %IrProgram{} = program) do
+    before_count = length(program.instructions)
+
+    {optimized, passes_run} =
+      Enum.reduce(passes, {clone_program(program), []}, fn pass, {current, names} ->
+        {pass.run(current), names ++ [pass.name()]}
+      end)
+
+    after_count = length(optimized.instructions)
+
+    %OptimizationResult{
+      program: optimized,
+      passes_run: passes_run,
+      instructions_before: before_count,
+      instructions_after: after_count,
+      instructions_eliminated: before_count - after_count
+    }
+  end
+
+  @doc false
+  @spec clone_program(IrProgram.t(), [IrInstruction.t()] | nil) :: IrProgram.t()
+  def clone_program(%IrProgram{} = program, instructions \\ nil) do
+    %IrProgram{
+      program
+      | data: Enum.map(program.data, & &1),
+        instructions: Enum.map(instructions || program.instructions, &clone_instruction/1)
+    }
+  end
+
+  @doc false
+  @spec clone_instruction(IrInstruction.t()) :: IrInstruction.t()
+  def clone_instruction(%IrInstruction{} = instruction) do
+    %{instruction | operands: Enum.map(instruction.operands, & &1)}
+  end
+end
+
+defmodule CodingAdventures.IrOptimizer.DeadCodeEliminator do
+  @moduledoc """
+  Removes instructions after unconditional branches until the next label.
+  """
+
+  @behaviour CodingAdventures.IrOptimizer.Pass
+
+  alias CodingAdventures.CompilerIr.IrProgram
+  alias CodingAdventures.IrOptimizer
+
+  @unconditional_branches MapSet.new([:jump, :ret, :halt])
+
+  @impl true
+  def name, do: "DeadCodeEliminator"
+
+  @impl true
+  def run(%IrProgram{} = program) do
+    {live, _reachable} =
+      Enum.reduce(program.instructions, {[], true}, fn instruction, {live, reachable} ->
+        reachable = if instruction.opcode == :label, do: true, else: reachable
+        live = if reachable, do: [IrOptimizer.clone_instruction(instruction) | live], else: live
+
+        reachable =
+          if MapSet.member?(@unconditional_branches, instruction.opcode),
+            do: false,
+            else: reachable
+
+        {live, reachable}
+      end)
+
+    IrOptimizer.clone_program(program, Enum.reverse(live))
+  end
+end
+
+defmodule CodingAdventures.IrOptimizer.ConstantFolder do
+  @moduledoc """
+  Folds simple constant load plus immediate arithmetic sequences.
+  """
+
+  @behaviour CodingAdventures.IrOptimizer.Pass
+
+  alias CodingAdventures.CompilerIr.{IrImmediate, IrProgram, IrRegister}
+  alias CodingAdventures.IrOptimizer
+
+  @foldable_imm_ops MapSet.new([:add_imm, :and_imm])
+  @writes_to_dest MapSet.new([
+                    :load_imm,
+                    :load_addr,
+                    :load_byte,
+                    :load_word,
+                    :add,
+                    :add_imm,
+                    :sub,
+                    :and,
+                    :and_imm,
+                    :cmp_eq,
+                    :cmp_ne,
+                    :cmp_lt,
+                    :cmp_gt
+                  ])
+
+  @impl true
+  def name, do: "ConstantFolder"
+
+  @impl true
+  def run(%IrProgram{} = program) do
+    {instructions, _pending_loads} =
+      Enum.reduce(program.instructions, {[], %{}}, fn instruction, {out, pending} ->
+        cond do
+          instruction.opcode == :load_imm ->
+            handle_load_imm(instruction, out, pending)
+
+          MapSet.member?(@foldable_imm_ops, instruction.opcode) ->
+            handle_foldable_immediate(instruction, out, pending)
+
+          true ->
+            handle_passthrough(instruction, out, pending)
+        end
+      end)
+
+    IrOptimizer.clone_program(program, instructions)
+  end
+
+  defp handle_load_imm(
+         %{operands: [%IrRegister{index: index}, %IrImmediate{value: value}]} = instruction,
+         out,
+         pending
+       ) do
+    {out ++ [IrOptimizer.clone_instruction(instruction)], Map.put(pending, index, value)}
+  end
+
+  defp handle_load_imm(instruction, out, pending) do
+    {out ++ [IrOptimizer.clone_instruction(instruction)], pending}
+  end
+
+  defp handle_foldable_immediate(
+         %{
+           opcode: opcode,
+           operands: [
+             %IrRegister{index: dest_index} = dest,
+             %IrRegister{index: src_index},
+             %IrImmediate{value: immediate}
+           ]
+         } = instruction,
+         out,
+         pending
+       )
+       when dest_index == src_index do
+    case Map.fetch(pending, dest_index) do
+      {:ok, base} ->
+        new_value =
+          if opcode == :add_imm, do: base + immediate, else: Bitwise.band(base, immediate)
+
+        out = replace_last_load(out, dest, new_value)
+        {out, Map.put(pending, dest_index, new_value)}
+
+      :error ->
+        handle_passthrough(instruction, out, pending)
+    end
+  end
+
+  defp handle_foldable_immediate(instruction, out, pending) do
+    handle_passthrough(instruction, out, pending)
+  end
+
+  defp handle_passthrough(instruction, out, pending) do
+    pending =
+      if MapSet.member?(@writes_to_dest, instruction.opcode) do
+        case instruction.operands do
+          [%IrRegister{index: index} | _] -> Map.delete(pending, index)
+          _ -> pending
+        end
+      else
+        pending
+      end
+
+    {out ++ [IrOptimizer.clone_instruction(instruction)], pending}
+  end
+
+  defp replace_last_load(out, %IrRegister{index: index} = dest, new_value) do
+    out
+    |> Enum.reverse()
+    |> replace_first_load(index, dest, new_value)
+    |> Enum.reverse()
+  end
+
+  defp replace_first_load(
+         [%{opcode: :load_imm, operands: [%IrRegister{index: index} | _]} = instruction | rest],
+         index,
+         dest,
+         value
+       ) do
+    [%{instruction | operands: [dest, %IrImmediate{value: value}]} | rest]
+  end
+
+  defp replace_first_load([instruction | rest], index, dest, value) do
+    [instruction | replace_first_load(rest, index, dest, value)]
+  end
+
+  defp replace_first_load([], _index, _dest, _value), do: []
+end
+
+defmodule CodingAdventures.IrOptimizer.PeepholeOptimizer do
+  @moduledoc """
+  Applies local two-instruction rewrite patterns until a fixed point.
+  """
+
+  @behaviour CodingAdventures.IrOptimizer.Pass
+
+  alias CodingAdventures.CompilerIr.{IrImmediate, IrInstruction, IrProgram, IrRegister}
+  alias CodingAdventures.IrOptimizer
+
+  @max_iterations 10
+
+  @impl true
+  def name, do: "PeepholeOptimizer"
+
+  @impl true
+  def run(%IrProgram{} = program) do
+    instructions =
+      Enum.reduce_while(1..@max_iterations, program.instructions, fn _iteration, current ->
+        next = apply_patterns(current)
+
+        if length(next) == length(current) do
+          {:halt, next}
+        else
+          {:cont, next}
+        end
+      end)
+
+    IrOptimizer.clone_program(program, instructions)
+  end
+
+  defp apply_patterns([current, next | rest]) do
+    case try_merge(current, next) do
+      nil -> [IrOptimizer.clone_instruction(current) | apply_patterns([next | rest])]
+      merged -> [merged | apply_patterns(rest)]
+    end
+  end
+
+  defp apply_patterns([last]), do: [IrOptimizer.clone_instruction(last)]
+  defp apply_patterns([]), do: []
+
+  defp try_merge(
+         %IrInstruction{
+           opcode: :add_imm,
+           operands: [
+             %IrRegister{index: index} = dest,
+             %IrRegister{index: index},
+             %IrImmediate{value: left}
+           ],
+           id: id
+         },
+         %IrInstruction{
+           opcode: :add_imm,
+           operands: [
+             %IrRegister{index: index},
+             %IrRegister{index: index},
+             %IrImmediate{value: right}
+           ]
+         }
+       ) do
+    %IrInstruction{
+      opcode: :add_imm,
+      operands: [dest, %IrRegister{index: index}, %IrImmediate{value: left + right}],
+      id: id
+    }
+  end
+
+  defp try_merge(
+         %IrInstruction{opcode: opcode, operands: [%IrRegister{index: index} | operands]} =
+           current,
+         %IrInstruction{
+           opcode: :and_imm,
+           operands: [
+             %IrRegister{index: index},
+             %IrRegister{index: index},
+             %IrImmediate{value: 255}
+           ]
+         }
+       )
+       when opcode in [:add_imm, :load_imm] do
+    case List.last(operands) do
+      %IrImmediate{value: value} when value >= 0 and value <= 255 ->
+        IrOptimizer.clone_instruction(current)
+
+      _other ->
+        nil
+    end
+  end
+
+  defp try_merge(
+         %IrInstruction{
+           opcode: :load_imm,
+           operands: [%IrRegister{index: index} = dest, %IrImmediate{value: 0}],
+           id: id
+         },
+         %IrInstruction{
+           opcode: :add_imm,
+           operands: [
+             %IrRegister{index: index},
+             %IrRegister{index: index},
+             %IrImmediate{} = immediate
+           ]
+         }
+       ) do
+    %IrInstruction{opcode: :load_imm, operands: [dest, immediate], id: id}
+  end
+
+  defp try_merge(_current, _next), do: nil
+end

--- a/code/packages/elixir/ir_optimizer/mix.exs
+++ b/code/packages/elixir/ir_optimizer/mix.exs
@@ -1,0 +1,28 @@
+defmodule CodingAdventures.IrOptimizer.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_ir_optimizer,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_compiler_ir, path: "../compiler_ir"}
+    ]
+  end
+end

--- a/code/packages/elixir/ir_optimizer/required_capabilities.json
+++ b/code/packages/elixir/ir_optimizer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/ir_optimizer",
+  "capabilities": [],
+  "justification": "Pure in-memory IR transformations. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/ir_optimizer/test/ir_optimizer_test.exs
+++ b/code/packages/elixir/ir_optimizer/test/ir_optimizer_test.exs
@@ -1,0 +1,196 @@
+defmodule CodingAdventures.IrOptimizerTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.CompilerIr.{IrImmediate, IrInstruction, IrLabel, IrProgram, IrRegister}
+
+  alias CodingAdventures.IrOptimizer
+
+  alias CodingAdventures.IrOptimizer.{
+    ConstantFolder,
+    DeadCodeEliminator,
+    OptimizationResult,
+    PeepholeOptimizer
+  }
+
+  defmodule IdentityPass do
+    @behaviour CodingAdventures.IrOptimizer.Pass
+
+    def name, do: "IdentityPass"
+    def run(program), do: program
+  end
+
+  defp make_program(instructions, entry \\ "_start") do
+    Enum.reduce(instructions, IrProgram.new(entry), &IrProgram.add_instruction(&2, &1))
+  end
+
+  defp load_imm(register, value, id) do
+    %IrInstruction{
+      opcode: :load_imm,
+      operands: [%IrRegister{index: register}, %IrImmediate{value: value}],
+      id: id
+    }
+  end
+
+  defp add_imm(dest, src, value, id) do
+    %IrInstruction{
+      opcode: :add_imm,
+      operands: [%IrRegister{index: dest}, %IrRegister{index: src}, %IrImmediate{value: value}],
+      id: id
+    }
+  end
+
+  defp and_imm(dest, src, value, id) do
+    %IrInstruction{
+      opcode: :and_imm,
+      operands: [%IrRegister{index: dest}, %IrRegister{index: src}, %IrImmediate{value: value}],
+      id: id
+    }
+  end
+
+  defp jump(target, id) do
+    %IrInstruction{opcode: :jump, operands: [%IrLabel{name: target}], id: id}
+  end
+
+  defp label(name), do: %IrInstruction{opcode: :label, operands: [%IrLabel{name: name}], id: -1}
+  defp halt(id \\ 0), do: %IrInstruction{opcode: :halt, operands: [], id: id}
+
+  test "OptimizationResult stores eliminated instruction counts" do
+    result = %OptimizationResult{
+      program: make_program([halt()]),
+      passes_run: ["TestPass"],
+      instructions_before: 10,
+      instructions_after: 7,
+      instructions_eliminated: 3
+    }
+
+    assert result.passes_run == ["TestPass"]
+    assert result.instructions_eliminated == 3
+  end
+
+  test "no_op keeps instructions and reports no passes" do
+    program = make_program([halt(0), add_imm(1, 1, 1, 1)])
+
+    result = IrOptimizer.optimize(IrOptimizer.no_op(), program)
+
+    assert length(result.program.instructions) == 2
+    assert result.passes_run == []
+    assert result.instructions_before == 2
+    assert result.instructions_after == 2
+    assert result.instructions_eliminated == 0
+  end
+
+  test "dead code eliminator removes instructions after unconditional branches" do
+    program =
+      make_program([
+        jump("done", 1),
+        add_imm(1, 1, 1, 2),
+        label("done"),
+        halt(3)
+      ])
+
+    result = DeadCodeEliminator.run(program)
+
+    assert Enum.map(result.instructions, & &1.id) == [1, -1, 3]
+  end
+
+  test "constant folder folds load_imm plus add_imm and and_imm" do
+    program =
+      make_program([
+        load_imm(1, 5, 1),
+        add_imm(1, 1, 3, 2),
+        and_imm(1, 1, 6, 3),
+        halt(4)
+      ])
+
+    result = ConstantFolder.run(program)
+
+    assert Enum.map(result.instructions, & &1.opcode) == [:load_imm, :halt]
+
+    assert Enum.at(result.instructions, 0).operands == [
+             %IrRegister{index: 1},
+             %IrImmediate{value: 0}
+           ]
+  end
+
+  test "constant folder clears stale pending loads after writes" do
+    program =
+      make_program([
+        load_imm(1, 5, 1),
+        %IrInstruction{opcode: :add, operands: [%IrRegister{index: 1}], id: 2},
+        add_imm(1, 1, 3, 3)
+      ])
+
+    result = ConstantFolder.run(program)
+
+    assert Enum.map(result.instructions, & &1.opcode) == [:load_imm, :add, :add_imm]
+  end
+
+  test "peephole optimizer merges add_imm chains" do
+    program =
+      make_program([
+        add_imm(2, 2, 2, 1),
+        add_imm(2, 2, 3, 2),
+        add_imm(2, 2, 4, 3)
+      ])
+
+    result = PeepholeOptimizer.run(program)
+
+    assert length(result.instructions) == 1
+
+    assert hd(result.instructions).operands == [
+             %IrRegister{index: 2},
+             %IrRegister{index: 2},
+             %IrImmediate{value: 9}
+           ]
+  end
+
+  test "peephole optimizer removes byte-mask no-ops and zero-load adds" do
+    program =
+      make_program([
+        load_imm(1, 7, 1),
+        and_imm(1, 1, 255, 2),
+        load_imm(2, 0, 3),
+        add_imm(2, 2, 5, 4)
+      ])
+
+    result = PeepholeOptimizer.run(program)
+
+    assert Enum.map(result.instructions, &(&1.operands |> List.last())) == [
+             %IrImmediate{value: 7},
+             %IrImmediate{value: 5}
+           ]
+  end
+
+  test "default pipeline runs passes in order and returns counts" do
+    program =
+      make_program([
+        load_imm(1, 5, 1),
+        add_imm(1, 1, 3, 2),
+        jump("done", 3),
+        add_imm(1, 1, 1, 4),
+        label("done"),
+        halt(5)
+      ])
+
+    result = IrOptimizer.optimize(program)
+
+    assert result.passes_run == ["DeadCodeEliminator", "ConstantFolder", "PeepholeOptimizer"]
+    assert result.instructions_before == 6
+    assert result.instructions_after == 4
+    assert result.instructions_eliminated == 2
+
+    assert Enum.at(result.program.instructions, 0).operands == [
+             %IrRegister{index: 1},
+             %IrImmediate{value: 8}
+           ]
+  end
+
+  test "custom pass lists are accepted" do
+    program = make_program([halt()])
+
+    result = IrOptimizer.optimize(program, [IdentityPass])
+
+    assert result.passes_run == ["IdentityPass"]
+    assert result.instructions_eliminated == 0
+  end
+end

--- a/code/packages/elixir/ir_optimizer/test/test_helper.exs
+++ b/code/packages/elixir/ir_optimizer/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add Elixir ir_optimizer package backed by the existing Elixir compiler_ir package
- implement dead-code elimination, constant folding, peephole optimization, no-op/default/custom pass pipelines, and optimization result metadata
- add capability manifest, build files, README/changelog docs, and parity tests

## Tests
- cd code/packages/elixir/ir_optimizer && mix deps.get --quiet; mix test --cover
- parsed required_capabilities.json