### PR TITLE
feat(macsyma-repl): interactive MACSYMA REPL program (Phase A capstone)

### DIFF
--- a/code/packages/python/cas-pretty-printer/BUILD
+++ b/code/packages/python/cas-pretty-printer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../symbolic-ir -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --tb=short

--- a/code/packages/python/cas-pretty-printer/BUILD_windows
+++ b/code/packages/python/cas-pretty-printer/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../symbolic-ir -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v --tb=short

--- a/code/packages/python/cas-pretty-printer/CHANGELOG.md
+++ b/code/packages/python/cas-pretty-printer/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.1.0 — 2026-04-25
+
+Initial release.
+
+- `Dialect` protocol and `BaseDialect` ABC.
+- Walker handles every IR node type (`IRSymbol`, `IRInteger`,
+  `IRRational`, `IRFloat`, `IRString`, `IRApply`).
+- Operator precedence and associativity tracking; parens inserted
+  only when required.
+- Surface-syntax sugar: `Add(x, Neg(y)) → x - y`, `Mul(x, Inv(y)) →
+  x / y`, `Mul(-1, x) → -x`.
+- `MacsymaDialect`, `MathematicaDialect`, `MapleDialect`,
+  `LispDialect` ship out of the box.
+- `register_head_formatter` hook for downstream packages to teach
+  the printer about new heads (Matrix, Determinant, Limit, etc.).
+- Type-checked (`py.typed`); ruff- and mypy-clean.

--- a/code/packages/python/cas-pretty-printer/README.md
+++ b/code/packages/python/cas-pretty-printer/README.md
@@ -1,0 +1,81 @@
+# cas-pretty-printer
+
+Pretty-print symbolic IR back to source text. The package walks an
+`IRNode` tree and emits a string. The walker is **shared across every
+dialect**; what changes per dialect is a small `Dialect` object that
+supplies operator spellings, function names, brackets, and a
+precedence table.
+
+## Quick start
+
+```python
+from cas_pretty_printer import pretty, MacsymaDialect
+from symbolic_ir import IRSymbol, IRInteger, IRApply, ADD, POW
+
+x = IRSymbol("x")
+expr = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
+
+print(pretty(expr, MacsymaDialect()))
+# x^2 + 1
+```
+
+## Dialects shipped
+
+- `MacsymaDialect()` — Maxima/MACSYMA syntax: `x^2`, `f(x, y)`,
+  `[a, b]`, `sin`/`cos`/`log`/`exp`.
+- `MathematicaDialect()` — Mathematica syntax: `x^2`, `Sin[x, y]`,
+  `{a, b}`.
+- `MapleDialect()` — Maple syntax.
+- `LispDialect()` — always-prefix debugging form: `(Add x y)`. Useful
+  when building a new dialect.
+
+## Custom dialects
+
+Sub-class `BaseDialect` and override the spellings you care about.
+Most dialects need fewer than 30 lines. See `mathematica.py` and
+`maple.py` for examples.
+
+## Operator precedence
+
+The walker tracks a minimum-precedence parameter as it descends.
+Parentheses are inserted only when a child's precedence is lower than
+the context demands. Right-associativity for `Pow` is handled
+correctly: `a^b^c` → `Pow(a, Pow(b, c))` round-trips without spurious
+parens; `Pow(Pow(a, b), c)` prints as `(a^b)^c`.
+
+## Sugar
+
+Each dialect can register surface-syntax sugar:
+
+- `Add(x, Neg(y))` → `x - y`
+- `Mul(x, Inv(y))` → `x / y`
+- `Mul(-1, x)`     → `-x`
+
+Plain dialects (`LispDialect`) skip the sugar and print every node
+verbatim.
+
+## Extending the printer with new heads
+
+Downstream packages that introduce new heads (e.g. `cas-matrix` adds
+`Matrix`, `Determinant`, `Inverse`) can register custom formatters:
+
+```python
+from cas_pretty_printer import register_head_formatter
+
+def format_matrix(node, dialect, fmt):
+    rows = [", ".join(fmt(c) for c in r.args) for r in node.args]
+    return "matrix(" + ", ".join(f"[{row}]" for row in rows) + ")"
+
+register_head_formatter("Matrix", format_matrix)
+```
+
+The walker calls registered formatters before its built-in dispatch
+when a head is recognized.
+
+## Dependencies
+
+- `coding-adventures-symbolic-ir`
+
+That's it. The pretty-printer has no other dependencies — it's
+deliberately a leaf in the package graph so any layer above can pull
+it in cheaply.

--- a/code/packages/python/cas-pretty-printer/pyproject.toml
+++ b/code/packages/python/cas-pretty-printer/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-cas-pretty-printer"
+version = "0.1.0"
+description = "Pretty-print symbolic IR back to source text — dialect-aware (MACSYMA, Mathematica, Maple, Lisp)."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["cas", "symbolic", "pretty-printer", "ir", "macsyma", "mathematica", "education"]
+dependencies = [
+    "coding-adventures-symbolic-ir>=0.5.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cas_pretty_printer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=cas_pretty_printer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/cas-pretty-printer/required_capabilities.json
+++ b/code/packages/python/cas-pretty-printer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/cas-pretty-printer",
+  "capabilities": [],
+  "justification": "Pure in-memory IR -> string transformation. No filesystem, network, or process access."
+}

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/__init__.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/__init__.py
@@ -1,0 +1,46 @@
+"""Pretty-print symbolic IR back to source text.
+
+The package is dialect-aware: the same walker emits MACSYMA, Mathematica,
+Maple, or Lisp by swapping a small :class:`Dialect` object.
+
+Quick start::
+
+    from cas_pretty_printer import pretty, MacsymaDialect
+    from symbolic_ir import IRSymbol, IRInteger, IRApply, ADD, POW
+
+    x = IRSymbol("x")
+    expr = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
+    print(pretty(expr, MacsymaDialect()))
+    # x^2 + 1
+
+For the always-prefix Lisp form, use :func:`format_lisp` (which bypasses
+the walker entirely)::
+
+    from cas_pretty_printer import format_lisp
+    print(format_lisp(expr))
+    # (Add (Pow x 2) 1)
+"""
+
+from cas_pretty_printer.dialect import BaseDialect, Dialect
+from cas_pretty_printer.lisp import LispDialect, format_lisp
+from cas_pretty_printer.macsyma import MacsymaDialect
+from cas_pretty_printer.maple import MapleDialect
+from cas_pretty_printer.mathematica import MathematicaDialect
+from cas_pretty_printer.walker import (
+    pretty,
+    register_head_formatter,
+    unregister_head_formatter,
+)
+
+__all__ = [
+    "BaseDialect",
+    "Dialect",
+    "LispDialect",
+    "MacsymaDialect",
+    "MapleDialect",
+    "MathematicaDialect",
+    "format_lisp",
+    "pretty",
+    "register_head_formatter",
+    "unregister_head_formatter",
+]

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/dialect.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/dialect.py
@@ -1,0 +1,234 @@
+"""Dialect protocol and `BaseDialect` defaults.
+
+A dialect tells the walker how to spell things in a particular CAS
+language. The walker is dialect-agnostic; the dialect supplies:
+
+- numeric formats (integers, rationals, floats, strings),
+- operator spellings (binary like `+`, unary like `-`),
+- function-call shape (parens vs. brackets, function name aliases),
+- list and call brackets,
+- a precedence table — used by the walker to decide where parens go.
+
+A dialect also gets a chance to apply *surface sugar* (e.g. turn
+``Add(x, Neg(y))`` into ``x - y``) before the walker dispatches —
+implementations can override :py:meth:`BaseDialect.try_sugar` for that.
+
+Most dialects subclass :class:`BaseDialect` and override only the
+spelling tables. See :mod:`cas_pretty_printer.macsyma` for a worked
+example.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from symbolic_ir import IRApply, IRNode
+
+# Default precedence levels — higher numbers bind tighter.
+# These are the canonical values most CAS languages use; a dialect can
+# override `precedence()` to change them.
+PREC_OR = 10
+PREC_AND = 20
+PREC_NOT = 25
+PREC_CMP = 30
+PREC_ADD = 40
+PREC_MUL = 50
+PREC_NEG = 55
+PREC_POW = 60
+PREC_CALL = 70
+PREC_ATOM = 100
+
+
+@runtime_checkable
+class Dialect(Protocol):
+    """The minimal protocol every dialect must satisfy.
+
+    Implementers should usually subclass :class:`BaseDialect` rather
+    than implement this directly.
+    """
+
+    name: str
+
+    # Numeric formatting -----------------------------------------------------
+    def format_integer(self, value: int) -> str: ...
+    def format_rational(self, numer: int, denom: int) -> str: ...
+    def format_float(self, value: float) -> str: ...
+    def format_string(self, value: str) -> str: ...
+    def format_symbol(self, name: str) -> str: ...
+
+    # Operator spellings — return None to fall back to function-call form.
+    def binary_op(self, head_name: str) -> str | None: ...
+    def unary_op(self, head_name: str) -> str | None: ...
+
+    # Function-call spelling.
+    def function_name(self, head_name: str) -> str: ...
+
+    # Container delimiters — (open, close) pairs.
+    def list_brackets(self) -> tuple[str, str]: ...
+    def call_brackets(self) -> tuple[str, str]: ...
+
+    # Precedence table.
+    def precedence(self, head_name: str) -> int: ...
+    def is_right_associative(self, head_name: str) -> bool: ...
+
+    # Surface sugar hook — return a rewritten IRApply or None.
+    def try_sugar(self, node: IRApply) -> IRNode | None: ...
+
+
+# Precedence assignments by head name. Used by `BaseDialect.precedence`.
+_DEFAULT_PRECEDENCE: dict[str, int] = {
+    "Or": PREC_OR,
+    "And": PREC_AND,
+    "Not": PREC_NOT,
+    "Equal": PREC_CMP,
+    "NotEqual": PREC_CMP,
+    "Less": PREC_CMP,
+    "Greater": PREC_CMP,
+    "LessEqual": PREC_CMP,
+    "GreaterEqual": PREC_CMP,
+    "Add": PREC_ADD,
+    "Sub": PREC_ADD,
+    "Mul": PREC_MUL,
+    "Div": PREC_MUL,
+    "Neg": PREC_NEG,
+    "Pow": PREC_POW,
+}
+
+# Heads that are right-associative when they appear in chains.
+_RIGHT_ASSOC: frozenset[str] = frozenset({"Pow"})
+
+# Default operator spellings. Most language dialects share these.
+_DEFAULT_BINARY: dict[str, str] = {
+    "Add": " + ",
+    "Sub": " - ",
+    "Mul": "*",
+    "Div": "/",
+    "Pow": "^",
+    "Or": " or ",
+    "And": " and ",
+    "Equal": " = ",
+    "NotEqual": " # ",
+    "Less": " < ",
+    "Greater": " > ",
+    "LessEqual": " <= ",
+    "GreaterEqual": " >= ",
+}
+
+_DEFAULT_UNARY: dict[str, str] = {
+    "Neg": "-",
+    "Not": "not ",
+}
+
+# Function-name aliasing — IR head name → surface name. Most dialects
+# use lowercase versions of the IR heads; Mathematica is one exception.
+_DEFAULT_FUNCTION_NAMES: dict[str, str] = {
+    "Sin": "sin",
+    "Cos": "cos",
+    "Tan": "tan",
+    "Exp": "exp",
+    "Log": "log",
+    "Sqrt": "sqrt",
+    "Abs": "abs",
+    "Asin": "asin",
+    "Acos": "acos",
+    "Atan": "atan",
+    "Sinh": "sinh",
+    "Cosh": "cosh",
+    "Tanh": "tanh",
+    "Asinh": "asinh",
+    "Acosh": "acosh",
+    "Atanh": "atanh",
+    "D": "diff",
+    "Integrate": "integrate",
+    "Simplify": "simplify",
+    "Expand": "expand",
+    "Factor": "factor",
+    "Subst": "subst",
+    "Solve": "solve",
+    "Limit": "limit",
+    "Taylor": "taylor",
+    "Length": "length",
+    "First": "first",
+    "Rest": "rest",
+    "Map": "map",
+    "Apply": "apply",
+}
+
+
+class BaseDialect:
+    """Default implementations for every method on :class:`Dialect`.
+
+    Subclasses typically override only ``name`` and the small spelling
+    tables (``binary_ops``, ``unary_ops``, ``function_names``). The
+    walker calls every method via this base, so individual subclasses
+    can stay short.
+    """
+
+    name: str = "base"
+
+    # Tables that subclasses may copy and modify.
+    binary_ops: dict[str, str] = _DEFAULT_BINARY
+    unary_ops: dict[str, str] = _DEFAULT_UNARY
+    function_names: dict[str, str] = _DEFAULT_FUNCTION_NAMES
+    precedence_table: dict[str, int] = _DEFAULT_PRECEDENCE
+    right_assoc: frozenset[str] = _RIGHT_ASSOC
+
+    # ---- numeric ----------------------------------------------------------
+
+    def format_integer(self, value: int) -> str:
+        return str(value)
+
+    def format_rational(self, numer: int, denom: int) -> str:
+        # Rationals like `-3/4` need parens around the numerator if
+        # negative AND the result will be embedded in a larger expression.
+        # The walker handles that via precedence; here we just render the
+        # raw text.
+        return f"{numer}/{denom}"
+
+    def format_float(self, value: float) -> str:
+        return repr(value)
+
+    def format_string(self, value: str) -> str:
+        return f'"{value}"'
+
+    def format_symbol(self, name: str) -> str:
+        return name
+
+    # ---- operators --------------------------------------------------------
+
+    def binary_op(self, head_name: str) -> str | None:
+        return self.binary_ops.get(head_name)
+
+    def unary_op(self, head_name: str) -> str | None:
+        return self.unary_ops.get(head_name)
+
+    def function_name(self, head_name: str) -> str:
+        return self.function_names.get(head_name, head_name)
+
+    # ---- containers -------------------------------------------------------
+
+    def list_brackets(self) -> tuple[str, str]:
+        return ("[", "]")
+
+    def call_brackets(self) -> tuple[str, str]:
+        return ("(", ")")
+
+    # ---- precedence -------------------------------------------------------
+
+    def precedence(self, head_name: str) -> int:
+        # Unknown heads are function calls — bind as tightly as atoms.
+        return self.precedence_table.get(head_name, PREC_CALL)
+
+    def is_right_associative(self, head_name: str) -> bool:
+        return head_name in self.right_assoc
+
+    # ---- sugar ------------------------------------------------------------
+
+    def try_sugar(self, node: IRApply) -> IRNode | None:
+        """Hook for dialect-specific surface rewrites.
+
+        Default: no sugar. Math dialects override this to convert
+        ``Add(x, Neg(y))`` to a `Sub`, ``Mul(x, Inv(y))`` to a `Div`,
+        and ``Mul(-1, x)`` to a `Neg`. See :class:`MathDialect`.
+        """
+        return None

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/lisp.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/lisp.py
@@ -1,0 +1,81 @@
+"""Always-prefix Lisp dialect — every node is rendered as ``(Head args...)``.
+
+Useful for debugging the IR shape itself: skips all sugar, all
+operator infix, all precedence — what you see is the tree.
+
+    Add(2, Mul(3, x))  →  ``(Add 2 (Mul 3 x))``
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRNode
+
+from cas_pretty_printer.dialect import BaseDialect
+
+
+class LispDialect(BaseDialect):
+    """No sugar, no infix — pure prefix form."""
+
+    name = "lisp"
+
+    # Disable every operator spelling so the walker falls through to
+    # function-call form on every IRApply.
+    binary_ops: dict[str, str] = {}
+    unary_ops: dict[str, str] = {}
+    function_names: dict[str, str] = {}
+
+    def call_brackets(self) -> tuple[str, str]:
+        # We override the walker behavior entirely via try_sugar to
+        # avoid emitting commas — Lisp uses spaces.
+        return ("(", ")")
+
+    def function_name(self, head_name: str) -> str:
+        return head_name
+
+    def try_sugar(self, node: IRApply) -> IRNode | None:
+        # Sugar is the wrong tool here, but we use it as a hook so that
+        # we own the formatting of every IRApply. We re-emit through a
+        # custom synthetic head — but that would recurse forever. Instead,
+        # leave try_sugar alone and rely on a custom head formatter
+        # registered at module-import time. That keeps the Lisp output
+        # uniform regardless of head.
+        return None
+
+
+def _lisp_format(node: IRApply, _dialect: object, fmt: object) -> str:
+    """Used by the custom head formatter registered for Lisp output.
+
+    Note that this function is intentionally reachable only when a user
+    explicitly opts in via :func:`format_lisp` — registering it as a
+    global head formatter would interfere with the other dialects.
+    """
+    raise NotImplementedError  # the actual entry point is `format_lisp`
+
+
+def format_lisp(node: IRNode) -> str:
+    """One-shot entry point for the Lisp dialect.
+
+    Bypasses the walker's normal dispatch entirely — every node is
+    rendered as either a leaf or ``(Head args...)``. Doesn't depend on
+    any registered head formatter, so it's safe to call regardless of
+    what other dialects have configured.
+    """
+    from symbolic_ir import IRFloat, IRInteger, IRRational, IRString, IRSymbol
+
+    if isinstance(node, IRInteger):
+        return str(node.value)
+    if isinstance(node, IRRational):
+        return f"{node.numer}/{node.denom}"
+    if isinstance(node, IRFloat):
+        return repr(node.value)
+    if isinstance(node, IRString):
+        return f'"{node.value}"'
+    if isinstance(node, IRSymbol):
+        return node.name
+    if isinstance(node, IRApply):
+        head_text = format_lisp(node.head)
+        if not node.args:
+            return f"({head_text})"
+        args_text = " ".join(format_lisp(a) for a in node.args)
+        return f"({head_text} {args_text})"
+    raise TypeError(f"cannot Lisp-format node of type {type(node).__name__}")

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/macsyma.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/macsyma.py
@@ -1,0 +1,72 @@
+"""MACSYMA / Maxima dialect.
+
+Surface syntax conventions:
+
+- Function calls use parens: ``sin(x)``, ``f(x, y)``.
+- Lists use square brackets: ``[1, 2, 3]``.
+- Power is ``^`` (also accepts ``**`` on input — output uses ``^``).
+- Equality is ``=``; not-equal is ``#``.
+- Function names are lowercase: ``sin``, ``cos``, ``log``, ``exp``,
+  ``diff``, ``integrate``.
+- Surface sugar:
+    - ``Add(x, Neg(y))`` displays as ``x - y``.
+    - ``Mul(x, Inv(y))`` displays as ``x / y``.
+    - ``Mul(-1, x)`` displays as ``-x``.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRNode, IRSymbol
+
+from cas_pretty_printer.dialect import BaseDialect
+
+_NEG = IRSymbol("Neg")
+_INV = IRSymbol("Inv")
+_SUB = IRSymbol("Sub")
+_DIV = IRSymbol("Div")
+_ADD = IRSymbol("Add")
+_MUL = IRSymbol("Mul")
+
+
+class MacsymaDialect(BaseDialect):
+    """Maxima/MACSYMA flavor of CAS source text."""
+
+    name = "macsyma"
+
+    def try_sugar(self, node: IRApply) -> IRNode | None:
+        head = node.head
+        if not isinstance(head, IRSymbol):
+            return None
+
+        # Mul(-1, x) → Neg(x)
+        if head.name == "Mul" and len(node.args) >= 2:
+            first = node.args[0]
+            if isinstance(first, IRInteger) and first.value == -1:
+                rest = node.args[1:]
+                inner = rest[0] if len(rest) == 1 else IRApply(_MUL, tuple(rest))
+                return IRApply(_NEG, (inner,))
+
+        # Add(a, Neg(b)) → Sub(a, b). Apply only when there's exactly
+        # one negated trailing argument, to keep the rule predictable.
+        if head.name == "Add" and len(node.args) == 2:
+            a, b = node.args
+            if (
+                isinstance(b, IRApply)
+                and isinstance(b.head, IRSymbol)
+                and b.head.name == "Neg"
+                and len(b.args) == 1
+            ):
+                return IRApply(_SUB, (a, b.args[0]))
+
+        # Mul(a, Inv(b)) → Div(a, b). Same caution: only the 2-arg case.
+        if head.name == "Mul" and len(node.args) == 2:
+            a, b = node.args
+            if (
+                isinstance(b, IRApply)
+                and isinstance(b.head, IRSymbol)
+                and b.head.name == "Inv"
+                and len(b.args) == 1
+            ):
+                return IRApply(_DIV, (a, b.args[0]))
+
+        return None

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/maple.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/maple.py
@@ -1,0 +1,23 @@
+"""Maple dialect.
+
+Surface syntax differences from MACSYMA:
+
+- Power can be ``^`` or ``**`` — output uses ``^``.
+- Function names use Maple conventions (``diff`` not ``D``).
+
+Otherwise mostly identical to MACSYMA: parens for calls, square
+brackets for lists, lowercase function names.
+"""
+
+from __future__ import annotations
+
+from cas_pretty_printer.macsyma import MacsymaDialect
+
+
+class MapleDialect(MacsymaDialect):
+    """Maple flavor — same spellings as MACSYMA for everything we cover so far."""
+
+    name = "maple"
+    # Maple uses `<>` for not-equal but accepts `#` like MACSYMA in some
+    # contexts; use `<>` for output.
+    binary_ops = {**MacsymaDialect.binary_ops, "NotEqual": " <> "}

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/mathematica.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/mathematica.py
@@ -1,0 +1,45 @@
+"""Mathematica dialect.
+
+Surface syntax differences from MACSYMA:
+
+- Function calls use square brackets: ``Sin[x]``, ``D[f, x]``.
+- Lists use curly braces: ``{1, 2, 3}``.
+- Function names are CamelCase (matches the IR head names directly).
+- Equality is ``==``.
+"""
+
+from __future__ import annotations
+
+from cas_pretty_printer.dialect import BaseDialect
+from cas_pretty_printer.macsyma import MacsymaDialect
+
+
+class MathematicaDialect(MacsymaDialect):
+    """Mathematica flavor — reuses MACSYMA's sugar but swaps spellings."""
+
+    name = "mathematica"
+
+    # Override only the spellings.
+    binary_ops = {
+        **BaseDialect.binary_ops,
+        "Equal": " == ",
+        "NotEqual": " != ",
+        "And": " && ",
+        "Or": " || ",
+    }
+    unary_ops = {
+        **BaseDialect.unary_ops,
+        "Not": "!",
+    }
+
+    # Mathematica keeps capitalised names — `Sin`, `Cos`, etc. stay as-is.
+    function_names: dict[str, str] = {}
+
+    def list_brackets(self) -> tuple[str, str]:
+        return ("{", "}")
+
+    def call_brackets(self) -> tuple[str, str]:
+        return ("[", "]")
+
+    def function_name(self, head_name: str) -> str:
+        return head_name

