### PR TITLE
feat(parity): add dotnet vigenere cipher packages

### DIFF
--- a/code/packages/csharp/vigenere-cipher/BUILD
+++ b/code/packages/csharp/vigenere-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vigenere-cipher/BUILD
+++ b/code/packages/csharp/vigenere-cipher/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet .dotnet/tmp .artifacts && TMPDIR="$PWD/.dotnet/tmp" HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vigenere-cipher/BUILD_windows
+++ b/code/packages/csharp/vigenere-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vigenere-cipher/BUILD_windows
+++ b/code/packages/csharp/vigenere-cipher/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vigenere-cipher/CHANGELOG.md
+++ b/code/packages/csharp/vigenere-cipher/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# implementation of the Vigenere cipher and basic cryptanalysis helpers.

--- a/code/packages/csharp/vigenere-cipher/CodingAdventures.VigenereCipher.csproj
+++ b/code/packages/csharp/vigenere-cipher/CodingAdventures.VigenereCipher.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VigenereCipher.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Vigenere cipher with key recovery helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vigenere-cipher/README.md
+++ b/code/packages/csharp/vigenere-cipher/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.VigenereCipher.CSharp
+
+Vigenere cipher helpers for encrypting, decrypting, estimating key length,
+recovering keys with frequency analysis, and breaking sufficiently long
+ciphertexts.

