### PR TITLE
feat(parity): add elixir intel 4004 assembler

### DIFF
--- a/code/packages/elixir/intel_4004_assembler/BUILD
+++ b/code/packages/elixir/intel_4004_assembler/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/intel_4004_assembler/BUILD_windows
+++ b/code/packages/elixir/intel_4004_assembler/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/intel_4004_assembler/CHANGELOG.md
+++ b/code/packages/elixir/intel_4004_assembler/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added an Elixir Intel 4004 assembler with lexing, two-pass label resolution, ORG padding, and instruction encoding.
+- Added tagged and bang assembly APIs, capability manifest, build files, README docs, and parity tests.

--- a/code/packages/elixir/intel_4004_assembler/README.md
+++ b/code/packages/elixir/intel_4004_assembler/README.md
@@ -1,0 +1,22 @@
+# Intel 4004 Assembler (Elixir)
+
+An Intel 4004 assembler for educational emulator and compiler backends.
+
+The package parses assembly text, resolves labels in a first pass, then emits Intel 4004 machine-code bytes in a second pass.
+
+## Example
+
+```elixir
+alias CodingAdventures.Intel4004Assembler
+
+{:ok, binary} =
+  Intel4004Assembler.assemble("""
+  ORG 0x000
+  _start:
+    LDM 5
+    XCH R2
+    HLT
+  """)
+
+binary == <<0xD5, 0xB2, 0x01>>
+```

