### PR TITLE
feat(parity): add kotlin binary search tree package

### DIFF
--- a/code/packages/kotlin/binary-search-tree/.gitignore
+++ b/code/packages/kotlin/binary-search-tree/.gitignore
@@ -1,0 +1,6 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/
+/kotlinc-out/

--- a/code/packages/kotlin/binary-search-tree/BUILD
+++ b/code/packages/kotlin/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/binary-search-tree/BUILD_windows
+++ b/code/packages/kotlin/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/binary-search-tree/CHANGELOG.md
+++ b/code/packages/kotlin/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Kotlin binary search tree package.

--- a/code/packages/kotlin/binary-search-tree/README.md
+++ b/code/packages/kotlin/binary-search-tree/README.md
@@ -1,0 +1,3 @@
+# kotlin/binary-search-tree
+
+Native Kotlin immutable binary search tree with insert/delete, search, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/kotlin/binary-search-tree/build.gradle.kts
+++ b/code/packages/kotlin/binary-search-tree/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/binary-search-tree/required_capabilities.json
+++ b/code/packages/kotlin/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/binary-search-tree/settings.gradle.kts
+++ b/code/packages/kotlin/binary-search-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "binary-search-tree"

--- a/code/packages/kotlin/binary-search-tree/src/main/kotlin/com/codingadventures/binarysearchtree/BinarySearchTree.kt
+++ b/code/packages/kotlin/binary-search-tree/src/main/kotlin/com/codingadventures/binarysearchtree/BinarySearchTree.kt
@@ -1,0 +1,230 @@
+package com.codingadventures.binarysearchtree
+
+data class BstNode<T : Comparable<T>>(
+    val value: T,
+    val left: BstNode<T>? = null,
+    val right: BstNode<T>? = null,
+    val size: Int = 1,
+) {
+    companion object {
+        fun <T : Comparable<T>> leaf(value: T): BstNode<T> = BstNode(value)
+
+        fun <T : Comparable<T>> create(
+            value: T,
+            left: BstNode<T>?,
+            right: BstNode<T>?,
+        ): BstNode<T> = BstNode(value, left, right, 1 + size(left) + size(right))
+
+        fun <T : Comparable<T>> size(node: BstNode<T>?): Int = node?.size ?: 0
+    }
+}
+
+class BinarySearchTree<T : Comparable<T>>(val root: BstNode<T>? = null) {
+    fun insert(value: T): BinarySearchTree<T> = BinarySearchTree(insertNode(root, value))
+
+    fun delete(value: T): BinarySearchTree<T> = BinarySearchTree(deleteNode(root, value))
+
+    fun search(value: T): BstNode<T>? = searchNode(root, value)
+
+    fun contains(value: T): Boolean = search(value) != null
+
+    fun minValue(): T? = minValue(root)
+
+    fun maxValue(): T? = maxValue(root)
+
+    fun predecessor(value: T): T? = predecessor(root, value)
+
+    fun successor(value: T): T? = successor(root, value)
+
+    fun kthSmallest(k: Int): T? = kthSmallest(root, k)
+
+    fun rank(value: T): Int = rank(root, value)
+
+    fun toSortedArray(): List<T> = toSortedArray(root)
+
+    fun isValid(): Boolean = isValid(root)
+
+    fun height(): Int = height(root)
+
+    fun size(): Int = BstNode.size(root)
+
+    override fun toString(): String {
+        val rootValue = root?.value?.toString() ?: "null"
+        return "BinarySearchTree(root=$rootValue, size=${size()})"
+    }
+
+    companion object {
+        fun <T : Comparable<T>> empty(): BinarySearchTree<T> = BinarySearchTree()
+
+        fun <T : Comparable<T>> fromSortedArray(values: List<T>): BinarySearchTree<T> =
+            BinarySearchTree(buildBalanced(values, 0, values.size))
+
+        fun <T : Comparable<T>> searchNode(root: BstNode<T>?, value: T): BstNode<T>? {
+            var current = root
+            while (current != null) {
+                current = when {
+                    value < current.value -> current.left
+                    value > current.value -> current.right
+                    else -> return current
+                }
+            }
+            return null
+        }
+
+        fun <T : Comparable<T>> insertNode(root: BstNode<T>?, value: T): BstNode<T> {
+            if (root == null) return BstNode.leaf(value)
+
+            return when {
+                value < root.value -> BstNode.create(root.value, insertNode(root.left, value), root.right)
+                value > root.value -> BstNode.create(root.value, root.left, insertNode(root.right, value))
+                else -> root
+            }
+        }
+
+        fun <T : Comparable<T>> deleteNode(root: BstNode<T>?, value: T): BstNode<T>? {
+            if (root == null) return null
+
+            return when {
+                value < root.value -> BstNode.create(root.value, deleteNode(root.left, value), root.right)
+                value > root.value -> BstNode.create(root.value, root.left, deleteNode(root.right, value))
+                root.left == null -> root.right
+                root.right == null -> root.left
+                else -> {
+                    val extracted = extractMin(root.right)
+                    BstNode.create(extracted.minimum, root.left, extracted.root)
+                }
+            }
+        }
+
+        fun <T : Comparable<T>> minValue(root: BstNode<T>?): T? {
+            var current = root
+            while (current?.left != null) {
+                current = current.left
+            }
+            return current?.value
+        }
+
+        fun <T : Comparable<T>> maxValue(root: BstNode<T>?): T? {
+            var current = root
+            while (current?.right != null) {
+                current = current.right
+            }
+            return current?.value
+        }
+
+        fun <T : Comparable<T>> predecessor(root: BstNode<T>?, value: T): T? {
+            var current = root
+            var best: T? = null
+
+            while (current != null) {
+                if (value <= current.value) {
+                    current = current.left
+                } else {
+                    best = current.value
+                    current = current.right
+                }
+            }
+
+            return best
+        }
+
+        fun <T : Comparable<T>> successor(root: BstNode<T>?, value: T): T? {
+            var current = root
+            var best: T? = null
+
+            while (current != null) {
+                if (value >= current.value) {
+                    current = current.right
+                } else {
+                    best = current.value
+                    current = current.left
+                }
+            }
+
+            return best
+        }
+
+        fun <T : Comparable<T>> kthSmallest(root: BstNode<T>?, k: Int): T? {
+            if (root == null || k <= 0) return null
+
+            val leftSize = BstNode.size(root.left)
+            return when {
+                k == leftSize + 1 -> root.value
+                k <= leftSize -> kthSmallest(root.left, k)
+                else -> kthSmallest(root.right, k - leftSize - 1)
+            }
+        }
+
+        fun <T : Comparable<T>> rank(root: BstNode<T>?, value: T): Int {
+            if (root == null) return 0
+
+            return when {
+                value < root.value -> rank(root.left, value)
+                value > root.value -> BstNode.size(root.left) + 1 + rank(root.right, value)
+                else -> BstNode.size(root.left)
+            }
+        }
+
+        fun <T : Comparable<T>> toSortedArray(root: BstNode<T>?): List<T> {
+            val output = mutableListOf<T>()
+            inOrder(root, output)
+            return output
+        }
+
+        fun <T : Comparable<T>> isValid(root: BstNode<T>?): Boolean =
+            validate(root, null, null) != null
+
+        fun <T : Comparable<T>> height(root: BstNode<T>?): Int =
+            if (root == null) -1 else 1 + maxOf(height(root.left), height(root.right))
+
+        private fun <T : Comparable<T>> extractMin(root: BstNode<T>): Extracted<T> {
+            if (root.left == null) {
+                return Extracted(root.right, root.value)
+            }
+
+            val extracted = extractMin(root.left)
+            return Extracted(
+                BstNode.create(root.value, extracted.root, root.right),
+                extracted.minimum,
+            )
+        }
+
+        private fun <T : Comparable<T>> buildBalanced(values: List<T>, start: Int, end: Int): BstNode<T>? {
+            if (start >= end) return null
+
+            val mid = start + (end - start) / 2
+            return BstNode.create(
+                values[mid],
+                buildBalanced(values, start, mid),
+                buildBalanced(values, mid + 1, end),
+            )
+        }
+
+        private fun <T : Comparable<T>> inOrder(root: BstNode<T>?, output: MutableList<T>) {
+            if (root == null) return
+            inOrder(root.left, output)
+            output += root.value
+            inOrder(root.right, output)
+        }
+
+        private fun <T : Comparable<T>> validate(
+            root: BstNode<T>?,
+            minimum: T?,
+            maximum: T?,
+        ): Validation? {
+            if (root == null) return Validation(-1, 0)
+            if (minimum != null && root.value <= minimum) return null
+            if (maximum != null && root.value >= maximum) return null
+
+            val left = validate(root.left, minimum, root.value) ?: return null
+            val right = validate(root.right, root.value, maximum) ?: return null
+            val expectedSize = 1 + left.size + right.size
+            if (root.size != expectedSize) return null
+            return Validation(1 + maxOf(left.height, right.height), expectedSize)
+        }
+
+        private data class Extracted<T : Comparable<T>>(val root: BstNode<T>?, val minimum: T)
+
+        private data class Validation(val height: Int, val size: Int)
+    }
+}

