### PR TITLE
feat(parity): add java binary search tree package

### DIFF
--- a/code/packages/java/binary-search-tree/.gitignore
+++ b/code/packages/java/binary-search-tree/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/javac-out/

--- a/code/packages/java/binary-search-tree/BUILD
+++ b/code/packages/java/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/binary-search-tree/BUILD_windows
+++ b/code/packages/java/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/binary-search-tree/CHANGELOG.md
+++ b/code/packages/java/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Java binary search tree package.

--- a/code/packages/java/binary-search-tree/README.md
+++ b/code/packages/java/binary-search-tree/README.md
@@ -1,0 +1,3 @@
+# java/binary-search-tree
+
+Native Java immutable binary search tree with insert/delete, search, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/java/binary-search-tree/build.gradle.kts
+++ b/code/packages/java/binary-search-tree/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/binary-search-tree/required_capabilities.json
+++ b/code/packages/java/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/binary-search-tree/settings.gradle.kts
+++ b/code/packages/java/binary-search-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "binary-search-tree"

--- a/code/packages/java/binary-search-tree/src/main/java/com/codingadventures/binarysearchtree/BinarySearchTree.java
+++ b/code/packages/java/binary-search-tree/src/main/java/com/codingadventures/binarysearchtree/BinarySearchTree.java
@@ -1,0 +1,295 @@
+package com.codingadventures.binarysearchtree;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class BinarySearchTree<T extends Comparable<? super T>> {
+    private final BstNode<T> root;
+
+    public BinarySearchTree() {
+        this(null);
+    }
+
+    public BinarySearchTree(BstNode<T> root) {
+        this.root = root;
+    }
+
+    public static <T extends Comparable<? super T>> BinarySearchTree<T> empty() {
+        return new BinarySearchTree<>();
+    }
+
+    public static <T extends Comparable<? super T>> BinarySearchTree<T> fromSortedArray(List<T> values) {
+        Objects.requireNonNull(values, "values");
+        return new BinarySearchTree<>(buildBalanced(values, 0, values.size()));
+    }
+
+    public BstNode<T> root() {
+        return root;
+    }
+
+    public BinarySearchTree<T> insert(T value) {
+        return new BinarySearchTree<>(insertNode(root, value));
+    }
+
+    public BinarySearchTree<T> delete(T value) {
+        return new BinarySearchTree<>(deleteNode(root, value));
+    }
+
+    public BstNode<T> search(T value) {
+        return searchNode(root, value);
+    }
+
+    public boolean contains(T value) {
+        return search(value) != null;
+    }
+
+    public T minValue() {
+        return minValue(root);
+    }
+
+    public T maxValue() {
+        return maxValue(root);
+    }
+
+    public T predecessor(T value) {
+        return predecessor(root, value);
+    }
+
+    public T successor(T value) {
+        return successor(root, value);
+    }
+
+    public T kthSmallest(int k) {
+        return kthSmallest(root, k);
+    }
+
+    public int rank(T value) {
+        return rank(root, value);
+    }
+
+    public List<T> toSortedArray() {
+        return toSortedArray(root);
+    }
+
+    public boolean isValid() {
+        return isValid(root);
+    }
+
+    public int height() {
+        return height(root);
+    }
+
+    public int size() {
+        return BstNode.size(root);
+    }
+
+    @Override
+    public String toString() {
+        String rootValue = root == null ? "null" : String.valueOf(root.value());
+        return "BinarySearchTree(root=" + rootValue + ", size=" + size() + ")";
+    }
+
+    public static <T extends Comparable<? super T>> BstNode<T> searchNode(BstNode<T> root, T value) {
+        BstNode<T> current = root;
+        while (current != null) {
+            int comparison = value.compareTo(current.value());
+            if (comparison < 0) {
+                current = current.left();
+            } else if (comparison > 0) {
+                current = current.right();
+            } else {
+                return current;
+            }
+        }
+        return null;
+    }
+
+    public static <T extends Comparable<? super T>> BstNode<T> insertNode(BstNode<T> root, T value) {
+        if (root == null) {
+            return new BstNode<>(value);
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return new BstNode<>(root.value(), insertNode(root.left(), value), root.right());
+        }
+        if (comparison > 0) {
+            return new BstNode<>(root.value(), root.left(), insertNode(root.right(), value));
+        }
+        return root;
+    }
+
+    public static <T extends Comparable<? super T>> BstNode<T> deleteNode(BstNode<T> root, T value) {
+        if (root == null) {
+            return null;
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return new BstNode<>(root.value(), deleteNode(root.left(), value), root.right());
+        }
+        if (comparison > 0) {
+            return new BstNode<>(root.value(), root.left(), deleteNode(root.right(), value));
+        }
+
+        if (root.left() == null) {
+            return root.right();
+        }
+        if (root.right() == null) {
+            return root.left();
+        }
+
+        Extracted<T> extracted = extractMin(root.right());
+        return new BstNode<>(extracted.minimum(), root.left(), extracted.root());
+    }
+
+    public static <T extends Comparable<? super T>> T minValue(BstNode<T> root) {
+        BstNode<T> current = root;
+        while (current != null && current.left() != null) {
+            current = current.left();
+        }
+        return current == null ? null : current.value();
+    }
+
+    public static <T extends Comparable<? super T>> T maxValue(BstNode<T> root) {
+        BstNode<T> current = root;
+        while (current != null && current.right() != null) {
+            current = current.right();
+        }
+        return current == null ? null : current.value();
+    }
+
+    public static <T extends Comparable<? super T>> T predecessor(BstNode<T> root, T value) {
+        BstNode<T> current = root;
+        T best = null;
+        while (current != null) {
+            if (value.compareTo(current.value()) <= 0) {
+                current = current.left();
+            } else {
+                best = current.value();
+                current = current.right();
+            }
+        }
+        return best;
+    }
+
+    public static <T extends Comparable<? super T>> T successor(BstNode<T> root, T value) {
+        BstNode<T> current = root;
+        T best = null;
+        while (current != null) {
+            if (value.compareTo(current.value()) >= 0) {
+                current = current.right();
+            } else {
+                best = current.value();
+                current = current.left();
+            }
+        }
+        return best;
+    }
+
+    public static <T extends Comparable<? super T>> T kthSmallest(BstNode<T> root, int k) {
+        if (root == null || k <= 0) {
+            return null;
+        }
+
+        int leftSize = BstNode.size(root.left());
+        if (k == leftSize + 1) {
+            return root.value();
+        }
+        if (k <= leftSize) {
+            return kthSmallest(root.left(), k);
+        }
+        return kthSmallest(root.right(), k - leftSize - 1);
+    }
+
+    public static <T extends Comparable<? super T>> int rank(BstNode<T> root, T value) {
+        if (root == null) {
+            return 0;
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return rank(root.left(), value);
+        }
+        if (comparison > 0) {
+            return BstNode.size(root.left()) + 1 + rank(root.right(), value);
+        }
+        return BstNode.size(root.left());
+    }
+
+    public static <T extends Comparable<? super T>> List<T> toSortedArray(BstNode<T> root) {
+        List<T> output = new ArrayList<>();
+        inOrder(root, output);
+        return output;
+    }
+
+    public static <T extends Comparable<? super T>> boolean isValid(BstNode<T> root) {
+        return validate(root, null, null) != null;
+    }
+
+    public static <T> int height(BstNode<T> root) {
+        return root == null ? -1 : 1 + Math.max(height(root.left()), height(root.right()));
+    }
+
+    private static <T extends Comparable<? super T>> Extracted<T> extractMin(BstNode<T> root) {
+        if (root.left() == null) {
+            return new Extracted<>(root.right(), root.value());
+        }
+
+        Extracted<T> extracted = extractMin(root.left());
+        return new Extracted<>(
+                new BstNode<>(root.value(), extracted.root(), root.right()),
+                extracted.minimum());
+    }
+
+    private static <T extends Comparable<? super T>> BstNode<T> buildBalanced(List<T> values, int start, int end) {
+        if (start >= end) {
+            return null;
+        }
+        int mid = start + (end - start) / 2;
+        return new BstNode<>(
+                values.get(mid),
+                buildBalanced(values, start, mid),
+                buildBalanced(values, mid + 1, end));
+    }
+
+    private static <T extends Comparable<? super T>> void inOrder(BstNode<T> root, List<T> output) {
+        if (root == null) {
+            return;
+        }
+        inOrder(root.left(), output);
+        output.add(root.value());
+        inOrder(root.right(), output);
+    }
+
+    private static <T extends Comparable<? super T>> Validation validate(BstNode<T> root, T minimum, T maximum) {
+        if (root == null) {
+            return new Validation(-1, 0);
+        }
+        if (minimum != null && root.value().compareTo(minimum) <= 0) {
+            return null;
+        }
+        if (maximum != null && root.value().compareTo(maximum) >= 0) {
+            return null;
+        }
+
+        Validation left = validate(root.left(), minimum, root.value());
+        Validation right = validate(root.right(), root.value(), maximum);
+        if (left == null || right == null) {
+            return null;
+        }
+
+        int expectedSize = 1 + left.size() + right.size();
+        if (root.size() != expectedSize) {
+            return null;
+        }
+        return new Validation(1 + Math.max(left.height(), right.height()), expectedSize);
+    }
+
+    private record Extracted<T>(BstNode<T> root, T minimum) {
+    }
+
+    private record Validation(int height, int size) {
+    }
+}

