### PR TITLE
feat(macsyma-runtime): MACSYMA-specific runtime layer

### DIFF
--- a/code/packages/python/macsyma-runtime/BUILD
+++ b/code/packages/python/macsyma-runtime/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ../polynomial -e ../macsyma-compiler -e ../symbolic-vm -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --tb=short

--- a/code/packages/python/macsyma-runtime/BUILD_windows
+++ b/code/packages/python/macsyma-runtime/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ../polynomial -e ../macsyma-compiler -e ../symbolic-vm -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v --tb=short

--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.1.0 — 2026-04-25
+
+Initial release — Phase A skeleton.
+
+- `MacsymaBackend` — `SymbolicBackend` subclass with MACSYMA-specific
+  heads (`Display`, `Suppress`, `Kill`, `Ev`) and option flags.
+- `History` — input/output table, resolves `%`, `%i1`, `%o1`, ...
+  via a backend lookup hook.
+- `Display` / `Suppress` heads (`;` vs `$` statement terminators).
+  Identity handlers; the REPL inspects the wrapper before eval to
+  decide whether to print.
+- `Kill(symbol)` and `Kill(all)` handlers.
+- `Ev(expr, ...flags)` — minimal first cut: only the `numer` flag
+  is honored.
+- `MACSYMA_NAME_TABLE` — extends `macsyma-compiler`'s standard-name
+  map so identifiers like `expand`, `factor`, `subst`, `solve`,
+  `taylor`, `limit` route to canonical heads (the substrate handlers
+  may not yet exist; the user gets `Expand(...)` unevaluated until
+  they do).
+- Type-checked, ruff- and mypy-clean.

