### PR TITLE
feat(parity): add fsharp binary search tree package

### DIFF
--- a/code/packages/fsharp/binary-search-tree/BUILD
+++ b/code/packages/fsharp/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/binary-search-tree/BUILD_windows
+++ b/code/packages/fsharp/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/binary-search-tree/BinarySearchTree.fs
+++ b/code/packages/fsharp/binary-search-tree/BinarySearchTree.fs
@@ -1,0 +1,270 @@
+namespace CodingAdventures.BinarySearchTree
+
+open System.Collections.Generic
+
+type BstNode<'T> =
+    { Value: 'T
+      Left: BstNode<'T> option
+      Right: BstNode<'T> option
+      Size: int }
+
+    static member Leaf(value: 'T) =
+        { Value = value
+          Left = None
+          Right = None
+          Size = 1 }
+
+    static member Create(value: 'T, left: BstNode<'T> option, right: BstNode<'T> option) =
+        let nodeSize node =
+            match node with
+            | None -> 0
+            | Some current -> current.Size
+
+        { Value = value
+          Left = left
+          Right = right
+          Size = 1 + nodeSize left + nodeSize right }
+
+module private BstHelpers =
+    let comparer<'T> = Comparer<'T>.Default
+
+    let compareValues left right = comparer.Compare(left, right)
+
+    let nodeSize root =
+        match root with
+        | None -> 0
+        | Some node -> node.Size
+
+    let rec search root value =
+        match root with
+        | None -> None
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 -> search node.Left value
+            | comparison when comparison > 0 -> search node.Right value
+            | _ -> Some node
+
+    let rec insert root value =
+        match root with
+        | None -> Some(BstNode.Leaf value)
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 ->
+                Some(BstNode.Create(node.Value, insert node.Left value, node.Right))
+            | comparison when comparison > 0 ->
+                Some(BstNode.Create(node.Value, node.Left, insert node.Right value))
+            | _ -> root
+
+    let rec private extractMin root =
+        match root.Left with
+        | None -> root.Right, root.Value
+        | Some left ->
+            let newLeft, minimum = extractMin left
+            Some(BstNode.Create(root.Value, newLeft, root.Right)), minimum
+
+    let rec delete root value =
+        match root with
+        | None -> None
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 ->
+                Some(BstNode.Create(node.Value, delete node.Left value, node.Right))
+            | comparison when comparison > 0 ->
+                Some(BstNode.Create(node.Value, node.Left, delete node.Right value))
+            | _ ->
+                match node.Left, node.Right with
+                | None, None -> None
+                | Some left, None -> Some left
+                | None, Some right -> Some right
+                | Some left, Some right ->
+                    let newRight, successor = extractMin right
+                    Some(BstNode.Create(successor, Some left, newRight))
+
+    let minValue root =
+        let rec walk current =
+            match current with
+            | None -> None
+            | Some node ->
+                match node.Left with
+                | None -> Some node.Value
+                | Some _ -> walk node.Left
+
+        walk root
+
+    let maxValue root =
+        let rec walk current =
+            match current with
+            | None -> None
+            | Some node ->
+                match node.Right with
+                | None -> Some node.Value
+                | Some _ -> walk node.Right
+
+        walk root
+
+    let predecessor root value =
+        let rec walk current best =
+            match current with
+            | None -> best
+            | Some node ->
+                if compareValues value node.Value <= 0 then
+                    walk node.Left best
+                else
+                    walk node.Right (Some node.Value)
+
+        walk root None
+
+    let successor root value =
+        let rec walk current best =
+            match current with
+            | None -> best
+            | Some node ->
+                if compareValues value node.Value >= 0 then
+                    walk node.Right best
+                else
+                    walk node.Left (Some node.Value)
+
+        walk root None
+
+    let rec kthSmallest root k =
+        match root with
+        | None -> None
+        | Some _ when k <= 0 -> None
+        | Some node ->
+            let leftSize = nodeSize node.Left
+
+            if k = leftSize + 1 then
+                Some node.Value
+            elif k <= leftSize then
+                kthSmallest node.Left k
+            else
+                kthSmallest node.Right (k - leftSize - 1)
+
+    let rec rank root value =
+        match root with
+        | None -> 0
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 -> rank node.Left value
+            | comparison when comparison > 0 -> nodeSize node.Left + 1 + rank node.Right value
+            | _ -> nodeSize node.Left
+
+    let rec inOrder root =
+        match root with
+        | None -> []
+        | Some node -> inOrder node.Left @ [ node.Value ] @ inOrder node.Right
+
+    let rec height root =
+        match root with
+        | None -> -1
+        | Some node -> 1 + max (height node.Left) (height node.Right)
+
+    let rec buildBalanced (values: 'T array) start finish =
+        if start >= finish then
+            None
+        else
+            let mid = start + ((finish - start) / 2)
+
+            Some(
+                BstNode.Create(
+                    values[mid],
+                    buildBalanced values start mid,
+                    buildBalanced values (mid + 1) finish
+                )
+            )
+
+    let rec validate root minimum maximum =
+        match root with
+        | None -> Some(-1, 0)
+        | Some node ->
+            match minimum, maximum with
+            | Some lower, _ when compareValues node.Value lower <= 0 -> None
+            | _, Some upper when compareValues node.Value upper >= 0 -> None
+            | _ ->
+                match validate node.Left minimum (Some node.Value), validate node.Right (Some node.Value) maximum with
+                | Some(leftHeight, leftSize), Some(rightHeight, rightSize) ->
+                    let expectedSize = 1 + leftSize + rightSize
+
+                    if node.Size = expectedSize then
+                        Some(1 + max leftHeight rightHeight, expectedSize)
+                    else
+                        None
+                | _ -> None
+
+type BinarySearchTree<'T>(root: BstNode<'T> option) =
+    new() = BinarySearchTree<'T>(None)
+
+    member _.Root = root
+
+    static member Empty() = BinarySearchTree<'T>(None)
+
+    static member FromSortedArray(values: seq<'T>) =
+        if isNull (box values) then
+            nullArg "values"
+
+        values
+        |> Seq.toArray
+        |> fun items -> BinarySearchTree<'T>(BstHelpers.buildBalanced items 0 items.Length)
+
+    member _.Insert(value: 'T) = BinarySearchTree<'T>(BstHelpers.insert root value)
+
+    member _.Delete(value: 'T) = BinarySearchTree<'T>(BstHelpers.delete root value)
+
+    member _.Search(value: 'T) = BstHelpers.search root value
+
+    member this.Contains(value: 'T) = this.Search(value).IsSome
+
+    member _.MinValue() = BstHelpers.minValue root
+
+    member _.MaxValue() = BstHelpers.maxValue root
+
+    member _.Predecessor(value: 'T) = BstHelpers.predecessor root value
+
+    member _.Successor(value: 'T) = BstHelpers.successor root value
+
+    member _.KthSmallest(k: int) = BstHelpers.kthSmallest root k
+
+    member _.Rank(value: 'T) = BstHelpers.rank root value
+
+    member _.ToSortedArray() = BstHelpers.inOrder root
+
+    member _.IsValid() = BstHelpers.validate root None None |> Option.isSome
+
+    member _.Height() = BstHelpers.height root
+
+    member _.Size() = BstHelpers.nodeSize root
+
+    override _.ToString() =
+        let rootLabel =
+            match root with
+            | None -> "null"
+            | Some node -> sprintf "%A" node.Value
+
+        sprintf "BinarySearchTree(root=%s, size=%d)" rootLabel (BstHelpers.nodeSize root)
+
+module BinarySearchTreeAlgorithms =
+    let search value (root: BstNode<'T> option) = BstHelpers.search root value
+
+    let insert value (root: BstNode<'T> option) = BstHelpers.insert root value
+
+    let delete value (root: BstNode<'T> option) = BstHelpers.delete root value
+
+    let minValue root = BstHelpers.minValue root
+
+    let maxValue root = BstHelpers.maxValue root
+
+    let predecessor value root = BstHelpers.predecessor root value
+
+    let successor value root = BstHelpers.successor root value
+
+    let kthSmallest k root = BstHelpers.kthSmallest root k
+
+    let rank value root = BstHelpers.rank root value
+
+    let toSortedArray root = BstHelpers.inOrder root
+
+    let isValid root = BstHelpers.validate root None None |> Option.isSome
+
+    let height root = BstHelpers.height root
+
+    let size root = BstHelpers.nodeSize root

--- a/code/packages/fsharp/binary-search-tree/CHANGELOG.md
+++ b/code/packages/fsharp/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# binary search tree package.

--- a/code/packages/fsharp/binary-search-tree/CodingAdventures.BinarySearchTree.fsproj
+++ b/code/packages/fsharp/binary-search-tree/CodingAdventures.BinarySearchTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BinarySearchTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Immutable F# binary search tree with order-statistic helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BinarySearchTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/binary-search-tree/README.md
+++ b/code/packages/fsharp/binary-search-tree/README.md
@@ -1,0 +1,3 @@
+# fsharp/binary-search-tree
+
+Immutable F# binary search tree with insert/delete, search, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/fsharp/binary-search-tree/required_capabilities.json
+++ b/code/packages/fsharp/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/BinarySearchTreeTests.fs
+++ b/code/packages/fsharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/BinarySearchTreeTests.fs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.BinarySearchTree.Tests
+
+open Xunit
+open CodingAdventures.BinarySearchTree
+
+type BinarySearchTreeTests() =
+    let populated() =
+        [ 5; 1; 8; 3; 7 ]
+        |> List.fold (fun (tree: BinarySearchTree<int>) value -> tree.Insert(value)) (BinarySearchTree<int>.Empty())
+
+    [<Fact>]
+    member _.``insert search and delete work immutably``() =
+        let tree = populated()
+
+        Assert.Equal<int list>([ 1; 3; 5; 7; 8 ], tree.ToSortedArray())
+        Assert.Equal(5, tree.Size())
+        Assert.True(tree.Contains(7))
+        Assert.Equal(Some 7, tree.Search(7) |> Option.map _.Value)
+        Assert.Equal(Some 1, tree.MinValue())
+        Assert.Equal(Some 8, tree.MaxValue())
+        Assert.Equal(Some 3, tree.Predecessor(5))
+        Assert.Equal(Some 7, tree.Successor(5))
+        Assert.Equal(2, tree.Rank(4))
+        Assert.Equal(Some 7, tree.KthSmallest(4))
+
+        let deleted = tree.Delete(5)
+        Assert.False(deleted.Contains(5))
+        Assert.True(deleted.IsValid())
+        Assert.True(tree.Contains(5))
+
+    [<Fact>]
+    member _.``from sorted array builds a balanced tree``() =
+        let tree = BinarySearchTree<int>.FromSortedArray([ 1; 2; 3; 4; 5; 6; 7 ])
+
+        Assert.Equal<int list>([ 1; 2; 3; 4; 5; 6; 7 ], tree.ToSortedArray())
+        Assert.Equal(2, tree.Height())
+        Assert.Equal(7, tree.Size())
+        Assert.True(tree.IsValid())
+        Assert.Equal(Some 4, tree.Root |> Option.map _.Value)
+
+    [<Fact>]
+    member _.``empty tree returns options and neutral metrics``() =
+        let tree = BinarySearchTree<int>.Empty()
+
+        Assert.Equal<BstNode<int> option>(None, tree.Search(1))
+        Assert.Equal<int option>(None, tree.MinValue())
+        Assert.Equal<int option>(None, tree.MaxValue())
+        Assert.Equal<int option>(None, tree.Predecessor(1))
+        Assert.Equal<int option>(None, tree.Successor(1))
+        Assert.Equal<int option>(None, tree.KthSmallest(0))
+        Assert.Equal<int option>(None, tree.KthSmallest(1))
+        Assert.Equal(0, tree.Rank(1))
+        Assert.Equal(-1, tree.Height())
+        Assert.Equal(0, tree.Size())
+        Assert.Equal("BinarySearchTree(root=null, size=0)", tree.ToString())
+
+    [<Fact>]
+    member _.``duplicates and single child delete keep persistent shape``() =
+        let tree = BinarySearchTree<int>.FromSortedArray([ 2; 4; 6; 8 ])
+
+        Assert.Equal(Some 6, tree.Root |> Option.map _.Value)
+
+        let duplicate = tree.Insert(4)
+        Assert.Equal<int list>(tree.ToSortedArray(), duplicate.ToSortedArray())
+        Assert.Equal<int list>([ 4; 6; 8 ], tree.Delete(2).ToSortedArray())
+
+    [<Fact>]
+    member _.``validation catches bad ordering and stale sizes``() =
+        let badOrder =
+            BinarySearchTree<int>(
+                Some
+                    { Value = 5
+                      Left = Some(BstNode.Leaf 6)
+                      Right = None
+                      Size = 2 }
+            )
+
+        let badSize =
+            BinarySearchTree<int>(
+                Some
+                    { Value = 5
+                      Left = Some(BstNode.Leaf 3)
+                      Right = None
+                      Size = 99 }
+            )
+
+        Assert.False(badOrder.IsValid())
+        Assert.False(badSize.IsValid())
+
+    [<Fact>]
+    member _.``module functions support raw root composition``() =
+        let root =
+            None
+            |> BinarySearchTreeAlgorithms.insert 5
+            |> BinarySearchTreeAlgorithms.insert 2
+            |> BinarySearchTreeAlgorithms.insert 9
+
+        Assert.Equal(Some 5, BinarySearchTreeAlgorithms.search 5 root |> Option.map _.Value)
+        Assert.Equal(Some 2, BinarySearchTreeAlgorithms.minValue root)
+        Assert.Equal(Some 9, BinarySearchTreeAlgorithms.maxValue root)
+        Assert.Equal(Some 5, BinarySearchTreeAlgorithms.kthSmallest 2 root)
+        Assert.Equal(1, BinarySearchTreeAlgorithms.rank 5 root)
+        Assert.Equal(1, BinarySearchTreeAlgorithms.height root)
+        Assert.Equal(3, BinarySearchTreeAlgorithms.size root)
+        Assert.True(BinarySearchTreeAlgorithms.isValid root)
+        Assert.Equal<int list>([ 2; 5; 9 ], BinarySearchTreeAlgorithms.toSortedArray root)
+
+        let deleted = BinarySearchTreeAlgorithms.delete 2 root
+        Assert.Equal<int list>([ 5; 9 ], BinarySearchTreeAlgorithms.toSortedArray deleted)
+
+    [<Fact>]
+    member _.``reference comparable values retain sorted order``() =
+        let tree =
+            BinarySearchTree<string>.Empty()
+                .Insert("delta")
+                .Insert("alpha")
+                .Insert("gamma")
+
+        Assert.Equal<string list>([ "alpha"; "delta"; "gamma" ], tree.ToSortedArray())
+        Assert.Equal("BinarySearchTree(root=\"delta\", size=3)", tree.ToString())
+        Assert.Equal(Some "gamma", tree.Successor("delta"))
+        Assert.Equal<string option>(None, tree.Predecessor("alpha"))

--- a/code/packages/fsharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.fsproj
+++ b/code/packages/fsharp/binary-search-tree/tests/CodingAdventures.BinarySearchTree.Tests/CodingAdventures.BinarySearchTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BinarySearchTree.fsproj" />
+    <Compile Include="BinarySearchTreeTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an F# binary-search-tree package with immutable insert/delete, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose a BinarySearchTree wrapper plus module helpers for raw node composition
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.BinarySearchTree.Tests\\CodingAdventures.BinarySearchTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line