### PR TITLE
feat(parity): add java binary tree package

### DIFF
--- a/code/packages/java/binary-tree/.gitignore
+++ b/code/packages/java/binary-tree/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/binary-tree/BUILD
+++ b/code/packages/java/binary-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/binary-tree/BUILD_windows
+++ b/code/packages/java/binary-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/binary-tree/CHANGELOG.md
+++ b/code/packages/java/binary-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Java binary tree package.

--- a/code/packages/java/binary-tree/README.md
+++ b/code/packages/java/binary-tree/README.md
@@ -1,0 +1,3 @@
+# java/binary-tree
+
+Native Java binary tree with level-order construction, traversals, shape predicates, array projection, and ASCII rendering.

--- a/code/packages/java/binary-tree/build.gradle.kts
+++ b/code/packages/java/binary-tree/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/binary-tree/required_capabilities.json
+++ b/code/packages/java/binary-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/binary-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/binary-tree/settings.gradle.kts
+++ b/code/packages/java/binary-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "binary-tree"

--- a/code/packages/java/binary-tree/src/main/java/com/codingadventures/binarytree/BinaryTree.java
+++ b/code/packages/java/binary-tree/src/main/java/com/codingadventures/binarytree/BinaryTree.java
@@ -1,0 +1,311 @@
+package com.codingadventures.binarytree;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+
+public final class BinaryTree<T> {
+    private final BinaryTreeNode<T> root;
+
+    public BinaryTree() {
+        this(null);
+    }
+
+    public BinaryTree(BinaryTreeNode<T> root) {
+        this.root = root;
+    }
+
+    public static <T> BinaryTree<T> empty() {
+        return new BinaryTree<>();
+    }
+
+    public static <T> BinaryTree<T> singleton(T value) {
+        return new BinaryTree<>(new BinaryTreeNode<>(value));
+    }
+
+    public static <T> BinaryTree<T> withRoot(BinaryTreeNode<T> root) {
+        return new BinaryTree<>(root);
+    }
+
+    public static <T> BinaryTree<T> fromLevelOrder(List<T> values) {
+        Objects.requireNonNull(values, "values");
+        return new BinaryTree<>(buildFromLevelOrder(values, 0));
+    }
+
+    public BinaryTreeNode<T> root() {
+        return root;
+    }
+
+    public BinaryTreeNode<T> find(T value) {
+        return find(root, value);
+    }
+
+    public BinaryTreeNode<T> leftChild(T value) {
+        BinaryTreeNode<T> node = find(value);
+        return node == null ? null : node.left();
+    }
+
+    public BinaryTreeNode<T> rightChild(T value) {
+        BinaryTreeNode<T> node = find(value);
+        return node == null ? null : node.right();
+    }
+
+    public boolean isFull() {
+        return isFull(root);
+    }
+
+    public boolean isComplete() {
+        return isComplete(root);
+    }
+
+    public boolean isPerfect() {
+        return isPerfect(root);
+    }
+
+    public int height() {
+        return height(root);
+    }
+
+    public int size() {
+        return size(root);
+    }
+
+    public List<T> inorder() {
+        return inorder(root);
+    }
+
+    public List<T> preorder() {
+        return preorder(root);
+    }
+
+    public List<T> postorder() {
+        return postorder(root);
+    }
+
+    public List<T> levelOrder() {
+        return levelOrder(root);
+    }
+
+    public List<T> toArray() {
+        return toArray(root);
+    }
+
+    public String toAscii() {
+        return toAscii(root);
+    }
+
+    @Override
+    public String toString() {
+        String rootValue = root == null ? "null" : String.valueOf(root.value());
+        return "BinaryTree(root=" + rootValue + ", size=" + size() + ")";
+    }
+
+    public static <T> BinaryTreeNode<T> find(BinaryTreeNode<T> root, T value) {
+        if (root == null) {
+            return null;
+        }
+        if (Objects.equals(root.value(), value)) {
+            return root;
+        }
+        BinaryTreeNode<T> left = find(root.left(), value);
+        return left != null ? left : find(root.right(), value);
+    }
+
+    public static <T> BinaryTreeNode<T> leftChild(BinaryTreeNode<T> root, T value) {
+        BinaryTreeNode<T> node = find(root, value);
+        return node == null ? null : node.left();
+    }
+
+    public static <T> BinaryTreeNode<T> rightChild(BinaryTreeNode<T> root, T value) {
+        BinaryTreeNode<T> node = find(root, value);
+        return node == null ? null : node.right();
+    }
+
+    public static <T> boolean isFull(BinaryTreeNode<T> root) {
+        if (root == null) {
+            return true;
+        }
+        if (root.left() == null && root.right() == null) {
+            return true;
+        }
+        if (root.left() == null || root.right() == null) {
+            return false;
+        }
+        return isFull(root.left()) && isFull(root.right());
+    }
+
+    public static <T> boolean isComplete(BinaryTreeNode<T> root) {
+        Queue<BinaryTreeNode<T>> queue = new LinkedList<>();
+        queue.add(root);
+        boolean seenNull = false;
+
+        while (!queue.isEmpty()) {
+            BinaryTreeNode<T> node = queue.remove();
+            if (node == null) {
+                seenNull = true;
+                continue;
+            }
+            if (seenNull) {
+                return false;
+            }
+            queue.add(node.left());
+            queue.add(node.right());
+        }
+
+        return true;
+    }
+
+    public static <T> boolean isPerfect(BinaryTreeNode<T> root) {
+        int treeHeight = height(root);
+        if (treeHeight < 0) {
+            return size(root) == 0;
+        }
+        return size(root) == (1 << (treeHeight + 1)) - 1;
+    }
+
+    public static <T> int height(BinaryTreeNode<T> root) {
+        return root == null ? -1 : 1 + Math.max(height(root.left()), height(root.right()));
+    }
+
+    public static <T> int size(BinaryTreeNode<T> root) {
+        return root == null ? 0 : 1 + size(root.left()) + size(root.right());
+    }
+
+    public static <T> List<T> inorder(BinaryTreeNode<T> root) {
+        List<T> output = new ArrayList<>();
+        inorder(root, output);
+        return output;
+    }
+
+    public static <T> List<T> preorder(BinaryTreeNode<T> root) {
+        List<T> output = new ArrayList<>();
+        preorder(root, output);
+        return output;
+    }
+
+    public static <T> List<T> postorder(BinaryTreeNode<T> root) {
+        List<T> output = new ArrayList<>();
+        postorder(root, output);
+        return output;
+    }
+
+    public static <T> List<T> levelOrder(BinaryTreeNode<T> root) {
+        List<T> output = new ArrayList<>();
+        if (root == null) {
+            return output;
+        }
+
+        Queue<BinaryTreeNode<T>> queue = new ArrayDeque<>();
+        queue.add(root);
+        while (!queue.isEmpty()) {
+            BinaryTreeNode<T> node = queue.remove();
+            output.add(node.value());
+            if (node.left() != null) {
+                queue.add(node.left());
+            }
+            if (node.right() != null) {
+                queue.add(node.right());
+            }
+        }
+
+        return output;
+    }
+
+    public static <T> List<T> toArray(BinaryTreeNode<T> root) {
+        int treeHeight = height(root);
+        if (treeHeight < 0) {
+            return List.of();
+        }
+
+        int length = (1 << (treeHeight + 1)) - 1;
+        List<T> output = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            output.add(null);
+        }
+        fillArray(root, 0, output);
+        return output;
+    }
+
+    public static <T> String toAscii(BinaryTreeNode<T> root) {
+        if (root == null) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        renderAscii(root, "", true, builder);
+        return builder.toString().stripTrailing();
+    }
+
+    private static <T> BinaryTreeNode<T> buildFromLevelOrder(List<T> values, int index) {
+        if (index >= values.size()) {
+            return null;
+        }
+        T value = values.get(index);
+        if (value == null) {
+            return null;
+        }
+        return new BinaryTreeNode<>(
+                value,
+                buildFromLevelOrder(values, (2 * index) + 1),
+                buildFromLevelOrder(values, (2 * index) + 2));
+    }
+
+    private static <T> void inorder(BinaryTreeNode<T> root, List<T> output) {
+        if (root == null) {
+            return;
+        }
+        inorder(root.left(), output);
+        output.add(root.value());
+        inorder(root.right(), output);
+    }
+
+    private static <T> void preorder(BinaryTreeNode<T> root, List<T> output) {
+        if (root == null) {
+            return;
+        }
+        output.add(root.value());
+        preorder(root.left(), output);
+        preorder(root.right(), output);
+    }
+
+    private static <T> void postorder(BinaryTreeNode<T> root, List<T> output) {
+        if (root == null) {
+            return;
+        }
+        postorder(root.left(), output);
+        postorder(root.right(), output);
+        output.add(root.value());
+    }
+
+    private static <T> void fillArray(BinaryTreeNode<T> root, int index, List<T> output) {
+        if (root == null || index >= output.size()) {
+            return;
+        }
+        output.set(index, root.value());
+        fillArray(root.left(), (2 * index) + 1, output);
+        fillArray(root.right(), (2 * index) + 2, output);
+    }
+
+    private static <T> void renderAscii(BinaryTreeNode<T> node, String prefix, boolean isTail, StringBuilder output) {
+        output.append(prefix)
+                .append(isTail ? "`-- " : "|-- ")
+                .append(node.value())
+                .append(System.lineSeparator());
+
+        List<BinaryTreeNode<T>> children = new ArrayList<>(2);
+        if (node.left() != null) {
+            children.add(node.left());
+        }
+        if (node.right() != null) {
+            children.add(node.right());
+        }
+
+        String nextPrefix = prefix + (isTail ? "    " : "|   ");
+        for (int i = 0; i < children.size(); i++) {
+            renderAscii(children.get(i), nextPrefix, i + 1 == children.size(), output);
+        }
+    }
+}

