### PR TITLE
feat(coverage-hdl): functional + toggle coverage

### DIFF
--- a/code/packages/python/coverage-hdl/BUILD
+++ b/code/packages/python/coverage-hdl/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../hdl-ir -e ../hardware-vm -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/coverage-hdl/BUILD_windows
+++ b/code/packages/python/coverage-hdl/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../hdl-ir -e ../hardware-vm -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/coverage-hdl/CHANGELOG.md
+++ b/code/packages/python/coverage-hdl/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.1.0] — Unreleased
+
+### Added
+- `Coverpoint(name, signal, bins=...)`: watches one signal, hits accumulate in matching bins.
+- `Bin` + helpers: `bin_value(name, v)`, `bin_range(name, lo, hi)`, `bin_default()`.
+- `CrossPoint(name, coverpoints)`: cross-product of bins across multiple coverpoints; sampled via `recorder.sample_cross(name=None)`.
+- `CoverageRecorder(vm)`: subscribes to HardwareVM events. Auto-samples coverpoints on relevant signal changes; tracks toggle counts via `enable_toggle_coverage([signals])`.
+- `CoverageReport`: dict-of-dict hits + per-signal `ToggleStats`.
+- `overall_coverage` property: average across all coverpoints + crosses (value in [0, 1]).
+
+### Out of scope (v0.2.0)
+- Code coverage (line/branch/path) — needs HIR provenance instrumentation in the simulation path.
+- FSM-state and FSM-transition coverage helpers.
+- HTML reports.
+- MC/DC analysis.
+- Coverage merging.

--- a/code/packages/python/coverage-hdl/README.md
+++ b/code/packages/python/coverage-hdl/README.md
@@ -1,0 +1,69 @@
+# coverage-hdl
+
+Functional + toggle coverage for the silicon stack. Subscribes to HardwareVM value-change events; records hits in user-defined bins.
+
+See [`code/specs/coverage.md`](../../../specs/coverage.md).
+
+## Quick start
+
+```python
+from coverage_hdl import (
+    CoverageRecorder, Coverpoint, CrossPoint,
+    bin_value, bin_range,
+)
+from hardware_vm import HardwareVM
+
+vm = HardwareVM(hir)
+cov = CoverageRecorder(vm)
+
+cov.enable_toggle_coverage(["sum", "cout"])
+
+cov.add_coverpoint(Coverpoint(
+    name="cin",
+    signal="cin",
+    bins=[bin_value("zero", 0), bin_value("one", 1)],
+))
+
+cov.add_coverpoint(Coverpoint(
+    name="overflow",
+    signal="cout",
+    bins=[bin_value("yes", 1), bin_value("no", 0)],
+))
+
+# Drive stimulus...
+for a in range(16):
+    for b in range(16):
+        for cin in (0, 1):
+            vm.set_input("a", a)
+            vm.set_input("b", b)
+            vm.set_input("cin", cin)
+
+print(cov.overall_coverage)   # 1.0 if every bin hit at least once
+print(cov.report().toggle)
+```
+
+## v0.1.0 scope
+
+- `Coverpoint`: watches one signal; samples produce hits in matching bins.
+- `Bin` constructors: `bin_value(name, v)`, `bin_range(name, lo, hi)`, `bin_default()`.
+- `CrossPoint`: cross-product of multiple coverpoints; sampled manually via `sample_cross()`.
+- `enable_toggle_coverage(signals)`: counts 0->1 (rising) and 1->0 (falling) transitions.
+- `CoverageReport`: per-coverpoint hits, per-cross hits, per-signal toggle stats.
+- `overall_coverage` property: average across all coverpoints + crosses.
+
+## Out of scope (v0.2.0)
+
+- Code coverage (line/branch/path) — needs HIR provenance instrumentation.
+- FSM-state and FSM-transition coverage helpers.
+- HTML reports.
+- MC/DC analysis.
+- Coverage merging across multiple test runs.
+
+## Testing
+
+```bash
+pytest tests/
+ruff check src/
+```
+
+MIT.

