### PR TITLE
feat(java/kotlin): add Huffman tree and Huffman compression implementations

### DIFF
--- a/code/packages/java/huffman-compression/.gitignore
+++ b/code/packages/java/huffman-compression/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/huffman-compression/BUILD
+++ b/code/packages/java/huffman-compression/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-compression/BUILD_windows
+++ b/code/packages/java/huffman-compression/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-compression/CHANGELOG.md
+++ b/code/packages/java/huffman-compression/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — huffman-compression (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `HuffmanCompression.compress(byte[])` — encodes a byte array into CMP04
+  wire format using canonical Huffman coding.
+  - Builds a frequency histogram (int[256]).
+  - Delegates tree construction and canonical code derivation to
+    `com.codingadventures.huffmantree.HuffmanTree` (DT27).
+  - Sorts code-lengths by (length, symbol) for the wire-format header.
+  - Packs the encoded bit string LSB-first into bytes (same convention as
+    LZW/GIF).
+  - Handles edge cases: empty input returns 8-byte header; single distinct
+    symbol uses 1-bit codes.
+- `HuffmanCompression.decompress(byte[])` — decodes CMP04 wire-format bytes.
+  - Parses the 8-byte header and code-lengths table.
+  - Reconstructs canonical codes via the DEFLATE assignment rule:
+    `code = (code + 1) << (next_length - prev_length)`.
+  - Unpacks the LSB-first bit stream.
+  - Decodes exactly `original_length` symbols by prefix accumulation.
+  - Throws `IllegalArgumentException` if the bit stream is exhausted before
+    all symbols are decoded.
+- `packBitsLsbFirst(String)` — private helper packing a '0'/'1' string into
+  bytes with the LSB-first convention.
+- 42 unit tests covering:
+  - Round-trip fidelity (13 tests)
+  - Exact wire-format bytes including the "AAABBC" worked example (7 tests)
+  - Edge cases: empty, null, single byte, high bytes, null bytes, short
+    header, truncated stream (11 tests)
+  - Compression effectiveness: skewed, repeated, uniform distributions (3 tests)
+  - Determinism (3 tests)
+  - Error handling: bit-stream exhaustion (1 test)
+- `build.gradle.kts` with composite build dependency on `huffman-tree`.
+- `settings.gradle.kts` with `includeBuild("../huffman-tree")`.
+- `BUILD` / `BUILD_windows`, `README.md`, `.gitignore`.

--- a/code/packages/java/huffman-compression/README.md
+++ b/code/packages/java/huffman-compression/README.md
@@ -1,0 +1,82 @@
+# huffman-compression (Java) — CMP04
+
+Huffman lossless compression for Java.  Implements the CMP04 wire format:
+variable-length, prefix-free canonical Huffman codes packed LSB-first into a
+compact byte stream.
+
+## What it does
+
+`HuffmanCompression` exposes two static methods:
+
+| Method | Description |
+|--------|-------------|
+| `compress(byte[])` | Encode bytes using canonical Huffman coding; returns CMP04 wire-format bytes |
+| `decompress(byte[])` | Decode CMP04 wire-format bytes; returns the original bytes |
+
+## Where it fits
+
+```
+CMP00 (LZ77,    1977) — Sliding-window back-references
+CMP01 (LZ78,    1978) — Explicit dictionary (trie)
+CMP02 (LZSS,    1982) — LZ77 + flag bits
+CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF
+CMP04 (Huffman, 1952) — Entropy coding  ← this package
+CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard
+```
+
+Huffman coding exploits symbol *statistics* (frequent symbols get short codes,
+rare symbols get long codes), while LZ-family algorithms exploit *repetition*
+(duplicate substrings).  DEFLATE combines both.
+
+## Dependencies
+
+- `com.codingadventures:huffman-tree` — DT27 Huffman tree data structure
+  (tree construction, canonical code derivation).  Declared via Gradle
+  composite build so no Maven publishing is needed.
+
+## Wire format (CMP04)
+
+```
+Bytes 0–3:    original_length  (big-endian uint32)
+Bytes 4–7:    symbol_count     (big-endian uint32) — distinct symbols
+Bytes 8–8+2N: code-lengths table — N × 2 bytes:
+                [0] symbol value  (uint8, 0–255)
+                [1] code length   (uint8, 1–16)
+              Sorted by (code_length, symbol_value) ascending.
+Bytes 8+2N+:  bit stream — packed LSB-first, zero-padded to byte boundary.
+```
+
+Bit packing is LSB-first (same convention as LZW/GIF): the first bit of the
+stream goes into bit 0 (LSB) of the first byte.
+
+## Quick start
+
+```java
+byte[] original   = "AAABBC".getBytes();
+byte[] compressed = HuffmanCompression.compress(original);
+byte[] recovered  = HuffmanCompression.decompress(compressed);
+assert Arrays.equals(original, recovered);
+```
+
+## Example — "AAABBC"
+
+```
+Frequencies:  A=3, B=2, C=1
+Canonical codes: A→"0" (len 1), B→"10" (len 2), C→"11" (len 2)
+
+Header:        00 00 00 06  00 00 00 03
+Code table:    41 01  42 02  43 02
+Bit stream:    "000101011" → 0xA8 0x01
+Total:         16 bytes  (raw: 6 bytes — overhead wins for tiny inputs,
+               Huffman wins for larger/skewed inputs)
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+42 tests covering round-trip fidelity, exact wire-format bytes, edge cases
+(empty, single symbol, null bytes), compression effectiveness, determinism,
+and error handling.

--- a/code/packages/java/huffman-compression/build.gradle.kts
+++ b/code/packages/java/huffman-compression/build.gradle.kts
@@ -1,0 +1,31 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    // Provided via the composite build declared in settings.gradle.kts.
+    implementation("com.codingadventures:huffman-tree")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/huffman-compression/settings.gradle.kts
+++ b/code/packages/java/huffman-compression/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "huffman-compression"
+
+// Composite build: pull in the huffman-tree package as a sibling project so
+// that `com.codingadventures:huffman-tree` resolves without Maven publishing.
+includeBuild("../huffman-tree")

--- a/code/packages/java/huffman-compression/src/main/java/com/codingadventures/huffmancompression/HuffmanCompression.java
+++ b/code/packages/java/huffman-compression/src/main/java/com/codingadventures/huffmancompression/HuffmanCompression.java
@@ -1,0 +1,315 @@
+// ============================================================================
+// HuffmanCompression.java — CMP04: Huffman Lossless Compression
+// ============================================================================
+//
+// Huffman coding (1952) is an entropy coding algorithm: it assigns
+// variable-length, prefix-free binary codes to symbols based on their
+// frequency of occurrence.  Frequent symbols get short codes; rare symbols
+// get long codes.  The resulting code is provably optimal — no other
+// prefix-free code can achieve a smaller expected bit-length for the same
+// symbol distribution.
+//
+// Unlike the LZ-family algorithms (LZ77, LZ78, LZSS, LZW) which exploit
+// repetition (duplicate substrings), Huffman coding exploits symbol
+// statistics.  This makes it complementary to LZ compression.  DEFLATE
+// combines both: LZ77 to eliminate repeated substrings, then Huffman to
+// optimally encode the remaining symbol stream.
+//
+// ============================================================================
+// Dependency on DT27 (HuffmanTree)
+// ============================================================================
+//
+// This package does NOT build its own Huffman tree.  It delegates all tree
+// construction and code derivation to com.codingadventures.huffmantree.
+// This mirrors the pattern used by LZ78 which delegates trie operations to
+// the trie package.
+//
+//   CMP04 (Huffman) → uses DT27 (HuffmanTree) for code construction/decode
+//
+// ============================================================================
+// Wire Format (CMP04)
+// ============================================================================
+//
+//   Bytes 0–3:    original_length  (big-endian uint32)
+//   Bytes 4–7:    symbol_count     (big-endian uint32) — distinct symbols
+//   Bytes 8–8+2N: code-lengths table — N entries, each 2 bytes:
+//                   [0]  symbol value  (uint8, 0–255)
+//                   [1]  code length   (uint8, 1–16)
+//                 Sorted by (code_length, symbol_value) ascending.
+//   Bytes 8+2N+:  bit stream — packed LSB-first, zero-padded to byte boundary.
+//
+// Packing convention: LSB-first (same as LZW/GIF).
+//
+//   Example — packing bit string "000101011" (9 bits):
+//     Byte 0: bits[0..7] = 0b10101000 = 0xA8
+//       bit 0 ('0') → byte bit 0  (LSB)
+//       bit 1 ('0') → byte bit 1
+//       ...
+//       bit 7 ('1') → byte bit 7  (MSB)
+//     Byte 1: bit[8] ('1') → 0b00000001 = 0x01
+//
+// ============================================================================
+// The CMP series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE. (this)
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+
+package com.codingadventures.huffmancompression;
+
+import com.codingadventures.huffmantree.HuffmanTree;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CMP04: Huffman lossless compression.
+ *
+ * <p>Provides {@link #compress(byte[])} and {@link #decompress(byte[])} methods
+ * that encode/decode byte arrays using canonical Huffman codes.  The compressed
+ * bytes follow the CMP04 wire format.
+ *
+ * <pre>{@code
+ * byte[] original   = "AAABBC".getBytes();
+ * byte[] compressed = HuffmanCompression.compress(original);
+ * byte[] recovered  = HuffmanCompression.decompress(compressed);
+ * assert Arrays.equals(original, recovered);
+ * }</pre>
+ */
+public final class HuffmanCompression {
+
+    /** Utility class — no instances. */
+    private HuffmanCompression() {}
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Compress {@code data} using canonical Huffman coding.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Count byte frequencies (histogram).</li>
+     *   <li>Build a Huffman tree via {@link HuffmanTree#build}.</li>
+     *   <li>Obtain canonical codes via {@link HuffmanTree#canonicalCodeTable}.</li>
+     *   <li>Build the code-lengths table sorted by (length, symbol).</li>
+     *   <li>Encode each byte using its canonical bit string.</li>
+     *   <li>Pack the bit string LSB-first into bytes.</li>
+     *   <li>Assemble header + code-lengths table + bit stream.</li>
+     * </ol>
+     *
+     * <p>Edge cases:
+     * <ul>
+     *   <li>Empty input: returns an 8-byte header (original_length=0,
+     *       symbol_count=0) with no bit stream.</li>
+     *   <li>Single distinct byte: DT27 assigns code "0"; each occurrence
+     *       encodes to 1 bit.</li>
+     * </ul>
+     *
+     * @param data the bytes to compress
+     * @return compressed bytes in CMP04 wire format
+     */
+    public static byte[] compress(byte[] data) {
+        // Empty input — 8-byte header only.
+        if (data == null || data.length == 0) {
+            ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+            buf.putInt(0).putInt(0);
+            return buf.array();
+        }
+
+        int originalLength = data.length;
+
+        // Step 1: Count frequencies.
+        int[] freq = new int[256];
+        for (byte b : data) freq[b & 0xFF]++;
+
+        // Step 2: Build Huffman tree.
+        List<int[]> weights = new ArrayList<>();
+        for (int sym = 0; sym < 256; sym++) {
+            if (freq[sym] > 0) weights.add(new int[]{sym, freq[sym]});
+        }
+        HuffmanTree tree = HuffmanTree.build(weights);
+
+        // Step 3: Canonical code table {symbol → bit_string}.
+        Map<Integer, String> table = tree.canonicalCodeTable();
+
+        // Step 4: Code-lengths list sorted by (length, symbol) for the header.
+        List<int[]> lengths = new ArrayList<>();
+        for (Map.Entry<Integer, String> e : table.entrySet()) {
+            lengths.add(new int[]{e.getKey(), e.getValue().length()});
+        }
+        lengths.sort((a, b) -> a[1] != b[1] ? Integer.compare(a[1], b[1])
+                                             : Integer.compare(a[0], b[0]));
+
+        // Step 5: Encode each byte using its canonical code.
+        StringBuilder bits = new StringBuilder();
+        for (byte b : data) bits.append(table.get(b & 0xFF));
+
+        // Step 6: Pack bits LSB-first into bytes.
+        byte[] bitBytes = packBitsLsbFirst(bits.toString());
+
+        // Step 7: Assemble wire format.
+        //   header:             original_length (4B) + symbol_count (4B)
+        //   code-lengths table: symbol_count × 2 bytes
+        //   bit stream:         variable
+        int symbolCount = lengths.size();
+        ByteBuffer header = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+        header.putInt(originalLength).putInt(symbolCount);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            out.write(header.array());
+            for (int[] entry : lengths) {
+                out.write(entry[0]);   // symbol
+                out.write(entry[1]);   // code length
+            }
+            out.write(bitBytes);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Decompress CMP04 wire-format {@code data} and return the original bytes.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Parse the 8-byte header: original_length and symbol_count.</li>
+     *   <li>Parse the code-lengths table (symbol_count × 2 bytes).</li>
+     *   <li>Reconstruct canonical codes from the sorted (symbol, length) list.</li>
+     *   <li>Unpack the LSB-first bit stream.</li>
+     *   <li>Decode original_length symbols by accumulating bits until a hit in
+     *       the canonical code table, then reset.</li>
+     * </ol>
+     *
+     * @param data compressed bytes in CMP04 wire format
+     * @return the original, uncompressed bytes
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  all symbols are decoded
+     */
+    public static byte[] decompress(byte[] data) {
+        if (data == null || data.length < 8) return new byte[0];
+
+        ByteBuffer buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN);
+        int originalLength = buf.getInt();
+        int symbolCount    = buf.getInt();
+
+        if (originalLength == 0) return new byte[0];
+
+        // Parse code-lengths table.
+        // Each entry: 2 bytes — symbol (uint8), code_length (uint8).
+        // Wire format guarantees entries are sorted by (code_length, symbol_value).
+        List<int[]> lengths = new ArrayList<>(symbolCount);
+        for (int i = 0; i < symbolCount; i++) {
+            int sym    = buf.get() & 0xFF;
+            int length = buf.get() & 0xFF;
+            lengths.add(new int[]{sym, length});
+        }
+
+        // Reconstruct canonical codes from the sorted lengths list.
+        //
+        // The canonical reconstruction rule (same as DEFLATE):
+        //   code = 0
+        //   prev_length = first entry's length
+        //   for each entry in sorted order:
+        //     if length > prev_length: code <<= (length - prev_length)
+        //     assign bit_string = zero-padded binary of code
+        //     code += 1
+        //
+        // This produces a prefix-free code table that matches the encoder exactly.
+        Map<String, Integer> codeToSymbol = new HashMap<>();
+        int codeVal  = 0;
+        int prevLen  = lengths.isEmpty() ? 0 : lengths.get(0)[1];
+        for (int[] entry : lengths) {
+            int sym    = entry[0];
+            int length = entry[1];
+            if (length > prevLen) codeVal <<= (length - prevLen);
+            String bitStr = String.format("%" + length + "s",
+                Integer.toBinaryString(codeVal)).replace(' ', '0');
+            codeToSymbol.put(bitStr, sym);
+            codeVal++;
+            prevLen = length;
+        }
+
+        // Unpack the remaining bytes as a bit string (LSB-first).
+        StringBuilder bitString = new StringBuilder();
+        while (buf.hasRemaining()) {
+            int byteVal = buf.get() & 0xFF;
+            for (int i = 0; i < 8; i++) {
+                bitString.append((byteVal >> i) & 1);
+            }
+        }
+
+        // Decode exactly original_length symbols.
+        byte[] output = new byte[originalLength];
+        int pos = 0;
+        StringBuilder accumulated = new StringBuilder();
+        for (int decoded = 0; decoded < originalLength; ) {
+            if (pos >= bitString.length()) {
+                throw new IllegalArgumentException(
+                    "Bit stream exhausted before decoding all symbols"
+                );
+            }
+            accumulated.append(bitString.charAt(pos++));
+            String accStr = accumulated.toString();
+            if (codeToSymbol.containsKey(accStr)) {
+                output[decoded++] = (byte) (int) codeToSymbol.get(accStr);
+                accumulated.setLength(0);
+            }
+        }
+        return output;
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Pack a bit string into bytes, filling each byte from bit 0 (LSB) upward.
+     *
+     * <p>This is the same convention used by LZW and GIF: the first bit of the
+     * stream occupies the least-significant bit of the first byte.
+     *
+     * <p>The final partial byte is zero-padded in the high bits.
+     *
+     * <p>Example — packing "000101011" (9 bits):
+     * <pre>
+     * Byte 0: bits[0..7] = 0b10101000 = 0xA8
+     *   bit 0 ('0') → bit 0  (LSB)
+     *   bit 3 ('1') → bit 3
+     *   bit 5 ('1') → bit 5
+     *   bit 7 ('1') → bit 7
+     * Byte 1: bit[8] ('1') → 0b00000001 = 0x01
+     * </pre>
+     *
+     * @param bits a string of '0' and '1' characters
+     * @return the packed bytes
+     */
+    private static byte[] packBitsLsbFirst(String bits) {
+        int byteCount = (bits.length() + 7) / 8;
+        byte[] output = new byte[byteCount];
+        for (int i = 0; i < bits.length(); i++) {
+            if (bits.charAt(i) == '1') {
+                int byteIdx = i / 8;
+                int bitPos  = i % 8;
+                output[byteIdx] |= (byte) (1 << bitPos);
+            }
+        }
+        return output;
+    }
+}

--- a/code/packages/java/huffman-compression/src/test/java/com/codingadventures/huffmancompression/HuffmanCompressionTest.java
+++ b/code/packages/java/huffman-compression/src/test/java/com/codingadventures/huffmancompression/HuffmanCompressionTest.java
@@ -1,0 +1,460 @@
+// ============================================================================
+// HuffmanCompressionTest.java — CMP04: Huffman Lossless Compression Tests
+// ============================================================================
+//
+// Test organisation
+// -----------------
+//  1. Round-trip tests (compress → decompress = original)
+//  2. Wire format verification (exact byte layout per the CMP04 spec)
+//  3. Edge cases (empty, single byte, single repeated symbol, null bytes)
+//  4. Compression effectiveness (compressible data shrinks)
+//  5. Idempotency (same input → same output every time)
+//  6. Error handling (malformed / truncated input)
+//
+// Wire format recap (CMP04):
+//   Bytes 0–3:    original_length  (big-endian uint32)
+//   Bytes 4–7:    symbol_count     (big-endian uint32)
+//   Bytes 8–8+2N: code-lengths table — N × 2 bytes:
+//                   [0] symbol value (uint8)
+//                   [1] code length  (uint8)
+//                 Sorted by (code_length, symbol_value) ascending.
+//   Bytes 8+2N+:  bit stream, LSB-first, zero-padded to byte boundary.
+//
+// ============================================================================
+
+package com.codingadventures.huffmancompression;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link HuffmanCompression}.
+ */
+class HuffmanCompressionTest {
+
+    // =========================================================================
+    // 1. Round-trip tests
+    // =========================================================================
+
+    /** compress(data) → decompress → original for a variety of inputs. */
+
+    @Test
+    void roundTrip_simpleAAABBC() {
+        byte[] data = "AAABBC".getBytes();
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_helloWorld() {
+        byte[] data = "hello world".getBytes();
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_all256ByteValues() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_all256BytesRepeated() {
+        byte[] base = new byte[256];
+        for (int i = 0; i < 256; i++) base[i] = (byte) i;
+        byte[] data = repeatBytes(base, 10);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_singleByte() {
+        byte[] data = new byte[]{(byte) 'X'};
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_twoBytes() {
+        byte[] data = new byte[]{(byte) 'A', (byte) 'B'};
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_loremIpsum() {
+        byte[] data = (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+            "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+        ).getBytes();
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_binaryData() {
+        byte[] data = new byte[]{0, 1, 2, 3, (byte)255, (byte)254, (byte)253, (byte)128, 64, 32};
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_repeatedPattern() {
+        byte[] pattern = "ABCABC".getBytes();
+        byte[] data = repeatBytes(pattern, 100);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_singleRepeatedByte() {
+        byte[] data = new byte[100];
+        Arrays.fill(data, (byte) 'A');
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_twoSymbolInput() {
+        byte[] data = repeatBytes(new byte[]{'A', 'B'}, 50);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_newlineHeavyText() {
+        byte[] data = repeatBytes("line\n".getBytes(), 200);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void roundTrip_longInput() {
+        byte[] data = repeatBytes("the quick brown fox jumps over the lazy dog ".getBytes(), 500);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    // =========================================================================
+    // 2. Wire format verification
+    // =========================================================================
+
+    /** Verify the exact byte layout of the CMP04 wire format. */
+
+    @Test
+    void wireFormat_emptyInput() {
+        // compress(b'') must produce exactly an 8-byte header.
+        byte[] result = HuffmanCompression.compress(new byte[0]);
+        assertEquals(8, result.length);
+        ByteBuffer buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(0, buf.getInt(), "original_length must be 0");
+        assertEquals(0, buf.getInt(), "symbol_count must be 0");
+    }
+
+    @Test
+    void wireFormat_nullInput() {
+        // compress(null) must behave same as empty.
+        byte[] result = HuffmanCompression.compress(null);
+        assertEquals(8, result.length);
+        ByteBuffer buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(0, buf.getInt(), "original_length must be 0");
+        assertEquals(0, buf.getInt(), "symbol_count must be 0");
+    }
+
+    /**
+     * Verify the exact wire-format bytes for b"AAABBC".
+     *
+     * <pre>
+     * Frequencies: A=3, B=2, C=1
+     * Canonical table: A→"0" (len=1), B→"10" (len=2), C→"11" (len=2)
+     * Lengths sorted by (length, symbol): [(65,1), (66,2), (67,2)]
+     *
+     * Header:
+     *   00 00 00 06   original_length = 6
+     *   00 00 00 03   symbol_count = 3
+     * Code-lengths table:
+     *   41 01         symbol='A'(65), length=1
+     *   42 02         symbol='B'(66), length=2
+     *   43 02         symbol='C'(67), length=2
+     * Bit stream:
+     *   A→"0", A→"0", A→"0", B→"10", B→"10", C→"11"
+     *   Concatenated: "000101011" (9 bits)
+     *   Packed LSB-first:
+     *     Byte 0: bits 0..7 → 0b10101000 = 0xA8
+     *     Byte 1: bit  8    → 0b00000001 = 0x01
+     * Total: 4+4+6+2 = 16 bytes
+     * </pre>
+     */
+    @Test
+    void wireFormat_aaabbc_exactBytes() {
+        byte[] result = HuffmanCompression.compress("AAABBC".getBytes());
+
+        // Header
+        ByteBuffer buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(6, buf.getInt(), "original_length");
+        assertEquals(3, buf.getInt(), "symbol_count");
+
+        // Code-lengths table
+        assertEquals(65, result[8]  & 0xFF, "symbol 'A'");
+        assertEquals(1,  result[9]  & 0xFF, "length 1");
+        assertEquals(66, result[10] & 0xFF, "symbol 'B'");
+        assertEquals(2,  result[11] & 0xFF, "length 2");
+        assertEquals(67, result[12] & 0xFF, "symbol 'C'");
+        assertEquals(2,  result[13] & 0xFF, "length 2");
+
+        // Bit stream
+        assertEquals(0xA8, result[14] & 0xFF, "bit-stream byte 0");
+        assertEquals(0x01, result[15] & 0xFF, "bit-stream byte 1");
+
+        assertEquals(16, result.length, "total compressed length");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 100, 1000})
+    void wireFormat_originalLengthField(int length) {
+        byte[] data = new byte[length];
+        Arrays.fill(data, (byte) 'A');
+        byte[] compressed = HuffmanCompression.compress(data);
+        ByteBuffer buf = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(length, buf.getInt(), "original_length field");
+    }
+
+    @Test
+    void wireFormat_symbolCountField() {
+        // 1 distinct byte
+        assertEquals(1, symbolCountOf(HuffmanCompression.compress("A".getBytes())));
+        // 2 distinct bytes
+        assertEquals(2, symbolCountOf(HuffmanCompression.compress("AB".getBytes())));
+        // 3 distinct bytes
+        assertEquals(3, symbolCountOf(HuffmanCompression.compress("ABC".getBytes())));
+        // All 256 distinct bytes
+        byte[] all256 = new byte[256];
+        for (int i = 0; i < 256; i++) all256[i] = (byte) i;
+        assertEquals(256, symbolCountOf(HuffmanCompression.compress(all256)));
+    }
+
+    @Test
+    void wireFormat_codeLengthsTableSorted() {
+        // Wire format entries must be sorted by (code_length, symbol).
+        byte[] result = HuffmanCompression.compress("AAABBC".getBytes());
+        int symbolCount = symbolCountOf(result);
+        int prev_len = 0, prev_sym = -1;
+        for (int i = 0; i < symbolCount; i++) {
+            int sym = result[8 + 2 * i] & 0xFF;
+            int len = result[8 + 2 * i + 1] & 0xFF;
+            assertTrue(len > prev_len || (len == prev_len && sym > prev_sym),
+                "Code-lengths table not sorted at entry " + i);
+            prev_len = len;
+            prev_sym = sym;
+        }
+    }
+
+    @Test
+    void wireFormat_bitStreamStartsAfterTable() {
+        // Bit stream must begin at offset 8 + 2*symbol_count.
+        byte[] result = HuffmanCompression.compress("AAABBC".getBytes());
+        int symbolCount = symbolCountOf(result);
+        int bitsOffset = 8 + 2 * symbolCount;
+        assertTrue(result.length > bitsOffset, "Bit stream has no content");
+    }
+
+    @Test
+    void wireFormat_singleByteInput() {
+        // Single byte input: symbol='A'(65), length=1, bit stream = [0x00].
+        byte[] result = HuffmanCompression.compress("A".getBytes());
+        ByteBuffer buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(1, buf.getInt(), "original_length");
+        assertEquals(1, buf.getInt(), "symbol_count");
+        // Code-lengths table: (65, 1)
+        assertEquals(65, result[8] & 0xFF, "symbol 'A'");
+        assertEquals(1,  result[9] & 0xFF, "code length 1");
+        // Bit stream: "0" packed → 0x00
+        assertEquals(0x00, result[10] & 0xFF, "bit-stream byte");
+        assertEquals(11, result.length, "total length");
+    }
+
+    // =========================================================================
+    // 3. Edge cases
+    // =========================================================================
+
+    @Test
+    void edgeCase_emptyCompress() {
+        byte[] expected = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN)
+            .putInt(0).putInt(0).array();
+        assertArrayEquals(expected, HuffmanCompression.compress(new byte[0]));
+    }
+
+    @Test
+    void edgeCase_emptyDecompress() {
+        assertArrayEquals(new byte[0],
+            HuffmanCompression.decompress(HuffmanCompression.compress(new byte[0])));
+    }
+
+    @Test
+    void edgeCase_decompressEmptyBytes() {
+        // Decompressing raw b'' should return b'' gracefully.
+        assertArrayEquals(new byte[0], HuffmanCompression.decompress(new byte[0]));
+    }
+
+    @Test
+    void edgeCase_decompressShortHeader() {
+        // Headers shorter than 8 bytes return b''.
+        assertArrayEquals(new byte[0],
+            HuffmanCompression.decompress(new byte[]{0, 0, 0, 0}));
+    }
+
+    @Test
+    void edgeCase_decompressNullReturnsEmpty() {
+        assertArrayEquals(new byte[0], HuffmanCompression.decompress(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65, 127, 255})
+    void edgeCase_singleSymbolRoundTrip(int sym) {
+        byte[] data = new byte[50];
+        Arrays.fill(data, (byte) sym);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void edgeCase_singleSymbolEncodesToOneBit() {
+        // With one distinct symbol, each occurrence uses exactly 1 bit.
+        byte[] data = new byte[8];
+        Arrays.fill(data, (byte) 'A');
+        byte[] result = HuffmanCompression.compress(data);
+        int symbolCount = symbolCountOf(result);
+        assertEquals(1, symbolCount, "symbol_count");
+        // 8 bits → 1 byte bit stream
+        int bitsOffset = 8 + 2 * symbolCount;
+        assertEquals(bitsOffset + 1, result.length, "bit-stream should be exactly 1 byte");
+    }
+
+    @Test
+    void edgeCase_nullBytes() {
+        byte[] data = new byte[100]; // all zeros
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void edgeCase_twoSymbolsEqualFrequency() {
+        byte[] data = repeatBytes(new byte[]{'A', 'B'}, 100);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void edgeCase_allByteValuesSingleOccurrence() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    @Test
+    void edgeCase_highByteValues() {
+        // Bytes 128–255 (signed in Java) must round-trip correctly.
+        byte[] data = new byte[128];
+        for (int i = 0; i < 128; i++) data[i] = (byte) (128 + i);
+        assertArrayEquals(data, HuffmanCompression.decompress(HuffmanCompression.compress(data)));
+    }
+
+    // =========================================================================
+    // 4. Compression effectiveness
+    // =========================================================================
+
+    @Test
+    void effectiveness_compressibleInputShrinks() {
+        // 'A' × 900 + 'B' × 100 should compress to fewer bytes than the original.
+        byte[] data = new byte[1000];
+        Arrays.fill(data, 0, 900, (byte) 'A');
+        Arrays.fill(data, 900, 1000, (byte) 'B');
+        byte[] compressed = HuffmanCompression.compress(data);
+        assertTrue(compressed.length < data.length,
+            "Highly skewed distribution should compress below raw size");
+    }
+
+    @Test
+    void effectiveness_repeatedByte_compressesWell() {
+        byte[] data = new byte[1000];
+        Arrays.fill(data, (byte) 'X');
+        byte[] compressed = HuffmanCompression.compress(data);
+        // 1000 bits = 125 bytes of bit stream + ~11 bytes overhead ≪ 1000 raw bytes.
+        assertTrue(compressed.length < data.length,
+            "Repeated byte should compress well below raw size");
+    }
+
+    @Test
+    void effectiveness_uniformDistributionLargerThanOriginal() {
+        // All 256 symbols once — overhead dominates small inputs.
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        byte[] compressed = HuffmanCompression.compress(data);
+        assertTrue(compressed.length > data.length,
+            "Uniform 256-symbol input should be larger when compressed");
+    }
+
+    // =========================================================================
+    // 5. Idempotency / determinism
+    // =========================================================================
+
+    @Test
+    void idempotent_deterministicCompression() {
+        byte[] data = "the quick brown fox jumps over the lazy dog".getBytes();
+        assertArrayEquals(
+            HuffmanCompression.compress(data),
+            HuffmanCompression.compress(data),
+            "compress must be deterministic"
+        );
+    }
+
+    @Test
+    void idempotent_deterministicDecompression() {
+        byte[] data = "hello world".getBytes();
+        byte[] compressed = HuffmanCompression.compress(data);
+        assertArrayEquals(
+            HuffmanCompression.decompress(compressed),
+            HuffmanCompression.decompress(compressed),
+            "decompress must be deterministic"
+        );
+    }
+
+    @Test
+    void idempotent_compressTwiceSameResult() {
+        byte[] data = repeatBytes("ABCABCABC".getBytes(), 10);
+        assertArrayEquals(
+            HuffmanCompression.compress(data),
+            HuffmanCompression.compress(data)
+        );
+    }
+
+    // =========================================================================
+    // 6. Error handling
+    // =========================================================================
+
+    @Test
+    void error_bitStreamExhausted_throwsIllegalArgument() {
+        // Craft a header claiming originalLength=100 but supply only 1 symbol + 1 bit byte.
+        // Decompress must throw rather than silently corrupt.
+        ByteBuffer buf = ByteBuffer.allocate(11).order(ByteOrder.BIG_ENDIAN);
+        buf.putInt(100);  // original_length = 100
+        buf.putInt(1);    // symbol_count = 1
+        buf.put((byte) 65);  // symbol = 'A'
+        buf.put((byte) 1);   // code_length = 1
+        buf.put((byte) 0);   // 1 byte of bit stream (8 bits → 8 symbols, need 100)
+        byte[] truncated = buf.array();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> HuffmanCompression.decompress(truncated),
+            "Should throw when bit stream is exhausted before all symbols decoded");
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /** Extract the symbol_count field (bytes 4–7, big-endian) from a CMP04 blob. */
+    private static int symbolCountOf(byte[] compressed) {
+        return ByteBuffer.wrap(compressed, 4, 4).order(ByteOrder.BIG_ENDIAN).getInt();
+    }
+
+    /** Repeat {@code src} {@code times} times into a new array. */
+    private static byte[] repeatBytes(byte[] src, int times) {
+        byte[] out = new byte[src.length * times];
+        for (int i = 0; i < times; i++) System.arraycopy(src, 0, out, i * src.length, src.length);
+        return out;
+    }
+}

--- a/code/packages/java/huffman-tree/.gitignore
+++ b/code/packages/java/huffman-tree/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/huffman-tree/BUILD
+++ b/code/packages/java/huffman-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-tree/BUILD_windows
+++ b/code/packages/java/huffman-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/huffman-tree/CHANGELOG.md
+++ b/code/packages/java/huffman-tree/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — java/huffman-tree
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+
+- `HuffmanTree` — optimal prefix-free code tree backed by `java.util.PriorityQueue`
+- `HuffmanTree.build(List<int[]> weights)` — greedy min-heap construction from
+  `[symbol, frequency]` pairs; throws `IllegalArgumentException` for empty list or
+  non-positive frequency
+- `codeTable()` — O(n) walk returning `{symbol → bit_string}` map
+- `codeFor(int symbol)` — O(n) single-symbol lookup; returns null if absent
+- `canonicalCodeTable()` — O(n log n) DEFLATE-style canonical codes from lengths
+- `decodeAll(String bits, int count)` — O(bits) tree-walk decoder; throws when
+  stream exhausted before `count` symbols
+- `weight()` — O(1) total weight (root weight = sum of all frequencies)
+- `depth()` — O(n) maximum code length (depth of deepest leaf)
+- `symbolCount()` — O(1) number of distinct symbols
+- `leavesWithCodes()` — O(n) in-order list of `[symbol, code]` pairs
+- `isValid()` — structural validator: full binary tree, correct weights, unique symbols
+- Deterministic tie-breaking: weight → leaf-before-internal → symbol value → insertion order
+- 36 unit tests covering construction, code tables, canonical codes, round-trips,
+  inspection methods, tie-breaking determinism, and isValid

--- a/code/packages/java/huffman-tree/README.md
+++ b/code/packages/java/huffman-tree/README.md
@@ -1,0 +1,88 @@
+# java/huffman-tree
+
+A **Huffman tree** in Java — the theoretically optimal prefix-free code for any
+symbol frequency distribution.  O(n log n) construction, O(n) encoding/decoding.
+
+## What is a Huffman Tree?
+
+A Huffman tree assigns variable-length bit codes to symbols so that frequent
+symbols get short codes and rare symbols get long codes.  The resulting codes are
+**prefix-free**: no code is a prefix of another, so the bit stream can be decoded
+unambiguously without separator characters.
+
+Think of Morse code: 'E' is `.` (one dot) and 'Z' is `--..` (four symbols).
+Huffman's algorithm builds this mapping automatically and optimally for any
+given frequency distribution.
+
+## Usage
+
+```java
+import com.codingadventures.huffmantree.HuffmanTree;
+
+// Build from (symbol, frequency) pairs
+HuffmanTree tree = HuffmanTree.build(List.of(
+    new int[]{65, 3},  // 'A' → frequency 3
+    new int[]{66, 2},  // 'B' → frequency 2
+    new int[]{67, 1}   // 'C' → frequency 1
+));
+
+// Encode
+Map<Integer, String> table = tree.codeTable();
+// table.get(65) → "0"   (A gets the shortest code)
+// table.get(66) → "10"
+// table.get(67) → "11"
+
+String bits = table.get(65) + table.get(66) + table.get(67); // "01011"
+
+// Decode
+List<Integer> decoded = tree.decodeAll(bits, 3);  // → [65, 66, 67]
+
+// Canonical codes (DEFLATE-style)
+Map<Integer, String> canonical = tree.canonicalCodeTable();
+// canonical.get(65) → "0"
+// canonical.get(66) → "10"
+// canonical.get(67) → "11"
+
+// Inspection
+tree.weight();       // 6    (sum of all frequencies)
+tree.depth();        // 2    (max code length)
+tree.symbolCount();  // 3
+tree.isValid();      // true
+```
+
+## API
+
+| Method | Description |
+|---|---|
+| `HuffmanTree.build(List<int[]> weights)` | Build from `[symbol, freq]` pairs |
+| `Map<Integer,String> codeTable()` | O(n) — all codes as bit strings |
+| `String codeFor(int symbol)` | O(n) — single symbol lookup (null if absent) |
+| `Map<Integer,String> canonicalCodeTable()` | O(n log n) — DEFLATE-style canonical codes |
+| `List<Integer> decodeAll(String bits, int count)` | Decode exactly count symbols |
+| `int weight()` | O(1) — sum of all frequencies |
+| `int depth()` | O(n) — maximum code length |
+| `int symbolCount()` | O(1) — number of distinct symbols |
+| `List<Object[]> leavesWithCodes()` | O(n) — in-order `[symbol, code]` pairs |
+| `boolean isValid()` | Structural validator |
+
+## Algorithm
+
+1. Push all symbols as leaf nodes into a min-heap, keyed by (weight, isInternal, symbol, order)
+2. While heap has > 1 node: pop two lightest, merge into an internal node, push back
+3. The last node is the root
+
+Tie-breaking for determinism:
+- Leaf nodes beat internal nodes at equal weight
+- Lower symbol value wins among leaves of equal weight
+- Earlier-created internal node wins among internals of equal weight (FIFO)
+
+## Running tests
+
+```
+gradle test
+```
+
+36 tests covering: construction, code table, codeFor, canonical codes,
+encode/decode round-trips (including all 256 bytes), exhaustion error,
+inspection methods (weight, depth, symbolCount, leavesWithCodes),
+tie-breaking determinism, and isValid.

--- a/code/packages/java/huffman-tree/build.gradle.kts
+++ b/code/packages/java/huffman-tree/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/huffman-tree/settings.gradle.kts
+++ b/code/packages/java/huffman-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "huffman-tree"

--- a/code/packages/java/huffman-tree/src/main/java/com/codingadventures/huffmantree/HuffmanTree.java
+++ b/code/packages/java/huffman-tree/src/main/java/com/codingadventures/huffmantree/HuffmanTree.java
@@ -1,0 +1,651 @@
+// ============================================================================
+// HuffmanTree.java — Optimal Prefix-Free Code Tree
+// ============================================================================
+//
+// A Huffman tree is a full binary tree (every internal node has exactly two
+// children) built from a symbol alphabet so that each symbol gets a unique
+// variable-length bit code.  Symbols that appear often get short codes;
+// symbols that appear rarely get long codes.  The total bits needed to
+// encode a message is minimised — it is the theoretically optimal prefix-free
+// code for a given symbol frequency distribution.
+//
+// Think of it like Morse code.  In Morse, 'E' is '.' (one dot) and 'Z' is
+// '--..' (four symbols).  The designers knew 'E' is the most common letter
+// in English so they gave it the shortest code.  Huffman's algorithm does
+// this automatically and optimally for any alphabet with any frequency
+// distribution.
+//
+// ============================================================================
+// Algorithm: Greedy construction via min-heap
+// ============================================================================
+//
+// 1. Create one leaf node per distinct symbol, each with its frequency as
+//    its weight.  Push all leaves onto a min-heap keyed by weight.
+//
+// 2. While the heap has more than one node:
+//      a. Pop the two nodes with the smallest weight.
+//      b. Create a new internal node whose weight = sum of the two children.
+//      c. Set left = the first popped node, right = the second popped node.
+//      d. Push the new internal node back onto the heap.
+//
+// 3. The one remaining node is the root of the Huffman tree.
+//
+// ============================================================================
+// Tie-breaking for determinism
+// ============================================================================
+//
+// Without tie-breaking, different implementations build structurally different
+// trees from the same input — producing different (but equally valid) codes.
+// We enforce these rules (lower key = higher priority):
+//
+//   Priority tuple: (weight, isInternal, symbolOrNeg1, insertionOrder)
+//
+//   1. Lowest weight pops first.
+//   2. Leaf nodes (isInternal=0) beat internal nodes (isInternal=1) at equal
+//      weight.
+//   3. Among leaves of equal weight, lower symbol value wins (symbolOrNeg1).
+//   4. Among internal nodes of equal weight, earlier-created node wins
+//      (insertion order, FIFO).
+//
+// ============================================================================
+// Prefix-free property: why it works
+// ============================================================================
+//
+//   In a Huffman tree:
+//     - Symbols live ONLY at the leaves, never at internal nodes.
+//     - The code for a symbol is the path from root to its leaf
+//       (left edge = '0', right edge = '1').
+//
+//   Since one leaf is never an ancestor of another, no code can be a prefix
+//   of another code.  This means the bit stream can be decoded unambiguously
+//   without separator characters: just walk the tree bit by bit until you
+//   reach a leaf.
+//
+// ============================================================================
+// Canonical codes (DEFLATE / zlib style)
+// ============================================================================
+//
+//   The standard tree-walk produces valid codes, but different tree shapes
+//   can produce different codes for the same symbol lengths.  Canonical codes
+//   normalise this: given only the code *lengths*, you can reconstruct the
+//   exact canonical code table without transmitting the tree structure.
+//
+//   Algorithm:
+//     1. Collect (symbol, code_length) pairs from the tree.
+//     2. Sort by (code_length, symbol_value).
+//     3. Assign codes numerically:
+//          code[0] = 0  (left-padded to length[0] bits)
+//          code[i] = (code[i-1] + 1) << (length[i] - length[i-1])
+//
+//   This is exactly what DEFLATE uses: the compressed stream contains only
+//   the length table, not the tree, saving space.
+//
+//   Example with AAABBC (A=3, B=2, C=1):
+//     Tree:      [6]
+//                / \
+//               A  [3]
+//              (3)  / \
+//                  B   C
+//                 (2) (1)
+//     Lengths: A=1, B=2, C=2
+//     Sorted by (length, symbol): A(1), B(2), C(2)
+//     Canonical codes:
+//       A → 0       (length 1, code = 0)
+//       B → 10      (length 2, code = 0+1=1, shifted 1 bit → 10)
+//       C → 11      (length 2, code = 10+1 = 11)
+//
+// ============================================================================
+
+package com.codingadventures.huffmantree;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * A Huffman tree that assigns optimal prefix-free bit codes to integer symbols.
+ *
+ * <p>Build the tree once from symbol frequencies; then:
+ * <ul>
+ *   <li>Use {@link #codeTable()} to get a {@code {symbol → bit_string}} map for encoding.</li>
+ *   <li>Use {@link #decodeAll(String, int)} to decode a bit stream back to symbols.</li>
+ *   <li>Use {@link #canonicalCodeTable()} for DEFLATE-style transmissible codes.</li>
+ * </ul>
+ *
+ * <p>All symbols are non-negative integers (typically 0–255 for byte-level
+ * coding, but any non-negative integer is valid).  Frequencies must be positive.
+ *
+ * <p>The tree is immutable after construction.
+ *
+ * <pre>{@code
+ * HuffmanTree tree = HuffmanTree.build(List.of(
+ *     new int[]{65, 3},  // 'A' → frequency 3
+ *     new int[]{66, 2},  // 'B' → frequency 2
+ *     new int[]{67, 1}   // 'C' → frequency 1
+ * ));
+ *
+ * Map<Integer, String> table = tree.codeTable();
+ * // table.get(65) → "0"   (A gets the shortest code)
+ * // table.get(66) → "10"
+ * // table.get(67) → "11"
+ *
+ * List<Integer> decoded = tree.decodeAll("010011", 4);
+ * // → [65, 65, 66, 67]  == [A, A, B, C]
+ * }</pre>
+ */
+public final class HuffmanTree {
+
+    // =========================================================================
+    // Node types
+    // =========================================================================
+
+    /**
+     * A leaf node representing a single symbol.
+     *
+     * <p>Leaves are always at the bottom of the tree; they carry the actual
+     * encoded symbol.  Their code is the path from the root to this node.
+     */
+    static final class Leaf extends Node {
+        final int symbol;
+
+        Leaf(int symbol, int weight) {
+            super(weight);
+            this.symbol = symbol;
+        }
+    }
+
+    /**
+     * An internal node combining two sub-trees.
+     *
+     * <p>Internal nodes have no symbol — they are bookkeeping nodes that
+     * encode branching structure.  Their weight is the sum of their children's
+     * weights.
+     */
+    static final class Internal extends Node {
+        final Node  left;
+        final Node  right;
+        final int   order;   // Insertion order for tie-breaking (FIFO for internals)
+
+        Internal(int weight, Node left, Node right, int order) {
+            super(weight);
+            this.left  = left;
+            this.right = right;
+            this.order = order;
+        }
+    }
+
+    /**
+     * Common base for Leaf and Internal.
+     *
+     * <p>Holds only the weight so both node types share the same field.
+     */
+    static abstract class Node {
+        final int weight;
+
+        Node(int weight) {
+            this.weight = weight;
+        }
+    }
+
+    // =========================================================================
+    // Priority comparator
+    // =========================================================================
+
+    /**
+     * Comparator for the min-heap during tree construction.
+     *
+     * <p>Four-level ordering (lower = higher priority):
+     * <ol>
+     *   <li>Weight (lighter wins)</li>
+     *   <li>Node type (leaf=0 before internal=1)</li>
+     *   <li>Symbol value for leaves (lower symbol wins)</li>
+     *   <li>Insertion order for internals (earlier wins = FIFO)</li>
+     * </ol>
+     */
+    private static final Comparator<Node> PRIORITY = (a, b) -> {
+        // Field 0: weight
+        int cmp = Integer.compare(a.weight, b.weight);
+        if (cmp != 0) return cmp;
+
+        // Field 1: leaf (0) before internal (1)
+        int typeA = (a instanceof Leaf) ? 0 : 1;
+        int typeB = (b instanceof Leaf) ? 0 : 1;
+        cmp = Integer.compare(typeA, typeB);
+        if (cmp != 0) return cmp;
+
+        // Field 2 / 3: among same type
+        if (a instanceof Leaf la && b instanceof Leaf lb) {
+            // Lower symbol wins
+            return Integer.compare(la.symbol, lb.symbol);
+        } else {
+            // Both internal: earlier-created wins (FIFO)
+            return Integer.compare(((Internal) a).order, ((Internal) b).order);
+        }
+    };
+
+    // =========================================================================
+    // Fields
+    // =========================================================================
+
+    private final Node root;
+    private final int  symbolCount;
+
+    // =========================================================================
+    // Constructor (private — use build())
+    // =========================================================================
+
+    private HuffmanTree(Node root, int symbolCount) {
+        this.root        = root;
+        this.symbolCount = symbolCount;
+    }
+
+    // =========================================================================
+    // Public factory
+    // =========================================================================
+
+    /**
+     * Construct a Huffman tree from {@code (symbol, frequency)} pairs.
+     *
+     * <p>The greedy algorithm uses a min-heap.  At each step it pops the two
+     * lowest-weight nodes, combines them into a new internal node, and pushes
+     * the result back.  The single remaining node is the root.
+     *
+     * <p>Tie-breaking (for deterministic output across implementations):
+     * <ol>
+     *   <li>Lowest weight pops first.</li>
+     *   <li>Leaves before internal nodes at equal weight.</li>
+     *   <li>Lower symbol value wins among leaves of equal weight.</li>
+     *   <li>Earlier-created internal node wins among internals of equal weight
+     *       (FIFO insertion order).</li>
+     * </ol>
+     *
+     * @param weights a list of {@code int[2]} arrays: {@code [symbol, frequency]}.
+     *                Each symbol must be a non-negative integer; each frequency
+     *                must be &gt; 0.
+     * @return a {@code HuffmanTree} ready for encoding/decoding
+     * @throws IllegalArgumentException if {@code weights} is empty, or if any
+     *                                  frequency is ≤ 0
+     */
+    public static HuffmanTree build(List<int[]> weights) {
+        if (weights == null || weights.isEmpty()) {
+            throw new IllegalArgumentException("weights must not be empty");
+        }
+        for (int[] pair : weights) {
+            if (pair[1] <= 0) {
+                throw new IllegalArgumentException(
+                    "frequency must be positive; got symbol=" + pair[0] + ", freq=" + pair[1]
+                );
+            }
+        }
+
+        PriorityQueue<Node> heap = new PriorityQueue<>(weights.size(), PRIORITY);
+        for (int[] pair : weights) {
+            heap.add(new Leaf(pair[0], pair[1]));
+        }
+
+        int orderCounter = 0;
+        while (heap.size() > 1) {
+            Node left  = heap.poll();
+            Node right = heap.poll();
+            heap.add(new Internal(left.weight + right.weight, left, right, orderCounter++));
+        }
+
+        return new HuffmanTree(heap.poll(), weights.size());
+    }
+
+    // =========================================================================
+    // Encoding helpers
+    // =========================================================================
+
+    /**
+     * Return a {@code {symbol → bit_string}} map for all symbols in the tree.
+     *
+     * <p>Left edges are {@code '0'}, right edges are {@code '1'}.  For a
+     * single-symbol tree the convention is {@code {symbol → "0"}} (one bit
+     * per occurrence).
+     *
+     * <p>Time: O(n) where n = number of distinct symbols.
+     *
+     * <pre>{@code
+     * HuffmanTree tree = HuffmanTree.build(List.of(
+     *     new int[]{65, 3}, new int[]{66, 2}, new int[]{67, 1}
+     * ));
+     * tree.codeTable().get(65); // "0"
+     * tree.codeTable().get(66); // "10"
+     * tree.codeTable().get(67); // "11"
+     * }</pre>
+     *
+     * @return map from symbol to its bit string
+     */
+    public Map<Integer, String> codeTable() {
+        Map<Integer, String> table = new HashMap<>();
+        walkTree(root, "", table);
+        return table;
+    }
+
+    /**
+     * Return the bit string for a specific symbol, or {@code null} if not in
+     * the tree.
+     *
+     * <p>Walks the tree searching for the leaf with the given symbol.  Does NOT
+     * build the full code table.
+     *
+     * <p>Time: O(n) worst case (full tree traversal).
+     *
+     * @param symbol the symbol to look up
+     * @return the bit string, or {@code null} if absent
+     */
+    public String codeFor(int symbol) {
+        return findCode(root, symbol, "");
+    }
+
+    /**
+     * Return canonical Huffman codes (DEFLATE-style).
+     *
+     * <p>Sorted by {@code (code_length, symbol_value)}; codes assigned
+     * numerically.  Canonical codes allow transmitting only code lengths, not
+     * the tree structure, which saves space.
+     *
+     * <p>Time: O(n log n).
+     *
+     * <pre>{@code
+     * tree.canonicalCodeTable().get(65); // "0"
+     * tree.canonicalCodeTable().get(66); // "10"
+     * tree.canonicalCodeTable().get(67); // "11"
+     * }</pre>
+     *
+     * @return map from symbol to its canonical bit string
+     */
+    public Map<Integer, String> canonicalCodeTable() {
+        // Step 1: collect code lengths from tree
+        Map<Integer, Integer> lengths = new HashMap<>();
+        collectLengths(root, 0, lengths);
+
+        // Single-leaf edge case: assign length 1 by convention
+        if (lengths.size() == 1) {
+            int sym = lengths.keySet().iterator().next();
+            Map<Integer, String> result = new HashMap<>();
+            result.put(sym, "0");
+            return result;
+        }
+
+        // Step 2: sort by (length, symbol)
+        List<Map.Entry<Integer, Integer>> sorted = new ArrayList<>(lengths.entrySet());
+        sorted.sort((a, b) -> {
+            int cmp = Integer.compare(a.getValue(), b.getValue());
+            return cmp != 0 ? cmp : Integer.compare(a.getKey(), b.getKey());
+        });
+
+        // Step 3: assign canonical codes numerically
+        Map<Integer, String> result = new LinkedHashMap<>();
+        int codeVal  = 0;
+        int prevLen  = sorted.get(0).getValue();
+
+        for (Map.Entry<Integer, Integer> entry : sorted) {
+            int sym    = entry.getKey();
+            int length = entry.getValue();
+            if (length > prevLen) {
+                codeVal <<= (length - prevLen);
+            }
+            // Format as binary string, left-padded with zeros to 'length' bits
+            result.put(sym, String.format("%" + length + "s",
+                Integer.toBinaryString(codeVal)).replace(' ', '0'));
+            codeVal++;
+            prevLen = length;
+        }
+        return result;
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode exactly {@code count} symbols from a bit string by walking the tree.
+     *
+     * <p>For each symbol: follow the tree from the root, taking the left child
+     * on '0' and the right child on '1', until a leaf is reached.  The leaf's
+     * symbol is appended to the output; the walk restarts at the root.
+     *
+     * <p>For a single-leaf tree, each '0' bit decodes to that symbol.
+     *
+     * <p>Time: O(total bits consumed).
+     *
+     * <pre>{@code
+     * tree.decodeAll("010011", 4); // → [65, 65, 66, 67]
+     * }</pre>
+     *
+     * @param bits  a string of '0' and '1' characters
+     * @param count the exact number of symbols to decode
+     * @return a list of decoded symbols of length {@code count}
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  {@code count} symbols are decoded
+     */
+    public List<Integer> decodeAll(String bits, int count) {
+        List<Integer> result  = new ArrayList<>(count);
+        Node          current = root;
+        int           i       = 0;
+        boolean       singleLeaf = (root instanceof Leaf);
+
+        while (result.size() < count) {
+            if (current instanceof Leaf leaf) {
+                result.add(leaf.symbol);
+                current = root;
+                if (singleLeaf) {
+                    // Consume the '0' bit for this symbol
+                    if (i < bits.length()) i++;
+                }
+                continue;
+            }
+
+            if (i >= bits.length()) {
+                throw new IllegalArgumentException(
+                    "Bit stream exhausted after " + result.size() +
+                    " symbols; expected " + count
+                );
+            }
+
+            char bit = bits.charAt(i++);
+            Internal internal = (Internal) current;
+            current = (bit == '0') ? internal.left : internal.right;
+        }
+
+        return result;
+    }
+
+    // =========================================================================
+    // Inspection
+    // =========================================================================
+
+    /**
+     * Total weight of the tree = sum of all leaf frequencies = root weight.
+     *
+     * <p>O(1) — stored at the root.
+     *
+     * @return sum of all symbol frequencies
+     */
+    public int weight() {
+        return root.weight;
+    }
+
+    /**
+     * Maximum code length = depth of the deepest leaf.
+     *
+     * <p>O(n) — must traverse the tree.
+     *
+     * @return depth of the deepest leaf (0 for a single-symbol tree)
+     */
+    public int depth() {
+        return maxDepth(root, 0);
+    }
+
+    /**
+     * Number of distinct symbols = number of leaf nodes.
+     *
+     * <p>O(1) — stored at construction time.
+     *
+     * @return number of distinct symbols
+     */
+    public int symbolCount() {
+        return symbolCount;
+    }
+
+    /**
+     * In-order traversal of leaves.
+     *
+     * <p>Returns {@code (symbol, code)} pairs, left subtree before right
+     * subtree.  Useful for visualisation and debugging.
+     *
+     * <p>Time: O(n).
+     *
+     * @return list of {@code int[2]} arrays: {@code [symbol, unused]}, paired
+     *         with a String; actually returned as pairs via a 2D structure.
+     *         Each element is a {@code int[]{symbol}} and the code string.
+     */
+    public List<int[]> leaves() {
+        Map<Integer, String> table = codeTable();
+        List<int[]> result = new ArrayList<>();
+        // We store symbol and code-string together as a parallel pair.
+        // Return as a list of [symbol, codeAsInt? — no, code is a string].
+        // Use a separate method that returns the paired list.
+        collectLeavesInOrder(root, result, table);
+        return result;
+    }
+
+    /**
+     * Return leaves as {@code (symbol, bitString)} pairs in in-order (left-to-right)
+     * traversal order.
+     *
+     * <p>Time: O(n).
+     *
+     * @return list of {@code Object[]{Integer symbol, String code}} pairs
+     */
+    public List<Object[]> leavesWithCodes() {
+        Map<Integer, String> table = codeTable();
+        List<Object[]> result = new ArrayList<>();
+        collectLeavesInOrderWithCodes(root, result, table);
+        return result;
+    }
+
+    /**
+     * Check structural invariants.
+     *
+     * <ol>
+     *   <li>Every internal node has exactly 2 children (full binary tree).</li>
+     *   <li>{@code weight(internal) == weight(left) + weight(right)}.</li>
+     *   <li>No symbol appears in more than one leaf.</li>
+     * </ol>
+     *
+     * <p>Returns {@code true} if all invariants hold.
+     *
+     * @return true if the tree is structurally valid
+     */
+    public boolean isValid() {
+        java.util.Set<Integer> seen = new java.util.HashSet<>();
+        return checkInvariants(root, seen);
+    }
+
+    // =========================================================================
+    // Private helpers — tree walk
+    // =========================================================================
+
+    /**
+     * Recursively walk the tree building the code table.
+     *
+     * <p>At each internal node we append '0' for the left branch and '1' for
+     * the right branch.  At each leaf we record the accumulated prefix.
+     */
+    private static void walkTree(Node node, String prefix, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            // Single-leaf edge case: no edges traversed; use "0" by convention
+            table.put(leaf.symbol, prefix.isEmpty() ? "0" : prefix);
+            return;
+        }
+        Internal internal = (Internal) node;
+        walkTree(internal.left,  prefix + "0", table);
+        walkTree(internal.right, prefix + "1", table);
+    }
+
+    /**
+     * Search the tree for a specific symbol, returning its code or {@code null}.
+     */
+    private static String findCode(Node node, int symbol, String prefix) {
+        if (node instanceof Leaf leaf) {
+            if (leaf.symbol == symbol) {
+                return prefix.isEmpty() ? "0" : prefix;
+            }
+            return null;
+        }
+        Internal internal = (Internal) node;
+        String left = findCode(internal.left,  symbol, prefix + "0");
+        if (left != null) return left;
+        return findCode(internal.right, symbol, prefix + "1");
+    }
+
+    /**
+     * Collect code lengths for all leaves (depth at each leaf = code length).
+     *
+     * <p>For a single-leaf tree (depth 0) we assign length 1 by convention.
+     */
+    private static void collectLengths(Node node, int depth, Map<Integer, Integer> lengths) {
+        if (node instanceof Leaf leaf) {
+            lengths.put(leaf.symbol, depth > 0 ? depth : 1);
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLengths(internal.left,  depth + 1, lengths);
+        collectLengths(internal.right, depth + 1, lengths);
+    }
+
+    /** Return the maximum depth of any leaf. */
+    private static int maxDepth(Node node, int depth) {
+        if (node instanceof Leaf) return depth;
+        Internal internal = (Internal) node;
+        return Math.max(maxDepth(internal.left,  depth + 1),
+                        maxDepth(internal.right, depth + 1));
+    }
+
+    /** Collect leaf symbols in left-to-right (in-order) traversal. */
+    private static void collectLeavesInOrder(
+            Node node, List<int[]> result, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            result.add(new int[]{leaf.symbol});
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLeavesInOrder(internal.left,  result, table);
+        collectLeavesInOrder(internal.right, result, table);
+    }
+
+    /** Collect (symbol, code) pairs in left-to-right in-order traversal. */
+    private static void collectLeavesInOrderWithCodes(
+            Node node, List<Object[]> result, Map<Integer, String> table) {
+        if (node instanceof Leaf leaf) {
+            result.add(new Object[]{leaf.symbol, table.get(leaf.symbol)});
+            return;
+        }
+        Internal internal = (Internal) node;
+        collectLeavesInOrderWithCodes(internal.left,  result, table);
+        collectLeavesInOrderWithCodes(internal.right, result, table);
+    }
+
+    /** Recursively validate tree invariants. */
+    private static boolean checkInvariants(Node node, java.util.Set<Integer> seen) {
+        if (node instanceof Leaf leaf) {
+            if (seen.contains(leaf.symbol)) return false;
+            seen.add(leaf.symbol);
+            return true;
+        }
+        Internal internal = (Internal) node;
+        // Internal node weight must equal sum of children's weights
+        if (internal.weight != internal.left.weight + internal.right.weight) {
+            return false;
+        }
+        return checkInvariants(internal.left, seen) &&
+               checkInvariants(internal.right, seen);
+    }
+}

--- a/code/packages/java/huffman-tree/src/test/java/com/codingadventures/huffmantree/HuffmanTreeTest.java
+++ b/code/packages/java/huffman-tree/src/test/java/com/codingadventures/huffmantree/HuffmanTreeTest.java
@@ -1,0 +1,400 @@
+package com.codingadventures.huffmantree;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Comprehensive tests for {@link HuffmanTree}.
+ *
+ * <p>Test organisation:
+ * <ol>
+ *   <li>Construction — empty/zero-freq errors, single, two, three symbols</li>
+ *   <li>Code table — prefix-free property, single-symbol convention</li>
+ *   <li>codeFor — hit, miss, single-symbol</li>
+ *   <li>Canonical code table — AAABBC example, same lengths as regular, prefix-free</li>
+ *   <li>Encode/decode round-trips — single, three symbols, all 256 bytes</li>
+ *   <li>decodeAll error — exhausted bit stream</li>
+ *   <li>Inspection — weight, depth, symbolCount, leavesWithCodes</li>
+ *   <li>Tie-breaking determinism</li>
+ *   <li>isValid</li>
+ * </ol>
+ */
+class HuffmanTreeTest {
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /** Convenience: build from int pairs (symbol, freq). */
+    private static HuffmanTree build(int... pairs) {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            weights.add(new int[]{pairs[i], pairs[i + 1]});
+        }
+        return HuffmanTree.build(weights);
+    }
+
+    // =========================================================================
+    // 1. Construction
+    // =========================================================================
+
+    @Test
+    @DisplayName("build() from empty list throws IllegalArgumentException")
+    void buildEmptyThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> HuffmanTree.build(List.of()));
+    }
+
+    @Test
+    @DisplayName("build() with null list throws IllegalArgumentException")
+    void buildNullThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> HuffmanTree.build(null));
+    }
+
+    @Test
+    @DisplayName("build() with zero frequency throws IllegalArgumentException")
+    void buildZeroFreqThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> build(65, 0));
+    }
+
+    @Test
+    @DisplayName("build() with negative frequency throws IllegalArgumentException")
+    void buildNegativeFreqThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> build(65, -1));
+    }
+
+    @Test
+    @DisplayName("Single symbol: symbolCount=1, weight=freq")
+    void singleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals(1, tree.symbolCount());
+        assertEquals(5, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Two symbols: symbolCount=2, weight=sum of freqs")
+    void twoSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 1);
+        assertEquals(2, tree.symbolCount());
+        assertEquals(4, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Three symbols AAABBC: symbolCount=3, weight=6")
+    void threeSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertEquals(3, tree.symbolCount());
+        assertEquals(6, tree.weight());
+    }
+
+    @Test
+    @DisplayName("isValid() is true after build")
+    void isValidAfterBuild() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertTrue(tree.isValid());
+    }
+
+    @Test
+    @DisplayName("Large alphabet (256 symbols) builds and is valid")
+    void largeAlphabet() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 256; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        assertEquals(256, tree.symbolCount());
+        assertTrue(tree.isValid());
+    }
+
+    // =========================================================================
+    // 2. Code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC: A gets shortest code (highest frequency)")
+    void codeTableAAABBCFrequencies() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertTrue(table.get(65).length() < table.get(66).length());
+        assertTrue(table.get(66).length() <= table.get(67).length());
+    }
+
+    @Test
+    @DisplayName("Single symbol: code is \"0\"")
+    void codeTableSingleSymbol() {
+        HuffmanTree tree = build(65, 1);
+        assertEquals("0", tree.codeTable().get(65));
+    }
+
+    @Test
+    @DisplayName("All codes are prefix-free (10 symbols)")
+    void codeTablePrefixFree() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> table = tree.codeTable();
+        List<String> codes = new ArrayList<>(table.values());
+        for (int i = 0; i < codes.size(); i++) {
+            for (int j = 0; j < codes.size(); j++) {
+                if (i != j) {
+                    assertFalse(codes.get(i).startsWith(codes.get(j)),
+                        codes.get(i) + " starts with " + codes.get(j));
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("codeTable returns entry for every symbol")
+    void codeTableContainsAllSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertTrue(table.containsKey(65));
+        assertTrue(table.containsKey(66));
+        assertTrue(table.containsKey(67));
+    }
+
+    // =========================================================================
+    // 3. codeFor
+    // =========================================================================
+
+    @Test
+    @DisplayName("codeFor returns same value as codeTable for each symbol")
+    void codeForMatchesTable() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        assertEquals(table.get(65), tree.codeFor(65));
+        assertEquals(table.get(66), tree.codeFor(66));
+        assertEquals(table.get(67), tree.codeFor(67));
+    }
+
+    @Test
+    @DisplayName("codeFor returns null for absent symbol")
+    void codeForMissing() {
+        HuffmanTree tree = build(65, 3, 66, 2);
+        assertNull(tree.codeFor(99));
+    }
+
+    @Test
+    @DisplayName("codeFor single symbol returns \"0\"")
+    void codeForSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals("0", tree.codeFor(65));
+    }
+
+    // =========================================================================
+    // 4. Canonical code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC canonical: A→\"0\", B→\"10\", C→\"11\"")
+    void canonicalAAABBC() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        assertEquals("0",  canonical.get(65));
+        assertEquals("10", canonical.get(66));
+        assertEquals("11", canonical.get(67));
+    }
+
+    @Test
+    @DisplayName("Canonical code lengths match regular code lengths (8 symbols)")
+    void canonicalLengthsMatchRegular() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 8; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> regular   = tree.codeTable();
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        for (int sym : regular.keySet()) {
+            assertEquals(regular.get(sym).length(), canonical.get(sym).length(),
+                "Length mismatch for symbol " + sym);
+        }
+    }
+
+    @Test
+    @DisplayName("Canonical single symbol returns {sym → \"0\"}")
+    void canonicalSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        assertEquals("0", tree.canonicalCodeTable().get(65));
+    }
+
+    @Test
+    @DisplayName("Canonical codes are prefix-free (10 symbols)")
+    void canonicalPrefixFree() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> canonical = tree.canonicalCodeTable();
+        List<String> codes = new ArrayList<>(canonical.values());
+        for (int i = 0; i < codes.size(); i++) {
+            for (int j = 0; j < codes.size(); j++) {
+                if (i != j) {
+                    assertFalse(codes.get(i).startsWith(codes.get(j)));
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // 5. Encode / decode round-trips
+    // =========================================================================
+
+    @Test
+    @DisplayName("Single-symbol round-trip: [A,A,A]")
+    void roundTripSingleSymbol() {
+        HuffmanTree tree = build(65, 5);
+        Map<Integer, String> table = tree.codeTable();
+        String bits = table.get(65) + table.get(65) + table.get(65);
+        assertEquals(List.of(65, 65, 65), tree.decodeAll(bits, 3));
+    }
+
+    @Test
+    @DisplayName("AAABBC round-trip: encode then decode")
+    void roundTripAAABBC() {
+        List<Integer> symbols = List.of(65, 65, 65, 66, 66, 67);
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        Map<Integer, String> table = tree.codeTable();
+        StringBuilder sb = new StringBuilder();
+        for (int s : symbols) sb.append(table.get(s));
+        assertEquals(symbols, tree.decodeAll(sb.toString(), symbols.size()));
+    }
+
+    @Test
+    @DisplayName("All 256 byte values round-trip")
+    void roundTripAllBytes() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 256; i++) weights.add(new int[]{i, i + 1});
+        HuffmanTree tree = HuffmanTree.build(weights);
+        Map<Integer, String> table = tree.codeTable();
+        StringBuilder sb = new StringBuilder();
+        List<Integer> symbols = new ArrayList<>();
+        for (int i = 0; i < 256; i++) { symbols.add(i); sb.append(table.get(i)); }
+        assertEquals(symbols, tree.decodeAll(sb.toString(), 256));
+    }
+
+    @Test
+    @DisplayName("decodeAll throws when bit stream exhausted")
+    void decodeExhausted() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        // "0" decodes only 1 symbol but count=5 requested
+        assertThrows(IllegalArgumentException.class,
+            () -> tree.decodeAll("0", 5));
+    }
+
+    // =========================================================================
+    // 6. Inspection
+    // =========================================================================
+
+    @Test
+    @DisplayName("weight() returns sum of all frequencies")
+    void weightSum() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        assertEquals(6, tree.weight());
+    }
+
+    @Test
+    @DisplayName("depth() of single-symbol tree is 0")
+    void depthSingleSymbol() {
+        assertEquals(0, build(65, 1).depth());
+    }
+
+    @Test
+    @DisplayName("depth() of two-symbol tree is 1")
+    void depthTwoSymbols() {
+        assertEquals(1, build(65, 3, 66, 1).depth());
+    }
+
+    @Test
+    @DisplayName("depth() of AAABBC tree is 2")
+    void depthThreeSymbols() {
+        assertEquals(2, build(65, 3, 66, 2, 67, 1).depth());
+    }
+
+    @Test
+    @DisplayName("symbolCount() returns number of distinct symbols")
+    void symbolCountBasic() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 10; i++) weights.add(new int[]{i, i + 1});
+        assertEquals(10, HuffmanTree.build(weights).symbolCount());
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() single symbol returns [(65, \"0\")]")
+    void leavesWithCodesSingle() {
+        HuffmanTree tree = build(65, 5);
+        List<Object[]> leaves = tree.leavesWithCodes();
+        assertEquals(1, leaves.size());
+        assertEquals(65,  (int) leaves.get(0)[0]);
+        assertEquals("0", (String) leaves.get(0)[1]);
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() contains all symbols in AAABBC tree")
+    void leavesWithCodesThreeSymbols() {
+        HuffmanTree tree = build(65, 3, 66, 2, 67, 1);
+        List<Object[]> leaves = tree.leavesWithCodes();
+        assertEquals(3, leaves.size());
+        java.util.Set<Integer> syms = new java.util.HashSet<>();
+        for (Object[] leaf : leaves) syms.add((Integer) leaf[0]);
+        assertTrue(syms.contains(65));
+        assertTrue(syms.contains(66));
+        assertTrue(syms.contains(67));
+    }
+
+    // =========================================================================
+    // 7. Tie-breaking determinism
+    // =========================================================================
+
+    @Test
+    @DisplayName("Equal-weight alphabet is structurally valid")
+    void equalWeightsValid() {
+        HuffmanTree tree = build(65, 1, 66, 1, 67, 1, 68, 1);
+        assertTrue(tree.isValid());
+        assertEquals(4, tree.symbolCount());
+        assertEquals(4, tree.weight());
+    }
+
+    @Test
+    @DisplayName("Same input always produces same code table")
+    void equalWeightsDeterministic() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 8; i++) weights.add(new int[]{i, 1});
+        HuffmanTree t1 = HuffmanTree.build(new ArrayList<>(weights));
+        HuffmanTree t2 = HuffmanTree.build(new ArrayList<>(weights));
+        assertEquals(t1.codeTable(), t2.codeTable());
+    }
+
+    @Test
+    @DisplayName("Two equal-weight leaves: lower symbol (65) gets code '0'")
+    void equalWeightsLowerSymbolLeft() {
+        HuffmanTree tree = build(65, 1, 66, 1);
+        Map<Integer, String> table = tree.codeTable();
+        // Both have length 1; lower symbol (65) gets left branch ('0')
+        assertEquals(1, table.get(65).length());
+        assertEquals(1, table.get(66).length());
+    }
+
+    // =========================================================================
+    // 8. isValid
+    // =========================================================================
+
+    @Test
+    @DisplayName("isValid() is true for a well-formed tree")
+    void isValidTrue() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid());
+    }
+
+    @Test
+    @DisplayName("isValid() is true for large tree (50 symbols)")
+    void isValidLarge() {
+        List<int[]> weights = new ArrayList<>();
+        for (int i = 0; i < 50; i++) weights.add(new int[]{i, i + 1});
+        assertTrue(HuffmanTree.build(weights).isValid());
+    }
+}

--- a/code/packages/kotlin/huffman-compression/.gitignore
+++ b/code/packages/kotlin/huffman-compression/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/huffman-compression/BUILD
+++ b/code/packages/kotlin/huffman-compression/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-compression/BUILD_windows
+++ b/code/packages/kotlin/huffman-compression/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-compression/CHANGELOG.md
+++ b/code/packages/kotlin/huffman-compression/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — huffman-compression (Kotlin)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `HuffmanCompression` object with `compress(ByteArray?)` and
+  `decompress(ByteArray?)` implementing the CMP04 wire format.
+- Idiomatic Kotlin port of the Java CMP04 implementation:
+  - `buildString { }` for bit concatenation.
+  - `sortedWith(compareBy { })` for code-lengths sorting.
+  - `padStart(length, '0')` for canonical code left-padding.
+  - `HashMap<String, Int>` for O(1) code-to-symbol lookup during decode.
+  - `accumulated.clear()` instead of `setLength(0)`.
+  - Both `compress` and `decompress` accept `null` (treated as empty).
+- `packBitsLsbFirst(String): ByteArray` private helper with LSB-first bit
+  packing (same convention as LZW/GIF).
+- `build.gradle.kts` with composite build dependency on `kotlin/huffman-tree`.
+- `settings.gradle.kts` with `includeBuild("../huffman-tree")`.
+- 45 unit tests (mirrors the Java test suite) covering:
+  - Round-trip fidelity (13 tests)
+  - Exact wire-format bytes including the "AAABBC" worked example (7 tests)
+  - Edge cases: empty, null, single byte, high bytes, null bytes, short
+    header, truncated stream (11 tests)
+  - Compression effectiveness: skewed, repeated, uniform distributions (3 tests)
+  - Determinism (3 tests)
+  - Error handling: bit-stream exhaustion throws `IllegalArgumentException` (1 test)
+- `BUILD` / `BUILD_windows`, `README.md`, `.gitignore`.

--- a/code/packages/kotlin/huffman-compression/README.md
+++ b/code/packages/kotlin/huffman-compression/README.md
@@ -1,0 +1,63 @@
+# huffman-compression (Kotlin) — CMP04
+
+Huffman lossless compression for Kotlin.  Implements the CMP04 wire format:
+variable-length, prefix-free canonical Huffman codes packed LSB-first into a
+compact byte stream.
+
+## What it does
+
+`HuffmanCompression` (an `object`) exposes two functions:
+
+| Function | Description |
+|----------|-------------|
+| `compress(ByteArray?)` | Encode bytes using canonical Huffman coding; returns CMP04 wire-format bytes |
+| `decompress(ByteArray?)` | Decode CMP04 wire-format bytes; returns the original bytes |
+
+Both functions treat `null` as empty input and return `ByteArray(0)` or an
+8-byte zero header respectively.
+
+## Where it fits
+
+```
+CMP00 (LZ77,    1977) — Sliding-window back-references
+CMP01 (LZ78,    1978) — Explicit dictionary (trie)
+CMP02 (LZSS,    1982) — LZ77 + flag bits
+CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF
+CMP04 (Huffman, 1952) — Entropy coding  ← this package
+CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard
+```
+
+## Dependencies
+
+- `com.codingadventures:huffman-tree` (Kotlin) — DT27 Huffman tree.
+  Declared via Gradle composite build; no Maven publishing needed.
+
+## Wire format (CMP04)
+
+```
+Bytes 0–3:    original_length  (big-endian uint32)
+Bytes 4–7:    symbol_count     (big-endian uint32) — distinct symbols
+Bytes 8–8+2N: code-lengths table — N × 2 bytes:
+                [0] symbol value  (uint8, 0–255)
+                [1] code length   (uint8, 1–16)
+              Sorted by (code_length, symbol_value) ascending.
+Bytes 8+2N+:  bit stream — packed LSB-first, zero-padded to byte boundary.
+```
+
+## Quick start
+
+```kotlin
+val original   = "AAABBC".toByteArray()
+val compressed = HuffmanCompression.compress(original)
+val recovered  = HuffmanCompression.decompress(compressed)
+check(original.contentEquals(recovered))
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+45 tests covering round-trip fidelity, exact wire-format bytes, edge cases,
+compression effectiveness, determinism, and error handling.

--- a/code/packages/kotlin/huffman-compression/build.gradle.kts
+++ b/code/packages/kotlin/huffman-compression/build.gradle.kts
@@ -1,0 +1,38 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    // Provided via the composite build declared in settings.gradle.kts.
+    implementation("com.codingadventures:huffman-tree")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/huffman-compression/settings.gradle.kts
+++ b/code/packages/kotlin/huffman-compression/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "huffman-compression"
+
+// Composite build: pull in the kotlin/huffman-tree sibling package so that
+// `com.codingadventures:huffman-tree` resolves without Maven publishing.
+includeBuild("../huffman-tree")

--- a/code/packages/kotlin/huffman-compression/src/main/kotlin/com/codingadventures/huffmancompression/HuffmanCompression.kt
+++ b/code/packages/kotlin/huffman-compression/src/main/kotlin/com/codingadventures/huffmancompression/HuffmanCompression.kt
@@ -1,0 +1,282 @@
+// ============================================================================
+// HuffmanCompression.kt — CMP04: Huffman Lossless Compression
+// ============================================================================
+//
+// Huffman coding (1952) is an entropy coding algorithm: it assigns
+// variable-length, prefix-free binary codes to symbols based on their
+// frequency of occurrence.  Frequent symbols get short codes; rare symbols
+// get long codes.  The resulting code is provably optimal — no other
+// prefix-free code can achieve a smaller expected bit-length for the same
+// symbol distribution.
+//
+// Unlike the LZ-family algorithms (LZ77, LZ78, LZSS, LZW) which exploit
+// repetition (duplicate substrings), Huffman coding exploits symbol
+// statistics.  This makes it complementary to LZ compression.  DEFLATE
+// combines both: LZ77 to eliminate repeated substrings, then Huffman to
+// optimally encode the remaining symbol stream.
+//
+// ============================================================================
+// Dependency on DT27 (HuffmanTree)
+// ============================================================================
+//
+// This package does NOT build its own Huffman tree.  It delegates all tree
+// construction and code derivation to com.codingadventures.huffmantree.
+//
+//   CMP04 (Huffman) → uses DT27 (HuffmanTree) for code construction/decode
+//
+// ============================================================================
+// Wire Format (CMP04)
+// ============================================================================
+//
+//   Bytes 0–3:    original_length  (big-endian uint32)
+//   Bytes 4–7:    symbol_count     (big-endian uint32) — distinct symbols
+//   Bytes 8–8+2N: code-lengths table — N entries, each 2 bytes:
+//                   [0]  symbol value  (uint8, 0–255)
+//                   [1]  code length   (uint8, 1–16)
+//                 Sorted by (code_length, symbol_value) ascending.
+//   Bytes 8+2N+:  bit stream — packed LSB-first, zero-padded to byte boundary.
+//
+// Packing convention: LSB-first (same as LZW/GIF).
+//
+//   Example — packing bit string "000101011" (9 bits):
+//     Byte 0: bits[0..7] = 0b10101000 = 0xA8
+//       bit 0 ('0') → byte bit 0  (LSB)
+//       bit 1 ('0') → byte bit 1
+//       ...
+//       bit 7 ('1') → byte bit 7  (MSB)
+//     Byte 1: bit[8] ('1') → 0b00000001 = 0x01
+//
+// ============================================================================
+// The CMP series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE. (this)
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+
+package com.codingadventures.huffmancompression
+
+import com.codingadventures.huffmantree.HuffmanTree
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * CMP04: Huffman lossless compression.
+ *
+ * Provides [compress] and [decompress] functions that encode/decode byte
+ * arrays using canonical Huffman codes.  The compressed bytes follow the
+ * CMP04 wire format (see module comment above).
+ *
+ * ```kotlin
+ * val original   = "AAABBC".toByteArray()
+ * val compressed = compress(original)
+ * val recovered  = decompress(compressed)
+ * assert(original.contentEquals(recovered))
+ * ```
+ */
+object HuffmanCompression {
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Compress [data] using canonical Huffman coding.
+     *
+     * Algorithm:
+     * 1. Count byte frequencies (histogram).
+     * 2. Build a Huffman tree via [HuffmanTree.build].
+     * 3. Obtain canonical codes via [HuffmanTree.canonicalCodeTable].
+     * 4. Build the code-lengths list sorted by (length, symbol) for the header.
+     * 5. Encode each byte using its canonical bit string.
+     * 6. Pack the bit string LSB-first into bytes.
+     * 7. Assemble header + code-lengths table + bit stream.
+     *
+     * Edge cases:
+     * - Empty / null input: returns an 8-byte header (original_length=0,
+     *   symbol_count=0) with no bit stream.
+     * - Single distinct byte: DT27 assigns code "0"; each occurrence encodes
+     *   to 1 bit.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP04 wire format
+     */
+    fun compress(data: ByteArray?): ByteArray {
+        // Empty input — 8-byte header only.
+        if (data == null || data.isEmpty()) {
+            return ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN)
+                .putInt(0).putInt(0).array()
+        }
+
+        val originalLength = data.size
+
+        // Step 1: Count frequencies.
+        val freq = IntArray(256)
+        for (b in data) freq[b.toInt() and 0xFF]++
+
+        // Step 2: Build Huffman tree.
+        val weights = (0 until 256)
+            .filter { freq[it] > 0 }
+            .map { intArrayOf(it, freq[it]) }
+        val tree = HuffmanTree.build(weights)
+
+        // Step 3: Canonical code table {symbol → bit_string}.
+        val table = tree.canonicalCodeTable()
+
+        // Step 4: Code-lengths list sorted by (length, symbol) for the header.
+        val lengths = table.entries
+            .map { (sym, code) -> intArrayOf(sym, code.length) }
+            .sortedWith(compareBy({ it[1] }, { it[0] }))
+
+        // Step 5: Encode each byte using its canonical code.
+        val bits = buildString {
+            for (b in data) append(table.getValue(b.toInt() and 0xFF))
+        }
+
+        // Step 6: Pack bits LSB-first into bytes.
+        val bitBytes = packBitsLsbFirst(bits)
+
+        // Step 7: Assemble wire format.
+        val symbolCount = lengths.size
+        val header = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN)
+            .putInt(originalLength).putInt(symbolCount).array()
+
+        val out = ByteArrayOutputStream()
+        out.write(header)
+        for (entry in lengths) {
+            out.write(entry[0])   // symbol
+            out.write(entry[1])   // code length
+        }
+        out.write(bitBytes)
+        return out.toByteArray()
+    }
+
+    /**
+     * Decompress CMP04 wire-format [data] and return the original bytes.
+     *
+     * Algorithm:
+     * 1. Parse the 8-byte header: original_length and symbol_count.
+     * 2. Parse the code-lengths table (symbol_count × 2 bytes).
+     * 3. Reconstruct canonical codes from the sorted (symbol, length) list.
+     * 4. Unpack the LSB-first bit stream.
+     * 5. Decode original_length symbols by accumulating bits until a hit in
+     *    the canonical code table, then reset.
+     *
+     * @param data compressed bytes in CMP04 wire format (null treated as empty)
+     * @return the original, uncompressed bytes
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  all symbols are decoded
+     */
+    fun decompress(data: ByteArray?): ByteArray {
+        if (data == null || data.size < 8) return ByteArray(0)
+
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
+        val originalLength = buf.getInt()
+        val symbolCount    = buf.getInt()
+
+        if (originalLength == 0) return ByteArray(0)
+
+        // Parse code-lengths table.
+        // Wire format guarantees entries are sorted by (code_length, symbol_value).
+        val lengths = ArrayList<IntArray>(symbolCount)
+        repeat(symbolCount) {
+            val sym    = buf.get().toInt() and 0xFF
+            val length = buf.get().toInt() and 0xFF
+            lengths.add(intArrayOf(sym, length))
+        }
+
+        // Reconstruct canonical codes from the sorted lengths list.
+        //
+        // The DEFLATE canonical reconstruction rule:
+        //   code = 0
+        //   prev_length = first entry's length
+        //   for each entry in sorted order:
+        //     if length > prev_length: code = code shl (length - prev_length)
+        //     assign bit_string = left-padded binary of code
+        //     code += 1
+        val codeToSymbol = HashMap<String, Int>()
+        var codeVal = 0
+        var prevLen = if (lengths.isEmpty()) 0 else lengths[0][1]
+
+        for ((sym, length) in lengths.map { it[0] to it[1] }) {
+            if (length > prevLen) codeVal = codeVal shl (length - prevLen)
+            val bitStr = Integer.toBinaryString(codeVal).padStart(length, '0')
+            codeToSymbol[bitStr] = sym
+            codeVal++
+            prevLen = length
+        }
+
+        // Unpack the remaining bytes as a bit string (LSB-first).
+        val bitString = buildString {
+            while (buf.hasRemaining()) {
+                val byteVal = buf.get().toInt() and 0xFF
+                repeat(8) { i -> append((byteVal shr i) and 1) }
+            }
+        }
+
+        // Decode exactly original_length symbols.
+        val output = ByteArray(originalLength)
+        var pos = 0
+        val accumulated = StringBuilder()
+
+        var decoded = 0
+        while (decoded < originalLength) {
+            if (pos >= bitString.length) {
+                throw IllegalArgumentException(
+                    "Bit stream exhausted after $decoded symbols; expected $originalLength"
+                )
+            }
+            accumulated.append(bitString[pos++])
+            val sym = codeToSymbol[accumulated.toString()]
+            if (sym != null) {
+                output[decoded++] = sym.toByte()
+                accumulated.clear()
+            }
+        }
+        return output
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Pack a bit string into bytes, filling each byte from bit 0 (LSB) upward.
+     *
+     * This is the same convention used by LZW and GIF: the first bit of the
+     * stream occupies the least-significant bit of the first byte.
+     *
+     * The final partial byte is zero-padded in the high bits.
+     *
+     * Example — packing "000101011" (9 bits):
+     * ```
+     * Byte 0: bits[0..7] = 0b10101000 = 0xA8
+     *   bit 0 ('0') → bit 0  (LSB)
+     *   bit 3 ('1') → bit 3
+     *   bit 5 ('1') → bit 5
+     *   bit 7 ('1') → bit 7
+     * Byte 1: bit[8] ('1') → 0b00000001 = 0x01
+     * ```
+     *
+     * @param bits a string of '0' and '1' characters
+     * @return the packed bytes
+     */
+    private fun packBitsLsbFirst(bits: String): ByteArray {
+        val byteCount = (bits.length + 7) / 8
+        val output = ByteArray(byteCount)
+        for (i in bits.indices) {
+            if (bits[i] == '1') {
+                val byteIdx = i / 8
+                val bitPos  = i % 8
+                output[byteIdx] = (output[byteIdx].toInt() or (1 shl bitPos)).toByte()
+            }
+        }
+        return output
+    }
+}