--- a/code/packages/kotlin/binary-search-tree/src/test/kotlin/com/codingadventures/binarysearchtree/BinarySearchTreeTest.kt
+++ b/code/packages/kotlin/binary-search-tree/src/test/kotlin/com/codingadventures/binarysearchtree/BinarySearchTreeTest.kt
@@ -1,0 +1,119 @@
+package com.codingadventures.binarysearchtree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class BinarySearchTreeTest {
+    @Test
+    fun insertSearchAndDeleteWorkImmutably() {
+        val tree = populated()
+
+        assertEquals(listOf(1, 3, 5, 7, 8), tree.toSortedArray())
+        assertEquals(5, tree.size())
+        assertTrue(tree.contains(7))
+        assertEquals(7, tree.search(7)?.value)
+        assertEquals(1, tree.minValue())
+        assertEquals(8, tree.maxValue())
+        assertEquals(3, tree.predecessor(5))
+        assertEquals(7, tree.successor(5))
+        assertEquals(2, tree.rank(4))
+        assertEquals(7, tree.kthSmallest(4))
+
+        val deleted = tree.delete(5)
+        assertFalse(deleted.contains(5))
+        assertTrue(deleted.isValid())
+        assertTrue(tree.contains(5))
+    }
+
+    @Test
+    fun fromSortedArrayBuildsBalancedTree() {
+        val tree = BinarySearchTree.fromSortedArray(listOf(1, 2, 3, 4, 5, 6, 7))
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6, 7), tree.toSortedArray())
+        assertEquals(2, tree.height())
+        assertEquals(7, tree.size())
+        assertTrue(tree.isValid())
+        assertEquals(4, tree.root?.value)
+    }
+
+    @Test
+    fun emptyTreeReturnsNullsAndNeutralMetrics() {
+        val tree = BinarySearchTree.empty<Int>()
+
+        assertNull(tree.search(1))
+        assertNull(tree.minValue())
+        assertNull(tree.maxValue())
+        assertNull(tree.predecessor(1))
+        assertNull(tree.successor(1))
+        assertNull(tree.kthSmallest(0))
+        assertNull(tree.kthSmallest(1))
+        assertEquals(0, tree.rank(1))
+        assertEquals(-1, tree.height())
+        assertEquals(0, tree.size())
+        assertEquals("BinarySearchTree(root=null, size=0)", tree.toString())
+    }
+
+    @Test
+    fun duplicatesAndSingleChildDeleteKeepPersistentShape() {
+        val tree = BinarySearchTree.fromSortedArray(listOf(2, 4, 6, 8))
+
+        assertEquals(6, tree.root?.value)
+        val duplicate = tree.insert(4)
+
+        assertSame(tree.root?.left, duplicate.root?.left)
+        assertEquals(tree.toSortedArray(), duplicate.toSortedArray())
+        assertEquals(listOf(4, 6, 8), tree.delete(2).toSortedArray())
+    }
+
+    @Test
+    fun validationCatchesBadOrderingAndStaleSizes() {
+        val badOrder = BinarySearchTree(BstNode(5, left = BstNode.leaf(6), size = 2))
+        val badSize = BinarySearchTree(BstNode(5, left = BstNode.leaf(3), size = 99))
+
+        assertFalse(badOrder.isValid())
+        assertFalse(badSize.isValid())
+    }
+
+    @Test
+    fun staticHelpersSupportRawRootComposition() {
+        var root: BstNode<Int>? = null
+        root = BinarySearchTree.insertNode(root, 5)
+        root = BinarySearchTree.insertNode(root, 2)
+        root = BinarySearchTree.insertNode(root, 9)
+
+        assertEquals(5, BinarySearchTree.searchNode(root, 5)?.value)
+        assertEquals(2, BinarySearchTree.minValue(root))
+        assertEquals(9, BinarySearchTree.maxValue(root))
+        assertEquals(5, BinarySearchTree.kthSmallest(root, 2))
+        assertEquals(1, BinarySearchTree.rank(root, 5))
+        assertEquals(1, BinarySearchTree.height(root))
+        assertTrue(BinarySearchTree.isValid(root))
+        assertEquals(listOf(2, 5, 9), BinarySearchTree.toSortedArray(root))
+
+        val deleted = BinarySearchTree.deleteNode(root, 2)
+        assertEquals(listOf(5, 9), BinarySearchTree.toSortedArray(deleted))
+        assertNull(BinarySearchTree.deleteNode(null, 2))
+    }
+
+    @Test
+    fun referenceComparableValuesRetainSortedOrder() {
+        val tree = BinarySearchTree.empty<String>()
+            .insert("delta")
+            .insert("alpha")
+            .insert("gamma")
+
+        assertEquals(listOf("alpha", "delta", "gamma"), tree.toSortedArray())
+        assertEquals("BinarySearchTree(root=delta, size=3)", tree.toString())
+        assertEquals("gamma", tree.successor("delta"))
+        assertNull(tree.predecessor("alpha"))
+    }
+
+    private fun populated(): BinarySearchTree<Int> =
+        listOf(5, 1, 8, 3, 7).fold(BinarySearchTree.empty()) { tree, value ->
+            tree.insert(value)
+        }
+}


### PR DESCRIPTION
## Summary
- add a Kotlin binary-search-tree package with immutable insert/delete, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose BinarySearchTree/BstNode plus companion helpers for raw node composition
- add kotlin.test coverage and Gradle package metadata/build wrappers

## Verification
- kotlinc src\\main\\kotlin\\com\\codingadventures\\binarysearchtree\\BinarySearchTree.kt -d kotlinc-out\\classes
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)