--- a/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/walker.py
+++ b/code/packages/python/cas-pretty-printer/src/cas_pretty_printer/walker.py
@@ -1,0 +1,221 @@
+"""The dialect-agnostic IR walker.
+
+The walker descends an IR tree and emits source text. It tracks one
+piece of state — `min_prec`, the minimum precedence the emitted text
+must have to avoid being parenthesized by its parent. Every dialect
+hook (operator spellings, brackets, sugar) is consulted via the
+`Dialect` protocol; the walker itself does not know which language it
+is printing.
+
+Algorithm
+---------
+
+For an `IRApply(head, args)` whose head is a known operator:
+
+1. Try `dialect.try_sugar(node)`; if it returns a rewritten tree,
+   format that recursively.
+2. Try a registered head formatter (see :func:`register_head_formatter`).
+3. If `head` is a binary operator with arity ≥ 2, emit
+   ``arg op arg op ...`` with each child formatted at the correct
+   `min_prec`. Left-associative operators give the rightmost child
+   `parent_prec + 1`; right-associative operators give the leftmost
+   child `parent_prec + 1`. (Variadic flat operators are unaffected
+   either way — the same precedence on every child works.)
+4. If `head` is a unary operator with arity 1, emit ``op{arg}`` with
+   `arg` formatted at `parent_prec`.
+5. If `head` is `List`, emit the list brackets.
+6. Otherwise, function-call form: ``name(arg, arg, ...)``.
+
+After step 3 or 4, parentheses are wrapped iff the operator's
+precedence is strictly less than `min_prec`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from symbolic_ir import (
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRString,
+    IRSymbol,
+)
+
+if TYPE_CHECKING:
+    from cas_pretty_printer.dialect import Dialect
+
+# Type alias for a custom head formatter.
+# Receives (node, dialect, format_recursively_fn) and returns a string.
+HeadFormatter = Callable[[IRApply, "Dialect", Callable[[IRNode], str]], str]
+
+# Registry consulted by the walker. Downstream packages register their
+# heads here so cas-pretty-printer doesn't need to know about them.
+_HEAD_FORMATTERS: dict[str, HeadFormatter] = {}
+
+
+def register_head_formatter(head_name: str, formatter: HeadFormatter) -> None:
+    """Teach the walker about a new head.
+
+    The formatter is called whenever the walker encounters an
+    ``IRApply`` whose head is a symbol with the given name. It receives
+    the node, the active dialect, and a `fmt(child)` helper that
+    formats children with no precedence context (the formatter is
+    responsible for any nesting concerns). It must return a string.
+
+    Example::
+
+        def format_matrix(node, dialect, fmt):
+            rows = [", ".join(fmt(c) for c in row.args)
+                    for row in node.args]
+            return "matrix(" + ", ".join(f"[{r}]" for r in rows) + ")"
+
+        register_head_formatter("Matrix", format_matrix)
+    """
+    _HEAD_FORMATTERS[head_name] = formatter
+
+
+def unregister_head_formatter(head_name: str) -> None:
+    """Reverse of :func:`register_head_formatter`. Mostly for tests."""
+    _HEAD_FORMATTERS.pop(head_name, None)
+
+
+_PREC_ATOM = 100  # mirrors dialect.PREC_ATOM; duplicated here to avoid import cycle
+
+
+def pretty(node: IRNode, dialect: Dialect, *, style: str = "linear") -> str:
+    """Format `node` as source text in the given dialect.
+
+    Args:
+        node: The IR tree.
+        dialect: A :class:`Dialect` instance (typically a subclass of
+            :class:`BaseDialect`).
+        style: Reserved for future ``"2d"`` ASCII output. Currently only
+            ``"linear"`` is supported.
+
+    Returns:
+        A single-line (linear style) string.
+    """
+    if style != "linear":
+        raise ValueError(f"unsupported style {style!r}")
+    return _format(node, dialect, min_prec=0)
+
+
+def _format(node: IRNode, dialect: Dialect, min_prec: int) -> str:
+    if isinstance(node, IRInteger):
+        return _format_integer(node, dialect, min_prec)
+    if isinstance(node, IRRational):
+        return _format_rational(node, dialect, min_prec)
+    if isinstance(node, IRFloat):
+        return _format_float(node, dialect, min_prec)
+    if isinstance(node, IRString):
+        return dialect.format_string(node.value)
+    if isinstance(node, IRSymbol):
+        return dialect.format_symbol(node.name)
+    if isinstance(node, IRApply):
+        return _format_apply(node, dialect, min_prec)
+    raise TypeError(f"cannot pretty-print node of type {type(node).__name__}")
+
+
+def _format_integer(node: IRInteger, dialect: Dialect, min_prec: int) -> str:
+    text = dialect.format_integer(node.value)
+    # Negative literals need parens when nested inside a tighter-binding
+    # operator (e.g. `2^-3` needs `2^(-3)` to round-trip in MACSYMA).
+    if node.value < 0 and min_prec > 0:
+        return f"({text})"
+    return text
+
+
+def _format_rational(node: IRRational, dialect: Dialect, min_prec: int) -> str:
+    text = dialect.format_rational(node.numer, node.denom)
+    if (node.numer < 0 or "/" in text) and min_prec > 0:
+        return f"({text})"
+    return text
+
+
+def _format_float(node: IRFloat, dialect: Dialect, min_prec: int) -> str:
+    text = dialect.format_float(node.value)
+    if node.value < 0 and min_prec > 0:
+        return f"({text})"
+    return text
+
+
+def _format_apply(node: IRApply, dialect: Dialect, min_prec: int) -> str:
+    # 1. Sugar.
+    sugared = dialect.try_sugar(node)
+    if sugared is not None and sugared is not node:
+        return _format(sugared, dialect, min_prec)
+
+    head = node.head
+    head_name = head.name if isinstance(head, IRSymbol) else None
+
+    # 2. Custom head formatter.
+    if head_name is not None and head_name in _HEAD_FORMATTERS:
+        def fmt_helper(child: IRNode) -> str:
+            return _format(child, dialect, 0)
+        return _HEAD_FORMATTERS[head_name](node, dialect, fmt_helper)
+
+    # 3. List literal.
+    if head_name == "List":
+        return _format_list(node, dialect)
+
+    # 4. Unary op.
+    if head_name is not None and len(node.args) == 1:
+        op_text = dialect.unary_op(head_name)
+        if op_text is not None:
+            prec = dialect.precedence(head_name)
+            inner = _format(node.args[0], dialect, prec)
+            text = f"{op_text}{inner}"
+            return _wrap_if_needed(text, prec, min_prec)
+
+    # 5. Binary / n-ary op.
+    if head_name is not None and len(node.args) >= 2:
+        op_text = dialect.binary_op(head_name)
+        if op_text is not None:
+            prec = dialect.precedence(head_name)
+            right_assoc = dialect.is_right_associative(head_name)
+            parts: list[str] = []
+            n = len(node.args)
+            for i, arg in enumerate(node.args):
+                # For variadic flattened ops, parent_prec on every child
+                # is fine. For binary 2-arg with associativity:
+                #   left-assoc: rightmost child needs prec+1
+                #   right-assoc: leftmost child needs prec+1
+                if right_assoc and i < n - 1 or (not right_assoc) and i > 0:
+                    child_prec = prec + 1
+                else:
+                    child_prec = prec
+                parts.append(_format(arg, dialect, child_prec))
+            text = op_text.join(parts)
+            return _wrap_if_needed(text, prec, min_prec)
+
+    # 6. Function call.
+    return _format_call(node, dialect)
+
+
+def _format_list(node: IRApply, dialect: Dialect) -> str:
+    open_b, close_b = dialect.list_brackets()
+    args = ", ".join(_format(a, dialect, 0) for a in node.args)
+    return f"{open_b}{args}{close_b}"
+
+
+def _format_call(node: IRApply, dialect: Dialect) -> str:
+    head = node.head
+    if isinstance(head, IRSymbol):
+        name = dialect.function_name(head.name)
+    else:
+        # Higher-order: head is itself a compound expression.
+        # Render it at atom precedence so it gets wrapped if needed.
+        name = _format(head, dialect, _PREC_ATOM)
+    open_b, close_b = dialect.call_brackets()
+    args = ", ".join(_format(a, dialect, 0) for a in node.args)
+    return f"{name}{open_b}{args}{close_b}"
+
+
+def _wrap_if_needed(text: str, prec: int, min_prec: int) -> str:
+    if prec < min_prec:
+        return f"({text})"
+    return text

--- a/code/packages/python/cas-pretty-printer/tests/test_dialect_extensibility.py
+++ b/code/packages/python/cas-pretty-printer/tests/test_dialect_extensibility.py
@@ -1,0 +1,62 @@
+"""Custom head formatter registration — package-extension surface."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+
+from cas_pretty_printer import (
+    MacsymaDialect,
+    pretty,
+    register_head_formatter,
+    unregister_head_formatter,
+)
+
+
+def test_register_custom_head_formatter() -> None:
+    """A custom formatter for a new head 'Matrix' is consulted by the walker."""
+
+    def fmt_matrix(node, dialect, fmt):
+        rows = [
+            "[" + ", ".join(fmt(c) for c in row.args) + "]" for row in node.args
+        ]
+        return "matrix(" + ", ".join(rows) + ")"
+
+    register_head_formatter("Matrix", fmt_matrix)
+    try:
+        list_head = IRSymbol("List")
+        matrix_head = IRSymbol("Matrix")
+        row1 = IRApply(list_head, (IRInteger(1), IRInteger(2)))
+        row2 = IRApply(list_head, (IRInteger(3), IRInteger(4)))
+        m = IRApply(matrix_head, (row1, row2))
+        assert pretty(m, MacsymaDialect()) == "matrix([1, 2], [3, 4])"
+    finally:
+        unregister_head_formatter("Matrix")
+
+
+def test_unregister_clears_formatter() -> None:
+    """After unregister, the head falls back to function-call form."""
+
+    def noop(node, dialect, fmt):
+        return "CUSTOM"
+
+    register_head_formatter("Foo", noop)
+    unregister_head_formatter("Foo")
+
+    foo_head = IRSymbol("Foo")
+    expr = IRApply(foo_head, (IRInteger(1),))
+    # No registered formatter — falls back to default function-call form.
+    assert pretty(expr, MacsymaDialect()) == "Foo(1)"
+
+
+def test_custom_dialect_subclass() -> None:
+    """A dialect subclass that overrides operator spelling works end-to-end."""
+    from symbolic_ir import ADD
+
+    from cas_pretty_printer.dialect import BaseDialect
+
+    class Verbose(BaseDialect):
+        name = "verbose"
+        binary_ops = {**BaseDialect.binary_ops, "Add": " plus "}
+
+    expr = IRApply(ADD, (IRSymbol("a"), IRSymbol("b")))
+    assert pretty(expr, Verbose()) == "a plus b"