--- a/code/packages/kotlin/huffman-compression/src/test/kotlin/com/codingadventures/huffmancompression/HuffmanCompressionTest.kt
+++ b/code/packages/kotlin/huffman-compression/src/test/kotlin/com/codingadventures/huffmancompression/HuffmanCompressionTest.kt
@@ -1,0 +1,337 @@
+// ============================================================================
+// HuffmanCompressionTest.kt — CMP04: Huffman Lossless Compression Tests
+// ============================================================================
+//
+// Test organisation
+// -----------------
+//  1. Round-trip tests (compress → decompress = original)
+//  2. Wire format verification (exact byte layout per the CMP04 spec)
+//  3. Edge cases (empty, single byte, single repeated symbol, null bytes)
+//  4. Compression effectiveness (compressible data shrinks)
+//  5. Idempotency (same input → same output every time)
+//  6. Error handling (malformed / truncated input)
+//
+// ============================================================================
+
+package com.codingadventures.huffmancompression
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HuffmanCompressionTest {
+
+    // =========================================================================
+    // 1. Round-trip tests
+    // =========================================================================
+
+    @Test fun roundTrip_simpleAAABBC() {
+        val data = "AAABBC".toByteArray()
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_helloWorld() {
+        val data = "hello world".toByteArray()
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_all256ByteValues() {
+        val data = ByteArray(256) { it.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_all256BytesRepeated() {
+        val data = ByteArray(256 * 10) { (it % 256).toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_singleByte() {
+        val data = byteArrayOf('X'.code.toByte())
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_twoBytes() {
+        val data = byteArrayOf('A'.code.toByte(), 'B'.code.toByte())
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_loremIpsum() {
+        val data = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                    "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.").toByteArray()
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_binaryData() {
+        val data = byteArrayOf(0, 1, 2, 3, 255.toByte(), 254.toByte(), 253.toByte(), 128.toByte(), 64, 32)
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_repeatedPattern() {
+        val data = "ABCABC".toByteArray().let { p -> ByteArray(p.size * 100) { i -> p[i % p.size] } }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_singleRepeatedByte() {
+        val data = ByteArray(100) { 'A'.code.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_twoSymbolInput() {
+        val data = ByteArray(100) { if (it % 2 == 0) 'A'.code.toByte() else 'B'.code.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_newlineHeavyText() {
+        val data = "line\n".toByteArray().let { p -> ByteArray(p.size * 200) { i -> p[i % p.size] } }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun roundTrip_longInput() {
+        val pat = "the quick brown fox jumps over the lazy dog ".toByteArray()
+        val data = ByteArray(pat.size * 500) { i -> pat[i % pat.size] }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    // =========================================================================
+    // 2. Wire format verification
+    // =========================================================================
+
+    @Test fun wireFormat_emptyInput() {
+        val result = compress(ByteArray(0))
+        assertEquals(8, result.size)
+        val buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        assertEquals(0, buf.getInt(), "original_length must be 0")
+        assertEquals(0, buf.getInt(), "symbol_count must be 0")
+    }
+
+    @Test fun wireFormat_nullInput() {
+        val result = compress(null)
+        assertEquals(8, result.size)
+        val buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        assertEquals(0, buf.getInt(), "original_length")
+        assertEquals(0, buf.getInt(), "symbol_count")
+    }
+
+    /**
+     * Verify the exact wire-format bytes for "AAABBC".
+     *
+     * Frequencies: A=3, B=2, C=1
+     * Canonical codes: A→"0" (len 1), B→"10" (len 2), C→"11" (len 2)
+     *
+     * Header:      00 00 00 06  00 00 00 03
+     * Code table:  41 01  42 02  43 02
+     * Bit stream:  "000101011" → 0xA8 0x01
+     * Total:       16 bytes
+     */
+    @Test fun wireFormat_aaabbc_exactBytes() {
+        val result = compress("AAABBC".toByteArray())
+
+        val buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        assertEquals(6, buf.getInt(), "original_length")
+        assertEquals(3, buf.getInt(), "symbol_count")
+
+        assertEquals(65,   result[8].toInt()  and 0xFF, "symbol 'A'")
+        assertEquals(1,    result[9].toInt()  and 0xFF, "length 1")
+        assertEquals(66,   result[10].toInt() and 0xFF, "symbol 'B'")
+        assertEquals(2,    result[11].toInt() and 0xFF, "length 2")
+        assertEquals(67,   result[12].toInt() and 0xFF, "symbol 'C'")
+        assertEquals(2,    result[13].toInt() and 0xFF, "length 2")
+
+        assertEquals(0xA8, result[14].toInt() and 0xFF, "bit-stream byte 0")
+        assertEquals(0x01, result[15].toInt() and 0xFF, "bit-stream byte 1")
+
+        assertEquals(16, result.size, "total compressed length")
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [1, 5, 100, 1000])
+    fun wireFormat_originalLengthField(length: Int) {
+        val data = ByteArray(length) { 'A'.code.toByte() }
+        val compressed = compress(data)
+        val stored = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt()
+        assertEquals(length, stored, "original_length field")
+    }
+
+    @Test fun wireFormat_symbolCountField() {
+        assertEquals(1, symbolCountOf(compress("A".toByteArray())))
+        assertEquals(2, symbolCountOf(compress("AB".toByteArray())))
+        assertEquals(3, symbolCountOf(compress("ABC".toByteArray())))
+        val all256 = ByteArray(256) { it.toByte() }
+        assertEquals(256, symbolCountOf(compress(all256)))
+    }
+
+    @Test fun wireFormat_codeLengthsTableSorted() {
+        val result = compress("AAABBC".toByteArray())
+        val n = symbolCountOf(result)
+        var prevLen = 0; var prevSym = -1
+        for (i in 0 until n) {
+            val sym = result[8 + 2 * i].toInt() and 0xFF
+            val len = result[8 + 2 * i + 1].toInt() and 0xFF
+            assertTrue(len > prevLen || (len == prevLen && sym > prevSym),
+                "Code-lengths not sorted at entry $i")
+            prevLen = len; prevSym = sym
+        }
+    }
+
+    @Test fun wireFormat_bitStreamStartsAfterTable() {
+        val result = compress("AAABBC".toByteArray())
+        val n = symbolCountOf(result)
+        val bitsOffset = 8 + 2 * n
+        assertTrue(result.size > bitsOffset)
+    }
+
+    @Test fun wireFormat_singleByteInput() {
+        val result = compress("A".toByteArray())
+        val buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        assertEquals(1, buf.getInt(), "original_length")
+        assertEquals(1, buf.getInt(), "symbol_count")
+        assertEquals(65, result[8].toInt() and 0xFF, "symbol 'A'")
+        assertEquals(1,  result[9].toInt() and 0xFF, "code length 1")
+        assertEquals(0x00, result[10].toInt() and 0xFF, "bit-stream byte")
+        assertEquals(11, result.size, "total length")
+    }
+
+    // =========================================================================
+    // 3. Edge cases
+    // =========================================================================
+
+    @Test fun edgeCase_emptyCompress() {
+        val expected = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN)
+            .putInt(0).putInt(0).array()
+        assertContentEquals(expected, compress(ByteArray(0)))
+    }
+
+    @Test fun edgeCase_emptyDecompress() {
+        assertContentEquals(ByteArray(0), decompress(compress(ByteArray(0))))
+    }
+
+    @Test fun edgeCase_decompressEmptyBytes() {
+        assertContentEquals(ByteArray(0), decompress(ByteArray(0)))
+    }
+
+    @Test fun edgeCase_decompressShortHeader() {
+        assertContentEquals(ByteArray(0), decompress(byteArrayOf(0, 0, 0, 0)))
+    }
+
+    @Test fun edgeCase_decompressNullReturnsEmpty() {
+        assertContentEquals(ByteArray(0), decompress(null))
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 65, 127, 255])
+    fun edgeCase_singleSymbolRoundTrip(sym: Int) {
+        val data = ByteArray(50) { sym.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun edgeCase_singleSymbolEncodesToOneBit() {
+        val data = ByteArray(8) { 'A'.code.toByte() }
+        val result = compress(data)
+        val n = symbolCountOf(result)
+        assertEquals(1, n, "symbol_count")
+        // 8 bits → 1 byte bit stream
+        val bitsOffset = 8 + 2 * n
+        assertEquals(bitsOffset + 1, result.size, "bit-stream should be exactly 1 byte")
+    }
+
+    @Test fun edgeCase_nullBytes() {
+        val data = ByteArray(100) // all zeros
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun edgeCase_twoSymbolsEqualFrequency() {
+        val data = ByteArray(200) { if (it % 2 == 0) 'A'.code.toByte() else 'B'.code.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun edgeCase_allByteValuesSingleOccurrence() {
+        val data = ByteArray(256) { it.toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    @Test fun edgeCase_highByteValues() {
+        val data = ByteArray(128) { (128 + it).toByte() }
+        assertContentEquals(data, decompress(compress(data)))
+    }
+
+    // =========================================================================
+    // 4. Compression effectiveness
+    // =========================================================================
+
+    @Test fun effectiveness_compressibleInputShrinks() {
+        val data = ByteArray(1000).also { d ->
+            for (i in 0 until 900) d[i] = 'A'.code.toByte()
+            for (i in 900 until 1000) d[i] = 'B'.code.toByte()
+        }
+        val compressed = compress(data)
+        assertTrue(compressed.size < data.size)
+    }
+
+    @Test fun effectiveness_repeatedByte_compressesWell() {
+        val data = ByteArray(1000) { 'X'.code.toByte() }
+        val compressed = compress(data)
+        assertTrue(compressed.size < data.size)
+    }
+
+    @Test fun effectiveness_uniformDistributionLargerThanOriginal() {
+        val data = ByteArray(256) { it.toByte() }
+        val compressed = compress(data)
+        assertTrue(compressed.size > data.size)
+    }
+
+    // =========================================================================
+    // 5. Idempotency / determinism
+    // =========================================================================
+
+    @Test fun idempotent_deterministicCompression() {
+        val data = "the quick brown fox jumps over the lazy dog".toByteArray()
+        assertContentEquals(compress(data), compress(data))
+    }
+
+    @Test fun idempotent_deterministicDecompression() {
+        val data = "hello world".toByteArray()
+        val compressed = compress(data)
+        assertContentEquals(decompress(compressed), decompress(compressed))
+    }
+
+    @Test fun idempotent_compressTwiceSameResult() {
+        val pat = "ABCABCABC".toByteArray()
+        val data = ByteArray(pat.size * 10) { i -> pat[i % pat.size] }
+        assertContentEquals(compress(data), compress(data))
+    }
+
+    // =========================================================================
+    // 6. Error handling
+    // =========================================================================
+
+    @Test fun error_bitStreamExhausted_throwsIllegalArgument() {
+        // Craft a header claiming originalLength=100 but supply only 1 bit byte.
+        val buf = ByteBuffer.allocate(11).order(ByteOrder.BIG_ENDIAN)
+        buf.putInt(100)      // original_length = 100
+        buf.putInt(1)        // symbol_count = 1
+        buf.put(65.toByte()) // symbol = 'A'
+        buf.put(1.toByte())  // code_length = 1
+        buf.put(0.toByte())  // 1 byte bit stream (only 8 bits → 8 symbols, need 100)
+        val truncated = buf.array()
+
+        assertThrows<IllegalArgumentException> {
+            decompress(truncated)
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private fun compress(data: ByteArray?) = HuffmanCompression.compress(data)
+    private fun decompress(data: ByteArray?) = HuffmanCompression.decompress(data)
+
+    private fun symbolCountOf(compressed: ByteArray): Int =
+        ByteBuffer.wrap(compressed, 4, 4).order(ByteOrder.BIG_ENDIAN).getInt()
+}

--- a/code/packages/kotlin/huffman-tree/.gitignore
+++ b/code/packages/kotlin/huffman-tree/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/huffman-tree/BUILD
+++ b/code/packages/kotlin/huffman-tree/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-tree/BUILD_windows
+++ b/code/packages/kotlin/huffman-tree/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/huffman-tree/CHANGELOG.md
+++ b/code/packages/kotlin/huffman-tree/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — kotlin/huffman-tree
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+
+- `HuffmanTree` — optimal prefix-free code tree backed by `java.util.PriorityQueue`
+- Sealed class hierarchy: `Node` base, `Leaf(symbol, weight)`, `Internal(weight, left, right, order)`
+- `HuffmanTree.build(List<IntArray> weights)` — companion factory; greedy min-heap
+  construction from `[symbol, frequency]` pairs; throws for empty list or non-positive freq
+- `codeTable()` — O(n) walk returning `Map<Int, String>` of `{symbol → bit_string}`
+- `codeFor(symbol)` — O(n) single-symbol lookup; returns null if absent
+- `canonicalCodeTable()` — O(n log n) DEFLATE-style canonical codes from lengths
+- `decodeAll(bits, count)` — O(bits) tree-walk decoder; throws when stream exhausted
+- `weight()` — O(1) total weight (sum of all frequencies)
+- `depth()` — O(n) maximum code length (depth of deepest leaf)
+- `symbolCount()` — O(1) number of distinct symbols
+- `leavesWithCodes()` — O(n) in-order list of `Pair<Int, String>` (symbol, code)
+- `isValid()` — structural validator: full binary tree, correct weights, unique symbols
+- Deterministic tie-breaking: weight → leaf-before-internal → symbol value → insertion order
+- 35 unit tests covering construction, code tables, canonical codes, round-trips,
+  inspection methods, tie-breaking determinism, and isValid

--- a/code/packages/kotlin/huffman-tree/README.md
+++ b/code/packages/kotlin/huffman-tree/README.md
@@ -1,0 +1,88 @@
+# kotlin/huffman-tree
+
+A **Huffman tree** in idiomatic Kotlin — the theoretically optimal prefix-free
+code for any symbol frequency distribution.  O(n log n) construction, O(n)
+encoding/decoding.
+
+## What is a Huffman Tree?
+
+A Huffman tree assigns variable-length bit codes to symbols so that frequent
+symbols get short codes and rare symbols get long codes.  The resulting codes are
+**prefix-free**: no code is a prefix of another, so the bit stream can be decoded
+unambiguously without separator characters.
+
+Think of Morse code: 'E' is `.` (one dot) and 'Z' is `--..` (four symbols).
+Huffman's algorithm builds this mapping automatically and optimally for any
+given frequency distribution.
+
+## Usage
+
+```kotlin
+import com.codingadventures.huffmantree.HuffmanTree
+
+// Build from (symbol, frequency) pairs
+val tree = HuffmanTree.build(listOf(
+    intArrayOf(65, 3),  // 'A' → frequency 3
+    intArrayOf(66, 2),  // 'B' → frequency 2
+    intArrayOf(67, 1)   // 'C' → frequency 1
+))
+
+// Encode
+val table = tree.codeTable()
+// table[65] → "0"   (A gets the shortest code)
+// table[66] → "10"
+// table[67] → "11"
+
+val bits = table.getValue(65) + table.getValue(66) + table.getValue(67) // "01011"
+
+// Decode
+val decoded = tree.decodeAll(bits, 3)  // → [65, 66, 67]
+
+// Canonical codes (DEFLATE-style)
+val canonical = tree.canonicalCodeTable()
+// canonical[65] → "0"
+// canonical[66] → "10"
+// canonical[67] → "11"
+
+// Inspection
+tree.weight()       // 6    (sum of all frequencies)
+tree.depth()        // 2    (max code length)
+tree.symbolCount()  // 3
+tree.isValid()      // true
+```
+
+## API
+
+| Member | Description |
+|---|---|
+| `HuffmanTree.build(List<IntArray>)` | Build from `[symbol, freq]` pairs |
+| `fun codeTable(): Map<Int, String>` | O(n) — all codes as bit strings |
+| `fun codeFor(symbol: Int): String?` | O(n) — single symbol lookup |
+| `fun canonicalCodeTable(): Map<Int, String>` | O(n log n) — DEFLATE-style canonical codes |
+| `fun decodeAll(bits: String, count: Int): List<Int>` | Decode exactly count symbols |
+| `fun weight(): Int` | O(1) — sum of all frequencies |
+| `fun depth(): Int` | O(n) — maximum code length |
+| `fun symbolCount(): Int` | O(1) — number of distinct symbols |
+| `fun leavesWithCodes(): List<Pair<Int, String>>` | O(n) — in-order leaf pairs |
+| `fun isValid(): Boolean` | Structural validator |
+
+## Design
+
+Uses a **sealed class** hierarchy:
+- `sealed class Node(weight: Int)` — base
+- `data class Leaf(symbol, weight)` — leaf with symbol
+- `data class Internal(weight, left, right, order)` — internal branching node
+
+Pattern-matching `when` expressions in all tree traversals keep code concise
+and exhaustive.
+
+## Running tests
+
+```
+gradle test
+```
+
+35 tests covering: construction, code table, codeFor, canonical codes,
+encode/decode round-trips (including all 256 bytes), exhaustion error,
+inspection methods (weight, depth, symbolCount, leavesWithCodes),
+tie-breaking determinism, and isValid.

--- a/code/packages/kotlin/huffman-tree/build.gradle.kts
+++ b/code/packages/kotlin/huffman-tree/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/huffman-tree/settings.gradle.kts
+++ b/code/packages/kotlin/huffman-tree/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "huffman-tree"

--- a/code/packages/kotlin/huffman-tree/src/main/kotlin/com/codingadventures/huffmantree/HuffmanTree.kt
+++ b/code/packages/kotlin/huffman-tree/src/main/kotlin/com/codingadventures/huffmantree/HuffmanTree.kt
@@ -1,0 +1,462 @@
+// ============================================================================
+// HuffmanTree.kt — Optimal Prefix-Free Code Tree
+// ============================================================================
+//
+// A Huffman tree is a full binary tree (every internal node has exactly two
+// children) built from a symbol alphabet so that each symbol gets a unique
+// variable-length bit code.  Symbols that appear often get short codes;
+// symbols that appear rarely get long codes.  The total bits needed to
+// encode a message is minimised — it is the theoretically optimal prefix-free
+// code for a given symbol frequency distribution.
+//
+// Think of it like Morse code.  In Morse, 'E' is '.' (one dot) and 'Z' is
+// '--..' (four symbols).  The designers knew 'E' is the most common letter
+// in English so they gave it the shortest code.  Huffman's algorithm does
+// this automatically and optimally for any alphabet with any frequency
+// distribution.
+//
+// ============================================================================
+// Algorithm: Greedy construction via min-heap
+// ============================================================================
+//
+// 1. Create one leaf node per distinct symbol, each with its frequency as
+//    its weight.  Push all leaves onto a min-heap keyed by weight.
+//
+// 2. While the heap has more than one node:
+//      a. Pop the two nodes with the smallest weight.
+//      b. Create a new internal node whose weight = sum of the two children.
+//      c. Set left = the first popped node, right = the second popped node.
+//      d. Push the new internal node back onto the heap.
+//
+// 3. The one remaining node is the root of the Huffman tree.
+//
+// ============================================================================
+// Tie-breaking for determinism
+// ============================================================================
+//
+// Without tie-breaking, different implementations build structurally different
+// trees from the same input — producing different (but equally valid) codes.
+// We enforce these rules (lower key = higher priority):
+//
+//   Priority tuple: (weight, isInternal, symbolOrNeg1, insertionOrder)
+//
+//   1. Lowest weight pops first.
+//   2. Leaf nodes (isInternal=0) beat internal nodes (isInternal=1) at equal
+//      weight.
+//   3. Among leaves of equal weight, lower symbol value wins.
+//   4. Among internal nodes of equal weight, earlier-created node wins
+//      (insertion order, FIFO).
+//
+// ============================================================================
+// Prefix-free property: why it works
+// ============================================================================
+//
+//   In a Huffman tree:
+//     - Symbols live ONLY at the leaves, never at internal nodes.
+//     - The code for a symbol is the path from root to its leaf
+//       (left edge = '0', right edge = '1').
+//
+//   Since one leaf is never an ancestor of another, no code can be a prefix
+//   of another code.  This means the bit stream can be decoded unambiguously
+//   without separator characters: just walk the tree bit by bit until you
+//   reach a leaf.
+//
+// ============================================================================
+// Canonical codes (DEFLATE / zlib style)
+// ============================================================================
+//
+//   The standard tree-walk produces valid codes, but different tree shapes
+//   can produce different codes for the same symbol lengths.  Canonical codes
+//   normalise this: given only the code *lengths*, you can reconstruct the
+//   exact canonical code table without transmitting the tree structure.
+//
+//   Algorithm:
+//     1. Collect (symbol, code_length) pairs from the tree.
+//     2. Sort by (code_length, symbol_value).
+//     3. Assign codes numerically:
+//          code[0] = 0  (left-padded to length[0] bits)
+//          code[i] = (code[i-1] + 1) shl (length[i] - length[i-1])
+//
+//   This is exactly what DEFLATE uses: the compressed stream contains only
+//   the length table, not the tree, saving space.
+//
+//   Example with AAABBC (A=3, B=2, C=1):
+//     Tree:      [6]
+//                / \
+//               A  [3]
+//              (3)  / \
+//                  B   C
+//                 (2) (1)
+//     Lengths: A=1, B=2, C=2
+//     Sorted by (length, symbol): A(1), B(2), C(2)
+//     Canonical codes:
+//       A → "0"   (length 1, code = 0)
+//       B → "10"  (length 2, code = 0+1=1, shifted 1 bit → 10)
+//       C → "11"  (length 2, code = 10+1 = 11)
+//
+// ============================================================================
+
+package com.codingadventures.huffmantree
+
+import java.util.PriorityQueue
+
+// ============================================================================
+// Node types
+// ============================================================================
+
+/**
+ * Base class for all nodes in the Huffman tree.
+ *
+ * Every node carries a [weight]: for leaves it is the symbol's frequency;
+ * for internal nodes it is the sum of its children's weights.
+ */
+sealed class Node(open val weight: Int)
+
+/**
+ * A leaf node representing a single symbol.
+ *
+ * Leaves are always at the bottom of the tree.  Their code is the
+ * path from the root to this node (left='0', right='1').
+ *
+ * @param symbol   the encoded symbol (non-negative integer)
+ * @param weight   the symbol's frequency
+ */
+data class Leaf(val symbol: Int, override val weight: Int) : Node(weight)
+
+/**
+ * An internal node combining two sub-trees.
+ *
+ * Internal nodes have no symbol — they are bookkeeping nodes encoding
+ * branching structure.  Their [weight] = [left].weight + [right].weight.
+ *
+ * @param weight  sum of children's weights
+ * @param left    left child (code bit '0')
+ * @param right   right child (code bit '1')
+ * @param order   monotonic insertion counter for tie-breaking (FIFO among internals)
+ */
+data class Internal(
+    override val weight: Int,
+    val left:   Node,
+    val right:  Node,
+    val order:  Int = 0
+) : Node(weight)
+
+// ============================================================================
+// HuffmanTree
+// ============================================================================
+
+/**
+ * A Huffman tree that assigns optimal prefix-free bit codes to integer symbols.
+ *
+ * Build the tree once from symbol frequencies; then:
+ * - Use [codeTable] to get a `{symbol → bit_string}` map for encoding.
+ * - Use [decodeAll] to decode a bit stream back to symbols.
+ * - Use [canonicalCodeTable] for DEFLATE-style transmissible codes.
+ *
+ * All symbols are non-negative integers (typically 0–255 for byte-level
+ * coding, but any non-negative integer is valid).  Frequencies must be
+ * positive.  The tree is immutable after construction.
+ *
+ * ```kotlin
+ * val tree = HuffmanTree.build(listOf(
+ *     intArrayOf(65, 3),  // 'A' → frequency 3
+ *     intArrayOf(66, 2),  // 'B' → frequency 2
+ *     intArrayOf(67, 1)   // 'C' → frequency 1
+ * ))
+ *
+ * val table = tree.codeTable()
+ * // table[65] → "0"    (A gets the shortest code)
+ * // table[66] → "10"
+ * // table[67] → "11"
+ *
+ * val decoded = tree.decodeAll("010011", 4)
+ * // → [65, 65, 66, 67]
+ * ```
+ */
+class HuffmanTree private constructor(
+    private val root:        Node,
+    private val symbolCount: Int
+) {
+
+    // =========================================================================
+    // Companion (factory)
+    // =========================================================================
+
+    companion object {
+
+        /**
+         * Comparator for the min-heap during tree construction.
+         *
+         * Four-level ordering (lower = higher priority):
+         * 1. Weight (lighter wins)
+         * 2. Node type: leaf (0) before internal (1)
+         * 3. Symbol value for leaves (lower wins)
+         * 4. Insertion order for internals (earlier = FIFO)
+         */
+        private val PRIORITY = Comparator<Node> { a, b ->
+            // Field 0: weight
+            a.weight.compareTo(b.weight).takeIf { it != 0 }?.let { return@Comparator it }
+
+            // Field 1: leaf (0) before internal (1)
+            val typeA = if (a is Leaf) 0 else 1
+            val typeB = if (b is Leaf) 0 else 1
+            typeA.compareTo(typeB).takeIf { it != 0 }?.let { return@Comparator it }
+
+            // Field 2 / 3: among same type
+            when {
+                a is Leaf && b is Leaf -> a.symbol.compareTo(b.symbol)
+                a is Internal && b is Internal -> a.order.compareTo(b.order)
+                else -> 0
+            }
+        }
+
+        /**
+         * Construct a Huffman tree from `(symbol, frequency)` pairs.
+         *
+         * Each element of [weights] must be an `IntArray` of size ≥ 2:
+         * `[symbol, frequency, ...]`.  Symbols must be non-negative integers;
+         * frequencies must be > 0.
+         *
+         * Tie-breaking (for deterministic output):
+         * 1. Lowest weight pops first.
+         * 2. Leaves before internal nodes at equal weight.
+         * 3. Lower symbol value wins among leaves of equal weight.
+         * 4. Earlier-created internal wins among internals of equal weight (FIFO).
+         *
+         * @param weights list of `IntArray(symbol, frequency)` pairs
+         * @return a [HuffmanTree] ready for encoding/decoding
+         * @throws IllegalArgumentException if [weights] is empty or any frequency ≤ 0
+         */
+        fun build(weights: List<IntArray>): HuffmanTree {
+            require(weights.isNotEmpty()) { "weights must not be empty" }
+            for ((sym, freq) in weights.map { it[0] to it[1] }) {
+                require(freq > 0) {
+                    "frequency must be positive; got symbol=$sym, freq=$freq"
+                }
+            }
+
+            val heap = PriorityQueue(weights.size, PRIORITY)
+            for (pair in weights) heap.add(Leaf(pair[0], pair[1]))
+
+            var orderCounter = 0
+            while (heap.size > 1) {
+                val left  = heap.poll()
+                val right = heap.poll()
+                heap.add(Internal(left.weight + right.weight, left, right, orderCounter++))
+            }
+
+            return HuffmanTree(heap.poll(), weights.size)
+        }
+    }
+
+    // =========================================================================
+    // Encoding helpers
+    // =========================================================================
+
+    /**
+     * Return a `{symbol → bit_string}` map for all symbols in the tree.
+     *
+     * Left edges are `'0'`, right edges are `'1'`.  For a single-symbol tree
+     * the convention is `{symbol → "0"}` (one bit per occurrence).
+     *
+     * Time: O(n) where n = number of distinct symbols.
+     *
+     * ```kotlin
+     * tree.codeTable()[65]  // "0"
+     * tree.codeTable()[66]  // "10"
+     * tree.codeTable()[67]  // "11"
+     * ```
+     */
+    fun codeTable(): Map<Int, String> {
+        val table = mutableMapOf<Int, String>()
+        walkTree(root, "", table)
+        return table
+    }
+
+    /**
+     * Return the bit string for [symbol], or `null` if not in the tree.
+     *
+     * Does NOT build the full code table — traverses only until found.
+     *
+     * Time: O(n) worst case.
+     */
+    fun codeFor(symbol: Int): String? = findCode(root, symbol, "")
+
+    /**
+     * Return canonical Huffman codes (DEFLATE-style).
+     *
+     * Sorted by `(code_length, symbol_value)`; codes assigned numerically.
+     * Allows transmitting only code lengths, not the tree structure.
+     *
+     * Time: O(n log n).
+     */
+    fun canonicalCodeTable(): Map<Int, String> {
+        val lengths = mutableMapOf<Int, Int>()
+        collectLengths(root, 0, lengths)
+
+        // Single-leaf edge case
+        if (lengths.size == 1) {
+            val sym = lengths.keys.first()
+            return mapOf(sym to "0")
+        }
+
+        // Sort by (length, symbol)
+        val sorted = lengths.entries.sortedWith(compareBy({ it.value }, { it.key }))
+
+        val result  = mutableMapOf<Int, String>()
+        var codeVal = 0
+        var prevLen = sorted.first().value
+
+        for ((sym, length) in sorted) {
+            if (length > prevLen) codeVal = codeVal shl (length - prevLen)
+            result[sym] = Integer.toBinaryString(codeVal).padStart(length, '0')
+            codeVal++
+            prevLen = length
+        }
+        return result
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode exactly [count] symbols from a bit string by walking the tree.
+     *
+     * For each symbol: follow the tree from the root, taking the left child
+     * on '0' and the right child on '1', until a leaf is reached.  The leaf's
+     * symbol is appended; the walk restarts at the root.
+     *
+     * For a single-leaf tree, each '0' bit decodes to that symbol.
+     *
+     * Time: O(total bits consumed).
+     *
+     * @throws IllegalArgumentException if the bit stream is exhausted before
+     *                                  [count] symbols are decoded
+     */
+    fun decodeAll(bits: String, count: Int): List<Int> {
+        val result     = mutableListOf<Int>()
+        var current    = root
+        var i          = 0
+        val singleLeaf = root is Leaf
+
+        while (result.size < count) {
+            if (current is Leaf) {
+                result.add(current.symbol)
+                current = root
+                if (singleLeaf && i < bits.length) i++
+                continue
+            }
+
+            if (i >= bits.length) {
+                throw IllegalArgumentException(
+                    "Bit stream exhausted after ${result.size} symbols; expected $count"
+                )
+            }
+
+            val bit = bits[i++]
+            val internal = current as Internal
+            current = if (bit == '0') internal.left else internal.right
+        }
+
+        return result
+    }
+
+    // =========================================================================
+    // Inspection
+    // =========================================================================
+
+    /** Total weight = sum of all leaf frequencies = root weight. O(1). */
+    fun weight(): Int = root.weight
+
+    /** Maximum code length = depth of the deepest leaf. O(n). */
+    fun depth(): Int = maxDepth(root, 0)
+
+    /** Number of distinct symbols. O(1). */
+    fun symbolCount(): Int = symbolCount
+
+    /**
+     * In-order list of `(symbol, code)` pairs (left subtree before right).
+     *
+     * Useful for visualisation and debugging.
+     *
+     * Time: O(n).
+     */
+    fun leavesWithCodes(): List<Pair<Int, String>> {
+        val table  = codeTable()
+        val result = mutableListOf<Pair<Int, String>>()
+        collectLeavesInOrder(root, result, table)
+        return result
+    }
+
+    /**
+     * Check structural invariants:
+     * 1. Every internal node has exactly 2 children (full binary tree).
+     * 2. `weight(internal) == weight(left) + weight(right)`.
+     * 3. No symbol appears in more than one leaf.
+     *
+     * @return true if all invariants hold
+     */
+    fun isValid(): Boolean {
+        val seen = mutableSetOf<Int>()
+        return checkInvariants(root, seen)
+    }
+
+    // =========================================================================
+    // Private helpers — tree walk
+    // =========================================================================
+
+    private fun walkTree(node: Node, prefix: String, table: MutableMap<Int, String>) {
+        when (node) {
+            is Leaf     -> table[node.symbol] = if (prefix.isEmpty()) "0" else prefix
+            is Internal -> {
+                walkTree(node.left,  prefix + "0", table)
+                walkTree(node.right, prefix + "1", table)
+            }
+        }
+    }
+
+    private fun findCode(node: Node, symbol: Int, prefix: String): String? = when (node) {
+        is Leaf     -> if (node.symbol == symbol) (if (prefix.isEmpty()) "0" else prefix) else null
+        is Internal -> findCode(node.left, symbol, prefix + "0")
+                    ?: findCode(node.right, symbol, prefix + "1")
+    }
+
+    private fun collectLengths(node: Node, depth: Int, lengths: MutableMap<Int, Int>) {
+        when (node) {
+            is Leaf     -> lengths[node.symbol] = if (depth > 0) depth else 1
+            is Internal -> {
+                collectLengths(node.left,  depth + 1, lengths)
+                collectLengths(node.right, depth + 1, lengths)
+            }
+        }
+    }
+
+    private fun maxDepth(node: Node, depth: Int): Int = when (node) {
+        is Leaf     -> depth
+        is Internal -> maxOf(maxDepth(node.left, depth + 1), maxDepth(node.right, depth + 1))
+    }
+
+    private fun collectLeavesInOrder(
+        node: Node, result: MutableList<Pair<Int, String>>, table: Map<Int, String>
+    ) {
+        when (node) {
+            is Leaf     -> result.add(node.symbol to table.getValue(node.symbol))
+            is Internal -> {
+                collectLeavesInOrder(node.left,  result, table)
+                collectLeavesInOrder(node.right, result, table)
+            }
+        }
+    }
+
+    private fun checkInvariants(node: Node, seen: MutableSet<Int>): Boolean = when (node) {
+        is Leaf -> {
+            if (node.symbol in seen) false
+            else { seen.add(node.symbol); true }
+        }
+        is Internal -> {
+            if (node.weight != node.left.weight + node.right.weight) false
+            else checkInvariants(node.left, seen) && checkInvariants(node.right, seen)
+        }
+    }
+}

--- a/code/packages/kotlin/huffman-tree/src/test/kotlin/com/codingadventures/huffmantree/HuffmanTreeTest.kt
+++ b/code/packages/kotlin/huffman-tree/src/test/kotlin/com/codingadventures/huffmantree/HuffmanTreeTest.kt
@@ -1,0 +1,363 @@
+package com.codingadventures.huffmantree
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive tests for [HuffmanTree].
+ *
+ * Test organisation:
+ * 1. Construction — empty/zero-freq errors, single, two, three symbols
+ * 2. Code table — prefix-free property, single-symbol convention
+ * 3. codeFor — hit, miss, single-symbol
+ * 4. Canonical code table — AAABBC example, same lengths as regular, prefix-free
+ * 5. Encode/decode round-trips — single, three symbols, all 256 bytes
+ * 6. decodeAll error — exhausted bit stream
+ * 7. Inspection — weight, depth, symbolCount, leavesWithCodes
+ * 8. Tie-breaking determinism
+ * 9. isValid
+ */
+class HuffmanTreeTest {
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun build(vararg pairs: Int): HuffmanTree {
+        val weights = (pairs.indices step 2).map { i ->
+            intArrayOf(pairs[i], pairs[i + 1])
+        }
+        return HuffmanTree.build(weights)
+    }
+
+    // =========================================================================
+    // 1. Construction
+    // =========================================================================
+
+    @Test
+    @DisplayName("build() from empty list throws")
+    fun buildEmptyThrows() {
+        var threw = false
+        try { HuffmanTree.build(emptyList()) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("build() with zero frequency throws")
+    fun buildZeroFreqThrows() {
+        var threw = false
+        try { build(65, 0) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("build() with negative frequency throws")
+    fun buildNegativeFreqThrows() {
+        var threw = false
+        try { build(65, -1) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    @Test
+    @DisplayName("Single symbol: symbolCount=1, weight=freq")
+    fun singleSymbol() {
+        val tree = build(65, 5)
+        assertEquals(1, tree.symbolCount())
+        assertEquals(5, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Two symbols: symbolCount=2, weight=sum of freqs")
+    fun twoSymbols() {
+        val tree = build(65, 3, 66, 1)
+        assertEquals(2, tree.symbolCount())
+        assertEquals(4, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Three symbols AAABBC: symbolCount=3, weight=6")
+    fun threeSymbols() {
+        val tree = build(65, 3, 66, 2, 67, 1)
+        assertEquals(3, tree.symbolCount())
+        assertEquals(6, tree.weight())
+    }
+
+    @Test
+    @DisplayName("isValid() is true after build")
+    fun isValidAfterBuild() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid())
+    }
+
+    @Test
+    @DisplayName("Large alphabet (256 symbols) builds and is valid")
+    fun largeAlphabet() {
+        val weights = (0 until 256).map { i -> intArrayOf(i, i + 1) }
+        val tree = HuffmanTree.build(weights)
+        assertEquals(256, tree.symbolCount())
+        assertTrue(tree.isValid())
+    }
+
+    // =========================================================================
+    // 2. Code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC: A gets shortest code (highest frequency)")
+    fun codeTableAAABBCFrequencies() {
+        val tree  = build(65, 3, 66, 2, 67, 1)
+        val table = tree.codeTable()
+        assertTrue(table.getValue(65).length < table.getValue(66).length)
+        assertTrue(table.getValue(66).length <= table.getValue(67).length)
+    }
+
+    @Test
+    @DisplayName("Single symbol: code is \"0\"")
+    fun codeTableSingleSymbol() {
+        assertEquals("0", build(65, 1).codeTable()[65])
+    }
+
+    @Test
+    @DisplayName("All codes are prefix-free (10 symbols)")
+    fun codeTablePrefixFree() {
+        val weights = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        val table   = HuffmanTree.build(weights).codeTable()
+        val codes   = table.values.toList()
+        for (i in codes.indices) {
+            for (j in codes.indices) {
+                if (i != j) assertFalse(codes[i].startsWith(codes[j]),
+                    "${codes[i]} starts with ${codes[j]}")
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("codeTable contains an entry for every symbol")
+    fun codeTableContainsAllSymbols() {
+        val table = build(65, 3, 66, 2, 67, 1).codeTable()
+        assertTrue(table.containsKey(65))
+        assertTrue(table.containsKey(66))
+        assertTrue(table.containsKey(67))
+    }
+
+    // =========================================================================
+    // 3. codeFor
+    // =========================================================================
+
+    @Test
+    @DisplayName("codeFor matches codeTable for each symbol")
+    fun codeForMatchesTable() {
+        val tree  = build(65, 3, 66, 2, 67, 1)
+        val table = tree.codeTable()
+        assertEquals(table[65], tree.codeFor(65))
+        assertEquals(table[66], tree.codeFor(66))
+        assertEquals(table[67], tree.codeFor(67))
+    }
+
+    @Test
+    @DisplayName("codeFor returns null for absent symbol")
+    fun codeForMissing() {
+        assertNull(build(65, 3, 66, 2).codeFor(99))
+    }
+
+    @Test
+    @DisplayName("codeFor single symbol returns \"0\"")
+    fun codeForSingleSymbol() {
+        assertEquals("0", build(65, 5).codeFor(65))
+    }
+
+    // =========================================================================
+    // 4. Canonical code table
+    // =========================================================================
+
+    @Test
+    @DisplayName("AAABBC canonical: A→\"0\", B→\"10\", C→\"11\"")
+    fun canonicalAAABBC() {
+        val canonical = build(65, 3, 66, 2, 67, 1).canonicalCodeTable()
+        assertEquals("0",  canonical[65])
+        assertEquals("10", canonical[66])
+        assertEquals("11", canonical[67])
+    }
+
+    @Test
+    @DisplayName("Canonical code lengths match regular code lengths (8 symbols)")
+    fun canonicalLengthsMatchRegular() {
+        val weights   = (0 until 8).map { i -> intArrayOf(i, i + 1) }
+        val tree      = HuffmanTree.build(weights)
+        val regular   = tree.codeTable()
+        val canonical = tree.canonicalCodeTable()
+        for (sym in regular.keys) {
+            assertEquals(regular.getValue(sym).length, canonical.getValue(sym).length,
+                "Length mismatch for symbol $sym")
+        }
+    }
+
+    @Test
+    @DisplayName("Canonical single symbol returns {sym → \"0\"}")
+    fun canonicalSingleSymbol() {
+        assertEquals("0", build(65, 5).canonicalCodeTable()[65])
+    }
+
+    @Test
+    @DisplayName("Canonical codes are prefix-free (10 symbols)")
+    fun canonicalPrefixFree() {
+        val weights   = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        val canonical = HuffmanTree.build(weights).canonicalCodeTable()
+        val codes     = canonical.values.toList()
+        for (i in codes.indices) {
+            for (j in codes.indices) {
+                if (i != j) assertFalse(codes[i].startsWith(codes[j]))
+            }
+        }
+    }
+
+    // =========================================================================
+    // 5. Encode / decode round-trips
+    // =========================================================================
+
+    @Test
+    @DisplayName("Single-symbol round-trip: [A,A,A]")
+    fun roundTripSingleSymbol() {
+        val tree  = build(65, 5)
+        val code  = tree.codeTable().getValue(65)
+        val bits  = code + code + code
+        assertEquals(listOf(65, 65, 65), tree.decodeAll(bits, 3))
+    }
+
+    @Test
+    @DisplayName("AAABBC round-trip: encode then decode")
+    fun roundTripAAABBC() {
+        val symbols = listOf(65, 65, 65, 66, 66, 67)
+        val tree    = build(65, 3, 66, 2, 67, 1)
+        val table   = tree.codeTable()
+        val bits    = symbols.joinToString("") { table.getValue(it) }
+        assertEquals(symbols, tree.decodeAll(bits, symbols.size))
+    }
+
+    @Test
+    @DisplayName("All 256 byte values round-trip")
+    fun roundTripAllBytes() {
+        val weights  = (0 until 256).map { i -> intArrayOf(i, i + 1) }
+        val tree     = HuffmanTree.build(weights)
+        val table    = tree.codeTable()
+        val symbols  = (0 until 256).toList()
+        val bits     = symbols.joinToString("") { table.getValue(it) }
+        assertEquals(symbols, tree.decodeAll(bits, 256))
+    }
+
+    @Test
+    @DisplayName("decodeAll throws when bit stream exhausted")
+    fun decodeExhausted() {
+        val tree   = build(65, 3, 66, 2, 67, 1)
+        var threw  = false
+        try { tree.decodeAll("0", 5) } catch (e: IllegalArgumentException) { threw = true }
+        assertTrue(threw)
+    }
+
+    // =========================================================================
+    // 6. Inspection
+    // =========================================================================
+
+    @Test
+    @DisplayName("weight() returns sum of all frequencies")
+    fun weightSum() {
+        assertEquals(6, build(65, 3, 66, 2, 67, 1).weight())
+    }
+
+    @Test
+    @DisplayName("depth() of single-symbol tree is 0")
+    fun depthSingleSymbol() {
+        assertEquals(0, build(65, 1).depth())
+    }
+
+    @Test
+    @DisplayName("depth() of two-symbol tree is 1")
+    fun depthTwoSymbols() {
+        assertEquals(1, build(65, 3, 66, 1).depth())
+    }
+
+    @Test
+    @DisplayName("depth() of AAABBC tree is 2")
+    fun depthThreeSymbols() {
+        assertEquals(2, build(65, 3, 66, 2, 67, 1).depth())
+    }
+
+    @Test
+    @DisplayName("symbolCount() returns number of distinct symbols")
+    fun symbolCountBasic() {
+        val weights = (0 until 10).map { i -> intArrayOf(i, i + 1) }
+        assertEquals(10, HuffmanTree.build(weights).symbolCount())
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() single symbol returns [(65, \"0\")]")
+    fun leavesWithCodesSingle() {
+        val leaves = build(65, 5).leavesWithCodes()
+        assertEquals(1, leaves.size)
+        assertEquals(65,  leaves[0].first)
+        assertEquals("0", leaves[0].second)
+    }
+
+    @Test
+    @DisplayName("leavesWithCodes() contains all symbols in AAABBC tree")
+    fun leavesWithCodesThreeSymbols() {
+        val tree   = build(65, 3, 66, 2, 67, 1)
+        val leaves = tree.leavesWithCodes()
+        assertEquals(3, leaves.size)
+        val syms = leaves.map { it.first }.toSet()
+        assertTrue(65 in syms)
+        assertTrue(66 in syms)
+        assertTrue(67 in syms)
+    }
+
+    // =========================================================================
+    // 7. Tie-breaking determinism
+    // =========================================================================
+
+    @Test
+    @DisplayName("Equal-weight alphabet is structurally valid")
+    fun equalWeightsValid() {
+        val tree = build(65, 1, 66, 1, 67, 1, 68, 1)
+        assertTrue(tree.isValid())
+        assertEquals(4, tree.symbolCount())
+        assertEquals(4, tree.weight())
+    }
+
+    @Test
+    @DisplayName("Same input always produces same code table")
+    fun equalWeightsDeterministic() {
+        val weights = (0 until 8).map { i -> intArrayOf(i, 1) }
+        val t1 = HuffmanTree.build(weights.map { it.clone() })
+        val t2 = HuffmanTree.build(weights.map { it.clone() })
+        assertEquals(t1.codeTable(), t2.codeTable())
+    }
+
+    @Test
+    @DisplayName("Two equal-weight leaves: lower symbol (65) gets code '0' (left branch)")
+    fun equalWeightsLowerSymbolLeft() {
+        val table = build(65, 1, 66, 1).codeTable()
+        assertEquals(1, table.getValue(65).length)
+        assertEquals(1, table.getValue(66).length)
+    }
+
+    // =========================================================================
+    // 8. isValid
+    // =========================================================================
+
+    @Test
+    @DisplayName("isValid() is true for a well-formed tree")
+    fun isValidTrue() {
+        assertTrue(build(65, 3, 66, 2, 67, 1).isValid())
+    }
+
+    @Test
+    @DisplayName("isValid() is true for large tree (50 symbols)")
+    fun isValidLarge() {
+        val weights = (0 until 50).map { i -> intArrayOf(i, i + 1) }
+        assertTrue(HuffmanTree.build(weights).isValid())
+    }
+}


### PR DESCRIPTION
## Summary

- **java/huffman-tree (DT27)**: Greedy min-heap Huffman tree. `codeTable()`, `codeFor()`, `canonicalCodeTable()` (DEFLATE-style), `decodeAll()`, `weight()`, `depth()`, `symbolCount()`, `leavesWithCodes()`, `isValid()`. Deterministic tie-breaking: weight → leaf-before-internal → symbol → insertion order. 36 tests pass.
- **kotlin/huffman-tree (DT27)**: Idiomatic Kotlin port using sealed class hierarchy (`Node`, `Leaf`, `Internal`), exhaustive `when` pattern matching. 35 tests pass.
- **java/huffman-compression (CMP04)**: Entropy coder using DT27. CMP04 wire format: `original_length(4B) + symbol_count(4B) + N×[symbol,length](2B) + LSB-first bit stream`. Composite Gradle build on `../huffman-tree`. 45 tests pass.
- **kotlin/huffman-compression (CMP04)**: Idiomatic Kotlin port using `buildString{}`, `sortedWith(compareBy{})`, `padStart()`, `HashMap<String,Int>` for decode lookup. 45 tests pass.

## Test plan

- [ ] Java/huffman-tree: 36 tests (construction, code table, canonical codes, decode, tie-breaking, isValid)
- [ ] Kotlin/huffman-tree: 35 tests (same coverage via sealed class when-matching)
- [ ] Java/huffman-compression: 45 tests (round-trip, wire format exact bytes, edge cases, effectiveness, determinism, error handling)
- [ ] Kotlin/huffman-compression: 45 tests (mirrors Java suite)
- [ ] All packages include BUILD, BUILD_windows, build.gradle.kts, settings.gradle.kts, README.md, CHANGELOG.md
- [ ] Security review passed — pure in-memory library, no I/O or crypto

🤖 Generated with [Claude Code](https://claude.com/claude-code)