### PR TITLE
feat(parity): add java avl tree package

### DIFF
--- a/code/packages/java/avl-tree/.gitignore
+++ b/code/packages/java/avl-tree/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/javac-out/

--- a/code/packages/java/avl-tree/BUILD
+++ b/code/packages/java/avl-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/avl-tree/BUILD_windows
+++ b/code/packages/java/avl-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/avl-tree/CHANGELOG.md
+++ b/code/packages/java/avl-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Java AVL tree package.

--- a/code/packages/java/avl-tree/README.md
+++ b/code/packages/java/avl-tree/README.md
@@ -1,0 +1,3 @@
+# java/avl-tree
+
+Native Java immutable AVL tree with rotations, search, delete, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/java/avl-tree/build.gradle.kts
+++ b/code/packages/java/avl-tree/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/avl-tree/required_capabilities.json
+++ b/code/packages/java/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/avl-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/avl-tree/settings.gradle.kts
+++ b/code/packages/java/avl-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "avl-tree"

--- a/code/packages/java/avl-tree/src/main/java/com/codingadventures/avltree/AvlNode.java
+++ b/code/packages/java/avl-tree/src/main/java/com/codingadventures/avltree/AvlNode.java
@@ -1,0 +1,19 @@
+package com.codingadventures.avltree;
+
+public record AvlNode<T>(T value, AvlNode<T> left, AvlNode<T> right, int height, int size) {
+    public AvlNode(T value) {
+        this(value, null, null, 0, 1);
+    }
+
+    public AvlNode(T value, AvlNode<T> left, AvlNode<T> right) {
+        this(value, left, right, 1 + Math.max(height(left), height(right)), 1 + size(left) + size(right));
+    }
+
+    public static <T> int height(AvlNode<T> node) {
+        return node == null ? -1 : node.height();
+    }
+
+    public static <T> int size(AvlNode<T> node) {
+        return node == null ? 0 : node.size();
+    }
+}

