### PR TITLE
feat(parity): add elixir intel 4004 ir validator

### DIFF
--- a/code/packages/elixir/intel_4004_ir_validator/BUILD
+++ b/code/packages/elixir/intel_4004_ir_validator/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/intel_4004_ir_validator/BUILD_windows
+++ b/code/packages/elixir/intel_4004_ir_validator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/intel_4004_ir_validator/CHANGELOG.md
+++ b/code/packages/elixir/intel_4004_ir_validator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added an Elixir Intel 4004 IR validator for checking compiler IR against 4004 backend constraints.
+- Added validation rules for word operations, static RAM, call depth and recursion, virtual register count, and immediate ranges.

--- a/code/packages/elixir/intel_4004_ir_validator/README.md
+++ b/code/packages/elixir/intel_4004_ir_validator/README.md
@@ -1,0 +1,23 @@
+# Intel 4004 IR Validator (Elixir)
+
+Validates `compiler_ir` programs against the Intel 4004 backend constraints.
+
+The validator reports all detected issues as rule-tagged errors so callers can show actionable diagnostics before lowering IR to assembly.
+
+## Example
+
+```elixir
+alias CodingAdventures.CompilerIr.{IrImmediate, IrInstruction, IrProgram, IrRegister}
+alias CodingAdventures.Intel4004IrValidator
+
+program =
+  IrProgram.new("_start")
+  |> IrProgram.add_instruction(%IrInstruction{
+    opcode: :load_imm,
+    operands: [%IrRegister{index: 0}, %IrImmediate{value: 0}],
+    id: 1
+  })
+
+Intel4004IrValidator.validate(program)
+# []
+```