--- a/code/packages/python/cas-pretty-printer/tests/test_lisp_dialect.py
+++ b/code/packages/python/cas-pretty-printer/tests/test_lisp_dialect.py
@@ -1,0 +1,60 @@
+"""Lisp dialect — always-prefix output."""
+
+from __future__ import annotations
+
+from symbolic_ir import (
+    ADD,
+    MUL,
+    POW,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRString,
+    IRSymbol,
+)
+
+from cas_pretty_printer import format_lisp
+
+
+def test_integer() -> None:
+    assert format_lisp(IRInteger(5)) == "5"
+
+
+def test_rational() -> None:
+    assert format_lisp(IRRational(3, 4)) == "3/4"
+
+
+def test_float() -> None:
+    assert format_lisp(IRFloat(2.5)) == "2.5"
+
+
+def test_string() -> None:
+    assert format_lisp(IRString("hi")) == '"hi"'
+
+
+def test_symbol() -> None:
+    assert format_lisp(IRSymbol("x")) == "x"
+
+
+def test_simple_apply() -> None:
+    expr = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    assert format_lisp(expr) == "(Add x 1)"
+
+
+def test_nested_apply() -> None:
+    """Add(2, Mul(3, x)) → (Add 2 (Mul 3 x))."""
+    expr = IRApply(ADD, (IRInteger(2), IRApply(MUL, (IRInteger(3), IRSymbol("x")))))
+    assert format_lisp(expr) == "(Add 2 (Mul 3 x))"
+
+
+def test_pow_no_special_handling() -> None:
+    """Pow stays prefix even though MACSYMA would give it ^."""
+    expr = IRApply(POW, (IRSymbol("x"), IRInteger(2)))
+    assert format_lisp(expr) == "(Pow x 2)"
+
+
+def test_no_arg_apply() -> None:
+    """A call with no args still gets parens around the head."""
+    expr = IRApply(IRSymbol("Now"), ())
+    assert format_lisp(expr) == "(Now)"

--- a/code/packages/python/cas-pretty-printer/tests/test_macsyma_dialect.py
+++ b/code/packages/python/cas-pretty-printer/tests/test_macsyma_dialect.py
@@ -1,0 +1,263 @@
+"""MACSYMA dialect — round-trip and shape tests."""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EQUAL,
+    GREATER,
+    INV,
+    LESS,
+    LIST,
+    MUL,
+    NEG,
+    NOT_EQUAL,
+    POW,
+    SIN,
+    SUB,
+    D,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRString,
+    IRSymbol,
+)
+
+from cas_pretty_printer import MacsymaDialect, pretty
+
+D_MAC = MacsymaDialect()
+
+
+def fmt(node: object) -> str:
+    return pretty(node, D_MAC)  # type: ignore[arg-type]
+
+
+# ---- leaves ----------------------------------------------------------------
+
+
+def test_integer_positive() -> None:
+    assert fmt(IRInteger(42)) == "42"
+
+
+def test_integer_negative_at_top() -> None:
+    # At the top level, no surrounding context — emit raw.
+    assert fmt(IRInteger(-5)) == "-5"
+
+
+def test_rational() -> None:
+    assert fmt(IRRational(3, 4)) == "3/4"
+
+
+def test_float() -> None:
+    text = fmt(IRFloat(3.14))
+    assert text.startswith("3.14")
+
+
+def test_string() -> None:
+    assert fmt(IRString("hello")) == '"hello"'
+
+
+def test_symbol() -> None:
+    assert fmt(IRSymbol("x")) == "x"
+
+
+# ---- binary ops ------------------------------------------------------------
+
+
+def test_add_two_args() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(ADD, (x, IRInteger(1)))) == "x + 1"
+
+
+def test_add_three_args() -> None:
+    a, b, c = IRSymbol("a"), IRSymbol("b"), IRSymbol("c")
+    assert fmt(IRApply(ADD, (a, b, c))) == "a + b + c"
+
+
+def test_mul_basic() -> None:
+    x, y = IRSymbol("x"), IRSymbol("y")
+    assert fmt(IRApply(MUL, (x, y))) == "x*y"
+
+
+def test_pow_basic() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(POW, (x, IRInteger(2)))) == "x^2"
+
+
+# ---- precedence and parens -------------------------------------------------
+
+
+def test_add_inside_mul_no_parens() -> None:
+    """Add(x, Mul(y, z)) prints as `x + y*z` — Mul binds tighter."""
+    y, z = IRSymbol("y"), IRSymbol("z")
+    expr = IRApply(ADD, (IRSymbol("x"), IRApply(MUL, (y, z))))
+    assert fmt(expr) == "x + y*z"
+
+
+def test_mul_of_add_needs_parens() -> None:
+    """Mul(Add(x, y), z) prints as `(x + y)*z`."""
+    x, y, z = IRSymbol("x"), IRSymbol("y"), IRSymbol("z")
+    expr = IRApply(MUL, (IRApply(ADD, (x, y)), z))
+    assert fmt(expr) == "(x + y)*z"
+
+
+def test_pow_right_associative() -> None:
+    """Pow(a, Pow(b, c)) prints as `a^b^c` — right child takes prec, no parens."""
+    a, b, c = IRSymbol("a"), IRSymbol("b"), IRSymbol("c")
+    expr = IRApply(POW, (a, IRApply(POW, (b, c))))
+    assert fmt(expr) == "a^b^c"
+
+
+def test_pow_left_side_needs_parens() -> None:
+    """Pow(Pow(a, b), c) prints as `(a^b)^c`."""
+    a, b, c = IRSymbol("a"), IRSymbol("b"), IRSymbol("c")
+    expr = IRApply(POW, (IRApply(POW, (a, b)), c))
+    assert fmt(expr) == "(a^b)^c"
+
+
+def test_unary_neg() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(NEG, (x,))) == "-x"
+
+
+def test_neg_of_add_needs_parens() -> None:
+    x, y = IRSymbol("x"), IRSymbol("y")
+    assert fmt(IRApply(NEG, (IRApply(ADD, (x, y)),))) == "-(x + y)"
+
+
+# ---- sugar -----------------------------------------------------------------
+
+
+def test_sub_sugar() -> None:
+    """Add(x, Neg(y)) sugars to `x - y`."""
+    x, y = IRSymbol("x"), IRSymbol("y")
+    expr = IRApply(ADD, (x, IRApply(NEG, (y,))))
+    assert fmt(expr) == "x - y"
+
+
+def test_div_sugar() -> None:
+    """Mul(x, Inv(y)) sugars to `x/y`."""
+    x, y = IRSymbol("x"), IRSymbol("y")
+    expr = IRApply(MUL, (x, IRApply(INV, (y,))))
+    assert fmt(expr) == "x/y"
+
+
+def test_neg_via_minus_one_sugar() -> None:
+    """Mul(-1, x) sugars to `-x`."""
+    x = IRSymbol("x")
+    expr = IRApply(MUL, (IRInteger(-1), x))
+    assert fmt(expr) == "-x"
+
+
+# ---- containers ------------------------------------------------------------
+
+
+def test_list_brackets() -> None:
+    assert fmt(IRApply(LIST, (IRInteger(1), IRInteger(2), IRInteger(3)))) == "[1, 2, 3]"
+
+
+def test_empty_list() -> None:
+    assert fmt(IRApply(LIST, ())) == "[]"
+
+
+# ---- function calls --------------------------------------------------------
+
+
+def test_sin_call() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(SIN, (x,))) == "sin(x)"
+
+
+def test_diff_call() -> None:
+    x = IRSymbol("x")
+    expr = IRApply(D, (IRApply(POW, (x, IRInteger(2))), x))
+    assert fmt(expr) == "diff(x^2, x)"
+
+
+def test_user_function() -> None:
+    f = IRSymbol("foo")
+    x = IRSymbol("x")
+    assert fmt(IRApply(f, (x, IRInteger(1)))) == "foo(x, 1)"
+
+
+def test_no_arg_call() -> None:
+    f = IRSymbol("hello")
+    assert fmt(IRApply(f, ())) == "hello()"
+
+
+# ---- comparisons / divisions / explicit Sub & Div --------------------------
+
+
+def test_explicit_sub() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(SUB, (a, b))) == "a - b"
+
+
+def test_explicit_div() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(DIV, (a, b))) == "a/b"
+
+
+def test_equal() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(EQUAL, (a, b))) == "a = b"
+
+
+def test_not_equal() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(NOT_EQUAL, (a, b))) == "a # b"
+
+
+def test_less() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(LESS, (a, b))) == "a < b"
+
+
+def test_greater() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(GREATER, (a, b))) == "a > b"
+
+
+# ---- nested expression -----------------------------------------------------
+
+
+def test_polynomial() -> None:
+    """`x^2 + 2*x + 1`."""
+    x = IRSymbol("x")
+    expr = IRApply(
+        ADD,
+        (
+            IRApply(POW, (x, IRInteger(2))),
+            IRApply(MUL, (IRInteger(2), x)),
+            IRInteger(1),
+        ),
+    )
+    assert fmt(expr) == "x^2 + 2*x + 1"
+
+
+def test_diff_call_with_compound_arg() -> None:
+    """`diff(sin(x) + cos(x), x)`."""
+    x = IRSymbol("x")
+    inner = IRApply(ADD, (IRApply(SIN, (x,)), IRApply(COS, (x,))))
+    expr = IRApply(D, (inner, x))
+    assert fmt(expr) == "diff(sin(x) + cos(x), x)"
+
+
+# ---- error path ------------------------------------------------------------
+
+
+def test_unknown_node_type_raises() -> None:
+    class Bogus:
+        pass
+
+    with pytest.raises(TypeError):
+        pretty(Bogus(), D_MAC)  # type: ignore[arg-type]
+
+
+def test_unsupported_style_raises() -> None:
+    with pytest.raises(ValueError):
+        pretty(IRInteger(1), D_MAC, style="2d")

