### PR TITLE
feat(java/kotlin): add Huffman tree implementation

### DIFF
--- a/code/packages/java/huffman-tree/.gitignore
+++ b/code/packages/java/huffman-tree/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/huffman-tree/BUILD
+++ b/code/packages/java/huffman-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-tree/BUILD_windows
+++ b/code/packages/java/huffman-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-tree/CHANGELOG.md
+++ b/code/packages/java/huffman-tree/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — java/huffman-tree
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+
+- `HuffmanTree` — optimal prefix-free code tree backed by `java.util.PriorityQueue`
+- `HuffmanTree.build(List<int[]> weights)` — greedy min-heap construction from
+  `[symbol, frequency]` pairs; throws `IllegalArgumentException` for empty list or
+  non-positive frequency
+- `codeTable()` — O(n) walk returning `{symbol → bit_string}` map
+- `codeFor(int symbol)` — O(n) single-symbol lookup; returns null if absent
+- `canonicalCodeTable()` — O(n log n) DEFLATE-style canonical codes from lengths
+- `decodeAll(String bits, int count)` — O(bits) tree-walk decoder; throws when
+  stream exhausted before `count` symbols
+- `weight()` — O(1) total weight (root weight = sum of all frequencies)
+- `depth()` — O(n) maximum code length (depth of deepest leaf)
+- `symbolCount()` — O(1) number of distinct symbols
+- `leavesWithCodes()` — O(n) in-order list of `[symbol, code]` pairs
+- `isValid()` — structural validator: full binary tree, correct weights, unique symbols
+- Deterministic tie-breaking: weight → leaf-before-internal → symbol value → insertion order
+- 36 unit tests covering construction, code tables, canonical codes, round-trips,
+  inspection methods, tie-breaking determinism, and isValid

--- a/code/packages/java/huffman-tree/README.md
+++ b/code/packages/java/huffman-tree/README.md
@@ -1,0 +1,88 @@
+# java/huffman-tree
+
+A **Huffman tree** in Java — the theoretically optimal prefix-free code for any
+symbol frequency distribution.  O(n log n) construction, O(n) encoding/decoding.
+
+## What is a Huffman Tree?
+
+A Huffman tree assigns variable-length bit codes to symbols so that frequent
+symbols get short codes and rare symbols get long codes.  The resulting codes are
+**prefix-free**: no code is a prefix of another, so the bit stream can be decoded
+unambiguously without separator characters.
+
+Think of Morse code: 'E' is `.` (one dot) and 'Z' is `--..` (four symbols).
+Huffman's algorithm builds this mapping automatically and optimally for any
+given frequency distribution.
+
+## Usage
+
+```java
+import com.codingadventures.huffmantree.HuffmanTree;
+
+// Build from (symbol, frequency) pairs
+HuffmanTree tree = HuffmanTree.build(List.of(
+    new int[]{65, 3},  // 'A' → frequency 3
+    new int[]{66, 2},  // 'B' → frequency 2
+    new int[]{67, 1}   // 'C' → frequency 1
+));
+
+// Encode
+Map<Integer, String> table = tree.codeTable();
+// table.get(65) → "0"   (A gets the shortest code)
+// table.get(66) → "10"
+// table.get(67) → "11"
+
+String bits = table.get(65) + table.get(66) + table.get(67); // "01011"
+
+// Decode
+List<Integer> decoded = tree.decodeAll(bits, 3);  // → [65, 66, 67]
+
+// Canonical codes (DEFLATE-style)
+Map<Integer, String> canonical = tree.canonicalCodeTable();
+// canonical.get(65) → "0"
+// canonical.get(66) → "10"
+// canonical.get(67) → "11"
+
+// Inspection
+tree.weight();       // 6    (sum of all frequencies)
+tree.depth();        // 2    (max code length)
+tree.symbolCount();  // 3
+tree.isValid();      // true
+```
+
+## API
+
+| Method | Description |
+|---|---|
+| `HuffmanTree.build(List<int[]> weights)` | Build from `[symbol, freq]` pairs |
+| `Map<Integer,String> codeTable()` | O(n) — all codes as bit strings |
+| `String codeFor(int symbol)` | O(n) — single symbol lookup (null if absent) |
+| `Map<Integer,String> canonicalCodeTable()` | O(n log n) — DEFLATE-style canonical codes |
+| `List<Integer> decodeAll(String bits, int count)` | Decode exactly count symbols |
+| `int weight()` | O(1) — sum of all frequencies |
+| `int depth()` | O(n) — maximum code length |
+| `int symbolCount()` | O(1) — number of distinct symbols |
+| `List<Object[]> leavesWithCodes()` | O(n) — in-order `[symbol, code]` pairs |
+| `boolean isValid()` | Structural validator |
+
+## Algorithm
+
+1. Push all symbols as leaf nodes into a min-heap, keyed by (weight, isInternal, symbol, order)
+2. While heap has > 1 node: pop two lightest, merge into an internal node, push back
+3. The last node is the root
+
+Tie-breaking for determinism:
+- Leaf nodes beat internal nodes at equal weight
+- Lower symbol value wins among leaves of equal weight
+- Earlier-created internal node wins among internals of equal weight (FIFO)
+
+## Running tests
+
+```
+gradle test
+```
+
+36 tests covering: construction, code table, codeFor, canonical codes,
+encode/decode round-trips (including all 256 bytes), exhaustion error,
+inspection methods (weight, depth, symbolCount, leavesWithCodes),
+tie-breaking determinism, and isValid.

--- a/code/packages/java/huffman-tree/build.gradle.kts
+++ b/code/packages/java/huffman-tree/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/huffman-tree/settings.gradle.kts
+++ b/code/packages/java/huffman-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "huffman-tree"

