### PR TITLE
feat(parity): add dotnet bloom filter packages

### DIFF
--- a/code/packages/csharp/bloom-filter/BUILD
+++ b/code/packages/csharp/bloom-filter/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bloom-filter/BUILD_windows
+++ b/code/packages/csharp/bloom-filter/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bloom-filter/BloomFilter.cs
+++ b/code/packages/csharp/bloom-filter/BloomFilter.cs
@@ -1,0 +1,249 @@
+using System.Text;
+
+namespace CodingAdventures.BloomFilter;
+
+/// <summary>
+/// Space-efficient probabilistic set membership filter.
+/// </summary>
+public sealed class BloomFilter<T>
+    where T : notnull
+{
+    private const int Fnv32OffsetBasis = unchecked((int)0x811C9DC5);
+    private const int Fnv32Prime = 0x01000193;
+    private const int MaxBits = 1 << 30;
+
+    private readonly int _bitCount;
+    private readonly int _hashCount;
+    private readonly int _expectedItems;
+    private readonly byte[] _bits;
+    private int _bitsSet;
+    private int _count;
+
+    /// <summary>
+    /// Create a filter sized for the requested expected count and false-positive rate.
+    /// </summary>
+    public BloomFilter(int expectedItems, double falsePositiveRate)
+    {
+        if (expectedItems <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedItems), "Expected items must be positive.");
+        }
+
+        if (falsePositiveRate <= 0.0 || falsePositiveRate >= 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(falsePositiveRate), "False-positive rate must be in (0, 1).");
+        }
+
+        var bitCount = OptimalM(expectedItems, falsePositiveRate);
+        if (bitCount > MaxBits)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedItems), "Required bit array exceeds the maximum size.");
+        }
+
+        _bitCount = checked((int)bitCount);
+        _hashCount = OptimalK(_bitCount, expectedItems);
+        _expectedItems = expectedItems;
+        _bits = new byte[(_bitCount + 7) / 8];
+    }
+
+    /// <summary>
+    /// Create a filter with explicit bit and hash counts.
+    /// </summary>
+    public BloomFilter(int bitCount, int hashCount, bool explicitParameters)
+    {
+        if (bitCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitCount), "Bit count must be positive.");
+        }
+
+        if (hashCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hashCount), "Hash count must be positive.");
+        }
+
+        if (bitCount > MaxBits)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitCount), "Bit count exceeds the maximum size.");
+        }
+
+        _bitCount = bitCount;
+        _hashCount = hashCount;
+        _expectedItems = 0;
+        _bits = new byte[(bitCount + 7) / 8];
+    }
+
+    /// <summary>Total number of bits in the filter.</summary>
+    public int BitCount => _bitCount;
+
+    /// <summary>Number of hash probes per element.</summary>
+    public int HashCount => _hashCount;
+
+    /// <summary>Number of bits currently set.</summary>
+    public int BitsSet => _bitsSet;
+
+    /// <summary>Number of elements added.</summary>
+    public int Count => _count;
+
+    /// <summary>Number of elements added.</summary>
+    public int Size => _count;
+
+    /// <summary>Memory used by the packed bit array.</summary>
+    public int SizeBytes => _bits.Length;
+
+    /// <summary>Current fraction of set bits.</summary>
+    public double FillRatio => (double)_bitsSet / _bitCount;
+
+    /// <summary>Estimated false-positive rate based on the current fill ratio.</summary>
+    public double EstimatedFalsePositiveRate => _bitsSet == 0 ? 0.0 : Math.Pow(FillRatio, _hashCount);
+
+    /// <summary>True when more elements were added than the auto-sizing target.</summary>
+    public bool IsOverCapacity => _expectedItems != 0 && _count > _expectedItems;
+
+    /// <summary>Add an element to the filter.</summary>
+    public void Add(T element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        foreach (var index in HashIndices(element))
+        {
+            var byteIndex = index >>> 3;
+            var bitMask = 1 << (index & 7);
+            if ((_bits[byteIndex] & bitMask) == 0)
+            {
+                _bits[byteIndex] = (byte)(_bits[byteIndex] | bitMask);
+                _bitsSet++;
+            }
+        }
+
+        _count++;
+    }
+
+    /// <summary>Return true if the element is probably present.</summary>
+    public bool Contains(T element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        foreach (var index in HashIndices(element))
+        {
+            var byteIndex = index >>> 3;
+            var bitMask = 1 << (index & 7);
+            if ((_bits[byteIndex] & bitMask) == 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private int[] HashIndices(T element)
+    {
+        var text = element.ToString() ?? string.Empty;
+        var raw = Encoding.UTF8.GetBytes(text);
+        var h1 = (uint)Fmix32(Fnv1a32(raw));
+        var h2 = (uint)Fmix32(Djb2_32(raw)) | 1U;
+
+        var indices = new int[_hashCount];
+        for (var i = 0; i < _hashCount; i++)
+        {
+            indices[i] = (int)(((ulong)h1 + (ulong)i * h2) % (ulong)_bitCount);
+        }
+
+        return indices;
+    }
+
+    private static int Fnv1a32(byte[] data)
+    {
+        unchecked
+        {
+            var hash = Fnv32OffsetBasis;
+            foreach (var value in data)
+            {
+                hash ^= value;
+                hash *= Fnv32Prime;
+            }
+
+            return hash;
+        }
+    }
+
+    private static int Djb2_32(byte[] data)
+    {
+        unchecked
+        {
+            var hash = 5381UL;
+            foreach (var value in data)
+            {
+                hash = (hash << 5) + hash + value;
+            }
+
+            return (int)((hash ^ (hash >> 32)) & 0xFFFFFFFFUL);
+        }
+    }
+
+    private static int Fmix32(int value)
+    {
+        unchecked
+        {
+            var hash = (uint)value;
+            hash ^= hash >> 16;
+            hash *= 0x85EBCA6BU;
+            hash ^= hash >> 13;
+            hash *= 0xC2B2AE35U;
+            hash ^= hash >> 16;
+            return (int)hash;
+        }
+    }
+
+    /// <summary>Optimal bit count for n elements and false-positive rate p.</summary>
+    public static long OptimalM(long n, double p)
+    {
+        if (n <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(n), "n must be positive.");
+        }
+
+        if (p <= 0.0 || p >= 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(p), "p must be in (0, 1).");
+        }
+
+        var ln2 = Math.Log(2.0);
+        return (long)Math.Ceiling(-n * Math.Log(p) / (ln2 * ln2));
+    }
+
+    /// <summary>Optimal hash count for m bits and n expected elements.</summary>
+    public static int OptimalK(long m, long n)
+    {
+        if (n <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(n), "n must be positive.");
+        }
+
+        return Math.Max(1, (int)Math.Round((double)m / n * Math.Log(2.0)));
+    }
+
+    /// <summary>Estimate capacity for a memory budget and false-positive rate.</summary>
+    public static long CapacityForMemory(long memoryBytes, double p)
+    {
+        if (memoryBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(memoryBytes), "Memory budget must be positive.");
+        }
+
+        if (p <= 0.0 || p >= 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(p), "p must be in (0, 1).");
+        }
+
+        var bits = memoryBytes * 8.0;
+        var ln2 = Math.Log(2.0);
+        return (long)(-bits * ln2 * ln2 / Math.Log(p));
+    }
+
+    /// <summary>
+    /// Return a compact summary of sizing and current saturation.
+    /// </summary>
+    public override string ToString() =>
+        $"BloomFilter(m={_bitCount}, k={_hashCount}, bitsSet={_bitsSet}/{_bitCount} ({FillRatio * 100.0:F2}%), ~fp={EstimatedFalsePositiveRate * 100.0:F4}%)";
+}

