### PR TITLE
feat(parity): add csharp avl tree package

### DIFF
--- a/code/packages/csharp/avl-tree/AvlTree.cs
+++ b/code/packages/csharp/avl-tree/AvlTree.cs
@@ -1,0 +1,448 @@
+using System.Collections;
+
+namespace CodingAdventures.AvlTree;
+
+public sealed class AvlNode<T>
+    where T : IComparable<T>
+{
+    public AvlNode(
+        T value,
+        AvlNode<T>? left = null,
+        AvlNode<T>? right = null,
+        int? height = null,
+        int? size = null)
+    {
+        Value = value;
+        Left = left;
+        Right = right;
+        Height = height ?? 1 + Math.Max(AvlTree<T>.NodeHeight(left), AvlTree<T>.NodeHeight(right));
+        Size = size ?? 1 + AvlTree<T>.NodeSize(left) + AvlTree<T>.NodeSize(right);
+    }
+
+    public T Value { get; }
+
+    public AvlNode<T>? Left { get; }
+
+    public AvlNode<T>? Right { get; }
+
+    public int Height { get; }
+
+    public int Size { get; }
+}
+
+public sealed class AvlTree<T> : IReadOnlyCollection<T>
+    where T : IComparable<T>
+{
+    public AvlTree(AvlNode<T>? root = null)
+    {
+        Root = root;
+    }
+
+    public AvlNode<T>? Root { get; }
+
+    public int Count => Size();
+
+    public static AvlTree<T> Empty() => new();
+
+    public static AvlTree<T> FromValues(IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var tree = Empty();
+        foreach (var value in values)
+        {
+            tree = tree.Insert(value);
+        }
+
+        return tree;
+    }
+
+    public AvlTree<T> Insert(T value) => new(InsertNode(Root, value));
+
+    public AvlTree<T> Delete(T value) => new(DeleteNode(Root, value));
+
+    public AvlNode<T>? Search(T value) => SearchNode(Root, value);
+
+    public bool Contains(T value) => Search(value) is not null;
+
+    public T? MinValue() => MinValue(Root);
+
+    public T? MaxValue() => MaxValue(Root);
+
+    public T? Predecessor(T value) => Predecessor(Root, value);
+
+    public T? Successor(T value) => Successor(Root, value);
+
+    public T? KthSmallest(int k) => KthSmallest(Root, k);
+
+    public int Rank(T value) => Rank(Root, value);
+
+    public List<T> ToSortedArray()
+    {
+        var output = new List<T>();
+        InOrder(Root, output);
+        return output;
+    }
+
+    public bool IsValidBst() => IsValidBst(Root);
+
+    public bool IsValidAvl() => ValidateAvl(Root, default, default, hasMinimum: false, hasMaximum: false) is not null;
+
+    public int BalanceFactor(AvlNode<T>? node) => BalanceFactorNode(node);
+
+    public int Height() => NodeHeight(Root);
+
+    public int Size() => NodeSize(Root);
+
+    public IEnumerator<T> GetEnumerator() => ToSortedArray().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString()
+    {
+        var root = Root is null ? "null" : Root.Value?.ToString();
+        return $"AvlTree(root={root}, size={Size()}, height={Height()})";
+    }
+
+    public static AvlNode<T>? SearchNode(AvlNode<T>? root, T value)
+    {
+        var current = root;
+        while (current is not null)
+        {
+            var comparison = value.CompareTo(current.Value);
+            if (comparison < 0)
+            {
+                current = current.Left;
+            }
+            else if (comparison > 0)
+            {
+                current = current.Right;
+            }
+            else
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    public static AvlNode<T> InsertNode(AvlNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return new AvlNode<T>(value);
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return Rebalance(new AvlNode<T>(root.Value, InsertNode(root.Left, value), root.Right));
+        }
+
+        if (comparison > 0)
+        {
+            return Rebalance(new AvlNode<T>(root.Value, root.Left, InsertNode(root.Right, value)));
+        }
+
+        return root;
+    }
+
+    public static AvlNode<T>? DeleteNode(AvlNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return null;
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return Rebalance(new AvlNode<T>(root.Value, DeleteNode(root.Left, value), root.Right));
+        }
+
+        if (comparison > 0)
+        {
+            return Rebalance(new AvlNode<T>(root.Value, root.Left, DeleteNode(root.Right, value)));
+        }
+
+        if (root.Left is null)
+        {
+            return root.Right;
+        }
+
+        if (root.Right is null)
+        {
+            return root.Left;
+        }
+
+        var (newRight, successor) = ExtractMin(root.Right);
+        return Rebalance(new AvlNode<T>(successor, root.Left, newRight));
+    }
+
+    public static T? MinValue(AvlNode<T>? root)
+    {
+        var current = root;
+        while (current?.Left is not null)
+        {
+            current = current.Left;
+        }
+
+        return current is null ? default : current.Value;
+    }
+
+    public static T? MaxValue(AvlNode<T>? root)
+    {
+        var current = root;
+        while (current?.Right is not null)
+        {
+            current = current.Right;
+        }
+
+        return current is null ? default : current.Value;
+    }
+
+    public static T? Predecessor(AvlNode<T>? root, T value)
+    {
+        var current = root;
+        var best = default(T);
+        var hasBest = false;
+
+        while (current is not null)
+        {
+            if (value.CompareTo(current.Value) <= 0)
+            {
+                current = current.Left;
+            }
+            else
+            {
+                best = current.Value;
+                hasBest = true;
+                current = current.Right;
+            }
+        }
+
+        return hasBest ? best : default;
+    }
+
+    public static T? Successor(AvlNode<T>? root, T value)
+    {
+        var current = root;
+        var best = default(T);
+        var hasBest = false;
+
+        while (current is not null)
+        {
+            if (value.CompareTo(current.Value) >= 0)
+            {
+                current = current.Right;
+            }
+            else
+            {
+                best = current.Value;
+                hasBest = true;
+                current = current.Left;
+            }
+        }
+
+        return hasBest ? best : default;
+    }
+
+    public static T? KthSmallest(AvlNode<T>? root, int k)
+    {
+        if (root is null || k <= 0)
+        {
+            return default;
+        }
+
+        var leftSize = NodeSize(root.Left);
+        if (k == leftSize + 1)
+        {
+            return root.Value;
+        }
+
+        return k <= leftSize
+            ? KthSmallest(root.Left, k)
+            : KthSmallest(root.Right, k - leftSize - 1);
+    }
+
+    public static int Rank(AvlNode<T>? root, T value)
+    {
+        if (root is null)
+        {
+            return 0;
+        }
+
+        var comparison = value.CompareTo(root.Value);
+        if (comparison < 0)
+        {
+            return Rank(root.Left, value);
+        }
+
+        if (comparison > 0)
+        {
+            return NodeSize(root.Left) + 1 + Rank(root.Right, value);
+        }
+
+        return NodeSize(root.Left);
+    }
+
+    public static bool IsValidBst(AvlNode<T>? root)
+    {
+        return ValidateBst(root, default, default, hasMinimum: false, hasMaximum: false);
+    }
+
+    public static bool IsValidAvl(AvlNode<T>? root)
+    {
+        return ValidateAvl(root, default, default, hasMinimum: false, hasMaximum: false) is not null;
+    }
+
+    public static int BalanceFactorNode(AvlNode<T>? node)
+    {
+        return node is null ? 0 : NodeHeight(node.Left) - NodeHeight(node.Right);
+    }
+
+    public static int NodeHeight(AvlNode<T>? root) => root?.Height ?? -1;
+
+    public static int NodeSize(AvlNode<T>? root) => root?.Size ?? 0;
+
+    private static AvlNode<T> Rebalance(AvlNode<T> node)
+    {
+        var balance = BalanceFactorNode(node);
+
+        if (balance > 1)
+        {
+            var left = node.Left;
+            if (left is not null && BalanceFactorNode(left) < 0)
+            {
+                left = RotateLeft(left);
+            }
+
+            return RotateRight(new AvlNode<T>(node.Value, left, node.Right));
+        }
+
+        if (balance < -1)
+        {
+            var right = node.Right;
+            if (right is not null && BalanceFactorNode(right) > 0)
+            {
+                right = RotateRight(right);
+            }
+
+            return RotateLeft(new AvlNode<T>(node.Value, node.Left, right));
+        }
+
+        return node;
+    }
+
+    private static AvlNode<T> RotateLeft(AvlNode<T> root)
+    {
+        var right = root.Right;
+        if (right is null)
+        {
+            return root;
+        }
+
+        var newLeft = new AvlNode<T>(root.Value, root.Left, right.Left);
+        return new AvlNode<T>(right.Value, newLeft, right.Right);
+    }
+
+    private static AvlNode<T> RotateRight(AvlNode<T> root)
+    {
+        var left = root.Left;
+        if (left is null)
+        {
+            return root;
+        }
+
+        var newRight = new AvlNode<T>(root.Value, left.Right, root.Right);
+        return new AvlNode<T>(left.Value, left.Left, newRight);
+    }
+
+    private static (AvlNode<T>? Root, T Minimum) ExtractMin(AvlNode<T> root)
+    {
+        if (root.Left is null)
+        {
+            return (root.Right, root.Value);
+        }
+
+        var (newLeft, minimum) = ExtractMin(root.Left);
+        return (Rebalance(new AvlNode<T>(root.Value, newLeft, root.Right)), minimum);
+    }
+
+    private static void InOrder(AvlNode<T>? root, List<T> output)
+    {
+        if (root is null)
+        {
+            return;
+        }
+
+        InOrder(root.Left, output);
+        output.Add(root.Value);
+        InOrder(root.Right, output);
+    }
+
+    private static bool ValidateBst(
+        AvlNode<T>? root,
+        T? minimum,
+        T? maximum,
+        bool hasMinimum,
+        bool hasMaximum)
+    {
+        if (root is null)
+        {
+            return true;
+        }
+
+        if (hasMinimum && root.Value.CompareTo(minimum!) <= 0)
+        {
+            return false;
+        }
+
+        if (hasMaximum && root.Value.CompareTo(maximum!) >= 0)
+        {
+            return false;
+        }
+
+        return ValidateBst(root.Left, minimum, root.Value, hasMinimum, hasMaximum: true)
+            && ValidateBst(root.Right, root.Value, maximum, hasMinimum: true, hasMaximum);
+    }
+
+    private static (int Height, int Size)? ValidateAvl(
+        AvlNode<T>? root,
+        T? minimum,
+        T? maximum,
+        bool hasMinimum,
+        bool hasMaximum)
+    {
+        if (root is null)
+        {
+            return (-1, 0);
+        }
+
+        if (hasMinimum && root.Value.CompareTo(minimum!) <= 0)
+        {
+            return null;
+        }
+
+        if (hasMaximum && root.Value.CompareTo(maximum!) >= 0)
+        {
+            return null;
+        }
+
+        var left = ValidateAvl(root.Left, minimum, root.Value, hasMinimum, hasMaximum: true);
+        var right = ValidateAvl(root.Right, root.Value, maximum, hasMinimum: true, hasMaximum);
+        if (left is null || right is null)
+        {
+            return null;
+        }
+
+        var height = 1 + Math.Max(left.Value.Height, right.Value.Height);
+        var size = 1 + left.Value.Size + right.Value.Size;
+        if (root.Height != height || root.Size != size || Math.Abs(left.Value.Height - right.Value.Height) > 1)
+        {
+            return null;
+        }
+
+        return (height, size);
+    }
+}

