### PR TITLE
feat(parity): add fsharp avl tree package

### DIFF
--- a/code/packages/fsharp/avl-tree/AvlTree.fs
+++ b/code/packages/fsharp/avl-tree/AvlTree.fs
@@ -1,0 +1,322 @@
+namespace CodingAdventures.AvlTree
+
+open System.Collections.Generic
+
+type AvlNode<'T> =
+    { Value: 'T
+      Left: AvlNode<'T> option
+      Right: AvlNode<'T> option
+      Height: int
+      Size: int }
+
+    static member Leaf(value: 'T) =
+        { Value = value
+          Left = None
+          Right = None
+          Height = 0
+          Size = 1 }
+
+    static member Create(value: 'T, left: AvlNode<'T> option, right: AvlNode<'T> option) =
+        let nodeHeight node =
+            match node with
+            | None -> -1
+            | Some current -> current.Height
+
+        let nodeSize node =
+            match node with
+            | None -> 0
+            | Some current -> current.Size
+
+        { Value = value
+          Left = left
+          Right = right
+          Height = 1 + max (nodeHeight left) (nodeHeight right)
+          Size = 1 + nodeSize left + nodeSize right }
+
+module private AvlHelpers =
+    let comparer<'T> = Comparer<'T>.Default
+
+    let compareValues left right = comparer.Compare(left, right)
+
+    let nodeHeight root =
+        match root with
+        | None -> -1
+        | Some node -> node.Height
+
+    let nodeSize root =
+        match root with
+        | None -> 0
+        | Some node -> node.Size
+
+    let balanceFactor root =
+        match root with
+        | None -> 0
+        | Some node -> nodeHeight node.Left - nodeHeight node.Right
+
+    let rotateLeft root =
+        match root.Right with
+        | None -> root
+        | Some right ->
+            let newLeft = AvlNode.Create(root.Value, root.Left, right.Left)
+            AvlNode.Create(right.Value, Some newLeft, right.Right)
+
+    let rotateRight root =
+        match root.Left with
+        | None -> root
+        | Some left ->
+            let newRight = AvlNode.Create(root.Value, left.Right, root.Right)
+            AvlNode.Create(left.Value, left.Left, Some newRight)
+
+    let rebalance node =
+        let bf = balanceFactor (Some node)
+
+        if bf > 1 then
+            let left =
+                match node.Left with
+                | Some child when balanceFactor (Some child) < 0 -> Some(rotateLeft child)
+                | other -> other
+
+            rotateRight (AvlNode.Create(node.Value, left, node.Right))
+        elif bf < -1 then
+            let right =
+                match node.Right with
+                | Some child when balanceFactor (Some child) > 0 -> Some(rotateRight child)
+                | other -> other
+
+            rotateLeft (AvlNode.Create(node.Value, node.Left, right))
+        else
+            node
+
+    let rec search root value =
+        match root with
+        | None -> None
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 -> search node.Left value
+            | comparison when comparison > 0 -> search node.Right value
+            | _ -> Some node
+
+    let rec insert root value =
+        match root with
+        | None -> Some(AvlNode.Leaf value)
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 ->
+                Some(rebalance (AvlNode.Create(node.Value, insert node.Left value, node.Right)))
+            | comparison when comparison > 0 ->
+                Some(rebalance (AvlNode.Create(node.Value, node.Left, insert node.Right value)))
+            | _ -> root
+
+    let rec private extractMin root =
+        match root.Left with
+        | None -> root.Right, root.Value
+        | Some left ->
+            let newLeft, minimum = extractMin left
+            Some(rebalance (AvlNode.Create(root.Value, newLeft, root.Right))), minimum
+
+    let rec delete root value =
+        match root with
+        | None -> None
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 ->
+                Some(rebalance (AvlNode.Create(node.Value, delete node.Left value, node.Right)))
+            | comparison when comparison > 0 ->
+                Some(rebalance (AvlNode.Create(node.Value, node.Left, delete node.Right value)))
+            | _ ->
+                match node.Left, node.Right with
+                | None, None -> None
+                | Some left, None -> Some left
+                | None, Some right -> Some right
+                | Some left, Some right ->
+                    let newRight, successor = extractMin right
+                    Some(rebalance (AvlNode.Create(successor, Some left, newRight)))
+
+    let minValue root =
+        let rec walk current =
+            match current with
+            | None -> None
+            | Some node ->
+                match node.Left with
+                | None -> Some node.Value
+                | Some _ -> walk node.Left
+
+        walk root
+
+    let maxValue root =
+        let rec walk current =
+            match current with
+            | None -> None
+            | Some node ->
+                match node.Right with
+                | None -> Some node.Value
+                | Some _ -> walk node.Right
+
+        walk root
+
+    let predecessor root value =
+        let rec walk current best =
+            match current with
+            | None -> best
+            | Some node ->
+                if compareValues value node.Value <= 0 then
+                    walk node.Left best
+                else
+                    walk node.Right (Some node.Value)
+
+        walk root None
+
+    let successor root value =
+        let rec walk current best =
+            match current with
+            | None -> best
+            | Some node ->
+                if compareValues value node.Value >= 0 then
+                    walk node.Right best
+                else
+                    walk node.Left (Some node.Value)
+
+        walk root None
+
+    let rec kthSmallest root k =
+        match root with
+        | None -> None
+        | Some _ when k <= 0 -> None
+        | Some node ->
+            let leftSize = nodeSize node.Left
+
+            if k = leftSize + 1 then
+                Some node.Value
+            elif k <= leftSize then
+                kthSmallest node.Left k
+            else
+                kthSmallest node.Right (k - leftSize - 1)
+
+    let rec rank root value =
+        match root with
+        | None -> 0
+        | Some node ->
+            match compareValues value node.Value with
+            | comparison when comparison < 0 -> rank node.Left value
+            | comparison when comparison > 0 -> nodeSize node.Left + 1 + rank node.Right value
+            | _ -> nodeSize node.Left
+
+    let rec inOrder root =
+        match root with
+        | None -> []
+        | Some node -> inOrder node.Left @ [ node.Value ] @ inOrder node.Right
+
+    let rec validateBst root minimum maximum =
+        match root with
+        | None -> true
+        | Some node ->
+            match minimum, maximum with
+            | Some lower, _ when compareValues node.Value lower <= 0 -> false
+            | _, Some upper when compareValues node.Value upper >= 0 -> false
+            | _ -> validateBst node.Left minimum (Some node.Value) && validateBst node.Right (Some node.Value) maximum
+
+    let rec validateAvl root minimum maximum =
+        match root with
+        | None -> Some(-1, 0)
+        | Some node ->
+            match minimum, maximum with
+            | Some lower, _ when compareValues node.Value lower <= 0 -> None
+            | _, Some upper when compareValues node.Value upper >= 0 -> None
+            | _ ->
+                match validateAvl node.Left minimum (Some node.Value), validateAvl node.Right (Some node.Value) maximum with
+                | Some(leftHeight, leftSize), Some(rightHeight, rightSize) ->
+                    let expectedHeight = 1 + max leftHeight rightHeight
+                    let expectedSize = 1 + leftSize + rightSize
+
+                    if node.Height = expectedHeight
+                       && node.Size = expectedSize
+                       && abs (leftHeight - rightHeight) <= 1 then
+                        Some(expectedHeight, expectedSize)
+                    else
+                        None
+                | _ -> None
+
+type AvlTree<'T>(root: AvlNode<'T> option) =
+    new() = AvlTree<'T>(None)
+
+    member _.Root = root
+
+    static member Empty() = AvlTree<'T>(None)
+
+    static member FromValues(values: seq<'T>) =
+        if isNull (box values) then
+            nullArg "values"
+
+        values
+        |> Seq.fold (fun (tree: AvlTree<'T>) value -> tree.Insert(value)) (AvlTree<'T>.Empty())
+
+    member _.Insert(value: 'T) = AvlTree<'T>(AvlHelpers.insert root value)
+
+    member _.Delete(value: 'T) = AvlTree<'T>(AvlHelpers.delete root value)
+
+    member _.Search(value: 'T) = AvlHelpers.search root value
+
+    member this.Contains(value: 'T) = this.Search(value).IsSome
+
+    member _.MinValue() = AvlHelpers.minValue root
+
+    member _.MaxValue() = AvlHelpers.maxValue root
+
+    member _.Predecessor(value: 'T) = AvlHelpers.predecessor root value
+
+    member _.Successor(value: 'T) = AvlHelpers.successor root value
+
+    member _.KthSmallest(k: int) = AvlHelpers.kthSmallest root k
+
+    member _.Rank(value: 'T) = AvlHelpers.rank root value
+
+    member _.ToSortedArray() = AvlHelpers.inOrder root
+
+    member _.IsValidBst() = AvlHelpers.validateBst root None None
+
+    member _.IsValidAvl() = AvlHelpers.validateAvl root None None |> Option.isSome
+
+    member _.BalanceFactor(node: AvlNode<'T> option) = AvlHelpers.balanceFactor node
+
+    member _.Height() = AvlHelpers.nodeHeight root
+
+    member _.Size() = AvlHelpers.nodeSize root
+
+    override _.ToString() =
+        let rootLabel =
+            match root with
+            | None -> "null"
+            | Some node -> sprintf "%A" node.Value
+
+        sprintf "AvlTree(root=%s, size=%d, height=%d)" rootLabel (AvlHelpers.nodeSize root) (AvlHelpers.nodeHeight root)
+
+module AvlTreeAlgorithms =
+    let search value (root: AvlNode<'T> option) = AvlHelpers.search root value
+
+    let insert value (root: AvlNode<'T> option) = AvlHelpers.insert root value
+
+    let delete value (root: AvlNode<'T> option) = AvlHelpers.delete root value
+
+    let minValue root = AvlHelpers.minValue root
+
+    let maxValue root = AvlHelpers.maxValue root
+
+    let predecessor value root = AvlHelpers.predecessor root value
+
+    let successor value root = AvlHelpers.successor root value
+
+    let kthSmallest k root = AvlHelpers.kthSmallest root k
+
+    let rank value root = AvlHelpers.rank root value
+
+    let toSortedArray root = AvlHelpers.inOrder root
+
+    let isValidBst root = AvlHelpers.validateBst root None None
+
+    let isValidAvl root = AvlHelpers.validateAvl root None None |> Option.isSome
+
+    let balanceFactor root = AvlHelpers.balanceFactor root
+
+    let height root = AvlHelpers.nodeHeight root
+
+    let size root = AvlHelpers.nodeSize root

--- a/code/packages/fsharp/avl-tree/BUILD
+++ b/code/packages/fsharp/avl-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/avl-tree/BUILD_windows
+++ b/code/packages/fsharp/avl-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/avl-tree/CHANGELOG.md
+++ b/code/packages/fsharp/avl-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# AVL tree package.

--- a/code/packages/fsharp/avl-tree/CodingAdventures.AvlTree.fsproj
+++ b/code/packages/fsharp/avl-tree/CodingAdventures.AvlTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AvlTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Immutable F# AVL tree with order-statistic helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AvlTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/avl-tree/README.md
+++ b/code/packages/fsharp/avl-tree/README.md
@@ -1,0 +1,3 @@
+# fsharp/avl-tree
+
+Immutable F# AVL tree with rotations, search, delete, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/fsharp/avl-tree/required_capabilities.json
+++ b/code/packages/fsharp/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/avl-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/AvlTreeTests.fs
+++ b/code/packages/fsharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/AvlTreeTests.fs
@@ -1,0 +1,149 @@
+namespace CodingAdventures.AvlTree.Tests
+
+open Xunit
+open CodingAdventures.AvlTree
+
+type AvlTreeTests() =
+    [<Fact>]
+    member _.``rotations rebalance the tree``() =
+        let tree = AvlTree<int>.FromValues([ 10; 20; 30 ])
+
+        Assert.Equal<int list>([ 10; 20; 30 ], tree.ToSortedArray())
+        Assert.Equal<int option>(Some 20, tree.Root |> Option.map _.Value)
+        Assert.True(tree.IsValidBst())
+        Assert.True(tree.IsValidAvl())
+        Assert.Equal(1, tree.Height())
+        Assert.Equal(3, tree.Size())
+        Assert.Equal(0, tree.BalanceFactor(tree.Root))
+
+        let descending = AvlTree<int>.FromValues([ 30; 20; 10 ])
+        Assert.Equal<int option>(Some 20, descending.Root |> Option.map _.Value)
+        Assert.True(descending.IsValidAvl())
+
+    [<Fact>]
+    member _.``search and order statistics work``() =
+        let tree = AvlTree<int>.FromValues([ 40; 20; 60; 10; 30; 50; 70 ])
+
+        Assert.Equal<int option>(Some 20, tree.Search(20) |> Option.map _.Value)
+        Assert.True(tree.Contains(50))
+        Assert.Equal<int option>(Some 10, tree.MinValue())
+        Assert.Equal<int option>(Some 70, tree.MaxValue())
+        Assert.Equal<int option>(Some 30, tree.Predecessor(40))
+        Assert.Equal<int option>(Some 50, tree.Successor(40))
+        Assert.Equal<int option>(Some 40, tree.KthSmallest(4))
+        Assert.Equal(3, tree.Rank(35))
+
+        let deleted = tree.Delete(20)
+        Assert.False(deleted.Contains(20))
+        Assert.True(deleted.IsValidAvl())
+        Assert.True(tree.Contains(20))
+
+    [<Fact>]
+    member _.``edge cases and duplicates use options``() =
+        let empty = AvlTree<int>.Empty()
+
+        Assert.Equal<AvlNode<int> option>(None, empty.Search(1))
+        Assert.Equal<int option>(None, empty.MinValue())
+        Assert.Equal<int option>(None, empty.MaxValue())
+        Assert.Equal<int option>(None, empty.Predecessor(1))
+        Assert.Equal<int option>(None, empty.Successor(1))
+        Assert.Equal<int option>(None, empty.KthSmallest(0))
+        Assert.Equal(0, empty.Rank(1))
+        Assert.Equal(0, empty.BalanceFactor(None))
+        Assert.Equal(-1, empty.Height())
+        Assert.Equal(0, empty.Size())
+        Assert.Equal("AvlTree(root=null, size=0, height=-1)", empty.ToString())
+
+        let tree = AvlTree<int>.FromValues([ 30; 20; 40; 10; 25; 35; 50 ])
+        let duplicate = tree.Insert(25)
+        Assert.Equal<int list>(tree.ToSortedArray(), duplicate.ToSortedArray())
+        Assert.Equal<int list>(tree.ToSortedArray(), tree.Delete(999).ToSortedArray())
+
+        let single = AvlTree<int>(Some(AvlNode.Leaf 5))
+        Assert.Equal<int option>(Some 5, single.Root |> Option.map _.Value)
+        Assert.Equal(0, single.Height())
+        Assert.Equal<int list>([ 2 ], AvlTree<int>.FromValues([ 1; 2 ]).Delete(1).ToSortedArray())
+        Assert.Equal<int list>([ 1 ], AvlTree<int>.FromValues([ 2; 1 ]).Delete(2).ToSortedArray())
+
+    [<Fact>]
+    member _.``double rotations and validation failures are covered``() =
+        let leftRight = AvlTree<int>.FromValues([ 30; 10; 20 ])
+        let rightLeft = AvlTree<int>.FromValues([ 10; 30; 20 ])
+
+        Assert.Equal<int option>(Some 20, leftRight.Root |> Option.map _.Value)
+        Assert.Equal<int option>(Some 20, rightLeft.Root |> Option.map _.Value)
+        Assert.True(leftRight.IsValidAvl())
+        Assert.True(rightLeft.IsValidAvl())
+
+        let badOrder =
+            AvlTree<int>(
+                Some
+                    { Value = 5
+                      Left = Some(AvlNode.Leaf 6)
+                      Right = None
+                      Height = 1
+                      Size = 2 }
+            )
+
+        let badRightOrder =
+            AvlTree<int>(
+                Some
+                    { Value = 5
+                      Left = None
+                      Right = Some(AvlNode.Leaf 4)
+                      Height = 1
+                      Size = 2 }
+            )
+
+        let badHeight =
+            AvlTree<int>(
+                Some
+                    { Value = 5
+                      Left = Some(AvlNode.Leaf 3)
+                      Right = None
+                      Height = 99
+                      Size = 2 }
+            )
+
+        Assert.False(badOrder.IsValidBst())
+        Assert.False(badOrder.IsValidAvl())
+        Assert.False(badRightOrder.IsValidBst())
+        Assert.False(badRightOrder.IsValidAvl())
+        Assert.False(badHeight.IsValidAvl())
+
+    [<Fact>]
+    member _.``delete with nested successor and module helpers work``() =
+        let tree = AvlTree<int>.FromValues([ 5; 3; 8; 7; 9; 6 ])
+
+        let deleted = tree.Delete(5)
+        Assert.Equal<int list>([ 3; 6; 7; 8; 9 ], deleted.ToSortedArray())
+        Assert.True(deleted.IsValidAvl())
+        Assert.Equal<int option>(Some 3, tree.KthSmallest(1))
+        Assert.Equal<int option>(Some 9, tree.KthSmallest(6))
+        Assert.Equal(1, tree.Rank(5))
+
+        let root =
+            None
+            |> AvlTreeAlgorithms.insert 2
+            |> AvlTreeAlgorithms.insert 1
+            |> AvlTreeAlgorithms.insert 3
+
+        Assert.Equal<int option>(Some 2, AvlTreeAlgorithms.search 2 root |> Option.map _.Value)
+        Assert.Equal<int option>(Some 1, AvlTreeAlgorithms.minValue root)
+        Assert.Equal<int option>(Some 3, AvlTreeAlgorithms.maxValue root)
+        Assert.Equal<int option>(Some 2, AvlTreeAlgorithms.kthSmallest 2 root)
+        Assert.Equal(1, AvlTreeAlgorithms.rank 2 root)
+        Assert.Equal(0, AvlTreeAlgorithms.balanceFactor root)
+        Assert.True(AvlTreeAlgorithms.isValidBst root)
+        Assert.True(AvlTreeAlgorithms.isValidAvl root)
+        Assert.Equal<int list>([ 1; 2; 3 ], AvlTreeAlgorithms.toSortedArray root)
+        Assert.Equal<int list>([ 2; 3 ], AvlTreeAlgorithms.delete 1 root |> AvlTreeAlgorithms.toSortedArray)
+
+    [<Fact>]
+    member _.``reference comparable values retain sorted order``() =
+        let tree = AvlTree<string>.FromValues([ "delta"; "alpha"; "gamma" ])
+
+        Assert.Equal<string list>([ "alpha"; "delta"; "gamma" ], tree.ToSortedArray())
+        Assert.Equal("AvlTree(root=\"delta\", size=3, height=1)", tree.ToString())
+        Assert.Equal<string option>(Some "gamma", tree.Successor("delta"))
+        Assert.Equal<string option>(None, tree.Predecessor("alpha"))

--- a/code/packages/fsharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.fsproj
+++ b/code/packages/fsharp/avl-tree/tests/CodingAdventures.AvlTree.Tests/CodingAdventures.AvlTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AvlTree.fsproj" />
+    <Compile Include="AvlTreeTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an F# avl-tree package with immutable insert/delete, rotations, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose AvlTree/AvlNode plus module helpers for raw node composition
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.AvlTree.Tests\\CodingAdventures.AvlTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line