--- a/code/packages/java/huffman-tree/src/main/java/com/codingadventures/huffmantree/HuffmanTree.java
+++ b/code/packages/java/huffman-tree/src/main/java/com/codingadventures/huffmantree/HuffmanTree.java
@@ -1,0 +1,651 @@
+// ============================================================================
+// HuffmanTree.java — Optimal Prefix-Free Code Tree
+// ============================================================================
+//
+// A Huffman tree is a full binary tree (every internal node has exactly two
+// children) built from a symbol alphabet so that each symbol gets a unique
+// variable-length bit code.  Symbols that appear often get short codes;
+// symbols that appear rarely get long codes.  The total bits needed to
+// encode a message is minimised — it is the theoretically optimal prefix-free
+// code for a given symbol frequency distribution.
+//
+// Think of it like Morse code.  In Morse, 'E' is '.' (one dot) and 'Z' is
+// '--..' (four symbols).  The designers knew 'E' is the most common letter
+// in English so they gave it the shortest code.  Huffman's algorithm does
+// this automatically and optimally for any alphabet with any frequency
+// distribution.
+//
+// ============================================================================
+// Algorithm: Greedy construction via min-heap
+// ============================================================================
+//
+// 1. Create one leaf node per distinct symbol, each with its frequency as
+//    its weight.  Push all leaves onto a min-heap keyed by weight.
+//
+// 2. While the heap has more than one node:
+//      a. Pop the two nodes with the smallest weight.
+//      b. Create a new internal node whose weight = sum of the two children.
+//      c. Set left = the first popped node, right = the second popped node.
+//      d. Push the new internal node back onto the heap.
+//
+// 3. The one remaining node is the root of the Huffman tree.
+//
+// ============================================================================
+// Tie-breaking for determinism
+// ============================================================================
+//
+// Without tie-breaking, different implementations build structurally different
+// trees from the same input — producing different (but equally valid) codes.
+// We enforce these rules (lower key = higher priority):
+//
+//   Priority tuple: (weight, isInternal, symbolOrNeg1, insertionOrder)
+//
+//   1. Lowest weight pops first.
+//   2. Leaf nodes (isInternal=0) beat internal nodes (isInternal=1) at equal
+//      weight.
+//   3. Among leaves of equal weight, lower symbol value wins (symbolOrNeg1).
+//   4. Among internal nodes of equal weight, earlier-created node wins
+//      (insertion order, FIFO).
+//
+// ============================================================================
+// Prefix-free property: why it works
+// ============================================================================
+//
+//   In a Huffman tree:
+//     - Symbols live ONLY at the leaves, never at internal nodes.
+//     - The code for a symbol is the path from root to its leaf
+//       (left edge = '0', right edge = '1').
+//
+//   Since one leaf is never an ancestor of another, no code can be a prefix
+//   of another code.  This means the bit stream can be decoded unambiguously
+//   without separator characters: just walk the tree bit by bit until you
+//   reach a leaf.
+//
+// ============================================================================
+// Canonical codes (DEFLATE / zlib style)
+// ============================================================================
+//
+//   The standard tree-walk produces valid codes, but different tree shapes
+//   can produce different codes for the same symbol lengths.  Canonical codes
+//   normalise this: given only the code *lengths*, you can reconstruct the
+//   exact canonical code table without transmitting the tree structure.
+//
+//   Algorithm:
+//     1. Collect (symbol, code_length) pairs from the tree.
+//     2. Sort by (code_length, symbol_value).
+//     3. Assign codes numerically:
+//          code[0] = 0  (left-padded to length[0] bits)
+//          code[i] = (code[i-1] + 1) << (length[i] - length[i-1])
+//
+//   This is exactly what DEFLATE uses: the compressed stream contains only
+//   the length table, not the tree, saving space.
+//
+//   Example with AAABBC (A=3, B=2, C=1):
+//     Tree:      [6]
+//                / \
+//               A  [3]
+//              (3)  / \
+//                  B   C
+//                 (2) (1)
+//     Lengths: A=1, B=2, C=2
+//     Sorted by (length, symbol): A(1), B(2), C(2)
+//     Canonical codes:
+//       A → 0       (length 1, code = 0)
+//       B → 10      (length 2, code = 0+1=1, shifted 1 bit → 10)
+//       C → 11      (length 2, code = 10+1 = 11)
+//
+// ============================================================================
+
+package com.codingadventures.huffmantree;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * A Huffman tree that assigns optimal prefix-free bit codes to integer symbols.
+ *
+ * <p>Build the tree once from symbol frequencies; then:
+ * <ul>
+ *   <li>Use {@link #codeTable()} to get a {@code {symbol → bit_string}} map for encoding.</li>
+ *   <li>Use {@link #decodeAll(String, int)} to decode a bit stream back to symbols.</li>
+ *   <li>Use {@link #canonicalCodeTable()} for DEFLATE-style transmissible codes.</li>
+ * </ul>
+ *
+ * <p>All symbols are non-negative integers (typically 0–255 for byte-level
+ * coding, but any non-negative integer is valid).  Frequencies must be positive.
+ *
+ * <p>The tree is immutable after construction.
+ *
+ * <pre>{@code
+ * HuffmanTree tree = HuffmanTree.build(List.of(
+ *     new int[]{65, 3},  // 'A' → frequency 3
+ *     new int[]{66, 2},  // 'B' → frequency 2
+ *     new int[]{67, 1}   // 'C' → frequency 1
+ * ));
+ *
+ * Map<Integer, String> table = tree.codeTable();
+ * // table.get(65) → "0"   (A gets the shortest code)
+ * // table.get(66) → "10"
+ * // table.get(67) → "11"
+ *
+ * List<Integer> decoded = tree.decodeAll("010011", 4);
+ * // → [65, 65, 66, 67]  == [A, A, B, C]
+ * }</pre>
+ */
+public final class HuffmanTree {
+
+    // =========================================================================
+    // Node types
+    // =========================================================================
+
+    /**
+     * A leaf node representing a single symbol.
+     *
+     * <p>Leaves are always at the bottom of the tree; they carry the actual
+     * encoded symbol.  Their code is the path from the root to this node.
+     */
+    static final class Leaf extends Node {
+        final int symbol;
+
+        Leaf(int symbol, int weight) {
+            super(weight);
+            this.symbol = symbol;
+        }
+    }
+
+    /**
+     * An internal node combining two sub-trees.
+     *
+     * <p>Internal nodes have no symbol — they are bookkeeping nodes that
+     * encode branching structure.  Their weight is the sum of their children's
+     * weights.
+     */
+    static final class Internal extends Node {
+        final Node  left;
+        final Node  right;
+        final int   order;   // Insertion order for tie-breaking (FIFO for internals)
+
+        Internal(int weight, Node left, Node right, int order) {
+            super(weight);
+            this.left  = left;
+            this.right = right;
+            this.order = order;
+        }
+    }
+
+    /**
+     * Common base for Leaf and Internal.
+     *
+     * <p>Holds only the weight so both node types share the same field.
+     */
+    static abstract class Node {
+        final int weight;
+
+        Node(int weight) {
+            this.weight = weight;
+        }
+    }
+
+    // =========================================================================
+    // Priority comparator
+    // =========================================================================
+
+    /**
+     * Comparator for the min-heap during tree construction.
+     *
+     * <p>Four-level ordering (lower = higher priority):
+     * <ol>
+     *   <li>Weight (lighter wins)</li>
+     *   <li>Node type (leaf=0 before internal=1)</li>
+     *   <li>Symbol value for leaves (lower symbol wins)</li>
+     *   <li>Insertion order for internals (earlier wins = FIFO)</li>
+     * </ol>
+     */
+    private static final Comparator<Node> PRIORITY = (a, b) -> {
+        // Field 0: weight
+        int cmp = Integer.compare(a.weight, b.weight);
+        if (cmp != 0) return cmp;
+
+        // Field 1: leaf (0) before internal (1)
+        int typeA = (a instanceof Leaf) ? 0 : 1;
+        int typeB = (b instanceof Leaf) ? 0 : 1;
+        cmp = Integer.compare(typeA, typeB);
+        if (cmp != 0) return cmp;
+
+        // Field 2 / 3: among same type
+        if (a instanceof Leaf la && b instanceof Leaf lb) {
+            // Lower symbol wins
+            return Integer.compare(la.symbol, lb.symbol);
+        } else {
+            // Both internal: earlier-created wins (FIFO)
+            return Integer.compare(((Internal) a).order, ((Internal) b).order);
+        }
+    };
+
+    // =========================================================================
+    // Fields
+    // =========================================================================
+
+    private final Node root;
+    private final int  symbolCount;
+
+    // =========================================================================
+    // Constructor (private — use build())
+    // =========================================================================
+
+    private HuffmanTree(Node root, int symbolCount) {
+        this.root        = root;
+        this.symbolCount = symbolCount;
+    }
+
+    // =========================================================================
+    // Public factory
+    // =========================================================================
+
+    /**
+     * Construct a Huffman tree from {@code (symbol, frequency)} pairs.
+     *
+     * <p>The greedy algorithm uses a min-heap.  At each step it pops the two
+     * lowest-weight nodes, combines them into a new internal node, and pushes
+     * the result back.  The single remaining node is the root.
+     *
+     * <p>Tie-breaking (for deterministic output across implementations):
+     * <ol>
+     *   <li>Lowest weight pops first.</li>
+     *   <li>Leaves before internal nodes at equal weight.</li>
+     *   <li>Lower symbol value wins among leaves of equal weight.</li>
+     *   <li>Earlier-created internal node wins among internals of equal weight
+     *       (FIFO insertion order).</li>
+     * </ol>
+     *
+     * @param weights a list of {@code int[2]} arrays: {@code [symbol, frequency]}.
+     *                Each symbol must be a non-negative integer; each frequency
+     *                must be &gt; 0.
+     * @return a {@code HuffmanTree} ready for encoding/decoding
+     * @throws IllegalArgumentException if {@code weights} is empty, or if any
+     *                                  frequency is ≤ 0
+     */
+    public static HuffmanTree build(List<int[]> weights) {
+        if (weights == null || weights.isEmpty()) {
+            throw new IllegalArgumentException("weights must not be empty");
+        }
+        for (int[] pair : weights) {
+            if (pair[1] <= 0) {
+                throw new IllegalArgumentException(
+                    "frequency must be positive; got symbol=" + pair[0] + ", freq=" + pair[1]
+                );
+            }
+        }
+
+        PriorityQueue<Node> heap = new PriorityQueue<>(weights.size(), PRIORITY);
+        for (int[] pair : weights) {
+            heap.add(new Leaf(pair[0], pair[1]));
+        }
+
+        int orderCounter = 0;
+        while (heap.size() > 1) {
+            Node left  = heap.poll();
+            Node right = heap.poll();
+            heap.add(new Internal(left.weight + right.weight, left, right, orderCounter++));
+        }
+
+        return new HuffmanTree(heap.poll(), weights.size());
+    }
+
+    // =========================================================================
+    // Encoding helpers
+    // =========================================================================
+
+    /**
+     * Return a {@code {symbol → bit_string}} map for all symbols in the tree.
+     *
+     * <p>Left edges are {@code '0'}, right edges are {@code '1'}.  For a
+     * single-symbol tree the convention is {@code {symbol → "0"}} (one bit
+     * per occurrence).
+     *
+     * <p>Time: O(n) where n = number of distinct symbols.
+     *
+     * <pre>{@code
+     * HuffmanTree tree = HuffmanTree.build(List.of(
+     *     new int[]{65, 3}, new int[]{66, 2}, new int[]{67, 1}
+     * ));
+     * tree.codeTable().get(65); // "0"
+     * tree.codeTable().get(66); // "10"
+     * tree.codeTable().get(67); // "11"
+     * }</pre>
+     *
+     * @return map from symbol to its bit string
+     */
+    public Map<Integer, String> codeTable() {
+        Map<Integer, String> table = new HashMap<>();
+        walkTree(root, "", table);
+        return table;
+    }
+
+    /**
+     * Return the bit string for a specific symbol, or {@code null} if not in
+     * the tree.
+     *
+     * <p>Walks the tree searching for the leaf with the given symbol.  Does NOT
+     * build the full code table.
+     *
+     * <p>Time: O(n) worst case (full tree traversal).
+     *
+     * @param symbol the symbol to look up
+     * @return the bit string, or {@code null} if absent
+     */
+    public String codeFor(int symbol) {
+        return findCode(root, symbol, "");
+    }
+
+    /**
+     * Return canonical Huffman codes (DEFLATE-style).
+     *
+     * <p>Sorted by {@code (code_length, symbol_value)}; codes assigned
+     * numerically.  Canonical codes allow transmitting only code lengths, not
+     * the tree structure, which saves space.
+     *
+     * <p>Time: O(n log n).
+     *
+     * <pre>{@code
+     * tree.canonicalCodeTable().get(65); // "0"
+     * tree.canonicalCodeTable().get(66); // "10"
+     * tree.canonicalCodeTable().get(67); // "11"
+     * }</pre>
+     *
+     * @return map from symbol to its canonical bit string
+     */
+    public Map<Integer, String> canonicalCodeTable() {
+        // Step 1: collect code lengths from tree
+        Map<Integer, Integer> lengths = new HashMap<>();
+        collectLengths(root, 0, lengths);
+
+        // Single-leaf edge case: assign length 1 by convention
+        if (lengths.size() == 1) {
+            int sym = lengths.keySet().iterator().next();
+            Map<Integer, String> result = new HashMap<>();
+            result.put(sym, "0");
+            return result;
+        }
+
+        // Step 2: sort by (length, symbol)
+        List<Map.Entry<Integer, Integer>> sorted = new ArrayList<>(lengths.entrySet());
+        sorted.sort((a, b) -> {
+            int cmp = Integer.compare(a.getValue(), b.getValue());
+            return cmp != 0 ? cmp : Integer.compare(a.getKey(), b.getKey());
+        });
+
+        // Step 3: assign canonical codes numerically
+        Map<Integer, String> result = new LinkedHashMap<>();
+        int codeVal  = 0;
+        int prevLen  = sorted.get(0).getValue();
+
+        for (Map.Entry<Integer, Integer> entry : sorted) {
+            int sym    = entry.getKey();
+            int length = entry.getValue();
+            if (length > prevLen) {
+                codeVal <<= (length - prevLen);
+            }
+            // Format as binary string, left-padded with zeros to 'length' bits
+            result.put(sym, String.format("%" + length + "s",
+                Integer.toBinaryString(codeVal)).replace(' ', '0'));
+            codeVal++;
+            prevLen = length;
+        }
+        return result;
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode exactly {@code count} symbols from a bit string by walking the tree.
+     *
+     * <p>For each symbol: follow the tree from the root, taking the left child
+     * on '0' and the right child on '1', until a leaf is reached.  The leaf's
+     * symbol is appended to the output; the walk restarts at the root.
+     *
+     * <p>For a single-leaf tree, each '0' bit decodes to that symbol.
+     *
+     * <p>Time: O(total bits consumed).
+     *
+     * <pre>{@code
+     * tree.decodeAll("010011", 4); // → [65, 65, 66, 67]
+     * }</pre>
+     *
+     * @param bits  a string of '0' and '1' characters
+     * @param count the exact number of symbols to decode
+     * @return a list of decoded symbols of length {@code count}
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  {@code count} symbols are decoded
+     */
+    public List<Integer> decodeAll(String bits, int count) {
+        List<Integer> result  = new ArrayList<>(count);
+        Node          current = root;
+        int           i       = 0;
+        boolean       singleLeaf = (root instanceof Leaf);
+
+        while (result.size() < count) {
+            if (current instanceof Leaf leaf) {
+                result.add(leaf.symbol);
+                current = root;
+                if (singleLeaf) {
+                    // Consume the '0' bit for this symbol
+                    if (i < bits.length()) i++;
+                }
+                continue;
+            }
+
+            if (i >= bits.length()) {
+                throw new IllegalArgumentException(
+                    "Bit stream exhausted after " + result.size() +
+                    " symbols; expected " + count
+                );
+            }
+
+            char bit = bits.charAt(i++);
+            Internal internal = (Internal) current;
+            current = (bit == '0') ? internal.left : internal.right;
+        }
+
+        return result;
+    }
+
+    // =========================================================================
+    // Inspection
+    // =========================================================================
+
+    /**
+     * Total weight of the tree = sum of all leaf frequencies = root weight.
+     *
+     * <p>O(1) — stored at the root.
+     *
+     * @return sum of all symbol frequencies
+     */
+    public int weight() {
+        return root.weight;
+    }
+
+    /**
+     * Maximum code length = depth of the deepest leaf.
+     *
+     * <p>O(n) — must traverse the tree.
+     *
+     * @return depth of the deepest leaf (0 for a single-symbol tree)
+     */
+    public int depth() {
+        return maxDepth(root, 0);
+    }
+
+    /**
+     * Number of distinct symbols = number of leaf nodes.
+     *
+     * <p>O(1) — stored at construction time.
+     *
+     * @return number of distinct symbols
+     */
+    public int symbolCount() {
+        return symbolCount;
+    }
+
+    /**
+     * In-order traversal of leaves.
+     *
+     * <p>Returns {@code (symbol, code)} pairs, left subtree before right
+     * subtree.  Useful for visualisation and debugging.
+     *
+     * <p>Time: O(n).
+     *
+     * @return list of {@code int[2]} arrays: {@code [symbol, unused]}, paired
+     *         with a String; actually returned as pairs via a 2D structure.
+     *         Each element is a {@code int[]{symbol}} and the code string.
+     */
+    public List<int[]> leaves() {
+        Map<Integer, String> table = codeTable();
+        List<int[]> result = new ArrayList<>();
+        // We store symbol and code-string together as a parallel pair.
+        // Return as a list of [symbol, codeAsInt? — no, code is a string].
+        // Use a separate method that returns the paired list.
+        collectLeavesInOrder(root, result, table);
+        return result;
+    }
+
+    /**
+     * Return leaves as {@code (symbol, bitString)} pairs in in-order (left-to-right)
+     * traversal order.
+     *
+     * <p>Time: O(n).
+     *
+     * @return list of {@code Object[]{Integer symbol, String code}} pairs
+     */
+    public List<Object[]> leavesWithCodes() {
+        Map<Integer, String> table = codeTable();
+        List<Object[]> result = new ArrayList<>();
+        collectLeavesInOrderWithCodes(root, result, table);
+        return result;
+    }
+
+    /**
+     * Check structural invariants.
+     *
+     * <ol>
+     *   <li>Every internal node has exactly 2 children (full binary tree).</li>
+     *   <li>{@code weight(internal) == weight(left) + weight(right)}.</li>
+     *   <li>No symbol appears in more than one leaf.</li>
+     * </ol>
+     *
+     * <p>Returns {@code true} if all invariants hold.
+     *
+     * @return true if the tree is structurally valid
+     */
+    public boolean isValid() {
+        java.util.Set<Integer> seen = new java.util.HashSet<>();
+        return checkInvariants(root, seen);
+    }
+
+    // =========================================================================
+    // Private helpers — tree walk
+    // =========================================================================
+
+    /**
+     * Recursively walk the tree building the code table.
+     *
+     * <p>At each internal node we append '0' for the left branch and '1' for
+     * the right branch.  At each leaf we record the accumulated prefix.
+     */
+    private static void walkTree(Node node, String prefix, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            // Single-leaf edge case: no edges traversed; use "0" by convention
+            table.put(leaf.symbol, prefix.isEmpty() ? "0" : prefix);
+            return;
+        }
+        Internal internal = (Internal) node;
+        walkTree(internal.left,  prefix + "0", table);
+        walkTree(internal.right, prefix + "1", table);
+    }
+
+    /**
+     * Search the tree for a specific symbol, returning its code or {@code null}.
+     */
+    private static String findCode(Node node, int symbol, String prefix) {
+        if (node instanceof Leaf leaf) {
+            if (leaf.symbol == symbol) {
+                return prefix.isEmpty() ? "0" : prefix;
+            }
+            return null;
+        }
+        Internal internal = (Internal) node;
+        String left = findCode(internal.left,  symbol, prefix + "0");
+        if (left != null) return left;
+        return findCode(internal.right, symbol, prefix + "1");
+    }
+
+    /**
+     * Collect code lengths for all leaves (depth at each leaf = code length).
+     *
+     * <p>For a single-leaf tree (depth 0) we assign length 1 by convention.
+     */
+    private static void collectLengths(Node node, int depth, Map<Integer, Integer> lengths) {
+        if (node instanceof Leaf leaf) {
+            lengths.put(leaf.symbol, depth > 0 ? depth : 1);
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLengths(internal.left,  depth + 1, lengths);
+        collectLengths(internal.right, depth + 1, lengths);
+    }
+
+    /** Return the maximum depth of any leaf. */
+    private static int maxDepth(Node node, int depth) {
+        if (node instanceof Leaf) return depth;
+        Internal internal = (Internal) node;
+        return Math.max(maxDepth(internal.left,  depth + 1),
+                        maxDepth(internal.right, depth + 1));
+    }
+
+    /** Collect leaf symbols in left-to-right (in-order) traversal. */
+    private static void collectLeavesInOrder(
+            Node node, List<int[]> result, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            result.add(new int[]{leaf.symbol});
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLeavesInOrder(internal.left,  result, table);
+        collectLeavesInOrder(internal.right, result, table);
+    }
+
+    /** Collect (symbol, code) pairs in left-to-right in-order traversal. */
+    private static void collectLeavesInOrderWithCodes(
+            Node node, List<Object[]> result, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            result.add(new Object[]{leaf.symbol, table.get(leaf.symbol)});
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLeavesInOrderWithCodes(internal.left,  result, table);
+        collectLeavesInOrderWithCodes(internal.right, result, table);
+    }
+
+    /** Recursively validate tree invariants. */
+    private static boolean checkInvariants(Node node, java.util.Set<Integer> seen) {
+        if (node instanceof Leaf leaf) {
+            if (seen.contains(leaf.symbol)) return false;
+            seen.add(leaf.symbol);
+            return true;
+        }
+        Internal internal = (Internal) node;
+        // Internal node weight must equal sum of children's weights
+        if (internal.weight != internal.left.weight + internal.right.weight) {
+            return false;
+        }
+        return checkInvariants(internal.left, seen) &&
+               checkInvariants(internal.right, seen);
+    }
+}

--- a/code/packages/java/huffman-tree/src/test/java/com/codingadventures/huffmantree/HuffmanTreeTest.java
+++ b/code/packages/java/huffman-tree/src/test/java/com/codingadventures/huffmantree/HuffmanTreeTest.java
@@ -1,0 +1,400 @@
+package com.codingadventures.huffmantree;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Comprehensive tests for {@link HuffmanTree}.
+ *
+ * <p>Test organisation:
+ * <ol>
+ *   <li>Construction — empty/zero-freq errors, single, two, three symbols</li>
+ *   <li>Code table — prefix-free property, single-symbol convention</li>
+ *   <li>codeFor — hit, miss, single-symbol</li>
+ *   <li>Canonical code table — AAABBC example, same lengths as regular, prefix-free</li>
+ *   <li>Encode/decode round-trips — single, three symbols, all 256 bytes</li>
+ *   <li>decodeAll error — exhausted bit stream</li>
+ *   <li>Inspection — weight, depth, symbolCount, leavesWithCodes</li>
+ *   <li>Tie-breaking determinism</li>
+ *   <li>isValid</li>
+ * </ol>
+ */
+class HuffmanTreeTest {
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /** Convenience: build from int pairs (symbol, freq). */
+    private static HuffmanTree build(int... pairs) {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            weights.add(new int[]{pairs[i], pairs[i + 1]});
+        }
+        return HuffmanTree.build(weights);
+    }
+
+    // =========================================================================
+    // 1. Construction
+    // =========================================================================
+
+    @Test
+    @DisplayName("build() from empty list throws IllegalArgumentException")
+    void buildEmptyThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> HuffmanTree.build(List.of()));
+    }
+
+    @Test
+    @DisplayName("build() with null list throws IllegalArgumentException")
+    void buildNullThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> HuffmanTree.build(null));
+    }
+
+    @Test
+    @DisplayName("build() with zero frequency throws IllegalArgumentException")
+    void buildZeroFreqThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> build(65, 0));
+    }
+
+    @Test
+    @DisplayName("build() with negative frequency throws IllegalArgumentException")
+    void buildNegativeFreqThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> build(65, -1));
+    }
+
+    @Test
+    @DisplayName("Single symbol: symbolCount=1, weight=freq")
+    void singleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals(1, tree.symbolCount());
+        assertEquals(5, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Two symbols: symbolCount=2, weight=sum of freqs")
+    void twoSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 1);
+        assertEquals(2, tree.symbolCount());
+        assertEquals(4, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Three symbols AAABBC: symbolCount=3, weight=6")
+    void threeSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertEquals(3, tree.symbolCount());
+        assertEquals(6, tree.weight());
+    }
+
+    @Test
+    @DisplayName("isValid() is true after build")
+    void isValidAfterBuild() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertTrue(tree.isValid());
+    }
+
+    @Test
+    @DisplayName("Large alphabet (256 symbols) builds and is valid")
+    void largeAlphabet() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 256; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        assertEquals(256, tree.symbolCount());
+        assertTrue(tree.isValid());
+    }
+
+    // =========================================================================
+    // 2. Code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC: A gets shortest code (highest frequency)")
+    void codeTableAAABBCFrequencies() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertTrue(table.get(65).length() < table.get(66).length());
+        assertTrue(table.get(66).length() <= table.get(67).length());
+    }
+
+    @Test
+    @DisplayName("Single symbol: code is \"0\"")
+    void codeTableSingleSymbol() {
+        HuffmanTree tree = build(65, 1);
+        assertEquals("0", tree.codeTable().get(65));
+    }
+
+    @Test
+    @DisplayName("All codes are prefix-free (10 symbols)")
+    void codeTablePrefixFree() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> table = tree.codeTable();
+        List<String> codes = new ArrayList<>(table.values());
+        for (int i = 0; i < codes.size(); i++) {
+            for (int j = 0; j < codes.size(); j++) {
+                if (i != j) {
+                    assertFalse(codes.get(i).startsWith(codes.get(j)),
+                        codes.get(i) + " starts with " + codes.get(j));
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("codeTable returns entry for every symbol")
+    void codeTableContainsAllSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertTrue(table.containsKey(65));
+        assertTrue(table.containsKey(66));
+        assertTrue(table.containsKey(67));
+    }
+
+    // =========================================================================
+    // 3. codeFor
+    // =========================================================================
+
+    @Test
+    @DisplayName("codeFor returns same value as codeTable for each symbol")
+    void codeForMatchesTable() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertEquals(table.get(65), tree.codeFor(65));
+        assertEquals(table.get(66), tree.codeFor(66));
+        assertEquals(table.get(67), tree.codeFor(67));
+    }
+
+    @Test
+    @DisplayName("codeFor returns null for absent symbol")
+    void codeForMissing() {
+        HuffmanTree tree = build(65, 3, 66, 2);
+        assertNull(tree.codeFor(99));
+    }
+
+    @Test
+    @DisplayName("codeFor single symbol returns \"0\"")
+    void codeForSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals("0", tree.codeFor(65));
+    }
+
+    // =========================================================================
+    // 4. Canonical code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC canonical: A→\"0\", B→\"10\", C→\"11\"")
+    void canonicalAAABBC() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        assertEquals("0",  canonical.get(65));
+        assertEquals("10", canonical.get(66));
+        assertEquals("11", canonical.get(67));
+    }
+
+    @Test
+    @DisplayName("Canonical code lengths match regular code lengths (8 symbols)")
+    void canonicalLengthsMatchRegular() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 8; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> regular   = tree.codeTable();
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        for (int sym : regular.keySet()) {
+            assertEquals(regular.get(sym).length(), canonical.get(sym).length(),
+                "Length mismatch for symbol " + sym);
+        }
+    }
+
+    @Test
+    @DisplayName("Canonical single symbol returns {sym → \"0\"}")
+    void canonicalSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals("0", tree.canonicalCodeTable().get(65));
+    }
+
+    @Test
+    @DisplayName("Canonical codes are prefix-free (10 symbols)")
+    void canonicalPrefixFree() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        List<String> codes = new ArrayList<>(canonical.values());
+        for (int i = 0; i < codes.size(); i++) {
+            for (int j = 0; j < codes.size(); j++) {
+                if (i != j) {
+                    assertFalse(codes.get(i).startsWith(codes.get(j)));
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // 5. Encode / decode round-trips
+    // =========================================================================
+
+    @Test
+    @DisplayName("Single-symbol round-trip: [A,A,A]")
+    void roundTripSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        Map<Integer, String> table = tree.codeTable();
+        String bits = table.get(65) + table.get(65) + table.get(65);
+        assertEquals(List.of(65, 65, 65), tree.decodeAll(bits, 3));
+    }
+
+    @Test
+    @DisplayName("AAABBC round-trip: encode then decode")
+    void roundTripAAABBC() {
+        List<Integer> symbols = List.of(65, 65, 65, 66, 66, 67);
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        StringBuilder sb = new StringBuilder();
+        for (int s : symbols) sb.append(table.get(s));
+        assertEquals(symbols, tree.decodeAll(sb.toString(), symbols.size()));
+    }
+
+    @Test
+    @DisplayName("All 256 byte values round-trip")
+    void roundTripAllBytes() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 256; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> table = tree.codeTable();
+        StringBuilder sb = new StringBuilder();
+        List<Integer> symbols = new ArrayList<>();
+        for (int i = 0; i < 256; i++) { symbols.add(i); sb.append(table.get(i)); }
+        assertEquals(symbols, tree.decodeAll(sb.toString(), 256));
+    }
+
+    @Test
+    @DisplayName("decodeAll throws when bit stream exhausted")
+    void decodeExhausted() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        // "0" decodes only 1 symbol but count=5 requested
+        assertThrows(IllegalArgumentException.class,
+            () -> tree.decodeAll("0", 5));
+    }
+
+    // =========================================================================
+    // 6. Inspection
+    // =========================================================================
+
+    @Test
+    @DisplayName("weight() returns sum of all frequencies")
+    void weightSum() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertEquals(6, tree.weight());
+    }
+
+    @Test
+    @DisplayName("depth() of single-symbol tree is 0")
+    void depthSingleSymbol() {
+        assertEquals(0, build(65, 1).depth());
+    }
+
+    @Test
+    @DisplayName("depth() of two-symbol tree is 1")
+    void depthTwoSymbols() {
+        assertEquals(1, build(65, 3, 66, 1).depth());
+    }
+
+    @Test
+    @DisplayName("depth() of AAABBC tree is 2")
+    void depthThreeSymbols() {
+        assertEquals(2, build(65, 3, 66, 2, 67, 1).depth());
+    }
+
+    @Test
+    @DisplayName("symbolCount() returns number of distinct symbols")
+    void symbolCountBasic() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        assertEquals(10, HuffmanTree.build(weights).symbolCount());
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() single symbol returns [(65, \"0\")]")
+    void leavesWithCodesSingle() {
+        HuffmanTree tree = build(65, 5);
+        List<Object[]> leaves = tree.leavesWithCodes();
+        assertEquals(1, leaves.size());
+        assertEquals(65,  (int) leaves.get(0)[0]);
+        assertEquals("0", (String) leaves.get(0)[1]);
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() contains all symbols in AAABBC tree")
+    void leavesWithCodesThreeSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        List<Object[]> leaves = tree.leavesWithCodes();
+        assertEquals(3, leaves.size());
+        java.util.Set<Integer> syms = new java.util.HashSet<>();
+        for (Object[] leaf : leaves) syms.add((Integer) leaf[0]);
+        assertTrue(syms.contains(65));
+        assertTrue(syms.contains(66));
+        assertTrue(syms.contains(67));
+    }
+
+    // =========================================================================
+    // 7. Tie-breaking determinism
+    // =========================================================================
+
+    @Test
+    @DisplayName("Equal-weight alphabet is structurally valid")
+    void equalWeightsValid() {
+        HuffmanTree tree = build(65, 1, 66, 1, 67, 1, 68, 1);
+        assertTrue(tree.isValid());
+        assertEquals(4, tree.symbolCount());
+        assertEquals(4, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Same input always produces same code table")
+    void equalWeightsDeterministic() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 8; i++) weights.add(new int[]{i, 1});
+        HuffmanTree t1 = HuffmanTree.build(new ArrayList<>(weights));
+        HuffmanTree t2 = HuffmanTree.build(new ArrayList<>(weights));
+        assertEquals(t1.codeTable(), t2.codeTable());
+    }
+
+    @Test
+    @DisplayName("Two equal-weight leaves: lower symbol (65) gets code '0'")
+    void equalWeightsLowerSymbolLeft() {
+        HuffmanTree tree = build(65, 1, 66, 1);
+        Map<Integer, String> table = tree.codeTable();
+        // Both have length 1; lower symbol (65) gets left branch ('0')
+        assertEquals(1, table.get(65).length());
+        assertEquals(1, table.get(66).length());
+    }
+
+    // =========================================================================
+    // 8. isValid
+    // =========================================================================
+
+    @Test
+    @DisplayName("isValid() is true for a well-formed tree")
+    void isValidTrue() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid());
+    }
+
+    @Test
+    @DisplayName("isValid() is true for large tree (50 symbols)")
+    void isValidLarge() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 50; i++) weights.add(new int[]{i, i + 1});
+        assertTrue(HuffmanTree.build(weights).isValid());
+    }
+}

