### PR TITLE
feat(parity): add csharp binary search tree package

### DIFF
--- a/code/packages/csharp/binary-search-tree/BUILD
+++ b/code/packages/csharp/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/binary-search-tree/BUILD_windows
+++ b/code/packages/csharp/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/binary-search-tree/BinarySearchTree.cs
+++ b/code/packages/csharp/binary-search-tree/BinarySearchTree.cs
@@ -1,0 +1,367 @@
+using System.Collections;
+
+namespace CodingAdventures.BinarySearchTree;
+
+public sealed class BstNode<T>
+    where T : IComparable<T>
+{
+    public BstNode(T value, BstNode<T>? left = null, BstNode<T>? right = null, int? size = null)
+    {
+        Value = value;
+        Left = left;
+        Right = right;
+        Size = size ?? 1 + BinarySearchTree<T>.NodeSize(left) + BinarySearchTree<T>.NodeSize(right);
+    }
+
+    public T Value { get; }
+
+    public BstNode<T>? Left { get; }
+
+    public BstNode<T>? Right { get; }
+
+    public int Size { get; }
+}
+
+public sealed class BinarySearchTree<T> : IReadOnlyCollection<T>
+    where T : IComparable<T>
+{
+    public BinarySearchTree(BstNode<T>? root = null)
+    {
+        Root = root;
+    }
+
+    public BstNode<T>? Root { get; }
+
+    public int Count => Size();
+
+    public static BinarySearchTree<T> Empty() => new();
+
+    public static BinarySearchTree<T> FromSortedArray(IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var array = values.ToArray();
+        return new BinarySearchTree<T>(BuildBalanced(array, 0, array.Length));
+    }
+
+    public BinarySearchTree<T> Insert(T value) => new(InsertNode(Root, value));
+
+    public BinarySearchTree<T> Delete(T value) => new(DeleteNode(Root, value));
+
+    public BstNode<T>? Search(T value) => SearchNode(Root, value);
+
+    public bool Contains(T value) => Search(value) is not null;
+
+    public T? MinValue() => MinValue(Root);
+
+    public T? MaxValue() => MaxValue(Root);
+
+    public T? Predecessor(T value) => Predecessor(Root, value);
+
+    public T? Successor(T value) => Successor(Root, value);
+
+    public T? KthSmallest(int k) => KthSmallest(Root, k);
+
+    public int Rank(T value) => Rank(Root, value);
+
+    public List<T> ToSortedArray()
+    {
+        var output = new List<T>();
+        InOrder(Root, output);
+        return output;
+    }
+
+    public bool IsValid() => Validate(Root, default, default, hasMinimum: false, hasMaximum: false) is not null;
+
+    public int Height() => Height(Root);
+
+    public int Size() => NodeSize(Root);
+
+    public IEnumerator<T> GetEnumerator() => ToSortedArray().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString()
+    {
+        var root = Root is null ? "null" : Root.Value?.ToString();
+        return $"BinarySearchTree(root={root}, size={Size()})";
+    }
+
+    public static BstNode<T>? SearchNode(BstNode<T>? root, T value)
+    {
+        var current = root;
+        while (current is not null)
+        {
+            var comparison = value.CompareTo(current.Value);
+            if (comparison < 0)
+            {
+                current = current.Left;
+            }
+            else if (comparison > 0)
+            {
+                current = current.Right;
+            }
+            else
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    public static BstNode<T> InsertNode(BstNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return new BstNode<T>(value);
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return WithChildren(root, left: InsertNode(root.Left, value), replaceRight: false);
+        }
+
+        if (comparison > 0)
+        {
+            return WithChildren(root, right: InsertNode(root.Right, value), replaceLeft: false);
+        }
+
+        return root;
+    }
+
+    public static BstNode<T>? DeleteNode(BstNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return null;
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return WithChildren(root, left: DeleteNode(root.Left, value), replaceRight: false);
+        }
+
+        if (comparison > 0)
+        {
+            return WithChildren(root, right: DeleteNode(root.Right, value), replaceLeft: false);
+        }
+
+        if (root.Left is null)
+        {
+            return root.Right;
+        }
+
+        if (root.Right is null)
+        {
+            return root.Left;
+        }
+
+        var (newRight, successor) = ExtractMin(root.Right);
+        return new BstNode<T>(successor, root.Left, newRight);
+    }
+
+    public static T? MinValue(BstNode<T>? root)
+    {
+        var current = root;
+        while (current?.Left is not null)
+        {
+            current = current.Left;
+        }
+
+        return current is null ? default : current.Value;
+    }
+
+    public static T? MaxValue(BstNode<T>? root)
+    {
+        var current = root;
+        while (current?.Right is not null)
+        {
+            current = current.Right;
+        }
+
+        return current is null ? default : current.Value;
+    }
+
+    public static T? Predecessor(BstNode<T>? root, T value)
+    {
+        var current = root;
+        var best = default(T);
+        var hasBest = false;
+
+        while (current is not null)
+        {
+            if (value.CompareTo(current.Value) <= 0)
+            {
+                current = current.Left;
+            }
+            else
+            {
+                best = current.Value;
+                hasBest = true;
+                current = current.Right;
+            }
+        }
+
+        return hasBest ? best : default;
+    }
+
+    public static T? Successor(BstNode<T>? root, T value)
+    {
+        var current = root;
+        var best = default(T);
+        var hasBest = false;
+
+        while (current is not null)
+        {
+            if (value.CompareTo(current.Value) >= 0)
+            {
+                current = current.Right;
+            }
+            else
+            {
+                best = current.Value;
+                hasBest = true;
+                current = current.Left;
+            }
+        }
+
+        return hasBest ? best : default;
+    }
+
+    public static T? KthSmallest(BstNode<T>? root, int k)
+    {
+        if (root is null || k <= 0)
+        {
+            return default;
+        }
+
+        var leftSize = NodeSize(root.Left);
+        if (k == leftSize + 1)
+        {
+            return root.Value;
+        }
+
+        return k <= leftSize
+            ? KthSmallest(root.Left, k)
+            : KthSmallest(root.Right, k - leftSize - 1);
+    }
+
+    public static int Rank(BstNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return 0;
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return Rank(root.Left, value);
+        }
+
+        if (comparison > 0)
+        {
+            return NodeSize(root.Left) + 1 + Rank(root.Right, value);
+        }
+
+        return NodeSize(root.Left);
+    }
+
+    public static int Height(BstNode<T>? root)
+    {
+        return root is null ? -1 : 1 + Math.Max(Height(root.Left), Height(root.Right));
+    }
+
+    public static bool IsValid(BstNode<T>? root)
+    {
+        return Validate(root, default, default, hasMinimum: false, hasMaximum: false) is not null;
+    }
+
+    public static int NodeSize(BstNode<T>? root) => root?.Size ?? 0;
+
+    private static void InOrder(BstNode<T>? root, List<T> output)
+    {
+        if (root is null)
+        {
+            return;
+        }
+
+        InOrder(root.Left, output);
+        output.Add(root.Value);
+        InOrder(root.Right, output);
+    }
+
+    private static BstNode<T> WithChildren(
+        BstNode<T> root,
+        BstNode<T>? left = null,
+        BstNode<T>? right = null,
+        bool replaceLeft = true,
+        bool replaceRight = true)
+    {
+        return new BstNode<T>(
+            root.Value,
+            replaceLeft ? left : root.Left,
+            replaceRight ? right : root.Right);
+    }
+
+    private static (BstNode<T>? Root, T Minimum) ExtractMin(BstNode<T> root)
+    {
+        if (root.Left is null)
+        {
+            return (root.Right, root.Value);
+        }
+
+        var (newLeft, minimum) = ExtractMin(root.Left);
+        return (WithChildren(root, left: newLeft, right: root.Right), minimum);
+    }
+
+    private static BstNode<T>? BuildBalanced(T[] values, int start, int end)
+    {
+        if (start >= end)
+        {
+            return null;
+        }
+
+        var mid = start + (end - start) / 2;
+        return new BstNode<T>(
+            values[mid],
+            BuildBalanced(values, start, mid),
+            BuildBalanced(values, mid + 1, end));
+    }
+
+    private static (int Height, int Size)? Validate(
+        BstNode<T>? root,
+        T? minimum,
+        T? maximum,
+        bool hasMinimum,
+        bool hasMaximum)
+    {
+        if (root is null)
+        {
+            return (-1, 0);
+        }
+
+        if (hasMinimum && root.Value.CompareTo(minimum!) <= 0)
+        {
+            return null;
+        }
+
+        if (hasMaximum && root.Value.CompareTo(maximum!) >= 0)
+        {
+            return null;
+        }
+
+        var left = Validate(root.Left, minimum, root.Value, hasMinimum, hasMaximum: true);
+        var right = Validate(root.Right, root.Value, maximum, hasMinimum: true, hasMaximum);
+        if (left is null || right is null)
+        {
+            return null;
+        }
+
+        var height = 1 + Math.Max(left.Value.Height, right.Value.Height);
+        var size = 1 + left.Value.Size + right.Value.Size;
+        return root.Size == size ? (height, size) : null;
+    }
+}

