### PR TITLE
feat(vcd-writer): streaming VCD waveform writer (IEEE 1364 §18)

### DIFF
--- a/code/packages/python/vcd-writer/BUILD
+++ b/code/packages/python/vcd-writer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/vcd-writer/BUILD_windows
+++ b/code/packages/python/vcd-writer/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/vcd-writer/CHANGELOG.md
+++ b/code/packages/python/vcd-writer/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## [0.1.0] — Unreleased
+
+Initial implementation of the VCD waveform writer per IEEE 1364-2005 §18.
+
+### Added
+- `VcdWriter`: streaming text writer with `open_scope` / `close_scope` / `declare` / `end_definitions` / `time` / `value_change` / `dump_initial`. Context-manager support.
+- `_IdAllocator`: printable-ASCII compact identifier generation (94-char base, single char for the first 94 vars, 2-char for next ~9000).
+- `Scope`, `VarDef` data classes for hierarchy tracking.
+- `attach_to_callback_emitter`: returns a `hardware-vm`-compatible callback that maps `Event(time, signal, new_value)` to `writer.value_change(...)`.
+- 4-state value support: scalar `0`/`1`/`x`/`z`; vector binary strings; real values via `r<n>`.
+- Time-monotonicity check (raises if time goes backward).
+- Idempotence: emitting an unchanged value is a no-op (per VCD spec).
+
+### Conformance (IEEE 1364-2005 §18)
+- `$date`, `$version`, `$timescale`: full
+- `$scope` / `$upscope` / `$enddefinitions`: full
+- `$var wire/reg/integer/real`: full
+- `#t` time markers, scalar and vector value changes: full
+- `$dumpvars` initial dump: full
+- Extended VCD (4-state with strength): out of scope; future spec.
+- FST output: out of scope; future spec.

--- a/code/packages/python/vcd-writer/README.md
+++ b/code/packages/python/vcd-writer/README.md
@@ -1,0 +1,67 @@
+# vcd-writer
+
+Streaming VCD (Value Change Dump) waveform writer per IEEE 1364 §18. Output is consumable by GTKWave, surfer, ModelSim, and every other waveform viewer.
+
+Decoupled from any specific simulator: emit value changes via `writer.value_change(time, var_id, value)`. An attach helper for `hardware-vm` (or any callback-style event emitter) is provided.
+
+See [`code/specs/vcd-writer.md`](../../../specs/vcd-writer.md).
+
+## Quick start
+
+```python
+from vcd_writer import VcdWriter
+
+with VcdWriter("trace.vcd", timescale="1ps") as w:
+    w.open_scope("top", "module")
+    a_id   = w.declare("a", 4)
+    b_id   = w.declare("b", 4)
+    sum_id = w.declare("sum", 4)
+    w.close_scope()
+    w.end_definitions()
+
+    w.dump_initial({a_id: 0, b_id: 0, sum_id: 0})
+
+    w.value_change(10, a_id, 5)
+    w.value_change(10, b_id, 3)
+    w.value_change(10, sum_id, 8)
+
+    w.value_change(20, a_id, 7)
+    w.value_change(20, sum_id, 10)
+```
+
+## Wiring up to hardware-vm
+
+```python
+from hardware_vm import HardwareVM
+from vcd_writer import VcdWriter, attach_to_callback_emitter
+
+vm = HardwareVM(hir)
+
+with VcdWriter("trace.vcd") as w:
+    w.open_scope("top", "module")
+    name_to_id = {
+        "a":    w.declare("a", 4),
+        "b":    w.declare("b", 4),
+        "sum":  w.declare("sum", 4),
+        "cout": w.declare("cout", 1),
+    }
+    w.close_scope()
+    w.end_definitions()
+    w.dump_initial({})
+
+    vm.subscribe(attach_to_callback_emitter(w, name_to_var_id=name_to_id))
+
+    vm.set_input("a", 5)
+    vm.set_input("b", 3)
+    # trace.vcd now contains the value-change events
+```
+
+## v0.1.0 scope
+
+- Full IEEE 1364 §18 VCD subset: `$date`, `$version`, `$timescale`, `$scope`, `$var`, `$enddefinitions`, `$dumpvars`, `#t` time markers, scalar + vector value changes.
+- Identifier compaction (printable ASCII, base-94 → 1 char for first 94 vars, 2 for the next ~9000).
+- 4-state values: `0`, `1`, `x`, `z` for scalars; binary string for vectors.
+- Real values via `r<value>` form.
+- Coverage 95%+ on the implementation.
+
+MIT.