--- a/code/packages/python/macsyma-runtime/README.md
+++ b/code/packages/python/macsyma-runtime/README.md
@@ -1,0 +1,64 @@
+# macsyma-runtime
+
+The thin shell on top of `symbolic-vm` that holds genuinely-MACSYMA
+conventions. Everything reusable across CAS frontends lives in
+substrate packages (`cas-substitution`, `cas-simplify`,
+`cas-factor`, ...); this package holds only what is specifically
+MACSYMA / Maxima.
+
+## What's in here
+
+- `MacsymaBackend` — subclass of `SymbolicBackend` that adds the
+  MACSYMA-specific heads (`Display`, `Suppress`, `Kill`, `Ev`) and
+  the option flags (`numer`, `simp`, ...).
+- `History` — the `%i1`/`%o1`/`%i2`/`%o2`/... input/output table the
+  REPL writes and the VM reads via a binding-resolution hook.
+- Built-in name-table extensions — maps MACSYMA identifiers
+  (`expand`, `factor`, `subst`, `solve`, `taylor`, `limit`, ...) to
+  their canonical IR heads, so the compiler can route them to the
+  substrate handlers regardless of whether those handlers are yet
+  implemented.
+
+## Why this is the only deliberately-non-reusable package
+
+A future `mathematica-runtime` would sit at the same layer position —
+above `symbolic-vm`, alongside the language-specific
+`lexer/parser/compiler` — but it would write its own runtime entirely.
+Mathematica's `Hold`/`HoldComplete` semantics, `OwnValues`/`DownValues`
+rules, `Print[]`, and `Message[]` are very different from MACSYMA's
+`%i`/`%o`/`$`/`;`/`kill`/`ev`. Same for a `matlab-runtime` (with
+`ans`, `disp`, `clear`, `format`).
+
+Everything underneath the runtime is shared across all of them.
+
+## Phase A scope
+
+- `Display` / `Suppress` heads — wrappers the compiler emits around
+  each top-level statement so the REPL can distinguish `;` (display)
+  from `$` (suppress).
+- `History` and the `%`/`%i1`/`%o1` binding-resolution shim.
+- `Kill(name)` and `Kill(all)` for clearing bindings.
+- Basic `Ev(expr, numer)` — re-evaluate with the `numer` flag set.
+- Name-table additions for substrate heads (`Subst`, `Simplify`,
+  `Expand`, `Factor`, `Solve`, `Taylor`, `Limit`, `Length`, etc.).
+
+Later phases add `Block`, full `Ev`, `Assume`/`Forget`/`Is`.
+
+## Usage
+
+```python
+from macsyma_runtime import MacsymaBackend, History
+from symbolic_vm import VM
+
+history = History()
+backend = MacsymaBackend(history=history)
+vm = VM(backend)
+```
+
+The REPL program reads `History` to format `(%i1) ` / `(%o1) ` prompts
+and to resolve `%`, `%i1`, `%o1` references typed by the user.
+
+## Dependencies
+
+- `coding-adventures-symbolic-ir`
+- `coding-adventures-symbolic-vm`

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-macsyma-runtime"
+version = "0.1.0"
+description = "MACSYMA-specific runtime layer on top of the symbolic VM — history, $/; terminators, kill, ev, name table."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
+dependencies = [
+    "coding-adventures-symbolic-ir>=0.5.0",
+    "coding-adventures-symbolic-vm>=0.18.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/macsyma_runtime"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=macsyma_runtime --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/macsyma-runtime/required_capabilities.json
+++ b/code/packages/python/macsyma-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/macsyma-runtime",
+  "capabilities": [],
+  "justification": "Pure in-memory runtime layer. No filesystem, network, or process access of its own."
+}

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
@@ -1,0 +1,52 @@
+"""MACSYMA-specific runtime layer.
+
+Public API::
+
+    from macsyma_runtime import (
+        MacsymaBackend,
+        History,
+        DISPLAY,
+        SUPPRESS,
+        KILL,
+        EV,
+        MACSYMA_NAME_TABLE,
+        extend_compiler_name_table,
+    )
+
+The thin shell that turns the language-neutral ``symbolic-vm`` into a
+Maxima-flavored evaluator. See ``code/specs/macsyma-runtime.md``.
+"""
+
+from macsyma_runtime.backend import MacsymaBackend
+from macsyma_runtime.heads import (
+    ALL_SYMBOL,
+    ASSUME,
+    BLOCK,
+    DISPLAY,
+    EV,
+    FORGET,
+    IS,
+    KILL,
+    SUPPRESS,
+)
+from macsyma_runtime.history import History
+from macsyma_runtime.name_table import (
+    MACSYMA_NAME_TABLE,
+    extend_compiler_name_table,
+)
+
+__all__ = [
+    "ALL_SYMBOL",
+    "ASSUME",
+    "BLOCK",
+    "DISPLAY",
+    "EV",
+    "FORGET",
+    "History",
+    "IS",
+    "KILL",
+    "MACSYMA_NAME_TABLE",
+    "MacsymaBackend",
+    "SUPPRESS",
+    "extend_compiler_name_table",
+]

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
@@ -1,0 +1,144 @@
+"""The MACSYMA-flavored backend.
+
+:class:`MacsymaBackend` is a thin subclass of :class:`SymbolicBackend`.
+It adds:
+
+- A :class:`History` reference, consulted by :meth:`lookup` so user
+  references to ``%``, ``%i3``, ``%o3`` resolve transparently.
+- Handlers for the runtime-owned heads (`Display`, `Suppress`, `Kill`,
+  `Ev`).
+- Option-flag attributes (`numer`, `simp`, ...) plus a context-manager
+  helper :meth:`with_numer` for short-lived flag overrides used by `Ev`.
+
+Everything else — arithmetic, calculus, identity rewrites, list
+passthrough — comes from :class:`SymbolicBackend` unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+from symbolic_ir import IRNode, IRSymbol
+from symbolic_vm import SymbolicBackend
+from symbolic_vm.backend import Handler
+
+from macsyma_runtime.handlers import (
+    display_handler,
+    make_ev_handler,
+    make_kill_handler,
+    suppress_handler,
+)
+from macsyma_runtime.heads import DISPLAY, EV, KILL, SUPPRESS
+from macsyma_runtime.history import History
+
+
+class MacsymaBackend(SymbolicBackend):
+    """SymbolicBackend with the MACSYMA-specific runtime layer."""
+
+    #: Numeric-mode flag: when set, `Ev(expr, numer)` forces the
+    #: evaluator to collapse symbolic constants and arithmetic to
+    #: floats. Phase A treats `numer` as a hint that does not yet
+    #: change the symbolic backend's behavior — reserved.
+    numer: bool
+
+    #: Whether automatic simplification is enabled. Maxima's `simp`
+    #: flag. Phase A defaults true; not consulted yet.
+    simp: bool
+
+    #: The session's I/O history, owned by the REPL but referenced by
+    #: the backend so VM lookups can resolve `%`, `%iN`, `%oN`.
+    history: History
+
+    def __init__(self, *, history: History | None = None) -> None:
+        super().__init__()
+        self.history = history if history is not None else History()
+        self.numer = False
+        self.simp = True
+
+        # Patch the inherited handler table with the runtime's heads.
+        # ``SymbolicBackend.__init__`` filled ``self._handlers`` already.
+        runtime_handlers: dict[str, Handler] = {
+            DISPLAY.name: display_handler,
+            SUPPRESS.name: suppress_handler,
+            KILL.name: make_kill_handler(self),
+            EV.name: make_ev_handler(),
+        }
+        self._handlers = {**self._handlers, **runtime_handlers}
+
+        # ``Kill`` and ``Ev`` need their arguments raw — not pre-evaluated:
+        # ``kill(x)`` should clear the symbol ``x``, not evaluate ``x``
+        # to its current binding and then ignore the result. ``ev`` reads
+        # flag *names*, which would resolve to themselves under the
+        # symbolic backend but holding them costs nothing and keeps the
+        # contract obvious.
+        self._held_heads = super().hold_heads() | frozenset({KILL.name, EV.name})
+
+    def hold_heads(self) -> frozenset[str]:
+        return self._held_heads
+
+    # ---- environment helpers ------------------------------------------
+
+    def unbind(self, name: str) -> None:
+        """Remove ``name`` from the binding environment.
+
+        No-op if the name was never bound. Used by the ``Kill`` handler.
+        """
+        self._env.pop(name, None)
+
+    def reset_environment(self) -> None:
+        """Clear every user-introduced binding.
+
+        Re-installs the two pre-bound entries (``True``/``False``) that
+        :class:`SymbolicBackend` expects to find. Also clears the
+        history — Maxima's ``kill(all)`` does both.
+        """
+        # Cheapest correct approach: re-run the parent ``__init__``
+        # state setup. We don't want to re-install handlers (that would
+        # drop our runtime overrides), so we touch only ``_env``.
+        from symbolic_vm.handlers import FALSE, TRUE
+
+        self._env.clear()
+        self._env["True"] = TRUE
+        self._env["False"] = FALSE
+        self.history.reset()
+
+    # ---- name lookup with history fallback ----------------------------
+
+    def lookup(self, name: str) -> IRNode | None:
+        """Look up a binding, falling back to the history table.
+
+        First checks ``self._env`` (the normal binding store). If that
+        misses, asks the :class:`History` whether the name is one of
+        ``%``, ``%iN``, ``%oN``. Only then does the VM see ``None``.
+        """
+        env_value = super().lookup(name)
+        if env_value is not None:
+            return env_value
+        return self.history.resolve_history_symbol(name)
+
+    # ---- option-flag context manager ----------------------------------
+
+    @contextmanager
+    def with_numer(self) -> Iterator[None]:
+        """Temporarily enable the ``numer`` flag.
+
+        Used by ``Ev(expr, numer)``. The flag is restored on exit even
+        if the inner evaluation raises.
+        """
+        previous = self.numer
+        self.numer = True
+        try:
+            yield
+        finally:
+            self.numer = previous
+
+    def handlers(self) -> Mapping[str, Handler]:
+        return self._handlers
+
+    # The on_unresolved policy is inherited from SymbolicBackend:
+    # unbound names stay as free symbols. The history fallback above
+    # only kicks in for `%`/`%iN`/`%oN`; ordinary user variables that
+    # weren't assigned still reach this method and are returned as-is.
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode:
+        return symbol

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/handlers.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/handlers.py
@@ -1,0 +1,113 @@
+"""Handlers for the MACSYMA-runtime-owned heads.
+
+Each handler conforms to the symbolic-vm :data:`Handler` signature:
+
+    def handler(vm: VM, expr: IRApply) -> IRNode
+
+For Phase A the runtime owns five heads:
+
+- ``Display`` — terminator wrapper for ``;``. Identity-on-inner.
+- ``Suppress`` — terminator wrapper for ``$``. Identity-on-inner.
+- ``Kill``    — clear bindings.
+- ``Ev``      — re-evaluate with flags.
+- ``Block``   — reserved for Phase G.
+
+The runtime keeps these heads in :mod:`macsyma_runtime.heads` so they
+are easy to import as singletons.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from symbolic_ir import IRApply, IRNode, IRSymbol
+from symbolic_vm.backend import Handler
+
+if TYPE_CHECKING:
+    from symbolic_vm import VM
+
+    from macsyma_runtime.backend import MacsymaBackend
+
+
+def display_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Display(inner)`` returns ``inner`` unchanged.
+
+    The VM has already evaluated ``inner`` (held heads are an opt-in
+    list and Display is not held). The REPL inspected the head before
+    evaluation to decide whether to print. By the time we get here the
+    wrapper has done its job and we just unwrap.
+    """
+    if len(expr.args) != 1:
+        raise ValueError(f"Display takes 1 arg, got {len(expr.args)}")
+    return expr.args[0]
+
+
+def suppress_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Suppress(inner)`` returns ``inner`` unchanged. Twin of Display."""
+    if len(expr.args) != 1:
+        raise ValueError(f"Suppress takes 1 arg, got {len(expr.args)}")
+    return expr.args[0]
+
+
+def make_kill_handler(backend: MacsymaBackend) -> Handler:
+    """Build a ``Kill`` handler bound to a particular backend.
+
+    ``Kill`` mutates the backend's environment, so it can't be a plain
+    free function — it needs the backend reference.
+    """
+
+    def kill_handler(_vm: VM, expr: IRApply) -> IRNode:
+        # The args were evaluated before reaching us. But for `kill(x)`
+        # we want to clear the binding for the *symbol name x*, not
+        # whatever x evaluates to. The Symbolic backend leaves unbound
+        # names unchanged, so a fresh symbol still arrives as
+        # IRSymbol("x"). For names that *are* bound, the user's intent
+        # of `kill(x)` is to clear x, not to inspect its value — so
+        # we accept either form: if we see an IRSymbol we use its name;
+        # if we see anything else we silently do nothing for that arg.
+        for arg in expr.args:
+            if isinstance(arg, IRSymbol):
+                if arg.name == "all":
+                    backend.reset_environment()
+                else:
+                    backend.unbind(arg.name)
+        return _DONE
+
+    return kill_handler
+
+
+# A tiny sentinel that downstream code can ignore. Kill is "for its
+# side effect" — there is no meaningful return value. We use the
+# IRSymbol("done") shape Maxima itself uses.
+_DONE = IRSymbol("done")
+
+
+def make_ev_handler() -> Handler:
+    """Build the ``Ev(expr, *flags)`` handler.
+
+    Phase A only honours the ``numer`` flag (force-collapse to floats).
+    Future phases will add ``simp``, ``expand``, ``factor``, ``ratsimp``,
+    etc. For now, an unknown flag is silently ignored.
+    """
+
+    def ev_handler(vm: VM, expr: IRApply) -> IRNode:
+        # We need the un-evaluated expression form here. The simplest
+        # contract for Phase A: every flag is an IRSymbol that arrives
+        # as itself (because they are all unbound). Loop through flags,
+        # gather them into a set, then re-evaluate the first arg.
+        if not expr.args:
+            return expr
+        first = expr.args[0]
+        flags: set[str] = set()
+        for arg in expr.args[1:]:
+            if isinstance(arg, IRSymbol):
+                flags.add(arg.name)
+        if "numer" in flags:
+            # Re-evaluate `first` with the numer flag set on the backend.
+            backend = vm.backend
+            if hasattr(backend, "with_numer"):
+                with backend.with_numer():
+                    return vm.eval(first)
+        return first
+
+    return ev_handler

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/heads.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/heads.py
@@ -1,0 +1,30 @@
+"""IR head symbols introduced by macsyma-runtime.
+
+These heads are Maxima-specific: they don't have meaningful analogues
+in Mathematica or Maple's evaluation models, so they live in the
+runtime layer rather than in :mod:`symbolic_ir`. The runtime registers
+handlers for each one on :class:`MacsymaBackend`.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+# Statement-terminator wrappers. The compiler emits one of these around
+# each top-level statement based on whether the source ended with `;`
+# (display) or `$` (suppress). The REPL inspects the wrapper type
+# *before* eval to decide whether to print the result; the VM unwraps
+# them in the handler so downstream code never has to think about them.
+DISPLAY = IRSymbol("Display")
+SUPPRESS = IRSymbol("Suppress")
+
+# Bookkeeping operations.
+KILL = IRSymbol("Kill")
+EV = IRSymbol("Ev")
+BLOCK = IRSymbol("Block")  # reserved for Phase G; not yet handled.
+ASSUME = IRSymbol("Assume")
+FORGET = IRSymbol("Forget")
+IS = IRSymbol("Is")
+
+# A sentinel symbol that ``kill(all)`` matches.
+ALL_SYMBOL = IRSymbol("all")

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/history.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/history.py
@@ -1,0 +1,97 @@
+"""The MACSYMA `%i` / `%o` history table.
+
+Maxima labels every input as ``%iN`` and every output as ``%oN``. The
+``%`` shorthand resolves to the most recent ``%o``. The REPL writes
+to this table on each turn; the VM reads from it via a binding-lookup
+hook so user expressions like ``%i3 + 1`` work transparently.
+
+This is a session-local in-memory data structure. There is no
+persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from symbolic_ir import IRNode
+
+
+@dataclass
+class History:
+    """Input/output history for one MACSYMA REPL session.
+
+    Indices start at 1 (Maxima convention). After ``record_input(ir)``
+    returns ``n``, ``get_input(n)`` returns the same IR. Outputs follow
+    the same pattern.
+
+    The REPL is responsible for keeping inputs and outputs aligned;
+    typically every ``record_input`` is followed by exactly one
+    ``record_output`` before the next ``record_input`` happens.
+    """
+
+    inputs: list[IRNode] = field(default_factory=list)
+    outputs: list[IRNode] = field(default_factory=list)
+
+    # ---- writers ---------------------------------------------------------
+
+    def record_input(self, ir: IRNode) -> int:
+        """Append ``ir`` to the input history. Returns the new index."""
+        self.inputs.append(ir)
+        return len(self.inputs)
+
+    def record_output(self, ir: IRNode) -> int:
+        """Append ``ir`` to the output history. Returns the new index."""
+        self.outputs.append(ir)
+        return len(self.outputs)
+
+    # ---- readers ---------------------------------------------------------
+
+    def get_input(self, n: int) -> IRNode | None:
+        """Return ``%iN`` or None if out of range."""
+        if 1 <= n <= len(self.inputs):
+            return self.inputs[n - 1]
+        return None
+
+    def get_output(self, n: int) -> IRNode | None:
+        """Return ``%oN`` or None if out of range."""
+        if 1 <= n <= len(self.outputs):
+            return self.outputs[n - 1]
+        return None
+
+    def last_output(self) -> IRNode | None:
+        """Return the most recent ``%o`` or None if no outputs yet.
+
+        Used to resolve the bare ``%`` shorthand.
+        """
+        return self.outputs[-1] if self.outputs else None
+
+    def next_input_index(self) -> int:
+        """Return the index that the next ``record_input`` will produce.
+
+        Useful for prompts: ``(%i{history.next_input_index()}) ``.
+        """
+        return len(self.inputs) + 1
+
+    # ---- mutation --------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear the entire history."""
+        self.inputs.clear()
+        self.outputs.clear()
+
+    # ---- name-resolution hook --------------------------------------------
+
+    def resolve_history_symbol(self, name: str) -> IRNode | None:
+        """Resolve ``%``, ``%iN``, ``%oN`` symbol names to IR.
+
+        Returns the corresponding IR node or None if the name is not a
+        history reference (or is out of range). The MacsymaBackend
+        installs this as a fallback inside its ``lookup`` chain.
+        """
+        if name == "%":
+            return self.last_output()
+        if name.startswith("%i") and name[2:].isdigit():
+            return self.get_input(int(name[2:]))
+        if name.startswith("%o") and name[2:].isdigit():
+            return self.get_output(int(name[2:]))
+        return None

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
@@ -1,0 +1,129 @@
+"""Name-table extensions consumed by the MACSYMA compiler.
+
+The base ``macsyma-compiler`` package ships a small ``_STANDARD_FUNCTIONS``
+map covering the elementary operations (``diff``, ``integrate``, ``sin``,
+``cos``, ...). The runtime wants to map a much larger set of MACSYMA
+identifiers — ``factor``, ``expand``, ``simplify``, ``subst``, ``solve``,
+``taylor``, ``limit``, ``length``, ``first``, etc. — to canonical IR
+heads. This table is the central place where those mappings live.
+
+The substrate handlers for each of these heads may not yet be
+implemented; until they are, MACSYMA users will see e.g.
+``Expand(x^2 + 2*x + 1)`` returned unevaluated, which is the same
+fall-through behavior every CAS uses for unknown operations. Once the
+substrate package lands, the routing is automatically picked up — no
+compiler change required.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+# IR heads from substrate packages that may not exist yet — define
+# them here as :class:`IRSymbol` singletons so the table can reference
+# them. When the substrate package lands, it can re-export the same
+# symbol (or a binding-equivalent one) without breaking compatibility.
+SUBST = IRSymbol("Subst")
+SIMPLIFY = IRSymbol("Simplify")
+EXPAND = IRSymbol("Expand")
+FACTOR = IRSymbol("Factor")
+SOLVE = IRSymbol("Solve")
+TAYLOR = IRSymbol("Taylor")
+LIMIT = IRSymbol("Limit")
+
+LENGTH = IRSymbol("Length")
+FIRST = IRSymbol("First")
+REST = IRSymbol("Rest")
+LAST = IRSymbol("Last")
+APPEND = IRSymbol("Append")
+REVERSE = IRSymbol("Reverse")
+RANGE = IRSymbol("Range")
+MAP = IRSymbol("Map")
+APPLY = IRSymbol("Apply")
+SELECT = IRSymbol("Select")
+SORT = IRSymbol("Sort")
+PART = IRSymbol("Part")
+FLATTEN = IRSymbol("Flatten")
+JOIN = IRSymbol("Join")
+
+MATRIX = IRSymbol("Matrix")
+TRANSPOSE = IRSymbol("Transpose")
+DETERMINANT = IRSymbol("Determinant")
+INVERSE = IRSymbol("Inverse")
+
+GCD = IRSymbol("Gcd")
+LCM = IRSymbol("Lcm")
+MOD = IRSymbol("Mod")
+FLOOR = IRSymbol("Floor")
+CEILING = IRSymbol("Ceiling")
+ABS = IRSymbol("Abs")
+
+# Re-export the runtime-owned heads so callers have one import.
+from macsyma_runtime.heads import (  # noqa: E402
+    ASSUME,
+    BLOCK,
+    EV,
+    FORGET,
+    IS,
+    KILL,
+)
+
+# The map MACSYMA users see → canonical IR head.
+#
+# The MACSYMA compiler reads ``_STANDARD_FUNCTIONS`` (a similar table
+# scoped to the lexicon it ships with). The runtime's
+# :func:`extend_compiler_name_table` adds these on top.
+MACSYMA_NAME_TABLE: dict[str, IRSymbol] = {
+    # Algebraic operations
+    "subst": SUBST,
+    "simplify": SIMPLIFY,
+    "expand": EXPAND,
+    "factor": FACTOR,
+    "solve": SOLVE,
+    "taylor": TAYLOR,
+    "limit": LIMIT,
+    # List operations
+    "length": LENGTH,
+    "first": FIRST,
+    "rest": REST,
+    "last": LAST,
+    "append": APPEND,
+    "reverse": REVERSE,
+    "makelist": RANGE,
+    "map": MAP,
+    "apply": APPLY,
+    "sublist": SELECT,
+    "sort": SORT,
+    "part": PART,
+    "flatten": FLATTEN,
+    "join": JOIN,
+    # Matrix
+    "matrix": MATRIX,
+    "transpose": TRANSPOSE,
+    "determinant": DETERMINANT,
+    "invert": INVERSE,
+    # Number-theoretic
+    "gcd": GCD,
+    "lcm": LCM,
+    "mod": MOD,
+    "floor": FLOOR,
+    "ceiling": CEILING,
+    "abs": ABS,
+    # Runtime-owned operations
+    "kill": KILL,
+    "ev": EV,
+    "block": BLOCK,
+    "assume": ASSUME,
+    "forget": FORGET,
+    "is": IS,
+}
+
+
+def extend_compiler_name_table(target: dict[str, IRSymbol]) -> None:
+    """Merge :data:`MACSYMA_NAME_TABLE` into a compiler's name dict.
+
+    Used at REPL startup so the compiler's ``_STANDARD_FUNCTIONS`` map
+    knows about every name introduced here. Idempotent — calling twice
+    with the same target is safe.
+    """
+    target.update(MACSYMA_NAME_TABLE)

--- a/code/packages/python/macsyma-runtime/tests/test_backend_history_lookup.py
+++ b/code/packages/python/macsyma-runtime/tests/test_backend_history_lookup.py
@@ -1,0 +1,53 @@
+"""MacsymaBackend resolves %, %iN, %oN via the History."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import History, MacsymaBackend
+
+
+def test_history_fallback_resolves_percent() -> None:
+    h = History()
+    h.record_output(IRInteger(42))
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    # `%` evaluates to 42 — history fallback fires after env miss.
+    assert vm.eval(IRSymbol("%")) == IRInteger(42)
+
+
+def test_history_fallback_resolves_percent_o1() -> None:
+    h = History()
+    h.record_output(IRInteger(7))
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%o1")) == IRInteger(7)
+
+
+def test_history_fallback_resolves_percent_i2() -> None:
+    h = History()
+    x = IRSymbol("x")
+    h.record_input(IRInteger(1))
+    h.record_input(x)
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%i2")) == x
+
+
+def test_unbound_normal_name_stays_symbolic() -> None:
+    """A bare `xyz` with no env binding and not a history reference
+    stays symbolic (SymbolicBackend behavior)."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("xyz")) == IRSymbol("xyz")
+
+
+def test_env_binding_takes_precedence_over_history() -> None:
+    """If a user did `%o1: 99`, the env wins over the history."""
+    h = History()
+    h.record_output(IRInteger(42))
+    backend = MacsymaBackend(history=h)
+    backend.bind("%o1", IRInteger(99))
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%o1")) == IRInteger(99)

--- a/code/packages/python/macsyma-runtime/tests/test_backend_init.py
+++ b/code/packages/python/macsyma-runtime/tests/test_backend_init.py
@@ -1,0 +1,42 @@
+"""MacsymaBackend wiring — flags, default history, handler installation."""
+
+from __future__ import annotations
+
+from macsyma_runtime import DISPLAY, EV, KILL, SUPPRESS, History, MacsymaBackend
+
+
+def test_default_history_is_fresh() -> None:
+    b = MacsymaBackend()
+    assert b.history.next_input_index() == 1
+
+
+def test_explicit_history_is_used() -> None:
+    h = History()
+    b = MacsymaBackend(history=h)
+    assert b.history is h
+
+
+def test_default_flags() -> None:
+    b = MacsymaBackend()
+    assert b.numer is False
+    assert b.simp is True
+
+
+def test_runtime_handlers_installed() -> None:
+    b = MacsymaBackend()
+    handlers = b.handlers()
+    assert DISPLAY.name in handlers
+    assert SUPPRESS.name in handlers
+    assert KILL.name in handlers
+    assert EV.name in handlers
+
+
+def test_inherited_arithmetic_handlers_still_present() -> None:
+    """Subclassing must not drop the parent's handler table."""
+    b = MacsymaBackend()
+    handlers = b.handlers()
+    # SymbolicBackend installs Add, Mul, D, Integrate (among others).
+    assert "Add" in handlers
+    assert "Mul" in handlers
+    assert "D" in handlers
+    assert "Integrate" in handlers