--- a/code/packages/elixir/intel_4004_ir_validator/lib/coding_adventures/intel_4004_ir_validator.ex
+++ b/code/packages/elixir/intel_4004_ir_validator/lib/coding_adventures/intel_4004_ir_validator.ex
@@ -1,0 +1,270 @@
+defmodule CodingAdventures.Intel4004IrValidator.IrValidationError do
+  @moduledoc """
+  Rule-tagged validation error returned by the Intel 4004 IR validator.
+  """
+
+  defexception [:rule, :message]
+
+  @type t :: %__MODULE__{rule: String.t(), message: String.t()}
+
+  @impl true
+  def exception(opts) do
+    %__MODULE__{
+      rule: Keyword.fetch!(opts, :rule),
+      message: Keyword.fetch!(opts, :message)
+    }
+  end
+
+  @impl true
+  def message(%__MODULE__{message: message}), do: message
+end
+
+defimpl String.Chars, for: CodingAdventures.Intel4004IrValidator.IrValidationError do
+  def to_string(%{rule: rule, message: message}), do: "[#{rule}] #{message}"
+end
+
+defmodule CodingAdventures.Intel4004IrValidator.IrValidator do
+  @moduledoc """
+  Validates compiler IR programs against Intel 4004 backend limits.
+  """
+
+  alias CodingAdventures.CompilerIr.{
+    IrDataDecl,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrProgram,
+    IrRegister
+  }
+
+  alias CodingAdventures.Intel4004IrValidator.IrValidationError
+
+  @max_ram_bytes 160
+  @max_call_depth 2
+  @max_virtual_registers 12
+  @min_load_immediate 0
+  @max_load_immediate 255
+
+  @doc "Validate an IR program and return all detected errors."
+  @spec validate(IrProgram.t()) :: [IrValidationError.t()]
+  def validate(%IrProgram{} = program) do
+    []
+    |> Kernel.++(check_no_word_ops(program))
+    |> Kernel.++(check_static_ram(program))
+    |> Kernel.++(check_call_depth(program))
+    |> Kernel.++(check_register_count(program))
+    |> Kernel.++(check_operand_range(program))
+  end
+
+  defp check_no_word_ops(%IrProgram{} = program) do
+    {errors, _saw_load, _saw_store} =
+      Enum.reduce(program.instructions, {[], false, false}, fn instruction,
+                                                               {errors, saw_load, saw_store} ->
+        cond do
+          instruction.opcode == :load_word and not saw_load ->
+            {
+              [
+                error(
+                  "no_word_ops",
+                  "LOAD_WORD is not supported on Intel 4004. Replace it with byte-sized accesses."
+                )
+                | errors
+              ],
+              true,
+              saw_store
+            }
+
+          instruction.opcode == :store_word and not saw_store ->
+            {
+              [
+                error(
+                  "no_word_ops",
+                  "STORE_WORD is not supported on Intel 4004. Replace it with byte-sized accesses."
+                )
+                | errors
+              ],
+              saw_load,
+              true
+            }
+
+          true ->
+            {errors, saw_load, saw_store}
+        end
+      end)
+
+    Enum.reverse(errors)
+  end
+
+  defp check_static_ram(%IrProgram{} = program) do
+    total =
+      Enum.reduce(program.data, 0, fn
+        %IrDataDecl{size: size}, acc -> acc + size
+        _decl, acc -> acc
+      end)
+
+    if total <= @max_ram_bytes do
+      []
+    else
+      [
+        error(
+          "static_ram",
+          "Static RAM usage #{total} bytes exceeds the Intel 4004 limit of #{@max_ram_bytes} bytes."
+        )
+      ]
+    end
+  end
+
+  defp check_call_depth(%IrProgram{} = program) do
+    graph = build_call_graph(program)
+
+    cond do
+      cycle = find_cycle(graph) ->
+        [
+          error(
+            "call_depth",
+            "Recursive call graphs are not supported on Intel 4004. Found cycle: #{Enum.join(cycle, " -> ")}."
+          )
+        ]
+
+      (depth = max_call_depth(graph)) > @max_call_depth ->
+        [
+          error(
+            "call_depth",
+            "Call graph depth #{depth} exceeds the Intel 4004 hardware stack limit of #{@max_call_depth} nested calls."
+          )
+        ]
+
+      true ->
+        []
+    end
+  end
+
+  defp build_call_graph(%IrProgram{} = program) do
+    {graph, _current_label} =
+      Enum.reduce(program.instructions, {%{}, nil}, fn
+        %IrInstruction{opcode: :label, operands: [%IrLabel{name: name} | _]}, {graph, _current} ->
+          {Map.put_new(graph, name, []), name}
+
+        %IrInstruction{opcode: :call, operands: [%IrLabel{name: callee} | _]}, {graph, current}
+        when is_binary(current) ->
+          graph =
+            graph
+            |> Map.update(current, [callee], fn children -> children ++ [callee] end)
+            |> Map.put_new(callee, [])
+
+          {graph, current}
+
+        _instruction, state ->
+          state
+      end)
+
+    graph
+  end
+
+  defp find_cycle(graph) do
+    Enum.reduce_while(Map.keys(graph), nil, fn node, _acc ->
+      case dfs_cycle(node, graph, []) do
+        nil -> {:cont, nil}
+        cycle -> {:halt, cycle}
+      end
+    end)
+  end
+
+  defp dfs_cycle(node, graph, path) do
+    if node in path do
+      start = Enum.find_index(path, &(&1 == node)) || 0
+      path |> Enum.slice(start..-1//1) |> Kernel.++([node])
+    else
+      Enum.reduce_while(Map.get(graph, node, []), nil, fn child, _acc ->
+        case dfs_cycle(child, graph, path ++ [node]) do
+          nil -> {:cont, nil}
+          cycle -> {:halt, cycle}
+        end
+      end)
+    end
+  end
+
+  defp max_call_depth(graph) when map_size(graph) == 0, do: 0
+
+  defp max_call_depth(graph) do
+    graph
+    |> Map.keys()
+    |> Enum.map(&walk_depth(graph, &1, 0, MapSet.new()))
+    |> Enum.max()
+  end
+
+  defp walk_depth(graph, node, depth, visited) do
+    if MapSet.member?(visited, node) do
+      depth
+    else
+      children = Map.get(graph, node, [])
+
+      if children == [] do
+        depth
+      else
+        visited = MapSet.put(visited, node)
+
+        children
+        |> Enum.map(&walk_depth(graph, &1, depth + 1, visited))
+        |> Enum.max()
+      end
+    end
+  end
+
+  defp check_register_count(%IrProgram{} = program) do
+    register_count =
+      program.instructions
+      |> Enum.flat_map(fn instruction -> instruction.operands end)
+      |> Enum.reduce(MapSet.new(), fn
+        %IrRegister{index: index}, set -> MapSet.put(set, index)
+        _operand, set -> set
+      end)
+      |> MapSet.size()
+
+    if register_count <= @max_virtual_registers do
+      []
+    else
+      [
+        error(
+          "register_count",
+          "Program uses #{register_count} distinct virtual registers but Intel 4004 supports at most #{@max_virtual_registers}."
+        )
+      ]
+    end
+  end
+
+  defp check_operand_range(%IrProgram{} = program) do
+    program.instructions
+    |> Enum.flat_map(fn
+      %IrInstruction{opcode: :load_imm, operands: [_dest, %IrImmediate{value: value} | _]} ->
+        if value < @min_load_immediate or value > @max_load_immediate do
+          [
+            error(
+              "operand_range",
+              "LOAD_IMM immediate #{value} is out of range for Intel 4004. Valid range is [#{@min_load_immediate}, #{@max_load_immediate}]."
+            )
+          ]
+        else
+          []
+        end
+
+      _instruction ->
+        []
+    end)
+  end
+
+  defp error(rule, message), do: %IrValidationError{rule: rule, message: message}
+end
+
+defmodule CodingAdventures.Intel4004IrValidator do
+  @moduledoc """
+  Convenience facade for Intel 4004 IR validation.
+  """
+
+  alias CodingAdventures.CompilerIr.IrProgram
+  alias __MODULE__.{IrValidationError, IrValidator}
+
+  @doc "Validate an IR program and return all detected errors."
+  @spec validate(IrProgram.t()) :: [IrValidationError.t()]
+  def validate(%IrProgram{} = program), do: IrValidator.validate(program)
+end

--- a/code/packages/elixir/intel_4004_ir_validator/mix.exs
+++ b/code/packages/elixir/intel_4004_ir_validator/mix.exs
@@ -1,0 +1,28 @@
+defmodule CodingAdventures.Intel4004IrValidator.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_intel_4004_ir_validator,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_compiler_ir, path: "../compiler_ir"}
+    ]
+  end
+end

