### PR TITLE
feat(parity): add kotlin binary tree package

### DIFF
--- a/code/packages/kotlin/binary-tree/.gitignore
+++ b/code/packages/kotlin/binary-tree/.gitignore
@@ -1,0 +1,6 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/
+/kotlinc-out/

--- a/code/packages/kotlin/binary-tree/BUILD
+++ b/code/packages/kotlin/binary-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/binary-tree/BUILD_windows
+++ b/code/packages/kotlin/binary-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/binary-tree/CHANGELOG.md
+++ b/code/packages/kotlin/binary-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Kotlin binary tree package.

--- a/code/packages/kotlin/binary-tree/README.md
+++ b/code/packages/kotlin/binary-tree/README.md
@@ -1,0 +1,3 @@
+# kotlin/binary-tree
+
+Native Kotlin binary tree with level-order construction, traversals, shape predicates, array projection, and ASCII rendering.

--- a/code/packages/kotlin/binary-tree/build.gradle.kts
+++ b/code/packages/kotlin/binary-tree/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/binary-tree/required_capabilities.json
+++ b/code/packages/kotlin/binary-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/binary-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/binary-tree/settings.gradle.kts
+++ b/code/packages/kotlin/binary-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "binary-tree"

--- a/code/packages/kotlin/binary-tree/src/main/kotlin/com/codingadventures/binarytree/BinaryTree.kt
+++ b/code/packages/kotlin/binary-tree/src/main/kotlin/com/codingadventures/binarytree/BinaryTree.kt
@@ -1,0 +1,220 @@
+package com.codingadventures.binarytree
+
+import java.util.ArrayDeque
+import java.util.LinkedList
+import java.util.Queue
+
+data class BinaryTreeNode<T>(
+    val value: T,
+    val left: BinaryTreeNode<T>? = null,
+    val right: BinaryTreeNode<T>? = null,
+)
+
+class BinaryTree<T>(val root: BinaryTreeNode<T>? = null) {
+    fun find(value: T): BinaryTreeNode<T>? = find(root, value)
+
+    fun leftChild(value: T): BinaryTreeNode<T>? = find(value)?.left
+
+    fun rightChild(value: T): BinaryTreeNode<T>? = find(value)?.right
+
+    fun isFull(): Boolean = isFull(root)
+
+    fun isComplete(): Boolean = isComplete(root)
+
+    fun isPerfect(): Boolean = isPerfect(root)
+
+    fun height(): Int = height(root)
+
+    fun size(): Int = size(root)
+
+    fun inOrder(): List<T> = inOrder(root)
+
+    fun preOrder(): List<T> = preOrder(root)
+
+    fun postOrder(): List<T> = postOrder(root)
+
+    fun levelOrder(): List<T> = levelOrder(root)
+
+    fun toArray(): List<T?> = toArray(root)
+
+    fun toAscii(): String = toAscii(root)
+
+    override fun toString(): String {
+        val rootValue = root?.value?.toString() ?: "null"
+        return "BinaryTree(root=$rootValue, size=${size()})"
+    }
+
+    companion object {
+        fun <T> empty(): BinaryTree<T> = BinaryTree()
+
+        fun <T> singleton(value: T): BinaryTree<T> = BinaryTree(BinaryTreeNode(value))
+
+        fun <T> withRoot(root: BinaryTreeNode<T>?): BinaryTree<T> = BinaryTree(root)
+
+        fun <T> fromLevelOrder(values: List<T?>): BinaryTree<T> =
+            BinaryTree(buildFromLevelOrder(values, 0))
+
+        fun <T> find(root: BinaryTreeNode<T>?, value: T): BinaryTreeNode<T>? {
+            if (root == null) return null
+            if (root.value == value) return root
+            return find(root.left, value) ?: find(root.right, value)
+        }
+
+        fun <T> leftChild(root: BinaryTreeNode<T>?, value: T): BinaryTreeNode<T>? =
+            find(root, value)?.left
+
+        fun <T> rightChild(root: BinaryTreeNode<T>?, value: T): BinaryTreeNode<T>? =
+            find(root, value)?.right
+
+        fun <T> isFull(root: BinaryTreeNode<T>?): Boolean =
+            when {
+                root == null -> true
+                root.left == null && root.right == null -> true
+                root.left == null || root.right == null -> false
+                else -> isFull(root.left) && isFull(root.right)
+            }
+
+        fun <T> isComplete(root: BinaryTreeNode<T>?): Boolean {
+            val queue: Queue<BinaryTreeNode<T>?> = LinkedList()
+            queue.add(root)
+            var seenNull = false
+
+            while (queue.isNotEmpty()) {
+                val node = queue.remove()
+                if (node == null) {
+                    seenNull = true
+                    continue
+                }
+                if (seenNull) return false
+                queue.add(node.left)
+                queue.add(node.right)
+            }
+
+            return true
+        }
+
+        fun <T> isPerfect(root: BinaryTreeNode<T>?): Boolean {
+            val treeHeight = height(root)
+            return if (treeHeight < 0) {
+                size(root) == 0
+            } else {
+                size(root) == (1 shl (treeHeight + 1)) - 1
+            }
+        }
+
+        fun <T> height(root: BinaryTreeNode<T>?): Int =
+            if (root == null) -1 else 1 + maxOf(height(root.left), height(root.right))
+
+        fun <T> size(root: BinaryTreeNode<T>?): Int =
+            if (root == null) 0 else 1 + size(root.left) + size(root.right)
+
+        fun <T> inOrder(root: BinaryTreeNode<T>?): List<T> {
+            val output = mutableListOf<T>()
+            inOrder(root, output)
+            return output
+        }
+
+        fun <T> preOrder(root: BinaryTreeNode<T>?): List<T> {
+            val output = mutableListOf<T>()
+            preOrder(root, output)
+            return output
+        }
+
+        fun <T> postOrder(root: BinaryTreeNode<T>?): List<T> {
+            val output = mutableListOf<T>()
+            postOrder(root, output)
+            return output
+        }
+
+        fun <T> levelOrder(root: BinaryTreeNode<T>?): List<T> {
+            if (root == null) return emptyList()
+
+            val output = mutableListOf<T>()
+            val queue: Queue<BinaryTreeNode<T>> = ArrayDeque()
+            queue.add(root)
+
+            while (queue.isNotEmpty()) {
+                val node = queue.remove()
+                output += node.value
+                node.left?.let(queue::add)
+                node.right?.let(queue::add)
+            }
+
+            return output
+        }
+
+        fun <T> toArray(root: BinaryTreeNode<T>?): List<T?> {
+            val treeHeight = height(root)
+            if (treeHeight < 0) return emptyList()
+
+            val output = MutableList<T?>((1 shl (treeHeight + 1)) - 1) { null }
+            fillArray(root, 0, output)
+            return output
+        }
+
+        fun <T> toAscii(root: BinaryTreeNode<T>?): String {
+            if (root == null) return ""
+
+            val output = StringBuilder()
+            renderAscii(root, "", true, output)
+            return output.toString().trimEnd()
+        }
+
+        private fun <T> buildFromLevelOrder(values: List<T?>, index: Int): BinaryTreeNode<T>? {
+            if (index >= values.size) return null
+            val value = values[index] ?: return null
+            return BinaryTreeNode(
+                value,
+                buildFromLevelOrder(values, (2 * index) + 1),
+                buildFromLevelOrder(values, (2 * index) + 2),
+            )
+        }
+
+        private fun <T> inOrder(root: BinaryTreeNode<T>?, output: MutableList<T>) {
+            if (root == null) return
+            inOrder(root.left, output)
+            output += root.value
+            inOrder(root.right, output)
+        }
+
+        private fun <T> preOrder(root: BinaryTreeNode<T>?, output: MutableList<T>) {
+            if (root == null) return
+            output += root.value
+            preOrder(root.left, output)
+            preOrder(root.right, output)
+        }
+
+        private fun <T> postOrder(root: BinaryTreeNode<T>?, output: MutableList<T>) {
+            if (root == null) return
+            postOrder(root.left, output)
+            postOrder(root.right, output)
+            output += root.value
+        }
+
+        private fun <T> fillArray(root: BinaryTreeNode<T>?, index: Int, output: MutableList<T?>) {
+            if (root == null || index >= output.size) return
+            output[index] = root.value
+            fillArray(root.left, (2 * index) + 1, output)
+            fillArray(root.right, (2 * index) + 2, output)
+        }
+
+        private fun <T> renderAscii(
+            node: BinaryTreeNode<T>,
+            prefix: String,
+            isTail: Boolean,
+            output: StringBuilder,
+        ) {
+            output
+                .append(prefix)
+                .append(if (isTail) "`-- " else "|-- ")
+                .append(node.value)
+                .append(System.lineSeparator())
+
+            val children = listOfNotNull(node.left, node.right)
+            val nextPrefix = prefix + if (isTail) "    " else "|   "
+            children.forEachIndexed { index, child ->
+                renderAscii(child, nextPrefix, index + 1 == children.size, output)
+            }
+        }
+    }
+}