--- a/code/packages/java/binary-tree/src/main/java/com/codingadventures/binarytree/BinaryTreeNode.java
+++ b/code/packages/java/binary-tree/src/main/java/com/codingadventures/binarytree/BinaryTreeNode.java
@@ -1,0 +1,7 @@
+package com.codingadventures.binarytree;
+
+public record BinaryTreeNode<T>(T value, BinaryTreeNode<T> left, BinaryTreeNode<T> right) {
+    public BinaryTreeNode(T value) {
+        this(value, null, null);
+    }
+}

--- a/code/packages/java/binary-tree/src/test/java/com/codingadventures/binarytree/BinaryTreeTest.java
+++ b/code/packages/java/binary-tree/src/test/java/com/codingadventures/binarytree/BinaryTreeTest.java
@@ -1,0 +1,103 @@
+package com.codingadventures.binarytree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BinaryTreeTest {
+    @Test
+    void buildsFromLevelOrderAndProjectsBackToArray() {
+        BinaryTree<Integer> tree = BinaryTree.fromLevelOrder(List.of(1, 2, 3, 4, 5, 6, 7));
+
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7), tree.toArray());
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7), tree.levelOrder());
+        assertEquals(7, tree.size());
+        assertEquals(2, tree.height());
+    }
+
+    @Test
+    void shapeQueriesDistinguishFullCompleteAndPerfectTrees() {
+        BinaryTree<Integer> perfect = BinaryTree.fromLevelOrder(List.of(1, 2, 3, 4, 5, 6, 7));
+        assertTrue(perfect.isFull());
+        assertTrue(perfect.isComplete());
+        assertTrue(perfect.isPerfect());
+
+        BinaryTree<Integer> complete = BinaryTree.fromLevelOrder(Arrays.asList(1, 2, 3, 4, null, null, null));
+        assertFalse(complete.isFull());
+        assertTrue(complete.isComplete());
+        assertFalse(complete.isPerfect());
+
+        BinaryTree<Integer> incomplete = BinaryTree.fromLevelOrder(Arrays.asList(1, null, 3));
+        assertFalse(incomplete.isComplete());
+    }
+
+    @Test
+    void traversalsAndChildLookupMatchReferenceOrder() {
+        BinaryTree<Integer> tree = BinaryTree.fromLevelOrder(Arrays.asList(1, 2, 3, 4, null, 5, null));
+
+        assertEquals(List.of(4, 2, 1, 5, 3), tree.inorder());
+        assertEquals(List.of(1, 2, 4, 3, 5), tree.preorder());
+        assertEquals(List.of(4, 2, 5, 3, 1), tree.postorder());
+        assertEquals(List.of(1, 2, 3, 4, 5), tree.levelOrder());
+        assertEquals(2, tree.leftChild(1).value());
+        assertEquals(3, tree.rightChild(1).value());
+        assertNull(tree.find(99));
+    }
+
+    @Test
+    void emptyAndSingletonTreesExposeEdgeCases() {
+        BinaryTree<String> empty = BinaryTree.empty();
+        assertNull(empty.root());
+        assertEquals(-1, empty.height());
+        assertEquals(0, empty.size());
+        assertTrue(empty.isFull());
+        assertTrue(empty.isComplete());
+        assertTrue(empty.isPerfect());
+        assertEquals(List.of(), empty.inorder());
+        assertEquals(List.of(), empty.toArray());
+        assertEquals("", empty.toAscii());
+        assertEquals("BinaryTree(root=null, size=0)", empty.toString());
+
+        BinaryTree<String> single = BinaryTree.singleton("root");
+        assertEquals("root", single.root().value());
+        assertEquals(List.of("root"), single.toArray());
+        assertEquals("BinaryTree(root=root, size=1)", single.toString());
+    }
+
+    @Test
+    void asciiRenderingContainsValues() {
+        BinaryTree<String> tree = BinaryTree.fromLevelOrder(List.of("root", "left", "right"));
+        String ascii = tree.toAscii();
+
+        assertTrue(ascii.contains("root"));
+        assertTrue(ascii.contains("left"));
+        assertTrue(ascii.contains("right"));
+        assertTrue(ascii.contains("`--"));
+    }
+
+    @Test
+    void staticHelpersSupportRawRootComposition() {
+        BinaryTreeNode<Integer> root = new BinaryTreeNode<>(
+                1,
+                new BinaryTreeNode<>(2),
+                new BinaryTreeNode<>(3));
+
+        assertSame(root, BinaryTree.withRoot(root).root());
+        assertEquals(2, BinaryTree.leftChild(root, 1).value());
+        assertEquals(3, BinaryTree.rightChild(root, 1).value());
+        assertEquals(List.of(2, 1, 3), BinaryTree.inorder(root));
+        assertEquals(List.of(1, 2, 3), BinaryTree.preorder(root));
+        assertEquals(List.of(2, 3, 1), BinaryTree.postorder(root));
+        assertEquals(List.of(1, 2, 3), BinaryTree.levelOrder(root));
+        assertEquals(Arrays.asList(1, 2, 3), BinaryTree.toArray(root));
+        assertTrue(BinaryTree.isFull(root));
+        assertTrue(BinaryTree.isComplete(root));
+        assertTrue(BinaryTree.isPerfect(root));
+        assertEquals(1, BinaryTree.height(root));
+        assertEquals(3, BinaryTree.size(root));
+        assertTrue(BinaryTree.toAscii(root).contains("1"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Java binary-tree package with level-order construction, traversals, shape predicates, array projection, and ASCII rendering
- expose BinaryTree/BinaryTreeNode plus static helpers for raw node composition
- add JUnit tests and Gradle package metadata/build wrappers

## Verification
- javac --release 21 -d out\\classes src\\main\\java\\com\\codingadventures\\binarytree\\BinaryTreeNode.java src\\main\\java\\com\\codingadventures\\binarytree\\BinaryTree.java
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)