### PR TITLE
feat(testbench-framework): Pythonic harness around HardwareVM

### DIFF
--- a/code/packages/python/testbench-framework/BUILD
+++ b/code/packages/python/testbench-framework/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../hdl-ir -e ../hardware-vm -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/testbench-framework/BUILD_windows
+++ b/code/packages/python/testbench-framework/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../hdl-ir -e ../hardware-vm -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/testbench-framework/CHANGELOG.md
+++ b/code/packages/python/testbench-framework/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.1.0] — Unreleased
+
+### Added
+- `@test` decorator that registers a function in a global registry, optionally with `name=`, `timeout_s=`, `should_fail=` overrides.
+- `discover()` returns the current registry; `clear_registry()` empties it.
+- `run(hir, tests=None) -> TestReport` runs each test in a fresh `HardwareVM(hir)`, capturing `AssertionError` (failure) and other exceptions, supporting negative tests via `should_fail=True`.
+- `DUTHandle` / `SignalHandle`: attribute-access shim over `HardwareVM`. `dut.signal.value` reads via `vm.read`; `dut.signal.value = x` writes via `vm.set_input`.
+- `exhaustive(dut, inputs, on_step=None)` — every combination of up to 20 bits worth of inputs.
+- `random_stimulus(dut, inputs, iterations, seed=42, on_step=None)` — reproducible random vectors.
+- `TestReport.summary()` formats a human-readable line.
+
+### Out of scope (v0.2.0)
+- Async / clocked sequential testbenches (waits on hardware-vm v0.2).
+- Constrained-random with full constraint solver.
+- Scoreboard FIFO helpers.
+- Wave dump integration with `vcd-writer`.

--- a/code/packages/python/testbench-framework/README.md
+++ b/code/packages/python/testbench-framework/README.md
@@ -1,0 +1,68 @@
+# testbench-framework
+
+Pythonic harness around HardwareVM. Decorate test functions, get value-based assertions on signal handles. v0.1.0 is sync (since hardware-vm is combinational); async lands in v0.2.0 alongside sequential simulation.
+
+See [`code/specs/testbench-framework.md`](../../../specs/testbench-framework.md).
+
+## Quick start
+
+```python
+from testbench_framework import test, run, exhaustive
+from hdl_elaboration import elaborate_verilog
+
+src = """
+module adder4(input [3:0] a, input [3:0] b, input cin,
+              output [3:0] sum, output cout);
+  assign {cout, sum} = a + b + cin;
+endmodule
+"""
+hir = elaborate_verilog(src, top="adder4")
+
+@test
+def addition_works(dut):
+    dut.a.value = 5
+    dut.b.value = 3
+    dut.cin.value = 0
+    assert dut.sum.value == 8
+    assert dut.cout.value == 0
+
+@test
+def overflow_detected(dut):
+    dut.a.value = 0xF
+    dut.b.value = 1
+    dut.cin.value = 0
+    assert dut.cout.value == 1
+
+@test
+def adder_exhaustive(dut):
+    def check(d):
+        expected = (d.a.value + d.b.value + d.cin.value) & 0x1F
+        actual = (d.cout.value << 4) | d.sum.value
+        assert actual == expected
+
+    exhaustive(dut, inputs={"a": 4, "b": 4, "cin": 1}, on_step=check)
+
+report = run(hir)
+print(report.summary())  # "3 passed, 0 failed, 0 skipped in 0.045s"
+assert report.all_passed
+```
+
+## v0.1.0 scope
+
+- `@test` decorator: register a function as a testbench test.
+- `run(hir, tests=None)` runs all registered tests. Each test gets its own fresh VM so state never leaks.
+- `DUTHandle`: attribute-access wrapper over an HardwareVM. `dut.signal.value` reads/writes.
+- `TestReport`: passed/failed/skipped lists, durations, summary.
+- Stimulus helpers:
+  - `exhaustive(dut, inputs, on_step=None)`: drive every combination of input values (limited to ≤ 20 bits total).
+  - `random_stimulus(dut, inputs, iterations, seed=42, on_step=None)`: random vectors with reproducible seed.
+- `should_fail=True` on `@test` for negative tests.
+
+## Out of scope (v0.2.0)
+
+- Async / sequential testbenches with clocks (waits on `hardware-vm` v0.2 for clocked sim).
+- Constrained-random stimulus.
+- Reference-model + scoreboard pattern helpers.
+- Native HDL `initial` blocks (handled via `hardware-vm` directly when it gains `initial` support).
+
+MIT.

