### PR TITLE
feat(parity): add kotlin avl tree package

### DIFF
--- a/code/packages/kotlin/avl-tree/.gitignore
+++ b/code/packages/kotlin/avl-tree/.gitignore
@@ -1,0 +1,6 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/
+/kotlinc-out/

--- a/code/packages/kotlin/avl-tree/BUILD
+++ b/code/packages/kotlin/avl-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/avl-tree/BUILD_windows
+++ b/code/packages/kotlin/avl-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/avl-tree/CHANGELOG.md
+++ b/code/packages/kotlin/avl-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial Kotlin AVL tree package.

--- a/code/packages/kotlin/avl-tree/README.md
+++ b/code/packages/kotlin/avl-tree/README.md
@@ -1,0 +1,3 @@
+# kotlin/avl-tree
+
+Native Kotlin immutable AVL tree with rotations, search, delete, order-statistic helpers, sorted traversal, and validation.

--- a/code/packages/kotlin/avl-tree/build.gradle.kts
+++ b/code/packages/kotlin/avl-tree/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/avl-tree/required_capabilities.json
+++ b/code/packages/kotlin/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/avl-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/avl-tree/settings.gradle.kts
+++ b/code/packages/kotlin/avl-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "avl-tree"

--- a/code/packages/kotlin/avl-tree/src/main/kotlin/com/codingadventures/avltree/AvlTree.kt
+++ b/code/packages/kotlin/avl-tree/src/main/kotlin/com/codingadventures/avltree/AvlTree.kt
@@ -1,0 +1,279 @@
+package com.codingadventures.avltree
+
+data class AvlNode<T : Comparable<T>>(
+    val value: T,
+    val left: AvlNode<T>? = null,
+    val right: AvlNode<T>? = null,
+    val height: Int = 0,
+    val size: Int = 1,
+) {
+    companion object {
+        fun <T : Comparable<T>> leaf(value: T): AvlNode<T> = AvlNode(value)
+
+        fun <T : Comparable<T>> create(
+            value: T,
+            left: AvlNode<T>?,
+            right: AvlNode<T>?,
+        ): AvlNode<T> = AvlNode(value, left, right, 1 + maxOf(height(left), height(right)), 1 + size(left) + size(right))
+
+        fun <T : Comparable<T>> height(node: AvlNode<T>?): Int = node?.height ?: -1
+
+        fun <T : Comparable<T>> size(node: AvlNode<T>?): Int = node?.size ?: 0
+    }
+}
+
+class AvlTree<T : Comparable<T>>(val root: AvlNode<T>? = null) {
+    fun insert(value: T): AvlTree<T> = AvlTree(insertNode(root, value))
+
+    fun delete(value: T): AvlTree<T> = AvlTree(deleteNode(root, value))
+
+    fun search(value: T): AvlNode<T>? = searchNode(root, value)
+
+    fun contains(value: T): Boolean = search(value) != null
+
+    fun minValue(): T? = minValue(root)
+
+    fun maxValue(): T? = maxValue(root)
+
+    fun predecessor(value: T): T? = predecessor(root, value)
+
+    fun successor(value: T): T? = successor(root, value)
+
+    fun kthSmallest(k: Int): T? = kthSmallest(root, k)
+
+    fun rank(value: T): Int = rank(root, value)
+
+    fun toSortedArray(): List<T> = toSortedArray(root)
+
+    fun isValidBst(): Boolean = isValidBst(root)
+
+    fun isValidAvl(): Boolean = isValidAvl(root)
+
+    fun balanceFactor(node: AvlNode<T>?): Int = balanceFactorNode(node)
+
+    fun height(): Int = AvlNode.height(root)
+
+    fun size(): Int = AvlNode.size(root)
+
+    override fun toString(): String {
+        val rootValue = root?.value?.toString() ?: "null"
+        return "AvlTree(root=$rootValue, size=${size()}, height=${height()})"
+    }
+
+    companion object {
+        fun <T : Comparable<T>> empty(): AvlTree<T> = AvlTree()
+
+        fun <T : Comparable<T>> fromValues(values: Iterable<T>): AvlTree<T> =
+            values.fold(empty()) { tree, value -> tree.insert(value) }
+
+        fun <T : Comparable<T>> searchNode(root: AvlNode<T>?, value: T): AvlNode<T>? {
+            var current = root
+            while (current != null) {
+                current = when {
+                    value < current.value -> current.left
+                    value > current.value -> current.right
+                    else -> return current
+                }
+            }
+            return null
+        }
+
+        fun <T : Comparable<T>> insertNode(root: AvlNode<T>?, value: T): AvlNode<T> {
+            if (root == null) return AvlNode.leaf(value)
+
+            return when {
+                value < root.value -> rebalance(AvlNode.create(root.value, insertNode(root.left, value), root.right))
+                value > root.value -> rebalance(AvlNode.create(root.value, root.left, insertNode(root.right, value)))
+                else -> root
+            }
+        }
+
+        fun <T : Comparable<T>> deleteNode(root: AvlNode<T>?, value: T): AvlNode<T>? {
+            if (root == null) return null
+
+            return when {
+                value < root.value -> rebalance(AvlNode.create(root.value, deleteNode(root.left, value), root.right))
+                value > root.value -> rebalance(AvlNode.create(root.value, root.left, deleteNode(root.right, value)))
+                root.left == null -> root.right
+                root.right == null -> root.left
+                else -> {
+                    val extracted = extractMin(root.right)
+                    rebalance(AvlNode.create(extracted.minimum, root.left, extracted.root))
+                }
+            }
+        }
+
+        fun <T : Comparable<T>> minValue(root: AvlNode<T>?): T? {
+            var current = root
+            while (current?.left != null) {
+                current = current.left
+            }
+            return current?.value
+        }
+
+        fun <T : Comparable<T>> maxValue(root: AvlNode<T>?): T? {
+            var current = root
+            while (current?.right != null) {
+                current = current.right
+            }
+            return current?.value
+        }
+
+        fun <T : Comparable<T>> predecessor(root: AvlNode<T>?, value: T): T? {
+            var current = root
+            var best: T? = null
+
+            while (current != null) {
+                if (value <= current.value) {
+                    current = current.left
+                } else {
+                    best = current.value
+                    current = current.right
+                }
+            }
+
+            return best
+        }
+
+        fun <T : Comparable<T>> successor(root: AvlNode<T>?, value: T): T? {
+            var current = root
+            var best: T? = null
+
+            while (current != null) {
+                if (value >= current.value) {
+                    current = current.right
+                } else {
+                    best = current.value
+                    current = current.left
+                }
+            }
+
+            return best
+        }
+
+        fun <T : Comparable<T>> kthSmallest(root: AvlNode<T>?, k: Int): T? {
+            if (root == null || k <= 0) return null
+
+            val leftSize = AvlNode.size(root.left)
+            return when {
+                k == leftSize + 1 -> root.value
+                k <= leftSize -> kthSmallest(root.left, k)
+                else -> kthSmallest(root.right, k - leftSize - 1)
+            }
+        }
+
+        fun <T : Comparable<T>> rank(root: AvlNode<T>?, value: T): Int {
+            if (root == null) return 0
+
+            return when {
+                value < root.value -> rank(root.left, value)
+                value > root.value -> AvlNode.size(root.left) + 1 + rank(root.right, value)
+                else -> AvlNode.size(root.left)
+            }
+        }
+
+        fun <T : Comparable<T>> toSortedArray(root: AvlNode<T>?): List<T> {
+            val output = mutableListOf<T>()
+            inOrder(root, output)
+            return output
+        }
+
+        fun <T : Comparable<T>> isValidBst(root: AvlNode<T>?): Boolean =
+            validateBst(root, null, null)
+
+        fun <T : Comparable<T>> isValidAvl(root: AvlNode<T>?): Boolean =
+            validateAvl(root, null, null) != null
+
+        fun <T : Comparable<T>> balanceFactorNode(node: AvlNode<T>?): Int =
+            if (node == null) 0 else AvlNode.height(node.left) - AvlNode.height(node.right)
+
+        private fun <T : Comparable<T>> rebalance(node: AvlNode<T>): AvlNode<T> {
+            val balance = balanceFactorNode(node)
+
+            if (balance > 1) {
+                val left = if (node.left != null && balanceFactorNode(node.left) < 0) {
+                    rotateLeft(node.left)
+                } else {
+                    node.left
+                }
+                return rotateRight(AvlNode.create(node.value, left, node.right))
+            }
+
+            if (balance < -1) {
+                val right = if (node.right != null && balanceFactorNode(node.right) > 0) {
+                    rotateRight(node.right)
+                } else {
+                    node.right
+                }
+                return rotateLeft(AvlNode.create(node.value, node.left, right))
+            }
+
+            return node
+        }
+
+        private fun <T : Comparable<T>> rotateLeft(root: AvlNode<T>): AvlNode<T> {
+            val right = root.right ?: return root
+            val newLeft = AvlNode.create(root.value, root.left, right.left)
+            return AvlNode.create(right.value, newLeft, right.right)
+        }
+
+        private fun <T : Comparable<T>> rotateRight(root: AvlNode<T>): AvlNode<T> {
+            val left = root.left ?: return root
+            val newRight = AvlNode.create(root.value, left.right, root.right)
+            return AvlNode.create(left.value, left.left, newRight)
+        }
+
+        private fun <T : Comparable<T>> extractMin(root: AvlNode<T>): Extracted<T> {
+            if (root.left == null) {
+                return Extracted(root.right, root.value)
+            }
+
+            val extracted = extractMin(root.left)
+            return Extracted(
+                rebalance(AvlNode.create(root.value, extracted.root, root.right)),
+                extracted.minimum,
+            )
+        }
+
+        private fun <T : Comparable<T>> inOrder(root: AvlNode<T>?, output: MutableList<T>) {
+            if (root == null) return
+            inOrder(root.left, output)
+            output += root.value
+            inOrder(root.right, output)
+        }
+
+        private fun <T : Comparable<T>> validateBst(
+            root: AvlNode<T>?,
+            minimum: T?,
+            maximum: T?,
+        ): Boolean {
+            if (root == null) return true
+            if (minimum != null && root.value <= minimum) return false
+            if (maximum != null && root.value >= maximum) return false
+            return validateBst(root.left, minimum, root.value) && validateBst(root.right, root.value, maximum)
+        }
+
+        private fun <T : Comparable<T>> validateAvl(
+            root: AvlNode<T>?,
+            minimum: T?,
+            maximum: T?,
+        ): Validation? {
+            if (root == null) return Validation(-1, 0)
+            if (minimum != null && root.value <= minimum) return null
+            if (maximum != null && root.value >= maximum) return null
+
+            val left = validateAvl(root.left, minimum, root.value) ?: return null
+            val right = validateAvl(root.right, root.value, maximum) ?: return null
+            val expectedHeight = 1 + maxOf(left.height, right.height)
+            val expectedSize = 1 + left.size + right.size
+            if (root.height != expectedHeight || root.size != expectedSize || kotlin.math.abs(left.height - right.height) > 1) {
+                return null
+            }
+            return Validation(expectedHeight, expectedSize)
+        }
+
+        private data class Extracted<T : Comparable<T>>(val root: AvlNode<T>?, val minimum: T)
+
+        private data class Validation(val height: Int, val size: Int)
+    }
+}