--- a/code/packages/csharp/vigenere-cipher/VigenereCipher.cs
+++ b/code/packages/csharp/vigenere-cipher/VigenereCipher.cs
@@ -1,0 +1,314 @@
+using System.Text;
+
+namespace CodingAdventures.VigenereCipher;
+
+/// <summary>
+/// Result from ciphertext-only Vigenere analysis.
+/// </summary>
+public readonly record struct BreakResult(string Key, string Plaintext);
+
+/// <summary>
+/// Encrypt, decrypt, and analyze Vigenere ciphers.
+/// </summary>
+public static class VigenereCipher
+{
+    private static readonly double[] EnglishFrequenciesStorage =
+    [
+        0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228, 0.02015,
+        0.06094, 0.06966, 0.00153, 0.00772, 0.04025, 0.02406, 0.06749,
+        0.07507, 0.01929, 0.00095, 0.05987, 0.06327, 0.09056, 0.02758,
+        0.00978, 0.02360, 0.00150, 0.01974, 0.00074,
+    ];
+
+    /// <summary>
+    /// Expected English letter frequencies for A through Z.
+    /// </summary>
+    public static IReadOnlyList<double> EnglishFrequencies => EnglishFrequenciesStorage;
+
+    private static bool IsAsciiLetter(char ch) => ch is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+
+    private static string ValidateKey(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("Key must not be empty.", nameof(key));
+        }
+
+        var normalized = key.ToUpperInvariant();
+        foreach (var ch in normalized)
+        {
+            if (ch is < 'A' or > 'Z')
+            {
+                throw new ArgumentException("Key must contain only ASCII letters.", nameof(key));
+            }
+        }
+
+        return normalized;
+    }
+
+    private static StringBuilder ExtractAlphaUpper(string text)
+    {
+        var letters = new StringBuilder(text.Length);
+        foreach (var ch in text)
+        {
+            if (IsAsciiLetter(ch))
+            {
+                letters.Append(char.ToUpperInvariant(ch));
+            }
+        }
+
+        return letters;
+    }
+
+    private static string Transform(string text, string key, int direction)
+    {
+        var normalizedKey = ValidateKey(key);
+        var builder = new StringBuilder(text.Length);
+        var keyIndex = 0;
+
+        foreach (var ch in text)
+        {
+            if (ch is >= 'A' and <= 'Z')
+            {
+                var shift = direction * (normalizedKey[keyIndex % normalizedKey.Length] - 'A');
+                builder.Append((char)('A' + (ch - 'A' + shift + 26) % 26));
+                keyIndex++;
+            }
+            else if (ch is >= 'a' and <= 'z')
+            {
+                var shift = direction * (normalizedKey[keyIndex % normalizedKey.Length] - 'A');
+                builder.Append((char)('a' + (ch - 'a' + shift + 26) % 26));
+                keyIndex++;
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Encrypt plaintext using the Vigenere cipher.
+    /// </summary>
+    public static string Encrypt(string plaintext, string key)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        return Transform(plaintext, key, 1);
+    }
+
+    /// <summary>
+    /// Decrypt ciphertext using the Vigenere cipher.
+    /// </summary>
+    public static string Decrypt(string ciphertext, string key)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+        return Transform(ciphertext, key, -1);
+    }
+
+    private static double IndexOfCoincidence(int[] counts, int total)
+    {
+        if (total < 2)
+        {
+            return 0.0;
+        }
+
+        var numerator = 0L;
+        foreach (var count in counts)
+        {
+            numerator += (long)count * (count - 1);
+        }
+
+        return (double)numerator / ((long)total * (total - 1));
+    }
+
+    /// <summary>
+    /// Estimate the key length by averaging the index of coincidence for
+    /// candidate key-position groups.
+    /// </summary>
+    public static int FindKeyLength(string ciphertext, int maxLength = 20)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var letters = ExtractAlphaUpper(ciphertext);
+        if (letters.Length < 2)
+        {
+            return 1;
+        }
+
+        var limit = Math.Min(maxLength, letters.Length / 2);
+        if (limit < 2)
+        {
+            return 1;
+        }
+
+        var averageIcs = new double[limit + 1];
+        var bestAverageIc = 0.0;
+
+        for (var length = 2; length <= limit; length++)
+        {
+            var totalIc = 0.0;
+            var validGroups = 0;
+
+            for (var group = 0; group < length; group++)
+            {
+                var counts = new int[26];
+                var groupLength = 0;
+                for (var position = group; position < letters.Length; position += length)
+                {
+                    counts[letters[position] - 'A']++;
+                    groupLength++;
+                }
+
+                if (groupLength > 1)
+                {
+                    totalIc += IndexOfCoincidence(counts, groupLength);
+                    validGroups++;
+                }
+            }
+
+            if (validGroups > 0)
+            {
+                averageIcs[length] = totalIc / validGroups;
+                bestAverageIc = Math.Max(bestAverageIc, averageIcs[length]);
+            }
+        }
+
+        if (bestAverageIc <= 0.0)
+        {
+            return 1;
+        }
+
+        var threshold = bestAverageIc * 0.90;
+        var candidates = new List<int>();
+        for (var length = 2; length <= limit; length++)
+        {
+            if (averageIcs[length] >= threshold)
+            {
+                candidates.Add(length);
+            }
+        }
+
+        foreach (var smaller in candidates.ToArray())
+        {
+            candidates.RemoveAll(candidate => candidate != smaller && candidate % smaller == 0);
+        }
+
+        return candidates.Count == 0 ? 1 : candidates[0];
+    }
+
+    private static double ChiSquared(int[] counts, int total)
+    {
+        if (total == 0)
+        {
+            return double.PositiveInfinity;
+        }
+
+        var sum = 0.0;
+        for (var i = 0; i < 26; i++)
+        {
+            var expected = total * EnglishFrequenciesStorage[i];
+            var difference = counts[i] - expected;
+            sum += difference * difference / expected;
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Recover the uppercase key for a known key length using chi-squared
+    /// frequency analysis.
+    /// </summary>
+    public static string FindKey(string ciphertext, int keyLength)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+        if (keyLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keyLength), "Key length must be positive.");
+        }
+
+        var letters = ExtractAlphaUpper(ciphertext);
+        var key = new char[keyLength];
+
+        for (var group = 0; group < keyLength; group++)
+        {
+            var groupLetters = new List<char>();
+            for (var position = group; position < letters.Length; position += keyLength)
+            {
+                groupLetters.Add(letters[position]);
+            }
+
+            if (groupLetters.Count == 0)
+            {
+                key[group] = 'A';
+                continue;
+            }
+
+            var bestShift = 0;
+            var bestScore = double.PositiveInfinity;
+            for (var shift = 0; shift < 26; shift++)
+            {
+                var counts = new int[26];
+                foreach (var ch in groupLetters)
+                {
+                    var decrypted = (ch - 'A' + 26 - shift) % 26;
+                    counts[decrypted]++;
+                }
+
+                var score = ChiSquared(counts, groupLetters.Count);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    bestShift = shift;
+                }
+            }
+
+            key[group] = (char)('A' + bestShift);
+        }
+
+        return MinimalPeriod(new string(key));
+    }
+
+    private static string MinimalPeriod(string key)
+    {
+        for (var period = 1; period <= key.Length / 2; period++)
+        {
+            if (key.Length % period != 0)
+            {
+                continue;
+            }
+
+            var repeated = true;
+            for (var i = period; i < key.Length; i++)
+            {
+                if (key[i] != key[i % period])
+                {
+                    repeated = false;
+                    break;
+                }
+            }
+
+            if (repeated)
+            {
+                return key[..period];
+            }
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Estimate the key, then decrypt the ciphertext.
+    /// </summary>
+    public static BreakResult BreakCipher(string ciphertext)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var keyLength = FindKeyLength(ciphertext);
+        var key = FindKey(ciphertext, keyLength);
+        return new BreakResult(key, Decrypt(ciphertext, key));
+    }
+}