--- a/code/packages/kotlin/huffman-tree/.gitignore
+++ b/code/packages/kotlin/huffman-tree/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/huffman-tree/BUILD
+++ b/code/packages/kotlin/huffman-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-tree/BUILD_windows
+++ b/code/packages/kotlin/huffman-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-tree/CHANGELOG.md
+++ b/code/packages/kotlin/huffman-tree/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — kotlin/huffman-tree
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+
+- `HuffmanTree` — optimal prefix-free code tree backed by `java.util.PriorityQueue`
+- Sealed class hierarchy: `Node` base, `Leaf(symbol, weight)`, `Internal(weight, left, right, order)`
+- `HuffmanTree.build(List<IntArray> weights)` — companion factory; greedy min-heap
+  construction from `[symbol, frequency]` pairs; throws for empty list or non-positive freq
+- `codeTable()` — O(n) walk returning `Map<Int, String>` of `{symbol → bit_string}`
+- `codeFor(symbol)` — O(n) single-symbol lookup; returns null if absent
+- `canonicalCodeTable()` — O(n log n) DEFLATE-style canonical codes from lengths
+- `decodeAll(bits, count)` — O(bits) tree-walk decoder; throws when stream exhausted
+- `weight()` — O(1) total weight (sum of all frequencies)
+- `depth()` — O(n) maximum code length (depth of deepest leaf)
+- `symbolCount()` — O(1) number of distinct symbols
+- `leavesWithCodes()` — O(n) in-order list of `Pair<Int, String>` (symbol, code)
+- `isValid()` — structural validator: full binary tree, correct weights, unique symbols
+- Deterministic tie-breaking: weight → leaf-before-internal → symbol value → insertion order
+- 35 unit tests covering construction, code tables, canonical codes, round-trips,
+  inspection methods, tie-breaking determinism, and isValid