--- a/code/packages/kotlin/binary-tree/src/test/kotlin/com/codingadventures/binarytree/BinaryTreeTest.kt
+++ b/code/packages/kotlin/binary-tree/src/test/kotlin/com/codingadventures/binarytree/BinaryTreeTest.kt
@@ -1,0 +1,104 @@
+package com.codingadventures.binarytree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class BinaryTreeTest {
+    @Test
+    fun buildsFromLevelOrderAndProjectsBackToArray() {
+        val tree = BinaryTree.fromLevelOrder(listOf(1, 2, 3, 4, 5, 6, 7))
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7), tree.toArray())
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7), tree.levelOrder())
+        assertEquals(7, tree.size())
+        assertEquals(2, tree.height())
+    }
+
+    @Test
+    fun shapeQueriesDistinguishFullCompleteAndPerfectTrees() {
+        val perfect = BinaryTree.fromLevelOrder(listOf(1, 2, 3, 4, 5, 6, 7))
+        assertTrue(perfect.isFull())
+        assertTrue(perfect.isComplete())
+        assertTrue(perfect.isPerfect())
+
+        val complete = BinaryTree.fromLevelOrder(listOf(1, 2, 3, 4, null, null, null))
+        assertFalse(complete.isFull())
+        assertTrue(complete.isComplete())
+        assertFalse(complete.isPerfect())
+
+        val incomplete = BinaryTree.fromLevelOrder(listOf(1, null, 3))
+        assertFalse(incomplete.isComplete())
+    }
+
+    @Test
+    fun traversalsAndChildLookupMatchReferenceOrder() {
+        val tree = BinaryTree.fromLevelOrder(listOf(1, 2, 3, 4, null, 5, null))
+
+        assertEquals(listOf(4, 2, 1, 5, 3), tree.inOrder())
+        assertEquals(listOf(1, 2, 4, 3, 5), tree.preOrder())
+        assertEquals(listOf(4, 2, 5, 3, 1), tree.postOrder())
+        assertEquals(listOf(1, 2, 3, 4, 5), tree.levelOrder())
+        assertEquals(2, tree.leftChild(1)?.value)
+        assertEquals(3, tree.rightChild(1)?.value)
+        assertNull(tree.find(99))
+    }
+
+    @Test
+    fun emptyAndSingletonTreesExposeEdgeCases() {
+        val empty = BinaryTree.empty<String>()
+        assertNull(empty.root)
+        assertEquals(-1, empty.height())
+        assertEquals(0, empty.size())
+        assertTrue(empty.isFull())
+        assertTrue(empty.isComplete())
+        assertTrue(empty.isPerfect())
+        assertEquals(emptyList(), empty.inOrder())
+        assertEquals(emptyList(), empty.toArray())
+        assertEquals("", empty.toAscii())
+        assertEquals("BinaryTree(root=null, size=0)", empty.toString())
+
+        val single = BinaryTree.singleton("root")
+        assertEquals("root", single.root?.value)
+        assertEquals(listOf("root"), single.toArray())
+        assertEquals("BinaryTree(root=root, size=1)", single.toString())
+    }
+
+    @Test
+    fun asciiRenderingContainsValues() {
+        val tree = BinaryTree.fromLevelOrder(listOf("root", "left", "right"))
+        val ascii = tree.toAscii()
+
+        assertTrue("root" in ascii)
+        assertTrue("left" in ascii)
+        assertTrue("right" in ascii)
+        assertTrue("`--" in ascii)
+    }
+
+    @Test
+    fun staticHelpersSupportRawRootComposition() {
+        val root = BinaryTreeNode(
+            1,
+            BinaryTreeNode(2),
+            BinaryTreeNode(3),
+        )
+
+        assertSame(root, BinaryTree.withRoot(root).root)
+        assertEquals(2, BinaryTree.leftChild(root, 1)?.value)
+        assertEquals(3, BinaryTree.rightChild(root, 1)?.value)
+        assertEquals(listOf(2, 1, 3), BinaryTree.inOrder(root))
+        assertEquals(listOf(1, 2, 3), BinaryTree.preOrder(root))
+        assertEquals(listOf(2, 3, 1), BinaryTree.postOrder(root))
+        assertEquals(listOf(1, 2, 3), BinaryTree.levelOrder(root))
+        assertEquals(listOf(1, 2, 3), BinaryTree.toArray(root))
+        assertTrue(BinaryTree.isFull(root))
+        assertTrue(BinaryTree.isComplete(root))
+        assertTrue(BinaryTree.isPerfect(root))
+        assertEquals(1, BinaryTree.height(root))
+        assertEquals(3, BinaryTree.size(root))
+        assertTrue("1" in BinaryTree.toAscii(root))
+    }
+}


### PR DESCRIPTION
## Summary
- add a Kotlin binary-tree package with level-order construction, traversals, shape predicates, array projection, and ASCII rendering
- expose BinaryTree/BinaryTreeNode plus companion helpers for raw node composition
- add kotlin.test coverage and Gradle package metadata/build wrappers

## Verification
- kotlinc src\\main\\kotlin\\com\\codingadventures\\binarytree\\BinaryTree.kt -d kotlinc-out\\classes
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)