### PR TITLE
feat(parity): add fsharp binary tree package

### DIFF
--- a/code/packages/fsharp/binary-tree/BUILD
+++ b/code/packages/fsharp/binary-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinaryTree.Tests/CodingAdventures.BinaryTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/binary-tree/BUILD_windows
+++ b/code/packages/fsharp/binary-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinaryTree.Tests/CodingAdventures.BinaryTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/binary-tree/BinaryTree.fs
+++ b/code/packages/fsharp/binary-tree/BinaryTree.fs
@@ -1,0 +1,242 @@
+namespace CodingAdventures.BinaryTree
+
+open System
+open System.Collections.Generic
+
+type BinaryTreeNode<'T> =
+    { Value: 'T
+      Left: BinaryTreeNode<'T> option
+      Right: BinaryTreeNode<'T> option }
+
+    static member Leaf(value: 'T) =
+        { Value = value
+          Left = None
+          Right = None }
+
+    static member Create(value: 'T, left: BinaryTreeNode<'T> option, right: BinaryTreeNode<'T> option) =
+        { Value = value
+          Left = left
+          Right = right }
+
+module private BinaryTreeHelpers =
+    let comparer<'T> = EqualityComparer<'T>.Default
+
+    let rec find (root: BinaryTreeNode<'T> option) (value: 'T) =
+        match root with
+        | None -> None
+        | Some node when comparer.Equals(node.Value, value) -> Some node
+        | Some node ->
+            match find node.Left value with
+            | Some found -> Some found
+            | None -> find node.Right value
+
+    let rec isFull root =
+        match root with
+        | None -> true
+        | Some { Left = None; Right = None } -> true
+        | Some { Left = Some left; Right = Some right } -> isFull (Some left) && isFull (Some right)
+        | Some _ -> false
+
+    let isComplete root =
+        let queue = Queue<BinaryTreeNode<'T> option>()
+        queue.Enqueue root
+        let mutable seenNone = false
+        let mutable complete = true
+
+        while complete && queue.Count > 0 do
+            match queue.Dequeue() with
+            | None -> seenNone <- true
+            | Some node ->
+                if seenNone then
+                    complete <- false
+                else
+                    queue.Enqueue node.Left
+                    queue.Enqueue node.Right
+
+        complete
+
+    let rec height root =
+        match root with
+        | None -> -1
+        | Some node -> 1 + max (height node.Left) (height node.Right)
+
+    let rec size root =
+        match root with
+        | None -> 0
+        | Some node -> 1 + size node.Left + size node.Right
+
+    let isPerfect root =
+        let h = height root
+
+        if h < 0 then
+            size root = 0
+        else
+            size root = (1 <<< (h + 1)) - 1
+
+    let rec buildFromLevelOrder (values: 'T option array) index =
+        if index >= values.Length then
+            None
+        else
+            match values[index] with
+            | None -> None
+            | Some value ->
+                Some
+                    { Value = value
+                      Left = buildFromLevelOrder values ((2 * index) + 1)
+                      Right = buildFromLevelOrder values ((2 * index) + 2) }
+
+    let rec inorder root =
+        match root with
+        | None -> []
+        | Some node -> inorder node.Left @ [ node.Value ] @ inorder node.Right
+
+    let rec preorder root =
+        match root with
+        | None -> []
+        | Some node -> node.Value :: (preorder node.Left @ preorder node.Right)
+
+    let rec postorder root =
+        match root with
+        | None -> []
+        | Some node -> postorder node.Left @ postorder node.Right @ [ node.Value ]
+
+    let levelOrder root =
+        match root with
+        | None -> []
+        | Some start ->
+            let queue = Queue<BinaryTreeNode<'T>>()
+            let output = ResizeArray<'T>()
+            queue.Enqueue start
+
+            while queue.Count > 0 do
+                let node = queue.Dequeue()
+                output.Add node.Value
+
+                node.Left |> Option.iter queue.Enqueue
+                node.Right |> Option.iter queue.Enqueue
+
+            output |> Seq.toList
+
+    let toArray root =
+        let h = height root
+
+        if h < 0 then
+            []
+        else
+            let output: 'T option array = Array.create ((1 <<< (h + 1)) - 1) None
+
+            let rec fill node index =
+                match node with
+                | None -> ()
+                | Some current when index >= output.Length -> ()
+                | Some current ->
+                    output[index] <- Some current.Value
+                    fill current.Left ((2 * index) + 1)
+                    fill current.Right ((2 * index) + 2)
+
+            fill root 0
+            output |> Array.toList
+
+    let toAscii root =
+        let lines = ResizeArray<string>()
+
+        let rec render (node: BinaryTreeNode<'T>) prefix isTail =
+            let connector = if isTail then "`-- " else "|-- "
+            lines.Add(sprintf "%s%s%A" prefix connector node.Value)
+
+            let children =
+                [ node.Left; node.Right ]
+                |> List.choose id
+
+            let nextPrefix = prefix + if isTail then "    " else "|   "
+
+            children
+            |> List.iteri (fun index child -> render child nextPrefix (index + 1 = children.Length))
+
+        root |> Option.iter (fun node -> render node "" true)
+        String.Join(Environment.NewLine, lines)
+
+type BinaryTree<'T>(root: BinaryTreeNode<'T> option) =
+    new() = BinaryTree<'T>(None)
+
+    member _.Root = root
+
+    static member Empty() = BinaryTree<'T>(None)
+
+    static member Singleton(value: 'T) =
+        BinaryTree<'T>(Some(BinaryTreeNode.Leaf value))
+
+    static member WithRoot(root: BinaryTreeNode<'T> option) = BinaryTree<'T>(root)
+
+    static member FromLevelOrder(values: seq<'T option>) =
+        if isNull (box values) then
+            nullArg "values"
+
+        values
+        |> Seq.toArray
+        |> fun items -> BinaryTree<'T>(BinaryTreeHelpers.buildFromLevelOrder items 0)
+
+    member _.Find(value: 'T) = BinaryTreeHelpers.find root value
+
+    member this.LeftChild(value: 'T) = this.Find(value) |> Option.bind _.Left
+
+    member this.RightChild(value: 'T) = this.Find(value) |> Option.bind _.Right
+
+    member _.IsFull() = BinaryTreeHelpers.isFull root
+
+    member _.IsComplete() = BinaryTreeHelpers.isComplete root
+
+    member _.IsPerfect() = BinaryTreeHelpers.isPerfect root
+
+    member _.Height() = BinaryTreeHelpers.height root
+
+    member _.Size() = BinaryTreeHelpers.size root
+
+    member _.InOrder() = BinaryTreeHelpers.inorder root
+
+    member _.PreOrder() = BinaryTreeHelpers.preorder root
+
+    member _.PostOrder() = BinaryTreeHelpers.postorder root
+
+    member _.LevelOrder() = BinaryTreeHelpers.levelOrder root
+
+    member _.ToArray() = BinaryTreeHelpers.toArray root
+
+    member _.ToAscii() = BinaryTreeHelpers.toAscii root
+
+    override _.ToString() =
+        let rootLabel =
+            match root with
+            | None -> "null"
+            | Some node -> sprintf "%A" node.Value
+
+        sprintf "BinaryTree(root=%s, size=%d)" rootLabel (BinaryTreeHelpers.size root)
+
+module BinaryTreeAlgorithms =
+    let find value (root: BinaryTreeNode<'T> option) = BinaryTreeHelpers.find root value
+
+    let leftChild value (root: BinaryTreeNode<'T> option) = find value root |> Option.bind _.Left
+
+    let rightChild value (root: BinaryTreeNode<'T> option) = find value root |> Option.bind _.Right
+
+    let isFull root = BinaryTreeHelpers.isFull root
+
+    let isComplete root = BinaryTreeHelpers.isComplete root
+
+    let isPerfect root = BinaryTreeHelpers.isPerfect root
+
+    let height root = BinaryTreeHelpers.height root
+
+    let size root = BinaryTreeHelpers.size root
+
+    let inOrder root = BinaryTreeHelpers.inorder root
+
+    let preOrder root = BinaryTreeHelpers.preorder root
+
+    let postOrder root = BinaryTreeHelpers.postorder root
+
+    let levelOrder root = BinaryTreeHelpers.levelOrder root
+
+    let toArray root = BinaryTreeHelpers.toArray root
+
+    let toAscii root = BinaryTreeHelpers.toAscii root

--- a/code/packages/fsharp/binary-tree/CHANGELOG.md
+++ b/code/packages/fsharp/binary-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# binary tree package.

--- a/code/packages/fsharp/binary-tree/CodingAdventures.BinaryTree.fsproj
+++ b/code/packages/fsharp/binary-tree/CodingAdventures.BinaryTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BinaryTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Generic F# binary tree with traversal and shape helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BinaryTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/binary-tree/README.md
+++ b/code/packages/fsharp/binary-tree/README.md
@@ -1,0 +1,3 @@
+# fsharp/binary-tree
+
+Generic F# binary tree with level-order construction, traversals, shape predicates, array projection, and ASCII rendering.

--- a/code/packages/fsharp/binary-tree/required_capabilities.json
+++ b/code/packages/fsharp/binary-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/binary-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/binary-tree/tests/CodingAdventures.BinaryTree.Tests/BinaryTreeTests.fs
+++ b/code/packages/fsharp/binary-tree/tests/CodingAdventures.BinaryTree.Tests/BinaryTreeTests.fs
@@ -1,0 +1,110 @@
+namespace CodingAdventures.BinaryTree.Tests
+
+open System
+open Xunit
+open CodingAdventures.BinaryTree
+
+type BinaryTreeTests() =
+    let fullTree() =
+        BinaryTree<int>.FromLevelOrder(
+            [ Some 1
+              Some 2
+              Some 3
+              Some 4
+              Some 5
+              Some 6
+              Some 7 ]
+        )
+
+    [<Fact>]
+    member _.``from level order projects back to an array``() =
+        let tree = fullTree()
+
+        Assert.Equal<int option list>(
+            [ Some 1
+              Some 2
+              Some 3
+              Some 4
+              Some 5
+              Some 6
+              Some 7 ],
+            tree.ToArray()
+        )
+
+        Assert.Equal<int list>([ 1; 2; 3; 4; 5; 6; 7 ], tree.LevelOrder())
+
+    [<Fact>]
+    member _.``shape queries distinguish full complete and perfect trees``() =
+        let perfect = fullTree()
+        Assert.True(perfect.IsFull())
+        Assert.True(perfect.IsComplete())
+        Assert.True(perfect.IsPerfect())
+        Assert.Equal(2, perfect.Height())
+        Assert.Equal(7, perfect.Size())
+
+        let complete = BinaryTree<int>.FromLevelOrder([ Some 1; Some 2; Some 3; Some 4; None; None; None ])
+        Assert.False(complete.IsFull())
+        Assert.True(complete.IsComplete())
+        Assert.False(complete.IsPerfect())
+
+        let incomplete = BinaryTree<int>.FromLevelOrder([ Some 1; None; Some 3 ])
+        Assert.False(incomplete.IsComplete())
+
+    [<Fact>]
+    member _.``traversals and child lookup match reference order``() =
+        let tree = BinaryTree<int>.FromLevelOrder([ Some 1; Some 2; Some 3; Some 4; None; Some 5; None ])
+
+        Assert.Equal<int list>([ 4; 2; 1; 5; 3 ], tree.InOrder())
+        Assert.Equal<int list>([ 1; 2; 4; 3; 5 ], tree.PreOrder())
+        Assert.Equal<int list>([ 4; 2; 5; 3; 1 ], tree.PostOrder())
+        Assert.Equal<int list>([ 1; 2; 3; 4; 5 ], tree.LevelOrder())
+        Assert.Equal<int option>(Some 2, tree.LeftChild(1) |> Option.map _.Value)
+        Assert.Equal<int option>(Some 3, tree.RightChild(1) |> Option.map _.Value)
+        Assert.Equal<BinaryTreeNode<int> option>(None, tree.Find(99))
+
+    [<Fact>]
+    member _.``empty and singleton trees expose edge case behavior``() =
+        let empty = BinaryTree<string>.Empty()
+        Assert.Equal(-1, empty.Height())
+        Assert.Equal(0, empty.Size())
+        Assert.True(empty.IsFull())
+        Assert.True(empty.IsComplete())
+        Assert.True(empty.IsPerfect())
+        Assert.Equal<string list>([], empty.InOrder())
+        Assert.Equal<string option list>([], empty.ToArray())
+        Assert.Equal(String.Empty, empty.ToAscii())
+        Assert.Equal("BinaryTree(root=null, size=0)", empty.ToString())
+
+        let single = BinaryTree<string>.Singleton("root")
+        Assert.Equal<string option>(Some "root", single.Root |> Option.map _.Value)
+        Assert.Equal<string option list>([ Some "root" ], single.ToArray())
+        Assert.Equal("BinaryTree(root=\"root\", size=1)", single.ToString())
+
+    [<Fact>]
+    member _.``ascii rendering contains debug values``() =
+        let tree = BinaryTree<string>.FromLevelOrder([ Some "root"; Some "left"; Some "right" ])
+        let ascii = tree.ToAscii()
+
+        Assert.Contains("root", ascii)
+        Assert.Contains("left", ascii)
+        Assert.Contains("right", ascii)
+        Assert.Contains("`--", ascii)
+
+    [<Fact>]
+    member _.``module functions support raw root composition``() =
+        let left = Some(BinaryTreeNode.Leaf 2)
+        let right = Some(BinaryTreeNode.Leaf 3)
+        let root = Some(BinaryTreeNode.Create(1, left, right))
+
+        Assert.Equal<int option>(Some 2, BinaryTreeAlgorithms.leftChild 1 root |> Option.map _.Value)
+        Assert.Equal<int option>(Some 3, BinaryTreeAlgorithms.rightChild 1 root |> Option.map _.Value)
+        Assert.Equal<int list>([ 2; 1; 3 ], BinaryTreeAlgorithms.inOrder root)
+        Assert.Equal<int list>([ 1; 2; 3 ], BinaryTreeAlgorithms.preOrder root)
+        Assert.Equal<int list>([ 2; 3; 1 ], BinaryTreeAlgorithms.postOrder root)
+        Assert.Equal<int list>([ 1; 2; 3 ], BinaryTreeAlgorithms.levelOrder root)
+        Assert.True(BinaryTreeAlgorithms.isFull root)
+        Assert.True(BinaryTreeAlgorithms.isComplete root)
+        Assert.True(BinaryTreeAlgorithms.isPerfect root)
+        Assert.Equal(1, BinaryTreeAlgorithms.height root)
+        Assert.Equal(3, BinaryTreeAlgorithms.size root)
+        Assert.Contains("1", BinaryTreeAlgorithms.toAscii root)

--- a/code/packages/fsharp/binary-tree/tests/CodingAdventures.BinaryTree.Tests/CodingAdventures.BinaryTree.Tests.fsproj
+++ b/code/packages/fsharp/binary-tree/tests/CodingAdventures.BinaryTree.Tests/CodingAdventures.BinaryTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BinaryTree.fsproj" />
+    <Compile Include="BinaryTreeTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an F# binary-tree package with level-order construction, traversal helpers, shape predicates, array projection, and ASCII rendering
- expose a BinaryTree wrapper plus module helpers for raw node composition
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.BinaryTree.Tests\\CodingAdventures.BinaryTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line