--- a/code/packages/kotlin/huffman-tree/README.md
+++ b/code/packages/kotlin/huffman-tree/README.md
@@ -1,0 +1,88 @@
+# kotlin/huffman-tree
+
+A **Huffman tree** in idiomatic Kotlin — the theoretically optimal prefix-free
+code for any symbol frequency distribution.  O(n log n) construction, O(n)
+encoding/decoding.
+
+## What is a Huffman Tree?
+
+A Huffman tree assigns variable-length bit codes to symbols so that frequent
+symbols get short codes and rare symbols get long codes.  The resulting codes are
+**prefix-free**: no code is a prefix of another, so the bit stream can be decoded
+unambiguously without separator characters.
+
+Think of Morse code: 'E' is `.` (one dot) and 'Z' is `--..` (four symbols).
+Huffman's algorithm builds this mapping automatically and optimally for any
+given frequency distribution.
+
+## Usage
+
+```kotlin
+import com.codingadventures.huffmantree.HuffmanTree
+
+// Build from (symbol, frequency) pairs
+val tree = HuffmanTree.build(listOf(
+    intArrayOf(65, 3),  // 'A' → frequency 3
+    intArrayOf(66, 2),  // 'B' → frequency 2
+    intArrayOf(67, 1)   // 'C' → frequency 1
+))
+
+// Encode
+val table = tree.codeTable()
+// table[65] → "0"   (A gets the shortest code)
+// table[66] → "10"
+// table[67] → "11"
+
+val bits = table.getValue(65) + table.getValue(66) + table.getValue(67) // "01011"
+
+// Decode
+val decoded = tree.decodeAll(bits, 3)  // → [65, 66, 67]
+
+// Canonical codes (DEFLATE-style)
+val canonical = tree.canonicalCodeTable()
+// canonical[65] → "0"
+// canonical[66] → "10"
+// canonical[67] → "11"
+
+// Inspection
+tree.weight()       // 6    (sum of all frequencies)
+tree.depth()        // 2    (max code length)
+tree.symbolCount()  // 3
+tree.isValid()      // true
+```
+
+## API
+
+| Member | Description |
+|---|---|
+| `HuffmanTree.build(List<IntArray>)` | Build from `[symbol, freq]` pairs |
+| `fun codeTable(): Map<Int, String>` | O(n) — all codes as bit strings |
+| `fun codeFor(symbol: Int): String?` | O(n) — single symbol lookup |
+| `fun canonicalCodeTable(): Map<Int, String>` | O(n log n) — DEFLATE-style canonical codes |
+| `fun decodeAll(bits: String, count: Int): List<Int>` | Decode exactly count symbols |
+| `fun weight(): Int` | O(1) — sum of all frequencies |
+| `fun depth(): Int` | O(n) — maximum code length |
+| `fun symbolCount(): Int` | O(1) — number of distinct symbols |
+| `fun leavesWithCodes(): List<Pair<Int, String>>` | O(n) — in-order leaf pairs |
+| `fun isValid(): Boolean` | Structural validator |
+
+## Design
+
+Uses a **sealed class** hierarchy:
+- `sealed class Node(weight: Int)` — base
+- `data class Leaf(symbol, weight)` — leaf with symbol
+- `data class Internal(weight, left, right, order)` — internal branching node
+
+Pattern-matching `when` expressions in all tree traversals keep code concise
+and exhaustive.
+
+## Running tests
+
+```
+gradle test
+```
+
+35 tests covering: construction, code table, codeFor, canonical codes,
+encode/decode round-trips (including all 256 bytes), exhaustion error,
+inspection methods (weight, depth, symbolCount, leavesWithCodes),
+tie-breaking determinism, and isValid.