--- a/code/packages/java/avl-tree/src/main/java/com/codingadventures/avltree/AvlTree.java
+++ b/code/packages/java/avl-tree/src/main/java/com/codingadventures/avltree/AvlTree.java
@@ -1,0 +1,360 @@
+package com.codingadventures.avltree;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class AvlTree<T extends Comparable<? super T>> {
+    private final AvlNode<T> root;
+
+    public AvlTree() {
+        this(null);
+    }
+
+    public AvlTree(AvlNode<T> root) {
+        this.root = root;
+    }
+
+    public static <T extends Comparable<? super T>> AvlTree<T> empty() {
+        return new AvlTree<>();
+    }
+
+    public static <T extends Comparable<? super T>> AvlTree<T> fromValues(Iterable<T> values) {
+        Objects.requireNonNull(values, "values");
+        AvlTree<T> tree = empty();
+        for (T value : values) {
+            tree = tree.insert(value);
+        }
+        return tree;
+    }
+
+    public AvlNode<T> root() {
+        return root;
+    }
+
+    public AvlTree<T> insert(T value) {
+        return new AvlTree<>(insertNode(root, value));
+    }
+
+    public AvlTree<T> delete(T value) {
+        return new AvlTree<>(deleteNode(root, value));
+    }
+
+    public AvlNode<T> search(T value) {
+        return searchNode(root, value);
+    }
+
+    public boolean contains(T value) {
+        return search(value) != null;
+    }
+
+    public T minValue() {
+        return minValue(root);
+    }
+
+    public T maxValue() {
+        return maxValue(root);
+    }
+
+    public T predecessor(T value) {
+        return predecessor(root, value);
+    }
+
+    public T successor(T value) {
+        return successor(root, value);
+    }
+
+    public T kthSmallest(int k) {
+        return kthSmallest(root, k);
+    }
+
+    public int rank(T value) {
+        return rank(root, value);
+    }
+
+    public List<T> toSortedArray() {
+        return toSortedArray(root);
+    }
+
+    public boolean isValidBst() {
+        return isValidBst(root);
+    }
+
+    public boolean isValidAvl() {
+        return isValidAvl(root);
+    }
+
+    public int balanceFactor(AvlNode<T> node) {
+        return balanceFactorNode(node);
+    }
+
+    public int height() {
+        return AvlNode.height(root);
+    }
+
+    public int size() {
+        return AvlNode.size(root);
+    }
+
+    @Override
+    public String toString() {
+        String rootValue = root == null ? "null" : String.valueOf(root.value());
+        return "AvlTree(root=" + rootValue + ", size=" + size() + ", height=" + height() + ")";
+    }
+
+    public static <T extends Comparable<? super T>> AvlNode<T> searchNode(AvlNode<T> root, T value) {
+        AvlNode<T> current = root;
+        while (current != null) {
+            int comparison = value.compareTo(current.value());
+            if (comparison < 0) {
+                current = current.left();
+            } else if (comparison > 0) {
+                current = current.right();
+            } else {
+                return current;
+            }
+        }
+        return null;
+    }
+
+    public static <T extends Comparable<? super T>> AvlNode<T> insertNode(AvlNode<T> root, T value) {
+        if (root == null) {
+            return new AvlNode<>(value);
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return rebalance(new AvlNode<>(root.value(), insertNode(root.left(), value), root.right()));
+        }
+        if (comparison > 0) {
+            return rebalance(new AvlNode<>(root.value(), root.left(), insertNode(root.right(), value)));
+        }
+        return root;
+    }
+
+    public static <T extends Comparable<? super T>> AvlNode<T> deleteNode(AvlNode<T> root, T value) {
+        if (root == null) {
+            return null;
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return rebalance(new AvlNode<>(root.value(), deleteNode(root.left(), value), root.right()));
+        }
+        if (comparison > 0) {
+            return rebalance(new AvlNode<>(root.value(), root.left(), deleteNode(root.right(), value)));
+        }
+
+        if (root.left() == null) {
+            return root.right();
+        }
+        if (root.right() == null) {
+            return root.left();
+        }
+
+        Extracted<T> extracted = extractMin(root.right());
+        return rebalance(new AvlNode<>(extracted.minimum(), root.left(), extracted.root()));
+    }
+
+    public static <T extends Comparable<? super T>> T minValue(AvlNode<T> root) {
+        AvlNode<T> current = root;
+        while (current != null && current.left() != null) {
+            current = current.left();
+        }
+        return current == null ? null : current.value();
+    }
+
+    public static <T extends Comparable<? super T>> T maxValue(AvlNode<T> root) {
+        AvlNode<T> current = root;
+        while (current != null && current.right() != null) {
+            current = current.right();
+        }
+        return current == null ? null : current.value();
+    }
+
+    public static <T extends Comparable<? super T>> T predecessor(AvlNode<T> root, T value) {
+        AvlNode<T> current = root;
+        T best = null;
+        while (current != null) {
+            if (value.compareTo(current.value()) <= 0) {
+                current = current.left();
+            } else {
+                best = current.value();
+                current = current.right();
+            }
+        }
+        return best;
+    }
+
+    public static <T extends Comparable<? super T>> T successor(AvlNode<T> root, T value) {
+        AvlNode<T> current = root;
+        T best = null;
+        while (current != null) {
+            if (value.compareTo(current.value()) >= 0) {
+                current = current.right();
+            } else {
+                best = current.value();
+                current = current.left();
+            }
+        }
+        return best;
+    }
+
+    public static <T extends Comparable<? super T>> T kthSmallest(AvlNode<T> root, int k) {
+        if (root == null || k <= 0) {
+            return null;
+        }
+
+        int leftSize = AvlNode.size(root.left());
+        if (k == leftSize + 1) {
+            return root.value();
+        }
+        if (k <= leftSize) {
+            return kthSmallest(root.left(), k);
+        }
+        return kthSmallest(root.right(), k - leftSize - 1);
+    }
+
+    public static <T extends Comparable<? super T>> int rank(AvlNode<T> root, T value) {
+        if (root == null) {
+            return 0;
+        }
+
+        int comparison = value.compareTo(root.value());
+        if (comparison < 0) {
+            return rank(root.left(), value);
+        }
+        if (comparison > 0) {
+            return AvlNode.size(root.left()) + 1 + rank(root.right(), value);
+        }
+        return AvlNode.size(root.left());
+    }
+
+    public static <T extends Comparable<? super T>> List<T> toSortedArray(AvlNode<T> root) {
+        List<T> output = new ArrayList<>();
+        inOrder(root, output);
+        return output;
+    }
+
+    public static <T extends Comparable<? super T>> boolean isValidBst(AvlNode<T> root) {
+        return validateBst(root, null, null);
+    }
+
+    public static <T extends Comparable<? super T>> boolean isValidAvl(AvlNode<T> root) {
+        return validateAvl(root, null, null) != null;
+    }
+
+    public static <T> int balanceFactorNode(AvlNode<T> node) {
+        return node == null ? 0 : AvlNode.height(node.left()) - AvlNode.height(node.right());
+    }
+
+    private static <T extends Comparable<? super T>> AvlNode<T> rebalance(AvlNode<T> node) {
+        int balance = balanceFactorNode(node);
+
+        if (balance > 1) {
+            AvlNode<T> left = node.left();
+            if (left != null && balanceFactorNode(left) < 0) {
+                left = rotateLeft(left);
+            }
+            return rotateRight(new AvlNode<>(node.value(), left, node.right()));
+        }
+
+        if (balance < -1) {
+            AvlNode<T> right = node.right();
+            if (right != null && balanceFactorNode(right) > 0) {
+                right = rotateRight(right);
+            }
+            return rotateLeft(new AvlNode<>(node.value(), node.left(), right));
+        }
+
+        return node;
+    }
+
+    private static <T extends Comparable<? super T>> AvlNode<T> rotateLeft(AvlNode<T> root) {
+        AvlNode<T> right = root.right();
+        if (right == null) {
+            return root;
+        }
+
+        AvlNode<T> newLeft = new AvlNode<>(root.value(), root.left(), right.left());
+        return new AvlNode<>(right.value(), newLeft, right.right());
+    }
+
+    private static <T extends Comparable<? super T>> AvlNode<T> rotateRight(AvlNode<T> root) {
+        AvlNode<T> left = root.left();
+        if (left == null) {
+            return root;
+        }
+
+        AvlNode<T> newRight = new AvlNode<>(root.value(), left.right(), root.right());
+        return new AvlNode<>(left.value(), left.left(), newRight);
+    }
+
+    private static <T extends Comparable<? super T>> Extracted<T> extractMin(AvlNode<T> root) {
+        if (root.left() == null) {
+            return new Extracted<>(root.right(), root.value());
+        }
+
+        Extracted<T> extracted = extractMin(root.left());
+        return new Extracted<>(
+                rebalance(new AvlNode<>(root.value(), extracted.root(), root.right())),
+                extracted.minimum());
+    }
+
+    private static <T extends Comparable<? super T>> void inOrder(AvlNode<T> root, List<T> output) {
+        if (root == null) {
+            return;
+        }
+        inOrder(root.left(), output);
+        output.add(root.value());
+        inOrder(root.right(), output);
+    }
+
+    private static <T extends Comparable<? super T>> boolean validateBst(AvlNode<T> root, T minimum, T maximum) {
+        if (root == null) {
+            return true;
+        }
+        if (minimum != null && root.value().compareTo(minimum) <= 0) {
+            return false;
+        }
+        if (maximum != null && root.value().compareTo(maximum) >= 0) {
+            return false;
+        }
+        return validateBst(root.left(), minimum, root.value())
+                && validateBst(root.right(), root.value(), maximum);
+    }
+
+    private static <T extends Comparable<? super T>> Validation validateAvl(AvlNode<T> root, T minimum, T maximum) {
+        if (root == null) {
+            return new Validation(-1, 0);
+        }
+        if (minimum != null && root.value().compareTo(minimum) <= 0) {
+            return null;
+        }
+        if (maximum != null && root.value().compareTo(maximum) >= 0) {
+            return null;
+        }
+
+        Validation left = validateAvl(root.left(), minimum, root.value());
+        Validation right = validateAvl(root.right(), root.value(), maximum);
+        if (left == null || right == null) {
+            return null;
+        }
+
+        int expectedHeight = 1 + Math.max(left.height(), right.height());
+        int expectedSize = 1 + left.size() + right.size();
+        if (root.height() != expectedHeight
+                || root.size() != expectedSize
+                || Math.abs(left.height() - right.height()) > 1) {
+            return null;
+        }
+
+        return new Validation(expectedHeight, expectedSize);
+    }
+
+    private record Extracted<T>(AvlNode<T> root, T minimum) {
+    }
+
+    private record Validation(int height, int size) {
+    }
+}