--- a/code/packages/python/macsyma-runtime/tests/test_display_suppress.py
+++ b/code/packages/python/macsyma-runtime/tests/test_display_suppress.py
@@ -1,0 +1,40 @@
+"""Display / Suppress wrappers — identity-on-inner."""
+
+from __future__ import annotations
+
+from symbolic_ir import ADD, IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import DISPLAY, SUPPRESS, MacsymaBackend
+
+
+def test_display_unwraps() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(DISPLAY, (IRApply(ADD, (IRInteger(2), IRInteger(3))),))
+    # The inner Add evaluates first, then Display returns the result.
+    assert vm.eval(expr) == IRInteger(5)
+
+
+def test_suppress_unwraps() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(SUPPRESS, (IRApply(ADD, (IRInteger(1), IRInteger(2))),))
+    assert vm.eval(expr) == IRInteger(3)
+
+
+def test_display_with_symbolic_inner() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    x = IRSymbol("x")
+    expr = IRApply(DISPLAY, (x,))
+    assert vm.eval(expr) == x
+
+
+def test_display_arity_validation() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    import pytest
+
+    with pytest.raises(ValueError):
+        vm.eval(IRApply(DISPLAY, (IRInteger(1), IRInteger(2))))

--- a/code/packages/python/macsyma-runtime/tests/test_ev.py
+++ b/code/packages/python/macsyma-runtime/tests/test_ev.py
@@ -1,0 +1,48 @@
+"""Ev — phase-A skeleton (numer flag only)."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import EV, MacsymaBackend
+
+
+def test_ev_no_flags_returns_first_arg() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    # ev(x) with no flags returns x.
+    expr = IRApply(EV, (IRSymbol("x"),))
+    assert vm.eval(expr) == IRSymbol("x")
+
+
+def test_ev_unknown_flag_silently_ignored() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(EV, (IRInteger(2), IRSymbol("nonexistent_flag")))
+    assert vm.eval(expr) == IRInteger(2)
+
+
+def test_ev_numer_sets_flag_briefly() -> None:
+    """Phase-A `numer` is a hint; we only verify the with_numer
+    context manager toggles the flag during the evaluation, not that
+    the result actually changes (that's Phase B+ work)."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(EV, (IRInteger(2), IRSymbol("numer")))
+    # During eval, backend.numer should have flipped to True; after
+    # eval, it should be back to False (the default).
+    assert vm.eval(expr) == IRInteger(2)
+    assert backend.numer is False
+
+
+def test_with_numer_restores_on_exception() -> None:
+    backend = MacsymaBackend()
+    assert backend.numer is False
+    try:
+        with backend.with_numer():
+            assert backend.numer is True
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert backend.numer is False

--- a/code/packages/python/macsyma-runtime/tests/test_history.py
+++ b/code/packages/python/macsyma-runtime/tests/test_history.py
@@ -1,0 +1,81 @@
+"""History — input/output table tests."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRInteger, IRSymbol
+
+from macsyma_runtime import History
+
+
+def test_initial_state() -> None:
+    h = History()
+    assert h.next_input_index() == 1
+    assert h.last_output() is None
+    assert h.get_input(1) is None
+    assert h.get_output(1) is None
+
+
+def test_record_and_retrieve() -> None:
+    h = History()
+    n1 = h.record_input(IRInteger(1))
+    n2 = h.record_output(IRInteger(2))
+    assert n1 == 1 and n2 == 1
+    assert h.get_input(1) == IRInteger(1)
+    assert h.get_output(1) == IRInteger(2)
+
+
+def test_indices_advance() -> None:
+    h = History()
+    h.record_input(IRInteger(1))
+    h.record_input(IRInteger(2))
+    h.record_input(IRInteger(3))
+    assert h.next_input_index() == 4
+
+
+def test_last_output() -> None:
+    h = History()
+    h.record_output(IRInteger(1))
+    h.record_output(IRInteger(2))
+    assert h.last_output() == IRInteger(2)
+
+
+def test_resolve_percent_shorthand() -> None:
+    h = History()
+    h.record_output(IRInteger(42))
+    assert h.resolve_history_symbol("%") == IRInteger(42)
+
+
+def test_resolve_percent_iN() -> None:
+    h = History()
+    x = IRSymbol("x")
+    h.record_input(x)
+    assert h.resolve_history_symbol("%i1") == x
+
+
+def test_resolve_percent_oN() -> None:
+    h = History()
+    h.record_output(IRInteger(7))
+    assert h.resolve_history_symbol("%o1") == IRInteger(7)
+
+
+def test_resolve_unknown_returns_none() -> None:
+    h = History()
+    assert h.resolve_history_symbol("xyz") is None
+    assert h.resolve_history_symbol("%foo") is None
+    assert h.resolve_history_symbol("%i999") is None
+
+
+def test_resolve_with_no_history_returns_none() -> None:
+    h = History()
+    assert h.resolve_history_symbol("%") is None
+    assert h.resolve_history_symbol("%i1") is None
+    assert h.resolve_history_symbol("%o1") is None
+
+
+def test_reset() -> None:
+    h = History()
+    h.record_input(IRInteger(1))
+    h.record_output(IRInteger(2))
+    h.reset()
+    assert h.next_input_index() == 1
+    assert h.last_output() is None

--- a/code/packages/python/macsyma-runtime/tests/test_kill.py
+++ b/code/packages/python/macsyma-runtime/tests/test_kill.py
@@ -1,0 +1,58 @@
+"""Kill handler — clear bindings."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import KILL, MacsymaBackend
+
+
+def test_kill_removes_binding() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(5))
+    vm = VM(backend)
+    # Sanity: x evaluates to 5.
+    assert vm.eval(IRSymbol("x")) == IRInteger(5)
+    # kill(x) clears it.
+    vm.eval(IRApply(KILL, (IRSymbol("x"),)))
+    # Now x is symbolic again.
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+
+
+def test_kill_multiple_args() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(1))
+    backend.bind("y", IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("x"), IRSymbol("y"))))
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+    assert vm.eval(IRSymbol("y")) == IRSymbol("y")
+
+
+def test_kill_unbound_is_noop() -> None:
+    """kill(x) on a never-bound name does nothing — no error."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    # Should not raise.
+    vm.eval(IRApply(KILL, (IRSymbol("never_bound"),)))
+
+
+def test_kill_all_clears_environment() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(1))
+    backend.bind("y", IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("all"),)))
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+    assert vm.eval(IRSymbol("y")) == IRSymbol("y")
+
+
+def test_kill_all_clears_history() -> None:
+    backend = MacsymaBackend()
+    backend.history.record_input(IRInteger(1))
+    backend.history.record_output(IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("all"),)))
+    assert backend.history.next_input_index() == 1
+    assert backend.history.last_output() is None

--- a/code/packages/python/macsyma-runtime/tests/test_name_table.py
+++ b/code/packages/python/macsyma-runtime/tests/test_name_table.py
@@ -1,0 +1,42 @@
+"""Name-table extensions — coverage check."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+from macsyma_runtime import MACSYMA_NAME_TABLE, extend_compiler_name_table
+
+
+def test_table_is_a_dict() -> None:
+    assert isinstance(MACSYMA_NAME_TABLE, dict)
+
+
+def test_subst_routes_to_subst_head() -> None:
+    assert MACSYMA_NAME_TABLE["subst"] == IRSymbol("Subst")
+
+
+def test_factor_routes_to_factor_head() -> None:
+    assert MACSYMA_NAME_TABLE["factor"] == IRSymbol("Factor")
+
+
+def test_solve_routes_to_solve_head() -> None:
+    assert MACSYMA_NAME_TABLE["solve"] == IRSymbol("Solve")
+
+
+def test_kill_routes_to_kill_head() -> None:
+    assert MACSYMA_NAME_TABLE["kill"] == IRSymbol("Kill")
+
+
+def test_extend_compiler_name_table_merges() -> None:
+    target: dict[str, IRSymbol] = {}
+    extend_compiler_name_table(target)
+    assert "factor" in target
+    assert target["factor"] == IRSymbol("Factor")
+
+
+def test_extend_is_idempotent() -> None:
+    target: dict[str, IRSymbol] = {}
+    extend_compiler_name_table(target)
+    snapshot = dict(target)
+    extend_compiler_name_table(target)
+    assert target == snapshot


