### PR TITLE
feat(parity): add dotnet scytale cipher packages

### DIFF
--- a/code/packages/csharp/scytale-cipher/BUILD
+++ b/code/packages/csharp/scytale-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/scytale-cipher/BUILD_windows
+++ b/code/packages/csharp/scytale-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/scytale-cipher/CHANGELOG.md
+++ b/code/packages/csharp/scytale-cipher/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# Scytale cipher package.

--- a/code/packages/csharp/scytale-cipher/CodingAdventures.ScytaleCipher.csproj
+++ b/code/packages/csharp/scytale-cipher/CodingAdventures.ScytaleCipher.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.ScytaleCipher.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Scytale transposition cipher helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/scytale-cipher/README.md
+++ b/code/packages/csharp/scytale-cipher/README.md
@@ -1,0 +1,3 @@
+# csharp/scytale-cipher
+
+Pure C# Scytale transposition cipher helpers with encrypt, decrypt, and brute-force key enumeration.

--- a/code/packages/csharp/scytale-cipher/ScytaleCipher.cs
+++ b/code/packages/csharp/scytale-cipher/ScytaleCipher.cs
@@ -1,0 +1,104 @@
+namespace CodingAdventures.ScytaleCipher;
+
+public readonly record struct BruteForceResult(int Key, string Text);
+
+public static class ScytaleCipher
+{
+    public static string Encrypt(string text, int key)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (text.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        ValidateKey(text.Length, key);
+
+        var rowCount = (text.Length + key - 1) / key;
+        var paddedLength = rowCount * key;
+        var padded = text.PadRight(paddedLength).ToCharArray();
+        var result = new char[paddedLength];
+        var output = 0;
+
+        for (var column = 0; column < key; column++)
+        {
+            for (var row = 0; row < rowCount; row++)
+            {
+                result[output++] = padded[(row * key) + column];
+            }
+        }
+
+        return new string(result);
+    }
+
+    public static string Decrypt(string text, int key)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (text.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        ValidateKey(text.Length, key);
+
+        var rowCount = (text.Length + key - 1) / key;
+        var fullColumns = text.Length % key == 0 ? key : text.Length % key;
+        var columnStarts = new int[key];
+        var columnLengths = new int[key];
+        var offset = 0;
+
+        for (var column = 0; column < key; column++)
+        {
+            columnStarts[column] = offset;
+            var columnLength = text.Length % key == 0 || column < fullColumns ? rowCount : rowCount - 1;
+            columnLengths[column] = columnLength;
+            offset += columnLength;
+        }
+
+        var chars = text.ToCharArray();
+        var result = new List<char>(text.Length);
+        for (var row = 0; row < rowCount; row++)
+        {
+            for (var column = 0; column < key; column++)
+            {
+                if (row < columnLengths[column])
+                {
+                    result.Add(chars[columnStarts[column] + row]);
+                }
+            }
+        }
+
+        return new string(result.ToArray()).TrimEnd(' ');
+    }
+
+    public static IReadOnlyList<BruteForceResult> BruteForce(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (text.Length < 4)
+        {
+            return [];
+        }
+
+        var maxKey = text.Length / 2;
+        var results = new List<BruteForceResult>(maxKey - 1);
+        for (var key = 2; key <= maxKey; key++)
+        {
+            results.Add(new BruteForceResult(key, Decrypt(text, key)));
+        }
+
+        return results;
+    }
+
+    private static void ValidateKey(int textLength, int key)
+    {
+        if (key < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), key, "Key must be >= 2.");
+        }
+
+        if (key > textLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), key, "Key must be <= text length.");
+        }
+    }
+}

--- a/code/packages/csharp/scytale-cipher/required_capabilities.json
+++ b/code/packages/csharp/scytale-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/scytale-cipher",
+  "capabilities": [],
+  "justification": "Pure string transformation package and tests."
+}