--- a/code/packages/python/testbench-framework/pyproject.toml
+++ b/code/packages/python/testbench-framework/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-testbench-framework"
+version = "0.1.0"
+description = "Testbench framework for the silicon stack: stimulus, assertions, and a Pythonic test runner."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["testbench", "hdl", "verilog", "simulation", "education"]
+dependencies = [
+    "coding-adventures-hdl-ir",
+    "coding-adventures-hardware-vm",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/testbench-framework.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/testbench_framework"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ANN", "E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=testbench_framework --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/testbench_framework"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/testbench-framework/src/testbench_framework/__init__.py
+++ b/code/packages/python/testbench-framework/src/testbench_framework/__init__.py
@@ -1,0 +1,30 @@
+"""testbench-framework: Pythonic harness around HardwareVM."""
+
+from testbench_framework.runner import (
+    DUTHandle,
+    SignalHandle,
+    TestCase,
+    TestReport,
+    clear_registry,
+    discover,
+    exhaustive,
+    random_stimulus,
+    run,
+    test,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DUTHandle",
+    "SignalHandle",
+    "TestCase",
+    "TestReport",
+    "__version__",
+    "clear_registry",
+    "discover",
+    "exhaustive",
+    "random_stimulus",
+    "run",
+    "test",
+]

--- a/code/packages/python/testbench-framework/src/testbench_framework/runner.py
+++ b/code/packages/python/testbench-framework/src/testbench_framework/runner.py
@@ -1,0 +1,225 @@
+"""Testbench runner: a Pythonic harness around HardwareVM.
+
+v0.1.0 scope: Python-native API. Keeps things simple — no async/await yet
+since hardware-vm is currently combinational-only. When sequential simulation
+arrives in v0.2.0, an async layer will land alongside.
+"""
+
+from __future__ import annotations
+
+import time as _wallclock
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from hardware_vm import HardwareVM
+from hdl_ir import HIR
+
+# ---------------------------------------------------------------------------
+# Test discovery + registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TestCase:
+    """One named test against a DUT (HIR)."""
+
+    name: str
+    func: Callable[[DUTHandle], None]
+    timeout_s: float = 5.0
+    should_fail: bool = False
+
+
+_REGISTRY: list[TestCase] = []
+
+
+def test(
+    func: Callable[[DUTHandle], None] | None = None,
+    *,
+    name: str | None = None,
+    timeout_s: float = 5.0,
+    should_fail: bool = False,
+) -> Any:
+    """Decorator: register a function as a testbench test.
+
+    Usage:
+        @test
+        def my_test(dut):
+            dut.a.value = 1
+            assert dut.y.value == 1
+
+        @test(name="custom_name", timeout_s=10)
+        def another(dut):
+            ...
+    """
+
+    def _wrap(f: Callable[[DUTHandle], None]) -> Callable[[DUTHandle], None]:
+        tc = TestCase(name=name or f.__name__, func=f, timeout_s=timeout_s, should_fail=should_fail)
+        _REGISTRY.append(tc)
+        return f
+
+    if func is None:
+        return _wrap
+    return _wrap(func)
+
+
+def discover() -> list[TestCase]:
+    """Return all registered tests since the last clear."""
+    return list(_REGISTRY)
+
+
+def clear_registry() -> None:
+    """Clear the global test registry. Useful between runs."""
+    _REGISTRY.clear()
+
+
+# ---------------------------------------------------------------------------
+# DUT handle
+# ---------------------------------------------------------------------------
+
+
+class SignalHandle:
+    """Attribute access to one signal on the DUT."""
+
+    def __init__(self, vm: HardwareVM, name: str) -> None:
+        object.__setattr__(self, "_vm", vm)
+        object.__setattr__(self, "_name", name)
+
+    @property
+    def value(self) -> int:
+        return self._vm.read(self._name)  # type: ignore[attr-defined]
+
+    @value.setter
+    def value(self, v: int) -> None:
+        self._vm.set_input(self._name, v)  # type: ignore[attr-defined]
+
+    def __repr__(self) -> str:
+        return f"SignalHandle({self._name!r}, value={self.value})"  # type: ignore[attr-defined]
+
+
+class DUTHandle:
+    """Handle for a Device Under Test. Attribute access maps to signals."""
+
+    def __init__(self, vm: HardwareVM) -> None:
+        object.__setattr__(self, "_vm", vm)
+
+    def __getattr__(self, name: str) -> SignalHandle:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return SignalHandle(self._vm, name)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TestReport:
+    passed: list[str] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)  # (name, message)
+    skipped: list[str] = field(default_factory=list)
+    duration_s: float = 0.0
+
+    @property
+    def all_passed(self) -> bool:
+        return not self.failed
+
+    def summary(self) -> str:
+        return (
+            f"{len(self.passed)} passed, "
+            f"{len(self.failed)} failed, "
+            f"{len(self.skipped)} skipped "
+            f"in {self.duration_s:.3f}s"
+        )
+
+
+def run(hir: HIR, tests: list[TestCase] | None = None) -> TestReport:
+    """Run all registered (or explicitly given) tests against the HIR."""
+    if tests is None:
+        tests = discover()
+
+    report = TestReport()
+    start = _wallclock.perf_counter()
+
+    for tc in tests:
+        # Each test gets a fresh VM so state doesn't leak.
+        vm = HardwareVM(hir)
+        dut = DUTHandle(vm)
+        try:
+            tc.func(dut)
+            if tc.should_fail:
+                report.failed.append((tc.name, "expected failure but test passed"))
+            else:
+                report.passed.append(tc.name)
+        except AssertionError as e:
+            if tc.should_fail:
+                report.passed.append(tc.name)
+            else:
+                report.failed.append((tc.name, f"assertion failed: {e}"))
+        except Exception as e:
+            if tc.should_fail:
+                report.passed.append(tc.name)
+            else:
+                report.failed.append((tc.name, f"{type(e).__name__}: {e}"))
+
+    report.duration_s = _wallclock.perf_counter() - start
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Stimulus helpers
+# ---------------------------------------------------------------------------
+
+
+def exhaustive(
+    dut: DUTHandle,
+    inputs: dict[str, int],
+    *,
+    on_step: Callable[[DUTHandle], None] | None = None,
+) -> None:
+    """Drive each input through 0..(2^width - 1) and call ``on_step`` after
+    each combination. Useful for small designs (≤ ~20 input bits).
+
+    ``inputs`` maps signal name -> bit width.
+    """
+    names = list(inputs.keys())
+    widths = [inputs[n] for n in names]
+    total_bits = sum(widths)
+    if total_bits > 20:
+        raise ValueError(
+            f"exhaustive over {total_bits} bits would take 2^{total_bits} iterations"
+        )
+
+    n_combinations = 1 << total_bits
+    for combination in range(n_combinations):
+        # Decompose combination into per-input values.
+        offset = 0
+        for name, width in zip(names, widths, strict=False):
+            val = (combination >> offset) & ((1 << width) - 1)
+            getattr(dut, name).value = val
+            offset += width
+
+        if on_step is not None:
+            on_step(dut)
+
+
+def random_stimulus(
+    dut: DUTHandle,
+    inputs: dict[str, int],
+    iterations: int,
+    *,
+    seed: int = 42,
+    on_step: Callable[[DUTHandle], None] | None = None,
+) -> None:
+    """Drive each input with random values for ``iterations`` cycles.
+
+    ``inputs`` maps signal name -> bit width. ``seed`` makes runs reproducible."""
+    import random
+
+    rng = random.Random(seed)
+    for _ in range(iterations):
+        for name, width in inputs.items():
+            getattr(dut, name).value = rng.randint(0, (1 << width) - 1)
+        if on_step is not None:
+            on_step(dut)