### PR DESCRIPTION
## Summary

Phase A skeleton of `macsyma-runtime` — the thin shell on top of `symbolic-vm` that holds genuinely-MACSYMA conventions. Spec at `code/specs/macsyma-runtime.md` (in #1305).

This is deliberately **the only non-reusable package** in this work. Everything underneath (`cas-substitution`, `cas-simplify`, `cas-factor`, ...) is shared across CAS frontends; MACSYMA's `%i`/`%o`/`$`/`;`/`kill`/`ev` semantics live here. A future `mathematica-runtime`, `matlab-runtime`, or `octave-runtime` would sit at the same layer position with its own conventions.

## Phase A scope

- **`MacsymaBackend`** — `SymbolicBackend` subclass that installs the runtime heads and resolves `%`/`%iN`/`%oN` via the `History`.
- **`Display`/`Suppress`** wrappers — terminator markers for `;` vs `$`. Identity-on-inner; the REPL inspects the wrapper before eval.
- **`Kill(name)`** and **`Kill(all)`** — clear bindings. Held head so `kill(x)` clears `x` rather than evaluating it.
- **`Ev(expr, ...flags)`** — minimal first cut, `numer` flag honored via `with_numer()` context manager (restores on exception).
- **`History`** — input/output table with `resolve_history_symbol()` shim.
- **`MACSYMA_NAME_TABLE`** — maps MACSYMA identifiers (`expand`, `factor`, `subst`, `solve`, `taylor`, `limit`, `length`, `first`, `map`, `matrix`, ...) to canonical IR heads. Substrate handlers may not yet exist; until they do, those names return unevaluated, like any unknown head.

## Quality

- 40 tests, **98.85% coverage**
- ruff check clean
- mypy --strict clean
- Security review passed

## Independent of #1309

This PR depends only on `symbolic-ir` (merged) and `symbolic-vm` (merged). The pretty-printer (#1309) is consumed by `macsyma-repl`, not the runtime.

## Test plan

- [x] Unit tests cover history, name table, Display/Suppress, Kill, Ev, backend wiring
- [x] mypy --strict / ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)