--- a/code/packages/python/coverage-hdl/pyproject.toml
+++ b/code/packages/python/coverage-hdl/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-coverage-hdl"
+version = "0.1.0"
+description = "Code + functional coverage measurement for the silicon stack."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["coverage", "hdl", "verification", "education"]
+dependencies = [
+    "coding-adventures-hardware-vm",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/coverage.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coverage_hdl"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ANN", "E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=coverage_hdl --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/coverage_hdl"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/coverage-hdl/src/coverage_hdl/__init__.py
+++ b/code/packages/python/coverage-hdl/src/coverage_hdl/__init__.py
@@ -1,0 +1,28 @@
+"""coverage-hdl: code + functional coverage measurement for the silicon stack."""
+
+from coverage_hdl.coverage import (
+    Bin,
+    CoverageRecorder,
+    CoverageReport,
+    Coverpoint,
+    CrossPoint,
+    ToggleStats,
+    bin_default,
+    bin_range,
+    bin_value,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Bin",
+    "CoverageRecorder",
+    "CoverageReport",
+    "Coverpoint",
+    "CrossPoint",
+    "ToggleStats",
+    "__version__",
+    "bin_default",
+    "bin_range",
+    "bin_value",
+]

--- a/code/packages/python/coverage-hdl/src/coverage_hdl/coverage.py
+++ b/code/packages/python/coverage-hdl/src/coverage_hdl/coverage.py
@@ -1,0 +1,220 @@
+"""HDL coverage measurement.
+
+Subscribes to ``hardware-vm`` value-change events to record:
+- Toggle coverage (each signal: 0->1 and 1->0 transitions seen).
+- Functional coverage via covergroups: bins matched on signal values.
+
+Code coverage (line/branch) is documented as v0.2.0 work; it requires HIR
+provenance instrumentation that's not yet in the simulator path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Bin definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Bin:
+    """One bin in a coverpoint."""
+
+    name: str
+    matcher: Callable[[int], bool]
+
+
+def bin_value(name: str, value: int) -> Bin:
+    """Bin matching exactly one value."""
+    return Bin(name, lambda v: v == value)
+
+
+def bin_range(name: str, min: int, max: int) -> Bin:
+    """Bin matching values in [min, max] inclusive."""
+    return Bin(name, lambda v: min <= v <= max)
+
+
+def bin_default() -> Bin:
+    """Bin matching anything (catch-all)."""
+    return Bin("default", lambda _v: True)
+
+
+# ---------------------------------------------------------------------------
+# Coverpoint
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Coverpoint:
+    """A coverpoint watches one signal; samples produce hits in matching bins."""
+
+    name: str
+    signal: str
+    bins: list[Bin]
+    hits: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for b in self.bins:
+            self.hits.setdefault(b.name, 0)
+
+    def sample(self, value: int) -> None:
+        for b in self.bins:
+            if b.matcher(value):
+                self.hits[b.name] = self.hits.get(b.name, 0) + 1
+                return  # first-match-wins
+
+    @property
+    def coverage(self) -> float:
+        if not self.bins:
+            return 1.0
+        hit_count = sum(1 for b in self.bins if self.hits.get(b.name, 0) > 0)
+        return hit_count / len(self.bins)
+
+
+@dataclass
+class CrossPoint:
+    """Cross-product of two or more coverpoints. Records the joint hit-count
+    of every (bin_in_a, bin_in_b, ...) combination."""
+
+    name: str
+    coverpoints: list[Coverpoint]
+    hits: dict[tuple[str, ...], int] = field(default_factory=dict)
+    _last_values: dict[str, int] = field(default_factory=dict)
+
+    def sample(self) -> None:
+        """Record one sample, using the last-seen value for each constituent
+        coverpoint's signal."""
+        bins_hit = []
+        for cp in self.coverpoints:
+            v = self._last_values.get(cp.signal)
+            if v is None:
+                return
+            matched = next((b.name for b in cp.bins if b.matcher(v)), None)
+            if matched is None:
+                return
+            bins_hit.append(matched)
+        key = tuple(bins_hit)
+        self.hits[key] = self.hits.get(key, 0) + 1
+
+    @property
+    def coverage(self) -> float:
+        if not self.coverpoints:
+            return 1.0
+        total_combos = 1
+        for cp in self.coverpoints:
+            total_combos *= max(1, len(cp.bins))
+        hit_combos = sum(1 for v in self.hits.values() if v > 0)
+        return hit_combos / total_combos
+
+
+# ---------------------------------------------------------------------------
+# Coverage recorder
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToggleStats:
+    """Per-signal toggle counts."""
+
+    rising: int = 0
+    falling: int = 0
+
+
+@dataclass
+class CoverageReport:
+    coverpoints: dict[str, dict[str, int]]
+    crosses: dict[str, dict[tuple[str, ...], int]]
+    toggle: dict[str, ToggleStats]
+
+
+class CoverageRecorder:
+    """Subscribes to a HardwareVM, records value changes into coverage data."""
+
+    def __init__(self, vm: object) -> None:
+        self._vm = vm
+        self._coverpoints: dict[str, Coverpoint] = {}
+        self._crosses: dict[str, CrossPoint] = {}
+        self._toggle_signals: set[str] = set()
+        self._toggle: dict[str, ToggleStats] = {}
+        self._last_values: dict[str, int] = {}
+
+        # Subscribe.
+        if hasattr(vm, "subscribe"):
+            vm.subscribe(self._on_event)  # type: ignore[attr-defined]
+
+    # ----- Coverpoint registration -----
+
+    def add_coverpoint(self, cp: Coverpoint) -> None:
+        self._coverpoints[cp.name] = cp
+
+    def add_cross(self, cross: CrossPoint) -> None:
+        self._crosses[cross.name] = cross
+        # Make sure the cross sees subsequent value changes.
+
+    def enable_toggle_coverage(self, signals: list[str]) -> None:
+        for s in signals:
+            self._toggle_signals.add(s)
+            self._toggle.setdefault(s, ToggleStats())
+
+    # ----- Event handling -----
+
+    def _on_event(self, event: object) -> None:
+        signal = getattr(event, "signal", None)
+        new_value = getattr(event, "new_value", None)
+        old_value = getattr(event, "old_value", 0)
+
+        if signal is None or new_value is None:
+            return
+
+        # Record value for any covergroup using this signal as a watch.
+        self._last_values[signal] = int(new_value)
+
+        # Toggle counting (1-bit basis).
+        if signal in self._toggle_signals:
+            stats = self._toggle.setdefault(signal, ToggleStats())
+            if int(old_value) == 0 and int(new_value) != 0:
+                stats.rising += 1
+            elif int(old_value) != 0 and int(new_value) == 0:
+                stats.falling += 1
+
+        # Sample coverpoints whose signal matches.
+        for cp in self._coverpoints.values():
+            if cp.signal == signal:
+                cp.sample(int(new_value))
+
+        # Notify crosses
+        for cross in self._crosses.values():
+            cross._last_values[signal] = int(new_value)
+
+    # ----- Manual sampling -----
+
+    def sample_cross(self, cross_name: str | None = None) -> None:
+        """Sample one cross (or all crosses). Useful for clock-edge sampling."""
+        if cross_name is None:
+            for c in self._crosses.values():
+                c.sample()
+        else:
+            self._crosses[cross_name].sample()
+
+    # ----- Reporting -----
+
+    def report(self) -> CoverageReport:
+        return CoverageReport(
+            coverpoints={name: dict(cp.hits) for name, cp in self._coverpoints.items()},
+            crosses={name: dict(c.hits) for name, c in self._crosses.items()},
+            toggle=dict(self._toggle),
+        )
+
+    @property
+    def overall_coverage(self) -> float:
+        """Average coverage across all registered coverpoints + crosses."""
+        items: list[float] = []
+        for cp in self._coverpoints.values():
+            items.append(cp.coverage)
+        for cr in self._crosses.values():
+            items.append(cr.coverage)
+        if not items:
+            return 0.0
+        return sum(items) / len(items)

--- a/code/packages/python/coverage-hdl/tests/test_coverage.py
+++ b/code/packages/python/coverage-hdl/tests/test_coverage.py
@@ -1,0 +1,280 @@
+"""Tests for coverage measurement."""
+
+from coverage_hdl import (
+    CoverageRecorder,
+    CoverageReport,
+    Coverpoint,
+    CrossPoint,
+    bin_default,
+    bin_range,
+    bin_value,
+)
+from hardware_vm import HardwareVM
+from hdl_ir import (
+    HIR,
+    BinaryOp,
+    Concat,
+    ContAssign,
+    Direction,
+    Module,
+    Port,
+    PortRef,
+    TyLogic,
+    TyVector,
+)
+
+
+def make_buffer_hir() -> HIR:
+    m = Module(
+        name="bf",
+        ports=[
+            Port("a", Direction.IN, TyLogic()),
+            Port("y", Direction.OUT, TyLogic()),
+        ],
+        cont_assigns=[ContAssign(target=PortRef("y"), rhs=PortRef("a"))],
+    )
+    return HIR(top="bf", modules={"bf": m})
+
+
+def make_adder4_hir() -> HIR:
+    m = Module(
+        name="adder4",
+        ports=[
+            Port("a", Direction.IN, TyVector(TyLogic(), 4)),
+            Port("b", Direction.IN, TyVector(TyLogic(), 4)),
+            Port("cin", Direction.IN, TyLogic()),
+            Port("sum", Direction.OUT, TyVector(TyLogic(), 4)),
+            Port("cout", Direction.OUT, TyLogic()),
+        ],
+        cont_assigns=[
+            ContAssign(
+                target=Concat((PortRef("cout"), PortRef("sum"))),
+                rhs=BinaryOp(
+                    "+",
+                    BinaryOp("+", PortRef("a"), PortRef("b")),
+                    PortRef("cin"),
+                ),
+            )
+        ],
+    )
+    return HIR(top="adder4", modules={"adder4": m})
+
+
+# ---- Bin constructors ----
+
+
+def test_bin_value():
+    b = bin_value("v", 5)
+    assert b.matcher(5)
+    assert not b.matcher(6)
+
+
+def test_bin_range():
+    b = bin_range("r", 1, 10)
+    assert b.matcher(5)
+    assert b.matcher(1)
+    assert b.matcher(10)
+    assert not b.matcher(0)
+    assert not b.matcher(11)
+
+
+def test_bin_default():
+    b = bin_default()
+    assert b.matcher(0)
+    assert b.matcher(999)
+
+
+# ---- Coverpoint ----
+
+
+def test_coverpoint_initial_zero_hits():
+    cp = Coverpoint(
+        name="x", signal="s",
+        bins=[bin_value("a", 0), bin_value("b", 1)],
+    )
+    assert cp.hits["a"] == 0
+    assert cp.hits["b"] == 0
+
+
+def test_coverpoint_sample_first_match():
+    cp = Coverpoint(
+        name="x", signal="s",
+        bins=[bin_range("low", 0, 5), bin_range("high", 6, 10)],
+    )
+    cp.sample(3)
+    assert cp.hits["low"] == 1
+    assert cp.hits["high"] == 0
+    cp.sample(8)
+    assert cp.hits["high"] == 1
+
+
+def test_coverpoint_unmatched_value():
+    cp = Coverpoint(
+        name="x", signal="s",
+        bins=[bin_value("a", 0)],
+    )
+    cp.sample(99)  # no bin matches; nothing accumulates
+    assert cp.hits["a"] == 0
+
+
+def test_coverpoint_coverage_percentage():
+    cp = Coverpoint(
+        name="x", signal="s",
+        bins=[bin_value("a", 0), bin_value("b", 1)],
+    )
+    assert cp.coverage == 0.0
+    cp.sample(0)
+    assert cp.coverage == 0.5
+    cp.sample(1)
+    assert cp.coverage == 1.0
+
+
+def test_coverpoint_no_bins_is_full_coverage():
+    cp = Coverpoint(name="x", signal="s", bins=[])
+    assert cp.coverage == 1.0
+
+
+# ---- CoverageRecorder + toggle ----
+
+
+def test_toggle_rising_and_falling():
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+    cov.enable_toggle_coverage(["a", "y"])
+
+    vm.set_input("a", 1)  # 0->1 rising
+    vm.set_input("a", 0)  # 1->0 falling
+    vm.set_input("a", 1)  # rising
+
+    rep = cov.report()
+    assert rep.toggle["a"].rising == 2
+    assert rep.toggle["a"].falling == 1
+    # y also toggles since y = a
+    assert rep.toggle["y"].rising >= 1
+
+
+def test_toggle_only_for_enabled_signals():
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+    cov.enable_toggle_coverage(["a"])  # only a, not y
+
+    vm.set_input("a", 1)
+    rep = cov.report()
+    assert "a" in rep.toggle
+    assert "y" not in rep.toggle
+
+
+# ---- CoverageRecorder + coverpoints ----
+
+
+def test_coverpoint_via_vm():
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+
+    cov.add_coverpoint(Coverpoint(
+        name="a_val",
+        signal="a",
+        bins=[bin_value("zero", 0), bin_value("one", 1)],
+    ))
+
+    vm.set_input("a", 1)
+    rep = cov.report()
+    assert rep.coverpoints["a_val"]["one"] == 1
+    # 'zero' wasn't sampled because a started at 0 and the first event was 0->1.
+    # The recorder doesn't sample initial values; only changes.
+    assert rep.coverpoints["a_val"]["zero"] == 0
+
+
+def test_overall_coverage():
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+
+    cov.add_coverpoint(Coverpoint(
+        name="cp1",
+        signal="a",
+        bins=[bin_value("zero", 0), bin_value("one", 1)],
+    ))
+
+    assert cov.overall_coverage == 0.0
+    vm.set_input("a", 1)
+    # One bin hit out of two; coverage = 0.5
+    assert cov.overall_coverage == 0.5
+
+
+def test_overall_coverage_no_points():
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+    assert cov.overall_coverage == 0.0
+
+
+# ---- CrossPoint ----
+
+
+def test_cross_records_joint_hits():
+    vm = HardwareVM(make_adder4_hir())
+    cov = CoverageRecorder(vm)
+
+    cp_cin = Coverpoint(
+        name="cin",
+        signal="cin",
+        bins=[bin_value("zero", 0), bin_value("one", 1)],
+    )
+    cp_a = Coverpoint(
+        name="a",
+        signal="a",
+        bins=[bin_range("low", 0, 7), bin_range("high", 8, 15)],
+    )
+
+    cov.add_coverpoint(cp_cin)
+    cov.add_coverpoint(cp_a)
+
+    cross = CrossPoint(name="cin_x_a", coverpoints=[cp_cin, cp_a])
+    cov.add_cross(cross)
+
+    vm.set_input("a", 5)
+    vm.set_input("cin", 1)
+    cov.sample_cross()
+
+    rep = cov.report()
+    # Joint: cin=one, a=low
+    assert rep.crosses["cin_x_a"][("one", "low")] == 1
+
+
+def test_cross_coverage_zero_when_unsampled():
+    cp_a = Coverpoint(name="a", signal="a", bins=[bin_value("z", 0)])
+    cross = CrossPoint(name="x", coverpoints=[cp_a])
+    assert cross.coverage == 0.0
+
+
+def test_cross_coverage_no_coverpoints():
+    cross = CrossPoint(name="x", coverpoints=[])
+    assert cross.coverage == 1.0
+
+
+def test_cross_skips_unmatched_value():
+    """If the current signal value matches no bin, the cross sample is dropped."""
+    vm = HardwareVM(make_buffer_hir())
+    cov = CoverageRecorder(vm)
+    cp = Coverpoint(name="a", signal="a", bins=[bin_value("only_5", 5)])
+    cov.add_coverpoint(cp)
+    cross = CrossPoint(name="x", coverpoints=[cp])
+    cov.add_cross(cross)
+    vm.set_input("a", 1)  # not 5
+    cov.sample_cross()
+    assert cov.report().crosses["x"] == {}
+
+
+def test_sample_cross_by_name():
+    cp = Coverpoint(name="cp", signal="a", bins=[bin_default()])
+    cross = CrossPoint(name="cross", coverpoints=[cp])
+    cross._last_values["a"] = 3
+    cross.sample()
+    assert cross.hits[("default",)] == 1
+
+
+def test_sample_cross_returns_early_without_value():
+    cp = Coverpoint(name="cp", signal="a", bins=[bin_value("v", 0)])
+    cross = CrossPoint(name="cross", coverpoints=[cp])
+    # No _last_values populated -> sample short-circuits
+    cross.sample()
+    assert cross.hits == {}


### PR DESCRIPTION
## Summary

Functional + toggle coverage. Subscribes to HardwareVM events, accumulates hits in user-defined bins.

```python
from coverage_hdl import CoverageRecorder, Coverpoint, bin_value, bin_range

cov = CoverageRecorder(vm)
cov.enable_toggle_coverage(["sum", "cout"])
cov.add_coverpoint(Coverpoint(
    name="cin", signal="cin",
    bins=[bin_value("zero", 0), bin_value("one", 1)],
))

# Drive stimulus; cov auto-samples on every value change
print(cov.overall_coverage)
print(cov.report().toggle)
```

## Pipeline position

```
HardwareVM (MERGED) -- vm.subscribe(...) ──> CoverageRecorder (THIS PR)
                                                    │
                                                    v
                                             CoverageReport
```

## Quality

- 19/19 tests pass
- 98% coverage (target ≥ 80%)
- Ruff clean

## v0.1.0 scope

- `Coverpoint` + `Bin` (value, range, default) + `CrossPoint`
- `CoverageRecorder.enable_toggle_coverage(signals)` for rising/falling counts
- Cross-points sampled via `sample_cross(name=None)` (manual)
- Auto-sampling of coverpoints on signal value-change events
- `CoverageReport`: per-coverpoint hits, per-cross hits, per-signal `ToggleStats`
- `overall_coverage` property

## Out of scope (v0.2.0)

- Code coverage (line/branch/path) — needs HIR instrumentation
- FSM-state / FSM-transition helpers
- HTML reports
- MC/DC analysis
- Coverage merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)