--- a/code/packages/python/testbench-framework/tests/test_runner.py
+++ b/code/packages/python/testbench-framework/tests/test_runner.py
@@ -1,0 +1,290 @@
+"""Tests for the testbench framework."""
+
+import pytest
+
+from hdl_ir import (
+    HIR,
+    BinaryOp,
+    Concat,
+    ContAssign,
+    Direction,
+    Module,
+    Port,
+    PortRef,
+    TyLogic,
+    TyVector,
+)
+from testbench_framework import (
+    TestCase,
+    TestReport,
+    clear_registry,
+    discover,
+    exhaustive,
+    random_stimulus,
+    run,
+    test,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def make_buffer_hir() -> HIR:
+    m = Module(
+        name="bf",
+        ports=[
+            Port("a", Direction.IN, TyLogic()),
+            Port("y", Direction.OUT, TyLogic()),
+        ],
+        cont_assigns=[ContAssign(target=PortRef("y"), rhs=PortRef("a"))],
+    )
+    return HIR(top="bf", modules={"bf": m})
+
+
+def make_adder4_hir() -> HIR:
+    m = Module(
+        name="adder4",
+        ports=[
+            Port("a", Direction.IN, TyVector(TyLogic(), 4)),
+            Port("b", Direction.IN, TyVector(TyLogic(), 4)),
+            Port("cin", Direction.IN, TyLogic()),
+            Port("sum", Direction.OUT, TyVector(TyLogic(), 4)),
+            Port("cout", Direction.OUT, TyLogic()),
+        ],
+        cont_assigns=[
+            ContAssign(
+                target=Concat((PortRef("cout"), PortRef("sum"))),
+                rhs=BinaryOp(
+                    "+",
+                    BinaryOp("+", PortRef("a"), PortRef("b")),
+                    PortRef("cin"),
+                ),
+            )
+        ],
+    )
+    return HIR(top="adder4", modules={"adder4": m})
+
+
+# ---- Decorator + discovery ----
+
+
+def test_register_and_discover():
+    @test
+    def t1(dut):
+        pass
+
+    @test
+    def t2(dut):
+        pass
+
+    cases = discover()
+    assert len(cases) == 2
+    assert {c.name for c in cases} == {"t1", "t2"}
+
+
+def test_decorator_with_args():
+    @test(name="custom", timeout_s=10)
+    def t1(dut):
+        pass
+
+    cases = discover()
+    assert cases[0].name == "custom"
+    assert cases[0].timeout_s == 10
+
+
+def test_clear_registry_works():
+    @test
+    def t1(dut):
+        pass
+
+    assert len(discover()) == 1
+    clear_registry()
+    assert len(discover()) == 0
+
+
+# ---- run() ----
+
+
+def test_run_passing():
+    @test
+    def passes(dut):
+        dut.a.value = 1
+        assert dut.y.value == 1
+
+    rep = run(make_buffer_hir())
+    assert rep.all_passed
+    assert "passes" in rep.passed
+    assert rep.failed == []
+
+
+def test_run_failing():
+    @test
+    def fails(dut):
+        dut.a.value = 1
+        assert dut.y.value == 0  # wrong on purpose
+
+    rep = run(make_buffer_hir())
+    assert not rep.all_passed
+    assert any("fails" == n for n, _msg in rep.failed)
+
+
+def test_run_unexpected_exception():
+    @test
+    def explodes(dut):
+        raise RuntimeError("boom")
+
+    rep = run(make_buffer_hir())
+    assert not rep.all_passed
+    msg = rep.failed[0][1]
+    assert "boom" in msg
+
+
+def test_run_negative_test_passes():
+    @test(should_fail=True)
+    def must_fail(dut):
+        assert False, "intentional"
+
+    rep = run(make_buffer_hir())
+    assert rep.all_passed
+
+
+def test_run_negative_test_fails_when_passes():
+    @test(should_fail=True)
+    def should_have_failed(dut):
+        pass  # no assertion
+
+    rep = run(make_buffer_hir())
+    assert not rep.all_passed
+
+
+def test_run_with_explicit_tests_list():
+    def my_func(dut):
+        assert True
+
+    tc = TestCase(name="explicit", func=my_func)
+    rep = run(make_buffer_hir(), tests=[tc])
+    assert "explicit" in rep.passed
+
+
+def test_run_isolates_state_between_tests():
+    """Each test should get a fresh VM."""
+    @test
+    def first(dut):
+        dut.a.value = 1
+        assert dut.y.value == 1
+
+    @test
+    def second(dut):
+        # If state leaked, dut.a.value would still be 1
+        assert dut.a.value == 0
+        assert dut.y.value == 0
+
+    rep = run(make_buffer_hir())
+    assert rep.all_passed
+
+
+# ---- TestReport ----
+
+
+def test_report_summary():
+    rep = TestReport(passed=["a"], failed=[("b", "boom")], skipped=[])
+    s = rep.summary()
+    assert "1 passed" in s
+    assert "1 failed" in s
+
+
+# ---- DUTHandle ----
+
+
+def test_dut_handle_via_buffer():
+    @test
+    def buf_test(dut):
+        dut.a.value = 1
+        assert dut.y.value == 1
+        dut.a.value = 0
+        assert dut.y.value == 0
+
+    rep = run(make_buffer_hir())
+    assert rep.all_passed
+
+
+def test_signal_handle_repr():
+    from hardware_vm import HardwareVM
+    from testbench_framework.runner import SignalHandle
+
+    vm = HardwareVM(make_buffer_hir())
+    h = SignalHandle(vm, "a")
+    assert "a" in repr(h)
+    assert "value" in repr(h)
+
+
+# ---- Stimulus helpers ----
+
+
+def test_exhaustive_drives_all_combinations():
+    @test
+    def adder_exhaustive(dut):
+        seen = set()
+
+        def check(d):
+            seen.add((d.a.value, d.b.value, d.cin.value))
+            expected = (d.a.value + d.b.value + d.cin.value) & 0x1F
+            actual = (d.cout.value << 4) | d.sum.value
+            assert actual == expected
+
+        exhaustive(dut, inputs={"a": 4, "b": 4, "cin": 1}, on_step=check)
+        assert len(seen) == 16 * 16 * 2
+
+    rep = run(make_adder4_hir())
+    assert rep.all_passed
+
+
+def test_exhaustive_too_many_bits_raises():
+    from testbench_framework.runner import DUTHandle
+    from hardware_vm import HardwareVM
+
+    vm = HardwareVM(make_buffer_hir())
+    dut = DUTHandle(vm)
+    with pytest.raises(ValueError, match="exhaustive over"):
+        exhaustive(dut, inputs={"a": 25})
+
+
+def test_random_stimulus_reproducible():
+    @test
+    def adder_random(dut):
+        results_a = []
+
+        def collect(d):
+            results_a.append(d.a.value)
+
+        random_stimulus(dut, inputs={"a": 4, "b": 4, "cin": 1},
+                        iterations=20, seed=42, on_step=collect)
+        # Re-run with the same seed should produce same sequence
+        results_b = []
+
+        def collect2(d):
+            results_b.append(d.a.value)
+
+        random_stimulus(dut, inputs={"a": 4, "b": 4, "cin": 1},
+                        iterations=20, seed=42, on_step=collect2)
+        assert results_a == results_b
+
+    rep = run(make_adder4_hir())
+    assert rep.all_passed
+
+
+# ---- DUTHandle private attr ----
+
+
+def test_dut_handle_private_attr_raises():
+    from testbench_framework.runner import DUTHandle
+    from hardware_vm import HardwareVM
+
+    vm = HardwareVM(make_buffer_hir())
+    dut = DUTHandle(vm)
+    with pytest.raises(AttributeError):
+        _ = dut.__private__


### PR DESCRIPTION
## Summary

Pythonic test runner over HardwareVM. Decorator-based test discovery, attribute-access `DUTHandle` over signals, fresh VM per test for isolation, helpers for exhaustive and random stimulus.

```python
from testbench_framework import test, run, exhaustive

@test
def adder_works(dut):
    dut.a.value = 5
    dut.b.value = 3
    dut.cin.value = 0
    assert dut.sum.value == 8

@test
def adder_exhaustive(dut):
    def check(d):
        expected = (d.a.value + d.b.value + d.cin.value) & 0x1F
        actual = (d.cout.value << 4) | d.sum.value
        assert actual == expected
    exhaustive(dut, inputs={"a": 4, "b": 4, "cin": 1}, on_step=check)

report = run(hir)
assert report.all_passed
```

## Pipeline position

```
HIR (hdl-ir, MERGED) ──> hardware-vm (MERGED) ──> testbench-framework (THIS PR)
```

## Quality

- **18/18 tests pass**
- **99% coverage** (target ≥ 80%)
- **Ruff clean**
- 4-bit adder exhaustive test (512 vectors) verified end-to-end

## v0.1.0 scope

- `@test` decorator + `discover()` + `clear_registry()`
- `run(hir, tests=None) -> TestReport` with isolation between tests
- `DUTHandle` / `SignalHandle` attribute access
- `exhaustive(dut, inputs, on_step)` (≤ 20 bits total)
- `random_stimulus(dut, inputs, iterations, seed)` reproducible
- Negative-test support (`should_fail=True`)

## Out of scope (v0.2.0)

- Async / clocked sequential (needs hardware-vm v0.2)
- Constrained-random with SAT solver
- Scoreboard helpers
- VCD integration helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)