--- a/code/packages/java/binary-search-tree/src/main/java/com/codingadventures/binarysearchtree/BstNode.java
+++ b/code/packages/java/binary-search-tree/src/main/java/com/codingadventures/binarysearchtree/BstNode.java
@@ -1,0 +1,15 @@
+package com.codingadventures.binarysearchtree;
+
+public record BstNode<T>(T value, BstNode<T> left, BstNode<T> right, int size) {
+    public BstNode(T value) {
+        this(value, null, null, 1);
+    }
+
+    public BstNode(T value, BstNode<T> left, BstNode<T> right) {
+        this(value, left, right, 1 + size(left) + size(right));
+    }
+
+    public static <T> int size(BstNode<T> node) {
+        return node == null ? 0 : node.size();
+    }
+}

--- a/code/packages/java/binary-search-tree/src/test/java/com/codingadventures/binarysearchtree/BinarySearchTreeTest.java
+++ b/code/packages/java/binary-search-tree/src/test/java/com/codingadventures/binarysearchtree/BinarySearchTreeTest.java
@@ -1,0 +1,123 @@
+package com.codingadventures.binarysearchtree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BinarySearchTreeTest {
+    @Test
+    void insertSearchAndDeleteWorkImmutably() {
+        BinarySearchTree<Integer> tree = populated();
+
+        assertEquals(List.of(1, 3, 5, 7, 8), tree.toSortedArray());
+        assertEquals(5, tree.size());
+        assertTrue(tree.contains(7));
+        assertEquals(7, tree.search(7).value());
+        assertEquals(1, tree.minValue());
+        assertEquals(8, tree.maxValue());
+        assertEquals(3, tree.predecessor(5));
+        assertEquals(7, tree.successor(5));
+        assertEquals(2, tree.rank(4));
+        assertEquals(7, tree.kthSmallest(4));
+
+        BinarySearchTree<Integer> deleted = tree.delete(5);
+        assertFalse(deleted.contains(5));
+        assertTrue(deleted.isValid());
+        assertTrue(tree.contains(5));
+    }
+
+    @Test
+    void fromSortedArrayBuildsBalancedTree() {
+        BinarySearchTree<Integer> tree = BinarySearchTree.fromSortedArray(List.of(1, 2, 3, 4, 5, 6, 7));
+
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7), tree.toSortedArray());
+        assertEquals(2, tree.height());
+        assertEquals(7, tree.size());
+        assertTrue(tree.isValid());
+        assertEquals(4, tree.root().value());
+    }
+
+    @Test
+    void emptyTreeReturnsNullsAndNeutralMetrics() {
+        BinarySearchTree<Integer> tree = BinarySearchTree.empty();
+
+        assertNull(tree.search(1));
+        assertNull(tree.minValue());
+        assertNull(tree.maxValue());
+        assertNull(tree.predecessor(1));
+        assertNull(tree.successor(1));
+        assertNull(tree.kthSmallest(0));
+        assertNull(tree.kthSmallest(1));
+        assertEquals(0, tree.rank(1));
+        assertEquals(-1, tree.height());
+        assertEquals(0, tree.size());
+        assertEquals("BinarySearchTree(root=null, size=0)", tree.toString());
+    }
+
+    @Test
+    void duplicatesAndSingleChildDeleteKeepPersistentShape() {
+        BinarySearchTree<Integer> tree = BinarySearchTree.fromSortedArray(List.of(2, 4, 6, 8));
+
+        assertEquals(6, tree.root().value());
+        BinarySearchTree<Integer> duplicate = tree.insert(4);
+
+        assertSame(tree.root().left(), duplicate.root().left());
+        assertEquals(tree.toSortedArray(), duplicate.toSortedArray());
+        assertEquals(List.of(4, 6, 8), tree.delete(2).toSortedArray());
+    }
+
+    @Test
+    void validationCatchesBadOrderingAndStaleSizes() {
+        BinarySearchTree<Integer> badOrder = new BinarySearchTree<>(
+                new BstNode<>(5, new BstNode<>(6), null, 2));
+        BinarySearchTree<Integer> badSize = new BinarySearchTree<>(
+                new BstNode<>(5, new BstNode<>(3), null, 99));
+
+        assertFalse(badOrder.isValid());
+        assertFalse(badSize.isValid());
+    }
+
+    @Test
+    void staticHelpersSupportRawRootComposition() {
+        BstNode<Integer> root = null;
+        root = BinarySearchTree.insertNode(root, 5);
+        root = BinarySearchTree.insertNode(root, 2);
+        root = BinarySearchTree.insertNode(root, 9);
+
+        assertEquals(5, BinarySearchTree.searchNode(root, 5).value());
+        assertEquals(2, BinarySearchTree.minValue(root));
+        assertEquals(9, BinarySearchTree.maxValue(root));
+        assertEquals(5, BinarySearchTree.kthSmallest(root, 2));
+        assertEquals(1, BinarySearchTree.rank(root, 5));
+        assertEquals(1, BinarySearchTree.height(root));
+        assertTrue(BinarySearchTree.isValid(root));
+        assertEquals(List.of(2, 5, 9), BinarySearchTree.toSortedArray(root));
+
+        BstNode<Integer> deleted = BinarySearchTree.deleteNode(root, 2);
+        assertEquals(List.of(5, 9), BinarySearchTree.toSortedArray(deleted));
+        assertNull(BinarySearchTree.deleteNode(null, 2));
+    }
+
+    @Test
+    void referenceComparableValuesRetainSortedOrder() {
+        BinarySearchTree<String> tree = BinarySearchTree.<String>empty()
+                .insert("delta")
+                .insert("alpha")
+                .insert("gamma");
+
+        assertEquals(List.of("alpha", "delta", "gamma"), tree.toSortedArray());
+        assertEquals("BinarySearchTree(root=delta, size=3)", tree.toString());
+        assertEquals("gamma", tree.successor("delta"));
+        assertNull(tree.predecessor("alpha"));
+    }
+
+    private static BinarySearchTree<Integer> populated() {
+        BinarySearchTree<Integer> tree = BinarySearchTree.empty();
+        for (int value : List.of(5, 1, 8, 3, 7)) {
+            tree = tree.insert(value);
+        }
+        return tree;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Java binary-search-tree package with immutable insert/delete, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose BinarySearchTree/BstNode plus static helpers for raw node composition
- add JUnit tests and Gradle package metadata/build wrappers

## Verification
- javac --release 21 -d javac-out\\classes src\\main\\java\\com\\codingadventures\\binarysearchtree\\BstNode.java src\\main\\java\\com\\codingadventures\\binarysearchtree\\BinarySearchTree.java
- JShell smoke test for sorted traversal, delete, and validation using the compiled classes
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)