--- a/code/packages/python/cas-pretty-printer/tests/test_mathematica_dialect.py
+++ b/code/packages/python/cas-pretty-printer/tests/test_mathematica_dialect.py
@@ -1,0 +1,57 @@
+"""Mathematica dialect — bracket and spelling differences."""
+
+from __future__ import annotations
+
+from symbolic_ir import (
+    ADD,
+    COS,
+    EQUAL,
+    LIST,
+    NOT_EQUAL,
+    SIN,
+    IRApply,
+    IRInteger,
+    IRSymbol,
+)
+
+from cas_pretty_printer import MathematicaDialect, pretty
+
+D = MathematicaDialect()
+
+
+def fmt(node: object) -> str:
+    return pretty(node, D)  # type: ignore[arg-type]
+
+
+def test_function_call_uses_square_brackets() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(SIN, (x,))) == "Sin[x]"
+
+
+def test_function_keeps_camel_case() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(COS, (x,))) == "Cos[x]"
+
+
+def test_list_uses_curly_braces() -> None:
+    assert fmt(IRApply(LIST, (IRInteger(1), IRInteger(2)))) == "{1, 2}"
+
+
+def test_double_equals() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(EQUAL, (a, b))) == "a == b"
+
+
+def test_not_equal_bang() -> None:
+    a, b = IRSymbol("a"), IRSymbol("b")
+    assert fmt(IRApply(NOT_EQUAL, (a, b))) == "a != b"
+
+
+def test_basic_addition() -> None:
+    x = IRSymbol("x")
+    assert fmt(IRApply(ADD, (x, IRInteger(1)))) == "x + 1"
+
+
+def test_user_function_camel() -> None:
+    f = IRSymbol("Foo")
+    assert fmt(IRApply(f, (IRSymbol("x"),))) == "Foo[x]"

--- a/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
+++ b/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
@@ -75,6 +75,14 @@ from symbolic_ir import (
 )
 from symbolic_ir.nodes import AND, OR
 
+# Statement-terminator wrappers. The compiler emits one of these around
+# every top-level statement so the REPL can distinguish ``;`` (display
+# the result) from ``$`` (suppress). The macsyma-runtime backend
+# installs identity handlers for both, so non-REPL consumers (e.g.
+# tests that drive the VM directly) don't have to think about them.
+DISPLAY = IRSymbol("Display")
+SUPPRESS = IRSymbol("Suppress")
+
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
@@ -180,7 +188,18 @@ class Compiler:
     The class carries no mutable state; it is a namespace for the
     recursive compilation methods. Every ``_compile_*`` method returns
     an ``IRNode``.
+
+    Set ``wrap_terminators=True`` (default ``False``) to have every
+    top-level statement wrapped in either ``Display(expr)`` (for ``;``)
+    or ``Suppress(expr)`` (for ``$``) so a REPL can later distinguish
+    the two. The wrappers are off by default to preserve compatibility
+    with consumers that drive the VM directly without a REPL — they
+    can leave ``wrap_terminators=False`` and continue to receive raw
+    expressions.
     """
+
+    def __init__(self, *, wrap_terminators: bool = False) -> None:
+        self._wrap_terminators = wrap_terminators
 
     def compile_program(self, root: ASTNode) -> list[IRNode]:
         """Compile a ``program`` AST into a list of IR statements.
@@ -205,11 +224,33 @@ class Compiler:
 
     def _compile_statement(self, node: ASTNode) -> IRNode:
         # `statement = expression ( SEMI | DOLLAR ) ;`
+        #
         # The expression is always child 0; the terminator is child 1.
+        # If ``wrap_terminators`` is enabled (REPL mode), wrap the
+        # expression in ``Display(expr)`` or ``Suppress(expr)`` so the
+        # REPL can decide whether to print the result. Otherwise,
+        # return the inner expression directly — downstream consumers
+        # that don't care about ``;`` vs ``$`` see the same shape they
+        # always have.
+        if not node.children:
+            raise CompileError("statement has no children")
         expr_node = node.children[0]
         if not isinstance(expr_node, ASTNode):
             raise CompileError("statement's first child must be an AST node")
-        return self._compile_node(expr_node)
+        inner = self._compile_node(expr_node)
+
+        if not self._wrap_terminators:
+            return inner
+
+        if len(node.children) >= 2 and isinstance(node.children[1], Token):
+            term_type = _token_type_name(node.children[1])
+            if term_type == "DOLLAR":
+                return IRApply(SUPPRESS, (inner,))
+            if term_type == "SEMI":
+                return IRApply(DISPLAY, (inner,))
+        # Defensive fallback if the grammar ever lets a terminator slip
+        # past — pick Display so the user sees the result.
+        return IRApply(DISPLAY, (inner,))
 
     def _compile_node(self, node: ASTNode | Token) -> IRNode:
         """Dispatch to the handler for this node's rule or token type."""
@@ -505,17 +546,24 @@ class Compiler:
 # ---------------------------------------------------------------------------
 
 
-def compile_macsyma(ast: ASTNode) -> list[IRNode]:
+def compile_macsyma(
+    ast: ASTNode, *, wrap_terminators: bool = False
+) -> list[IRNode]:
     """Compile a MACSYMA ``program`` AST to a list of IR statements.
 
     Args:
         ast: The root ``ASTNode`` produced by ``parse_macsyma``.
+        wrap_terminators: If True, every top-level statement is wrapped
+            in ``Display(expr)`` (for ``;``) or ``Suppress(expr)`` (for
+            ``$``). The MACSYMA REPL passes True; consumers that drive
+            the VM directly (e.g. test harnesses for substrate handlers)
+            leave it False to receive raw expressions.
 
     Returns:
         One ``IRNode`` per top-level statement. Empty programs return
         an empty list.
     """
-    return Compiler().compile_program(ast)
+    return Compiler(wrap_terminators=wrap_terminators).compile_program(ast)
 
 
 def compile_expression(ast: ASTNode | Token) -> IRNode:

--- a/code/packages/python/macsyma-compiler/tests/test_terminators.py
+++ b/code/packages/python/macsyma-compiler/tests/test_terminators.py
@@ -1,0 +1,75 @@
+"""Statement-terminator preservation: ``;`` vs ``$``.
+
+The compiler wraps every top-level statement in a ``Display(...)`` or
+``Suppress(...)`` IR node when ``wrap_terminators=True`` is passed to
+``compile_macsyma``. The MACSYMA REPL turns that on so it can decide
+whether to print results; consumers that drive the VM directly leave
+it off and continue receiving raw expressions.
+
+The wrapper heads are introduced by the macsyma-runtime layer; the
+compiler emits them as plain ``IRSymbol`` literals (no import
+dependency on the runtime).
+"""
+
+from __future__ import annotations
+
+from macsyma_compiler import compile_macsyma
+from macsyma_parser import parse_macsyma
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+
+
+def _compile_all(source: str) -> list:
+    return compile_macsyma(parse_macsyma(source), wrap_terminators=True)
+
+
+def test_default_does_not_wrap() -> None:
+    """``compile_macsyma(ast)`` without the kwarg returns raw expressions."""
+    [stmt] = compile_macsyma(parse_macsyma("42;"))
+    assert stmt == IRInteger(42)
+
+
+def test_semicolon_emits_display_wrapper() -> None:
+    [stmt] = _compile_all("42;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    assert stmt.args == (IRInteger(42),)
+
+
+def test_dollar_emits_suppress_wrapper() -> None:
+    [stmt] = _compile_all("42$")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Suppress")
+    assert stmt.args == (IRInteger(42),)
+
+
+def test_mixed_terminators_preserve_each() -> None:
+    """A program with mixed terminators yields the right wrapper per stmt."""
+    stmts = _compile_all("1$ 2; 3$ 4;")
+    heads = [
+        s.head.name if isinstance(s, IRApply) and isinstance(s.head, IRSymbol)
+        else None
+        for s in stmts
+    ]
+    assert heads == ["Suppress", "Display", "Suppress", "Display"]
+
+
+def test_inner_expression_preserved_under_wrapper() -> None:
+    """``x + 1;`` wraps an `Add(x, 1)` in `Display`."""
+    [stmt] = _compile_all("x + 1;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    inner = stmt.args[0]
+    assert isinstance(inner, IRApply)
+    assert inner.head == IRSymbol("Add")
+    assert inner.args == (IRSymbol("x"), IRInteger(1))
+
+
+def test_function_definition_wrapped_in_display() -> None:
+    """``f(x) := x^2;`` is also wrapped (non-side-effect-free statements
+    get wrapped same as expressions)."""
+    [stmt] = _compile_all("f(x) := x^2;")
+    assert isinstance(stmt, IRApply)
+    assert stmt.head == IRSymbol("Display")
+    inner = stmt.args[0]
+    assert isinstance(inner, IRApply)
+    assert inner.head == IRSymbol("Define")

--- a/code/packages/python/macsyma-runtime/BUILD
+++ b/code/packages/python/macsyma-runtime/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ../polynomial -e ../macsyma-compiler -e ../symbolic-vm -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --tb=short

--- a/code/packages/python/macsyma-runtime/BUILD_windows
+++ b/code/packages/python/macsyma-runtime/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ../polynomial -e ../macsyma-compiler -e ../symbolic-vm -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v --tb=short

--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.1.0 — 2026-04-25
+
+Initial release — Phase A skeleton.
+
+- `MacsymaBackend` — `SymbolicBackend` subclass with MACSYMA-specific
+  heads (`Display`, `Suppress`, `Kill`, `Ev`) and option flags.
+- `History` — input/output table, resolves `%`, `%i1`, `%o1`, ...
+  via a backend lookup hook.
+- `Display` / `Suppress` heads (`;` vs `$` statement terminators).
+  Identity handlers; the REPL inspects the wrapper before eval to
+  decide whether to print.
+- `Kill(symbol)` and `Kill(all)` handlers.
+- `Ev(expr, ...flags)` — minimal first cut: only the `numer` flag
+  is honored.
+- `MACSYMA_NAME_TABLE` — extends `macsyma-compiler`'s standard-name
+  map so identifiers like `expand`, `factor`, `subst`, `solve`,
+  `taylor`, `limit` route to canonical heads (the substrate handlers
+  may not yet exist; the user gets `Expand(...)` unevaluated until
+  they do).
+- Type-checked, ruff- and mypy-clean.

--- a/code/packages/python/macsyma-runtime/README.md
+++ b/code/packages/python/macsyma-runtime/README.md
@@ -1,0 +1,64 @@
+# macsyma-runtime
+
+The thin shell on top of `symbolic-vm` that holds genuinely-MACSYMA
+conventions. Everything reusable across CAS frontends lives in
+substrate packages (`cas-substitution`, `cas-simplify`,
+`cas-factor`, ...); this package holds only what is specifically
+MACSYMA / Maxima.
+
+## What's in here
+
+- `MacsymaBackend` — subclass of `SymbolicBackend` that adds the
+  MACSYMA-specific heads (`Display`, `Suppress`, `Kill`, `Ev`) and
+  the option flags (`numer`, `simp`, ...).
+- `History` — the `%i1`/`%o1`/`%i2`/`%o2`/... input/output table the
+  REPL writes and the VM reads via a binding-resolution hook.
+- Built-in name-table extensions — maps MACSYMA identifiers
+  (`expand`, `factor`, `subst`, `solve`, `taylor`, `limit`, ...) to
+  their canonical IR heads, so the compiler can route them to the
+  substrate handlers regardless of whether those handlers are yet
+  implemented.
+
+## Why this is the only deliberately-non-reusable package
+
+A future `mathematica-runtime` would sit at the same layer position —
+above `symbolic-vm`, alongside the language-specific
+`lexer/parser/compiler` — but it would write its own runtime entirely.
+Mathematica's `Hold`/`HoldComplete` semantics, `OwnValues`/`DownValues`
+rules, `Print[]`, and `Message[]` are very different from MACSYMA's
+`%i`/`%o`/`$`/`;`/`kill`/`ev`. Same for a `matlab-runtime` (with
+`ans`, `disp`, `clear`, `format`).
+
+Everything underneath the runtime is shared across all of them.
+
+## Phase A scope
+
+- `Display` / `Suppress` heads — wrappers the compiler emits around
+  each top-level statement so the REPL can distinguish `;` (display)
+  from `$` (suppress).
+- `History` and the `%`/`%i1`/`%o1` binding-resolution shim.
+- `Kill(name)` and `Kill(all)` for clearing bindings.
+- Basic `Ev(expr, numer)` — re-evaluate with the `numer` flag set.
+- Name-table additions for substrate heads (`Subst`, `Simplify`,
+  `Expand`, `Factor`, `Solve`, `Taylor`, `Limit`, `Length`, etc.).
+
+Later phases add `Block`, full `Ev`, `Assume`/`Forget`/`Is`.
+
+## Usage
+
+```python
+from macsyma_runtime import MacsymaBackend, History
+from symbolic_vm import VM
+
+history = History()
+backend = MacsymaBackend(history=history)
+vm = VM(backend)
+```
+
+The REPL program reads `History` to format `(%i1) ` / `(%o1) ` prompts
+and to resolve `%`, `%i1`, `%o1` references typed by the user.
+
+## Dependencies
+
+- `coding-adventures-symbolic-ir`
+- `coding-adventures-symbolic-vm`

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-macsyma-runtime"
+version = "0.1.0"
+description = "MACSYMA-specific runtime layer on top of the symbolic VM — history, $/; terminators, kill, ev, name table."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
+dependencies = [
+    "coding-adventures-symbolic-ir>=0.5.0",
+    "coding-adventures-symbolic-vm>=0.18.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/macsyma_runtime"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=macsyma_runtime --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/macsyma-runtime/required_capabilities.json
+++ b/code/packages/python/macsyma-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/macsyma-runtime",
+  "capabilities": [],
+  "justification": "Pure in-memory runtime layer. No filesystem, network, or process access of its own."
+}

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
@@ -1,0 +1,52 @@
+"""MACSYMA-specific runtime layer.
+
+Public API::
+
+    from macsyma_runtime import (
+        MacsymaBackend,
+        History,
+        DISPLAY,
+        SUPPRESS,
+        KILL,
+        EV,
+        MACSYMA_NAME_TABLE,
+        extend_compiler_name_table,
+    )
+
+The thin shell that turns the language-neutral ``symbolic-vm`` into a
+Maxima-flavored evaluator. See ``code/specs/macsyma-runtime.md``.
+"""
+
+from macsyma_runtime.backend import MacsymaBackend
+from macsyma_runtime.heads import (
+    ALL_SYMBOL,
+    ASSUME,
+    BLOCK,
+    DISPLAY,
+    EV,
+    FORGET,
+    IS,
+    KILL,
+    SUPPRESS,
+)
+from macsyma_runtime.history import History
+from macsyma_runtime.name_table import (
+    MACSYMA_NAME_TABLE,
+    extend_compiler_name_table,
+)
+
+__all__ = [
+    "ALL_SYMBOL",
+    "ASSUME",
+    "BLOCK",
+    "DISPLAY",
+    "EV",
+    "FORGET",
+    "History",
+    "IS",
+    "KILL",
+    "MACSYMA_NAME_TABLE",
+    "MacsymaBackend",
+    "SUPPRESS",
+    "extend_compiler_name_table",
+]

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
@@ -1,0 +1,144 @@
+"""The MACSYMA-flavored backend.
+
+:class:`MacsymaBackend` is a thin subclass of :class:`SymbolicBackend`.
+It adds:
+
+- A :class:`History` reference, consulted by :meth:`lookup` so user
+  references to ``%``, ``%i3``, ``%o3`` resolve transparently.
+- Handlers for the runtime-owned heads (`Display`, `Suppress`, `Kill`,
+  `Ev`).
+- Option-flag attributes (`numer`, `simp`, ...) plus a context-manager
+  helper :meth:`with_numer` for short-lived flag overrides used by `Ev`.
+
+Everything else — arithmetic, calculus, identity rewrites, list
+passthrough — comes from :class:`SymbolicBackend` unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+from symbolic_ir import IRNode, IRSymbol
+from symbolic_vm import SymbolicBackend
+from symbolic_vm.backend import Handler
+
+from macsyma_runtime.handlers import (
+    display_handler,
+    make_ev_handler,
+    make_kill_handler,
+    suppress_handler,
+)
+from macsyma_runtime.heads import DISPLAY, EV, KILL, SUPPRESS
+from macsyma_runtime.history import History
+
+
+class MacsymaBackend(SymbolicBackend):
+    """SymbolicBackend with the MACSYMA-specific runtime layer."""
+
+    #: Numeric-mode flag: when set, `Ev(expr, numer)` forces the
+    #: evaluator to collapse symbolic constants and arithmetic to
+    #: floats. Phase A treats `numer` as a hint that does not yet
+    #: change the symbolic backend's behavior — reserved.
+    numer: bool
+
+    #: Whether automatic simplification is enabled. Maxima's `simp`
+    #: flag. Phase A defaults true; not consulted yet.
+    simp: bool
+
+    #: The session's I/O history, owned by the REPL but referenced by
+    #: the backend so VM lookups can resolve `%`, `%iN`, `%oN`.
+    history: History
+
+    def __init__(self, *, history: History | None = None) -> None:
+        super().__init__()
+        self.history = history if history is not None else History()
+        self.numer = False
+        self.simp = True
+
+        # Patch the inherited handler table with the runtime's heads.
+        # ``SymbolicBackend.__init__`` filled ``self._handlers`` already.
+        runtime_handlers: dict[str, Handler] = {
+            DISPLAY.name: display_handler,
+            SUPPRESS.name: suppress_handler,
+            KILL.name: make_kill_handler(self),
+            EV.name: make_ev_handler(),
+        }
+        self._handlers = {**self._handlers, **runtime_handlers}
+
+        # ``Kill`` and ``Ev`` need their arguments raw — not pre-evaluated:
+        # ``kill(x)`` should clear the symbol ``x``, not evaluate ``x``
+        # to its current binding and then ignore the result. ``ev`` reads
+        # flag *names*, which would resolve to themselves under the
+        # symbolic backend but holding them costs nothing and keeps the
+        # contract obvious.
+        self._held_heads = super().hold_heads() | frozenset({KILL.name, EV.name})
+
+    def hold_heads(self) -> frozenset[str]:
+        return self._held_heads
+
+    # ---- environment helpers ------------------------------------------
+
+    def unbind(self, name: str) -> None:
+        """Remove ``name`` from the binding environment.
+
+        No-op if the name was never bound. Used by the ``Kill`` handler.
+        """
+        self._env.pop(name, None)
+
+    def reset_environment(self) -> None:
+        """Clear every user-introduced binding.
+
+        Re-installs the two pre-bound entries (``True``/``False``) that
+        :class:`SymbolicBackend` expects to find. Also clears the
+        history — Maxima's ``kill(all)`` does both.
+        """
+        # Cheapest correct approach: re-run the parent ``__init__``
+        # state setup. We don't want to re-install handlers (that would
+        # drop our runtime overrides), so we touch only ``_env``.
+        from symbolic_vm.handlers import FALSE, TRUE
+
+        self._env.clear()
+        self._env["True"] = TRUE
+        self._env["False"] = FALSE
+        self.history.reset()
+
+    # ---- name lookup with history fallback ----------------------------
+
+    def lookup(self, name: str) -> IRNode | None:
+        """Look up a binding, falling back to the history table.
+
+        First checks ``self._env`` (the normal binding store). If that
+        misses, asks the :class:`History` whether the name is one of
+        ``%``, ``%iN``, ``%oN``. Only then does the VM see ``None``.
+        """
+        env_value = super().lookup(name)
+        if env_value is not None:
+            return env_value
+        return self.history.resolve_history_symbol(name)
+
+    # ---- option-flag context manager ----------------------------------
+
+    @contextmanager
+    def with_numer(self) -> Iterator[None]:
+        """Temporarily enable the ``numer`` flag.
+
+        Used by ``Ev(expr, numer)``. The flag is restored on exit even
+        if the inner evaluation raises.
+        """
+        previous = self.numer
+        self.numer = True
+        try:
+            yield
+        finally:
+            self.numer = previous
+
+    def handlers(self) -> Mapping[str, Handler]:
+        return self._handlers
+
+    # The on_unresolved policy is inherited from SymbolicBackend:
+    # unbound names stay as free symbols. The history fallback above
+    # only kicks in for `%`/`%iN`/`%oN`; ordinary user variables that
+    # weren't assigned still reach this method and are returned as-is.
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode:
+        return symbol

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/handlers.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/handlers.py
@@ -1,0 +1,113 @@
+"""Handlers for the MACSYMA-runtime-owned heads.
+
+Each handler conforms to the symbolic-vm :data:`Handler` signature:
+
+    def handler(vm: VM, expr: IRApply) -> IRNode
+
+For Phase A the runtime owns five heads:
+
+- ``Display`` — terminator wrapper for ``;``. Identity-on-inner.
+- ``Suppress`` — terminator wrapper for ``$``. Identity-on-inner.
+- ``Kill``    — clear bindings.
+- ``Ev``      — re-evaluate with flags.
+- ``Block``   — reserved for Phase G.
+
+The runtime keeps these heads in :mod:`macsyma_runtime.heads` so they
+are easy to import as singletons.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from symbolic_ir import IRApply, IRNode, IRSymbol
+from symbolic_vm.backend import Handler
+
+if TYPE_CHECKING:
+    from symbolic_vm import VM
+
+    from macsyma_runtime.backend import MacsymaBackend
+
+
+def display_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Display(inner)`` returns ``inner`` unchanged.
+
+    The VM has already evaluated ``inner`` (held heads are an opt-in
+    list and Display is not held). The REPL inspected the head before
+    evaluation to decide whether to print. By the time we get here the
+    wrapper has done its job and we just unwrap.
+    """
+    if len(expr.args) != 1:
+        raise ValueError(f"Display takes 1 arg, got {len(expr.args)}")
+    return expr.args[0]
+
+
+def suppress_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Suppress(inner)`` returns ``inner`` unchanged. Twin of Display."""
+    if len(expr.args) != 1:
+        raise ValueError(f"Suppress takes 1 arg, got {len(expr.args)}")
+    return expr.args[0]
+
+
+def make_kill_handler(backend: MacsymaBackend) -> Handler:
+    """Build a ``Kill`` handler bound to a particular backend.
+
+    ``Kill`` mutates the backend's environment, so it can't be a plain
+    free function — it needs the backend reference.
+    """
+
+    def kill_handler(_vm: VM, expr: IRApply) -> IRNode:
+        # The args were evaluated before reaching us. But for `kill(x)`
+        # we want to clear the binding for the *symbol name x*, not
+        # whatever x evaluates to. The Symbolic backend leaves unbound
+        # names unchanged, so a fresh symbol still arrives as
+        # IRSymbol("x"). For names that *are* bound, the user's intent
+        # of `kill(x)` is to clear x, not to inspect its value — so
+        # we accept either form: if we see an IRSymbol we use its name;
+        # if we see anything else we silently do nothing for that arg.
+        for arg in expr.args:
+            if isinstance(arg, IRSymbol):
+                if arg.name == "all":
+                    backend.reset_environment()
+                else:
+                    backend.unbind(arg.name)
+        return _DONE
+
+    return kill_handler
+
+
+# A tiny sentinel that downstream code can ignore. Kill is "for its
+# side effect" — there is no meaningful return value. We use the
+# IRSymbol("done") shape Maxima itself uses.
+_DONE = IRSymbol("done")
+
+
+def make_ev_handler() -> Handler:
+    """Build the ``Ev(expr, *flags)`` handler.
+
+    Phase A only honours the ``numer`` flag (force-collapse to floats).
+    Future phases will add ``simp``, ``expand``, ``factor``, ``ratsimp``,
+    etc. For now, an unknown flag is silently ignored.
+    """
+
+    def ev_handler(vm: VM, expr: IRApply) -> IRNode:
+        # We need the un-evaluated expression form here. The simplest
+        # contract for Phase A: every flag is an IRSymbol that arrives
+        # as itself (because they are all unbound). Loop through flags,
+        # gather them into a set, then re-evaluate the first arg.
+        if not expr.args:
+            return expr
+        first = expr.args[0]
+        flags: set[str] = set()
+        for arg in expr.args[1:]:
+            if isinstance(arg, IRSymbol):
+                flags.add(arg.name)
+        if "numer" in flags:
+            # Re-evaluate `first` with the numer flag set on the backend.
+            backend = vm.backend
+            if hasattr(backend, "with_numer"):
+                with backend.with_numer():
+                    return vm.eval(first)
+        return first
+
+    return ev_handler

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/heads.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/heads.py
@@ -1,0 +1,30 @@
+"""IR head symbols introduced by macsyma-runtime.
+
+These heads are Maxima-specific: they don't have meaningful analogues
+in Mathematica or Maple's evaluation models, so they live in the
+runtime layer rather than in :mod:`symbolic_ir`. The runtime registers
+handlers for each one on :class:`MacsymaBackend`.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+# Statement-terminator wrappers. The compiler emits one of these around
+# each top-level statement based on whether the source ended with `;`
+# (display) or `$` (suppress). The REPL inspects the wrapper type
+# *before* eval to decide whether to print the result; the VM unwraps
+# them in the handler so downstream code never has to think about them.
+DISPLAY = IRSymbol("Display")
+SUPPRESS = IRSymbol("Suppress")
+
+# Bookkeeping operations.
+KILL = IRSymbol("Kill")
+EV = IRSymbol("Ev")
+BLOCK = IRSymbol("Block")  # reserved for Phase G; not yet handled.
+ASSUME = IRSymbol("Assume")
+FORGET = IRSymbol("Forget")
+IS = IRSymbol("Is")
+
+# A sentinel symbol that ``kill(all)`` matches.
+ALL_SYMBOL = IRSymbol("all")

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/history.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/history.py
@@ -1,0 +1,97 @@
+"""The MACSYMA `%i` / `%o` history table.
+
+Maxima labels every input as ``%iN`` and every output as ``%oN``. The
+``%`` shorthand resolves to the most recent ``%o``. The REPL writes
+to this table on each turn; the VM reads from it via a binding-lookup
+hook so user expressions like ``%i3 + 1`` work transparently.
+
+This is a session-local in-memory data structure. There is no
+persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from symbolic_ir import IRNode
+
+
+@dataclass
+class History:
+    """Input/output history for one MACSYMA REPL session.
+
+    Indices start at 1 (Maxima convention). After ``record_input(ir)``
+    returns ``n``, ``get_input(n)`` returns the same IR. Outputs follow
+    the same pattern.
+
+    The REPL is responsible for keeping inputs and outputs aligned;
+    typically every ``record_input`` is followed by exactly one
+    ``record_output`` before the next ``record_input`` happens.
+    """
+
+    inputs: list[IRNode] = field(default_factory=list)
+    outputs: list[IRNode] = field(default_factory=list)
+
+    # ---- writers ---------------------------------------------------------
+
+    def record_input(self, ir: IRNode) -> int:
+        """Append ``ir`` to the input history. Returns the new index."""
+        self.inputs.append(ir)
+        return len(self.inputs)
+
+    def record_output(self, ir: IRNode) -> int:
+        """Append ``ir`` to the output history. Returns the new index."""
+        self.outputs.append(ir)
+        return len(self.outputs)
+
+    # ---- readers ---------------------------------------------------------
+
+    def get_input(self, n: int) -> IRNode | None:
+        """Return ``%iN`` or None if out of range."""
+        if 1 <= n <= len(self.inputs):
+            return self.inputs[n - 1]
+        return None
+
+    def get_output(self, n: int) -> IRNode | None:
+        """Return ``%oN`` or None if out of range."""
+        if 1 <= n <= len(self.outputs):
+            return self.outputs[n - 1]
+        return None
+
+    def last_output(self) -> IRNode | None:
+        """Return the most recent ``%o`` or None if no outputs yet.
+
+        Used to resolve the bare ``%`` shorthand.
+        """
+        return self.outputs[-1] if self.outputs else None
+
+    def next_input_index(self) -> int:
+        """Return the index that the next ``record_input`` will produce.
+
+        Useful for prompts: ``(%i{history.next_input_index()}) ``.
+        """
+        return len(self.inputs) + 1
+
+    # ---- mutation --------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear the entire history."""
+        self.inputs.clear()
+        self.outputs.clear()
+
+    # ---- name-resolution hook --------------------------------------------
+
+    def resolve_history_symbol(self, name: str) -> IRNode | None:
+        """Resolve ``%``, ``%iN``, ``%oN`` symbol names to IR.
+
+        Returns the corresponding IR node or None if the name is not a
+        history reference (or is out of range). The MacsymaBackend
+        installs this as a fallback inside its ``lookup`` chain.
+        """
+        if name == "%":
+            return self.last_output()
+        if name.startswith("%i") and name[2:].isdigit():
+            return self.get_input(int(name[2:]))
+        if name.startswith("%o") and name[2:].isdigit():
+            return self.get_output(int(name[2:]))
+        return None

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
@@ -1,0 +1,129 @@
+"""Name-table extensions consumed by the MACSYMA compiler.
+
+The base ``macsyma-compiler`` package ships a small ``_STANDARD_FUNCTIONS``
+map covering the elementary operations (``diff``, ``integrate``, ``sin``,
+``cos``, ...). The runtime wants to map a much larger set of MACSYMA
+identifiers — ``factor``, ``expand``, ``simplify``, ``subst``, ``solve``,
+``taylor``, ``limit``, ``length``, ``first``, etc. — to canonical IR
+heads. This table is the central place where those mappings live.
+
+The substrate handlers for each of these heads may not yet be
+implemented; until they are, MACSYMA users will see e.g.
+``Expand(x^2 + 2*x + 1)`` returned unevaluated, which is the same
+fall-through behavior every CAS uses for unknown operations. Once the
+substrate package lands, the routing is automatically picked up — no
+compiler change required.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+# IR heads from substrate packages that may not exist yet — define
+# them here as :class:`IRSymbol` singletons so the table can reference
+# them. When the substrate package lands, it can re-export the same
+# symbol (or a binding-equivalent one) without breaking compatibility.
+SUBST = IRSymbol("Subst")
+SIMPLIFY = IRSymbol("Simplify")
+EXPAND = IRSymbol("Expand")
+FACTOR = IRSymbol("Factor")
+SOLVE = IRSymbol("Solve")
+TAYLOR = IRSymbol("Taylor")
+LIMIT = IRSymbol("Limit")
+
+LENGTH = IRSymbol("Length")
+FIRST = IRSymbol("First")
+REST = IRSymbol("Rest")
+LAST = IRSymbol("Last")
+APPEND = IRSymbol("Append")
+REVERSE = IRSymbol("Reverse")
+RANGE = IRSymbol("Range")
+MAP = IRSymbol("Map")
+APPLY = IRSymbol("Apply")
+SELECT = IRSymbol("Select")
+SORT = IRSymbol("Sort")
+PART = IRSymbol("Part")
+FLATTEN = IRSymbol("Flatten")
+JOIN = IRSymbol("Join")
+
+MATRIX = IRSymbol("Matrix")
+TRANSPOSE = IRSymbol("Transpose")
+DETERMINANT = IRSymbol("Determinant")
+INVERSE = IRSymbol("Inverse")
+
+GCD = IRSymbol("Gcd")
+LCM = IRSymbol("Lcm")
+MOD = IRSymbol("Mod")
+FLOOR = IRSymbol("Floor")
+CEILING = IRSymbol("Ceiling")
+ABS = IRSymbol("Abs")
+
+# Re-export the runtime-owned heads so callers have one import.
+from macsyma_runtime.heads import (  # noqa: E402
+    ASSUME,
+    BLOCK,
+    EV,
+    FORGET,
+    IS,
+    KILL,
+)
+
+# The map MACSYMA users see → canonical IR head.
+#
+# The MACSYMA compiler reads ``_STANDARD_FUNCTIONS`` (a similar table
+# scoped to the lexicon it ships with). The runtime's
+# :func:`extend_compiler_name_table` adds these on top.
+MACSYMA_NAME_TABLE: dict[str, IRSymbol] = {
+    # Algebraic operations
+    "subst": SUBST,
+    "simplify": SIMPLIFY,
+    "expand": EXPAND,
+    "factor": FACTOR,
+    "solve": SOLVE,
+    "taylor": TAYLOR,
+    "limit": LIMIT,
+    # List operations
+    "length": LENGTH,
+    "first": FIRST,
+    "rest": REST,
+    "last": LAST,
+    "append": APPEND,
+    "reverse": REVERSE,
+    "makelist": RANGE,
+    "map": MAP,
+    "apply": APPLY,
+    "sublist": SELECT,
+    "sort": SORT,
+    "part": PART,
+    "flatten": FLATTEN,
+    "join": JOIN,
+    # Matrix
+    "matrix": MATRIX,
+    "transpose": TRANSPOSE,
+    "determinant": DETERMINANT,
+    "invert": INVERSE,
+    # Number-theoretic
+    "gcd": GCD,
+    "lcm": LCM,
+    "mod": MOD,
+    "floor": FLOOR,
+    "ceiling": CEILING,
+    "abs": ABS,
+    # Runtime-owned operations
+    "kill": KILL,
+    "ev": EV,
+    "block": BLOCK,
+    "assume": ASSUME,
+    "forget": FORGET,
+    "is": IS,
+}
+
+
+def extend_compiler_name_table(target: dict[str, IRSymbol]) -> None:
+    """Merge :data:`MACSYMA_NAME_TABLE` into a compiler's name dict.
+
+    Used at REPL startup so the compiler's ``_STANDARD_FUNCTIONS`` map
+    knows about every name introduced here. Idempotent — calling twice
+    with the same target is safe.
+    """
+    target.update(MACSYMA_NAME_TABLE)

--- a/code/packages/python/macsyma-runtime/tests/test_backend_history_lookup.py
+++ b/code/packages/python/macsyma-runtime/tests/test_backend_history_lookup.py
@@ -1,0 +1,53 @@
+"""MacsymaBackend resolves %, %iN, %oN via the History."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import History, MacsymaBackend
+
+
+def test_history_fallback_resolves_percent() -> None:
+    h = History()
+    h.record_output(IRInteger(42))
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    # `%` evaluates to 42 — history fallback fires after env miss.
+    assert vm.eval(IRSymbol("%")) == IRInteger(42)
+
+
+def test_history_fallback_resolves_percent_o1() -> None:
+    h = History()
+    h.record_output(IRInteger(7))
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%o1")) == IRInteger(7)
+
+
+def test_history_fallback_resolves_percent_i2() -> None:
+    h = History()
+    x = IRSymbol("x")
+    h.record_input(IRInteger(1))
+    h.record_input(x)
+    backend = MacsymaBackend(history=h)
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%i2")) == x
+
+
+def test_unbound_normal_name_stays_symbolic() -> None:
+    """A bare `xyz` with no env binding and not a history reference
+    stays symbolic (SymbolicBackend behavior)."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("xyz")) == IRSymbol("xyz")
+
+
+def test_env_binding_takes_precedence_over_history() -> None:
+    """If a user did `%o1: 99`, the env wins over the history."""
+    h = History()
+    h.record_output(IRInteger(42))
+    backend = MacsymaBackend(history=h)
+    backend.bind("%o1", IRInteger(99))
+    vm = VM(backend)
+    assert vm.eval(IRSymbol("%o1")) == IRInteger(99)

--- a/code/packages/python/macsyma-runtime/tests/test_backend_init.py
+++ b/code/packages/python/macsyma-runtime/tests/test_backend_init.py
@@ -1,0 +1,42 @@
+"""MacsymaBackend wiring — flags, default history, handler installation."""
+
+from __future__ import annotations
+
+from macsyma_runtime import DISPLAY, EV, KILL, SUPPRESS, History, MacsymaBackend
+
+
+def test_default_history_is_fresh() -> None:
+    b = MacsymaBackend()
+    assert b.history.next_input_index() == 1
+
+
+def test_explicit_history_is_used() -> None:
+    h = History()
+    b = MacsymaBackend(history=h)
+    assert b.history is h
+
+
+def test_default_flags() -> None:
+    b = MacsymaBackend()
+    assert b.numer is False
+    assert b.simp is True
+
+
+def test_runtime_handlers_installed() -> None:
+    b = MacsymaBackend()
+    handlers = b.handlers()
+    assert DISPLAY.name in handlers
+    assert SUPPRESS.name in handlers
+    assert KILL.name in handlers
+    assert EV.name in handlers
+
+
+def test_inherited_arithmetic_handlers_still_present() -> None:
+    """Subclassing must not drop the parent's handler table."""
+    b = MacsymaBackend()
+    handlers = b.handlers()
+    # SymbolicBackend installs Add, Mul, D, Integrate (among others).
+    assert "Add" in handlers
+    assert "Mul" in handlers
+    assert "D" in handlers
+    assert "Integrate" in handlers

--- a/code/packages/python/macsyma-runtime/tests/test_display_suppress.py
+++ b/code/packages/python/macsyma-runtime/tests/test_display_suppress.py
@@ -1,0 +1,40 @@
+"""Display / Suppress wrappers — identity-on-inner."""
+
+from __future__ import annotations
+
+from symbolic_ir import ADD, IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import DISPLAY, SUPPRESS, MacsymaBackend
+
+
+def test_display_unwraps() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(DISPLAY, (IRApply(ADD, (IRInteger(2), IRInteger(3))),))
+    # The inner Add evaluates first, then Display returns the result.
+    assert vm.eval(expr) == IRInteger(5)
+
+
+def test_suppress_unwraps() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(SUPPRESS, (IRApply(ADD, (IRInteger(1), IRInteger(2))),))
+    assert vm.eval(expr) == IRInteger(3)
+
+
+def test_display_with_symbolic_inner() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    x = IRSymbol("x")
+    expr = IRApply(DISPLAY, (x,))
+    assert vm.eval(expr) == x
+
+
+def test_display_arity_validation() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    import pytest
+
+    with pytest.raises(ValueError):
+        vm.eval(IRApply(DISPLAY, (IRInteger(1), IRInteger(2))))

--- a/code/packages/python/macsyma-runtime/tests/test_ev.py
+++ b/code/packages/python/macsyma-runtime/tests/test_ev.py
@@ -1,0 +1,48 @@
+"""Ev — phase-A skeleton (numer flag only)."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import EV, MacsymaBackend
+
+
+def test_ev_no_flags_returns_first_arg() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    # ev(x) with no flags returns x.
+    expr = IRApply(EV, (IRSymbol("x"),))
+    assert vm.eval(expr) == IRSymbol("x")
+
+
+def test_ev_unknown_flag_silently_ignored() -> None:
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(EV, (IRInteger(2), IRSymbol("nonexistent_flag")))
+    assert vm.eval(expr) == IRInteger(2)
+
+
+def test_ev_numer_sets_flag_briefly() -> None:
+    """Phase-A `numer` is a hint; we only verify the with_numer
+    context manager toggles the flag during the evaluation, not that
+    the result actually changes (that's Phase B+ work)."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    expr = IRApply(EV, (IRInteger(2), IRSymbol("numer")))
+    # During eval, backend.numer should have flipped to True; after
+    # eval, it should be back to False (the default).
+    assert vm.eval(expr) == IRInteger(2)
+    assert backend.numer is False
+
+
+def test_with_numer_restores_on_exception() -> None:
+    backend = MacsymaBackend()
+    assert backend.numer is False
+    try:
+        with backend.with_numer():
+            assert backend.numer is True
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert backend.numer is False

--- a/code/packages/python/macsyma-runtime/tests/test_history.py
+++ b/code/packages/python/macsyma-runtime/tests/test_history.py
@@ -1,0 +1,81 @@
+"""History — input/output table tests."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRInteger, IRSymbol
+
+from macsyma_runtime import History
+
+
+def test_initial_state() -> None:
+    h = History()
+    assert h.next_input_index() == 1
+    assert h.last_output() is None
+    assert h.get_input(1) is None
+    assert h.get_output(1) is None
+
+
+def test_record_and_retrieve() -> None:
+    h = History()
+    n1 = h.record_input(IRInteger(1))
+    n2 = h.record_output(IRInteger(2))
+    assert n1 == 1 and n2 == 1
+    assert h.get_input(1) == IRInteger(1)
+    assert h.get_output(1) == IRInteger(2)
+
+
+def test_indices_advance() -> None:
+    h = History()
+    h.record_input(IRInteger(1))
+    h.record_input(IRInteger(2))
+    h.record_input(IRInteger(3))
+    assert h.next_input_index() == 4
+
+
+def test_last_output() -> None:
+    h = History()
+    h.record_output(IRInteger(1))
+    h.record_output(IRInteger(2))
+    assert h.last_output() == IRInteger(2)
+
+
+def test_resolve_percent_shorthand() -> None:
+    h = History()
+    h.record_output(IRInteger(42))
+    assert h.resolve_history_symbol("%") == IRInteger(42)
+
+
+def test_resolve_percent_iN() -> None:
+    h = History()
+    x = IRSymbol("x")
+    h.record_input(x)
+    assert h.resolve_history_symbol("%i1") == x
+
+
+def test_resolve_percent_oN() -> None:
+    h = History()
+    h.record_output(IRInteger(7))
+    assert h.resolve_history_symbol("%o1") == IRInteger(7)
+
+
+def test_resolve_unknown_returns_none() -> None:
+    h = History()
+    assert h.resolve_history_symbol("xyz") is None
+    assert h.resolve_history_symbol("%foo") is None
+    assert h.resolve_history_symbol("%i999") is None
+
+
+def test_resolve_with_no_history_returns_none() -> None:
+    h = History()
+    assert h.resolve_history_symbol("%") is None
+    assert h.resolve_history_symbol("%i1") is None
+    assert h.resolve_history_symbol("%o1") is None
+
+
+def test_reset() -> None:
+    h = History()
+    h.record_input(IRInteger(1))
+    h.record_output(IRInteger(2))
+    h.reset()
+    assert h.next_input_index() == 1
+    assert h.last_output() is None

--- a/code/packages/python/macsyma-runtime/tests/test_kill.py
+++ b/code/packages/python/macsyma-runtime/tests/test_kill.py
@@ -1,0 +1,58 @@
+"""Kill handler — clear bindings."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRApply, IRInteger, IRSymbol
+from symbolic_vm import VM
+
+from macsyma_runtime import KILL, MacsymaBackend
+
+
+def test_kill_removes_binding() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(5))
+    vm = VM(backend)
+    # Sanity: x evaluates to 5.
+    assert vm.eval(IRSymbol("x")) == IRInteger(5)
+    # kill(x) clears it.
+    vm.eval(IRApply(KILL, (IRSymbol("x"),)))
+    # Now x is symbolic again.
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+
+
+def test_kill_multiple_args() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(1))
+    backend.bind("y", IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("x"), IRSymbol("y"))))
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+    assert vm.eval(IRSymbol("y")) == IRSymbol("y")
+
+
+def test_kill_unbound_is_noop() -> None:
+    """kill(x) on a never-bound name does nothing — no error."""
+    backend = MacsymaBackend()
+    vm = VM(backend)
+    # Should not raise.
+    vm.eval(IRApply(KILL, (IRSymbol("never_bound"),)))
+
+
+def test_kill_all_clears_environment() -> None:
+    backend = MacsymaBackend()
+    backend.bind("x", IRInteger(1))
+    backend.bind("y", IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("all"),)))
+    assert vm.eval(IRSymbol("x")) == IRSymbol("x")
+    assert vm.eval(IRSymbol("y")) == IRSymbol("y")
+
+
+def test_kill_all_clears_history() -> None:
+    backend = MacsymaBackend()
+    backend.history.record_input(IRInteger(1))
+    backend.history.record_output(IRInteger(2))
+    vm = VM(backend)
+    vm.eval(IRApply(KILL, (IRSymbol("all"),)))
+    assert backend.history.next_input_index() == 1
+    assert backend.history.last_output() is None