--- a/code/packages/kotlin/huffman-tree/build.gradle.kts
+++ b/code/packages/kotlin/huffman-tree/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/huffman-tree/settings.gradle.kts
+++ b/code/packages/kotlin/huffman-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "huffman-tree"

--- a/code/packages/kotlin/huffman-tree/src/main/kotlin/com/codingadventures/huffmantree/HuffmanTree.kt
+++ b/code/packages/kotlin/huffman-tree/src/main/kotlin/com/codingadventures/huffmantree/HuffmanTree.kt
@@ -1,0 +1,462 @@
+// ============================================================================
+// HuffmanTree.kt — Optimal Prefix-Free Code Tree
+// ============================================================================
+//
+// A Huffman tree is a full binary tree (every internal node has exactly two
+// children) built from a symbol alphabet so that each symbol gets a unique
+// variable-length bit code.  Symbols that appear often get short codes;
+// symbols that appear rarely get long codes.  The total bits needed to
+// encode a message is minimised — it is the theoretically optimal prefix-free
+// code for a given symbol frequency distribution.
+//
+// Think of it like Morse code.  In Morse, 'E' is '.' (one dot) and 'Z' is
+// '--..' (four symbols).  The designers knew 'E' is the most common letter
+// in English so they gave it the shortest code.  Huffman's algorithm does
+// this automatically and optimally for any alphabet with any frequency
+// distribution.
+//
+// ============================================================================
+// Algorithm: Greedy construction via min-heap
+// ============================================================================
+//
+// 1. Create one leaf node per distinct symbol, each with its frequency as
+//    its weight.  Push all leaves onto a min-heap keyed by weight.
+//
+// 2. While the heap has more than one node:
+//      a. Pop the two nodes with the smallest weight.
+//      b. Create a new internal node whose weight = sum of the two children.
+//      c. Set left = the first popped node, right = the second popped node.
+//      d. Push the new internal node back onto the heap.
+//
+// 3. The one remaining node is the root of the Huffman tree.
+//
+// ============================================================================
+// Tie-breaking for determinism
+// ============================================================================
+//
+// Without tie-breaking, different implementations build structurally different
+// trees from the same input — producing different (but equally valid) codes.
+// We enforce these rules (lower key = higher priority):
+//
+//   Priority tuple: (weight, isInternal, symbolOrNeg1, insertionOrder)
+//
+//   1. Lowest weight pops first.
+//   2. Leaf nodes (isInternal=0) beat internal nodes (isInternal=1) at equal
+//      weight.
+//   3. Among leaves of equal weight, lower symbol value wins.
+//   4. Among internal nodes of equal weight, earlier-created node wins
+//      (insertion order, FIFO).
+//
+// ============================================================================
+// Prefix-free property: why it works
+// ============================================================================
+//
+//   In a Huffman tree:
+//     - Symbols live ONLY at the leaves, never at internal nodes.
+//     - The code for a symbol is the path from root to its leaf
+//       (left edge = '0', right edge = '1').
+//
+//   Since one leaf is never an ancestor of another, no code can be a prefix
+//   of another code.  This means the bit stream can be decoded unambiguously
+//   without separator characters: just walk the tree bit by bit until you
+//   reach a leaf.
+//
+// ============================================================================
+// Canonical codes (DEFLATE / zlib style)
+// ============================================================================
+//
+//   The standard tree-walk produces valid codes, but different tree shapes
+//   can produce different codes for the same symbol lengths.  Canonical codes
+//   normalise this: given only the code *lengths*, you can reconstruct the
+//   exact canonical code table without transmitting the tree structure.
+//
+//   Algorithm:
+//     1. Collect (symbol, code_length) pairs from the tree.
+//     2. Sort by (code_length, symbol_value).
+//     3. Assign codes numerically:
+//          code[0] = 0  (left-padded to length[0] bits)
+//          code[i] = (code[i-1] + 1) shl (length[i] - length[i-1])
+//
+//   This is exactly what DEFLATE uses: the compressed stream contains only
+//   the length table, not the tree, saving space.
+//
+//   Example with AAABBC (A=3, B=2, C=1):
+//     Tree:      [6]
+//                / \
+//               A  [3]
+//              (3)  / \
+//                  B   C
+//                 (2) (1)
+//     Lengths: A=1, B=2, C=2
+//     Sorted by (length, symbol): A(1), B(2), C(2)
+//     Canonical codes:
+//       A → "0"   (length 1, code = 0)
+//       B → "10"  (length 2, code = 0+1=1, shifted 1 bit → 10)
+//       C → "11"  (length 2, code = 10+1 = 11)
+//
+// ============================================================================
+
+package com.codingadventures.huffmantree
+
+import java.util.PriorityQueue
+
+// ============================================================================
+// Node types
+// ============================================================================
+
+/**
+ * Base class for all nodes in the Huffman tree.
+ *
+ * Every node carries a [weight]: for leaves it is the symbol's frequency;
+ * for internal nodes it is the sum of its children's weights.
+ */
+sealed class Node(open val weight: Int)
+
+/**
+ * A leaf node representing a single symbol.
+ *
+ * Leaves are always at the bottom of the tree.  Their code is the
+ * path from the root to this node (left='0', right='1').
+ *
+ * @param symbol   the encoded symbol (non-negative integer)
+ * @param weight   the symbol's frequency
+ */
+data class Leaf(val symbol: Int, override val weight: Int) : Node(weight)
+
+/**
+ * An internal node combining two sub-trees.
+ *
+ * Internal nodes have no symbol — they are bookkeeping nodes encoding
+ * branching structure.  Their [weight] = [left].weight + [right].weight.
+ *
+ * @param weight  sum of children's weights
+ * @param left    left child (code bit '0')
+ * @param right   right child (code bit '1')
+ * @param order   monotonic insertion counter for tie-breaking (FIFO among internals)
+ */
+data class Internal(
+    override val weight: Int,
+    val left:   Node,
+    val right:  Node,
+    val order:  Int = 0
+) : Node(weight)
+
+// ============================================================================
+// HuffmanTree
+// ============================================================================
+
+/**
+ * A Huffman tree that assigns optimal prefix-free bit codes to integer symbols.
+ *
+ * Build the tree once from symbol frequencies; then:
+ * - Use [codeTable] to get a `{symbol → bit_string}` map for encoding.
+ * - Use [decodeAll] to decode a bit stream back to symbols.
+ * - Use [canonicalCodeTable] for DEFLATE-style transmissible codes.
+ *
+ * All symbols are non-negative integers (typically 0–255 for byte-level
+ * coding, but any non-negative integer is valid).  Frequencies must be
+ * positive.  The tree is immutable after construction.
+ *
+ * ```kotlin
+ * val tree = HuffmanTree.build(listOf(
+ *     intArrayOf(65, 3),  // 'A' → frequency 3
+ *     intArrayOf(66, 2),  // 'B' → frequency 2
+ *     intArrayOf(67, 1)   // 'C' → frequency 1
+ * ))
+ *
+ * val table = tree.codeTable()
+ * // table[65] → "0"    (A gets the shortest code)
+ * // table[66] → "10"
+ * // table[67] → "11"
+ *
+ * val decoded = tree.decodeAll("010011", 4)
+ * // → [65, 65, 66, 67]
+ * ```
+ */
+class HuffmanTree private constructor(
+    private val root:        Node,
+    private val symbolCount: Int
+) {
+
+    // =========================================================================
+    // Companion (factory)
+    // =========================================================================
+
+    companion object {
+
+        /**
+         * Comparator for the min-heap during tree construction.
+         *
+         * Four-level ordering (lower = higher priority):
+         * 1. Weight (lighter wins)
+         * 2. Node type: leaf (0) before internal (1)
+         * 3. Symbol value for leaves (lower wins)
+         * 4. Insertion order for internals (earlier = FIFO)
+         */
+        private val PRIORITY = Comparator<Node> { a, b ->
+            // Field 0: weight
+            a.weight.compareTo(b.weight).takeIf { it != 0 }?.let { return@Comparator it }
+
+            // Field 1: leaf (0) before internal (1)
+            val typeA = if (a is Leaf) 0 else 1
+            val typeB = if (b is Leaf) 0 else 1
+            typeA.compareTo(typeB).takeIf { it != 0 }?.let { return@Comparator it }
+
+            // Field 2 / 3: among same type
+            when {
+                a is Leaf && b is Leaf -> a.symbol.compareTo(b.symbol)
+                a is Internal && b is Internal -> a.order.compareTo(b.order)
+                else -> 0
+            }
+        }
+
+        /**
+         * Construct a Huffman tree from `(symbol, frequency)` pairs.
+         *
+         * Each element of [weights] must be an `IntArray` of size ≥ 2:
+         * `[symbol, frequency, ...]`.  Symbols must be non-negative integers;
+         * frequencies must be > 0.
+         *
+         * Tie-breaking (for deterministic output):
+         * 1. Lowest weight pops first.
+         * 2. Leaves before internal nodes at equal weight.
+         * 3. Lower symbol value wins among leaves of equal weight.
+         * 4. Earlier-created internal wins among internals of equal weight (FIFO).
+         *
+         * @param weights list of `IntArray(symbol, frequency)` pairs
+         * @return a [HuffmanTree] ready for encoding/decoding
+         * @throws IllegalArgumentException if [weights] is empty or any frequency ≤ 0
+         */
+        fun build(weights: List<IntArray>): HuffmanTree {
+            require(weights.isNotEmpty()) { "weights must not be empty" }
+            for ((sym, freq) in weights.map { it[0] to it[1] }) {
+                require(freq > 0) {
+                    "frequency must be positive; got symbol=$sym, freq=$freq"
+                }
+            }
+
+            val heap = PriorityQueue(weights.size, PRIORITY)
+            for (pair in weights) heap.add(Leaf(pair[0], pair[1]))
+
+            var orderCounter = 0
+            while (heap.size > 1) {
+                val left  = heap.poll()
+                val right = heap.poll()
+                heap.add(Internal(left.weight + right.weight, left, right, orderCounter++))
+            }
+
+            return HuffmanTree(heap.poll(), weights.size)
+        }
+    }
+
+    // =========================================================================
+    // Encoding helpers
+    // =========================================================================
+
+    /**
+     * Return a `{symbol → bit_string}` map for all symbols in the tree.
+     *
+     * Left edges are `'0'`, right edges are `'1'`.  For a single-symbol tree
+     * the convention is `{symbol → "0"}` (one bit per occurrence).
+     *
+     * Time: O(n) where n = number of distinct symbols.
+     *
+     * ```kotlin
+     * tree.codeTable()[65]  // "0"
+     * tree.codeTable()[66]  // "10"
+     * tree.codeTable()[67]  // "11"
+     * ```
+     */
+    fun codeTable(): Map<Int, String> {
+        val table = mutableMapOf<Int, String>()
+        walkTree(root, "", table)
+        return table
+    }
+
+    /**
+     * Return the bit string for [symbol], or `null` if not in the tree.
+     *
+     * Does NOT build the full code table — traverses only until found.
+     *
+     * Time: O(n) worst case.
+     */
+    fun codeFor(symbol: Int): String? = findCode(root, symbol, "")
+
+    /**
+     * Return canonical Huffman codes (DEFLATE-style).
+     *
+     * Sorted by `(code_length, symbol_value)`; codes assigned numerically.
+     * Allows transmitting only code lengths, not the tree structure.
+     *
+     * Time: O(n log n).
+     */
+    fun canonicalCodeTable(): Map<Int, String> {
+        val lengths = mutableMapOf<Int, Int>()
+        collectLengths(root, 0, lengths)
+
+        // Single-leaf edge case
+        if (lengths.size == 1) {
+            val sym = lengths.keys.first()
+            return mapOf(sym to "0")
+        }
+
+        // Sort by (length, symbol)
+        val sorted = lengths.entries.sortedWith(compareBy({ it.value }, { it.key }))
+
+        val result  = mutableMapOf<Int, String>()
+        var codeVal = 0
+        var prevLen = sorted.first().value
+
+        for ((sym, length) in sorted) {
+            if (length > prevLen) codeVal = codeVal shl (length - prevLen)
+            result[sym] = Integer.toBinaryString(codeVal).padStart(length, '0')
+            codeVal++
+            prevLen = length
+        }
+        return result
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode exactly [count] symbols from a bit string by walking the tree.
+     *
+     * For each symbol: follow the tree from the root, taking the left child
+     * on '0' and the right child on '1', until a leaf is reached.  The leaf's
+     * symbol is appended; the walk restarts at the root.
+     *
+     * For a single-leaf tree, each '0' bit decodes to that symbol.
+     *
+     * Time: O(total bits consumed).
+     *
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  [count] symbols are decoded
+     */
+    fun decodeAll(bits: String, count: Int): List<Int> {
+        val result     = mutableListOf<Int>()
+        var current    = root
+        var i          = 0
+        val singleLeaf = root is Leaf
+
+        while (result.size < count) {
+            if (current is Leaf) {
+                result.add(current.symbol)
+                current = root
+                if (singleLeaf && i < bits.length) i++
+                continue
+            }
+
+            if (i >= bits.length) {
+                throw IllegalArgumentException(
+                    "Bit stream exhausted after ${result.size} symbols; expected $count"
+                )
+            }
+
+            val bit = bits[i++]
+            val internal = current as Internal
+            current = if (bit == '0') internal.left else internal.right
+        }
+
+        return result
+    }
+
+    // =========================================================================
+    // Inspection
+    // =========================================================================
+
+    /** Total weight = sum of all leaf frequencies = root weight. O(1). */
+    fun weight(): Int = root.weight
+
+    /** Maximum code length = depth of the deepest leaf. O(n). */
+    fun depth(): Int = maxDepth(root, 0)
+
+    /** Number of distinct symbols. O(1). */
+    fun symbolCount(): Int = symbolCount
+
+    /**
+     * In-order list of `(symbol, code)` pairs (left subtree before right).
+     *
+     * Useful for visualisation and debugging.
+     *
+     * Time: O(n).
+     */
+    fun leavesWithCodes(): List<Pair<Int, String>> {
+        val table  = codeTable()
+        val result = mutableListOf<Pair<Int, String>>()
+        collectLeavesInOrder(root, result, table)
+        return result
+    }
+
+    /**
+     * Check structural invariants:
+     * 1. Every internal node has exactly 2 children (full binary tree).
+     * 2. `weight(internal) == weight(left) + weight(right)`.
+     * 3. No symbol appears in more than one leaf.
+     *
+     * @return true if all invariants hold
+     */
+    fun isValid(): Boolean {
+        val seen = mutableSetOf<Int>()
+        return checkInvariants(root, seen)
+    }
+
+    // =========================================================================
+    // Private helpers — tree walk
+    // =========================================================================
+
+    private fun walkTree(node: Node, prefix: String, table: MutableMap<Int, String>) {
+        when (node) {
+            is Leaf     -> table[node.symbol] = if (prefix.isEmpty()) "0" else prefix
+            is Internal -> {
+                walkTree(node.left,  prefix + "0", table)
+                walkTree(node.right, prefix + "1", table)
+            }
+        }
+    }
+
+    private fun findCode(node: Node, symbol: Int, prefix: String): String? = when (node) {
+        is Leaf     -> if (node.symbol == symbol) (if (prefix.isEmpty()) "0" else prefix) else null
+        is Internal -> findCode(node.left, symbol, prefix + "0")
+                    ?: findCode(node.right, symbol, prefix + "1")
+    }
+
+    private fun collectLengths(node: Node, depth: Int, lengths: MutableMap<Int, Int>) {
+        when (node) {
+            is Leaf     -> lengths[node.symbol] = if (depth > 0) depth else 1
+            is Internal -> {
+                collectLengths(node.left,  depth + 1, lengths)
+                collectLengths(node.right, depth + 1, lengths)
+            }
+        }
+    }
+
+    private fun maxDepth(node: Node, depth: Int): Int = when (node) {
+        is Leaf     -> depth
+        is Internal -> maxOf(maxDepth(node.left, depth + 1), maxDepth(node.right, depth + 1))
+    }
+
+    private fun collectLeavesInOrder(
+        node: Node, result: MutableList<Pair<Int, String>>, table: Map<Int, String>
+    ) {
+        when (node) {
+            is Leaf     -> result.add(node.symbol to table.getValue(node.symbol))
+            is Internal -> {
+                collectLeavesInOrder(node.left,  result, table)
+                collectLeavesInOrder(node.right, result, table)
+            }
+        }
+    }
+
+    private fun checkInvariants(node: Node, seen: MutableSet<Int>): Boolean = when (node) {
+        is Leaf -> {
+            if (node.symbol in seen) false
+            else { seen.add(node.symbol); true }
+        }
+        is Internal -> {
+            if (node.weight != node.left.weight + node.right.weight) false
+            else checkInvariants(node.left, seen) && checkInvariants(node.right, seen)
+        }
+    }
+}

--- a/code/packages/kotlin/huffman-tree/src/test/kotlin/com/codingadventures/huffmantree/HuffmanTreeTest.kt
+++ b/code/packages/kotlin/huffman-tree/src/test/kotlin/com/codingadventures/huffmantree/HuffmanTreeTest.kt
@@ -1,0 +1,363 @@
+package com.codingadventures.huffmantree
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive tests for [HuffmanTree].
+ *
+ * Test organisation:
+ * 1. Construction — empty/zero-freq errors, single, two, three symbols
+ * 2. Code table — prefix-free property, single-symbol convention
+ * 3. codeFor — hit, miss, single-symbol
+ * 4. Canonical code table — AAABBC example, same lengths as regular, prefix-free
+ * 5. Encode/decode round-trips — single, three symbols, all 256 bytes
+ * 6. decodeAll error — exhausted bit stream
+ * 7. Inspection — weight, depth, symbolCount, leavesWithCodes
+ * 8. Tie-breaking determinism
+ * 9. isValid
+ */
+class HuffmanTreeTest {
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun build(vararg pairs: Int): HuffmanTree {
+        val weights = (pairs.indices step 2).map { i ->
+            intArrayOf(pairs[i], pairs[i + 1])
+        }
+        return HuffmanTree.build(weights)
+    }
+
+    // =========================================================================
+    // 1. Construction
+    // =========================================================================
+
+    @Test
+    @DisplayName("build() from empty list throws")
+    fun buildEmptyThrows() {
+        var threw = false
+        try { HuffmanTree.build(emptyList()) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("build() with zero frequency throws")
+    fun buildZeroFreqThrows() {
+        var threw = false
+        try { build(65, 0) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("build() with negative frequency throws")
+    fun buildNegativeFreqThrows() {
+        var threw = false
+        try { build(65, -1) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("Single symbol: symbolCount=1, weight=freq")
+    fun singleSymbol() {
+        val tree = build(65, 5)
+        assertEquals(1, tree.symbolCount())
+        assertEquals(5, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Two symbols: symbolCount=2, weight=sum of freqs")
+    fun twoSymbols() {
+        val tree = build(65, 3, 66, 1)
+        assertEquals(2, tree.symbolCount())
+        assertEquals(4, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Three symbols AAABBC: symbolCount=3, weight=6")
+    fun threeSymbols() {
+        val tree = build(65, 3, 66, 2, 67, 1)
+        assertEquals(3, tree.symbolCount())
+        assertEquals(6, tree.weight())
+    }
+
+    @Test
+    @DisplayName("isValid() is true after build")
+    fun isValidAfterBuild() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid())
+    }
+
+    @Test
+    @DisplayName("Large alphabet (256 symbols) builds and is valid")
+    fun largeAlphabet() {
+        val weights = (0 until 256).map { i -> intArrayOf(i, i + 1) }
+        val tree = HuffmanTree.build(weights)
+        assertEquals(256, tree.symbolCount())
+        assertTrue(tree.isValid())
+    }
+
+    // =========================================================================
+    // 2. Code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC: A gets shortest code (highest frequency)")
+    fun codeTableAAABBCFrequencies() {
+        val tree  = build(65, 3, 66, 2, 67, 1)
+        val table = tree.codeTable()
+        assertTrue(table.getValue(65).length < table.getValue(66).length)
+        assertTrue(table.getValue(66).length <= table.getValue(67).length)
+    }
+
+    @Test
+    @DisplayName("Single symbol: code is \"0\"")
+    fun codeTableSingleSymbol() {
+        assertEquals("0", build(65, 1).codeTable()[65])
+    }
+
+    @Test
+    @DisplayName("All codes are prefix-free (10 symbols)")
+    fun codeTablePrefixFree() {
+        val weights = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        val table   = HuffmanTree.build(weights).codeTable()
+        val codes   = table.values.toList()
+        for (i in codes.indices) {
+            for (j in codes.indices) {
+                if (i != j) assertFalse(codes[i].startsWith(codes[j]),
+                    "${codes[i]} starts with ${codes[j]}")
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("codeTable contains an entry for every symbol")
+    fun codeTableContainsAllSymbols() {
+        val table = build(65, 3, 66, 2, 67, 1).codeTable()
+        assertTrue(table.containsKey(65))
+        assertTrue(table.containsKey(66))
+        assertTrue(table.containsKey(67))
+    }
+
+    // =========================================================================
+    // 3. codeFor
+    // =========================================================================
+
+    @Test
+    @DisplayName("codeFor matches codeTable for each symbol")
+    fun codeForMatchesTable() {
+        val tree  = build(65, 3, 66, 2, 67, 1)
+        val table = tree.codeTable()
+        assertEquals(table[65], tree.codeFor(65))
+        assertEquals(table[66], tree.codeFor(66))
+        assertEquals(table[67], tree.codeFor(67))
+    }
+
+    @Test
+    @DisplayName("codeFor returns null for absent symbol")
+    fun codeForMissing() {
+        assertNull(build(65, 3, 66, 2).codeFor(99))
+    }
+
+    @Test
+    @DisplayName("codeFor single symbol returns \"0\"")
+    fun codeForSingleSymbol() {
+        assertEquals("0", build(65, 5).codeFor(65))
+    }
+
+    // =========================================================================
+    // 4. Canonical code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC canonical: A→\"0\", B→\"10\", C→\"11\"")
+    fun canonicalAAABBC() {
+        val canonical = build(65, 3, 66, 2, 67, 1).canonicalCodeTable()
+        assertEquals("0",  canonical[65])
+        assertEquals("10", canonical[66])
+        assertEquals("11", canonical[67])
+    }
+
+    @Test
+    @DisplayName("Canonical code lengths match regular code lengths (8 symbols)")
+    fun canonicalLengthsMatchRegular() {
+        val weights   = (0 until 8).map { i -> intArrayOf(i, i + 1) }
+        val tree      = HuffmanTree.build(weights)
+        val regular   = tree.codeTable()
+        val canonical = tree.canonicalCodeTable()
+        for (sym in regular.keys) {
+            assertEquals(regular.getValue(sym).length, canonical.getValue(sym).length,
+                "Length mismatch for symbol $sym")
+        }
+    }
+
+    @Test
+    @DisplayName("Canonical single symbol returns {sym → \"0\"}")
+    fun canonicalSingleSymbol() {
+        assertEquals("0", build(65, 5).canonicalCodeTable()[65])
+    }
+
+    @Test
+    @DisplayName("Canonical codes are prefix-free (10 symbols)")
+    fun canonicalPrefixFree() {
+        val weights   = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        val canonical = HuffmanTree.build(weights).canonicalCodeTable()
+        val codes     = canonical.values.toList()
+        for (i in codes.indices) {
+            for (j in codes.indices) {
+                if (i != j) assertFalse(codes[i].startsWith(codes[j]))
+            }
+        }
+    }
+
+    // =========================================================================
+    // 5. Encode / decode round-trips
+    // =========================================================================
+
+    @Test
+    @DisplayName("Single-symbol round-trip: [A,A,A]")
+    fun roundTripSingleSymbol() {
+        val tree  = build(65, 5)
+        val code  = tree.codeTable().getValue(65)
+        val bits  = code + code + code
+        assertEquals(listOf(65, 65, 65), tree.decodeAll(bits, 3))
+    }
+
+    @Test
+    @DisplayName("AAABBC round-trip: encode then decode")
+    fun roundTripAAABBC() {
+        val symbols = listOf(65, 65, 65, 66, 66, 67)
+        val tree    = build(65, 3, 66, 2, 67, 1)
+        val table   = tree.codeTable()
+        val bits    = symbols.joinToString("") { table.getValue(it) }
+        assertEquals(symbols, tree.decodeAll(bits, symbols.size))
+    }
+
+    @Test
+    @DisplayName("All 256 byte values round-trip")
+    fun roundTripAllBytes() {
+        val weights  = (0 until 256).map { i -> intArrayOf(i, i + 1) }
+        val tree     = HuffmanTree.build(weights)
+        val table    = tree.codeTable()
+        val symbols  = (0 until 256).toList()
+        val bits     = symbols.joinToString("") { table.getValue(it) }
+        assertEquals(symbols, tree.decodeAll(bits, 256))
+    }
+
+    @Test
+    @DisplayName("decodeAll throws when bit stream exhausted")
+    fun decodeExhausted() {
+        val tree   = build(65, 3, 66, 2, 67, 1)
+        var threw  = false
+        try { tree.decodeAll("0", 5) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    // =========================================================================
+    // 6. Inspection
+    // =========================================================================
+
+    @Test
+    @DisplayName("weight() returns sum of all frequencies")
+    fun weightSum() {
+        assertEquals(6, build(65, 3, 66, 2, 67, 1).weight())
+    }
+
+    @Test
+    @DisplayName("depth() of single-symbol tree is 0")
+    fun depthSingleSymbol() {
+        assertEquals(0, build(65, 1).depth())
+    }
+
+    @Test
+    @DisplayName("depth() of two-symbol tree is 1")
+    fun depthTwoSymbols() {
+        assertEquals(1, build(65, 3, 66, 1).depth())
+    }
+
+    @Test
+    @DisplayName("depth() of AAABBC tree is 2")
+    fun depthThreeSymbols() {
+        assertEquals(2, build(65, 3, 66, 2, 67, 1).depth())
+    }
+
+    @Test
+    @DisplayName("symbolCount() returns number of distinct symbols")
+    fun symbolCountBasic() {
+        val weights = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        assertEquals(10, HuffmanTree.build(weights).symbolCount())
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() single symbol returns [(65, \"0\")]")
+    fun leavesWithCodesSingle() {
+        val leaves = build(65, 5).leavesWithCodes()
+        assertEquals(1, leaves.size)
+        assertEquals(65,  leaves[0].first)
+        assertEquals("0", leaves[0].second)
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() contains all symbols in AAABBC tree")
+    fun leavesWithCodesThreeSymbols() {
+        val tree   = build(65, 3, 66, 2, 67, 1)
+        val leaves = tree.leavesWithCodes()
+        assertEquals(3, leaves.size)
+        val syms = leaves.map { it.first }.toSet()
+        assertTrue(65 in syms)
+        assertTrue(66 in syms)
+        assertTrue(67 in syms)
+    }
+
+    // =========================================================================
+    // 7. Tie-breaking determinism
+    // =========================================================================
+
+    @Test
+    @DisplayName("Equal-weight alphabet is structurally valid")
+    fun equalWeightsValid() {
+        val tree = build(65, 1, 66, 1, 67, 1, 68, 1)
+        assertTrue(tree.isValid())
+        assertEquals(4, tree.symbolCount())
+        assertEquals(4, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Same input always produces same code table")
+    fun equalWeightsDeterministic() {
+        val weights = (0 until 8).map { i -> intArrayOf(i, 1) }
+        val t1 = HuffmanTree.build(weights.map { it.clone() })
+        val t2 = HuffmanTree.build(weights.map { it.clone() })
+        assertEquals(t1.codeTable(), t2.codeTable())
+    }
+
+    @Test
+    @DisplayName("Two equal-weight leaves: lower symbol (65) gets code '0' (left branch)")
+    fun equalWeightsLowerSymbolLeft() {
+        val table = build(65, 1, 66, 1).codeTable()
+        assertEquals(1, table.getValue(65).length)
+        assertEquals(1, table.getValue(66).length)
+    }
+
+    // =========================================================================
+    // 8. isValid
+    // =========================================================================
+
+    @Test
+    @DisplayName("isValid() is true for a well-formed tree")
+    fun isValidTrue() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid())
+    }
+
+    @Test
+    @DisplayName("isValid() is true for large tree (50 symbols)")
+    fun isValidLarge() {
+        val weights = (0 until 50).map { i -> intArrayOf(i, i + 1) }
+        assertTrue(HuffmanTree.build(weights).isValid())
+    }
+}


### PR DESCRIPTION
## Summary

- **java/huffman-tree**: greedy min-heap Huffman tree. Implements `codeTable()`, `codeFor()`, `canonicalCodeTable()` (DEFLATE-style), `decodeAll()`, `weight()`, `depth()`, `symbolCount()`, `leavesWithCodes()`, `isValid()`. Backed by `java.util.PriorityQueue`. 36 unit tests.
- **kotlin/huffman-tree**: idiomatic Kotlin port using sealed class hierarchy (`Node`, `Leaf`, `Internal`), pattern-matching `when` in all traversals, `Pair<Int,String>` for `leavesWithCodes()`. 35 unit tests.

Both packages include BUILD, BUILD_windows, build.gradle.kts, settings.gradle.kts, README.md, CHANGELOG.md, and .gitignore.

## Test plan

- [ ] java/huffman-tree: 36 tests pass (`gradle test` in `code/packages/java/huffman-tree/`)
- [ ] kotlin/huffman-tree: 35 tests pass (`gradle test` in `code/packages/kotlin/huffman-tree/`)
- [ ] Security review: passed (pure in-memory library, no I/O, no secrets)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)