--- a/code/packages/elixir/intel_4004_assembler/lib/coding_adventures/intel_4004_assembler.ex
+++ b/code/packages/elixir/intel_4004_assembler/lib/coding_adventures/intel_4004_assembler.ex
@@ -1,0 +1,395 @@
+defmodule CodingAdventures.Intel4004Assembler.AssemblerError do
+  @moduledoc """
+  Exception raised for assembler syntax, resolution, and encoding errors.
+  """
+
+  defexception [:message]
+end
+
+defmodule CodingAdventures.Intel4004Assembler.ParsedLine do
+  @moduledoc """
+  Parsed assembly line with optional label, mnemonic, operands, and source text.
+  """
+
+  defstruct label: nil, mnemonic: nil, operands: [], source: ""
+
+  @type t :: %__MODULE__{
+          label: String.t() | nil,
+          mnemonic: String.t() | nil,
+          operands: [String.t()],
+          source: String.t()
+        }
+end
+
+defmodule CodingAdventures.Intel4004Assembler.Lexer do
+  @moduledoc """
+  Line-oriented lexer for Intel 4004 assembly.
+  """
+
+  alias CodingAdventures.Intel4004Assembler.ParsedLine
+
+  @label_re ~r/^([A-Za-z_][A-Za-z0-9_]*):/
+
+  @doc "Lex one source line."
+  @spec lex_line(String.t()) :: ParsedLine.t()
+  def lex_line(source) when is_binary(source) do
+    comment_free =
+      source
+      |> String.split(";", parts: 2)
+      |> hd()
+      |> String.trim_trailing()
+
+    {label, stripped} = split_label(String.trim_leading(comment_free))
+
+    if stripped == "" do
+      %ParsedLine{label: label, source: source}
+    else
+      {mnemonic, operand_text} = split_mnemonic(stripped)
+
+      %ParsedLine{
+        label: label,
+        mnemonic: String.upcase(mnemonic),
+        operands: parse_operands(operand_text),
+        source: source
+      }
+    end
+  end
+
+  @doc "Lex a complete assembly source string."
+  @spec lex_program(String.t()) :: [ParsedLine.t()]
+  def lex_program(text) when is_binary(text) do
+    text
+    |> String.replace("\r\n", "\n")
+    |> String.split("\n")
+    |> Enum.map(&lex_line/1)
+  end
+
+  defp split_label(stripped) do
+    case Regex.run(@label_re, stripped) do
+      [match, label] ->
+        {label, stripped |> String.slice(byte_size(match)..-1//1) |> String.trim_leading()}
+
+      _none ->
+        {nil, stripped}
+    end
+  end
+
+  defp split_mnemonic(stripped) do
+    case Regex.run(~r/^(\S+)(?:\s+(.*))?$/, stripped) do
+      [_all, mnemonic, operand_text] -> {mnemonic, String.trim(operand_text)}
+      [_all, mnemonic] -> {mnemonic, ""}
+    end
+  end
+
+  defp parse_operands(""), do: []
+
+  defp parse_operands(operand_text) do
+    operand_text
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+end
+
+defmodule CodingAdventures.Intel4004Assembler.Encoder do
+  @moduledoc """
+  Intel 4004 instruction sizing and byte encoding.
+  """
+
+  import Bitwise
+
+  alias CodingAdventures.Intel4004Assembler.AssemblerError
+
+  @fixed_opcodes %{
+    "NOP" => 0x00,
+    "HLT" => 0x01,
+    "WRM" => 0xE0,
+    "WMP" => 0xE1,
+    "WRR" => 0xE2,
+    "WR0" => 0xE4,
+    "WR1" => 0xE5,
+    "WR2" => 0xE6,
+    "WR3" => 0xE7,
+    "SBM" => 0xE8,
+    "RDM" => 0xE9,
+    "RDR" => 0xEA,
+    "ADM" => 0xEB,
+    "RD0" => 0xEC,
+    "RD1" => 0xED,
+    "RD2" => 0xEE,
+    "RD3" => 0xEF,
+    "CLB" => 0xF0,
+    "CLC" => 0xF1,
+    "IAC" => 0xF2,
+    "CMC" => 0xF3,
+    "CMA" => 0xF4,
+    "RAL" => 0xF5,
+    "RAR" => 0xF6,
+    "TCC" => 0xF7,
+    "DAC" => 0xF8,
+    "TCS" => 0xF9,
+    "STC" => 0xFA,
+    "DAA" => 0xFB,
+    "KBP" => 0xFC,
+    "DCL" => 0xFD
+  }
+
+  @one_byte_ops MapSet.new(["INC", "ADD", "SUB", "LD", "XCH", "BBL", "LDM", "SRC", "FIN", "JIN"])
+  @two_byte_ops MapSet.new(["JCN", "FIM", "JUN", "JMS", "ISZ", "ADD_IMM"])
+
+  @doc "Return the encoded size of a mnemonic."
+  @spec instruction_size(String.t()) :: non_neg_integer()
+  def instruction_size(mnemonic) do
+    cond do
+      Map.has_key?(@fixed_opcodes, mnemonic) -> 1
+      MapSet.member?(@one_byte_ops, mnemonic) -> 1
+      MapSet.member?(@two_byte_ops, mnemonic) -> 2
+      mnemonic == "ORG" -> 0
+      true -> raise AssemblerError, "Unknown mnemonic: '#{mnemonic}'"
+    end
+  end
+
+  @doc "Encode one instruction into a list of bytes."
+  @spec encode_instruction(
+          String.t(),
+          [String.t()],
+          %{optional(String.t()) => non_neg_integer()},
+          non_neg_integer()
+        ) :: [
+          byte()
+        ]
+  def encode_instruction(mnemonic, operands, symbols, pc) do
+    cond do
+      Map.has_key?(@fixed_opcodes, mnemonic) ->
+        expect_operands(mnemonic, operands, 0)
+        [Map.fetch!(@fixed_opcodes, mnemonic)]
+
+      mnemonic == "ORG" ->
+        []
+
+      mnemonic == "LDM" ->
+        immediate = operands |> one_operand(mnemonic) |> resolve_operand(symbols, pc)
+        check_range("LDM", immediate, 0, 15)
+        [bor(0xD0, immediate)]
+
+      mnemonic == "BBL" ->
+        immediate = operands |> one_operand(mnemonic) |> resolve_operand(symbols, pc)
+        check_range("BBL", immediate, 0, 15)
+        [bor(0xC0, immediate)]
+
+      mnemonic in ["INC", "ADD", "SUB", "LD", "XCH"] ->
+        base = %{"INC" => 0x60, "ADD" => 0x80, "SUB" => 0x90, "LD" => 0xA0, "XCH" => 0xB0}
+        [bor(Map.fetch!(base, mnemonic), parse_register(one_operand(operands, mnemonic)))]
+
+      mnemonic == "SRC" ->
+        [bor(0x20, 2 * parse_pair(one_operand(operands, mnemonic)) + 1)]
+
+      mnemonic == "FIN" ->
+        [bor(0x30, 2 * parse_pair(one_operand(operands, mnemonic)))]
+
+      mnemonic == "JIN" ->
+        [bor(0x30, 2 * parse_pair(one_operand(operands, mnemonic)) + 1)]
+
+      mnemonic == "FIM" ->
+        expect_operands(mnemonic, operands, 2)
+        pair = parse_pair(Enum.at(operands, 0))
+        immediate = resolve_operand(Enum.at(operands, 1), symbols, pc)
+        check_range("FIM", immediate, 0, 255)
+        [bor(0x20, 2 * pair), immediate]
+
+      mnemonic == "JCN" ->
+        expect_operands(mnemonic, operands, 2)
+        condition = resolve_operand(Enum.at(operands, 0), symbols, pc)
+        address = resolve_operand(Enum.at(operands, 1), symbols, pc)
+        check_range("JCN condition", condition, 0, 15)
+        check_range("JCN address", address, 0, 0xFFF)
+        [bor(0x10, condition), band(address, 0xFF)]
+
+      mnemonic == "JUN" ->
+        address = operands |> one_operand(mnemonic) |> resolve_operand(symbols, pc)
+        check_range("JUN", address, 0, 0xFFF)
+        [bor(0x40, band(address >>> 8, 0xF)), band(address, 0xFF)]
+
+      mnemonic == "JMS" ->
+        address = operands |> one_operand(mnemonic) |> resolve_operand(symbols, pc)
+        check_range("JMS", address, 0, 0xFFF)
+        [bor(0x50, band(address >>> 8, 0xF)), band(address, 0xFF)]
+
+      mnemonic == "ISZ" ->
+        expect_operands(mnemonic, operands, 2)
+        register = parse_register(Enum.at(operands, 0))
+        address = resolve_operand(Enum.at(operands, 1), symbols, pc)
+        check_range("ISZ address", address, 0, 0xFF)
+        [bor(0x70, register), band(address, 0xFF)]
+
+      mnemonic == "ADD_IMM" ->
+        expect_operands(mnemonic, operands, 3)
+        register = parse_register(Enum.at(operands, 1))
+        immediate = resolve_operand(Enum.at(operands, 2), symbols, pc)
+        check_range("ADD_IMM immediate", immediate, 0, 15)
+        [bor(0xD0, immediate), bor(0x80, register)]
+
+      true ->
+        raise AssemblerError, "Unknown mnemonic: '#{mnemonic}'"
+    end
+  end
+
+  defp expect_operands(mnemonic, operands, count) do
+    if length(operands) != count do
+      raise AssemblerError, "#{mnemonic} expects #{count} operand(s), got #{length(operands)}"
+    end
+  end
+
+  defp one_operand(operands, mnemonic) do
+    expect_operands(mnemonic, operands, 1)
+    hd(operands)
+  end
+
+  defp parse_register(name) do
+    case Regex.run(~r/^R([0-9]|1[0-5])$/i, name) do
+      [_match, register] -> String.to_integer(register)
+      _none -> raise AssemblerError, "Invalid register name: '#{name}'"
+    end
+  end
+
+  defp parse_pair(name) do
+    case Regex.run(~r/^P([0-7])$/i, name) do
+      [_match, pair] -> String.to_integer(pair)
+      _none -> raise AssemblerError, "Invalid register pair name: '#{name}'"
+    end
+  end
+
+  defp resolve_operand("$", _symbols, pc), do: pc
+
+  defp resolve_operand(operand, symbols, _pc) do
+    cond do
+      numeric?(operand) ->
+        parse_number(operand)
+
+      Map.has_key?(symbols, operand) ->
+        Map.fetch!(symbols, operand)
+
+      true ->
+        raise AssemblerError, "Undefined label: '#{operand}'"
+    end
+  end
+
+  defp numeric?(operand),
+    do: String.match?(operand, ~r/^-?\d+$/) or String.match?(operand, ~r/^0x[0-9a-f]+$/i)
+
+  defp parse_number("0x" <> hex), do: parse_number_with_base(hex, 16, "0x" <> hex)
+  defp parse_number("0X" <> hex), do: parse_number_with_base(hex, 16, "0X" <> hex)
+  defp parse_number(decimal), do: parse_number_with_base(decimal, 10, decimal)
+
+  defp parse_number_with_base(value, base, original) do
+    case Integer.parse(value, base) do
+      {parsed, ""} -> parsed
+      _error -> raise AssemblerError, "Invalid numeric literal: '#{original}'"
+    end
+  end
+
+  defp check_range(name, value, low, high) do
+    if value < low or value > high do
+      raise AssemblerError,
+            "#{name} value #{value} (0x#{Integer.to_string(value, 16) |> String.upcase()}) is out of range [#{low}, #{high}]"
+    end
+  end
+end
+
+defmodule CodingAdventures.Intel4004Assembler do
+  @moduledoc """
+  Two-pass Intel 4004 assembler.
+  """
+
+  alias __MODULE__.{AssemblerError, Encoder, Lexer}
+
+  @doc "Assemble source text and return `{:ok, binary}` or `{:error, error}`."
+  @spec assemble(String.t()) :: {:ok, binary()} | {:error, AssemblerError.t()}
+  def assemble(text) when is_binary(text) do
+    {:ok, assemble!(text)}
+  rescue
+    error in AssemblerError -> {:error, error}
+  end
+
+  @doc "Assemble source text and raise `AssemblerError` on failure."
+  @spec assemble!(String.t()) :: binary()
+  def assemble!(text) when is_binary(text) do
+    lines = Lexer.lex_program(text)
+    symbols = pass1(lines)
+    pass2(lines, symbols)
+  end
+
+  @doc "Lex one source line."
+  defdelegate lex_line(source), to: Lexer
+
+  @doc "Lex a complete source string."
+  defdelegate lex_program(source), to: Lexer
+
+  defp pass1(lines) do
+    {symbols, _pc} =
+      Enum.reduce(lines, {%{}, 0}, fn line, {symbols, pc} ->
+        symbols = if line.label, do: Map.put(symbols, line.label, pc), else: symbols
+
+        cond do
+          is_nil(line.mnemonic) ->
+            {symbols, pc}
+
+          line.mnemonic == "ORG" ->
+            address = line.operands |> org_operand() |> parse_org_address()
+            {symbols, address}
+
+          true ->
+            {symbols, pc + Encoder.instruction_size(line.mnemonic)}
+        end
+      end)
+
+    symbols
+  end
+
+  defp pass2(lines, symbols) do
+    {bytes, _pc} =
+      Enum.reduce(lines, {[], 0}, fn line, {bytes, pc} ->
+        cond do
+          is_nil(line.mnemonic) ->
+            {bytes, pc}
+
+          line.mnemonic == "ORG" ->
+            address = line.operands |> org_operand() |> parse_org_address()
+            padding = if address > pc, do: List.duplicate(0x00, address - pc), else: []
+            {bytes ++ padding, address}
+
+          true ->
+            encoded = Encoder.encode_instruction(line.mnemonic, line.operands, symbols, pc)
+            {bytes ++ encoded, pc + length(encoded)}
+        end
+      end)
+
+    :erlang.list_to_binary(bytes)
+  end
+
+  defp org_operand([]), do: raise(AssemblerError, "ORG requires an address operand")
+  defp org_operand([address | _rest]), do: address
+
+  defp parse_org_address(operand) do
+    address =
+      if String.match?(operand, ~r/^0x[0-9a-f]+$/i) do
+        operand |> String.slice(2..-1//1) |> parse_int(16, operand)
+      else
+        parse_int(operand, 10, operand)
+      end
+
+    if address < 0 or address > 0xFFF do
+      raise AssemblerError,
+            "ORG address 0x#{Integer.to_string(address, 16) |> String.upcase()} exceeds 0xFFF"
+    end
+
+    address
+  end
+
+  defp parse_int(value, base, original) do
+    case Integer.parse(value, base) do
+      {parsed, ""} -> parsed
+      _error -> raise AssemblerError, "Invalid numeric literal: '#{original}'"
+    end
+  end
+end

--- a/code/packages/elixir/intel_4004_assembler/mix.exs
+++ b/code/packages/elixir/intel_4004_assembler/mix.exs
@@ -1,0 +1,26 @@
+defmodule CodingAdventures.Intel4004Assembler.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_intel_4004_assembler,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/code/packages/elixir/intel_4004_assembler/required_capabilities.json
+++ b/code/packages/elixir/intel_4004_assembler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/intel_4004_assembler",
+  "capabilities": [],
+  "justification": "Pure in-memory assembly and byte encoding. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/intel_4004_assembler/test/intel_4004_assembler_test.exs
+++ b/code/packages/elixir/intel_4004_assembler/test/intel_4004_assembler_test.exs
@@ -1,0 +1,77 @@
+defmodule CodingAdventures.Intel4004AssemblerTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.Intel4004Assembler
+  alias CodingAdventures.Intel4004Assembler.{AssemblerError, Encoder, ParsedLine}
+
+  test "lexes labels, mnemonics, operands, and comments" do
+    parsed = Intel4004Assembler.lex_line("loop: JCN 0x4, done ; comment")
+
+    assert %ParsedLine{
+             label: "loop",
+             mnemonic: "JCN",
+             operands: ["0x4", "done"],
+             source: "loop: JCN 0x4, done ; comment"
+           } = parsed
+  end
+
+  test "assembles a small program" do
+    assert {:ok, <<0xD5, 0xB2, 0x01>>} =
+             Intel4004Assembler.assemble("""
+             ORG 0x000
+             _start:
+               LDM 5
+               XCH R2
+               HLT
+             """)
+  end
+
+  test "assembles labels, padding, and current pc operands" do
+    binary =
+      Intel4004Assembler.assemble!("""
+      ORG 0x002
+      JUN done
+      JCN 0x4, $
+      done:
+      HLT
+      """)
+
+    assert binary == <<0x00, 0x00, 0x40, 0x06, 0x14, 0x04, 0x01>>
+  end
+
+  test "encodes register, register-pair, and immediate families" do
+    assert Encoder.encode_instruction("FIM", ["P0", "0xAB"], %{}, 0) == [0x20, 0xAB]
+    assert Encoder.encode_instruction("SRC", ["P2"], %{}, 0) == [0x25]
+    assert Encoder.encode_instruction("FIN", ["P2"], %{}, 0) == [0x34]
+    assert Encoder.encode_instruction("JIN", ["P2"], %{}, 0) == [0x35]
+    assert Encoder.encode_instruction("ADD", ["R3"], %{}, 0) == [0x83]
+    assert Encoder.encode_instruction("SUB", ["R4"], %{}, 0) == [0x94]
+    assert Encoder.encode_instruction("LD", ["R5"], %{}, 0) == [0xA5]
+    assert Encoder.encode_instruction("INC", ["R6"], %{}, 0) == [0x66]
+    assert Encoder.encode_instruction("BBL", ["9"], %{}, 0) == [0xC9]
+    assert Encoder.encode_instruction("ADD_IMM", ["R0", "R2", "7"], %{}, 0) == [0xD7, 0x82]
+  end
+
+  test "encodes jumps, subroutine calls, and indexed skips" do
+    symbols = %{"target" => 0x123, "near" => 0x23}
+
+    assert Encoder.encode_instruction("JUN", ["target"], symbols, 0) == [0x41, 0x23]
+    assert Encoder.encode_instruction("JMS", ["target"], symbols, 0) == [0x51, 0x23]
+    assert Encoder.encode_instruction("ISZ", ["R2", "near"], symbols, 0) == [0x72, 0x23]
+  end
+
+  test "rejects bad operands and out-of-range values" do
+    assert {:error, %AssemblerError{message: "Undefined label: 'missing'"}} =
+             Intel4004Assembler.assemble("JUN missing")
+
+    assert_raise AssemblerError, fn ->
+      Encoder.encode_instruction("FIM", ["P0", "0x1FF"], %{}, 0)
+    end
+
+    assert_raise AssemblerError, fn -> Encoder.encode_instruction("ADD", ["R16"], %{}, 0) end
+    assert_raise AssemblerError, fn -> Encoder.encode_instruction("SRC", ["P8"], %{}, 0) end
+    assert_raise AssemblerError, fn -> Encoder.encode_instruction("NOP", ["R0"], %{}, 0) end
+    assert_raise AssemblerError, fn -> Encoder.instruction_size("BOGUS") end
+    assert_raise AssemblerError, fn -> Intel4004Assembler.assemble!("ORG 0x1000\nHLT") end
+  end
+end

--- a/code/packages/elixir/intel_4004_assembler/test/test_helper.exs
+++ b/code/packages/elixir/intel_4004_assembler/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add Elixir intel_4004_assembler package with lexer, two-pass label resolution, ORG padding, and byte encoder
- support fixed opcodes, register/register-pair instructions, immediate/jump/call/skip forms, and tagged or bang assembly APIs
- include capability manifest, build files, README/changelog docs, and parity tests

## Tests
- cd code/packages/elixir/intel_4004_assembler && mix deps.get --quiet; mix test --cover
- parsed required_capabilities.json