--- a/code/packages/python/macsyma-runtime/tests/test_name_table.py
+++ b/code/packages/python/macsyma-runtime/tests/test_name_table.py
@@ -1,0 +1,42 @@
+"""Name-table extensions — coverage check."""
+
+from __future__ import annotations
+
+from symbolic_ir import IRSymbol
+
+from macsyma_runtime import MACSYMA_NAME_TABLE, extend_compiler_name_table
+
+
+def test_table_is_a_dict() -> None:
+    assert isinstance(MACSYMA_NAME_TABLE, dict)
+
+
+def test_subst_routes_to_subst_head() -> None:
+    assert MACSYMA_NAME_TABLE["subst"] == IRSymbol("Subst")
+
+
+def test_factor_routes_to_factor_head() -> None:
+    assert MACSYMA_NAME_TABLE["factor"] == IRSymbol("Factor")
+
+
+def test_solve_routes_to_solve_head() -> None:
+    assert MACSYMA_NAME_TABLE["solve"] == IRSymbol("Solve")
+
+
+def test_kill_routes_to_kill_head() -> None:
+    assert MACSYMA_NAME_TABLE["kill"] == IRSymbol("Kill")
+
+
+def test_extend_compiler_name_table_merges() -> None:
+    target: dict[str, IRSymbol] = {}
+    extend_compiler_name_table(target)
+    assert "factor" in target
+    assert target["factor"] == IRSymbol("Factor")
+
+
+def test_extend_is_idempotent() -> None:
+    target: dict[str, IRSymbol] = {}
+    extend_compiler_name_table(target)
+    snapshot = dict(target)
+    extend_compiler_name_table(target)
+    assert target == snapshot

