### PR TITLE
feat(macsyma-compiler): opt-in Display/Suppress terminator wrappers

### DIFF
--- a/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
+++ b/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
@@ -75,6 +75,14 @@ from symbolic_ir import (
 )
 from symbolic_ir.nodes import AND, OR
 
+# Statement-terminator wrappers. The compiler emits one of these around
+# every top-level statement so the REPL can distinguish ``;`` (display
+# the result) from ``$`` (suppress). The macsyma-runtime backend
+# installs identity handlers for both, so non-REPL consumers (e.g.
+# tests that drive the VM directly) don't have to think about them.
+DISPLAY = IRSymbol("Display")
+SUPPRESS = IRSymbol("Suppress")
+
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
@@ -180,7 +188,18 @@ class Compiler:
     The class carries no mutable state; it is a namespace for the
     recursive compilation methods. Every ``_compile_*`` method returns
     an ``IRNode``.
+
+    Set ``wrap_terminators=True`` (default ``False``) to have every
+    top-level statement wrapped in either ``Display(expr)`` (for ``;``)
+    or ``Suppress(expr)`` (for ``$``) so a REPL can later distinguish
+    the two. The wrappers are off by default to preserve compatibility
+    with consumers that drive the VM directly without a REPL — they
+    can leave ``wrap_terminators=False`` and continue to receive raw
+    expressions.
     """
+
+    def __init__(self, *, wrap_terminators: bool = False) -> None:
+        self._wrap_terminators = wrap_terminators
 
     def compile_program(self, root: ASTNode) -> list[IRNode]:
         """Compile a ``program`` AST into a list of IR statements.
@@ -205,11 +224,33 @@ class Compiler:
 
     def _compile_statement(self, node: ASTNode) -> IRNode:
         # `statement = expression ( SEMI | DOLLAR ) ;`
+        #
         # The expression is always child 0; the terminator is child 1.
+        # If ``wrap_terminators`` is enabled (REPL mode), wrap the
+        # expression in ``Display(expr)`` or ``Suppress(expr)`` so the
+        # REPL can decide whether to print the result. Otherwise,
+        # return the inner expression directly — downstream consumers
+        # that don't care about ``;`` vs ``$`` see the same shape they
+        # always have.
+        if not node.children:
+            raise CompileError("statement has no children")
         expr_node = node.children[0]
         if not isinstance(expr_node, ASTNode):
             raise CompileError("statement's first child must be an AST node")
-        return self._compile_node(expr_node)
+        inner = self._compile_node(expr_node)
+
+        if not self._wrap_terminators:
+            return inner
+
+        if len(node.children) >= 2 and isinstance(node.children[1], Token):
+            term_type = _token_type_name(node.children[1])
+            if term_type == "DOLLAR":
+                return IRApply(SUPPRESS, (inner,))
+            if term_type == "SEMI":
+                return IRApply(DISPLAY, (inner,))
+        # Defensive fallback if the grammar ever lets a terminator slip
+        # past — pick Display so the user sees the result.
+        return IRApply(DISPLAY, (inner,))
 
     def _compile_node(self, node: ASTNode | Token) -> IRNode:
         """Dispatch to the handler for this node's rule or token type."""
@@ -505,17 +546,24 @@ class Compiler:
 # ---------------------------------------------------------------------------
 
 
-def compile_macsyma(ast: ASTNode) -> list[IRNode]:
+def compile_macsyma(
+    ast: ASTNode, *, wrap_terminators: bool = False
+) -> list[IRNode]:
     """Compile a MACSYMA ``program`` AST to a list of IR statements.
 
     Args:
         ast: The root ``ASTNode`` produced by ``parse_macsyma``.
+        wrap_terminators: If True, every top-level statement is wrapped
+            in ``Display(expr)`` (for ``;``) or ``Suppress(expr)`` (for
+            ``$``). The MACSYMA REPL passes True; consumers that drive
+            the VM directly (e.g. test harnesses for substrate handlers)
+            leave it False to receive raw expressions.
 
     Returns:
         One ``IRNode`` per top-level statement. Empty programs return
         an empty list.
     """
-    return Compiler().compile_program(ast)
+    return Compiler(wrap_terminators=wrap_terminators).compile_program(ast)
 
 
 def compile_expression(ast: ASTNode | Token) -> IRNode:

--- a/code/packages/python/macsyma-compiler/tests/test_terminators.py
+++ b/code/packages/python/macsyma-compiler/tests/test_terminators.py
@@ -1,0 +1,75 @@
+"""Statement-terminator preservation: ``;`` vs ``$``.
+
+The compiler wraps every top-level statement in a ``Display(...)`` or
+``Suppress(...)`` IR node when ``wrap_terminators=True`` is passed to
+``compile_macsyma``. The MACSYMA REPL turns that on so it can decide
+whether to print results; consumers that drive the VM directly leave
+it off and continue receiving raw expressions.
+
+The wrapper heads are introduced by the macsyma-runtime layer; the
+compiler emits them as plain ``IRSymbol`` literals (no import
+dependency on the runtime).
+"""
+
+from __future__ import annotations
+
+from macsyma_compiler import compile_macsyma
+from macsyma_parser import parse_macsyma
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+
+
+def _compile_all(source: str) -> list:
+    return compile_macsyma(parse_macsyma(source), wrap_terminators=True)
+
+
+def test_default_does_not_wrap() -> None:
+    """``compile_macsyma(ast)`` without the kwarg returns raw expressions."""
+    [stmt] = compile_macsyma(parse_macsyma("42;"))
+    assert stmt == IRInteger(42)
+
+
+def test_semicolon_emits_display_wrapper() -> None:
+    [stmt] = _compile_all("42;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    assert stmt.args == (IRInteger(42),)
+
+
+def test_dollar_emits_suppress_wrapper() -> None:
+    [stmt] = _compile_all("42$")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Suppress")
+    assert stmt.args == (IRInteger(42),)
+
+
+def test_mixed_terminators_preserve_each() -> None:
+    """A program with mixed terminators yields the right wrapper per stmt."""
+    stmts = _compile_all("1$ 2; 3$ 4;")
+    heads = [
+        s.head.name if isinstance(s, IRApply) and isinstance(s.head, IRSymbol)
+        else None
+        for s in stmts
+    ]
+    assert heads == ["Suppress", "Display", "Suppress", "Display"]
+
+
+def test_inner_expression_preserved_under_wrapper() -> None:
+    """``x + 1;`` wraps an `Add(x, 1)` in `Display`."""
+    [stmt] = _compile_all("x + 1;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    inner = stmt.args[0]
+    assert isinstance(inner, IRApply)
+    assert inner.head == IRSymbol("Add")
+    assert inner.args == (IRSymbol("x"), IRInteger(1))
+
+
+def test_function_definition_wrapped_in_display() -> None:
+    """``f(x) := x^2;`` is also wrapped (non-side-effect-free statements
+    get wrapped same as expressions)."""
+    [stmt] = _compile_all("f(x) := x^2;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    inner = stmt.args[0]
+    assert isinstance(inner, IRApply)
+    assert inner.head == IRSymbol("Define")


### PR DESCRIPTION
## Summary

Add a ``wrap_terminators`` kwarg to ``compile_macsyma`` that wraps every top-level statement in ``Display(expr)`` (for ``;``) or ``Suppress(expr)`` (for ``$``) so the REPL can decide whether to print the result.

**Default is False** — preserves existing behavior for callers that drive the VM directly without a REPL (the symbolic-vm test suite, substrate package handlers, etc.). The MACSYMA REPL passes True.

The wrapper heads are emitted as plain ``IRSymbol`` literals; the compiler does NOT depend on `macsyma-runtime`. The runtime installs the identity handlers that make the wrappers transparent at evaluation time. So this PR and #1316 can land in either order.

## Why opt-in instead of always-on

Always-on broke ~18 tests in `symbolic-vm/tests/test_end_to_end.py` because `Display`/`Suppress` are unknown heads to the bare `SymbolicBackend` — `StrictBackend` raised, `SymbolicBackend` returned the wrapper unevaluated. Keeping the wrap behavior opt-in keeps every existing consumer untouched while still giving the REPL the wrapper data it needs.

## Quality

- 39 tests passing (6 new in `test_terminators.py`)
- `ruff check` clean
- Coverage 81.40% (above the 80% threshold)
- Security review passed
- Pre-existing `mypy --strict` warnings on `compiler.py:527` (a `_handlers: dict[str, callable]` annotation) are unchanged by this PR — they exist on main today.

## Test plan

- [x] Default behavior (no kwarg) returns raw expressions, unchanged
- [x] `wrap_terminators=True` emits `Display(...)` for `;` and `Suppress(...)` for `$`
- [x] Mixed-terminator programs preserve each wrapper independently
- [x] Function definitions also get wrapped
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)