--- a/code/packages/kotlin/avl-tree/src/test/kotlin/com/codingadventures/avltree/AvlTreeTest.kt
+++ b/code/packages/kotlin/avl-tree/src/test/kotlin/com/codingadventures/avltree/AvlTreeTest.kt
@@ -1,0 +1,127 @@
+package com.codingadventures.avltree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AvlTreeTest {
+    @Test
+    fun rotationsRebalanceTheTree() {
+        var tree = AvlTree.fromValues(listOf(10, 20, 30))
+
+        assertEquals(listOf(10, 20, 30), tree.toSortedArray())
+        assertEquals(20, tree.root?.value)
+        assertTrue(tree.isValidBst())
+        assertTrue(tree.isValidAvl())
+        assertEquals(1, tree.height())
+        assertEquals(3, tree.size())
+        assertEquals(0, tree.balanceFactor(tree.root))
+
+        tree = AvlTree.fromValues(listOf(30, 20, 10))
+        assertEquals(20, tree.root?.value)
+        assertTrue(tree.isValidAvl())
+    }
+
+    @Test
+    fun searchAndOrderStatisticsWork() {
+        val tree = AvlTree.fromValues(listOf(40, 20, 60, 10, 30, 50, 70))
+
+        assertEquals(20, tree.search(20)?.value)
+        assertTrue(tree.contains(50))
+        assertEquals(10, tree.minValue())
+        assertEquals(70, tree.maxValue())
+        assertEquals(30, tree.predecessor(40))
+        assertEquals(50, tree.successor(40))
+        assertEquals(40, tree.kthSmallest(4))
+        assertEquals(3, tree.rank(35))
+
+        val deleted = tree.delete(20)
+        assertFalse(deleted.contains(20))
+        assertTrue(deleted.isValidAvl())
+        assertTrue(tree.contains(20))
+    }
+
+    @Test
+    fun emptyTreeAndDuplicatesHandleEdges() {
+        val empty = AvlTree.empty<Int>()
+
+        assertNull(empty.search(1))
+        assertNull(empty.minValue())
+        assertNull(empty.maxValue())
+        assertNull(empty.predecessor(1))
+        assertNull(empty.successor(1))
+        assertNull(empty.kthSmallest(0))
+        assertEquals(0, empty.rank(1))
+        assertEquals(0, empty.balanceFactor(null))
+        assertEquals(-1, empty.height())
+        assertEquals(0, empty.size())
+        assertEquals("AvlTree(root=null, size=0, height=-1)", empty.toString())
+
+        val tree = AvlTree.fromValues(listOf(30, 20, 40, 10, 25, 35, 50))
+        val duplicate = tree.insert(25)
+        assertEquals(tree.toSortedArray(), duplicate.toSortedArray())
+        assertEquals(tree.toSortedArray(), tree.delete(999).toSortedArray())
+    }
+
+    @Test
+    fun doubleRotationsAndValidationFailuresAreCovered() {
+        val leftRight = AvlTree.fromValues(listOf(30, 10, 20))
+        val rightLeft = AvlTree.fromValues(listOf(10, 30, 20))
+
+        assertEquals(20, leftRight.root?.value)
+        assertEquals(20, rightLeft.root?.value)
+        assertTrue(leftRight.isValidAvl())
+        assertTrue(rightLeft.isValidAvl())
+
+        val badOrder = AvlTree(AvlNode(5, left = AvlNode.leaf(6), height = 1, size = 2))
+        val badRightOrder = AvlTree(AvlNode(5, right = AvlNode.leaf(4), height = 1, size = 2))
+        val badHeight = AvlTree(AvlNode(5, left = AvlNode.leaf(3), height = 99, size = 2))
+
+        assertFalse(badOrder.isValidBst())
+        assertFalse(badOrder.isValidAvl())
+        assertFalse(badRightOrder.isValidBst())
+        assertFalse(badRightOrder.isValidAvl())
+        assertFalse(badHeight.isValidAvl())
+    }
+
+    @Test
+    fun deleteWithNestedSuccessorAndStaticHelpersWork() {
+        val tree = AvlTree.fromValues(listOf(5, 3, 8, 7, 9, 6))
+
+        val deleted = tree.delete(5)
+        assertEquals(listOf(3, 6, 7, 8, 9), deleted.toSortedArray())
+        assertTrue(deleted.isValidAvl())
+        assertEquals(3, tree.kthSmallest(1))
+        assertEquals(9, tree.kthSmallest(6))
+        assertEquals(1, tree.rank(5))
+
+        var root: AvlNode<Int>? = null
+        root = AvlTree.insertNode(root, 2)
+        root = AvlTree.insertNode(root, 1)
+        root = AvlTree.insertNode(root, 3)
+
+        assertEquals(2, AvlTree.searchNode(root, 2)?.value)
+        assertEquals(1, AvlTree.minValue(root))
+        assertEquals(3, AvlTree.maxValue(root))
+        assertEquals(2, AvlTree.kthSmallest(root, 2))
+        assertEquals(1, AvlTree.rank(root, 2))
+        assertEquals(0, AvlTree.balanceFactorNode(root))
+        assertTrue(AvlTree.isValidBst(root))
+        assertTrue(AvlTree.isValidAvl(root))
+        assertEquals(listOf(1, 2, 3), AvlTree.toSortedArray(root))
+        assertEquals(listOf(2, 3), AvlTree.toSortedArray(AvlTree.deleteNode(root, 1)))
+        assertNull(AvlTree.deleteNode(null, 1))
+    }
+
+    @Test
+    fun referenceComparableValuesRetainSortedOrder() {
+        val tree = AvlTree.fromValues(listOf("delta", "alpha", "gamma"))
+
+        assertEquals(listOf("alpha", "delta", "gamma"), tree.toSortedArray())
+        assertEquals("AvlTree(root=delta, size=3, height=1)", tree.toString())
+        assertEquals("gamma", tree.successor("delta"))
+        assertNull(tree.predecessor("alpha"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a Kotlin avl-tree package with immutable insert/delete, rotations, search, min/max, predecessor/successor, rank, kth-smallest, sorted traversal, and validation helpers
- expose AvlTree/AvlNode plus companion helpers for raw node composition
- add kotlin.test coverage and Gradle package metadata/build wrappers

## Verification
- kotlinc src\\main\\kotlin\\com\\codingadventures\\avltree\\AvlTree.kt -d kotlinc-out\\classes
- gradle test (blocked locally: gradle is not installed/on PATH in this environment)