--- a/code/programs/python/macsyma-repl/BUILD
+++ b/code/programs/python/macsyma-repl/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../../../packages/python/grammar-tools -e ../../../packages/python/graph -e ../../../packages/python/directed-graph -e ../../../packages/python/state-machine -e ../../../packages/python/lexer -e ../../../packages/python/parser -e ../../../packages/python/macsyma-lexer -e ../../../packages/python/macsyma-parser -e ../../../packages/python/symbolic-ir -e ../../../packages/python/polynomial -e ../../../packages/python/macsyma-compiler -e ../../../packages/python/symbolic-vm -e ../../../packages/python/repl -e ../../../packages/python/cas-pretty-printer -e ../../../packages/python/macsyma-runtime -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --tb=short

--- a/code/programs/python/macsyma-repl/BUILD_windows
+++ b/code/programs/python/macsyma-repl/BUILD_windows
@@ -1,0 +1,3 @@
+python -m venv .venv --clear
+.venv\Scripts\pip install -e ../../../packages/python/grammar-tools -e ../../../packages/python/graph -e ../../../packages/python/directed-graph -e ../../../packages/python/state-machine -e ../../../packages/python/lexer -e ../../../packages/python/parser -e ../../../packages/python/macsyma-lexer -e ../../../packages/python/macsyma-parser -e ../../../packages/python/symbolic-ir -e ../../../packages/python/polynomial -e ../../../packages/python/macsyma-compiler -e ../../../packages/python/symbolic-vm -e ../../../packages/python/repl -e ../../../packages/python/cas-pretty-printer -e ../../../packages/python/macsyma-runtime -e .[dev] --quiet
+.venv\Scripts\python -m pytest tests/ -v --tb=short

--- a/code/programs/python/macsyma-repl/CHANGELOG.md
+++ b/code/programs/python/macsyma-repl/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.0 — 2026-04-25
+
+Initial release — Phase A.
+
+- Interactive REPL invocable via ``python main.py`` or ``python -m main``.
+- ``MacsymaLanguage`` plugin that ties together
+  ``macsyma-{lexer,parser,compiler}``, the ``symbolic-vm`` evaluator,
+  the ``macsyma-runtime`` backend, and the ``cas-pretty-printer``
+  output formatter.
+- ``MacsymaPrompt`` plugin showing ``(%iN) `` for the global prompt.
+- ``Display(expr)`` / ``Suppress(expr)`` wrappers from the compiler are
+  inspected before evaluation to decide whether to print results;
+  identity-on-inner under the runtime backend.
+- ``%``, ``%iN``, ``%oN`` resolve via the ``History`` table installed
+  on the backend.
+- ``quit;`` and ``:quit`` exit the session; parse / compile / runtime
+  errors are caught and the loop continues.

--- a/code/programs/python/macsyma-repl/README.md
+++ b/code/programs/python/macsyma-repl/README.md
@@ -1,0 +1,89 @@
+# macsyma-repl
+
+Interactive MACSYMA-flavored REPL built on top of the symbolic VM.
+
+## Run it
+
+```
+uv run python main.py
+```
+
+or:
+
+```
+.venv/bin/python -m main
+```
+
+You should see something like:
+
+```
+MACSYMA-on-symbolic-VM 0.1
+(%i1) f(x) := x^2$
+(%i2) diff(f(x), x);
+(%o2) 2*x
+(%i3) integrate(%, x);
+(%o3) x^3/3
+(%i4) quit;
+```
+
+## Wiring
+
+```
+                ┌─────────────────────┐
+                │  coding_adventures  │
+input  ─────▶  │   _repl.Repl        │  ───▶ output
+                │   .run_with_io()    │
+                └──────────┬──────────┘
+                           │
+                ┌──────────┴──────────┐
+                ▼                     ▼
+        MacsymaLanguage         MacsymaPrompt
+        (this program)          (this program)
+                │                     │
+   ┌────────────┼─────────────────────┘
+   │            │
+   ▼            ▼
+macsyma_lexer  macsyma_runtime.History  ── (%i / %o table)
+macsyma_parser
+macsyma_compiler (wrap_terminators=True)
+   │
+   ▼
+macsyma_runtime.MacsymaBackend
+   │
+   ▼
+symbolic_vm.VM
+   │
+   ▼
+cas_pretty_printer.pretty(.., MacsymaDialect())
+```
+
+## Phase A scope
+
+- Single-line input — every input must end with ``;`` or ``$``. Multi-line
+  buffering is a future extension (the REPL framework is missing the
+  ``needs_more?`` hook today).
+- ``(%iN) `` global prompt; result printed when the statement ends with
+  ``;``, suppressed when it ends with ``$``.
+- ``%``, ``%iN``, ``%oN`` resolve via :class:`History`.
+- ``quit;`` or ``:quit`` exits.
+- Parse, compile, and evaluation errors are caught and shown; the loop
+  never crashes on user mistakes.
+
+## Limitations (deferred)
+
+- No multi-line input.
+- No tab completion.
+- No syntax highlighting.
+- No ``batch("file.mac")`` file loading.
+- No 2D output.
+
+## Dependencies
+
+- `coding-adventures-repl` (generic REPL framework)
+- `coding-adventures-symbolic-ir`
+- `coding-adventures-symbolic-vm`
+- `coding-adventures-macsyma-lexer`
+- `coding-adventures-macsyma-parser`
+- `coding-adventures-macsyma-compiler` (>= 0.6 with `wrap_terminators`)
+- `coding-adventures-macsyma-runtime`
+- `coding-adventures-cas-pretty-printer`