--- a/code/packages/csharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.csproj
+++ b/code/packages/csharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.ScytaleCipher]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ScytaleCipher.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/ScytaleCipherTests.cs
+++ b/code/packages/csharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/ScytaleCipherTests.cs
@@ -1,0 +1,54 @@
+namespace CodingAdventures.ScytaleCipher.Tests;
+
+public sealed class ScytaleCipherTests
+{
+    [Fact]
+    public void EncryptMatchesReferenceExamples()
+    {
+        Assert.Equal("HLWLEOODL R ", ScytaleCipher.Encrypt("HELLO WORLD", 3));
+        Assert.Equal("ACEBDF", ScytaleCipher.Encrypt("ABCDEF", 2));
+        Assert.Equal("ADBECF", ScytaleCipher.Encrypt("ABCDEF", 3));
+        Assert.Equal("ABCD", ScytaleCipher.Encrypt("ABCD", 4));
+        Assert.Equal(string.Empty, ScytaleCipher.Encrypt(string.Empty, 2));
+    }
+
+    [Fact]
+    public void DecryptStripsPaddingAndMatchesReferenceExamples()
+    {
+        Assert.Equal("HELLO WORLD", ScytaleCipher.Decrypt("HLWLEOODL R ", 3));
+        Assert.Equal("ABCDEF", ScytaleCipher.Decrypt("ACEBDF", 2));
+        Assert.Equal("HELLO", ScytaleCipher.Decrypt(ScytaleCipher.Encrypt("HELLO", 3), 3));
+        Assert.Equal(string.Empty, ScytaleCipher.Decrypt(string.Empty, 2));
+    }
+
+    [Fact]
+    public void RoundTripsAcrossValidKeys()
+    {
+        var text = "The quick brown fox jumps over the lazy dog!";
+        for (var key = 2; key <= text.Length / 2; key++)
+        {
+            Assert.Equal(text, ScytaleCipher.Decrypt(ScytaleCipher.Encrypt(text, key), key));
+        }
+    }
+
+    [Fact]
+    public void BruteForceReturnsCandidatePlaintexts()
+    {
+        var ciphertext = ScytaleCipher.Encrypt("HELLO WORLD", 3);
+        var results = ScytaleCipher.BruteForce(ciphertext);
+
+        Assert.Contains(results, result => result.Key == 3 && result.Text == "HELLO WORLD");
+        Assert.Equal([2, 3, 4, 5], ScytaleCipher.BruteForce("ABCDEFGHIJ").Select(result => result.Key));
+        Assert.Empty(ScytaleCipher.BruteForce("ABC"));
+    }
+
+    [Fact]
+    public void InvalidInputsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => ScytaleCipher.Encrypt(null!, 2));
+        Assert.Throws<ArgumentNullException>(() => ScytaleCipher.Decrypt(null!, 2));
+        Assert.Throws<ArgumentNullException>(() => ScytaleCipher.BruteForce(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScytaleCipher.Encrypt("HELLO", 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScytaleCipher.Decrypt("HI", 3));
+    }
+}

--- a/code/packages/fsharp/scytale-cipher/BUILD
+++ b/code/packages/fsharp/scytale-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/scytale-cipher/BUILD_windows
+++ b/code/packages/fsharp/scytale-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/scytale-cipher/CHANGELOG.md
+++ b/code/packages/fsharp/scytale-cipher/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# Scytale cipher package.

--- a/code/packages/fsharp/scytale-cipher/CodingAdventures.ScytaleCipher.fsproj
+++ b/code/packages/fsharp/scytale-cipher/CodingAdventures.ScytaleCipher.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ScytaleCipher</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Scytale transposition cipher helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ScytaleCipher.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/scytale-cipher/README.md
+++ b/code/packages/fsharp/scytale-cipher/README.md
@@ -1,0 +1,3 @@
+# fsharp/scytale-cipher
+
+Pure F# Scytale transposition cipher helpers with encrypt, decrypt, and brute-force key enumeration.

--- a/code/packages/fsharp/scytale-cipher/ScytaleCipher.fs
+++ b/code/packages/fsharp/scytale-cipher/ScytaleCipher.fs
@@ -1,0 +1,79 @@
+namespace CodingAdventures.ScytaleCipher
+
+open System
+
+type BruteForceResult = {
+    Key: int
+    Text: string
+}
+
+[<RequireQualifiedAccess>]
+module ScytaleCipher =
+    let private validateKey textLength key =
+        if key < 2 then
+            invalidArg (nameof key) "Key must be >= 2."
+
+        if key > textLength then
+            invalidArg (nameof key) "Key must be <= text length."
+
+    let encrypt (text: string) (key: int) =
+        if isNull text then
+            nullArg (nameof text)
+
+        if text.Length = 0 then
+            String.Empty
+        else
+            validateKey text.Length key
+
+            let rowCount = (text.Length + key - 1) / key
+            let paddedLength = rowCount * key
+            let padded = text.PadRight(paddedLength).ToCharArray()
+
+            [|
+                for column in 0 .. key - 1 do
+                    for row in 0 .. rowCount - 1 do
+                        padded[(row * key) + column]
+            |]
+            |> fun chars -> String(chars)
+
+    let decrypt (text: string) (key: int) =
+        if isNull text then
+            nullArg (nameof text)
+
+        if text.Length = 0 then
+            String.Empty
+        else
+            validateKey text.Length key
+
+            let rowCount = (text.Length + key - 1) / key
+            let fullColumns = if text.Length % key = 0 then key else text.Length % key
+            let columnStarts = Array.zeroCreate<int> key
+            let columnLengths = Array.zeroCreate<int> key
+            let mutable offset = 0
+
+            for column in 0 .. key - 1 do
+                columnStarts[column] <- offset
+                let columnLength =
+                    if text.Length % key = 0 || column < fullColumns then rowCount else rowCount - 1
+
+                columnLengths[column] <- columnLength
+                offset <- offset + columnLength
+
+            let chars = text.ToCharArray()
+
+            [|
+                for row in 0 .. rowCount - 1 do
+                    for column in 0 .. key - 1 do
+                        if row < columnLengths[column] then
+                            chars[columnStarts[column] + row]
+            |]
+            |> fun chars -> String(chars).TrimEnd(' ')
+
+    let bruteForce (text: string) =
+        if isNull text then
+            nullArg (nameof text)
+
+        if text.Length < 4 then
+            []
+        else
+            [ for key in 2 .. text.Length / 2 -> { Key = key; Text = decrypt text key } ]