--- a/code/packages/csharp/bloom-filter/CHANGELOG.md
+++ b/code/packages/csharp/bloom-filter/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# Bloom filter implementation with sizing helpers and tests.

--- a/code/packages/csharp/bloom-filter/CodingAdventures.BloomFilter.csproj
+++ b/code/packages/csharp/bloom-filter/CodingAdventures.BloomFilter.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BloomFilter.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Probabilistic set membership filter</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/bloom-filter/README.md
+++ b/code/packages/csharp/bloom-filter/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.BloomFilter.CSharp
+
+Space-efficient probabilistic set membership filter with zero false negatives,
+tunable false-positive rates, and helper formulas for bit and hash counts.

--- a/code/packages/csharp/bloom-filter/required_capabilities.json
+++ b/code/packages/csharp/bloom-filter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/bloom-filter",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/BloomFilterTests.cs
+++ b/code/packages/csharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/BloomFilterTests.cs
@@ -1,0 +1,126 @@
+namespace CodingAdventures.BloomFilter.Tests;
+
+public sealed class BloomFilterTests
+{
+    [Fact]
+    public void ConstructorSizesFilter()
+    {
+        var filter = new BloomFilter<string>(1000, 0.01);
+
+        Assert.True(filter.BitCount > 8000);
+        Assert.True(filter.HashCount >= 5);
+        Assert.Equal(0, filter.BitsSet);
+        Assert.Equal(0, filter.Count);
+        Assert.True(filter.SizeBytes * 8 >= filter.BitCount);
+    }
+
+    [Fact]
+    public void ExplicitConstructorSetsParameters()
+    {
+        var filter = new BloomFilter<string>(1000, 5, explicitParameters: true);
+
+        Assert.Equal(1000, filter.BitCount);
+        Assert.Equal(5, filter.HashCount);
+        Assert.False(filter.IsOverCapacity);
+    }
+
+    [Fact]
+    public void AddedElementsAreAlwaysFound()
+    {
+        var filter = new BloomFilter<string>(1000, 0.01);
+        var words = new[] { "apple", "banana", "cherry", "date", "elderberry" };
+
+        foreach (var word in words)
+        {
+            filter.Add(word);
+        }
+
+        foreach (var word in words)
+        {
+            Assert.True(filter.Contains(word));
+        }
+
+        Assert.Equal(words.Length, filter.Size);
+        Assert.True(filter.BitsSet > 0);
+        Assert.InRange(filter.FillRatio, 0.0, 1.0);
+        Assert.True(filter.EstimatedFalsePositiveRate > 0.0);
+    }
+
+    [Fact]
+    public void EmptyFilterRejectsMissingItem()
+    {
+        var filter = new BloomFilter<string>(1000, 0.01);
+
+        Assert.False(filter.Contains("not-added"));
+        Assert.Equal(0.0, filter.FillRatio);
+        Assert.Equal(0.0, filter.EstimatedFalsePositiveRate);
+    }
+
+    [Fact]
+    public void WorksWithNonStringValues()
+    {
+        var filter = new BloomFilter<int>(1000, 0.01);
+        filter.Add(42);
+        filter.Add(100);
+
+        Assert.True(filter.Contains(42));
+        Assert.True(filter.Contains(100));
+    }
+
+    [Fact]
+    public void OverCapacityTracksAutoSizedFiltersOnly()
+    {
+        var auto = new BloomFilter<string>(2, 0.1);
+        auto.Add("a");
+        auto.Add("b");
+        Assert.False(auto.IsOverCapacity);
+        auto.Add("c");
+        Assert.True(auto.IsOverCapacity);
+
+        var explicitFilter = new BloomFilter<string>(16, 2, true);
+        for (var i = 0; i < 20; i++)
+        {
+            explicitFilter.Add(i.ToString());
+        }
+
+        Assert.False(explicitFilter.IsOverCapacity);
+    }
+
+    [Fact]
+    public void UtilityFunctionsMatchExpectedShape()
+    {
+        var m100 = BloomFilter<string>.OptimalM(100, 0.01);
+        var m1000 = BloomFilter<string>.OptimalM(1000, 0.01);
+        Assert.True(m1000 > m100);
+        Assert.True(BloomFilter<string>.OptimalM(1000, 0.001) > m1000);
+        Assert.True(BloomFilter<string>.OptimalK(100, 1000) >= 1);
+        Assert.True(BloomFilter<string>.CapacityForMemory(1_000_000, 0.01) > 0);
+    }
+
+    [Fact]
+    public void InvalidArgumentsAreRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter<string>(0, 0.01));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter<string>(100, 0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter<string>(0, 5, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter<string>(100, 0, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BloomFilter<string>.OptimalM(0, 0.01));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BloomFilter<string>.OptimalM(100, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BloomFilter<string>.OptimalK(100, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BloomFilter<string>.CapacityForMemory(0, 0.01));
+        Assert.Throws<ArgumentNullException>(() => new BloomFilter<string>(10, 0.1).Add(null!));
+    }
+
+    [Fact]
+    public void ToStringIncludesKeyFields()
+    {
+        var filter = new BloomFilter<string>(100, 0.01);
+        filter.Add("a");
+
+        var text = filter.ToString();
+        Assert.Contains("BloomFilter", text);
+        Assert.Contains("m=", text);
+        Assert.Contains("k=", text);
+        Assert.Contains("~fp=", text);
+    }
+}

--- a/code/packages/csharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.csproj
+++ b/code/packages/csharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BloomFilter.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bloom-filter/BUILD
+++ b/code/packages/fsharp/bloom-filter/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bloom-filter/BUILD_windows
+++ b/code/packages/fsharp/bloom-filter/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bloom-filter/BloomFilter.fs
+++ b/code/packages/fsharp/bloom-filter/BloomFilter.fs
@@ -1,0 +1,142 @@
+namespace CodingAdventures.BloomFilter
+
+open System
+open System.Text
+
+module private Hashing =
+    let fnv1a32 (data: byte array) =
+        let mutable hash = 0x811C9DC5u
+
+        for value in data do
+            hash <- hash ^^^ uint32 value
+            hash <- hash * 0x01000193u
+
+        hash
+
+    let djb2_32 (data: byte array) =
+        let mutable hash = 5381UL
+
+        for value in data do
+            hash <- (hash <<< 5) + hash + uint64 value
+
+        uint32 ((hash ^^^ (hash >>> 32)) &&& 0xFFFFFFFFUL)
+
+    let fmix32 (value: uint32) =
+        let mutable hash = value
+        hash <- hash ^^^ (hash >>> 16)
+        hash <- hash * 0x85EBCA6Bu
+        hash <- hash ^^^ (hash >>> 13)
+        hash <- hash * 0xC2B2AE35u
+        hash <- hash ^^^ (hash >>> 16)
+        hash
+
+type BloomFilter<'T> private (bitCount: int, hashCount: int, expectedItems: int) =
+    static let maxBits = 1 <<< 30
+
+    let bits = Array.zeroCreate<byte> ((bitCount + 7) / 8)
+    let mutable bitsSet = 0
+    let mutable count = 0
+
+    do
+        if bitCount <= 0 then
+            invalidArg (nameof bitCount) "Bit count must be positive."
+
+        if hashCount <= 0 then
+            invalidArg (nameof hashCount) "Hash count must be positive."
+
+        if bitCount > maxBits then
+            invalidArg (nameof bitCount) "Bit count exceeds the maximum size."
+
+    new (expectedItems: int, falsePositiveRate: float) =
+        if expectedItems <= 0 then
+            invalidArg (nameof expectedItems) "Expected items must be positive."
+
+        if falsePositiveRate <= 0.0 || falsePositiveRate >= 1.0 then
+            invalidArg (nameof falsePositiveRate) "False-positive rate must be in (0, 1)."
+
+        let bitCount = BloomFilter<'T>.OptimalM(int64 expectedItems, falsePositiveRate)
+
+        if bitCount > int64 maxBits then
+            invalidArg (nameof expectedItems) "Required bit array exceeds the maximum size."
+
+        let hashCount = BloomFilter<'T>.OptimalK(bitCount, int64 expectedItems)
+        BloomFilter<'T>(int bitCount, hashCount, expectedItems)
+
+    new (bitCount: int, hashCount: int, explicitParameters: bool) =
+        BloomFilter<'T>(bitCount, hashCount, 0)
+
+    member _.BitCount = bitCount
+    member _.HashCount = hashCount
+    member _.BitsSet = bitsSet
+    member _.Count = count
+    member _.Size = count
+    member _.SizeBytes = bits.Length
+    member _.FillRatio = float bitsSet / float bitCount
+
+    member this.EstimatedFalsePositiveRate =
+        if bitsSet = 0 then
+            0.0
+        else
+            Math.Pow(this.FillRatio, hashCount)
+
+    member _.IsOverCapacity =
+        expectedItems <> 0 && count > expectedItems
+
+    member private _.HashIndices(element: 'T) =
+        if Object.ReferenceEquals(box element, null) then
+            nullArg (nameof element)
+
+        let raw = Encoding.UTF8.GetBytes(element.ToString())
+        let h1 = Hashing.fmix32 (Hashing.fnv1a32 raw) |> uint64
+        let h2 = (Hashing.fmix32 (Hashing.djb2_32 raw) ||| 1u) |> uint64
+
+        Array.init hashCount (fun index ->
+            int ((h1 + uint64 index * h2) % uint64 bitCount))
+
+    member this.Add(element: 'T) =
+        for index in this.HashIndices(element) do
+            let byteIndex = index >>> 3
+            let bitMask = byte (1 <<< (index &&& 7))
+
+            if bits[byteIndex] &&& bitMask = 0uy then
+                bits[byteIndex] <- bits[byteIndex] ||| bitMask
+                bitsSet <- bitsSet + 1
+
+        count <- count + 1
+
+    member this.Contains(element: 'T) =
+        this.HashIndices(element)
+        |> Array.forall (fun index ->
+            let byteIndex = index >>> 3
+            let bitMask = byte (1 <<< (index &&& 7))
+            bits[byteIndex] &&& bitMask <> 0uy)
+
+    static member OptimalM(n: int64, p: float) =
+        if n <= 0L then
+            invalidArg (nameof n) "n must be positive."
+
+        if p <= 0.0 || p >= 1.0 then
+            invalidArg (nameof p) "p must be in (0, 1)."
+
+        let ln2 = Math.Log 2.0
+        int64 (Math.Ceiling(-float n * Math.Log(p) / (ln2 * ln2)))
+
+    static member OptimalK(m: int64, n: int64) =
+        if n <= 0L then
+            invalidArg (nameof n) "n must be positive."
+
+        max 1 (int (Math.Round(float m / float n * Math.Log 2.0)))
+
+    static member CapacityForMemory(memoryBytes: int64, p: float) =
+        if memoryBytes <= 0L then
+            invalidArg (nameof memoryBytes) "Memory budget must be positive."
+
+        if p <= 0.0 || p >= 1.0 then
+            invalidArg (nameof p) "p must be in (0, 1)."
+
+        let bits = float memoryBytes * 8.0
+        let ln2 = Math.Log 2.0
+        int64 (-bits * ln2 * ln2 / Math.Log p)
+
+    override this.ToString() =
+        $"BloomFilter(m={bitCount}, k={hashCount}, bitsSet={bitsSet}/{bitCount} ({this.FillRatio * 100.0:F2}%%), ~fp={this.EstimatedFalsePositiveRate * 100.0:F4}%%)"

--- a/code/packages/fsharp/bloom-filter/CHANGELOG.md
+++ b/code/packages/fsharp/bloom-filter/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# Bloom filter implementation with sizing helpers and tests.

--- a/code/packages/fsharp/bloom-filter/CodingAdventures.BloomFilter.fsproj
+++ b/code/packages/fsharp/bloom-filter/CodingAdventures.BloomFilter.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BloomFilter.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Probabilistic set membership filter</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BloomFilter.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bloom-filter/README.md
+++ b/code/packages/fsharp/bloom-filter/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.BloomFilter.FSharp
+
+Space-efficient probabilistic set membership filter with zero false negatives,
+tunable false-positive rates, and helper formulas for bit and hash counts.

--- a/code/packages/fsharp/bloom-filter/required_capabilities.json
+++ b/code/packages/fsharp/bloom-filter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/bloom-filter",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/BloomFilterTests.fs
+++ b/code/packages/fsharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/BloomFilterTests.fs
@@ -1,0 +1,98 @@
+namespace CodingAdventures.BloomFilter.Tests
+
+open System
+open Xunit
+open CodingAdventures.BloomFilter
+
+type BloomFilterTests() =
+    [<Fact>]
+    member _.``Constructor sizes filter``() =
+        let filter = BloomFilter<string>(1000, 0.01)
+        Assert.True(filter.BitCount > 8000)
+        Assert.True(filter.HashCount >= 5)
+        Assert.Equal(0, filter.BitsSet)
+        Assert.Equal(0, filter.Count)
+        Assert.True(filter.SizeBytes * 8 >= filter.BitCount)
+
+    [<Fact>]
+    member _.``Explicit constructor sets parameters``() =
+        let filter = BloomFilter<string>(1000, 5, true)
+        Assert.Equal(1000, filter.BitCount)
+        Assert.Equal(5, filter.HashCount)
+        Assert.False(filter.IsOverCapacity)
+
+    [<Fact>]
+    member _.``Added elements are always found``() =
+        let filter = BloomFilter<string>(1000, 0.01)
+        let words = [| "apple"; "banana"; "cherry"; "date"; "elderberry" |]
+
+        for word in words do
+            filter.Add word
+
+        for word in words do
+            Assert.True(filter.Contains word)
+
+        Assert.Equal(words.Length, filter.Size)
+        Assert.True(filter.BitsSet > 0)
+        Assert.InRange(filter.FillRatio, 0.0, 1.0)
+        Assert.True(filter.EstimatedFalsePositiveRate > 0.0)
+
+    [<Fact>]
+    member _.``Empty filter rejects missing item``() =
+        let filter = BloomFilter<string>(1000, 0.01)
+        Assert.False(filter.Contains "not-added")
+        Assert.Equal(0.0, filter.FillRatio)
+        Assert.Equal(0.0, filter.EstimatedFalsePositiveRate)
+
+    [<Fact>]
+    member _.``Works with non string values``() =
+        let filter = BloomFilter<int>(1000, 0.01)
+        filter.Add 42
+        filter.Add 100
+        Assert.True(filter.Contains 42)
+        Assert.True(filter.Contains 100)
+
+    [<Fact>]
+    member _.``Over capacity tracks auto sized filters only``() =
+        let auto = BloomFilter<string>(2, 0.1)
+        auto.Add "a"
+        auto.Add "b"
+        Assert.False(auto.IsOverCapacity)
+        auto.Add "c"
+        Assert.True(auto.IsOverCapacity)
+
+        let explicitFilter = BloomFilter<string>(16, 2, true)
+        for i in 0 .. 19 do
+            explicitFilter.Add(string i)
+
+        Assert.False(explicitFilter.IsOverCapacity)
+
+    [<Fact>]
+    member _.``Utility functions match expected shape``() =
+        let m100 = BloomFilter<string>.OptimalM(100L, 0.01)
+        let m1000 = BloomFilter<string>.OptimalM(1000L, 0.01)
+        Assert.True(m1000 > m100)
+        Assert.True(BloomFilter<string>.OptimalM(1000L, 0.001) > m1000)
+        Assert.True(BloomFilter<string>.OptimalK(100L, 1000L) >= 1)
+        Assert.True(BloomFilter<string>.CapacityForMemory(1_000_000L, 0.01) > 0L)
+
+    [<Fact>]
+    member _.``Invalid arguments are rejected``() =
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>(0, 0.01) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>(100, 0.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>(0, 5, true) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>(100, 0, true) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>.OptimalM(0L, 0.01) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>.OptimalM(100L, 1.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>.OptimalK(100L, 0L) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> BloomFilter<string>.CapacityForMemory(0L, 0.01) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``To string includes key fields``() =
+        let filter = BloomFilter<string>(100, 0.01)
+        filter.Add "a"
+        let text = filter.ToString()
+        Assert.Contains("BloomFilter", text)
+        Assert.Contains("m=", text)
+        Assert.Contains("k=", text)
+        Assert.Contains("~fp=", text)

--- a/code/packages/fsharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.fsproj
+++ b/code/packages/fsharp/bloom-filter/tests/CodingAdventures.BloomFilter.Tests/CodingAdventures.BloomFilter.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BloomFilter.fsproj" />
+    <Compile Include="BloomFilterTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# bloom-filter packages with auto-sized and explicit constructors
- implement add/contains, saturation stats, estimated false-positive rate, and capacity helpers
- add xUnit coverage and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.BloomFilter.Tests\\CodingAdventures.BloomFilter.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\\CodingAdventures.BloomFilter.Tests\\CodingAdventures.BloomFilter.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line