### PR TITLE
feat(java/kotlin): add atbash, caesar, scytale, and vigenere ciphers

### DIFF
--- a/code/packages/java/atbash-cipher/.gitignore
+++ b/code/packages/java/atbash-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/atbash-cipher/BUILD
+++ b/code/packages/java/atbash-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/atbash-cipher/BUILD_windows
+++ b/code/packages/java/atbash-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/atbash-cipher/CHANGELOG.md
+++ b/code/packages/java/atbash-cipher/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — atbash-cipher (Java)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Atbash substitution cipher.
+- `encrypt(text)` — maps every letter to its mirror in the alphabet; non-alpha unchanged; case preserved.
+- `decrypt(text)` — identical to `encrypt` because Atbash is self-inverse.
+- Literate source with inline alphabet mirror table, historical context, and self-inverse proof.
+- 18 unit tests covering: individual letters, full alphabet, case preservation, non-alpha pass-through, roundtrip (self-inverse property for all 26 letters), and known cross-language test vectors.

--- a/code/packages/java/atbash-cipher/README.md
+++ b/code/packages/java/atbash-cipher/README.md
@@ -1,0 +1,45 @@
+# atbash-cipher — Java
+
+The Atbash cipher: an ancient Hebrew substitution cipher that mirrors the alphabet. A↔Z, B↔Y, C↔X, and so on.
+
+## Usage
+
+```java
+import com.codingadventures.atbashcipher.AtbashCipher;
+
+AtbashCipher.encrypt("Hello, World!")   // → "Svool, Dliow!"
+AtbashCipher.decrypt("Svool, Dliow!")   // → "Hello, World!"
+AtbashCipher.encrypt("ABCXYZ")          // → "ZYXCBA"
+```
+
+## How it works
+
+Every letter is replaced by its mirror image: position `i` (0 = A) maps to position `25 - i` (Z).
+
+```
+A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕
+Z Y X W V U T S R Q P O N M L K J I H G F E D C B A
+```
+
+Non-alphabetic characters (digits, spaces, punctuation) pass through unchanged. Case is preserved.
+
+## Self-inverse property
+
+Applying Atbash twice returns the original text — so `encrypt` and `decrypt` are the same function:
+
+```java
+AtbashCipher.encrypt(AtbashCipher.encrypt("HELLO"))  // → "HELLO"
+```
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+18 tests covering individual letters, full alphabet, case preservation, non-alpha pass-through, and roundtrip self-inverse verification.
+
+## Part of the Coding Adventures series
+
+Java counterpart to the Python, Rust, Go, TypeScript, and Kotlin implementations.

--- a/code/packages/java/atbash-cipher/build.gradle.kts
+++ b/code/packages/java/atbash-cipher/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/atbash-cipher/settings.gradle.kts
+++ b/code/packages/java/atbash-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "atbash-cipher"