--- a/code/packages/csharp/binary-search-tree/CHANGELOG.md
+++ b/code/packages/csharp/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# binary search tree package.

--- a/code/packages/csharp/binary-search-tree/CodingAdventures.BinarySearchTree.csproj
+++ b/code/packages/csharp/binary-search-tree/CodingAdventures.BinarySearchTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.BinarySearchTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# immutable binary search tree with order-statistic helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/binary-search-tree/README.md
+++ b/code/packages/csharp/binary-search-tree/README.md
@@ -1,0 +1,3 @@
+# csharp/binary-search-tree
+
+Pure C# immutable binary search tree with search, delete, order-statistic, and validation helpers.

--- a/code/packages/csharp/binary-search-tree/required_capabilities.json
+++ b/code/packages/csharp/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/BinarySearchTreeTests.cs
+++ b/code/packages/csharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/BinarySearchTreeTests.cs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.BinarySearchTree.Tests;
+
+public sealed class BinarySearchTreeTests
+{
+    [Fact]
+    public void InsertSearchAndDeleteWorkImmutably()
+    {
+        var tree = Populated();
+
+        Assert.Equal([1, 3, 5, 7, 8], tree.ToSortedArray());
+        Assert.Equal(5, tree.Size());
+        Assert.True(tree.Contains(7));
+        Assert.Equal(7, tree.Search(7)?.Value);
+        Assert.Equal(1, tree.MinValue());
+        Assert.Equal(8, tree.MaxValue());
+        Assert.Equal(3, tree.Predecessor(5));
+        Assert.Equal(7, tree.Successor(5));
+        Assert.Equal(2, tree.Rank(4));
+        Assert.Equal(7, tree.KthSmallest(4));
+
+        var deleted = tree.Delete(5);
+
+        Assert.False(deleted.Contains(5));
+        Assert.True(deleted.IsValid());
+        Assert.True(tree.Contains(5));
+    }
+
+    [Fact]
+    public void FromSortedArrayBuildsBalancedTree()
+    {
+        var tree = BinarySearchTree<int>.FromSortedArray([1, 2, 3, 4, 5, 6, 7]);
+
+        Assert.Equal([1, 2, 3, 4, 5, 6, 7], tree.ToSortedArray());
+        Assert.Equal(2, tree.Height());
+        Assert.Equal(7, tree.Size());
+        Assert.True(tree.IsValid());
+        Assert.Equal([1, 2, 3, 4, 5, 6, 7], tree.ToList());
+        Assert.Equal(7, tree.Count);
+    }
+
+    [Fact]
+    public void EmptyTreeAndBoundaryQueriesReturnDefaults()
+    {
+        var tree = BinarySearchTree<int>.Empty();
+
+        Assert.Null(tree.Search(1));
+        Assert.Equal(0, tree.MinValue());
+        Assert.Equal(0, tree.MaxValue());
+        Assert.Equal(0, tree.Predecessor(1));
+        Assert.Equal(0, tree.Successor(1));
+        Assert.Equal(0, tree.KthSmallest(0));
+        Assert.Equal(0, tree.KthSmallest(1));
+        Assert.Equal(0, tree.Rank(1));
+        Assert.Equal(-1, tree.Height());
+        Assert.Equal(0, tree.Size());
+        Assert.Equal("BinarySearchTree(root=null, size=0)", tree.ToString());
+    }
+
+    [Fact]
+    public void DuplicateAndSingleChildDeletePreserveShape()
+    {
+        var tree = BinarySearchTree<int>.FromSortedArray([2, 4, 6, 8]);
+
+        Assert.Equal(6, tree.Root?.Value);
+        var duplicate = tree.Insert(4);
+
+        Assert.Equal(tree.ToSortedArray(), duplicate.ToSortedArray());
+        Assert.Equal([4, 6, 8], tree.Delete(2).ToSortedArray());
+    }
+
+    [Fact]
+    public void StaticNodeHelpersCoverRawNodeComposition()
+    {
+        var root = BinarySearchTree<int>.InsertNode(null, 5);
+        root = BinarySearchTree<int>.InsertNode(root, 2);
+        root = BinarySearchTree<int>.InsertNode(root, 9);
+
+        Assert.Equal(2, BinarySearchTree<int>.MinValue(root));
+        Assert.Equal(9, BinarySearchTree<int>.MaxValue(root));
+        Assert.Equal(5, BinarySearchTree<int>.KthSmallest(root, 2));
+        Assert.Equal(1, BinarySearchTree<int>.Rank(root, 5));
+        Assert.Equal(1, BinarySearchTree<int>.Height(root));
+        Assert.True(BinarySearchTree<int>.IsValid(root));
+        Assert.Same(root, BinarySearchTree<int>.InsertNode(root, 5));
+        Assert.Null(BinarySearchTree<int>.DeleteNode(null, 5));
+    }
+
+    [Fact]
+    public void ValidationCatchesBadOrderingAndStaleSizes()
+    {
+        var badOrder = new BinarySearchTree<int>(new BstNode<int>(5, left: new BstNode<int>(6)));
+        var badSize = new BinarySearchTree<int>(new BstNode<int>(5, left: new BstNode<int>(3), size: 99));
+
+        Assert.False(badOrder.IsValid());
+        Assert.False(badSize.IsValid());
+    }
+
+    [Fact]
+    public void HandlesReferenceComparableValues()
+    {
+        var tree = BinarySearchTree<string>.Empty()
+            .Insert("delta")
+            .Insert("alpha")
+            .Insert("gamma");
+
+        Assert.Equal(["alpha", "delta", "gamma"], tree.ToSortedArray());
+        Assert.Equal("BinarySearchTree(root=delta, size=3)", tree.ToString());
+        Assert.Equal("gamma", tree.Successor("delta"));
+        Assert.Null(tree.Predecessor("alpha"));
+    }
+
+    private static BinarySearchTree<int> Populated()
+    {
+        var tree = BinarySearchTree<int>.Empty();
+        foreach (var value in new[] { 5, 1, 8, 3, 7 })
+        {
+            tree = tree.Insert(value);
+        }
+
+        return tree;
+    }
+}

--- a/code/packages/csharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.csproj
+++ b/code/packages/csharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.BinarySearchTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BinarySearchTree.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a C# binary-search-tree package with immutable insert/delete, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.BinarySearchTree.Tests\\CodingAdventures.BinarySearchTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:ThresholdType=line /p:Threshold=80