--- a/code/packages/csharp/vigenere-cipher/required_capabilities.json
+++ b/code/packages/csharp/vigenere-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/vigenere-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj
+++ b/code/packages/csharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.VigenereCipher.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/VigenereCipherTests.cs
+++ b/code/packages/csharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/VigenereCipherTests.cs
@@ -1,0 +1,97 @@
+namespace CodingAdventures.VigenereCipher.Tests;
+
+public sealed class VigenereCipherTests
+{
+    private const string LongEnglishText =
+        "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+        "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+        "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+        "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS. " +
+        "CHARLES BABBAGE BROKE THE CIPHER IN THE EIGHTEEN FIFTIES USING THE INDEX.";
+
+    [Fact]
+    public void EncryptAndDecryptKnownVectors()
+    {
+        Assert.Equal("LXFOPVEFRNHR", VigenereCipher.Encrypt("ATTACKATDAWN", "LEMON"));
+        Assert.Equal("ATTACKATDAWN", VigenereCipher.Decrypt("LXFOPVEFRNHR", "LEMON"));
+        Assert.Equal("Rijvs, Uyvjn!", VigenereCipher.Encrypt("Hello, World!", "key"));
+        Assert.Equal("Hello, World!", VigenereCipher.Decrypt("Rijvs, Uyvjn!", "key"));
+    }
+
+    [Fact]
+    public void EncryptPreservesCaseAndPunctuation()
+    {
+        Assert.Equal("A B", VigenereCipher.Encrypt("A A", "AB"));
+        Assert.Equal("123 !@#", VigenereCipher.Encrypt("123 !@#", "key"));
+        Assert.Equal("Cafe\u0301 costs $3.50", VigenereCipher.Decrypt(VigenereCipher.Encrypt("Cafe\u0301 costs $3.50", "KEY"), "KEY"));
+        Assert.Equal("Hj", VigenereCipher.Encrypt("Hi", "ABCDEFGHIJ"));
+    }
+
+    [Fact]
+    public void RoundTripsAcrossKeys()
+    {
+        var texts = new[]
+        {
+            "ATTACKATDAWN",
+            "Hello, World!",
+            "The quick brown fox jumps over the lazy dog.",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "",
+        };
+        var keys = new[] { "KEY", "LEMON", "A", "SECRETKEY", "MiXeD" };
+
+        foreach (var text in texts)
+        {
+            foreach (var key in keys)
+            {
+                Assert.Equal(text, VigenereCipher.Decrypt(VigenereCipher.Encrypt(text, key), key));
+            }
+        }
+    }
+
+    [Fact]
+    public void InvalidKeysAreRejected()
+    {
+        Assert.Throws<ArgumentException>(() => VigenereCipher.Encrypt("hello", ""));
+        Assert.Throws<ArgumentException>(() => VigenereCipher.Encrypt("hello", "key1"));
+        Assert.Throws<ArgumentException>(() => VigenereCipher.Decrypt("hello", "ke y"));
+        Assert.Throws<ArgumentNullException>(() => VigenereCipher.Encrypt("hello", null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => VigenereCipher.FindKey("ABC", 0));
+    }
+
+    [Fact]
+    public void FindsKeyLengths()
+    {
+        Assert.Equal(1, VigenereCipher.FindKeyLength("A"));
+        Assert.Equal(5, VigenereCipher.FindKeyLength(VigenereCipher.Encrypt(LongEnglishText, "LEMON")));
+        Assert.Equal(3, VigenereCipher.FindKeyLength(VigenereCipher.Encrypt(LongEnglishText, "KEY")));
+    }
+
+    [Fact]
+    public void RecoversKeys()
+    {
+        Assert.Equal("LEMON", VigenereCipher.FindKey(VigenereCipher.Encrypt(LongEnglishText, "LEMON"), 5));
+        Assert.Equal("KEY", VigenereCipher.FindKey(VigenereCipher.Encrypt(LongEnglishText, "KEY"), 3));
+        var lowSignalKey = VigenereCipher.FindKey("A", 2);
+        Assert.Equal(2, lowSignalKey.Length);
+        Assert.EndsWith("A", lowSignalKey);
+    }
+
+    [Fact]
+    public void BreakCipherRecoversKeyAndPlaintext()
+    {
+        var ciphertext = VigenereCipher.Encrypt(LongEnglishText, "LEMON");
+        var result = VigenereCipher.BreakCipher(ciphertext);
+
+        Assert.Equal("LEMON", result.Key);
+        Assert.Equal(LongEnglishText, result.Plaintext);
+    }
+
+    [Fact]
+    public void EnglishFrequenciesMatchExpectations()
+    {
+        Assert.Equal(26, VigenereCipher.EnglishFrequencies.Count);
+        Assert.InRange(VigenereCipher.EnglishFrequencies.Sum(), 0.99, 1.01);
+        Assert.True(VigenereCipher.EnglishFrequencies[4] > VigenereCipher.EnglishFrequencies[25]);
+    }
+}

--- a/code/packages/fsharp/vigenere-cipher/BUILD
+++ b/code/packages/fsharp/vigenere-cipher/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet .dotnet/tmp .artifacts && TMPDIR="$PWD/.dotnet/tmp" HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vigenere-cipher/BUILD
+++ b/code/packages/fsharp/vigenere-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vigenere-cipher/BUILD_windows
+++ b/code/packages/fsharp/vigenere-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vigenere-cipher/BUILD_windows
+++ b/code/packages/fsharp/vigenere-cipher/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vigenere-cipher/CHANGELOG.md
+++ b/code/packages/fsharp/vigenere-cipher/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# implementation of the Vigenere cipher and basic cryptanalysis helpers.

--- a/code/packages/fsharp/vigenere-cipher/CodingAdventures.VigenereCipher.fsproj
+++ b/code/packages/fsharp/vigenere-cipher/CodingAdventures.VigenereCipher.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VigenereCipher.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Vigenere cipher with key recovery helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="VigenereCipher.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vigenere-cipher/README.md
+++ b/code/packages/fsharp/vigenere-cipher/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.VigenereCipher.FSharp
+
+Vigenere cipher helpers for encrypting, decrypting, estimating key length,
+recovering keys with frequency analysis, and breaking sufficiently long
+ciphertexts.

--- a/code/packages/fsharp/vigenere-cipher/VigenereCipher.fs
+++ b/code/packages/fsharp/vigenere-cipher/VigenereCipher.fs
@@ -1,0 +1,240 @@
+namespace CodingAdventures.VigenereCipher
+
+open System
+open System.Text
+
+type BreakResult = {
+    Key: string
+    Plaintext: string
+}
+
+/// Vigenere cipher helpers and basic ciphertext-only analysis.
+[<RequireQualifiedAccess>]
+module VigenereCipher =
+    let englishFrequencies =
+        [|
+            0.08167; 0.01492; 0.02782; 0.04253; 0.12702; 0.02228; 0.02015
+            0.06094; 0.06966; 0.00153; 0.00772; 0.04025; 0.02406; 0.06749
+            0.07507; 0.01929; 0.00095; 0.05987; 0.06327; 0.09056; 0.02758
+            0.00978; 0.02360; 0.00150; 0.01974; 0.00074
+        |]
+
+    let private isAsciiLetter (ch: char) =
+        (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+
+    let private validateKey (key: string) =
+        if isNull key then
+            nullArg (nameof key)
+
+        if key.Length = 0 then
+            invalidArg (nameof key) "Key must not be empty."
+
+        let normalized = key.ToUpperInvariant()
+
+        for ch in normalized do
+            if ch < 'A' || ch > 'Z' then
+                invalidArg (nameof key) "Key must contain only ASCII letters."
+
+        normalized
+
+    let private transform (text: string) (key: string) direction =
+        let normalizedKey = validateKey key
+        let builder = StringBuilder(text.Length)
+        let mutable keyIndex = 0
+
+        for ch in text do
+            if ch >= 'A' && ch <= 'Z' then
+                let shift = direction * (int normalizedKey[keyIndex % normalizedKey.Length] - int 'A')
+                let shifted = int 'A' + (int ch - int 'A' + shift + 26) % 26
+                builder.Append(char shifted) |> ignore
+                keyIndex <- keyIndex + 1
+            elif ch >= 'a' && ch <= 'z' then
+                let shift = direction * (int normalizedKey[keyIndex % normalizedKey.Length] - int 'A')
+                let shifted = int 'a' + (int ch - int 'a' + shift + 26) % 26
+                builder.Append(char shifted) |> ignore
+                keyIndex <- keyIndex + 1
+            else
+                builder.Append(ch) |> ignore
+
+        builder.ToString()
+
+    let encrypt (plaintext: string) (key: string) =
+        if isNull plaintext then
+            nullArg (nameof plaintext)
+
+        transform plaintext key 1
+
+    let decrypt (ciphertext: string) (key: string) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        transform ciphertext key -1
+
+    let private extractAlphaUpper (text: string) =
+        let builder = StringBuilder(text.Length)
+
+        for ch in text do
+            if isAsciiLetter ch then
+                builder.Append(Char.ToUpperInvariant(ch)) |> ignore
+
+        builder.ToString()
+
+    let private indexOfCoincidence (counts: int array) total =
+        if total < 2 then
+            0.0
+        else
+            let numerator =
+                counts
+                |> Array.sumBy (fun count -> int64 count * int64 (count - 1))
+
+            float numerator / float (int64 total * int64 (total - 1))
+
+    let findKeyLength (ciphertext: string) (maxLength: int) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        let letters = extractAlphaUpper ciphertext
+
+        if letters.Length < 2 then
+            1
+        else
+            let limit = min maxLength (letters.Length / 2)
+
+            if limit < 2 then
+                1
+            else
+                let averageIcs = Array.zeroCreate<float> (limit + 1)
+                let mutable bestAverageIc = 0.0
+
+                for length in 2 .. limit do
+                    let mutable totalIc = 0.0
+                    let mutable validGroups = 0
+
+                    for group in 0 .. length - 1 do
+                        let counts = Array.zeroCreate<int> 26
+                        let mutable groupLength = 0
+                        let mutable position = group
+
+                        while position < letters.Length do
+                            let index = int letters[position] - int 'A'
+                            counts[index] <- counts[index] + 1
+                            groupLength <- groupLength + 1
+                            position <- position + length
+
+                        if groupLength > 1 then
+                            totalIc <- totalIc + indexOfCoincidence counts groupLength
+                            validGroups <- validGroups + 1
+
+                    if validGroups > 0 then
+                        averageIcs[length] <- totalIc / float validGroups
+                        bestAverageIc <- max bestAverageIc averageIcs[length]
+
+                if bestAverageIc <= 0.0 then
+                    1
+                else
+                    let threshold = bestAverageIc * 0.90
+
+                    let candidates =
+                        [ for length in 2 .. limit do
+                            if averageIcs[length] >= threshold then
+                                length ]
+                        |> ResizeArray
+
+                    for smaller in List.ofSeq candidates do
+                        candidates.RemoveAll(fun candidate -> candidate <> smaller && candidate % smaller = 0)
+                        |> ignore
+
+                    if candidates.Count = 0 then 1 else candidates[0]
+
+    let findKeyLengthDefault (ciphertext: string) =
+        findKeyLength ciphertext 20
+
+    let private chiSquared (counts: int array) total =
+        if total = 0 then
+            Double.PositiveInfinity
+        else
+            let mutable sum = 0.0
+
+            for i in 0 .. 25 do
+                let expected = float total * englishFrequencies[i]
+                let difference = float counts[i] - expected
+                sum <- sum + difference * difference / expected
+
+            sum
+
+    let private minimalPeriod (key: string) =
+        let mutable result = key
+        let mutable found = false
+        let mutable period = 1
+
+        while not found && period <= key.Length / 2 do
+            if key.Length % period = 0 then
+                let mutable repeated = true
+                let mutable index = period
+
+                while repeated && index < key.Length do
+                    if key[index] <> key[index % period] then
+                        repeated <- false
+
+                    index <- index + 1
+
+                if repeated then
+                    result <- key.Substring(0, period)
+                    found <- true
+
+            period <- period + 1
+
+        result
+
+    let findKey (ciphertext: string) (keyLength: int) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        if keyLength <= 0 then
+            invalidArg (nameof keyLength) "Key length must be positive."
+
+        let letters = extractAlphaUpper ciphertext
+        let key = Array.zeroCreate<char> keyLength
+
+        for group in 0 .. keyLength - 1 do
+            let groupLetters = ResizeArray<char>()
+            let mutable position = group
+
+            while position < letters.Length do
+                groupLetters.Add(letters[position])
+                position <- position + keyLength
+
+            if groupLetters.Count = 0 then
+                key[group] <- 'A'
+            else
+                let mutable bestShift = 0
+                let mutable bestScore = Double.PositiveInfinity
+
+                for shift in 0 .. 25 do
+                    let counts = Array.zeroCreate<int> 26
+
+                    for ch in groupLetters do
+                        let decrypted = (int ch - int 'A' + 26 - shift) % 26
+                        counts[decrypted] <- counts[decrypted] + 1
+
+                    let score = chiSquared counts groupLetters.Count
+
+                    if score < bestScore then
+                        bestScore <- score
+                        bestShift <- shift
+
+                key[group] <- char (int 'A' + bestShift)
+
+        new string(key) |> minimalPeriod
+
+    let breakCipher (ciphertext: string) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        let keyLength = findKeyLengthDefault ciphertext
+        let key = findKey ciphertext keyLength
+
+        {
+            Key = key
+            Plaintext = decrypt ciphertext key
+        }

--- a/code/packages/fsharp/vigenere-cipher/required_capabilities.json
+++ b/code/packages/fsharp/vigenere-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/vigenere-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj
+++ b/code/packages/fsharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/CodingAdventures.VigenereCipher.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.VigenereCipher.fsproj" />
+    <Compile Include="VigenereCipherTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/VigenereCipherTests.fs
+++ b/code/packages/fsharp/vigenere-cipher/tests/CodingAdventures.VigenereCipher.Tests/VigenereCipherTests.fs
@@ -1,0 +1,83 @@
+namespace CodingAdventures.VigenereCipher.Tests
+
+open System
+open Xunit
+open CodingAdventures.VigenereCipher
+
+type VigenereCipherTests() =
+    let longEnglishText =
+        "THE ART OF ENCIPHERING AND DECIPHERING MESSAGES HAS A LONG AND STORIED " +
+        "HISTORY STRETCHING BACK TO ANCIENT TIMES. THE SPARTANS USED THE SCYTALE, " +
+        "JULIUS CAESAR USED A SIMPLE SHIFT CIPHER, AND DURING THE RENAISSANCE THE " +
+        "VIGENERE CIPHER WAS CONSIDERED UNBREAKABLE FOR NEARLY THREE HUNDRED YEARS. " +
+        "CHARLES BABBAGE BROKE THE CIPHER IN THE EIGHTEEN FIFTIES USING THE INDEX."
+
+    [<Fact>]
+    member _.``Encrypt and decrypt known vectors``() =
+        Assert.Equal("LXFOPVEFRNHR", VigenereCipher.encrypt "ATTACKATDAWN" "LEMON")
+        Assert.Equal("ATTACKATDAWN", VigenereCipher.decrypt "LXFOPVEFRNHR" "LEMON")
+        Assert.Equal("Rijvs, Uyvjn!", VigenereCipher.encrypt "Hello, World!" "key")
+        Assert.Equal("Hello, World!", VigenereCipher.decrypt "Rijvs, Uyvjn!" "key")
+
+    [<Fact>]
+    member _.``Encrypt preserves case and punctuation``() =
+        Assert.Equal("A B", VigenereCipher.encrypt "A A" "AB")
+        Assert.Equal("123 !@#", VigenereCipher.encrypt "123 !@#" "key")
+
+        let original = "Cafe\u0301 costs $3.50"
+        let encrypted = VigenereCipher.encrypt original "KEY"
+        Assert.Equal(original, VigenereCipher.decrypt encrypted "KEY")
+        Assert.Equal("Hj", VigenereCipher.encrypt "Hi" "ABCDEFGHIJ")
+
+    [<Fact>]
+    member _.``Round trips across keys``() =
+        let texts =
+            [|
+                "ATTACKATDAWN"
+                "Hello, World!"
+                "The quick brown fox jumps over the lazy dog."
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                ""
+            |]
+
+        let keys = [| "KEY"; "LEMON"; "A"; "SECRETKEY"; "MiXeD" |]
+
+        for text in texts do
+            for key in keys do
+                let encrypted = VigenereCipher.encrypt text key
+                Assert.Equal(text, VigenereCipher.decrypt encrypted key)
+
+    [<Fact>]
+    member _.``Invalid keys are rejected``() =
+        Assert.Throws<ArgumentException>(fun () -> VigenereCipher.encrypt "hello" "" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> VigenereCipher.encrypt "hello" "key1" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> VigenereCipher.decrypt "hello" "ke y" |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> VigenereCipher.encrypt "hello" null |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> VigenereCipher.findKey "ABC" 0 |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``Finds key lengths``() =
+        Assert.Equal(1, VigenereCipher.findKeyLengthDefault "A")
+        Assert.Equal(5, VigenereCipher.findKeyLengthDefault (VigenereCipher.encrypt longEnglishText "LEMON"))
+        Assert.Equal(3, VigenereCipher.findKeyLengthDefault (VigenereCipher.encrypt longEnglishText "KEY"))
+
+    [<Fact>]
+    member _.``Recovers keys``() =
+        Assert.Equal("LEMON", VigenereCipher.findKey (VigenereCipher.encrypt longEnglishText "LEMON") 5)
+        Assert.Equal("KEY", VigenereCipher.findKey (VigenereCipher.encrypt longEnglishText "KEY") 3)
+        let lowSignalKey = VigenereCipher.findKey "A" 2
+        Assert.Equal(2, lowSignalKey.Length)
+        Assert.EndsWith("A", lowSignalKey)
+
+    [<Fact>]
+    member _.``Break cipher recovers key and plaintext``() =
+        let ciphertext = VigenereCipher.encrypt longEnglishText "LEMON"
+        let result = VigenereCipher.breakCipher ciphertext
+        Assert.Equal("LEMON", result.Key)
+        Assert.Equal(longEnglishText, result.Plaintext)
+
+    [<Fact>]
+    member _.``English frequencies match expectations``() =
+        Assert.Equal(26, VigenereCipher.englishFrequencies.Length)
+        Assert.InRange(Array.sum VigenereCipher.englishFrequencies, 0.99, 1.01)
+        Assert.True(VigenereCipher.englishFrequencies[4] > VigenereCipher.englishFrequencies[25])

--- a/code/programs/go/build-tool/internal/executor/executor.go
+++ b/code/programs/go/build-tool/internal/executor/executor.go
@@ -471,6 +471,12 @@ func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, 
 			keys["global:cabal-store"] = true
 		}
 
+		if (pkg.Language == "csharp" || pkg.Language == "fsharp") && strings.Contains(command, "dotnet ") {
+			// NuGet first-run migrations use global process mutex state outside
+			// DOTNET_CLI_HOME. Parallel dotnet package builds can race there on CI.
+			keys["global:dotnet-cli"] = true
+		}
+
 		for _, raw := range relPathRe.FindAllString(command, -1) {
 			normalized := strings.ReplaceAll(raw, "\\", "/")
 			abs := filepath.Clean(filepath.Join(pkg.Path, filepath.FromSlash(normalized)))

--- a/code/programs/go/build-tool/internal/executor/executor_test.go
+++ b/code/programs/go/build-tool/internal/executor/executor_test.go
@@ -475,6 +475,49 @@ func TestBuildResourceKeysDoesNotIncludeGlobalCabalStoreLockWithoutCabalCommand(
 		t.Fatalf("expected keys not to include global cabal-store lock, got %v", keys)
 	}
 }
+
+func TestBuildResourceKeysIncludesGlobalDotnetLockForDotnetPackages(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "dotnet test tests/CodingAdventures.Tests.csproj --disable-build-servers",
+	})
+
+	pkg := discovery.Package{
+		Name:          "csharp/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"dotnet test tests/CodingAdventures.Tests.csproj --disable-build-servers"},
+		Language:      "csharp",
+	}
+
+	keys := buildResourceKeys(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "csharp/pkg",
+	})
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "global:dotnet-cli") {
+		t.Fatalf("expected keys to include global dotnet-cli lock, got %v", keys)
+	}
+}
+
+func TestBuildResourceKeysSkipsGlobalDotnetLockForNonDotnetPackages(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "echo dotnet test is only text here",
+	})
+
+	pkg := discovery.Package{
+		Name:          "typescript/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"echo dotnet test is only text here"},
+		Language:      "typescript",
+	}
+
+	keys := buildResourceKeys(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "typescript/pkg",
+	})
+	joined := strings.Join(keys, ",")
+	if strings.Contains(joined, "global:dotnet-cli") {
+		t.Fatalf("expected keys not to include global dotnet-cli lock, got %v", keys)
+	}
+}
+
 func TestBuildResourceKeysIncludesGlobalGradleLockForJavaOnWindows(t *testing.T) {
 	root := makeFixture(t, map[string]string{
 		"pkg/BUILD": "gradle test",


### PR DESCRIPTION
## Summary
- add C# and F# vigenere-cipher packages with encrypt/decrypt APIs
- include key-length estimation, chi-squared key recovery, and breakCipher helpers
- add xUnit test coverage and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.VigenereCipher.Tests\\CodingAdventures.VigenereCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\\CodingAdventures.VigenereCipher.Tests\\CodingAdventures.VigenereCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line