--- a/code/packages/fsharp/scytale-cipher/required_capabilities.json
+++ b/code/packages/fsharp/scytale-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/scytale-cipher",
+  "capabilities": [],
+  "justification": "Pure string transformation package and tests."
+}

--- a/code/packages/fsharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.fsproj
+++ b/code/packages/fsharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/CodingAdventures.ScytaleCipher.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ScytaleCipher.fsproj" />
+    <Compile Include="ScytaleCipherTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/ScytaleCipherTests.fs
+++ b/code/packages/fsharp/scytale-cipher/tests/CodingAdventures.ScytaleCipher.Tests/ScytaleCipherTests.fs
@@ -1,0 +1,45 @@
+namespace CodingAdventures.ScytaleCipher.Tests
+
+open System
+open Xunit
+open CodingAdventures.ScytaleCipher
+
+type ScytaleCipherTests() =
+    [<Fact>]
+    member _.``encrypt matches reference examples``() =
+        Assert.Equal("HLWLEOODL R ", ScytaleCipher.encrypt "HELLO WORLD" 3)
+        Assert.Equal("ACEBDF", ScytaleCipher.encrypt "ABCDEF" 2)
+        Assert.Equal("ADBECF", ScytaleCipher.encrypt "ABCDEF" 3)
+        Assert.Equal("ABCD", ScytaleCipher.encrypt "ABCD" 4)
+        Assert.Equal(String.Empty, ScytaleCipher.encrypt String.Empty 2)
+
+    [<Fact>]
+    member _.``decrypt strips padding and matches reference examples``() =
+        Assert.Equal("HELLO WORLD", ScytaleCipher.decrypt "HLWLEOODL R " 3)
+        Assert.Equal("ABCDEF", ScytaleCipher.decrypt "ACEBDF" 2)
+        Assert.Equal("HELLO", ScytaleCipher.decrypt (ScytaleCipher.encrypt "HELLO" 3) 3)
+        Assert.Equal(String.Empty, ScytaleCipher.decrypt String.Empty 2)
+
+    [<Fact>]
+    member _.``round trips across valid keys``() =
+        let text = "The quick brown fox jumps over the lazy dog!"
+
+        for key in 2 .. text.Length / 2 do
+            Assert.Equal(text, ScytaleCipher.decrypt (ScytaleCipher.encrypt text key) key)
+
+    [<Fact>]
+    member _.``brute force returns candidate plaintexts``() =
+        let ciphertext = ScytaleCipher.encrypt "HELLO WORLD" 3
+        let results = ScytaleCipher.bruteForce ciphertext
+
+        Assert.Contains(results, fun result -> result.Key = 3 && result.Text = "HELLO WORLD")
+        Assert.Equal<int list>([ 2; 3; 4; 5 ], ScytaleCipher.bruteForce "ABCDEFGHIJ" |> List.map _.Key)
+        Assert.Empty(ScytaleCipher.bruteForce "ABC")
+
+    [<Fact>]
+    member _.``invalid inputs throw``() =
+        Assert.Throws<ArgumentNullException>(fun () -> ScytaleCipher.encrypt null 2 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> ScytaleCipher.decrypt null 2 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> ScytaleCipher.bruteForce null |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ScytaleCipher.encrypt "HELLO" 1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ScytaleCipher.decrypt "HI" 3 |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# scytale-cipher packages with encrypt, decrypt, and brute-force key enumeration
- match Rust reference behavior for padding, key validation, and brute-force candidate ranges
- add xUnit tests and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.ScytaleCipher.Tests\\CodingAdventures.ScytaleCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\\CodingAdventures.ScytaleCipher.Tests\\CodingAdventures.ScytaleCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line