--- a/code/packages/java/atbash-cipher/src/main/java/com/codingadventures/atbashcipher/AtbashCipher.java
+++ b/code/packages/java/atbash-cipher/src/main/java/com/codingadventures/atbashcipher/AtbashCipher.java
@@ -1,0 +1,142 @@
+// ============================================================================
+// AtbashCipher.java — The ancient mirror substitution cipher
+// ============================================================================
+//
+// Atbash is one of the oldest known ciphers, originating in ancient Hebrew
+// writing (the name comes from the first two and last two letters of the
+// Hebrew alphabet: Aleph-Tav-Beth-Shin). It was used to encode portions of
+// the Hebrew Bible, including Jeremiah 25:26 and 51:41 where "Sheshach" is
+// understood to mean "Babel."
+//
+// The principle is elegantly simple: reverse the alphabet. A becomes Z,
+// B becomes Y, C becomes X, and so on. The mapping is a perfect mirror:
+//
+//   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+//   ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕
+//   Z Y X W V U T S R Q P O N M L K J I H G F E D C B A
+//
+// Self-inverse property:
+// ---------------------
+// Atbash has a beautiful mathematical property: applying it twice returns the
+// original text. This means encrypt and decrypt are the same operation:
+//
+//   encrypt("HELLO") = "SVOOL"
+//   encrypt("SVOOL") = "HELLO"   ← applying Atbash to the ciphertext recovers plaintext
+//
+// Why this works: if A is position 0 and Z is position 25, then Atbash maps
+// position i to position (25 - i). Applying it again gives (25 - (25 - i)) = i.
+// The operation is its own inverse.
+//
+// Security:
+// ---------
+// Atbash provides NO security by modern standards. It is a monoalphabetic
+// substitution cipher with a fixed, known key. Every letter always maps to the
+// same substitute, so frequency analysis immediately breaks it. The alphabet
+// has only 26 permutations even if the key were unknown, making brute force
+// trivial. Atbash is a useful teaching tool, not a security mechanism.
+//
+
+package com.codingadventures.atbashcipher;
+
+/**
+ * The Atbash cipher — a monoalphabetic substitution cipher that mirrors the alphabet.
+ *
+ * <p>Maps each letter to its mirror image: A↔Z, B↔Y, C↔X, and so on. Non-alphabetic
+ * characters (digits, spaces, punctuation) pass through unchanged. Case is preserved.
+ *
+ * <p>The cipher is self-inverse: {@code decrypt(encrypt(text)) == text} for any input,
+ * and in fact {@code encrypt} and {@code decrypt} perform the exact same operation.
+ *
+ * <pre>{@code
+ * AtbashCipher.encrypt("Hello, World!")  // → "Svool, Dliow!"
+ * AtbashCipher.decrypt("Svool, Dliow!")  // → "Hello, World!"
+ * AtbashCipher.encrypt("ABCXYZ")         // → "ZYXCBA"
+ * }</pre>
+ *
+ * <p>All methods are static — this is a pure utility class with no state.
+ */
+public final class AtbashCipher {
+
+    // Private constructor: no instances needed.
+    private AtbashCipher() {}
+
+    // =========================================================================
+    // Core mapping
+    // =========================================================================
+    //
+    // The Atbash mapping is equivalent to reflecting each letter around the
+    // midpoint of the alphabet. For any letter at position i (0-indexed from A):
+    //
+    //   mapped position = 25 - i
+    //
+    // Examples:
+    //   A (position  0) → Z (position 25)
+    //   B (position  1) → Y (position 24)
+    //   M (position 12) → N (position 13)
+    //   Z (position 25) → A (position  0)
+
+    /**
+     * Apply the Atbash mirror mapping to a single character.
+     *
+     * <p>Returns the mirror image if alphabetic, or the character unchanged if not.
+     *
+     * @param c any character
+     * @return the Atbash-mapped character
+     */
+    private static char mapChar(char c) {
+        if (c >= 'A' && c <= 'Z') {
+            // Mirror within uppercase: A(65) ↔ Z(90)
+            // 'A' + 'Z' = 65 + 90 = 155; mapped = 155 - c
+            return (char) ('A' + 'Z' - c);
+        } else if (c >= 'a' && c <= 'z') {
+            // Mirror within lowercase: a(97) ↔ z(122)
+            // 'a' + 'z' = 97 + 122 = 219; mapped = 219 - c
+            return (char) ('a' + 'z' - c);
+        } else {
+            return c;  // spaces, digits, punctuation pass through unchanged
+        }
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt a string using the Atbash cipher.
+     *
+     * <p>Maps every letter to its mirror image in the alphabet. Non-alphabetic
+     * characters are copied unchanged. Case is preserved.
+     *
+     * <p>Truth table for a few letters:
+     * <pre>
+     *   A → Z    B → Y    C → X    D → W    E → V    F → U
+     *   G → T    H → S    I → R    J → Q    K → P    L → O
+     *   M → N    N → M    O → L    P → K    Q → J    R → I
+     *   S → H    T → G    U → F    V → E    W → D    X → C
+     *   Y → B    Z → A
+     * </pre>
+     *
+     * @param text the plaintext to encrypt
+     * @return the ciphertext with letters mirrored
+     */
+    public static String encrypt(String text) {
+        StringBuilder sb = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            sb.append(mapChar(text.charAt(i)));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Decrypt a string that was encrypted with the Atbash cipher.
+     *
+     * <p>Identical to {@link #encrypt} because Atbash is its own inverse:
+     * applying the mirror mapping twice returns the original text.
+     *
+     * @param text the ciphertext to decrypt
+     * @return the original plaintext
+     */
+    public static String decrypt(String text) {
+        return encrypt(text);  // self-inverse: decrypt IS encrypt
+    }
+}

--- a/code/packages/java/atbash-cipher/src/test/java/com/codingadventures/atbashcipher/AtbashCipherTest.java
+++ b/code/packages/java/atbash-cipher/src/test/java/com/codingadventures/atbashcipher/AtbashCipherTest.java
@@ -1,0 +1,170 @@
+// ============================================================================
+// AtbashCipherTest.java — Unit Tests for AtbashCipher
+// ============================================================================
+
+package com.codingadventures.atbashcipher;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AtbashCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — basic correctness
+    // =========================================================================
+
+    @Test
+    void encryptSingleUppercaseLetter() {
+        assertEquals("Z", AtbashCipher.encrypt("A"));
+        assertEquals("A", AtbashCipher.encrypt("Z"));
+        assertEquals("N", AtbashCipher.encrypt("M"));
+        assertEquals("M", AtbashCipher.encrypt("N"));
+    }
+
+    @Test
+    void encryptSingleLowercaseLetter() {
+        assertEquals("z", AtbashCipher.encrypt("a"));
+        assertEquals("a", AtbashCipher.encrypt("z"));
+        assertEquals("n", AtbashCipher.encrypt("m"));
+        assertEquals("m", AtbashCipher.encrypt("n"));
+    }
+
+    @Test
+    void encryptFullUppercaseAlphabet() {
+        assertEquals("ZYXWVUTSRQPONMLKJIHGFEDCBA", AtbashCipher.encrypt("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+    }
+
+    @Test
+    void encryptFullLowercaseAlphabet() {
+        assertEquals("zyxwvutsrqponmlkjihgfedcba", AtbashCipher.encrypt("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @Test
+    void encryptPreservesCase() {
+        assertEquals("Svool", AtbashCipher.encrypt("Hello"));
+        assertEquals("SVOOL", AtbashCipher.encrypt("HELLO"));
+        assertEquals("svool", AtbashCipher.encrypt("hello"));
+    }
+
+    @Test
+    void encryptHelloWorld() {
+        assertEquals("Svool, Dliow!", AtbashCipher.encrypt("Hello, World!"));
+    }
+
+    @Test
+    void encryptPassesThroughNonAlpha() {
+        assertEquals("123", AtbashCipher.encrypt("123"));
+        assertEquals("!@#", AtbashCipher.encrypt("!@#"));
+        assertEquals(" ", AtbashCipher.encrypt(" "));
+        assertEquals("A1B2", AtbashCipher.encrypt("Z1Y2"));
+    }
+
+    @Test
+    void encryptEmptyString() {
+        assertEquals("", AtbashCipher.encrypt(""));
+    }
+
+    @Test
+    void encryptMixedContent() {
+        // "Attack at Dawn":
+        //   A→Z t→g t→g a→z c→x k→p ' ' a→z t→g ' ' D→W a→z w→d n→m
+        assertEquals("Zggzxp zg Wzdm", AtbashCipher.encrypt("Attack at Dawn"));
+    }
+
+    // =========================================================================
+    // 2. decrypt — same as encrypt (self-inverse)
+    // =========================================================================
+
+    @Test
+    void decryptIsEncrypt() {
+        String[] testCases = {
+            "Hello, World!", "ABCXYZ", "The quick brown fox", "", "123!@#", "Svool"
+        };
+        for (String text : testCases) {
+            assertEquals(
+                AtbashCipher.encrypt(text),
+                AtbashCipher.decrypt(text),
+                "decrypt should equal encrypt for: " + text
+            );
+        }
+    }
+
+    @Test
+    void decryptInvertsEncrypt() {
+        String[] plaintexts = {
+            "Hello, World!", "ATTACK AT DAWN", "The quick brown fox jumps over the lazy dog",
+            "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "Mixed CASE text!"
+        };
+        for (String plaintext : plaintexts) {
+            String roundtrip = AtbashCipher.decrypt(AtbashCipher.encrypt(plaintext));
+            assertEquals(plaintext, roundtrip, "Roundtrip failed for: " + plaintext);
+        }
+    }
+
+    @Test
+    void decryptEmptyString() {
+        assertEquals("", AtbashCipher.decrypt(""));
+    }
+
+    // =========================================================================
+    // 3. Self-inverse property
+    // =========================================================================
+
+    @Test
+    void selfInverseForEveryLetter() {
+        // Applying Atbash twice to any single letter returns the original
+        for (char c = 'A'; c <= 'Z'; c++) {
+            String s = String.valueOf(c);
+            assertEquals(s, AtbashCipher.encrypt(AtbashCipher.encrypt(s)),
+                "Self-inverse failed for: " + c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            String s = String.valueOf(c);
+            assertEquals(s, AtbashCipher.encrypt(AtbashCipher.encrypt(s)),
+                "Self-inverse failed for: " + c);
+        }
+    }
+
+    @Test
+    void selfInverseForSentence() {
+        String original = "The quick brown fox jumps over the lazy dog.";
+        assertEquals(original, AtbashCipher.encrypt(AtbashCipher.encrypt(original)));
+    }
+
+    // =========================================================================
+    // 4. Known test vectors (cross-language parity)
+    // =========================================================================
+
+    @Test
+    void knownVectorAttack() {
+        // "ATTACK" → each letter mirrored
+        // A→Z, T→G, T→G, A→Z, C→X, K→P
+        assertEquals("ZGGZXP", AtbashCipher.encrypt("ATTACK"));
+    }
+
+    @Test
+    void knownVectorHello() {
+        // H→S, E→V, L→O, L→O, O→L
+        assertEquals("SVOOL", AtbashCipher.encrypt("HELLO"));
+    }
+
+    @Test
+    void knownVectorMirrorPairs() {
+        assertEquals("ABCXYZ", AtbashCipher.encrypt("ZYXCBA"));
+        assertEquals("ZYXCBA", AtbashCipher.encrypt("ABCXYZ"));
+    }
+
+    // =========================================================================
+    // 5. Unicode / non-ASCII pass-through
+    // =========================================================================
+
+    @Test
+    void nonAsciiPassesThrough() {
+        // Characters outside A-Z a-z pass through unchanged
+        // "Xzuv" → X→C, z→a, u→f, v→e → "Cafe"
+        assertEquals("Cafe", AtbashCipher.encrypt("Xzuv"));
+        assertEquals("Svool Dliow", AtbashCipher.encrypt("Hello World"));
+        // Digits and punctuation pass through
+        assertEquals("C1f2", AtbashCipher.encrypt("X1u2"));
+    }
+}

--- a/code/packages/java/caesar-cipher/.gitignore
+++ b/code/packages/java/caesar-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/caesar-cipher/BUILD
+++ b/code/packages/java/caesar-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/caesar-cipher/BUILD_windows
+++ b/code/packages/java/caesar-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/caesar-cipher/CHANGELOG.md
+++ b/code/packages/java/caesar-cipher/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — caesar-cipher (Java)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Caesar shift cipher.
+- `encrypt(text, shift)` — shifts letters forward by `shift` mod 26; negative shifts work; non-alpha unchanged; case preserved.
+- `decrypt(text, shift)` — shifts backward; delegates to `encrypt(text, -shift)`.
+- `rot13(text)` — Caesar with shift=13; self-inverse.
+- `bruteForce(ciphertext)` — returns all 25 non-trivial (shift, plaintext) candidates as `List<BruteForceResult>`.
+- `frequencyAnalysis(ciphertext)` — chi-squared attack against English letter frequencies; returns best (shift, plaintext) guess.
+- `ENGLISH_FREQUENCIES` — public `double[]` of 26 letter frequencies (A–Z).
+- `BruteForceResult` and `FrequencyResult` inner classes.
+- Literate source with inline shift table, historical context, and security discussion.
+- 26 unit tests covering: shift arithmetic (mod 26, negatives, large values), case preservation, non-alpha passthrough, ROT13 self-inverse, brute force size/content, frequency analysis on long English texts (shift=3 and shift=13).

--- a/code/packages/java/caesar-cipher/README.md
+++ b/code/packages/java/caesar-cipher/README.md
@@ -1,0 +1,35 @@
+# caesar-cipher — Java
+
+The Caesar cipher: the classical shift cipher used by Julius Caesar himself, plus ROT13, brute-force, and frequency analysis.
+
+## Usage
+
+```java
+import com.codingadventures.caesarcipher.CaesarCipher;
+
+CaesarCipher.encrypt("Hello, World!", 3)   // → "Khoor, Zruog!"
+CaesarCipher.decrypt("Khoor, Zruog!", 3)   // → "Hello, World!"
+CaesarCipher.rot13("Hello")               // → "Uryyb"
+
+// Brute force: try all 25 shifts
+for (CaesarCipher.BruteForceResult r : CaesarCipher.bruteForce("KHOOR")) {
+    System.out.println("shift " + r.shift + ": " + r.text);
+}
+
+// Frequency analysis: automatic attack
+CaesarCipher.FrequencyResult result = CaesarCipher.frequencyAnalysis("KHOOR...");
+System.out.println("Likely shift: " + result.shift);
+System.out.println("Plaintext: " + result.text);
+```
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+26 tests covering shift arithmetic, ROT13, brute-force, and frequency analysis on long English texts.
+
+## Part of the Coding Adventures series
+
+Java counterpart to the Python, Rust, Go, TypeScript, and Kotlin implementations.

--- a/code/packages/java/caesar-cipher/build.gradle.kts
+++ b/code/packages/java/caesar-cipher/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/caesar-cipher/settings.gradle.kts
+++ b/code/packages/java/caesar-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "caesar-cipher"

--- a/code/packages/java/caesar-cipher/src/main/java/com/codingadventures/caesarcipher/CaesarCipher.java
+++ b/code/packages/java/caesar-cipher/src/main/java/com/codingadventures/caesarcipher/CaesarCipher.java
@@ -1,0 +1,274 @@
+// ============================================================================
+// CaesarCipher.java — The classical shift cipher
+// ============================================================================
+//
+// The Caesar cipher is named after Julius Caesar, who reportedly used a shift
+// of 3 to protect messages of military significance. Suetonius describes it:
+// "If he had anything confidential to say, he wrote it in cipher, that is, by
+// so changing the order of the letters of the alphabet, that not a word could
+// be made out."
+//
+// The principle is simple: shift every letter forward in the alphabet by a
+// fixed number of positions, wrapping around from Z back to A.
+//
+//   shift = 3:   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+//                ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
+//                D E F G H I J K L M N O P Q R S T U V W X Y Z A B C
+//
+//   encrypt("HELLO", 3) = "KHOOR"
+//   decrypt("KHOOR", 3) = "HELLO"
+//
+// ROT13:
+// ------
+// ROT13 is a special case of Caesar cipher with shift = 13. Because the
+// alphabet has 26 letters, shifting by 13 is self-inverse (just like Atbash):
+//   ROT13(ROT13("HELLO")) = "HELLO"
+// ROT13 is widely used on the internet to obscure spoilers and jokes.
+//
+// Security:
+// ---------
+// The Caesar cipher has only 26 possible keys (shifts 0–25). An attacker can
+// try all 26 in under a second. Even without brute force, frequency analysis
+// works: 'E' is the most common English letter. If 'H' appears most often in
+// the ciphertext, the shift is probably 3 (H - E = 3). This cipher provides
+// no real security and should never be used for sensitive data.
+//
+
+package com.codingadventures.caesarcipher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Caesar cipher — a classical shift cipher.
+ *
+ * <p>Shifts every letter forward in the alphabet by a fixed amount. Non-alphabetic
+ * characters pass through unchanged. Case is preserved.
+ *
+ * <p>Includes ROT13 (shift=13), brute-force decryption (all 25 shifts), and
+ * frequency analysis for automatic ciphertext-only attack.
+ *
+ * <pre>{@code
+ * CaesarCipher.encrypt("Hello, World!", 3)  // → "Khoor, Zruog!"
+ * CaesarCipher.decrypt("Khoor, Zruog!", 3)  // → "Hello, World!"
+ * CaesarCipher.rot13("Hello")               // → "Uryyb"
+ * }</pre>
+ */
+public final class CaesarCipher {
+
+    // Private constructor: pure utility class.
+    private CaesarCipher() {}
+
+    // =========================================================================
+    // English letter frequencies (for chi-squared analysis)
+    // =========================================================================
+    //
+    // The frequency of each letter A–Z in typical English text, as proportions
+    // (values sum to approximately 1.0). Source: Lewand (2000), "Cryptological
+    // Mathematics," based on large English corpora.
+    //
+    // Key insight: 'E' (index 4) is most common at ~12.7%, followed by 'T' at
+    // ~9.1%. If ciphertext has a different letter as the most common, the shift
+    // is the distance from that letter back to 'E'.
+
+    /** English letter frequencies indexed A=0 … Z=25. */
+    public static final double[] ENGLISH_FREQUENCIES = {
+        0.08167, // A
+        0.01492, // B
+        0.02782, // C
+        0.04253, // D
+        0.12702, // E  ← most common
+        0.02228, // F
+        0.02015, // G
+        0.06094, // H
+        0.06966, // I
+        0.00153, // J
+        0.00772, // K
+        0.04025, // L
+        0.02406, // M
+        0.06749, // N
+        0.07507, // O
+        0.01929, // P
+        0.00095, // Q
+        0.05987, // R
+        0.06327, // S
+        0.09056, // T
+        0.02758, // U
+        0.00978, // V
+        0.02360, // W
+        0.00150, // X
+        0.01974, // Y
+        0.00074, // Z
+    };
+
+    // =========================================================================
+    // Core shift
+    // =========================================================================
+
+    /**
+     * Shift a single alphabetic character by {@code shift} positions, wrapping.
+     * Returns non-alpha characters unchanged.
+     */
+    private static char shiftChar(char c, int shift) {
+        if (c >= 'A' && c <= 'Z') {
+            return (char) ('A' + ((c - 'A' + shift % 26 + 26) % 26));
+        } else if (c >= 'a' && c <= 'z') {
+            return (char) ('a' + ((c - 'a' + shift % 26 + 26) % 26));
+        } else {
+            return c;
+        }
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt a string by shifting every letter forward by {@code shift} positions.
+     *
+     * <p>Shift is taken modulo 26, so values outside 0–25 work correctly.
+     * Negative shifts are allowed (equivalent to decrypting with that shift).
+     *
+     * @param text  the plaintext
+     * @param shift any integer — taken mod 26 internally
+     * @return the ciphertext
+     */
+    public static String encrypt(String text, int shift) {
+        StringBuilder sb = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            sb.append(shiftChar(text.charAt(i), shift));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Decrypt a string by shifting every letter backward by {@code shift} positions.
+     *
+     * <p>Equivalent to {@code encrypt(text, -shift)}.
+     *
+     * @param text  the ciphertext
+     * @param shift the shift used during encryption
+     * @return the original plaintext
+     */
+    public static String decrypt(String text, int shift) {
+        return encrypt(text, -shift);
+    }
+
+    /**
+     * ROT13 — Caesar cipher with shift = 13.
+     *
+     * <p>Self-inverse: {@code rot13(rot13(text)) == text}. Applying ROT13 to
+     * plaintext encrypts it; applying it again decrypts it.
+     *
+     * <p>Widely used online to obscure spoilers and punchlines.
+     *
+     * @param text any string
+     * @return the ROT13 transformation
+     */
+    public static String rot13(String text) {
+        return encrypt(text, 13);
+    }
+
+    /**
+     * Try all 25 non-trivial shifts and return every possible decryption.
+     *
+     * <p>Returns a list of 25 {@code int[2]}-style records represented as
+     * {@code int[]{shift, index}} — actually a list of {@link BruteForceResult}.
+     * Shifts 1–25 are tried; shift 0 (identity) is omitted.
+     *
+     * @param ciphertext the ciphertext to crack
+     * @return list of (shift, plaintext) pairs for all 25 non-trivial shifts
+     */
+    public static List<BruteForceResult> bruteForce(String ciphertext) {
+        List<BruteForceResult> results = new ArrayList<>(25);
+        for (int shift = 1; shift <= 25; shift++) {
+            results.add(new BruteForceResult(shift, decrypt(ciphertext, shift)));
+        }
+        return results;
+    }
+
+    /**
+     * Automatic frequency-analysis attack — find the most likely shift.
+     *
+     * <p>Counts letters in the ciphertext, computes the chi-squared statistic
+     * against the expected English distribution for each of the 26 possible
+     * shifts, and returns the shift with the lowest chi-squared score.
+     *
+     * <p>Reliability increases with ciphertext length. For texts of fewer than
+     * ~20 alphabetic characters the result may be unreliable.
+     *
+     * @param ciphertext the ciphertext (only alphabetic characters are analysed)
+     * @return the best (shift, plaintext) guess; shift=0 for empty input
+     */
+    public static FrequencyResult frequencyAnalysis(String ciphertext) {
+        // Count each letter (case-insensitive).
+        int[] counts = new int[26];
+        int total = 0;
+        for (int i = 0; i < ciphertext.length(); i++) {
+            char c = ciphertext.charAt(i);
+            if (c >= 'A' && c <= 'Z') { counts[c - 'A']++; total++; }
+            else if (c >= 'a' && c <= 'z') { counts[c - 'a']++; total++; }
+        }
+        if (total == 0) return new FrequencyResult(0, ciphertext);
+
+        // For each candidate shift k, compute chi-squared against English freq.
+        // Chi-squared: Σ (observed - expected)² / expected
+        // We assume shift k means ciphertext letter i actually represents letter (i - k + 26) % 26.
+        double bestScore = Double.MAX_VALUE;
+        int bestShift = 0;
+        for (int k = 0; k < 26; k++) {
+            double chiSq = 0.0;
+            for (int i = 0; i < 26; i++) {
+                int plainIdx = (i - k + 26) % 26;
+                double expected = ENGLISH_FREQUENCIES[plainIdx] * total;
+                double diff = counts[i] - expected;
+                chiSq += (diff * diff) / expected;
+            }
+            if (chiSq < bestScore) {
+                bestScore = chiSq;
+                bestShift = k;
+            }
+        }
+        return new FrequencyResult(bestShift, decrypt(ciphertext, bestShift));
+    }
+
+    // =========================================================================
+    // Result types
+    // =========================================================================
+
+    /** A (shift, plaintext) pair returned by {@link #bruteForce}. */
+    public static final class BruteForceResult {
+        /** The shift tried (1–25). */
+        public final int shift;
+        /** The plaintext produced by this shift. */
+        public final String text;
+
+        public BruteForceResult(int shift, String text) {
+            this.shift = shift;
+            this.text  = text;
+        }
+
+        @Override
+        public String toString() {
+            return "BruteForceResult{shift=" + shift + ", text=\"" + text + "\"}";
+        }
+    }
+
+    /** A (shift, plaintext) pair returned by {@link #frequencyAnalysis}. */
+    public static final class FrequencyResult {
+        /** The shift determined by frequency analysis. */
+        public final int shift;
+        /** The plaintext produced by applying this shift. */
+        public final String text;
+
+        public FrequencyResult(int shift, String text) {
+            this.shift = shift;
+            this.text  = text;
+        }
+
+        @Override
+        public String toString() {
+            return "FrequencyResult{shift=" + shift + ", text=\"" + text + "\"}";
+        }
+    }
+}

--- a/code/packages/java/caesar-cipher/src/test/java/com/codingadventures/caesarcipher/CaesarCipherTest.java
+++ b/code/packages/java/caesar-cipher/src/test/java/com/codingadventures/caesarcipher/CaesarCipherTest.java
@@ -1,0 +1,226 @@
+// ============================================================================
+// CaesarCipherTest.java — Unit Tests for CaesarCipher
+// ============================================================================
+
+package com.codingadventures.caesarcipher;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CaesarCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — basic correctness
+    // =========================================================================
+
+    @Test
+    void encryptShift0IsIdentity() {
+        assertEquals("Hello", CaesarCipher.encrypt("Hello", 0));
+        assertEquals("ABCXYZ", CaesarCipher.encrypt("ABCXYZ", 0));
+    }
+
+    @Test
+    void encryptShift1() {
+        assertEquals("B", CaesarCipher.encrypt("A", 1));
+        assertEquals("A", CaesarCipher.encrypt("Z", 1));  // wraps
+    }
+
+    @Test
+    void encryptShift3Classic() {
+        assertEquals("KHOOR", CaesarCipher.encrypt("HELLO", 3));
+        assertEquals("Khoor, Zruog!", CaesarCipher.encrypt("Hello, World!", 3));
+    }
+
+    @Test
+    void encryptShift13Rot13() {
+        assertEquals("URYYB", CaesarCipher.encrypt("HELLO", 13));
+    }
+
+    @Test
+    void encryptShift25() {
+        // Shift 25 = shift -1 (back one)
+        assertEquals("Z", CaesarCipher.encrypt("A", 25));
+        assertEquals("ABCDE", CaesarCipher.encrypt("BCDEF", 25));
+    }
+
+    @Test
+    void encryptPreservesCase() {
+        assertEquals("Khoor", CaesarCipher.encrypt("Hello", 3));
+        assertEquals("KHOOR", CaesarCipher.encrypt("HELLO", 3));
+        assertEquals("khoor", CaesarCipher.encrypt("hello", 3));
+    }
+
+    @Test
+    void encryptNonAlphaPassesThrough() {
+        assertEquals("Khoor, Zruog!", CaesarCipher.encrypt("Hello, World!", 3));
+        assertEquals("123 !@#", CaesarCipher.encrypt("123 !@#", 7));
+    }
+
+    @Test
+    void encryptEmptyString() {
+        assertEquals("", CaesarCipher.encrypt("", 5));
+    }
+
+    // =========================================================================
+    // 2. shift arithmetic — mod 26 and negatives
+    // =========================================================================
+
+    @Test
+    void encryptShift26IsIdentity() {
+        assertEquals("HELLO", CaesarCipher.encrypt("HELLO", 26));
+        assertEquals("HELLO", CaesarCipher.encrypt("HELLO", 52));
+    }
+
+    @Test
+    void encryptNegativeShift() {
+        assertEquals("HELLO", CaesarCipher.encrypt("KHOOR", -3));
+    }
+
+    @Test
+    void encryptLargePositiveShift() {
+        // Shift 29 = shift 3 (29 mod 26)
+        assertEquals(CaesarCipher.encrypt("HELLO", 3), CaesarCipher.encrypt("HELLO", 29));
+    }
+
+    // =========================================================================
+    // 3. decrypt
+    // =========================================================================
+
+    @Test
+    void decryptShift3() {
+        assertEquals("HELLO", CaesarCipher.decrypt("KHOOR", 3));
+        assertEquals("Hello, World!", CaesarCipher.decrypt("Khoor, Zruog!", 3));
+    }
+
+    @Test
+    void decryptRoundtrip() {
+        String[] texts = { "Hello, World!", "ATTACK AT DAWN", "The quick brown fox.", "" };
+        int[] shifts = { 1, 3, 13, 25 };
+        for (String text : texts) {
+            for (int shift : shifts) {
+                assertEquals(text, CaesarCipher.decrypt(CaesarCipher.encrypt(text, shift), shift),
+                    "Roundtrip failed for text='" + text + "', shift=" + shift);
+            }
+        }
+    }
+
+    // =========================================================================
+    // 4. ROT13
+    // =========================================================================
+
+    @Test
+    void rot13BasicTest() {
+        assertEquals("URYYB", CaesarCipher.rot13("HELLO"));
+        assertEquals("HELLO", CaesarCipher.rot13("URYYB"));
+    }
+
+    @Test
+    void rot13SelfInverse() {
+        String[] tests = { "Hello, World!", "Why did the chicken cross the road?", "ABCxyz" };
+        for (String text : tests) {
+            assertEquals(text, CaesarCipher.rot13(CaesarCipher.rot13(text)),
+                "ROT13 self-inverse failed for: " + text);
+        }
+    }
+
+    @Test
+    void rot13NonAlphaUnchanged() {
+        assertEquals("Uryyb, Jbeyq!", CaesarCipher.rot13("Hello, World!"));
+    }
+
+    // =========================================================================
+    // 5. bruteForce
+    // =========================================================================
+
+    @Test
+    void bruteForceReturns25Results() {
+        List<CaesarCipher.BruteForceResult> results = CaesarCipher.bruteForce("KHOOR");
+        assertEquals(25, results.size());
+    }
+
+    @Test
+    void bruteForceShiftsAre1Through25() {
+        List<CaesarCipher.BruteForceResult> results = CaesarCipher.bruteForce("KHOOR");
+        for (int i = 0; i < 25; i++) {
+            assertEquals(i + 1, results.get(i).shift);
+        }
+    }
+
+    @Test
+    void bruteForceContainsCorrectDecryption() {
+        // "KHOOR" encrypted with shift 3 → plaintext is "HELLO" at shift 3
+        List<CaesarCipher.BruteForceResult> results = CaesarCipher.bruteForce("KHOOR");
+        boolean found = results.stream().anyMatch(r -> r.shift == 3 && r.text.equals("HELLO"));
+        assertTrue(found, "brute force should include shift=3, text=HELLO");
+    }
+
+    @Test
+    void bruteForceEmptyString() {
+        List<CaesarCipher.BruteForceResult> results = CaesarCipher.bruteForce("");
+        assertEquals(25, results.size());
+        for (CaesarCipher.BruteForceResult r : results) {
+            assertEquals("", r.text);
+        }
+    }
+
+    // =========================================================================
+    // 6. frequencyAnalysis
+    // =========================================================================
+
+    @Test
+    void frequencyAnalysisEmptyString() {
+        CaesarCipher.FrequencyResult result = CaesarCipher.frequencyAnalysis("");
+        assertEquals(0, result.shift);
+        assertEquals("", result.text);
+    }
+
+    @Test
+    void frequencyAnalysisLongEnglishText() {
+        // Encrypt a long English text with shift=13, then recover it
+        String plaintext = "The quick brown fox jumps over the lazy dog. " +
+            "Pack my box with five dozen liquor jugs. " +
+            "How vexingly quick daft zebras jump.";
+        String ciphertext = CaesarCipher.encrypt(plaintext, 13);
+        CaesarCipher.FrequencyResult result = CaesarCipher.frequencyAnalysis(ciphertext);
+        assertEquals(13, result.shift, "Frequency analysis should recover shift=13");
+        assertEquals(plaintext, result.text);
+    }
+
+    @Test
+    void frequencyAnalysisShift3() {
+        String plaintext = "In the beginning God created the heavens and the earth. " +
+            "The earth was without form and void and darkness was over the face of the deep.";
+        String ciphertext = CaesarCipher.encrypt(plaintext, 3);
+        CaesarCipher.FrequencyResult result = CaesarCipher.frequencyAnalysis(ciphertext);
+        assertEquals(3, result.shift, "Frequency analysis should recover shift=3");
+    }
+
+    // =========================================================================
+    // 7. ENGLISH_FREQUENCIES constant
+    // =========================================================================
+
+    @Test
+    void englishFrequenciesLength() {
+        assertEquals(26, CaesarCipher.ENGLISH_FREQUENCIES.length);
+    }
+
+    @Test
+    void englishFrequenciesSumToOne() {
+        double sum = 0.0;
+        for (double f : CaesarCipher.ENGLISH_FREQUENCIES) sum += f;
+        assertEquals(1.0, sum, 0.001, "Frequencies should sum to ~1.0");
+    }
+
+    @Test
+    void eIsTheMostCommonLetter() {
+        // E (index 4) should have the highest frequency
+        double eFreq = CaesarCipher.ENGLISH_FREQUENCIES[4];  // 'E'
+        for (int i = 0; i < 26; i++) {
+            if (i != 4) {
+                assertTrue(eFreq >= CaesarCipher.ENGLISH_FREQUENCIES[i],
+                    "E should be most frequent; index " + i + " had higher freq");
+            }
+        }
+    }
+}

--- a/code/packages/java/scytale-cipher/.gitignore
+++ b/code/packages/java/scytale-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/scytale-cipher/BUILD
+++ b/code/packages/java/scytale-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/scytale-cipher/BUILD_windows
+++ b/code/packages/java/scytale-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/scytale-cipher/CHANGELOG.md
+++ b/code/packages/java/scytale-cipher/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — scytale-cipher (Java)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Scytale columnar transposition cipher.
+- `encrypt(text, key)` — writes row-by-row into `key` columns with space padding, reads column-by-column.
+- `decrypt(text, key)` — inverse transposition; strips trailing padding spaces.
+- `bruteForce(text)` — tries keys 2 to `text.length / 2`; returns `List<BruteForceResult>`.
+- Input validation: `key < 2` or `key > text.length` throws `IllegalArgumentException`.
+- `BruteForceResult` inner class with `key` and `text` fields.
+- Literate source with grid diagram, historical context (Spartan scytale), and security discussion.
+- 22 unit tests covering: basic encryption/decryption, padding, roundtrip for multiple texts and keys, input validation, brute force.

--- a/code/packages/java/scytale-cipher/README.md
+++ b/code/packages/java/scytale-cipher/README.md
@@ -1,0 +1,46 @@
+# scytale-cipher — Java
+
+The Scytale cipher: the ancient Spartan transposition cipher. Messages are written into a grid and read column-by-column — the key is the number of columns.
+
+## Usage
+
+```java
+import com.codingadventures.scytalecipher.ScytaleCipher;
+
+ScytaleCipher.encrypt("HELLOSPARTANS", 4)   // → "HORSEST LPA LAN "
+ScytaleCipher.decrypt("HORSEST LPA LAN ", 4)  // → "HELLOSPARTANS"
+
+// Brute force all possible keys
+for (ScytaleCipher.BruteForceResult r : ScytaleCipher.bruteForce(ciphertext)) {
+    System.out.println("key " + r.key + ": " + r.text);
+}
+```
+
+## How it works
+
+Write the plaintext row-by-row into a grid of `key` columns (padding the last row with spaces), then read column-by-column:
+
+```
+Input: "HELLOSPARTANS"   key=4
+
+Grid:  H E L L
+       O S P A
+       R T A N
+       S _ _ _
+
+Output (read by columns): "HORSEST LPA LAN "
+```
+
+To decrypt: reverse the process and strip trailing spaces.
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+22 tests covering encryption, decryption, roundtrip, padding, input validation, and brute force.
+
+## Part of the Coding Adventures series
+
+Java counterpart to the Python, Rust, Go, TypeScript, and Kotlin implementations.

--- a/code/packages/java/scytale-cipher/build.gradle.kts
+++ b/code/packages/java/scytale-cipher/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/scytale-cipher/settings.gradle.kts
+++ b/code/packages/java/scytale-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "scytale-cipher"

--- a/code/packages/java/scytale-cipher/src/main/java/com/codingadventures/scytalecipher/ScytaleCipher.java
+++ b/code/packages/java/scytale-cipher/src/main/java/com/codingadventures/scytalecipher/ScytaleCipher.java
@@ -1,0 +1,213 @@
+// ============================================================================
+// ScytaleCipher.java — The ancient Greek transposition cipher
+// ============================================================================
+//
+// The scytale (pronounced "SKIT-uh-lee") was used by the Spartans around
+// 7th century BCE. A strip of parchment was wound helically around a wooden
+// staff (the scytale), and the message was written lengthwise. When unwound,
+// the strip appeared as a jumble of characters — unreadable without a staff of
+// the same diameter to re-wind it.
+//
+// The key is the diameter of the staff, which determines the number of
+// columns in a grid when translated to a paper cipher:
+//
+//   Plaintext: "HELLOSPARTANS"   key = 4 (columns)
+//
+//   Write row-by-row into 4 columns, padding with spaces:
+//
+//     Row 0:  H  E  L  L
+//     Row 1:  O  S  P  A
+//     Row 2:  R  T  A  N
+//     Row 3:  S  _  _  _     ← '_' represents space padding
+//
+//   Read column-by-column (down each column):
+//     Col 0: H O R S
+//     Col 1: E S T _
+//     Col 2: L P A _
+//     Col 3: L A N _
+//
+//   Ciphertext: "HORSEST LPAAL N "
+//
+//   To decrypt: write the ciphertext column-by-column into the same grid,
+//   then read row-by-row, stripping trailing padding spaces.
+//
+// This is a pure transposition cipher — the letters are not changed, only
+// their positions. Frequency analysis of individual letters is therefore
+// ineffective (the frequency distribution matches plaintext), but n-gram
+// analysis on the decrypted text breaks it easily.
+//
+
+package com.codingadventures.scytalecipher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Scytale cipher — a columnar transposition cipher.
+ *
+ * <p>Encrypts by writing plaintext row-by-row into a grid of {@code key} columns,
+ * then reading column-by-column. Padding spaces fill the last row.
+ *
+ * <p>Decrypts by writing ciphertext column-by-column, reading row-by-row,
+ * then stripping trailing padding spaces.
+ *
+ * <pre>{@code
+ * ScytaleCipher.encrypt("HELLOSPARTANS", 4)  // → "HORSEST LPAAL N "
+ * ScytaleCipher.decrypt("HORSEST LPAAL N ", 4)  // → "HELLOSPARTANS"
+ * }</pre>
+ *
+ * <p>All methods are static — pure utility class.
+ */
+public final class ScytaleCipher {
+
+    // Private constructor.
+    private ScytaleCipher() {}
+
+    // =========================================================================
+    // Validation helper
+    // =========================================================================
+
+    /**
+     * Validate that {@code key} is a usable cipher key for the given text length.
+     *
+     * @param key  the number of columns
+     * @param textLen the length of the text being processed
+     * @throws IllegalArgumentException if key < 2 or key > textLen (and textLen > 0)
+     */
+    private static void validateKey(int key, int textLen) {
+        if (key < 2) {
+            throw new IllegalArgumentException("key must be at least 2, got: " + key);
+        }
+        if (textLen > 0 && key > textLen) {
+            throw new IllegalArgumentException(
+                "key (" + key + ") must not exceed text length (" + textLen + ")");
+        }
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt plaintext using the Scytale cipher.
+     *
+     * <p>Writes text row-by-row into a grid of {@code key} columns, padding
+     * the last row with spaces, then reads column-by-column.
+     *
+     * <p>Example (key=4):
+     * <pre>
+     *   Input:   "HELLOSPARTANS"
+     *   Grid:    H E L L
+     *            O S P A
+     *            R T A N
+     *            S _ _ _   ← spaces
+     *   Output: "HORSEST LPAAL N "
+     * </pre>
+     *
+     * @param text the plaintext (any characters, including spaces/punctuation)
+     * @param key  the number of columns (≥ 2, ≤ text length if non-empty)
+     * @return the ciphertext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    public static String encrypt(String text, int key) {
+        if (text.isEmpty()) return "";
+        validateKey(key, text.length());
+
+        // Number of rows needed (ceiling division)
+        int rows = (text.length() + key - 1) / key;
+        int paddedLen = rows * key;
+
+        // Build the padded character grid
+        char[] padded = new char[paddedLen];
+        for (int i = 0; i < text.length(); i++) padded[i] = text.charAt(i);
+        for (int i = text.length(); i < paddedLen; i++) padded[i] = ' ';
+
+        // Read column-by-column
+        StringBuilder sb = new StringBuilder(paddedLen);
+        for (int col = 0; col < key; col++) {
+            for (int row = 0; row < rows; row++) {
+                sb.append(padded[row * key + col]);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Decrypt ciphertext that was encrypted with the Scytale cipher.
+     *
+     * <p>Writes ciphertext column-by-column into a grid, reads row-by-row,
+     * then strips trailing padding spaces.
+     *
+     * @param text the ciphertext
+     * @param key  the number of columns used during encryption (≥ 2)
+     * @return the original plaintext (trailing padding spaces stripped)
+     * @throws IllegalArgumentException if key is invalid
+     */
+    public static String decrypt(String text, int key) {
+        if (text.isEmpty()) return "";
+        validateKey(key, text.length());
+
+        int len = text.length();
+        int rows = (len + key - 1) / key;
+
+        // Ciphertext was read column-by-column: ciphertext[c*rows + r] = grid[r][c]
+        // To reverse: grid[r][c] = ciphertext[c*rows + r]
+        // Read grid row-by-row: grid[r][c] = ciphertext[c*rows + r]
+        char[] grid = new char[len];
+        for (int col = 0; col < key; col++) {
+            for (int row = 0; row < rows; row++) {
+                int cipherIdx = col * rows + row;
+                int gridIdx   = row * key  + col;
+                if (cipherIdx < len && gridIdx < len) {
+                    grid[gridIdx] = text.charAt(cipherIdx);
+                }
+            }
+        }
+
+        // Strip trailing padding spaces
+        String result = new String(grid);
+        int end = result.length();
+        while (end > 0 && result.charAt(end - 1) == ' ') end--;
+        return result.substring(0, end);
+    }
+
+    /**
+     * Brute-force attack: try all valid key values.
+     *
+     * <p>Tries key values from 2 up to {@code text.length() / 2}, inclusive.
+     * Returns an empty list if the text is too short (fewer than 4 characters).
+     *
+     * @param text the ciphertext
+     * @return list of {@link BruteForceResult} for all valid keys
+     */
+    public static List<BruteForceResult> bruteForce(String text) {
+        List<BruteForceResult> results = new ArrayList<>();
+        if (text.length() < 4) return results;
+        for (int key = 2; key <= text.length() / 2; key++) {
+            results.add(new BruteForceResult(key, decrypt(text, key)));
+        }
+        return results;
+    }
+
+    // =========================================================================
+    // Result type
+    // =========================================================================
+
+    /** A (key, plaintext) pair returned by {@link #bruteForce}. */
+    public static final class BruteForceResult {
+        /** The key tried. */
+        public final int key;
+        /** The plaintext produced by this key. */
+        public final String text;
+
+        public BruteForceResult(int key, String text) {
+            this.key  = key;
+            this.text = text;
+        }
+
+        @Override
+        public String toString() {
+            return "BruteForceResult{key=" + key + ", text=\"" + text + "\"}";
+        }
+    }
+}

--- a/code/packages/java/scytale-cipher/src/test/java/com/codingadventures/scytalecipher/ScytaleCipherTest.java
+++ b/code/packages/java/scytale-cipher/src/test/java/com/codingadventures/scytalecipher/ScytaleCipherTest.java
@@ -1,0 +1,189 @@
+// ============================================================================
+// ScytaleCipherTest.java — Unit Tests for ScytaleCipher
+// ============================================================================
+
+package com.codingadventures.scytalecipher;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScytaleCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — basic correctness
+    // =========================================================================
+
+    @Test
+    void encryptSimple() {
+        // "HELLOSPARTANS" key=4
+        // Grid:  H E L L
+        //        O S P A
+        //        R T A N
+        //        S _ _ _
+        // Cols: HORS | EST_ | LPAA | LANA_ → wait, let me recompute
+        // col 0: H,O,R,S → "HORS"
+        // col 1: E,S,T,_ → "EST "
+        // col 2: L,P,A,_ → "LPA "
+        // col 3: L,A,N,_ → "LAN "
+        assertEquals("HORSEST LPA LAN ", ScytaleCipher.encrypt("HELLOSPARTANS", 4));
+    }
+
+    @Test
+    void encryptKey2() {
+        // "ABCDEF" key=2
+        // Grid: A B
+        //       C D
+        //       E F
+        // cols: ACE | BDF
+        assertEquals("ACEBDF", ScytaleCipher.encrypt("ABCDEF", 2));
+    }
+
+    @Test
+    void encryptKey3Even() {
+        // "ABCDEF" key=3 (2 rows, no padding needed)
+        // Grid: A B C
+        //       D E F
+        // cols: AD | BE | CF
+        assertEquals("ADBECF", ScytaleCipher.encrypt("ABCDEF", 3));
+    }
+
+    @Test
+    void encryptPadsLastRow() {
+        // "HELLO" key=3
+        // Grid: H E L
+        //       L O _   ← padded
+        // cols: HL | EO | L_
+        assertEquals("HLEOL ", ScytaleCipher.encrypt("HELLO", 3));
+    }
+
+    @Test
+    void encryptEmptyString() {
+        assertEquals("", ScytaleCipher.encrypt("", 3));
+    }
+
+    @Test
+    void encryptSingleRow() {
+        // When text length == key, there's one row — ciphertext is text rotated
+        // "ABCD" key=4 → grid is just one row, columns are individual chars
+        assertEquals("ABCD", ScytaleCipher.encrypt("ABCD", 4));
+    }
+
+    @Test
+    void encryptPreservesNonAlpha() {
+        // All characters (spaces, digits, punctuation) are transposed as-is
+        // "ABCCDD" key=3: grid [A B C][C D D] → cols AC|BD|CD → "ACBDCD"
+        assertEquals("ACBDCD", ScytaleCipher.encrypt("ABCCDD", 3));
+    }
+
+    // =========================================================================
+    // 2. decrypt
+    // =========================================================================
+
+    @Test
+    void decryptSimple() {
+        assertEquals("HELLOSPARTANS", ScytaleCipher.decrypt("HORSEST LPA LAN ", 4));
+    }
+
+    @Test
+    void decryptKey2() {
+        assertEquals("ABCDEF", ScytaleCipher.decrypt("ACEBDF", 2));
+    }
+
+    @Test
+    void decryptKey3() {
+        assertEquals("ABCDEF", ScytaleCipher.decrypt("ADBECF", 3));
+    }
+
+    @Test
+    void decryptStripsPadding() {
+        // HLEOL_ where _ is a space
+        assertEquals("HELLO", ScytaleCipher.decrypt("HLEOL ", 3));
+    }
+
+    @Test
+    void decryptEmptyString() {
+        assertEquals("", ScytaleCipher.decrypt("", 4));
+    }
+
+    // =========================================================================
+    // 3. roundtrip
+    // =========================================================================
+
+    @Test
+    void roundtripNoSpecialChars() {
+        String[] texts = { "HELLOSPARTANS", "ABCDEFGHIJKLMNOP", "ATTACKATDAWN" };
+        int[] keys = { 2, 3, 4, 5 };
+        for (String text : texts) {
+            for (int key : keys) {
+                if (key <= text.length()) {
+                    assertEquals(text, ScytaleCipher.decrypt(ScytaleCipher.encrypt(text, key), key),
+                        "Roundtrip failed: text='" + text + "', key=" + key);
+                }
+            }
+        }
+    }
+
+    @Test
+    void roundtripWithSpacesInPlaintext() {
+        // Spaces in plaintext survive only when they're not at the very end
+        // (trailing spaces are stripped by decrypt). Test with spaces in the middle.
+        String text = "HELLO WORLD";
+        assertEquals(text, ScytaleCipher.decrypt(ScytaleCipher.encrypt(text, 4), 4));
+    }
+
+    // =========================================================================
+    // 4. Input validation
+    // =========================================================================
+
+    @Test
+    void encryptRejectsKey1() {
+        assertThrows(IllegalArgumentException.class, () -> ScytaleCipher.encrypt("HELLO", 1));
+    }
+
+    @Test
+    void encryptRejectsKey0() {
+        assertThrows(IllegalArgumentException.class, () -> ScytaleCipher.encrypt("HELLO", 0));
+    }
+
+    @Test
+    void encryptRejectsNegativeKey() {
+        assertThrows(IllegalArgumentException.class, () -> ScytaleCipher.encrypt("HELLO", -1));
+    }
+
+    @Test
+    void encryptRejectsKeyExceedingLength() {
+        assertThrows(IllegalArgumentException.class, () -> ScytaleCipher.encrypt("HI", 5));
+    }
+
+    @Test
+    void decryptRejectsKey1() {
+        assertThrows(IllegalArgumentException.class, () -> ScytaleCipher.decrypt("KHOOR", 1));
+    }
+
+    // =========================================================================
+    // 5. bruteForce
+    // =========================================================================
+
+    @Test
+    void bruteForceTooShortReturnsEmpty() {
+        assertEquals(0, ScytaleCipher.bruteForce("HI").size());
+        assertEquals(0, ScytaleCipher.bruteForce("HEL").size());
+    }
+
+    @Test
+    void bruteForceReturnsCorrectKeys() {
+        // "ABCDEF" (length 6) → keys 2, 3
+        List<ScytaleCipher.BruteForceResult> results = ScytaleCipher.bruteForce("ACEBDF");
+        assertEquals(2, results.get(0).key);
+        assertEquals(3, results.get(1).key);
+    }
+
+    @Test
+    void bruteForceContainsCorrectDecryption() {
+        String ciphertext = ScytaleCipher.encrypt("HELLOSPARTANS", 4);
+        List<ScytaleCipher.BruteForceResult> results = ScytaleCipher.bruteForce(ciphertext);
+        boolean found = results.stream().anyMatch(r -> r.key == 4 && r.text.equals("HELLOSPARTANS"));
+        assertTrue(found, "brute force should find key=4 → HELLOSPARTANS");
+    }
+}

--- a/code/packages/java/vigenere-cipher/.gitignore
+++ b/code/packages/java/vigenere-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/vigenere-cipher/BUILD
+++ b/code/packages/java/vigenere-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vigenere-cipher/BUILD_windows
+++ b/code/packages/java/vigenere-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vigenere-cipher/CHANGELOG.md
+++ b/code/packages/java/vigenere-cipher/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog — vigenere-cipher (Java)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Vigenère polyalphabetic substitution cipher as
+  a static utility class.
+- `encrypt(plaintext, key)` — shifts each alphabetic character by the
+  corresponding key letter; non-alpha characters pass through unchanged without
+  advancing the key position.
+- `decrypt(ciphertext, key)` — inverse shift, using `(c - shift + 26) % 26`.
+- `findKeyLength(ciphertext, maxLength)` — Index of Coincidence analysis to
+  estimate the key length; collects all candidates within 5% of the best
+  average IC, removes multiples of smaller candidates to avoid returning `2k`
+  instead of `k`, and returns the smallest residual.
+- `findKey(ciphertext, keyLength)` — chi-squared frequency analysis per group
+  to recover each keyword letter; includes minimal-period detection so that
+  even if `findKeyLength` returns a multiple of the true key, the correct
+  shorter key is returned.
+- `breakCipher(ciphertext)` — fully automatic ciphertext-only attack chaining
+  `findKeyLength` → `findKey` → `decrypt`; returns a `BreakResult` record.
+- `ENGLISH_FREQUENCIES` — public `double[]` of English letter frequencies
+  indexed A=0 … Z=25.
+- `BreakResult` — inner static final class holding the recovered `key` and
+  `plaintext`.
+- Input validation via `validateKey()`: empty key or non-alpha key throws
+  `IllegalArgumentException`.
+- Literate source with historical context, IC formula, and inline diagrams.
+- 22 unit tests covering: encryption/decryption, roundtrip, non-alpha handling,
+  key validation, IC key-length detection, chi-squared key recovery, and full
+  end-to-end break.

--- a/code/packages/java/vigenere-cipher/README.md
+++ b/code/packages/java/vigenere-cipher/README.md
@@ -1,0 +1,75 @@
+# vigenere-cipher — Java
+
+The Vigenère cipher: the "unbreakable" polyalphabetic substitution cipher that
+stumped cryptanalysts for three centuries. Also includes a full automatic
+ciphertext-only attack using the Index of Coincidence and chi-squared analysis.
+
+## Usage
+
+```java
+import com.codingadventures.vigenerecipher.VigenereCipher;
+
+VigenereCipher.encrypt("ATTACKATDAWN", "LEMON");  // → "LXFOPVEFRNHR"
+VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON");  // → "ATTACKATDAWN"
+
+// Case-insensitive key, preserves input case, non-alpha passes through
+VigenereCipher.encrypt("Hello, World!", "key");   // → "Rijvs, Uyvjn!"
+
+// Fully automatic ciphertext-only attack (needs ≥ 200 alphabetic chars)
+VigenereCipher.BreakResult result = VigenereCipher.breakCipher(ciphertext);
+System.out.println("Key: " + result.key);
+System.out.println("Plaintext: " + result.plaintext);
+
+// Step-by-step cryptanalysis
+int keyLen    = VigenereCipher.findKeyLength(ciphertext);     // → 5
+String key    = VigenereCipher.findKey(ciphertext, keyLen);   // → "LEMON"
+```
+
+## How it works
+
+### Encryption
+
+The keyword repeats to match the plaintext length. Each alphabetic character
+is shifted by the corresponding key letter (A=0, B=1, …, Z=25). Non-alpha
+characters are copied unchanged and do **not** advance the key position.
+
+```
+keyword:    L  E  M  O  N  L  E  M  O  N  L  E
+plaintext:  A  T  T  A  C  K  A  T  D  A  W  N
+shifts:    11  4 12 14 13 11  4 12 14 13  11  4
+ciphertext: L  X  F  O  P  V  E  F  R  N  H  R
+```
+
+Formula:
+- Encrypt: `C[i] = (P[i] + K[i mod len(K)]) mod 26`
+- Decrypt: `P[i] = (C[i] - K[i mod len(K)] + 26) mod 26`
+
+### Breaking it (Kasiski / Babbage method)
+
+1. **Key length** — Index of Coincidence. The IC of a random text is ≈ 0.038;
+   for English text ≈ 0.065. When the ciphertext is split into `L` groups
+   (positions 0, L, 2L, …; 1, L+1, …; etc.) and `L` equals the key length,
+   each group is a Caesar cipher and its IC is close to 0.065.
+
+2. **Key letters** — Chi-squared frequency analysis. Each group is treated as
+   a Caesar-cipher ciphertext; the shift minimising chi-squared against English
+   letter frequencies gives the key letter for that position.
+
+3. **Minimal period** — After recovering the full key, the implementation checks
+   whether it has a shorter repeating sub-period and returns that, so that even
+   if the IC analysis returns `2k` instead of `k`, the correct key is produced.
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+22 tests covering encryption, decryption, roundtrip, non-alpha handling, input
+validation, IC key-length detection, chi-squared key recovery, and the full
+end-to-end break.
+
+## Part of the Coding Adventures series
+
+Java counterpart to the Python, Rust, Go, TypeScript, and Kotlin
+implementations.

--- a/code/packages/java/vigenere-cipher/build.gradle.kts
+++ b/code/packages/java/vigenere-cipher/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/vigenere-cipher/settings.gradle.kts
+++ b/code/packages/java/vigenere-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "vigenere-cipher"

--- a/code/packages/java/vigenere-cipher/src/main/java/com/codingadventures/vigenerecipher/VigenereCipher.java
+++ b/code/packages/java/vigenere-cipher/src/main/java/com/codingadventures/vigenerecipher/VigenereCipher.java
@@ -1,0 +1,396 @@
+// ============================================================================
+// VigenereCipher.java — The polyalphabetic substitution cipher
+// ============================================================================
+//
+// The Vigenère cipher was described by Giovan Battista Bellaso in 1553 and
+// later misattributed to Blaise de Vigenère. It was called "le chiffre
+// indéchiffrable" (the unbreakable cipher) for three centuries until Charles
+// Babbage broke it around 1854 using the index of coincidence — a method
+// rediscovered independently by Friedrich Kasiski in 1863.
+//
+// The key idea:
+// -------------
+// Instead of one fixed shift (as in Caesar), the Vigenère cipher uses a
+// keyword to determine a different shift for each letter position.
+//
+//   keyword:    L E M O N L E M O N L E M O N ...  (repeats)
+//   plaintext:  A T T A C K A T D A W N
+//   shifts:     11 4 12 14 13 11 4 12 14 13 11 4
+//   ciphertext: L X F O P V E F R N H R
+//
+// Encryption formula:
+//   C[i] = (P[i] + K[i mod len(K)]) mod 26     (for alphabetic chars only)
+//
+// Decryption formula:
+//   P[i] = (C[i] - K[i mod len(K)] + 26) mod 26
+//
+// Key properties:
+// ---------------
+// - Non-alphabetic characters pass through unchanged and do NOT advance the
+//   key position counter. This matches the Python/Rust/TypeScript implementations.
+// - The key is case-insensitive (normalized to uppercase internally).
+// - An empty or non-alpha key raises IllegalArgumentException.
+//
+// Breaking Vigenère — Index of Coincidence method:
+// ------------------------------------------------
+// The Index of Coincidence (IC) of a text is the probability that two
+// randomly chosen characters are the same:
+//
+//   IC = Σ n_i(n_i - 1) / (N(N - 1))
+//
+// where n_i is the count of letter i and N is the total count of letters.
+//
+// For random text: IC ≈ 0.038
+// For English text: IC ≈ 0.065
+//
+// Key insight: if we know the key length L, we can split the ciphertext into
+// L groups (position 0, L, 2L, ...; position 1, L+1, 2L+1, ...; etc.). Each
+// group was encrypted with the SAME shift, so it behaves like a Caesar cipher.
+// The group IC will be close to English IC (0.065) when the key length is
+// correct and close to random IC (0.038) when it's wrong.
+//
+// Once we have the key length, each group is broken with chi-squared against
+// English letter frequencies — the same technique used in CaesarCipher.
+//
+
+package com.codingadventures.vigenerecipher;
+
+/**
+ * The Vigenère cipher — a polyalphabetic substitution cipher.
+ *
+ * <p>Uses a keyword to apply different Caesar shifts at each position.
+ * Non-alphabetic characters pass through unchanged without advancing the key.
+ *
+ * <p>Includes automatic ciphertext-only cryptanalysis via IC and chi-squared.
+ *
+ * <pre>{@code
+ * VigenereCipher.encrypt("ATTACKATDAWN", "LEMON")  // → "LXFOPVEFRNHR"
+ * VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON")  // → "ATTACKATDAWN"
+ *
+ * // Automatic attack (needs ≥ 200 chars for reliability)
+ * VigenereCipher.BreakResult r = VigenereCipher.breakCipher(ciphertext);
+ * System.out.println("Key: " + r.key + ", Plaintext: " + r.plaintext);
+ * }</pre>
+ */
+public final class VigenereCipher {
+
+    // Private constructor.
+    private VigenereCipher() {}
+
+    // =========================================================================
+    // English letter frequencies
+    // =========================================================================
+    //
+    // Indexed 0=A … 25=Z. Same table as CaesarCipher.
+
+    /** English letter frequencies indexed A=0 … Z=25. */
+    public static final double[] ENGLISH_FREQUENCIES = {
+        0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228, 0.02015,
+        0.06094, 0.06966, 0.00153, 0.00772, 0.04025, 0.02406, 0.06749,
+        0.07507, 0.01929, 0.00095, 0.05987, 0.06327, 0.09056, 0.02758,
+        0.00978, 0.02360, 0.00150, 0.01974, 0.00074,
+    };
+
+    // =========================================================================
+    // Key validation
+    // =========================================================================
+
+    /**
+     * Validate and normalise the keyword.
+     *
+     * @param key the raw keyword string
+     * @return the normalised keyword (uppercase, letters only confirmed)
+     * @throws IllegalArgumentException if the key is empty or contains non-alpha
+     */
+    private static String validateKey(String key) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("Key must not be empty");
+        }
+        String upper = key.toUpperCase();
+        for (int i = 0; i < upper.length(); i++) {
+            char c = upper.charAt(i);
+            if (c < 'A' || c > 'Z') {
+                throw new IllegalArgumentException(
+                    "Key must contain only letters, got: '" + key + "'");
+            }
+        }
+        return upper;
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt plaintext using the Vigenère cipher.
+     *
+     * <p>Advances the key position only on alphabetic characters. Non-alpha
+     * characters are copied unchanged.
+     *
+     * <p>Known test vector: {@code encrypt("ATTACKATDAWN", "LEMON")} → {@code "LXFOPVEFRNHR"}.
+     *
+     * @param plaintext the text to encrypt
+     * @param key       the keyword (letters only, case-insensitive)
+     * @return the ciphertext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    public static String encrypt(String plaintext, String key) {
+        String k = validateKey(key);
+        int kLen = k.length();
+        int kPos = 0;
+        StringBuilder sb = new StringBuilder(plaintext.length());
+        for (int i = 0; i < plaintext.length(); i++) {
+            char c = plaintext.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                int shift = k.charAt(kPos % kLen) - 'A';
+                sb.append((char) ('A' + (c - 'A' + shift) % 26));
+                kPos++;
+            } else if (c >= 'a' && c <= 'z') {
+                int shift = k.charAt(kPos % kLen) - 'A';
+                sb.append((char) ('a' + (c - 'a' + shift) % 26));
+                kPos++;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Decrypt ciphertext encrypted with the Vigenère cipher.
+     *
+     * @param ciphertext the text to decrypt
+     * @param key        the keyword used for encryption (letters only, case-insensitive)
+     * @return the original plaintext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    public static String decrypt(String ciphertext, String key) {
+        String k = validateKey(key);
+        int kLen = k.length();
+        int kPos = 0;
+        StringBuilder sb = new StringBuilder(ciphertext.length());
+        for (int i = 0; i < ciphertext.length(); i++) {
+            char c = ciphertext.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                int shift = k.charAt(kPos % kLen) - 'A';
+                sb.append((char) ('A' + (c - 'A' - shift + 26) % 26));
+                kPos++;
+            } else if (c >= 'a' && c <= 'z') {
+                int shift = k.charAt(kPos % kLen) - 'A';
+                sb.append((char) ('a' + (c - 'a' - shift + 26) % 26));
+                kPos++;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    // =========================================================================
+    // Cryptanalysis — Index of Coincidence key-length finder
+    // =========================================================================
+
+    /**
+     * Estimate the key length using the Index of Coincidence.
+     *
+     * <p>Tries candidate lengths from 2 to {@code maxLength} (default 20).
+     * For each candidate L, splits the ciphertext into L groups and computes
+     * the average IC across groups. The correct key length produces groups
+     * that look like Caesar-cipher ciphertext (IC ≈ 0.065) rather than random
+     * text (IC ≈ 0.038).
+     *
+     * <p>Returns the smallest candidate length within 5% of the best average IC.
+     *
+     * @param ciphertext the ciphertext (only alphabetic characters are analysed)
+     * @param maxLength  maximum key length to try (must be ≥ 2)
+     * @return the estimated key length
+     */
+    public static int findKeyLength(String ciphertext, int maxLength) {
+        // Extract only alphabetic characters
+        StringBuilder alphaOnly = new StringBuilder();
+        for (int i = 0; i < ciphertext.length(); i++) {
+            char c = ciphertext.charAt(i);
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+                alphaOnly.append(Character.toUpperCase(c));
+            }
+        }
+        String s = alphaOnly.toString();
+        int n = s.length();
+
+        int limit = Math.min(maxLength, n / 2);
+        double[] avgIcs = new double[limit + 1];
+        double bestAvgIc = -1.0;
+
+        for (int L = 2; L <= limit; L++) {
+            double totalIc = 0.0;
+            int validGroups = 0;
+            for (int g = 0; g < L; g++) {
+                // Extract every L-th character starting at position g
+                int[] counts = new int[26];
+                int groupLen = 0;
+                for (int pos = g; pos < n; pos += L) {
+                    counts[s.charAt(pos) - 'A']++;
+                    groupLen++;
+                }
+                // Compute IC for this group
+                if (groupLen < 2) continue;
+                long numerator = 0;
+                for (int i = 0; i < 26; i++) {
+                    numerator += (long) counts[i] * (counts[i] - 1);
+                }
+                totalIc += (double) numerator / ((long) groupLen * (groupLen - 1));
+                validGroups++;
+            }
+            if (validGroups > 0) {
+                avgIcs[L] = totalIc / validGroups;
+                if (avgIcs[L] > bestAvgIc) bestAvgIc = avgIcs[L];
+            }
+        }
+
+        // Return the SMALLEST candidate within 5% of the best average IC,
+        // excluding multiples of smaller candidates that also scored well.
+        //
+        // Multiples of the true key length also score well (k, 2k, 3k all
+        // produce Caesar-cipher groups). The divisor-filtering step below
+        // prevents returning 2k or 3k when k is already a qualifying candidate.
+        double threshold = bestAvgIc * 0.95;
+
+        // Collect all qualifying key-length candidates in ascending order.
+        java.util.List<Integer> candidates = new java.util.ArrayList<>();
+        for (int L = 2; L <= limit; L++) {
+            if (avgIcs[L] >= threshold) candidates.add(L);
+        }
+        if (candidates.isEmpty()) return 2;
+
+        // Remove any candidate that is a multiple of a smaller candidate in
+        // the list.  The smallest residual candidate is the true key length.
+        for (int i = 0; i < candidates.size(); i++) {
+            int smaller = candidates.get(i);
+            candidates.removeIf(bigger -> bigger != smaller && bigger % smaller == 0);
+        }
+        return candidates.get(0);
+    }
+
+    /** {@link #findKeyLength(String, int)} with default maxLength = 20. */
+    public static int findKeyLength(String ciphertext) {
+        return findKeyLength(ciphertext, 20);
+    }
+
+    // =========================================================================
+    // Cryptanalysis — chi-squared key recovery
+    // =========================================================================
+
+    /**
+     * Recover the keyword given the ciphertext and the correct key length.
+     *
+     * <p>Splits the ciphertext into {@code keyLength} groups (one per key position),
+     * then runs chi-squared analysis on each group to find the Caesar shift —
+     * which equals the corresponding keyword letter.
+     *
+     * @param ciphertext the ciphertext
+     * @param keyLength  the key length (from {@link #findKeyLength})
+     * @return the recovered keyword (uppercase)
+     */
+    public static String findKey(String ciphertext, int keyLength) {
+        // Extract alphabetic characters only, uppercase
+        StringBuilder alphaOnly = new StringBuilder();
+        for (int i = 0; i < ciphertext.length(); i++) {
+            char c = ciphertext.charAt(i);
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+                alphaOnly.append(Character.toUpperCase(c));
+            }
+        }
+        String s = alphaOnly.toString();
+
+        char[] keyChars = new char[keyLength];
+        for (int g = 0; g < keyLength; g++) {
+            // Extract every keyLength-th character
+            int[] counts = new int[26];
+            int groupLen = 0;
+            for (int pos = g; pos < s.length(); pos += keyLength) {
+                counts[s.charAt(pos) - 'A']++;
+                groupLen++;
+            }
+            if (groupLen == 0) { keyChars[g] = 'A'; continue; }
+
+            // Chi-squared against English frequencies for each shift
+            double bestScore = Double.MAX_VALUE;
+            int bestShift = 0;
+            for (int k = 0; k < 26; k++) {
+                double chiSq = 0.0;
+                for (int i = 0; i < 26; i++) {
+                    int plainIdx = (i - k + 26) % 26;
+                    double expected = ENGLISH_FREQUENCIES[plainIdx] * groupLen;
+                    double diff = counts[i] - expected;
+                    chiSq += (diff * diff) / expected;
+                }
+                if (chiSq < bestScore) {
+                    bestScore = chiSq;
+                    bestShift = k;
+                }
+            }
+            keyChars[g] = (char) ('A' + bestShift);
+        }
+
+        // If the recovered key has a repeating sub-period, return the minimal
+        // period.  This handles cases where the IC key-length estimator found
+        // a multiple of the true key length (e.g. 10 instead of 5 for LEMON).
+        String fullKey = new String(keyChars);
+        for (int p = 1; p <= keyLength / 2; p++) {
+            if (keyLength % p != 0) continue;
+            String base = fullKey.substring(0, p);
+            boolean repeated = true;
+            for (int i = p; i < keyLength; i++) {
+                if (fullKey.charAt(i) != fullKey.charAt(i % p)) {
+                    repeated = false;
+                    break;
+                }
+            }
+            if (repeated) return base;
+        }
+        return fullKey;
+    }
+
+    // =========================================================================
+    // Full automatic attack
+    // =========================================================================
+
+    /**
+     * Fully automatic ciphertext-only attack.
+     *
+     * <p>Chains {@link #findKeyLength} → {@link #findKey} → {@link #decrypt}.
+     *
+     * <p>Works best on ciphertexts of 200+ alphabetic characters.
+     *
+     * @param ciphertext the ciphertext to break
+     * @return a {@link BreakResult} with the recovered key and plaintext
+     */
+    public static BreakResult breakCipher(String ciphertext) {
+        int keyLen = findKeyLength(ciphertext);
+        String key = findKey(ciphertext, keyLen);
+        String plaintext = decrypt(ciphertext, key);
+        return new BreakResult(key, plaintext);
+    }
+
+    // =========================================================================
+    // Result type
+    // =========================================================================
+
+    /** The result of {@link #breakCipher}: recovered key and decrypted plaintext. */
+    public static final class BreakResult {
+        /** The recovered keyword (uppercase). */
+        public final String key;
+        /** The decrypted plaintext. */
+        public final String plaintext;
+
+        public BreakResult(String key, String plaintext) {
+            this.key       = key;
+            this.plaintext = plaintext;
+        }
+
+        @Override
+        public String toString() {
+            return "BreakResult{key=\"" + key + "\", plaintext=\"" + plaintext + "\"}";
+        }
+    }
+}

--- a/code/packages/java/vigenere-cipher/src/test/java/com/codingadventures/vigenerecipher/VigenereCipherTest.java
+++ b/code/packages/java/vigenere-cipher/src/test/java/com/codingadventures/vigenerecipher/VigenereCipherTest.java
@@ -1,0 +1,216 @@
+// ============================================================================
+// VigenereCipherTest.java — Unit Tests for VigenereCipher
+// ============================================================================
+
+package com.codingadventures.vigenerecipher;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VigenereCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — known test vectors
+    // =========================================================================
+
+    @Test
+    void encryptClassicLemon() {
+        // Cross-language test vector from the Python implementation
+        assertEquals("LXFOPVEFRNHR", VigenereCipher.encrypt("ATTACKATDAWN", "LEMON"));
+    }
+
+    @Test
+    void encryptMixedCase() {
+        // Key is case-insensitive; output preserves input case
+        assertEquals("Rijvs, Uyvjn!", VigenereCipher.encrypt("Hello, World!", "key"));
+    }
+
+    @Test
+    void encryptKeyRepeats() {
+        // Key "AB" means alternating shifts 0 and 1
+        // A+0=A, B+1=C, C+0=C, D+1=E, F+0=F
+        assertEquals("ACCEF", VigenereCipher.encrypt("ABCDF", "AB"));
+        // A+0=A, B+1=C, C+0=C, D+1=E, E+0=E
+        assertEquals("ACCEE", VigenereCipher.encrypt("ABCDE", "AB"));
+    }
+
+    @Test
+    void encryptNonAlphaPassesThrough() {
+        assertEquals("Rijvs, Uyvjn!", VigenereCipher.encrypt("Hello, World!", "key"));
+    }
+
+    @Test
+    void encryptNonAlphaDoesNotAdvanceKey() {
+        // "A B" with key "B": 'A' gets shifted by B(1)→B, ' ' passes through,
+        // 'B' also gets shifted by B(1)→C (key position still 1 → wraps to key[1%1=0] = B)
+        // key "B" length=1: every letter shifts by 1
+        assertEquals("B C", VigenereCipher.encrypt("A B", "B"));
+    }
+
+    @Test
+    void encryptEmptyString() {
+        assertEquals("", VigenereCipher.encrypt("", "KEY"));
+    }
+
+    @Test
+    void encryptKeyLongerThanText() {
+        // Only the first key letters are used
+        assertEquals("L", VigenereCipher.encrypt("A", "LEMON"));  // A+L=L
+    }
+
+    // =========================================================================
+    // 2. decrypt — known test vectors
+    // =========================================================================
+
+    @Test
+    void decryptClassicLemon() {
+        assertEquals("ATTACKATDAWN", VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON"));
+    }
+
+    @Test
+    void decryptMixedCase() {
+        assertEquals("Hello, World!", VigenereCipher.decrypt("Rijvs, Uyvjn!", "key"));
+    }
+
+    @Test
+    void decryptEmptyString() {
+        assertEquals("", VigenereCipher.decrypt("", "KEY"));
+    }
+
+    // =========================================================================
+    // 3. roundtrip
+    // =========================================================================
+
+    @Test
+    void roundtripVariousKeys() {
+        String[] texts = {
+            "ATTACKATDAWN", "Hello, World!", "The quick brown fox jumps over the lazy dog.",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        };
+        String[] keys = { "KEY", "LEMON", "A", "SECRETKEY" };
+        for (String text : texts) {
+            for (String key : keys) {
+                assertEquals(text, VigenereCipher.decrypt(VigenereCipher.encrypt(text, key), key),
+                    "Roundtrip failed for text='" + text + "', key=" + key);
+            }
+        }
+    }
+
+    @Test
+    void roundtripSingleCharKey() {
+        // Single-char key is equivalent to a Caesar cipher
+        String text = "Hello World";
+        assertEquals(text, VigenereCipher.decrypt(VigenereCipher.encrypt(text, "C"), "C"));
+    }
+
+    // =========================================================================
+    // 4. Input validation
+    // =========================================================================
+
+    @Test
+    void encryptRejectsEmptyKey() {
+        assertThrows(IllegalArgumentException.class, () -> VigenereCipher.encrypt("Hello", ""));
+    }
+
+    @Test
+    void encryptRejectsNonAlphaKey() {
+        assertThrows(IllegalArgumentException.class, () -> VigenereCipher.encrypt("Hello", "KEY1"));
+        assertThrows(IllegalArgumentException.class, () -> VigenereCipher.encrypt("Hello", "KE Y"));
+    }
+
+    @Test
+    void decryptRejectsEmptyKey() {
+        assertThrows(IllegalArgumentException.class, () -> VigenereCipher.decrypt("HELLO", ""));
+    }
+
+    // =========================================================================
+    // 5. findKeyLength
+    // =========================================================================
+
+    @Test
+    void findKeyLengthForLongText() {
+        // Use 300+ chars of natural English prose for reliable IC analysis
+        String plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS.";
+        String ciphertext = VigenereCipher.encrypt(plaintext, "LEMON");
+        int keyLen = VigenereCipher.findKeyLength(ciphertext);
+        assertEquals(5, keyLen);
+    }
+
+    @Test
+    void findKeyLengthKey3() {
+        String plaintext =
+            "THE HISTORY OF CRYPTOGRAPHY IS THE HISTORY OF ATTEMPTS TO COMMUNICATE " +
+            "PRIVATELY IN THE PRESENCE OF ADVERSARIES. SINCE THE EARLIEST RECORDED " +
+            "HISTORY MILITARY COMMANDERS AND DIPLOMATS HAVE USED SECRET CODES TO " +
+            "PROTECT SENSITIVE INFORMATION FROM ENEMIES AND RIVALS WHO MIGHT INTERCEPT.";
+        String ciphertext = VigenereCipher.encrypt(plaintext, "KEY");
+        int keyLen = VigenereCipher.findKeyLength(ciphertext);
+        assertEquals(3, keyLen);
+    }
+
+    // =========================================================================
+    // 6. findKey
+    // =========================================================================
+
+    @Test
+    void findKeyForLongTextLemon() {
+        String plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS.";
+        String ciphertext = VigenereCipher.encrypt(plaintext, "LEMON");
+        String recoveredKey = VigenereCipher.findKey(ciphertext, 5);
+        assertEquals("LEMON", recoveredKey);
+    }
+
+    @Test
+    void findKeyForKey3() {
+        String plaintext =
+            "THE HISTORY OF CRYPTOGRAPHY IS THE HISTORY OF ATTEMPTS TO COMMUNICATE " +
+            "PRIVATELY IN THE PRESENCE OF ADVERSARIES. SINCE THE EARLIEST RECORDED " +
+            "HISTORY MILITARY COMMANDERS AND DIPLOMATS HAVE USED SECRET CODES TO " +
+            "PROTECT SENSITIVE INFORMATION FROM ENEMIES AND RIVALS WHO MIGHT INTERCEPT.";
+        String ciphertext = VigenereCipher.encrypt(plaintext, "KEY");
+        String recoveredKey = VigenereCipher.findKey(ciphertext, 3);
+        assertEquals("KEY", recoveredKey);
+    }
+
+    // =========================================================================
+    // 7. breakCipher — full automatic attack
+    // =========================================================================
+
+    @Test
+    void breakCipherEndToEnd() {
+        String plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS. " +
+            "CHARLES BABBAGE BROKE THE CIPHER IN THE EIGHTEEN FIFTIES USING THE INDEX.";
+        String ciphertext = VigenereCipher.encrypt(plaintext, "LEMON");
+        VigenereCipher.BreakResult result = VigenereCipher.breakCipher(ciphertext);
+        assertEquals("LEMON", result.key);
+        assertEquals(plaintext, result.plaintext);
+    }
+
+    // =========================================================================
+    // 8. ENGLISH_FREQUENCIES
+    // =========================================================================
+
+    @Test
+    void englishFrequenciesLength() {
+        assertEquals(26, VigenereCipher.ENGLISH_FREQUENCIES.length);
+    }
+
+    @Test
+    void englishFrequenciesSumToOne() {
+        double sum = 0.0;
+        for (double f : VigenereCipher.ENGLISH_FREQUENCIES) sum += f;
+        assertEquals(1.0, sum, 0.001);
+    }
+}

--- a/code/packages/kotlin/atbash-cipher/.gitignore
+++ b/code/packages/kotlin/atbash-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/atbash-cipher/BUILD
+++ b/code/packages/kotlin/atbash-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/atbash-cipher/BUILD_windows
+++ b/code/packages/kotlin/atbash-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/atbash-cipher/CHANGELOG.md
+++ b/code/packages/kotlin/atbash-cipher/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — atbash-cipher (Kotlin)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Atbash substitution cipher as an idiomatic Kotlin `object`.
+- `encrypt(text)` — maps every letter to its mirror in the alphabet via `when` expression; non-alpha unchanged; case preserved.
+- `decrypt(text)` — delegates to `encrypt` because Atbash is self-inverse.
+- Literate source with inline alphabet mirror table, historical context, and self-inverse proof.
+- 24 unit tests covering: individual letters, full alphabet, case preservation, non-alpha pass-through, roundtrip (self-inverse property for all 26 letters), and known cross-language test vectors.

--- a/code/packages/kotlin/atbash-cipher/README.md
+++ b/code/packages/kotlin/atbash-cipher/README.md
@@ -1,0 +1,45 @@
+# atbash-cipher — Kotlin
+
+The Atbash cipher: an ancient Hebrew substitution cipher that mirrors the alphabet. A↔Z, B↔Y, C↔X, and so on.
+
+## Usage
+
+```kotlin
+import com.codingadventures.atbashcipher.AtbashCipher
+
+AtbashCipher.encrypt("Hello, World!")   // → "Svool, Dliow!"
+AtbashCipher.decrypt("Svool, Dliow!")   // → "Hello, World!"
+AtbashCipher.encrypt("ABCXYZ")          // → "ZYXCBA"
+```
+
+## How it works
+
+Every letter is replaced by its mirror image: position `i` (0 = A) maps to position `25 - i` (Z).
+
+```
+A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕
+Z Y X W V U T S R Q P O N M L K J I H G F E D C B A
+```
+
+Non-alphabetic characters (digits, spaces, punctuation) pass through unchanged. Case is preserved.
+
+## Self-inverse property
+
+Applying Atbash twice returns the original text — so `encrypt` and `decrypt` are the same function:
+
+```kotlin
+AtbashCipher.encrypt(AtbashCipher.encrypt("HELLO"))  // → "HELLO"
+```
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+24 tests covering individual letters, full alphabet, case preservation, non-alpha pass-through, and roundtrip self-inverse verification.
+
+## Part of the Coding Adventures series
+
+Kotlin counterpart to the Python, Rust, Go, TypeScript, and Java implementations.

--- a/code/packages/kotlin/atbash-cipher/build.gradle.kts
+++ b/code/packages/kotlin/atbash-cipher/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/atbash-cipher/settings.gradle.kts
+++ b/code/packages/kotlin/atbash-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "atbash-cipher"

--- a/code/packages/kotlin/atbash-cipher/src/main/kotlin/com/codingadventures/atbashcipher/AtbashCipher.kt
+++ b/code/packages/kotlin/atbash-cipher/src/main/kotlin/com/codingadventures/atbashcipher/AtbashCipher.kt
@@ -1,0 +1,117 @@
+// ============================================================================
+// AtbashCipher.kt — The ancient mirror substitution cipher
+// ============================================================================
+//
+// Atbash is one of the oldest known ciphers, originating in ancient Hebrew
+// writing (the name comes from the first two and last two letters of the
+// Hebrew alphabet: Aleph-Tav-Beth-Shin). It was used to encode portions of
+// the Hebrew Bible, including Jeremiah 25:26 and 51:41 where "Sheshach" is
+// understood to mean "Babel."
+//
+// The principle is elegantly simple: reverse the alphabet. A becomes Z,
+// B becomes Y, C becomes X, and so on. The mapping is a perfect mirror:
+//
+//   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+//   ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕ ↕
+//   Z Y X W V U T S R Q P O N M L K J I H G F E D C B A
+//
+// Self-inverse property:
+// ---------------------
+// Atbash has a beautiful mathematical property: applying it twice returns the
+// original text. This means encrypt and decrypt are the same operation:
+//
+//   encrypt("HELLO") = "SVOOL"
+//   encrypt("SVOOL") = "HELLO"   ← applying Atbash to the ciphertext recovers plaintext
+//
+// Why this works: if A is position 0 and Z is position 25, then Atbash maps
+// position i to position (25 - i). Applying it again gives (25 - (25 - i)) = i.
+// The operation is its own inverse.
+//
+// Security:
+// ---------
+// Atbash provides NO security by modern standards. It is a monoalphabetic
+// substitution cipher with a fixed, known key. Every letter always maps to the
+// same substitute, so frequency analysis immediately breaks it. Atbash is a
+// useful teaching tool, not a security mechanism.
+//
+
+package com.codingadventures.atbashcipher
+
+/**
+ * The Atbash cipher — a monoalphabetic substitution cipher that mirrors the alphabet.
+ *
+ * Maps each letter to its mirror image: A↔Z, B↔Y, C↔X, and so on. Non-alphabetic
+ * characters (digits, spaces, punctuation) pass through unchanged. Case is preserved.
+ *
+ * The cipher is self-inverse: `decrypt(encrypt(text)) == text` for any input,
+ * and in fact `encrypt` and `decrypt` perform the exact same operation.
+ *
+ * ```kotlin
+ * AtbashCipher.encrypt("Hello, World!")  // → "Svool, Dliow!"
+ * AtbashCipher.decrypt("Svool, Dliow!")  // → "Hello, World!"
+ * AtbashCipher.encrypt("ABCXYZ")         // → "ZYXCBA"
+ * ```
+ */
+object AtbashCipher {
+
+    // =========================================================================
+    // Core mapping
+    // =========================================================================
+    //
+    // The Atbash mapping is equivalent to reflecting each letter around the
+    // midpoint of the alphabet. For any letter at position i (0-indexed from A):
+    //
+    //   mapped position = 25 - i
+    //
+    // Examples:
+    //   A (position  0) → Z (position 25)
+    //   B (position  1) → Y (position 24)
+    //   M (position 12) → N (position 13)
+    //   Z (position 25) → A (position  0)
+
+    /**
+     * Apply the Atbash mirror mapping to a single character.
+     *
+     * Returns the mirror image if alphabetic, or the character unchanged if not.
+     */
+    private fun mapChar(c: Char): Char = when {
+        c in 'A'..'Z' -> ('A'.code + 'Z'.code - c.code).toChar()
+        c in 'a'..'z' -> ('a'.code + 'z'.code - c.code).toChar()
+        else -> c
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt a string using the Atbash cipher.
+     *
+     * Maps every letter to its mirror image in the alphabet. Non-alphabetic
+     * characters are copied unchanged. Case is preserved.
+     *
+     * Truth table for a few letters:
+     * ```
+     *   A → Z    B → Y    C → X    D → W    E → V    F → U
+     *   G → T    H → S    I → R    J → Q    K → P    L → O
+     *   M → N    N → M    O → L    P → K    Q → J    R → I
+     *   S → H    T → G    U → F    V → E    W → D    X → C
+     *   Y → B    Z → A
+     * ```
+     *
+     * @param text the plaintext to encrypt
+     * @return the ciphertext with letters mirrored
+     */
+    fun encrypt(text: String): String = text.map { mapChar(it) }.joinToString("")
+
+    /**
+     * Decrypt a string that was encrypted with the Atbash cipher.
+     *
+     * Identical to [encrypt] because Atbash is its own inverse:
+     * applying the mirror mapping twice returns the original text.
+     *
+     * @param text the ciphertext to decrypt
+     * @return the original plaintext
+     */
+    fun decrypt(text: String): String = encrypt(text)
+}

--- a/code/packages/kotlin/atbash-cipher/src/test/kotlin/com/codingadventures/atbashcipher/AtbashCipherTest.kt
+++ b/code/packages/kotlin/atbash-cipher/src/test/kotlin/com/codingadventures/atbashcipher/AtbashCipherTest.kt
@@ -1,0 +1,140 @@
+// ============================================================================
+// AtbashCipherTest.kt — Unit Tests for AtbashCipher
+// ============================================================================
+
+package com.codingadventures.atbashcipher
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class AtbashCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — basic correctness
+    // =========================================================================
+
+    @Test fun encryptSingleUpperA() = assertEquals("Z", AtbashCipher.encrypt("A"))
+    @Test fun encryptSingleUpperZ() = assertEquals("A", AtbashCipher.encrypt("Z"))
+    @Test fun encryptSingleUpperM() = assertEquals("N", AtbashCipher.encrypt("M"))
+    @Test fun encryptSingleUpperN() = assertEquals("M", AtbashCipher.encrypt("N"))
+
+    @Test fun encryptSingleLowerA() = assertEquals("z", AtbashCipher.encrypt("a"))
+    @Test fun encryptSingleLowerZ() = assertEquals("a", AtbashCipher.encrypt("z"))
+    @Test fun encryptSingleLowerM() = assertEquals("n", AtbashCipher.encrypt("m"))
+    @Test fun encryptSingleLowerN() = assertEquals("m", AtbashCipher.encrypt("n"))
+
+    @Test
+    fun encryptFullUppercaseAlphabet() =
+        assertEquals("ZYXWVUTSRQPONMLKJIHGFEDCBA", AtbashCipher.encrypt("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+
+    @Test
+    fun encryptFullLowercaseAlphabet() =
+        assertEquals("zyxwvutsrqponmlkjihgfedcba", AtbashCipher.encrypt("abcdefghijklmnopqrstuvwxyz"))
+
+    @Test
+    fun encryptPreservesCase() {
+        assertEquals("Svool", AtbashCipher.encrypt("Hello"))
+        assertEquals("SVOOL", AtbashCipher.encrypt("HELLO"))
+        assertEquals("svool", AtbashCipher.encrypt("hello"))
+    }
+
+    @Test
+    fun encryptHelloWorld() = assertEquals("Svool, Dliow!", AtbashCipher.encrypt("Hello, World!"))
+
+    @Test
+    fun encryptPassesThroughNonAlpha() {
+        assertEquals("123", AtbashCipher.encrypt("123"))
+        assertEquals("!@#", AtbashCipher.encrypt("!@#"))
+        assertEquals(" ", AtbashCipher.encrypt(" "))
+        assertEquals("A1B2", AtbashCipher.encrypt("Z1Y2"))
+    }
+
+    @Test fun encryptEmptyString() = assertEquals("", AtbashCipher.encrypt(""))
+
+    @Test
+    fun encryptMixedContent() =
+        // A→Z t→g t→g a→z c→x k→p ' ' a→z t→g ' ' D→W a→z w→d n→m
+        assertEquals("Zggzxp zg Wzdm", AtbashCipher.encrypt("Attack at Dawn"))
+
+    // =========================================================================
+    // 2. decrypt — same as encrypt (self-inverse)
+    // =========================================================================
+
+    @Test
+    fun decryptIsEncrypt() {
+        listOf("Hello, World!", "ABCXYZ", "The quick brown fox", "", "123!@#", "Svool")
+            .forEach { text ->
+                assertEquals(
+                    AtbashCipher.encrypt(text),
+                    AtbashCipher.decrypt(text),
+                    "decrypt should equal encrypt for: $text"
+                )
+            }
+    }
+
+    @Test
+    fun decryptInvertsEncrypt() {
+        listOf(
+            "Hello, World!", "ATTACK AT DAWN",
+            "The quick brown fox jumps over the lazy dog",
+            "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "Mixed CASE text!"
+        ).forEach { plaintext ->
+            assertEquals(
+                plaintext,
+                AtbashCipher.decrypt(AtbashCipher.encrypt(plaintext)),
+                "Roundtrip failed for: $plaintext"
+            )
+        }
+    }
+
+    @Test fun decryptEmptyString() = assertEquals("", AtbashCipher.decrypt(""))
+
+    // =========================================================================
+    // 3. Self-inverse property
+    // =========================================================================
+
+    @Test
+    fun selfInverseForEveryLetter() {
+        for (c in 'A'..'Z') {
+            val s = c.toString()
+            assertEquals(s, AtbashCipher.encrypt(AtbashCipher.encrypt(s)), "Failed for: $c")
+        }
+        for (c in 'a'..'z') {
+            val s = c.toString()
+            assertEquals(s, AtbashCipher.encrypt(AtbashCipher.encrypt(s)), "Failed for: $c")
+        }
+    }
+
+    @Test
+    fun selfInverseForSentence() {
+        val original = "The quick brown fox jumps over the lazy dog."
+        assertEquals(original, AtbashCipher.encrypt(AtbashCipher.encrypt(original)))
+    }
+
+    // =========================================================================
+    // 4. Known test vectors (cross-language parity)
+    // =========================================================================
+
+    @Test fun knownVectorAttack() = assertEquals("ZGGZXP", AtbashCipher.encrypt("ATTACK"))
+    @Test fun knownVectorHello()  = assertEquals("SVOOL",  AtbashCipher.encrypt("HELLO"))
+
+    @Test
+    fun knownVectorMirrorPairs() {
+        assertEquals("ABCXYZ", AtbashCipher.encrypt("ZYXCBA"))
+        assertEquals("ZYXCBA", AtbashCipher.encrypt("ABCXYZ"))
+    }
+
+    // =========================================================================
+    // 5. Non-ASCII pass-through
+    // =========================================================================
+
+    @Test
+    fun nonAsciiPassesThrough() {
+        // "Xzuv" → X→C, z→a, u→f, v→e → "Cafe"
+        assertEquals("Cafe", AtbashCipher.encrypt("Xzuv"))
+        assertEquals("Svool Dliow", AtbashCipher.encrypt("Hello World"))
+        assertEquals("C1f2", AtbashCipher.encrypt("X1u2"))
+    }
+}

--- a/code/packages/kotlin/caesar-cipher/.gitignore
+++ b/code/packages/kotlin/caesar-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/caesar-cipher/BUILD
+++ b/code/packages/kotlin/caesar-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/caesar-cipher/BUILD_windows
+++ b/code/packages/kotlin/caesar-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/caesar-cipher/CHANGELOG.md
+++ b/code/packages/kotlin/caesar-cipher/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog — caesar-cipher (Kotlin)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Caesar shift cipher as an idiomatic Kotlin `object`.
+- `encrypt(text, shift)` — shifts letters forward by `shift` mod 26; negative shifts work; non-alpha unchanged; case preserved.
+- `decrypt(text, shift)` — delegates to `encrypt(text, -shift)`.
+- `rot13(text)` — Caesar with shift=13; self-inverse.
+- `bruteForce(ciphertext)` — returns all 25 non-trivial candidates as `List<BruteForceResult>` (data class).
+- `frequencyAnalysis(ciphertext)` — chi-squared attack against English letter frequencies; returns `FrequencyResult` (data class).
+- `ENGLISH_FREQUENCIES` — public `DoubleArray` of 26 letter frequencies (A–Z).
+- Literate source with inline shift table, historical context, and security discussion.
+- 26 unit tests covering: shift arithmetic (mod 26, negatives, large values), case preservation, non-alpha passthrough, ROT13 self-inverse, brute force size/content, frequency analysis on long English texts (shift=3 and shift=13).

--- a/code/packages/kotlin/caesar-cipher/README.md
+++ b/code/packages/kotlin/caesar-cipher/README.md
@@ -1,0 +1,34 @@
+# caesar-cipher — Kotlin
+
+The Caesar cipher: the classical shift cipher used by Julius Caesar himself, plus ROT13, brute-force, and frequency analysis.
+
+## Usage
+
+```kotlin
+import com.codingadventures.caesarcipher.CaesarCipher
+
+CaesarCipher.encrypt("Hello, World!", 3)  // → "Khoor, Zruog!"
+CaesarCipher.decrypt("Khoor, Zruog!", 3)  // → "Hello, World!"
+CaesarCipher.rot13("Hello")               // → "Uryyb"
+
+// Brute force: try all 25 shifts
+CaesarCipher.bruteForce("KHOOR").forEach { (shift, text) ->
+    println("shift $shift: $text")
+}
+
+// Frequency analysis: automatic attack
+val (shift, plaintext) = CaesarCipher.frequencyAnalysis("KHOOR...")
+println("Likely shift: $shift, plaintext: $plaintext")
+```
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+26 tests covering shift arithmetic, ROT13, brute-force, and frequency analysis on long English texts.
+
+## Part of the Coding Adventures series
+
+Kotlin counterpart to the Python, Rust, Go, TypeScript, and Java implementations.

--- a/code/packages/kotlin/caesar-cipher/build.gradle.kts
+++ b/code/packages/kotlin/caesar-cipher/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/caesar-cipher/settings.gradle.kts
+++ b/code/packages/kotlin/caesar-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "caesar-cipher"

--- a/code/packages/kotlin/caesar-cipher/src/main/kotlin/com/codingadventures/caesarcipher/CaesarCipher.kt
+++ b/code/packages/kotlin/caesar-cipher/src/main/kotlin/com/codingadventures/caesarcipher/CaesarCipher.kt
@@ -1,0 +1,196 @@
+// ============================================================================
+// CaesarCipher.kt — The classical shift cipher
+// ============================================================================
+//
+// The Caesar cipher is named after Julius Caesar, who reportedly used a shift
+// of 3 to protect messages of military significance.
+//
+// The principle is simple: shift every letter forward in the alphabet by a
+// fixed number of positions, wrapping around from Z back to A.
+//
+//   shift = 3:   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+//                ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
+//                D E F G H I J K L M N O P Q R S T U V W X Y Z A B C
+//
+//   encrypt("HELLO", 3) = "KHOOR"
+//   decrypt("KHOOR", 3) = "HELLO"
+//
+// ROT13:
+// ------
+// ROT13 is a special case with shift = 13. Because the alphabet has 26 letters,
+// shifting by 13 is self-inverse: ROT13(ROT13("HELLO")) = "HELLO".
+//
+// Security:
+// ---------
+// The Caesar cipher has only 26 possible keys (shifts 0–25). An attacker can
+// try all 26 in under a second. Even without brute force, frequency analysis
+// works instantly. This cipher provides no real security.
+//
+
+package com.codingadventures.caesarcipher
+
+/**
+ * The Caesar cipher — a classical shift cipher.
+ *
+ * Shifts every letter forward in the alphabet by a fixed amount. Non-alphabetic
+ * characters pass through unchanged. Case is preserved.
+ *
+ * Includes ROT13 (shift=13), brute-force decryption (all 25 shifts), and
+ * frequency analysis for automatic ciphertext-only attack.
+ *
+ * ```kotlin
+ * CaesarCipher.encrypt("Hello, World!", 3)  // → "Khoor, Zruog!"
+ * CaesarCipher.decrypt("Khoor, Zruog!", 3)  // → "Hello, World!"
+ * CaesarCipher.rot13("Hello")               // → "Uryyb"
+ * ```
+ */
+object CaesarCipher {
+
+    // =========================================================================
+    // English letter frequencies (for chi-squared analysis)
+    // =========================================================================
+    //
+    // The frequency of each letter A–Z in typical English text.
+    // Key insight: 'E' (index 4) is most common at ~12.7%.
+
+    /** English letter frequencies indexed A=0 … Z=25. */
+    val ENGLISH_FREQUENCIES: DoubleArray = doubleArrayOf(
+        0.08167, // A
+        0.01492, // B
+        0.02782, // C
+        0.04253, // D
+        0.12702, // E  ← most common
+        0.02228, // F
+        0.02015, // G
+        0.06094, // H
+        0.06966, // I
+        0.00153, // J
+        0.00772, // K
+        0.04025, // L
+        0.02406, // M
+        0.06749, // N
+        0.07507, // O
+        0.01929, // P
+        0.00095, // Q
+        0.05987, // R
+        0.06327, // S
+        0.09056, // T
+        0.02758, // U
+        0.00978, // V
+        0.02360, // W
+        0.00150, // X
+        0.01974, // Y
+        0.00074, // Z
+    )
+
+    // =========================================================================
+    // Core shift
+    // =========================================================================
+
+    /** Shift a single alphabetic character. Non-alpha returned unchanged. */
+    private fun shiftChar(c: Char, shift: Int): Char {
+        val normalizedShift = ((shift % 26) + 26) % 26
+        return when {
+            c in 'A'..'Z' -> ('A'.code + (c.code - 'A'.code + normalizedShift) % 26).toChar()
+            c in 'a'..'z' -> ('a'.code + (c.code - 'a'.code + normalizedShift) % 26).toChar()
+            else -> c
+        }
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt a string by shifting every letter forward by [shift] positions.
+     *
+     * Shift is taken modulo 26, so values outside 0–25 work correctly.
+     * Negative shifts are allowed (equivalent to decrypting with that shift).
+     *
+     * @param text  the plaintext
+     * @param shift any integer — taken mod 26 internally
+     * @return the ciphertext
+     */
+    fun encrypt(text: String, shift: Int): String =
+        text.map { shiftChar(it, shift) }.joinToString("")
+
+    /**
+     * Decrypt a string by shifting every letter backward by [shift] positions.
+     *
+     * Equivalent to `encrypt(text, -shift)`.
+     *
+     * @param text  the ciphertext
+     * @param shift the shift used during encryption
+     * @return the original plaintext
+     */
+    fun decrypt(text: String, shift: Int): String = encrypt(text, -shift)
+
+    /**
+     * ROT13 — Caesar cipher with shift = 13.
+     *
+     * Self-inverse: `rot13(rot13(text)) == text`. Widely used online to
+     * obscure spoilers and punchlines.
+     *
+     * @param text any string
+     * @return the ROT13 transformation
+     */
+    fun rot13(text: String): String = encrypt(text, 13)
+
+    /**
+     * Try all 25 non-trivial shifts and return every possible decryption.
+     *
+     * @param ciphertext the ciphertext to crack
+     * @return list of [BruteForceResult] for shifts 1–25
+     */
+    fun bruteForce(ciphertext: String): List<BruteForceResult> =
+        (1..25).map { shift -> BruteForceResult(shift, decrypt(ciphertext, shift)) }
+
+    /**
+     * Automatic frequency-analysis attack — find the most likely shift.
+     *
+     * Counts letters in the ciphertext, computes chi-squared against the
+     * expected English distribution for each possible shift, and returns
+     * the shift with the lowest chi-squared score.
+     *
+     * @param ciphertext the ciphertext (only alphabetic characters are analysed)
+     * @return the best (shift, plaintext) guess; shift=0 for empty input
+     */
+    fun frequencyAnalysis(ciphertext: String): FrequencyResult {
+        val counts = IntArray(26)
+        var total = 0
+        for (c in ciphertext) {
+            when {
+                c in 'A'..'Z' -> { counts[c - 'A']++; total++ }
+                c in 'a'..'z' -> { counts[c - 'a']++; total++ }
+            }
+        }
+        if (total == 0) return FrequencyResult(0, ciphertext)
+
+        var bestScore = Double.MAX_VALUE
+        var bestShift = 0
+        for (k in 0 until 26) {
+            var chiSq = 0.0
+            for (i in 0 until 26) {
+                val plainIdx = (i - k + 26) % 26
+                val expected = ENGLISH_FREQUENCIES[plainIdx] * total
+                val diff = counts[i] - expected
+                chiSq += diff * diff / expected
+            }
+            if (chiSq < bestScore) {
+                bestScore = chiSq
+                bestShift = k
+            }
+        }
+        return FrequencyResult(bestShift, decrypt(ciphertext, bestShift))
+    }
+
+    // =========================================================================
+    // Result types
+    // =========================================================================
+
+    /** A (shift, plaintext) pair returned by [bruteForce]. */
+    data class BruteForceResult(val shift: Int, val text: String)
+
+    /** A (shift, plaintext) pair returned by [frequencyAnalysis]. */
+    data class FrequencyResult(val shift: Int, val text: String)
+}

--- a/code/packages/kotlin/caesar-cipher/src/test/kotlin/com/codingadventures/caesarcipher/CaesarCipherTest.kt
+++ b/code/packages/kotlin/caesar-cipher/src/test/kotlin/com/codingadventures/caesarcipher/CaesarCipherTest.kt
@@ -1,0 +1,186 @@
+// ============================================================================
+// CaesarCipherTest.kt — Unit Tests for CaesarCipher
+// ============================================================================
+
+package com.codingadventures.caesarcipher
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaesarCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — basic correctness
+    // =========================================================================
+
+    @Test fun encryptShift0IsIdentity() {
+        assertEquals("Hello", CaesarCipher.encrypt("Hello", 0))
+        assertEquals("ABCXYZ", CaesarCipher.encrypt("ABCXYZ", 0))
+    }
+
+    @Test fun encryptShift1Wrap() {
+        assertEquals("B", CaesarCipher.encrypt("A", 1))
+        assertEquals("A", CaesarCipher.encrypt("Z", 1))  // wraps
+    }
+
+    @Test fun encryptShift3Classic() {
+        assertEquals("KHOOR", CaesarCipher.encrypt("HELLO", 3))
+        assertEquals("Khoor, Zruog!", CaesarCipher.encrypt("Hello, World!", 3))
+    }
+
+    @Test fun encryptShift13Rot13() =
+        assertEquals("URYYB", CaesarCipher.encrypt("HELLO", 13))
+
+    @Test fun encryptShift25() {
+        assertEquals("Z", CaesarCipher.encrypt("A", 25))
+        assertEquals("ABCDE", CaesarCipher.encrypt("BCDEF", 25))
+    }
+
+    @Test fun encryptPreservesCase() {
+        assertEquals("Khoor", CaesarCipher.encrypt("Hello", 3))
+        assertEquals("KHOOR", CaesarCipher.encrypt("HELLO", 3))
+        assertEquals("khoor", CaesarCipher.encrypt("hello", 3))
+    }
+
+    @Test fun encryptNonAlphaPassesThrough() {
+        assertEquals("Khoor, Zruog!", CaesarCipher.encrypt("Hello, World!", 3))
+        assertEquals("123 !@#", CaesarCipher.encrypt("123 !@#", 7))
+    }
+
+    @Test fun encryptEmptyString() = assertEquals("", CaesarCipher.encrypt("", 5))
+
+    // =========================================================================
+    // 2. shift arithmetic — mod 26 and negatives
+    // =========================================================================
+
+    @Test fun encryptShift26IsIdentity() {
+        assertEquals("HELLO", CaesarCipher.encrypt("HELLO", 26))
+        assertEquals("HELLO", CaesarCipher.encrypt("HELLO", 52))
+    }
+
+    @Test fun encryptNegativeShift() =
+        assertEquals("HELLO", CaesarCipher.encrypt("KHOOR", -3))
+
+    @Test fun encryptLargePositiveShift() =
+        assertEquals(CaesarCipher.encrypt("HELLO", 3), CaesarCipher.encrypt("HELLO", 29))
+
+    // =========================================================================
+    // 3. decrypt
+    // =========================================================================
+
+    @Test fun decryptShift3() {
+        assertEquals("HELLO", CaesarCipher.decrypt("KHOOR", 3))
+        assertEquals("Hello, World!", CaesarCipher.decrypt("Khoor, Zruog!", 3))
+    }
+
+    @Test fun decryptRoundtrip() {
+        val texts = listOf("Hello, World!", "ATTACK AT DAWN", "The quick brown fox.", "")
+        val shifts = listOf(1, 3, 13, 25)
+        for (text in texts) {
+            for (shift in shifts) {
+                assertEquals(
+                    text,
+                    CaesarCipher.decrypt(CaesarCipher.encrypt(text, shift), shift),
+                    "Roundtrip failed for text='$text', shift=$shift"
+                )
+            }
+        }
+    }
+
+    // =========================================================================
+    // 4. ROT13
+    // =========================================================================
+
+    @Test fun rot13Basic() {
+        assertEquals("URYYB", CaesarCipher.rot13("HELLO"))
+        assertEquals("HELLO", CaesarCipher.rot13("URYYB"))
+    }
+
+    @Test fun rot13SelfInverse() {
+        listOf("Hello, World!", "Why did the chicken cross the road?", "ABCxyz")
+            .forEach { text ->
+                assertEquals(
+                    text,
+                    CaesarCipher.rot13(CaesarCipher.rot13(text)),
+                    "ROT13 self-inverse failed for: $text"
+                )
+            }
+    }
+
+    @Test fun rot13NonAlphaUnchanged() =
+        assertEquals("Uryyb, Jbeyq!", CaesarCipher.rot13("Hello, World!"))
+
+    // =========================================================================
+    // 5. bruteForce
+    // =========================================================================
+
+    @Test fun bruteForceReturns25Results() =
+        assertEquals(25, CaesarCipher.bruteForce("KHOOR").size)
+
+    @Test fun bruteForceShiftsAre1Through25() {
+        CaesarCipher.bruteForce("KHOOR").forEachIndexed { i, r ->
+            assertEquals(i + 1, r.shift)
+        }
+    }
+
+    @Test fun bruteForceContainsCorrectDecryption() {
+        val results = CaesarCipher.bruteForce("KHOOR")
+        assertTrue(results.any { it.shift == 3 && it.text == "HELLO" },
+            "brute force should include shift=3, text=HELLO")
+    }
+
+    @Test fun bruteForceEmptyString() {
+        val results = CaesarCipher.bruteForce("")
+        assertEquals(25, results.size)
+        assertTrue(results.all { it.text == "" })
+    }
+
+    // =========================================================================
+    // 6. frequencyAnalysis
+    // =========================================================================
+
+    @Test fun frequencyAnalysisEmptyString() {
+        val result = CaesarCipher.frequencyAnalysis("")
+        assertEquals(0, result.shift)
+        assertEquals("", result.text)
+    }
+
+    @Test fun frequencyAnalysisLongEnglishText() {
+        val plaintext = "The quick brown fox jumps over the lazy dog. " +
+            "Pack my box with five dozen liquor jugs. " +
+            "How vexingly quick daft zebras jump."
+        val ciphertext = CaesarCipher.encrypt(plaintext, 13)
+        val result = CaesarCipher.frequencyAnalysis(ciphertext)
+        assertEquals(13, result.shift, "Frequency analysis should recover shift=13")
+        assertEquals(plaintext, result.text)
+    }
+
+    @Test fun frequencyAnalysisShift3() {
+        val plaintext = "In the beginning God created the heavens and the earth. " +
+            "The earth was without form and void and darkness was over the face of the deep."
+        val ciphertext = CaesarCipher.encrypt(plaintext, 3)
+        val result = CaesarCipher.frequencyAnalysis(ciphertext)
+        assertEquals(3, result.shift, "Frequency analysis should recover shift=3")
+    }
+
+    // =========================================================================
+    // 7. ENGLISH_FREQUENCIES constant
+    // =========================================================================
+
+    @Test fun englishFrequenciesLength() =
+        assertEquals(26, CaesarCipher.ENGLISH_FREQUENCIES.size)
+
+    @Test fun englishFrequenciesSumToOne() {
+        val sum = CaesarCipher.ENGLISH_FREQUENCIES.sum()
+        assertEquals(1.0, sum, 0.001, "Frequencies should sum to ~1.0")
+    }
+
+    @Test fun eIsTheMostCommonLetter() {
+        val eFreq = CaesarCipher.ENGLISH_FREQUENCIES[4]  // 'E'
+        for (i in 0 until 26) {
+            if (i != 4) assertTrue(eFreq >= CaesarCipher.ENGLISH_FREQUENCIES[i],
+                "E should be most frequent; index $i had higher freq")
+        }
+    }
+}

--- a/code/packages/kotlin/scytale-cipher/.gitignore
+++ b/code/packages/kotlin/scytale-cipher/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/scytale-cipher/BUILD
+++ b/code/packages/kotlin/scytale-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/scytale-cipher/BUILD_windows
+++ b/code/packages/kotlin/scytale-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/scytale-cipher/CHANGELOG.md
+++ b/code/packages/kotlin/scytale-cipher/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — scytale-cipher (Kotlin)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Scytale columnar transposition cipher as an idiomatic Kotlin `object`.
+- `encrypt(text, key)` — writes row-by-row with `padEnd` space padding, reads column-by-column via `buildString`.
+- `decrypt(text, key)` — inverse transposition; uses `trimEnd` to strip padding spaces.
+- `bruteForce(text)` — tries keys 2 to `text.length / 2`; returns `List<BruteForceResult>` (data class).
+- Input validation via `require()`.
+- Literate source with grid diagram, historical context, and security discussion.
+- 17 unit tests covering: basic encryption/decryption, padding, roundtrip, input validation, and brute force.

--- a/code/packages/kotlin/scytale-cipher/README.md
+++ b/code/packages/kotlin/scytale-cipher/README.md
@@ -1,0 +1,44 @@
+# scytale-cipher — Kotlin
+
+The Scytale cipher: the ancient Spartan transposition cipher. Messages are written into a grid and read column-by-column — the key is the number of columns.
+
+## Usage
+
+```kotlin
+import com.codingadventures.scytalecipher.ScytaleCipher
+
+ScytaleCipher.encrypt("HELLOSPARTANS", 4)     // → "HORSEST LPA LAN "
+ScytaleCipher.decrypt("HORSEST LPA LAN ", 4)  // → "HELLOSPARTANS"
+
+// Brute force all possible keys
+ScytaleCipher.bruteForce(ciphertext).forEach { (key, text) ->
+    println("key $key: $text")
+}
+```
+
+## How it works
+
+Write the plaintext row-by-row into a grid of `key` columns (padding the last row with spaces), then read column-by-column:
+
+```
+Input: "HELLOSPARTANS"   key=4
+
+Grid:  H E L L
+       O S P A
+       R T A N
+       S _ _ _
+
+Output (read by columns): "HORSEST LPA LAN "
+```
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+17 tests covering encryption, decryption, roundtrip, padding, input validation, and brute force.
+
+## Part of the Coding Adventures series
+
+Kotlin counterpart to the Python, Rust, Go, TypeScript, and Java implementations.

--- a/code/packages/kotlin/scytale-cipher/build.gradle.kts
+++ b/code/packages/kotlin/scytale-cipher/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/scytale-cipher/settings.gradle.kts
+++ b/code/packages/kotlin/scytale-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "scytale-cipher"

--- a/code/packages/kotlin/scytale-cipher/src/main/kotlin/com/codingadventures/scytalecipher/ScytaleCipher.kt
+++ b/code/packages/kotlin/scytale-cipher/src/main/kotlin/com/codingadventures/scytalecipher/ScytaleCipher.kt
@@ -1,0 +1,146 @@
+// ============================================================================
+// ScytaleCipher.kt — The ancient Greek transposition cipher
+// ============================================================================
+//
+// The scytale (pronounced "SKIT-uh-lee") was used by the Spartans around
+// 7th century BCE. A strip of parchment was wound helically around a wooden
+// staff, and the message was written lengthwise. When unwound, the strip
+// appeared as a jumble of characters — unreadable without a staff of the
+// same diameter to re-wind it.
+//
+// The key is the diameter of the staff, translated to the number of columns
+// in a grid:
+//
+//   Plaintext: "HELLOSPARTANS"   key = 4 (columns)
+//
+//   Write row-by-row into 4 columns, padding with spaces:
+//     Row 0:  H  E  L  L
+//     Row 1:  O  S  P  A
+//     Row 2:  R  T  A  N
+//     Row 3:  S  _  _  _
+//
+//   Read column-by-column:
+//     Col 0: H O R S
+//     Col 1: E S T _
+//     Col 2: L P A _
+//     Col 3: L A N _
+//
+//   Ciphertext: "HORSEST LPA LAN "
+//
+// This is a pure transposition cipher — letters are not changed, only their
+// positions are rearranged.
+//
+
+package com.codingadventures.scytalecipher
+
+/**
+ * The Scytale cipher — a columnar transposition cipher.
+ *
+ * Encrypts by writing plaintext row-by-row into a grid of [key] columns,
+ * then reading column-by-column. Padding spaces fill the last row.
+ *
+ * Decrypts by writing ciphertext column-by-column, reading row-by-row,
+ * then stripping trailing padding spaces.
+ *
+ * ```kotlin
+ * ScytaleCipher.encrypt("HELLOSPARTANS", 4)  // → "HORSEST LPA LAN "
+ * ScytaleCipher.decrypt("HORSEST LPA LAN ", 4)  // → "HELLOSPARTANS"
+ * ```
+ */
+object ScytaleCipher {
+
+    // =========================================================================
+    // Validation helper
+    // =========================================================================
+
+    private fun validateKey(key: Int, textLen: Int) {
+        require(key >= 2) { "key must be at least 2, got: $key" }
+        require(textLen == 0 || key <= textLen) {
+            "key ($key) must not exceed text length ($textLen)"
+        }
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt plaintext using the Scytale cipher.
+     *
+     * Writes text row-by-row into a grid of [key] columns, padding the last
+     * row with spaces, then reads column-by-column.
+     *
+     * @param text the plaintext
+     * @param key  the number of columns (≥ 2, ≤ text length if non-empty)
+     * @return the ciphertext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    fun encrypt(text: String, key: Int): String {
+        if (text.isEmpty()) return ""
+        validateKey(key, text.length)
+
+        val rows = (text.length + key - 1) / key
+        val paddedLen = rows * key
+        val padded = text.padEnd(paddedLen, ' ')
+
+        return buildString(paddedLen) {
+            for (col in 0 until key) {
+                for (row in 0 until rows) {
+                    append(padded[row * key + col])
+                }
+            }
+        }
+    }
+
+    /**
+     * Decrypt ciphertext that was encrypted with the Scytale cipher.
+     *
+     * Writes ciphertext column-by-column into a grid, reads row-by-row,
+     * then strips trailing padding spaces.
+     *
+     * @param text the ciphertext
+     * @param key  the number of columns used during encryption (≥ 2)
+     * @return the original plaintext (trailing padding spaces stripped)
+     * @throws IllegalArgumentException if key is invalid
+     */
+    fun decrypt(text: String, key: Int): String {
+        if (text.isEmpty()) return ""
+        validateKey(key, text.length)
+
+        val len = text.length
+        val rows = (len + key - 1) / key
+        val grid = CharArray(len)
+
+        for (col in 0 until key) {
+            for (row in 0 until rows) {
+                val cipherIdx = col * rows + row
+                val gridIdx   = row * key  + col
+                if (cipherIdx < len && gridIdx < len) {
+                    grid[gridIdx] = text[cipherIdx]
+                }
+            }
+        }
+
+        return String(grid).trimEnd(' ')
+    }
+
+    /**
+     * Brute-force attack: try all valid key values from 2 to text.length / 2.
+     *
+     * Returns an empty list if the text is too short (fewer than 4 characters).
+     *
+     * @param text the ciphertext
+     * @return list of [BruteForceResult] for all valid keys
+     */
+    fun bruteForce(text: String): List<BruteForceResult> {
+        if (text.length < 4) return emptyList()
+        return (2..text.length / 2).map { key -> BruteForceResult(key, decrypt(text, key)) }
+    }
+
+    // =========================================================================
+    // Result type
+    // =========================================================================
+
+    /** A (key, plaintext) pair returned by [bruteForce]. */
+    data class BruteForceResult(val key: Int, val text: String)
+}

--- a/code/packages/kotlin/scytale-cipher/src/test/kotlin/com/codingadventures/scytalecipher/ScytaleCipherTest.kt
+++ b/code/packages/kotlin/scytale-cipher/src/test/kotlin/com/codingadventures/scytalecipher/ScytaleCipherTest.kt
@@ -1,0 +1,112 @@
+// ============================================================================
+// ScytaleCipherTest.kt — Unit Tests for ScytaleCipher
+// ============================================================================
+
+package com.codingadventures.scytalecipher
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ScytaleCipherTest {
+
+    // =========================================================================
+    // 1. encrypt
+    // =========================================================================
+
+    @Test
+    fun encryptSimple() =
+        // "HELLOSPARTANS" key=4 → cols HORS|EST_|LPA_|LAN_ → "HORSEST LPA LAN "
+        assertEquals("HORSEST LPA LAN ", ScytaleCipher.encrypt("HELLOSPARTANS", 4))
+
+    @Test fun encryptKey2() = assertEquals("ACEBDF", ScytaleCipher.encrypt("ABCDEF", 2))
+
+    @Test fun encryptKey3Even() = assertEquals("ADBECF", ScytaleCipher.encrypt("ABCDEF", 3))
+
+    @Test
+    fun encryptPadsLastRow() =
+        // "HELLO" key=3: [H E L][L O _] → cols HL|EO|L_ → "HLEOL "
+        assertEquals("HLEOL ", ScytaleCipher.encrypt("HELLO", 3))
+
+    @Test fun encryptEmptyString() = assertEquals("", ScytaleCipher.encrypt("", 3))
+
+    @Test fun encryptSingleRow() = assertEquals("ABCD", ScytaleCipher.encrypt("ABCD", 4))
+
+    @Test
+    fun encryptPreservesNonAlpha() =
+        // "ABCCDD" key=3: [A B C][C D D] → cols AC|BD|CD → "ACBDCD"
+        assertEquals("ACBDCD", ScytaleCipher.encrypt("ABCCDD", 3))
+
+    // =========================================================================
+    // 2. decrypt
+    // =========================================================================
+
+    @Test fun decryptSimple() = assertEquals("HELLOSPARTANS", ScytaleCipher.decrypt("HORSEST LPA LAN ", 4))
+    @Test fun decryptKey2()  = assertEquals("ABCDEF", ScytaleCipher.decrypt("ACEBDF", 2))
+    @Test fun decryptKey3()  = assertEquals("ABCDEF", ScytaleCipher.decrypt("ADBECF", 3))
+
+    @Test
+    fun decryptStripsPadding() = assertEquals("HELLO", ScytaleCipher.decrypt("HLEOL ", 3))
+
+    @Test fun decryptEmptyString() = assertEquals("", ScytaleCipher.decrypt("", 4))
+
+    // =========================================================================
+    // 3. roundtrip
+    // =========================================================================
+
+    @Test
+    fun roundtripNoSpecialChars() {
+        val texts = listOf("HELLOSPARTANS", "ABCDEFGHIJKLMNOP", "ATTACKATDAWN")
+        val keys  = listOf(2, 3, 4, 5)
+        for (text in texts) for (key in keys) {
+            if (key <= text.length) {
+                assertEquals(
+                    text,
+                    ScytaleCipher.decrypt(ScytaleCipher.encrypt(text, key), key),
+                    "Roundtrip failed: text='$text', key=$key"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun roundtripWithSpacesInMiddle() {
+        val text = "HELLO WORLD"
+        assertEquals(text, ScytaleCipher.decrypt(ScytaleCipher.encrypt(text, 4), 4))
+    }
+
+    // =========================================================================
+    // 4. Input validation
+    // =========================================================================
+
+    @Test fun encryptRejectsKey1()       = assertThrows<IllegalArgumentException> { ScytaleCipher.encrypt("HELLO", 1) }
+    @Test fun encryptRejectsKey0()       = assertThrows<IllegalArgumentException> { ScytaleCipher.encrypt("HELLO", 0) }
+    @Test fun encryptRejectsNegativeKey()= assertThrows<IllegalArgumentException> { ScytaleCipher.encrypt("HELLO", -1) }
+    @Test fun encryptRejectsKeyTooLarge()= assertThrows<IllegalArgumentException> { ScytaleCipher.encrypt("HI", 5) }
+    @Test fun decryptRejectsKey1()       = assertThrows<IllegalArgumentException> { ScytaleCipher.decrypt("KHOOR", 1) }
+
+    // =========================================================================
+    // 5. bruteForce
+    // =========================================================================
+
+    @Test fun bruteForceTooShortReturnsEmpty() {
+        assertEquals(0, ScytaleCipher.bruteForce("HI").size)
+        assertEquals(0, ScytaleCipher.bruteForce("HEL").size)
+    }
+
+    @Test
+    fun bruteForceReturnsCorrectKeys() {
+        val results = ScytaleCipher.bruteForce("ACEBDF")  // length 6 → keys 2, 3
+        assertEquals(2, results[0].key)
+        assertEquals(3, results[1].key)
+    }
+
+    @Test
+    fun bruteForceContainsCorrectDecryption() {
+        val ciphertext = ScytaleCipher.encrypt("HELLOSPARTANS", 4)
+        val results = ScytaleCipher.bruteForce(ciphertext)
+        assertTrue(results.any { it.key == 4 && it.text == "HELLOSPARTANS" },
+            "brute force should find key=4 → HELLOSPARTANS")
+    }
+}

--- a/code/packages/kotlin/vigenere-cipher/.gitignore
+++ b/code/packages/kotlin/vigenere-cipher/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+gradle-build/

--- a/code/packages/kotlin/vigenere-cipher/BUILD
+++ b/code/packages/kotlin/vigenere-cipher/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vigenere-cipher/BUILD_windows
+++ b/code/packages/kotlin/vigenere-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vigenere-cipher/CHANGELOG.md
+++ b/code/packages/kotlin/vigenere-cipher/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — vigenere-cipher (Kotlin)
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- Initial implementation of the Vigenère polyalphabetic substitution cipher as
+  an idiomatic Kotlin `object`.
+- `encrypt(text, key)` — shifts each alphabetic character by the corresponding
+  key letter; non-alpha characters pass through unchanged without advancing the
+  key position.
+- `decrypt(text, key)` — inverse shift, using `(c - shift + 26) % 26`.
+- `findKeyLength(ciphertext, maxLength)` — Index of Coincidence analysis to
+  estimate the key length; collects all candidates within 5% of the best
+  average IC and removes multiples of smaller candidates, then returns the
+  smallest residual to avoid returning `2k` or `3k` instead of the true `k`.
+- `findKey(ciphertext, keyLength)` — chi-squared frequency analysis per group
+  to recover each keyword letter; includes minimal-period detection so that
+  even if `findKeyLength` returns a multiple of the true key, the correct
+  shorter key is returned.
+- `breakCipher(ciphertext)` — fully automatic ciphertext-only attack chaining
+  `findKeyLength` → `findKey` → `decrypt`; returns a `BreakResult` data class.
+- `ENGLISH_FREQUENCIES` — public `DoubleArray` of English letter frequencies
+  indexed A=0 … Z=25.
+- `BreakResult` — `data class` holding the recovered `key` and `plaintext`.
+- Input validation via `require()`: empty key or non-alpha key throws
+  `IllegalArgumentException`.
+- Literate source with historical context, IC formula, and inline diagrams.
+- 22 unit tests covering: encryption/decryption, roundtrip, non-alpha handling,
+  key validation, IC key-length detection, chi-squared key recovery, full
+  end-to-end break, and `BreakResult` data class behaviour.

--- a/code/packages/kotlin/vigenere-cipher/README.md
+++ b/code/packages/kotlin/vigenere-cipher/README.md
@@ -1,0 +1,75 @@
+# vigenere-cipher — Kotlin
+
+The Vigenère cipher: the "unbreakable" polyalphabetic substitution cipher that
+stumped cryptanalysts for three centuries. Also includes a full automatic
+ciphertext-only attack using the Index of Coincidence and chi-squared analysis.
+
+## Usage
+
+```kotlin
+import com.codingadventures.vigenerecipher.VigenereCipher
+
+VigenereCipher.encrypt("ATTACKATDAWN", "LEMON")  // → "LXFOPVEFRNHR"
+VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON")  // → "ATTACKATDAWN"
+
+// Case-insensitive key, preserves input case, non-alpha passes through
+VigenereCipher.encrypt("Hello, World!", "key")    // → "Rijvs, Uyvjn!"
+
+// Fully automatic ciphertext-only attack (needs ≥ 200 alphabetic chars)
+val result = VigenereCipher.breakCipher(ciphertext)
+println("Key: ${result.key}")        // → "LEMON"
+println("Plaintext: ${result.plaintext}")
+
+// Step-by-step cryptanalysis
+val keyLen = VigenereCipher.findKeyLength(ciphertext)   // → 5
+val key    = VigenereCipher.findKey(ciphertext, keyLen) // → "LEMON"
+```
+
+## How it works
+
+### Encryption
+
+The keyword repeats to match the plaintext length. Each alphabetic character
+is shifted by the corresponding key letter (A=0, B=1, …, Z=25). Non-alpha
+characters are copied unchanged and do **not** advance the key position.
+
+```
+keyword:    L  E  M  O  N  L  E  M  O  N  L  E
+plaintext:  A  T  T  A  C  K  A  T  D  A  W  N
+shifts:    11  4 12 14 13 11  4 12 14 13 11  4
+ciphertext: L  X  F  O  P  V  E  F  R  N  H  R
+```
+
+Formula:
+- Encrypt: `C[i] = (P[i] + K[i mod len(K)]) mod 26`
+- Decrypt: `P[i] = (C[i] - K[i mod len(K)] + 26) mod 26`
+
+### Breaking it (Kasiski / Babbage method)
+
+1. **Key length** — Index of Coincidence. The IC of a random text is ≈ 0.038;
+   for English text ≈ 0.065. When the ciphertext is split into `L` groups
+   (positions 0, L, 2L, …; 1, L+1, …; etc.) and `L` equals the key length,
+   each group is a Caesar cipher and its IC is close to 0.065.
+
+2. **Key letters** — Chi-squared frequency analysis. Each group is treated as
+   a Caesar-cipher ciphertext; the shift minimising chi-squared against English
+   letter frequencies gives the key letter for that position.
+
+3. **Minimal period** — After recovering the full key, the implementation checks
+   whether it has a shorter repeating sub-period and returns that, so that even
+   if the IC analysis returns `2k` instead of `k`, the correct key is produced.
+
+## Running Tests
+
+```bash
+gradle test
+```
+
+22 tests covering encryption, decryption, roundtrip, non-alpha handling, input
+validation, IC key-length detection, chi-squared key recovery, and the full
+end-to-end break.
+
+## Part of the Coding Adventures series
+
+Kotlin counterpart to the Python, Rust, Go, TypeScript, and Java
+implementations.

--- a/code/packages/kotlin/vigenere-cipher/build.gradle.kts
+++ b/code/packages/kotlin/vigenere-cipher/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/vigenere-cipher/settings.gradle.kts
+++ b/code/packages/kotlin/vigenere-cipher/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "vigenere-cipher"

--- a/code/packages/kotlin/vigenere-cipher/src/main/kotlin/com/codingadventures/vigenerecipher/VigenereCipher.kt
+++ b/code/packages/kotlin/vigenere-cipher/src/main/kotlin/com/codingadventures/vigenerecipher/VigenereCipher.kt
@@ -1,0 +1,347 @@
+// ============================================================================
+// VigenereCipher.kt — The polyalphabetic substitution cipher
+// ============================================================================
+//
+// The Vigenère cipher was described by Giovan Battista Bellaso in 1553 and
+// later misattributed to Blaise de Vigenère. It was called "le chiffre
+// indéchiffrable" (the unbreakable cipher) for three centuries until Charles
+// Babbage broke it around 1854 using the index of coincidence — a method
+// rediscovered independently by Friedrich Kasiski in 1863.
+//
+// The key idea:
+// -------------
+// Instead of one fixed shift (as in Caesar), the Vigenère cipher uses a
+// keyword to determine a different shift for each letter position.
+//
+//   keyword:    L E M O N L E M O N L E M O N ...  (repeats)
+//   plaintext:  A T T A C K A T D A W N
+//   shifts:     11 4 12 14 13 11 4 12 14 13 11 4
+//   ciphertext: L X F O P V E F R N H R
+//
+// Encryption formula:
+//   C[i] = (P[i] + K[i mod len(K)]) mod 26     (for alphabetic chars only)
+//
+// Decryption formula:
+//   P[i] = (C[i] - K[i mod len(K)] + 26) mod 26
+//
+// Key properties:
+// ---------------
+// - Non-alphabetic characters pass through unchanged and do NOT advance the
+//   key position counter.  This matches the Java/Python/Rust/TypeScript
+//   implementations.
+// - The key is case-insensitive (normalised to uppercase internally).
+// - An empty or non-alpha key raises IllegalArgumentException.
+//
+// Breaking Vigenère — Index of Coincidence method:
+// ------------------------------------------------
+// The Index of Coincidence (IC) of a text is the probability that two
+// randomly chosen characters are the same:
+//
+//   IC = Σ n_i(n_i - 1) / (N(N - 1))
+//
+// where n_i is the count of letter i and N is the total count of letters.
+//
+// For random text: IC ≈ 0.038
+// For English text: IC ≈ 0.065
+//
+// Key insight: if we know the key length L, we can split the ciphertext into
+// L groups (position 0, L, 2L, ...; position 1, L+1, 2L+1, ...; etc.).  Each
+// group was encrypted with the SAME shift, so it behaves like a Caesar cipher.
+// The group IC will be close to English IC (0.065) when the key length is
+// correct and close to random IC (0.038) when it's wrong.
+//
+// Once we have the key length, each group is broken with chi-squared against
+// English letter frequencies — the same technique used in CaesarCipher.
+//
+
+package com.codingadventures.vigenerecipher
+
+/**
+ * The Vigenère cipher — a polyalphabetic substitution cipher.
+ *
+ * Uses a keyword to apply different Caesar shifts at each position.
+ * Non-alphabetic characters pass through unchanged without advancing the key.
+ *
+ * Includes automatic ciphertext-only cryptanalysis via IC and chi-squared.
+ *
+ * ```kotlin
+ * VigenereCipher.encrypt("ATTACKATDAWN", "LEMON")  // → "LXFOPVEFRNHR"
+ * VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON")  // → "ATTACKATDAWN"
+ *
+ * // Automatic attack (needs ≥ 200 chars for reliability)
+ * val r = VigenereCipher.breakCipher(ciphertext)
+ * println("Key: ${r.key}, Plaintext: ${r.plaintext}")
+ * ```
+ */
+object VigenereCipher {
+
+    // =========================================================================
+    // English letter frequencies
+    // =========================================================================
+    //
+    // Indexed 0=A … 25=Z.  Same table as CaesarCipher.
+
+    /** English letter frequencies indexed A=0 … Z=25. */
+    val ENGLISH_FREQUENCIES: DoubleArray = doubleArrayOf(
+        0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228, 0.02015,
+        0.06094, 0.06966, 0.00153, 0.00772, 0.04025, 0.02406, 0.06749,
+        0.07507, 0.01929, 0.00095, 0.05987, 0.06327, 0.09056, 0.02758,
+        0.00978, 0.02360, 0.00150, 0.01974, 0.00074,
+    )
+
+    // =========================================================================
+    // Key validation
+    // =========================================================================
+
+    /**
+     * Validate and normalise the keyword.
+     *
+     * @throws IllegalArgumentException if the key is empty or contains non-alpha
+     */
+    private fun validateKey(key: String): String {
+        require(key.isNotEmpty()) { "Key must not be empty" }
+        val upper = key.uppercase()
+        require(upper.all { it in 'A'..'Z' }) {
+            "Key must contain only letters, got: '$key'"
+        }
+        return upper
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Encrypt [plaintext] using the Vigenère cipher.
+     *
+     * Advances the key position only on alphabetic characters.  Non-alpha
+     * characters are copied unchanged.
+     *
+     * Known test vector: `encrypt("ATTACKATDAWN", "LEMON")` → `"LXFOPVEFRNHR"`.
+     *
+     * @param plaintext the text to encrypt
+     * @param key       the keyword (letters only, case-insensitive)
+     * @return the ciphertext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    fun encrypt(plaintext: String, key: String): String {
+        val k = validateKey(key)
+        val kLen = k.length
+        var kPos = 0
+        return buildString(plaintext.length) {
+            for (c in plaintext) {
+                when {
+                    c in 'A'..'Z' -> {
+                        val shift = k[kPos % kLen].code - 'A'.code
+                        append(('A'.code + (c.code - 'A'.code + shift) % 26).toChar())
+                        kPos++
+                    }
+                    c in 'a'..'z' -> {
+                        val shift = k[kPos % kLen].code - 'A'.code
+                        append(('a'.code + (c.code - 'a'.code + shift) % 26).toChar())
+                        kPos++
+                    }
+                    else -> append(c)
+                }
+            }
+        }
+    }
+
+    /**
+     * Decrypt [ciphertext] encrypted with the Vigenère cipher.
+     *
+     * @param ciphertext the text to decrypt
+     * @param key        the keyword used for encryption (letters only, case-insensitive)
+     * @return the original plaintext
+     * @throws IllegalArgumentException if key is invalid
+     */
+    fun decrypt(ciphertext: String, key: String): String {
+        val k = validateKey(key)
+        val kLen = k.length
+        var kPos = 0
+        return buildString(ciphertext.length) {
+            for (c in ciphertext) {
+                when {
+                    c in 'A'..'Z' -> {
+                        val shift = k[kPos % kLen].code - 'A'.code
+                        append(('A'.code + (c.code - 'A'.code - shift + 26) % 26).toChar())
+                        kPos++
+                    }
+                    c in 'a'..'z' -> {
+                        val shift = k[kPos % kLen].code - 'A'.code
+                        append(('a'.code + (c.code - 'a'.code - shift + 26) % 26).toChar())
+                        kPos++
+                    }
+                    else -> append(c)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Cryptanalysis — Index of Coincidence key-length finder
+    // =========================================================================
+
+    /**
+     * Estimate the key length using the Index of Coincidence.
+     *
+     * Tries candidate lengths from 2 to [maxLength] (default 20).  For each
+     * candidate L, splits the ciphertext into L groups and computes the average
+     * IC across groups.  The correct key length produces groups that look like
+     * Caesar-cipher ciphertext (IC ≈ 0.065) rather than random text (IC ≈ 0.038).
+     *
+     * Returns the smallest candidate length within 5% of the best average IC,
+     * after filtering out any candidates that are multiples of smaller
+     * qualifying candidates (since k, 2k, 3k … all produce high IC).
+     *
+     * @param ciphertext the ciphertext (only alphabetic characters are analysed)
+     * @param maxLength  maximum key length to try (must be ≥ 2)
+     * @return the estimated key length
+     */
+    fun findKeyLength(ciphertext: String, maxLength: Int = 20): Int {
+        // Extract only alphabetic characters, uppercase.
+        val s = ciphertext.filter { it.isLetter() }.uppercase()
+        val n = s.length
+
+        val limit = minOf(maxLength, n / 2)
+        val avgIcs = DoubleArray(limit + 1)
+        var bestAvgIc = -1.0
+
+        for (l in 2..limit) {
+            var totalIc = 0.0
+            var validGroups = 0
+            for (g in 0 until l) {
+                // Extract every l-th character starting at position g.
+                val counts = IntArray(26)
+                var groupLen = 0
+                var pos = g
+                while (pos < n) {
+                    counts[s[pos].code - 'A'.code]++
+                    groupLen++
+                    pos += l
+                }
+                if (groupLen < 2) continue
+                // IC = Σ n_i(n_i - 1) / (N(N - 1))
+                val numerator = counts.sumOf { c -> c.toLong() * (c - 1) }
+                totalIc += numerator.toDouble() / (groupLen.toLong() * (groupLen - 1))
+                validGroups++
+            }
+            if (validGroups > 0) {
+                avgIcs[l] = totalIc / validGroups
+                if (avgIcs[l] > bestAvgIc) bestAvgIc = avgIcs[l]
+            }
+        }
+
+        // Collect all candidates within 5% of the best average IC.
+        val threshold = bestAvgIc * 0.95
+        val candidates = (2..limit).filter { avgIcs[it] >= threshold }.toMutableList()
+        if (candidates.isEmpty()) return 2
+
+        // Remove any candidate that is a multiple of a smaller candidate in the
+        // list.  Multiples of the true key length also score well; the smallest
+        // residual is the true key length.
+        for (smaller in candidates.toList()) {
+            candidates.removeAll { bigger -> bigger != smaller && bigger % smaller == 0 }
+        }
+        return candidates.first()
+    }
+
+    // =========================================================================
+    // Cryptanalysis — chi-squared key recovery
+    // =========================================================================
+
+    /**
+     * Recover the keyword given the ciphertext and the correct key length.
+     *
+     * Splits the ciphertext into [keyLength] groups (one per key position),
+     * then runs chi-squared analysis on each group to find the Caesar shift —
+     * which equals the corresponding keyword letter.
+     *
+     * After recovering all characters, checks whether the key has a repeating
+     * sub-period and returns the minimal period.  This makes [findKey] robust
+     * even when [findKeyLength] returns a multiple of the true key length.
+     *
+     * @param ciphertext the ciphertext
+     * @param keyLength  the key length (from [findKeyLength])
+     * @return the recovered keyword (uppercase)
+     */
+    fun findKey(ciphertext: String, keyLength: Int): String {
+        val s = ciphertext.filter { it.isLetter() }.uppercase()
+        val keyChars = CharArray(keyLength)
+
+        for (g in 0 until keyLength) {
+            // Build letter-frequency counts for group g.
+            val counts = IntArray(26)
+            var groupLen = 0
+            var pos = g
+            while (pos < s.length) {
+                counts[s[pos].code - 'A'.code]++
+                groupLen++
+                pos += keyLength
+            }
+            if (groupLen == 0) { keyChars[g] = 'A'; continue }
+
+            // Chi-squared against English frequencies for each shift.
+            var bestScore = Double.MAX_VALUE
+            var bestShift = 0
+            for (k in 0 until 26) {
+                var chiSq = 0.0
+                for (i in 0 until 26) {
+                    val plainIdx = (i - k + 26) % 26
+                    val expected = ENGLISH_FREQUENCIES[plainIdx] * groupLen
+                    val diff = counts[i] - expected
+                    chiSq += (diff * diff) / expected
+                }
+                if (chiSq < bestScore) {
+                    bestScore = chiSq
+                    bestShift = k
+                }
+            }
+            keyChars[g] = ('A'.code + bestShift).toChar()
+        }
+
+        // Return the minimal period of the key.  If the IC estimator returned
+        // a multiple of the true key (e.g. 10 for LEMON), the full key is
+        // LEMONLEMON — which has minimal period 5, giving back "LEMON".
+        val fullKey = String(keyChars)
+        for (p in 1..keyLength / 2) {
+            if (keyLength % p != 0) continue
+            val base = fullKey.substring(0, p)
+            if ((p until keyLength).all { i -> fullKey[i] == fullKey[i % p] }) return base
+        }
+        return fullKey
+    }
+
+    // =========================================================================
+    // Full automatic attack
+    // =========================================================================
+
+    /**
+     * Fully automatic ciphertext-only attack.
+     *
+     * Chains [findKeyLength] → [findKey] → [decrypt].
+     *
+     * Works best on ciphertexts of 200+ alphabetic characters.
+     *
+     * @param ciphertext the ciphertext to break
+     * @return a [BreakResult] with the recovered key and plaintext
+     */
+    fun breakCipher(ciphertext: String): BreakResult {
+        val keyLen = findKeyLength(ciphertext)
+        val key = findKey(ciphertext, keyLen)
+        val plaintext = decrypt(ciphertext, key)
+        return BreakResult(key, plaintext)
+    }
+
+    // =========================================================================
+    // Result type
+    // =========================================================================
+
+    /** The result of [breakCipher]: recovered key and decrypted plaintext. */
+    data class BreakResult(
+        /** The recovered keyword (uppercase). */
+        val key: String,
+        /** The decrypted plaintext. */
+        val plaintext: String,
+    )
+}

--- a/code/packages/kotlin/vigenere-cipher/src/test/kotlin/com/codingadventures/vigenerecipher/VigenereCipherTest.kt
+++ b/code/packages/kotlin/vigenere-cipher/src/test/kotlin/com/codingadventures/vigenerecipher/VigenereCipherTest.kt
@@ -1,0 +1,240 @@
+// ============================================================================
+// VigenereCipherTest.kt — Unit Tests for VigenereCipher
+// ============================================================================
+
+package com.codingadventures.vigenerecipher
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class VigenereCipherTest {
+
+    // =========================================================================
+    // 1. encrypt — known test vectors
+    // =========================================================================
+
+    @Test
+    fun encryptClassicLemon() {
+        // Cross-language test vector from the Python/Java implementations
+        assertEquals("LXFOPVEFRNHR", VigenereCipher.encrypt("ATTACKATDAWN", "LEMON"))
+    }
+
+    @Test
+    fun encryptMixedCase() {
+        // Key is case-insensitive; output preserves input case
+        assertEquals("Rijvs, Uyvjn!", VigenereCipher.encrypt("Hello, World!", "key"))
+    }
+
+    @Test
+    fun encryptKeyRepeats() {
+        // Key "AB" means alternating shifts 0 and 1
+        // A+0=A, B+1=C, C+0=C, D+1=E, F+0=F
+        assertEquals("ACCEF", VigenereCipher.encrypt("ABCDF", "AB"))
+        // A+0=A, B+1=C, C+0=C, D+1=E, E+0=E
+        assertEquals("ACCEE", VigenereCipher.encrypt("ABCDE", "AB"))
+    }
+
+    @Test
+    fun encryptNonAlphaPassesThrough() {
+        assertEquals("Rijvs, Uyvjn!", VigenereCipher.encrypt("Hello, World!", "key"))
+    }
+
+    @Test
+    fun encryptNonAlphaDoesNotAdvanceKey() {
+        // "A B" with key "B": 'A' shifted by B(1) → B, ' ' passes through,
+        // 'B' also shifted by B(1) → C (key length=1, every letter shifts by 1)
+        assertEquals("B C", VigenereCipher.encrypt("A B", "B"))
+    }
+
+    @Test
+    fun encryptEmptyString() {
+        assertEquals("", VigenereCipher.encrypt("", "KEY"))
+    }
+
+    @Test
+    fun encryptKeyLongerThanText() {
+        // Only the first key letters are used
+        assertEquals("L", VigenereCipher.encrypt("A", "LEMON"))  // A+L=L
+    }
+
+    // =========================================================================
+    // 2. decrypt — known test vectors
+    // =========================================================================
+
+    @Test
+    fun decryptClassicLemon() {
+        assertEquals("ATTACKATDAWN", VigenereCipher.decrypt("LXFOPVEFRNHR", "LEMON"))
+    }
+
+    @Test
+    fun decryptMixedCase() {
+        assertEquals("Hello, World!", VigenereCipher.decrypt("Rijvs, Uyvjn!", "key"))
+    }
+
+    @Test
+    fun decryptEmptyString() {
+        assertEquals("", VigenereCipher.decrypt("", "KEY"))
+    }
+
+    // =========================================================================
+    // 3. roundtrip
+    // =========================================================================
+
+    @Test
+    fun roundtripVariousKeys() {
+        val texts = listOf(
+            "ATTACKATDAWN", "Hello, World!", "The quick brown fox jumps over the lazy dog.",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        )
+        val keys = listOf("KEY", "LEMON", "A", "SECRETKEY")
+        for (text in texts) {
+            for (key in keys) {
+                assertEquals(
+                    text,
+                    VigenereCipher.decrypt(VigenereCipher.encrypt(text, key), key),
+                    "Roundtrip failed for text='$text', key=$key",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun roundtripSingleCharKey() {
+        // Single-char key is equivalent to a Caesar cipher
+        val text = "Hello World"
+        assertEquals(text, VigenereCipher.decrypt(VigenereCipher.encrypt(text, "C"), "C"))
+    }
+
+    // =========================================================================
+    // 4. Input validation
+    // =========================================================================
+
+    @Test
+    fun encryptRejectsEmptyKey() {
+        assertFailsWith<IllegalArgumentException> { VigenereCipher.encrypt("Hello", "") }
+    }
+
+    @Test
+    fun encryptRejectsNonAlphaKey() {
+        assertFailsWith<IllegalArgumentException> { VigenereCipher.encrypt("Hello", "KEY1") }
+        assertFailsWith<IllegalArgumentException> { VigenereCipher.encrypt("Hello", "KE Y") }
+    }
+
+    @Test
+    fun decryptRejectsEmptyKey() {
+        assertFailsWith<IllegalArgumentException> { VigenereCipher.decrypt("HELLO", "") }
+    }
+
+    // =========================================================================
+    // 5. findKeyLength
+    // =========================================================================
+
+    @Test
+    fun findKeyLengthForLongText() {
+        // Use 300+ chars of natural English prose for reliable IC analysis
+        val plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS."
+        val ciphertext = VigenereCipher.encrypt(plaintext, "LEMON")
+        val keyLen = VigenereCipher.findKeyLength(ciphertext)
+        assertEquals(5, keyLen)
+    }
+
+    @Test
+    fun findKeyLengthKey3() {
+        val plaintext =
+            "THE HISTORY OF CRYPTOGRAPHY IS THE HISTORY OF ATTEMPTS TO COMMUNICATE " +
+            "PRIVATELY IN THE PRESENCE OF ADVERSARIES. SINCE THE EARLIEST RECORDED " +
+            "HISTORY MILITARY COMMANDERS AND DIPLOMATS HAVE USED SECRET CODES TO " +
+            "PROTECT SENSITIVE INFORMATION FROM ENEMIES AND RIVALS WHO MIGHT INTERCEPT."
+        val ciphertext = VigenereCipher.encrypt(plaintext, "KEY")
+        val keyLen = VigenereCipher.findKeyLength(ciphertext)
+        assertEquals(3, keyLen)
+    }
+
+    // =========================================================================
+    // 6. findKey
+    // =========================================================================
+
+    @Test
+    fun findKeyForLongTextLemon() {
+        val plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS."
+        val ciphertext = VigenereCipher.encrypt(plaintext, "LEMON")
+        val recoveredKey = VigenereCipher.findKey(ciphertext, 5)
+        assertEquals("LEMON", recoveredKey)
+    }
+
+    @Test
+    fun findKeyForKey3() {
+        val plaintext =
+            "THE HISTORY OF CRYPTOGRAPHY IS THE HISTORY OF ATTEMPTS TO COMMUNICATE " +
+            "PRIVATELY IN THE PRESENCE OF ADVERSARIES. SINCE THE EARLIEST RECORDED " +
+            "HISTORY MILITARY COMMANDERS AND DIPLOMATS HAVE USED SECRET CODES TO " +
+            "PROTECT SENSITIVE INFORMATION FROM ENEMIES AND RIVALS WHO MIGHT INTERCEPT."
+        val ciphertext = VigenereCipher.encrypt(plaintext, "KEY")
+        val recoveredKey = VigenereCipher.findKey(ciphertext, 3)
+        assertEquals("KEY", recoveredKey)
+    }
+
+    // =========================================================================
+    // 7. breakCipher — full automatic attack
+    // =========================================================================
+
+    @Test
+    fun breakCipherEndToEnd() {
+        val plaintext =
+            "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+            "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+            "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+            "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS. " +
+            "CHARLES BABBAGE BROKE THE CIPHER IN THE EIGHTEEN FIFTIES USING THE INDEX."
+        val ciphertext = VigenereCipher.encrypt(plaintext, "LEMON")
+        val result = VigenereCipher.breakCipher(ciphertext)
+        assertEquals("LEMON", result.key)
+        assertEquals(plaintext, result.plaintext)
+    }
+
+    // =========================================================================
+    // 8. ENGLISH_FREQUENCIES
+    // =========================================================================
+
+    @Test
+    fun englishFrequenciesLength() {
+        assertEquals(26, VigenereCipher.ENGLISH_FREQUENCIES.size)
+    }
+
+    @Test
+    fun englishFrequenciesSumToOne() {
+        val sum = VigenereCipher.ENGLISH_FREQUENCIES.sum()
+        assertEquals(1.0, sum, 0.001)
+    }
+
+    // =========================================================================
+    // 9. BreakResult data class
+    // =========================================================================
+
+    @Test
+    fun breakResultDataClass() {
+        val r = VigenereCipher.BreakResult("LEMON", "ATTACKATDAWN")
+        assertEquals("LEMON", r.key)
+        assertEquals("ATTACKATDAWN", r.plaintext)
+        // Data class equality
+        val r2 = VigenereCipher.BreakResult("LEMON", "ATTACKATDAWN")
+        assertEquals(r, r2)
+    }
+
+    @Test
+    fun breakResultToString() {
+        val r = VigenereCipher.BreakResult("KEY", "HELLO")
+        val s = r.toString()
+        assert(s.contains("KEY")) { "toString should include key: $s" }
+        assert(s.contains("HELLO")) { "toString should include plaintext: $s" }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds Java + Kotlin implementations of 4 classic ciphers: **Atbash**, **Caesar**, **Scytale**, and **Vigenère** (8 new packages total)
- Each package has literate source, comprehensive tests, BUILD files, README, and CHANGELOG

### Package highlights

| Package | Tests | Notes |
|---------|-------|-------|
| `java/atbash-cipher` | 18 | Self-inverse mirror cipher; `encrypt = decrypt` |
| `kotlin/atbash-cipher` | 24 | Kotlin `object`; uses `.code` arithmetic for Char math |
| `java/caesar-cipher` | 26 | ROT13, brute force, chi-squared frequency analysis |
| `kotlin/caesar-cipher` | 26 | Same; `data class BruteForceResult / FrequencyResult` |
| `java/scytale-cipher` | 22 | Columnar transposition with brute force |
| `kotlin/scytale-cipher` | 17 | `padEnd` + `buildString` + `trimEnd` idioms |
| `java/vigenere-cipher` | 22 | IC key-length finder + chi-squared key recovery + `breakCipher` |
| `kotlin/vigenere-cipher` | 22 | Same algorithm; `data class BreakResult` |

### Vigenère cryptanalysis
The IC algorithm collects all candidates within 5% of the best IC score, removes multiples of smaller candidates (prevents returning 2k instead of k), and `findKey` has minimal-period detection so even if the IC returns a multiple of the true key, the correct shorter key is recovered.

### Security review
1 round — passed. 3 LOW findings (integer overflow edge cases in Scytale size arithmetic for pathological inputs; unbounded `maxLength` in Vigenère `findKeyLength` capped by `n/2`) and 1 INFO finding (chi-squared denominator invariant). None exploitable in educational/library use.

## Test plan

- [ ] All 8 packages build with `gradle test` (0 failures)
- [ ] Verify 153 total tests across all 8 packages pass in CI
- [ ] No build artifacts committed (gradle-build/ excluded via .gitignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)