--- a/code/packages/elixir/intel_4004_ir_validator/required_capabilities.json
+++ b/code/packages/elixir/intel_4004_ir_validator/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/intel_4004_ir_validator",
+  "capabilities": [],
+  "justification": "Pure in-memory IR validation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/intel_4004_ir_validator/test/intel_4004_ir_validator_test.exs
+++ b/code/packages/elixir/intel_4004_ir_validator/test/intel_4004_ir_validator_test.exs
@@ -1,0 +1,108 @@
+defmodule CodingAdventures.Intel4004IrValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.CompilerIr.{
+    IrDataDecl,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrProgram,
+    IrRegister
+  }
+
+  alias CodingAdventures.Intel4004IrValidator
+  alias CodingAdventures.Intel4004IrValidator.{IrValidationError, IrValidator}
+
+  defp program(instructions, data \\ []) do
+    %IrProgram{IrProgram.new("_start") | instructions: instructions, data: data}
+  end
+
+  defp label(name), do: %IrInstruction{opcode: :label, operands: [%IrLabel{name: name}], id: -1}
+  defp call(name, id), do: %IrInstruction{opcode: :call, operands: [%IrLabel{name: name}], id: id}
+
+  defp load_imm(register, value, id \\ 1) do
+    %IrInstruction{
+      opcode: :load_imm,
+      operands: [%IrRegister{index: register}, %IrImmediate{value: value}],
+      id: id
+    }
+  end
+
+  test "accepts a small feasible program" do
+    valid = program([label("_start"), load_imm(0, 0), %IrInstruction{opcode: :halt, id: 2}])
+
+    assert Intel4004IrValidator.validate(valid) == []
+    assert IrValidator.validate(valid) == []
+  end
+
+  test "rejects unsupported word operations once per operation family" do
+    invalid =
+      program([
+        %IrInstruction{opcode: :load_word, id: 1},
+        %IrInstruction{opcode: :load_word, id: 2},
+        %IrInstruction{opcode: :store_word, id: 3},
+        %IrInstruction{opcode: :store_word, id: 4}
+      ])
+
+    errors = IrValidator.validate(invalid)
+
+    assert Enum.map(errors, & &1.rule) == ["no_word_ops", "no_word_ops"]
+    assert Enum.at(errors, 0).message =~ "LOAD_WORD"
+    assert Enum.at(errors, 1).message =~ "STORE_WORD"
+  end
+
+  test "rejects excessive static RAM" do
+    invalid = program([], [%IrDataDecl{label: "huge", size: 200, init: 0}])
+
+    assert [%IrValidationError{rule: "static_ram"}] = IrValidator.validate(invalid)
+  end
+
+  test "rejects recursive call graphs" do
+    invalid =
+      program([
+        label("_fn_a"),
+        call("_fn_b", 1),
+        label("_fn_b"),
+        call("_fn_a", 2)
+      ])
+
+    assert [%IrValidationError{rule: "call_depth"} = error] = IrValidator.validate(invalid)
+    assert error.message =~ "_fn_a -> _fn_b -> _fn_a"
+    assert Exception.message(error) == error.message
+    assert Kernel.to_string(error) =~ "[call_depth]"
+  end
+
+  test "rejects call graphs deeper than the hardware stack" do
+    invalid =
+      program([
+        label("_start"),
+        call("_a", 1),
+        label("_a"),
+        call("_b", 2),
+        label("_b"),
+        call("_c", 3),
+        label("_c")
+      ])
+
+    assert [%IrValidationError{rule: "call_depth", message: message}] =
+             IrValidator.validate(invalid)
+
+    assert message =~ "depth 3"
+  end
+
+  test "rejects too many distinct virtual registers" do
+    instructions = Enum.map(0..12, fn index -> load_imm(index, index, index) end)
+    invalid = program(instructions)
+
+    assert [%IrValidationError{rule: "register_count"}] = IrValidator.validate(invalid)
+  end
+
+  test "rejects load immediates outside Intel 4004 byte range" do
+    invalid = program([load_imm(0, -1, 1), load_imm(1, 256, 2), load_imm(2, 255, 3)])
+
+    errors = IrValidator.validate(invalid)
+
+    assert Enum.map(errors, & &1.rule) == ["operand_range", "operand_range"]
+    assert Enum.all?(errors, &String.contains?(&1.message, "LOAD_IMM"))
+  end
+end

--- a/code/packages/elixir/intel_4004_ir_validator/test/test_helper.exs
+++ b/code/packages/elixir/intel_4004_ir_validator/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add Elixir intel_4004_ir_validator package backed by the existing Elixir compiler_ir package
- validate no word ops, static RAM budget, call recursion/depth, distinct register count, and LOAD_IMM byte range
- include capability manifest, build files, README/changelog docs, and focused parity tests

## Tests
- cd code/packages/elixir/intel_4004_ir_validator && mix deps.get --quiet; mix test --cover
- parsed required_capabilities.json