--- a/code/programs/python/macsyma-repl/__main__.py
+++ b/code/programs/python/macsyma-repl/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m`` entry point — defers to :func:`main.main`."""
+
+from __future__ import annotations
+
+from main import main
+
+if __name__ == "__main__":
+    main()

--- a/code/programs/python/macsyma-repl/language.py
+++ b/code/programs/python/macsyma-repl/language.py
@@ -1,0 +1,125 @@
+"""``MacsymaLanguage`` — the language plugin for ``coding_adventures_repl``.
+
+Wires together::
+
+    user input  →  macsyma_lexer.tokenize
+                →  macsyma_parser.parse
+                →  macsyma_compiler.compile_macsyma(wrap_terminators=True)
+                →  symbolic_vm.VM(macsyma_runtime.MacsymaBackend).eval
+                →  cas_pretty_printer.pretty(.., MacsymaDialect())
+
+For each top-level statement in the input, the language records the
+input IR in :class:`History`, evaluates it, records the output, and
+returns one combined string (one line per displayed result, or
+``None`` if every statement was suppressed).
+"""
+
+from __future__ import annotations
+
+import re
+
+from cas_pretty_printer import MacsymaDialect, pretty
+from coding_adventures_repl import Language
+from macsyma_compiler import compile_macsyma
+from macsyma_parser import parse_macsyma
+from macsyma_runtime import History, MacsymaBackend
+from symbolic_ir import IRApply, IRNode, IRSymbol
+from symbolic_vm import VM
+
+_DIALECT = MacsymaDialect()
+_QUIT_COMMANDS = frozenset({":quit", ":q", "quit", "quit()", "quit();", "quit;"})
+
+# The macsyma lexer's NAME regex requires `%` to be followed by an
+# identifier character (so `%pi`, `%e`, `%o3` lex as one NAME). Bare
+# `%` — the user-facing shorthand for "the most recent output" — is
+# not a valid NAME on its own. We rewrite it to ``%oN`` (where N is
+# the current last-output index) before the lexer sees it.
+_BARE_PERCENT_RE = re.compile(r"%(?![a-zA-Z0-9_])")
+
+
+class MacsymaLanguage(Language):
+    """REPL language plugin for the MACSYMA pipeline.
+
+    Holds the persistent state that survives across evaluation turns:
+    the :class:`History` table and the :class:`MacsymaBackend` (whose
+    environment carries variable bindings and function definitions).
+
+    Each call to :meth:`eval` may evaluate one *or several* top-level
+    statements (a single user line can contain ``a:1$ a + 1;``). The
+    return value is a single string suitable for display, or ``None``
+    when every statement was suppressed with ``$``.
+    """
+
+    history: History
+    backend: MacsymaBackend
+    vm: VM
+
+    def __init__(self) -> None:
+        self.history = History()
+        self.backend = MacsymaBackend(history=self.history)
+        self.vm = VM(self.backend)
+
+    # ------------------------------------------------------------------
+    # Language protocol
+    # ------------------------------------------------------------------
+
+    def eval(self, input: str) -> tuple[str, str | None] | str:
+        stripped = input.strip()
+        if not stripped:
+            return ("ok", None)
+        if stripped.lower() in _QUIT_COMMANDS:
+            return "quit"
+
+        # Auto-append ``;`` so a line typed without a terminator still
+        # parses (better UX than rejecting valid expressions).
+        source = stripped if stripped.endswith((";", "$")) else stripped + ";"
+
+        # Rewrite bare ``%`` (Maxima's "most recent output" shorthand)
+        # to ``%oN`` where N is the index of the most recent output.
+        # If there is no recent output yet, leave it alone — the lexer
+        # will raise an "unexpected character" error which we surface.
+        last_n = len(self.history.outputs)
+        if last_n > 0:
+            source = _BARE_PERCENT_RE.sub(f"%o{last_n}", source)
+
+        try:
+            ast = parse_macsyma(source)
+            statements = compile_macsyma(ast, wrap_terminators=True)
+        except Exception as exc:
+            return ("error", f"parse error: {exc}")
+
+        outputs: list[str] = []
+        for stmt in statements:
+            displayed, inner = _split_wrapper(stmt)
+            try:
+                result = self.vm.eval(inner)
+            except Exception as exc:
+                return ("error", f"runtime error: {exc}")
+            self.history.record_input(inner)
+            self.history.record_output(result)
+            if displayed:
+                idx = len(self.history.outputs)
+                outputs.append(f"(%o{idx}) {pretty(result, _DIALECT)}")
+
+        if not outputs:
+            return ("ok", None)
+        return ("ok", "\n".join(outputs))
+
+
+def _split_wrapper(stmt: IRNode) -> tuple[bool, IRNode]:
+    """Return ``(should_display, inner)`` from a Display/Suppress wrapper.
+
+    Statements that aren't wrapped are treated as Display (best-effort —
+    the user typed something the compiler returned without a wrapper,
+    which shouldn't normally happen when ``wrap_terminators=True``).
+    """
+    if (
+        isinstance(stmt, IRApply)
+        and isinstance(stmt.head, IRSymbol)
+        and len(stmt.args) == 1
+    ):
+        if stmt.head.name == "Display":
+            return True, stmt.args[0]
+        if stmt.head.name == "Suppress":
+            return False, stmt.args[0]
+    return True, stmt

--- a/code/programs/python/macsyma-repl/main.py
+++ b/code/programs/python/macsyma-repl/main.py
@@ -1,0 +1,26 @@
+"""Entry point for ``python main.py`` and ``python -m main``.
+
+Wires :class:`MacsymaLanguage` and :class:`MacsymaPrompt` to the
+generic REPL framework's :func:`run` and runs it.
+"""
+
+from __future__ import annotations
+
+from coding_adventures_repl import Repl
+
+from language import MacsymaLanguage
+from prompt import MacsymaPrompt
+
+_BANNER = "MACSYMA-on-symbolic-VM 0.1\n(C) 2026 — derived from MACSYMA at MIT\n"
+
+
+def main() -> None:
+    """Start an interactive MACSYMA session on the current terminal."""
+    language = MacsymaLanguage()
+    prompt = MacsymaPrompt(history=language.history)
+    print(_BANNER)
+    Repl.run(language=language, prompt=prompt)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/programs/python/macsyma-repl/prompt.py
+++ b/code/programs/python/macsyma-repl/prompt.py
@@ -1,0 +1,31 @@
+"""``MacsymaPrompt`` — provides Maxima-style ``(%iN) `` prompts.
+
+The prompt has a reference to the language plugin's :class:`History`
+so it can use the next input index without duplicating state.
+"""
+
+from __future__ import annotations
+
+from coding_adventures_repl import Prompt
+from macsyma_runtime import History
+
+
+class MacsymaPrompt(Prompt):
+    """Renders ``(%iN) `` as the global prompt and ``        `` for continuation.
+
+    The continuation prompt is unused by the current REPL framework
+    (which doesn't have a ``needs_more?`` hook), but we ship one for
+    forward-compatibility.
+    """
+
+    history: History
+
+    def __init__(self, history: History) -> None:
+        self.history = history
+
+    def global_prompt(self) -> str:
+        return f"(%i{self.history.next_input_index()}) "
+
+    def line_prompt(self) -> str:
+        # Maxima's continuation indent — eight spaces.
+        return "        "

--- a/code/programs/python/macsyma-repl/pyproject.toml
+++ b/code/programs/python/macsyma-repl/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "coding-adventures-macsyma-repl-program"
+version = "0.1.0"
+description = "Interactive MACSYMA-flavored REPL on top of the symbolic VM."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = [
+    "coding-adventures-cas-pretty-printer",
+    "coding-adventures-macsyma-compiler",
+    "coding-adventures-macsyma-lexer",
+    "coding-adventures-macsyma-parser",
+    "coding-adventures-macsyma-runtime",
+    "coding-adventures-repl",
+    "coding-adventures-symbolic-ir",
+    "coding-adventures-symbolic-vm",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.setuptools]
+py-modules = ["language", "prompt", "main"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["language", "prompt", "main"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -1,0 +1,143 @@
+"""End-to-end MACSYMA REPL session tests.
+
+Drive the language plugin via ``Repl.run_with_io`` so no real terminal
+is needed. Each test queues up a list of inputs, captures the outputs,
+and verifies the recorded transcript.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the program's root to sys.path so language/prompt/main are importable
+# under pytest, which runs from the package's ``tests/`` directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from coding_adventures_repl import Repl  # noqa: E402
+
+from language import MacsymaLanguage  # noqa: E402
+from prompt import MacsymaPrompt  # noqa: E402
+
+
+def _run(inputs: list[str]) -> list[str]:
+    """Drive a session with the given input lines; return collected outputs.
+
+    The framework writes the prompt followed by a newline before each
+    read, then writes each ``ok``/``error`` value on its own line.
+    Synchronous mode keeps tests fast and deterministic.
+    """
+    language = MacsymaLanguage()
+    prompt = MacsymaPrompt(history=language.history)
+    queue = iter(inputs)
+    outputs: list[str] = []
+
+    def input_fn() -> str | None:
+        return next(queue, None)
+
+    Repl.run_with_io(
+        language=language,
+        prompt=prompt,
+        input_fn=input_fn,
+        output_fn=outputs.append,
+        mode="sync",
+    )
+    return outputs
+
+
+# ---------------------------------------------------------------------------
+# Basic arithmetic and persistence
+# ---------------------------------------------------------------------------
+
+
+def test_simple_arithmetic() -> None:
+    out = _run(["2 + 3;", ":quit"])
+    # Output sequence: "(%i1) " (prompt), "(%o1) 5" (result), "(%i2) " (next prompt)
+    assert "(%o1) 5" in out
+
+
+def test_variable_persistence_across_turns() -> None:
+    out = _run(["x: 5$", "x + 1;", ":quit"])
+    # x:5$ suppresses output. Next turn shows (%o2) 6.
+    assert any(line == "(%o2) 6" for line in out)
+
+
+def test_function_definition_and_call() -> None:
+    out = _run(["f(x) := x^2$", "f(3);", ":quit"])
+    assert any(line == "(%o2) 9" for line in out)
+
+
+# ---------------------------------------------------------------------------
+# Display / Suppress
+# ---------------------------------------------------------------------------
+
+
+def test_dollar_suppresses_output() -> None:
+    """``42$`` records to history but emits no displayed line."""
+    out = _run(["42$", ":quit"])
+    # No (%o1) line should appear.
+    assert not any(line.startswith("(%o1) ") for line in out)
+
+
+def test_semicolon_displays_output() -> None:
+    out = _run(["42;", ":quit"])
+    assert any(line == "(%o1) 42" for line in out)
+
+
+def test_mixed_terminators_in_one_line() -> None:
+    """``a:1$ a + 2;`` — first stmt suppressed, second displayed."""
+    out = _run(["a:1$ a + 2;", ":quit"])
+    # The first statement's output is suppressed; the second shows (%o2) 3.
+    assert any(line == "(%o2) 3" for line in out)
+
+
+# ---------------------------------------------------------------------------
+# History references
+# ---------------------------------------------------------------------------
+
+
+def test_percent_resolves_to_last_output() -> None:
+    out = _run(["2 + 3;", "% * 2;", ":quit"])
+    assert any(line == "(%o2) 10" for line in out)
+
+
+def test_percent_oN_resolves_named_output() -> None:
+    out = _run(["10;", "20;", "%o1 + %o2;", ":quit"])
+    assert any(line == "(%o3) 30" for line in out)
+
+
+# ---------------------------------------------------------------------------
+# Quit and error handling
+# ---------------------------------------------------------------------------
+
+
+def test_colon_quit_ends_session() -> None:
+    """``:quit`` ends the session immediately."""
+    out = _run([":quit"])
+    # No output expected besides the initial prompt.
+    assert all(not line.startswith("(%o") for line in out)
+
+
+def test_quit_keyword_ends_session() -> None:
+    out = _run(["quit;"])
+    assert all(not line.startswith("(%o") for line in out)
+
+
+def test_parse_error_does_not_kill_session() -> None:
+    """A bad input emits an error line and the session continues."""
+    out = _run(["1 +;", "2 + 3;", ":quit"])
+    # An error message appears.
+    assert any("Error" in line or "error" in line.lower() for line in out)
+    # And the next valid input still works.
+    assert any(line.endswith(") 5") for line in out)
+
+
+def test_blank_line_is_ignored() -> None:
+    out = _run(["", "2 + 3;", ":quit"])
+    assert any(line == "(%o1) 5" for line in out)
+
+
+def test_auto_terminator_appended() -> None:
+    """Input without a trailing ``;`` or ``$`` is treated as ``;``."""
+    out = _run(["2 + 3", ":quit"])
+    assert any(line == "(%o1) 5" for line in out)


### PR DESCRIPTION
## Summary

Phase A capstone — closes the loop on the symbolic VM with an interactive REPL. Run with `python main.py` or `python -m main`:

```
MACSYMA-on-symbolic-VM 0.1
(%i1) f(x) := x^2$
(%i2) diff(f(x), x);
(%o2) 2*x
(%i3) integrate(%, x);
(%o3) x^3/3
```

## Wiring

This program is the model future CAS REPLs follow — copy `macsyma-repl/`, swap the lexer/parser/compiler/runtime imports, ship.

```
coding_adventures_repl.Repl.run_with_io
  ├─ language: MacsymaLanguage(this program)
  ├─ prompt:   MacsymaPrompt(this program)
  └─ waiting:  SilentWaiting

MacsymaLanguage.eval(input):
  1. Pre-rewrite bare `%` → `%oN`
  2. parse_macsyma → compile_macsyma(wrap_terminators=True)
  3. For each Display/Suppress wrapper:
       evaluate inner via VM
       record I/O in History
       emit "(%oN) <pretty>" if Display
  4. Return joined output, or None if everything was suppressed
```

## Niceties

- **`%` shorthand** — bare `%` is rewritten to `%oN` before lexing so Maxima users get their reflex back.
- **Auto-terminator** — input without `;`/`$` gets one appended for better UX.
- **`quit;` / `:quit`** — exit cleanly.
- **Errors caught** — parse/compile/runtime errors become user-visible messages; the loop never dies.

## Quality

- 13 end-to-end session tests, **94.12% coverage**
- `ruff check` clean
- Security review passed

## Deferred (Phase A scope)

- Multi-line input (the REPL framework lacks a `needs_more?` hook).
- Tab completion.
- Syntax highlighting.
- `batch("file.mac")` file loading.
- 2D output (waits on `cas-pretty-printer` 2D mode).

## Branch contents (will shrink)

This branch merges in #1309 (cas-pretty-printer), #1316 (macsyma-runtime), and #1319 (macsyma-compiler terminators) so tests can run locally. As those merge to main, rebasing this branch will strip them out and the diff will reduce to just `code/programs/python/macsyma-repl/`.

## Test plan

- [x] Variable persistence across turns (`x: 5$ x + 1;` → `6`)
- [x] Function definition + call (`f(x):=x^2$ f(3);` → `9`)
- [x] `;` displays, `$` suppresses
- [x] `%`, `%oN`, `%iN` resolve to history
- [x] Quit and error recovery
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)