--- a/code/packages/java/avl-tree/src/test/java/com/codingadventures/avltree/AvlTreeTest.java
+++ b/code/packages/java/avl-tree/src/test/java/com/codingadventures/avltree/AvlTreeTest.java
@@ -1,0 +1,127 @@
+package com.codingadventures.avltree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AvlTreeTest {
+    @Test
+    void rotationsRebalanceTheTree() {
+        AvlTree<Integer> tree = AvlTree.fromValues(List.of(10, 20, 30));
+
+        assertEquals(List.of(10, 20, 30), tree.toSortedArray());
+        assertEquals(20, tree.root().value());
+        assertTrue(tree.isValidBst());
+        assertTrue(tree.isValidAvl());
+        assertEquals(1, tree.height());
+        assertEquals(3, tree.size());
+        assertEquals(0, tree.balanceFactor(tree.root()));
+
+        tree = AvlTree.fromValues(List.of(30, 20, 10));
+        assertEquals(20, tree.root().value());
+        assertTrue(tree.isValidAvl());
+    }
+
+    @Test
+    void searchAndOrderStatisticsWork() {
+        AvlTree<Integer> tree = AvlTree.fromValues(List.of(40, 20, 60, 10, 30, 50, 70));
+
+        assertEquals(20, tree.search(20).value());
+        assertTrue(tree.contains(50));
+        assertEquals(10, tree.minValue());
+        assertEquals(70, tree.maxValue());
+        assertEquals(30, tree.predecessor(40));
+        assertEquals(50, tree.successor(40));
+        assertEquals(40, tree.kthSmallest(4));
+        assertEquals(3, tree.rank(35));
+
+        AvlTree<Integer> deleted = tree.delete(20);
+        assertFalse(deleted.contains(20));
+        assertTrue(deleted.isValidAvl());
+        assertTrue(tree.contains(20));
+    }
+
+    @Test
+    void emptyTreeAndDuplicatesHandleEdges() {
+        AvlTree<Integer> empty = AvlTree.empty();
+
+        assertNull(empty.search(1));
+        assertNull(empty.minValue());
+        assertNull(empty.maxValue());
+        assertNull(empty.predecessor(1));
+        assertNull(empty.successor(1));
+        assertNull(empty.kthSmallest(0));
+        assertEquals(0, empty.rank(1));
+        assertEquals(0, empty.balanceFactor(null));
+        assertEquals(-1, empty.height());
+        assertEquals(0, empty.size());
+        assertEquals("AvlTree(root=null, size=0, height=-1)", empty.toString());
+
+        AvlTree<Integer> tree = AvlTree.fromValues(List.of(30, 20, 40, 10, 25, 35, 50));
+        AvlTree<Integer> duplicate = tree.insert(25);
+        assertEquals(tree.toSortedArray(), duplicate.toSortedArray());
+        assertEquals(tree.toSortedArray(), tree.delete(999).toSortedArray());
+    }
+
+    @Test
+    void doubleRotationsAndValidationFailuresAreCovered() {
+        AvlTree<Integer> leftRight = AvlTree.fromValues(List.of(30, 10, 20));
+        AvlTree<Integer> rightLeft = AvlTree.fromValues(List.of(10, 30, 20));
+
+        assertEquals(20, leftRight.root().value());
+        assertEquals(20, rightLeft.root().value());
+        assertTrue(leftRight.isValidAvl());
+        assertTrue(rightLeft.isValidAvl());
+
+        AvlTree<Integer> badOrder = new AvlTree<>(new AvlNode<>(5, new AvlNode<>(6), null, 1, 2));
+        AvlTree<Integer> badRightOrder = new AvlTree<>(new AvlNode<>(5, null, new AvlNode<>(4), 1, 2));
+        AvlTree<Integer> badHeight = new AvlTree<>(new AvlNode<>(5, new AvlNode<>(3), null, 99, 2));
+
+        assertFalse(badOrder.isValidBst());
+        assertFalse(badOrder.isValidAvl());
+        assertFalse(badRightOrder.isValidBst());
+        assertFalse(badRightOrder.isValidAvl());
+        assertFalse(badHeight.isValidAvl());
+    }
+
+    @Test
+    void deleteWithNestedSuccessorAndStaticHelpersWork() {
+        AvlTree<Integer> tree = AvlTree.fromValues(List.of(5, 3, 8, 7, 9, 6));
+
+        AvlTree<Integer> deleted = tree.delete(5);
+        assertEquals(List.of(3, 6, 7, 8, 9), deleted.toSortedArray());
+        assertTrue(deleted.isValidAvl());
+        assertEquals(3, tree.kthSmallest(1));
+        assertEquals(9, tree.kthSmallest(6));
+        assertEquals(1, tree.rank(5));
+
+        AvlNode<Integer> root = null;
+        root = AvlTree.insertNode(root, 2);
+        root = AvlTree.insertNode(root, 1);
+        root = AvlTree.insertNode(root, 3);
+
+        assertEquals(2, AvlTree.searchNode(root, 2).value());
+        assertEquals(1, AvlTree.minValue(root));
+        assertEquals(3, AvlTree.maxValue(root));
+        assertEquals(2, AvlTree.kthSmallest(root, 2));
+        assertEquals(1, AvlTree.rank(root, 2));
+        assertEquals(0, AvlTree.balanceFactorNode(root));
+        assertTrue(AvlTree.isValidBst(root));
+        assertTrue(AvlTree.isValidAvl(root));
+        assertEquals(List.of(1, 2, 3), AvlTree.toSortedArray(root));
+        assertEquals(List.of(2, 3), AvlTree.toSortedArray(AvlTree.deleteNode(root, 1)));
+        assertNull(AvlTree.deleteNode(null, 1));
+    }
+
+    @Test
+    void referenceComparableValuesRetainSortedOrder() {
+        AvlTree<String> tree = AvlTree.fromValues(List.of("delta", "alpha", "gamma"));
+
+        assertEquals(List.of("alpha", "delta", "gamma"), tree.toSortedArray());
+        assertEquals("AvlTree(root=delta, size=3, height=1)", tree.toString());
+        assertEquals("gamma", tree.successor("delta"));
+        assertNull(tree.predecessor("alpha"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Java avl-tree package with immutable insert/delete, rotations, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose AvlTree/AvlNode plus static helpers for raw node composition
- add JUnit tests and Gradle package metadata/build wrappers

## Verification
- javac --release 21 -d javac-out\\classes src\\main\\java\\com\\codingadventures\\avltree\\AvlNode.java src\\main\\java\\com\\codingadventures\\avltree\\AvlTree.java
- JShell smoke test for sorted traversal, delete, and AVL validation using the compiled classes
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)