--- a/code/packages/csharp/avl-tree/BUILD
+++ b/code/packages/csharp/avl-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/avl-tree/BUILD_windows
+++ b/code/packages/csharp/avl-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/avl-tree/CHANGELOG.md
+++ b/code/packages/csharp/avl-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# AVL tree package.

--- a/code/packages/csharp/avl-tree/CodingAdventures.AvlTree.csproj
+++ b/code/packages/csharp/avl-tree/CodingAdventures.AvlTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.AvlTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# immutable AVL tree with order-statistic helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/avl-tree/README.md
+++ b/code/packages/csharp/avl-tree/README.md
@@ -1,0 +1,3 @@
+# csharp/avl-tree
+
+Pure C# immutable AVL tree with rotations, search, delete, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/csharp/avl-tree/required_capabilities.json
+++ b/code/packages/csharp/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/avl-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/AvlTreeTests.cs
+++ b/code/packages/csharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/AvlTreeTests.cs
@@ -1,0 +1,135 @@
+namespace CodingAdventures.AvlTree.Tests;
+
+public sealed class AvlTreeTests
+{
+    [Fact]
+    public void RotationsRebalanceTheTree()
+    {
+        var tree = AvlTree<int>.FromValues([10, 20, 30]);
+
+        Assert.Equal([10, 20, 30], tree.ToSortedArray());
+        Assert.Equal(20, tree.Root?.Value);
+        Assert.True(tree.IsValidBst());
+        Assert.True(tree.IsValidAvl());
+        Assert.Equal(1, tree.Height());
+        Assert.Equal(3, tree.Size());
+        Assert.Equal(0, tree.BalanceFactor(tree.Root));
+        Assert.Equal(3, tree.Count);
+
+        tree = AvlTree<int>.FromValues([30, 20, 10]);
+        Assert.Equal(20, tree.Root?.Value);
+        Assert.True(tree.IsValidAvl());
+    }
+
+    [Fact]
+    public void SearchAndOrderStatisticsWork()
+    {
+        var tree = AvlTree<int>.FromValues([40, 20, 60, 10, 30, 50, 70]);
+
+        Assert.Equal(20, tree.Search(20)?.Value);
+        Assert.True(tree.Contains(50));
+        Assert.Equal(10, tree.MinValue());
+        Assert.Equal(70, tree.MaxValue());
+        Assert.Equal(30, tree.Predecessor(40));
+        Assert.Equal(50, tree.Successor(40));
+        Assert.Equal(40, tree.KthSmallest(4));
+        Assert.Equal(3, tree.Rank(35));
+        Assert.Equal([10, 20, 30, 40, 50, 60, 70], tree.ToList());
+
+        var deleted = tree.Delete(20);
+
+        Assert.False(deleted.Contains(20));
+        Assert.True(deleted.IsValidAvl());
+        Assert.True(tree.Contains(20));
+    }
+
+    [Fact]
+    public void EdgeCasesAndDuplicatesReturnDefaults()
+    {
+        var tree = AvlTree<int>.Empty();
+
+        Assert.Null(tree.Search(1));
+        Assert.Equal(0, tree.MinValue());
+        Assert.Equal(0, tree.MaxValue());
+        Assert.Equal(0, tree.Predecessor(1));
+        Assert.Equal(0, tree.Successor(1));
+        Assert.Equal(0, tree.KthSmallest(0));
+        Assert.Equal(0, tree.Rank(1));
+        Assert.Equal(0, tree.BalanceFactor(null));
+        Assert.Equal(-1, tree.Height());
+        Assert.Equal(0, tree.Size());
+        Assert.Equal("AvlTree(root=null, size=0, height=-1)", tree.ToString());
+
+        tree = AvlTree<int>.FromValues([30, 20, 40, 10, 25, 35, 50]);
+        var duplicate = tree.Insert(25);
+        Assert.Equal(tree.ToSortedArray(), duplicate.ToSortedArray());
+        Assert.Equal(tree.ToSortedArray(), tree.Delete(999).ToSortedArray());
+
+        var single = new AvlTree<int>(new AvlNode<int>(5));
+        Assert.Equal(5, single.Root?.Value);
+        Assert.Equal(0, single.Height());
+        Assert.Equal([2], AvlTree<int>.FromValues([1, 2]).Delete(1).ToSortedArray());
+        Assert.Equal([1], AvlTree<int>.FromValues([2, 1]).Delete(2).ToSortedArray());
+    }
+
+    [Fact]
+    public void DoubleRotationsAndValidationFailuresAreCovered()
+    {
+        var leftRight = AvlTree<int>.FromValues([30, 10, 20]);
+        var rightLeft = AvlTree<int>.FromValues([10, 30, 20]);
+
+        Assert.Equal(20, leftRight.Root?.Value);
+        Assert.Equal(20, rightLeft.Root?.Value);
+        Assert.True(leftRight.IsValidAvl());
+        Assert.True(rightLeft.IsValidAvl());
+
+        var badOrder = new AvlTree<int>(new AvlNode<int>(5, left: new AvlNode<int>(6), height: 1, size: 2));
+        var badRightOrder = new AvlTree<int>(new AvlNode<int>(5, right: new AvlNode<int>(4), height: 1, size: 2));
+        var badHeight = new AvlTree<int>(new AvlNode<int>(5, left: new AvlNode<int>(3), height: 99, size: 2));
+
+        Assert.False(badOrder.IsValidBst());
+        Assert.False(badOrder.IsValidAvl());
+        Assert.False(badRightOrder.IsValidBst());
+        Assert.False(badRightOrder.IsValidAvl());
+        Assert.False(badHeight.IsValidAvl());
+    }
+
+    [Fact]
+    public void DeleteWithNestedSuccessorAndStaticHelpersWork()
+    {
+        var tree = AvlTree<int>.FromValues([5, 3, 8, 7, 9, 6]);
+
+        var deleted = tree.Delete(5);
+        Assert.Equal([3, 6, 7, 8, 9], deleted.ToSortedArray());
+        Assert.True(deleted.IsValidAvl());
+        Assert.Equal(3, tree.KthSmallest(1));
+        Assert.Equal(9, tree.KthSmallest(6));
+        Assert.Equal(1, tree.Rank(5));
+
+        AvlNode<int>? root = null;
+        root = AvlTree<int>.InsertNode(root, 2);
+        root = AvlTree<int>.InsertNode(root, 1);
+        root = AvlTree<int>.InsertNode(root, 3);
+
+        Assert.Equal(2, AvlTree<int>.SearchNode(root, 2)?.Value);
+        Assert.Equal(1, AvlTree<int>.MinValue(root));
+        Assert.Equal(3, AvlTree<int>.MaxValue(root));
+        Assert.Equal(2, AvlTree<int>.KthSmallest(root, 2));
+        Assert.Equal(1, AvlTree<int>.Rank(root, 2));
+        Assert.Equal(0, AvlTree<int>.BalanceFactorNode(root));
+        Assert.True(AvlTree<int>.IsValidBst(root));
+        Assert.True(AvlTree<int>.IsValidAvl(root));
+        Assert.Null(AvlTree<int>.DeleteNode(null, 1));
+    }
+
+    [Fact]
+    public void ReferenceComparableValuesRetainSortedOrder()
+    {
+        var tree = AvlTree<string>.FromValues(["delta", "alpha", "gamma"]);
+
+        Assert.Equal(["alpha", "delta", "gamma"], tree.ToSortedArray());
+        Assert.Equal("AvlTree(root=delta, size=3, height=1)", tree.ToString());
+        Assert.Equal("gamma", tree.Successor("delta"));
+        Assert.Null(tree.Predecessor("alpha"));
+    }
+}

--- a/code/packages/csharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.csproj
+++ b/code/packages/csharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.AvlTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AvlTree.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a C# avl-tree package with immutable insert/delete, rotations, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose AvlTree/AvlNode plus static helpers for raw node composition
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.AvlTree.Tests\\CodingAdventures.AvlTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line