--- a/code/packages/python/vcd-writer/pyproject.toml
+++ b/code/packages/python/vcd-writer/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-vcd-writer"
+version = "0.1.0"
+description = "VCD (Value Change Dump) waveform writer per IEEE 1364 §18 — streaming output for any HDL simulator."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["vcd", "waveform", "hdl", "verilog", "simulator", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/vcd-writer.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/vcd_writer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ANN", "E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=vcd_writer --cov-report=term-missing --cov-fail-under=85"
+
+[tool.coverage.run]
+source = ["src/vcd_writer"]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true

--- a/code/packages/python/vcd-writer/src/vcd_writer/__init__.py
+++ b/code/packages/python/vcd-writer/src/vcd_writer/__init__.py
@@ -1,0 +1,23 @@
+"""vcd-writer: streaming VCD waveform output (IEEE 1364 §18).
+
+Decoupled from the hardware-vm package by design. Sources call
+``writer.value_change(time, signal_id, value)``; this package handles
+formatting and file output.
+"""
+
+from vcd_writer.writer import (
+    Scope,
+    VarDef,
+    VcdWriter,
+    attach_to_callback_emitter,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Scope",
+    "VarDef",
+    "VcdWriter",
+    "__version__",
+    "attach_to_callback_emitter",
+]

--- a/code/packages/python/vcd-writer/src/vcd_writer/writer.py
+++ b/code/packages/python/vcd-writer/src/vcd_writer/writer.py
@@ -1,0 +1,267 @@
+"""VCD writer — Value Change Dump format per IEEE 1364-2005 §18.
+
+Streaming text writer. Produces a ``.vcd`` file readable by GTKWave, surfer,
+ModelSim, and every other waveform viewer.
+
+Design intentionally decoupled from any specific simulator: emit value changes
+via ``value_change(time, signal_id, value)``. An attach helper for hardware-vm
+(or any callback-style emitter) is provided in ``attach_to_callback_emitter``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import string
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+
+@dataclass(frozen=True, slots=True)
+class VarDef:
+    """One variable declaration in the VCD."""
+
+    name: str
+    width: int
+    var_id: str
+    kind: str = "wire"  # 'wire' | 'reg' | 'integer' | 'real'
+
+
+@dataclass
+class Scope:
+    """A scope in the VCD hierarchy. Holds variables and child scopes."""
+
+    name: str
+    kind: str = "module"
+    vars: list[VarDef] = field(default_factory=list)
+    children: list[Scope] = field(default_factory=list)
+
+
+class _IdAllocator:
+    """Generates compact printable-ASCII identifiers ('!' through '~').
+
+    First 94 use 1 char; thereafter 2-char combinations. Practically unlimited."""
+
+    _CHARS = string.printable.replace(string.whitespace, "")[: ord("~") - ord("!") + 1]
+
+    def __init__(self) -> None:
+        self._next = 0
+
+    def alloc(self) -> str:
+        # Encode self._next in base-94 using printable ASCII offset from '!' (33).
+        n = self._next
+        self._next += 1
+        chars = []
+        while True:
+            chars.append(chr(33 + (n % 94)))
+            n //= 94
+            if n == 0:
+                break
+            n -= 1
+        return "".join(chars)
+
+
+class VcdWriter:
+    """Streaming VCD writer.
+
+    Two phases:
+    1. Header — declare timescale, scopes, variables. Call ``end_definitions()``.
+    2. Body — call ``time(t)`` to advance, then ``value_change(var_id, value)``
+       repeatedly. Or call the convenience ``value_change(time, var_id, value)``
+       which handles time-tracking internally.
+
+    Close with ``close()`` or use as a context manager.
+    """
+
+    def __init__(self, path: str | Path, timescale: str = "1ps") -> None:
+        self.path = Path(path)
+        self.timescale = timescale
+        self._fh: TextIO | None = None
+        self._id_alloc = _IdAllocator()
+        self._defs_ended = False
+        self._cur_time: int = -1  # -1 = no #t emitted yet
+        self._values: dict[str, int | str] = {}  # last-emitted values; for $dumpvars
+        self._var_defs: dict[str, VarDef] = {}  # var_id -> VarDef
+        self._scopes: list[Scope] = []  # current open-scope stack
+
+    def __enter__(self) -> VcdWriter:
+        self.open()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Header
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        self._fh = self.path.open("w", encoding="utf-8")
+        self._write_header_preamble()
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+
+    def _w(self, line: str) -> None:
+        if self._fh is None:
+            raise RuntimeError("VcdWriter not open")
+        self._fh.write(line)
+        if not line.endswith("\n"):
+            self._fh.write("\n")
+
+    def _write_header_preamble(self) -> None:
+        date_str = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+        self._w(f"$date {date_str} $end")
+        self._w("$version Silicon-Stack VCD Writer 0.1.0 $end")
+        self._w(f"$timescale {self.timescale} $end")
+
+    def open_scope(self, name: str, kind: str = "module") -> Scope:
+        if self._defs_ended:
+            raise RuntimeError("cannot open_scope after end_definitions")
+        self._w(f"$scope {kind} {name} $end")
+        scope = Scope(name=name, kind=kind)
+        if self._scopes:
+            self._scopes[-1].children.append(scope)
+        self._scopes.append(scope)
+        return scope
+
+    def close_scope(self) -> None:
+        if not self._scopes:
+            raise RuntimeError("close_scope without matching open_scope")
+        self._w("$upscope $end")
+        self._scopes.pop()
+
+    def declare(self, name: str, width: int, kind: str = "wire") -> str:
+        """Declare a variable and return its compact VCD id."""
+        if self._defs_ended:
+            raise RuntimeError("cannot declare after end_definitions")
+        if width < 1:
+            raise ValueError(f"width must be >= 1, got {width}")
+        var_id = self._id_alloc.alloc()
+        var_def = VarDef(name=name, width=width, var_id=var_id, kind=kind)
+        self._var_defs[var_id] = var_def
+        if self._scopes:
+            self._scopes[-1].vars.append(var_def)
+        # In VCD, multi-bit names are written as `name [w-1:0]`
+        if width > 1:
+            self._w(f"$var {kind} {width} {var_id} {name} [{width - 1}:0] $end")
+        else:
+            self._w(f"$var {kind} {width} {var_id} {name} $end")
+        return var_id
+
+    def end_definitions(self) -> None:
+        # Close any open scopes that the user forgot.
+        while self._scopes:
+            self.close_scope()
+        self._w("$enddefinitions $end")
+        self._defs_ended = True
+
+    # ------------------------------------------------------------------
+    # Body
+    # ------------------------------------------------------------------
+
+    def time(self, t: int) -> None:
+        if not self._defs_ended:
+            self.end_definitions()
+        if t < self._cur_time:
+            raise ValueError(f"time must not decrease: {t} < {self._cur_time}")
+        if t != self._cur_time:
+            self._w(f"#{t}")
+            self._cur_time = t
+
+    def dump_initial(self, values: dict[str, int | str]) -> None:
+        """Emit a $dumpvars block with initial values for every declared var.
+
+        ``values`` maps var_id -> initial value. Vars not in the dict default to 0.
+        """
+        if self._cur_time == -1:
+            self.time(0)
+        self._w("$dumpvars")
+        for var_id, var_def in self._var_defs.items():
+            v = values.get(var_id, 0)
+            self._w(self._format_value_change(var_def, v))
+            self._values[var_id] = v
+        self._w("$end")
+
+    def value_change(
+        self, time_or_var: int | str, var_id: str | None = None, value: int | str | None = None
+    ) -> None:
+        """Emit a value change. Two call signatures:
+
+        1. ``value_change(time, var_id, value)`` — advance time first, then emit.
+        2. ``value_change(var_id, value)`` — emit at the current time."""
+        if isinstance(time_or_var, int):
+            assert var_id is not None
+            assert value is not None
+            self.time(time_or_var)
+            target_id = var_id
+            new_value = value
+        else:
+            # Two-arg form: (var_id, value)
+            assert var_id is not None
+            target_id = time_or_var
+            new_value = var_id  # type: ignore[assignment]
+            value = var_id  # placate type-checker
+
+        if target_id not in self._var_defs:
+            raise KeyError(f"unknown var_id: {target_id!r}")
+
+        # Skip if value didn't change
+        if self._values.get(target_id) == new_value:
+            return
+        self._values[target_id] = new_value
+
+        var_def = self._var_defs[target_id]
+        self._w(self._format_value_change(var_def, new_value))
+
+    def _format_value_change(self, var_def: VarDef, value: int | str) -> str:
+        var_id = var_def.var_id
+        if var_def.kind == "real":
+            return f"r{value} {var_id}"
+        if isinstance(value, str):
+            # Already a VCD value string (e.g., 'x' or 'z' or '1010xz')
+            if var_def.width == 1:
+                return f"{value}{var_id}"
+            return f"b{value} {var_id}"
+        # Integer
+        if var_def.width == 1:
+            return f"{int(value) & 1}{var_id}"
+        # Multi-bit: emit as binary, no leading zeros (VCD convention)
+        bits = bin(int(value) & ((1 << var_def.width) - 1))[2:]
+        return f"b{bits} {var_id}"
+
+
+# ----------------------------------------------------------------------------
+# Convenience: attach to a callback-style event emitter (e.g., hardware-vm)
+# ----------------------------------------------------------------------------
+
+
+def attach_to_callback_emitter(
+    writer: VcdWriter,
+    *,
+    name_to_var_id: dict[str, str],
+) -> Callable[[object], None]:
+    """Return a callback suitable for hardware-vm's ``vm.subscribe(callback)``.
+
+    The returned function expects an object with attributes
+    ``time`` (int), ``signal`` (str), and ``new_value`` (int) — exactly the
+    shape of ``hardware_vm.Event``.
+
+    ``name_to_var_id`` maps signal names to the VCD var_ids returned by
+    ``writer.declare(...)``."""
+
+    def cb(event: object) -> None:
+        signal = getattr(event, "signal", None)
+        time_ = getattr(event, "time", 0)
+        value = getattr(event, "new_value", 0)
+        if signal is None:
+            return
+        var_id = name_to_var_id.get(signal)
+        if var_id is None:
+            return
+        writer.value_change(time_, var_id, value)
+
+    return cb

--- a/code/packages/python/vcd-writer/tests/test_writer.py
+++ b/code/packages/python/vcd-writer/tests/test_writer.py
@@ -1,0 +1,304 @@
+"""Tests for VcdWriter."""
+
+from pathlib import Path
+
+import pytest
+
+from vcd_writer import VcdWriter, attach_to_callback_emitter
+
+
+# ---- Header generation ----
+
+
+def test_basic_header(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p, timescale="1ns") as w:
+        w.end_definitions()
+    text = p.read_text()
+    assert "$date" in text
+    assert "$timescale 1ns $end" in text
+    assert "$enddefinitions $end" in text
+
+
+def test_scope_hierarchy(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        w.open_scope("u_dut", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.close_scope()
+        w.end_definitions()
+    text = p.read_text()
+    assert "$scope module top $end" in text
+    assert "$scope module u_dut $end" in text
+    assert text.count("$upscope $end") == 2
+    assert f"$var wire 1 {a} a $end" in text
+
+
+def test_multi_bit_var_format(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        sum_id = w.declare("sum", 4)
+        w.close_scope()
+        w.end_definitions()
+    text = p.read_text()
+    assert f"$var wire 4 {sum_id} sum [3:0] $end" in text
+
+
+def test_declare_after_end_raises(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.end_definitions()
+        with pytest.raises(RuntimeError, match="end_definitions"):
+            w.declare("a", 1)
+
+
+def test_declare_zero_width_raises(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        with pytest.raises(ValueError, match="width"):
+            w.declare("a", 0)
+
+
+def test_close_scope_without_open_raises(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        with pytest.raises(RuntimeError, match="without matching"):
+            w.close_scope()
+
+
+def test_open_scope_after_end_raises(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.end_definitions()
+        with pytest.raises(RuntimeError, match="end_definitions"):
+            w.open_scope("top")
+
+
+# ---- Identifier compaction ----
+
+
+def test_id_uniqueness_first_100(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        ids = [w.declare(f"v{i}", 1) for i in range(100)]
+        w.end_definitions()
+    assert len(set(ids)) == 100  # all unique
+
+
+def test_id_compaction_first_94_single_char(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        for i in range(94):
+            id_ = w.declare(f"v{i}", 1)
+            assert len(id_) == 1
+        # 95th should still be 1 char (with carry overflow into 2nd)
+        # Actually our impl rolls over to 2-char at index 94
+        id95 = w.declare("v94", 1)
+        assert len(id95) == 2
+        w.end_definitions()
+
+
+# ---- Value changes ----
+
+
+def test_scalar_value_change(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, a, 1)
+    text = p.read_text()
+    assert "#10" in text
+    assert f"1{a}" in text
+
+
+def test_vector_value_change(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        sum_id = w.declare("sum", 4)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, sum_id, 0xA)  # 1010
+    text = p.read_text()
+    assert "#10" in text
+    assert f"b1010 {sum_id}" in text
+
+
+def test_repeated_value_no_emit(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, a, 1)
+        w.value_change(20, a, 1)  # unchanged - should not emit value line
+    text = p.read_text()
+    # We should see #10 and the value, but #20 may or may not be emitted
+    # Either way, the value line should appear only once.
+    assert text.count(f"1{a}") == 1
+
+
+def test_time_monotonic(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, a, 1)
+        with pytest.raises(ValueError, match="must not decrease"):
+            w.value_change(5, a, 0)
+
+
+def test_unknown_var_id(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.end_definitions()
+        with pytest.raises(KeyError, match="unknown var_id"):
+            w.value_change(10, "!", 1)
+
+
+# ---- Initial dump ----
+
+
+def test_dump_initial(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        b = w.declare("b", 4)
+        w.close_scope()
+        w.end_definitions()
+        w.dump_initial({a: 1, b: 0xC})
+    text = p.read_text()
+    assert "$dumpvars" in text
+    assert "$end" in text
+    assert f"1{a}" in text
+    assert f"b1100 {b}" in text
+
+
+def test_dump_initial_default_values(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.end_definitions()
+        w.dump_initial({})
+    text = p.read_text()
+    assert f"0{a}" in text  # default 0
+
+
+# ---- 4-state x/z values ----
+
+
+def test_x_value_scalar(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, a, "x")
+    text = p.read_text()
+    assert f"x{a}" in text
+
+
+def test_xz_string_in_vector(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        b = w.declare("b", 4)
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, b, "10xz")
+    text = p.read_text()
+    assert f"b10xz {b}" in text
+
+
+# ---- Real value ----
+
+
+def test_real_value(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        v = w.declare("voltage", 64, kind="real")
+        w.close_scope()
+        w.end_definitions()
+        w.value_change(10, v, 1.5)
+    text = p.read_text()
+    assert f"r1.5 {v}" in text
+
+
+# ---- attach_to_callback_emitter ----
+
+
+class FakeEvent:
+    def __init__(self, time: int, signal: str, new_value: int):
+        self.time = time
+        self.signal = signal
+        self.new_value = new_value
+
+
+def test_attach_to_callback_emitter(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        a = w.declare("a", 1)
+        sum_id = w.declare("sum", 4)
+        w.close_scope()
+        w.end_definitions()
+
+        cb = attach_to_callback_emitter(w, name_to_var_id={"a": a, "sum": sum_id})
+        cb(FakeEvent(time=10, signal="a", new_value=1))
+        cb(FakeEvent(time=20, signal="sum", new_value=0xA))
+        # Unknown signal should be silently dropped
+        cb(FakeEvent(time=30, signal="not_declared", new_value=99))
+
+    text = p.read_text()
+    assert "#10" in text
+    assert "#20" in text
+    assert f"1{a}" in text
+    assert f"b1010 {sum_id}" in text
+
+
+def test_attach_handles_non_event_objects(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.end_definitions()
+        cb = attach_to_callback_emitter(w, name_to_var_id={})
+        # No exception when called with random object
+        cb(object())
+
+
+# ---- Auto-close scopes on end ----
+
+
+def test_auto_close_scopes_on_end_definitions(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    with VcdWriter(p) as w:
+        w.open_scope("top", "module")
+        w.declare("a", 1)
+        # Don't close_scope explicitly; end_definitions does it for us.
+        w.end_definitions()
+    text = p.read_text()
+    assert "$upscope $end" in text
+
+
+# ---- Errors ----
+
+
+def test_writing_when_not_open_raises(tmp_path: Path):
+    p = tmp_path / "x.vcd"
+    w = VcdWriter(p)
+    # haven't called .open()
+    with pytest.raises(RuntimeError, match="not open"):
+        w._w("test")


### PR DESCRIPTION
## Summary

VCD (Value Change Dump) waveform writer per IEEE 1364-2005 §18. Output is consumable by GTKWave, surfer, ModelSim, and every other waveform viewer.

**Zero hard deps.** Decoupled from any specific simulator: emit value changes via `writer.value_change(time, var_id, value)`. An `attach_to_callback_emitter` helper provides a `hardware-vm`-compatible callback.

## Pipeline position

```
hardware-vm Event(time, signal, new_value)
        |
        v
attach_to_callback_emitter(writer, name_to_var_id)
        |
        v
   VcdWriter.value_change(...)
        |
        v
       .vcd file -> GTKWave
```

## Quality

- **23/23 tests pass**
- **97% coverage** (target ≥ 85%)
- **Ruff clean**

## Test plan

- [x] Header (`$date`, `$version`, `$timescale`) emitted correctly
- [x] Scope hierarchy (`$scope` / `$upscope` / `$enddefinitions`)
- [x] Variable declarations (scalar, multi-bit vectors with `[N-1:0]` range)
- [x] Identifier compaction (94-char base; tested first 100 → all unique)
- [x] Scalar value change `1!` and vector `b1010 #`
- [x] Time monotonicity (raises if time decreases)
- [x] Idempotence (no emit on unchanged value)
- [x] $dumpvars initial dump
- [x] 4-state x/z values (scalar and within vectors)
- [x] Real values via `r<n>`
- [x] `attach_to_callback_emitter` wired up correctly
- [x] Auto-close open scopes on `end_definitions()`
- [x] Various error cases (close without open; declare after end; etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)