### PR TITLE
feat(parity): add dotnet logic gates packages

### DIFF
--- a/code/packages/csharp/logic-gates/BUILD
+++ b/code/packages/csharp/logic-gates/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/logic-gates/BUILD_windows
+++ b/code/packages/csharp/logic-gates/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/logic-gates/CHANGELOG.md
+++ b/code/packages/csharp/logic-gates/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# implementation of core logic gates, NAND-derived gates, and multi-input variants.

--- a/code/packages/csharp/logic-gates/CodingAdventures.LogicGates.csproj
+++ b/code/packages/csharp/logic-gates/CodingAdventures.LogicGates.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LogicGates.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Core digital logic gates and NAND-derived variants</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/logic-gates/LogicGates.cs
+++ b/code/packages/csharp/logic-gates/LogicGates.cs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.LogicGates;
+
+/// <summary>
+/// Core digital logic gates over integer bits.
+/// </summary>
+public static class LogicGates
+{
+    private static void ValidateBit(int value, string name)
+    {
+        if (value is not (0 or 1))
+        {
+            throw new ArgumentOutOfRangeException(name, value, "Bit values must be 0 or 1.");
+        }
+    }
+
+    /// <summary>Invert a bit.</summary>
+    public static int Not(int a)
+    {
+        ValidateBit(a, nameof(a));
+        return a == 0 ? 1 : 0;
+    }
+
+    /// <summary>Return 1 only when both inputs are 1.</summary>
+    public static int And(int a, int b)
+    {
+        ValidateBit(a, nameof(a));
+        ValidateBit(b, nameof(b));
+        return a == 1 && b == 1 ? 1 : 0;
+    }
+
+    /// <summary>Return 1 when either input is 1.</summary>
+    public static int Or(int a, int b)
+    {
+        ValidateBit(a, nameof(a));
+        ValidateBit(b, nameof(b));
+        return a == 1 || b == 1 ? 1 : 0;
+    }
+
+    /// <summary>Return 1 when inputs differ.</summary>
+    public static int Xor(int a, int b)
+    {
+        ValidateBit(a, nameof(a));
+        ValidateBit(b, nameof(b));
+        return a != b ? 1 : 0;
+    }
+
+    /// <summary>Return NOT(AND(a, b)).</summary>
+    public static int Nand(int a, int b) => Not(And(a, b));
+
+    /// <summary>Return NOT(OR(a, b)).</summary>
+    public static int Nor(int a, int b) => Not(Or(a, b));
+
+    /// <summary>Return NOT(XOR(a, b)).</summary>
+    public static int Xnor(int a, int b) => Not(Xor(a, b));
+
+    /// <summary>Build NOT from NAND only.</summary>
+    public static int NandNot(int a) => Nand(a, a);
+
+    /// <summary>Build AND from NAND only.</summary>
+    public static int NandAnd(int a, int b) => NandNot(Nand(a, b));
+
+    /// <summary>Build OR from NAND only.</summary>
+    public static int NandOr(int a, int b) => Nand(NandNot(a), NandNot(b));
+
+    /// <summary>Build XOR from NAND only.</summary>
+    public static int NandXor(int a, int b)
+    {
+        var nand = Nand(a, b);
+        return Nand(Nand(a, nand), Nand(b, nand));
+    }
+
+    /// <summary>AND over two or more inputs.</summary>
+    public static int AndN(params int[] inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        if (inputs.Length < 2)
+        {
+            throw new ArgumentException("AndN requires at least two inputs.", nameof(inputs));
+        }
+
+        var result = And(inputs[0], inputs[1]);
+        for (var i = 2; i < inputs.Length; i++)
+        {
+            result = And(result, inputs[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>OR over two or more inputs.</summary>
+    public static int OrN(params int[] inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        if (inputs.Length < 2)
+        {
+            throw new ArgumentException("OrN requires at least two inputs.", nameof(inputs));
+        }
+
+        var result = Or(inputs[0], inputs[1]);
+        for (var i = 2; i < inputs.Length; i++)
+        {
+            result = Or(result, inputs[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>Return odd parity over zero or more inputs.</summary>
+    public static int XorN(params int[] inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var result = 0;
+        for (var i = 0; i < inputs.Length; i++)
+        {
+            ValidateBit(inputs[i], $"inputs[{i}]");
+            result = Xor(result, inputs[i]);
+        }
+
+        return result;
+    }
+}

--- a/code/packages/csharp/logic-gates/README.md
+++ b/code/packages/csharp/logic-gates/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.LogicGates.CSharp
+
+Core digital logic gates with validated bit inputs, NAND-derived equivalents,
+and multi-input AND/OR/XOR helpers.

--- a/code/packages/csharp/logic-gates/required_capabilities.json
+++ b/code/packages/csharp/logic-gates/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/logic-gates",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.csproj
+++ b/code/packages/csharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.LogicGates.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/LogicGatesTests.cs
+++ b/code/packages/csharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/LogicGatesTests.cs
@@ -1,0 +1,76 @@
+namespace CodingAdventures.LogicGates.Tests;
+
+public sealed class LogicGatesTests
+{
+    private static readonly (int A, int B, int NotA, int And, int Or, int Xor, int Nand, int Nor, int Xnor)[] TruthTable =
+    [
+        (0, 0, 1, 0, 0, 0, 1, 1, 1),
+        (0, 1, 1, 0, 1, 1, 1, 0, 0),
+        (1, 0, 0, 0, 1, 1, 1, 0, 0),
+        (1, 1, 0, 1, 1, 0, 0, 0, 1),
+    ];
+
+    [Fact]
+    public void FundamentalGatesMatchTruthTables()
+    {
+        foreach (var row in TruthTable)
+        {
+            Assert.Equal(row.NotA, LogicGates.Not(row.A));
+            Assert.Equal(row.And, LogicGates.And(row.A, row.B));
+            Assert.Equal(row.Or, LogicGates.Or(row.A, row.B));
+            Assert.Equal(row.Xor, LogicGates.Xor(row.A, row.B));
+            Assert.Equal(row.Nand, LogicGates.Nand(row.A, row.B));
+            Assert.Equal(row.Nor, LogicGates.Nor(row.A, row.B));
+            Assert.Equal(row.Xnor, LogicGates.Xnor(row.A, row.B));
+        }
+    }
+
+    [Fact]
+    public void NandDerivedGatesMatchDirectGates()
+    {
+        foreach (var row in TruthTable)
+        {
+            Assert.Equal(LogicGates.Not(row.A), LogicGates.NandNot(row.A));
+            Assert.Equal(LogicGates.And(row.A, row.B), LogicGates.NandAnd(row.A, row.B));
+            Assert.Equal(LogicGates.Or(row.A, row.B), LogicGates.NandOr(row.A, row.B));
+            Assert.Equal(LogicGates.Xor(row.A, row.B), LogicGates.NandXor(row.A, row.B));
+        }
+    }
+
+    [Fact]
+    public void MultiInputGatesWork()
+    {
+        Assert.Equal(1, LogicGates.AndN(1, 1, 1, 1));
+        Assert.Equal(0, LogicGates.AndN(1, 1, 0, 1));
+        Assert.Equal(0, LogicGates.OrN(0, 0, 0));
+        Assert.Equal(1, LogicGates.OrN(0, 0, 1, 0));
+        Assert.Equal(0, LogicGates.XorN());
+        Assert.Equal(1, LogicGates.XorN(1));
+        Assert.Equal(0, LogicGates.XorN(1, 1, 1, 1));
+        Assert.Equal(1, LogicGates.XorN(1, 1, 1));
+    }
+
+    [Fact]
+    public void InvalidInputsAreRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => LogicGates.Not(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => LogicGates.And(2, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => LogicGates.Or(0, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => LogicGates.Xor(0, 2));
+        Assert.Throws<ArgumentException>(() => LogicGates.AndN(1));
+        Assert.Throws<ArgumentException>(() => LogicGates.OrN());
+        Assert.Throws<ArgumentOutOfRangeException>(() => LogicGates.XorN(0, 2));
+        Assert.Throws<ArgumentNullException>(() => LogicGates.AndN(null!));
+    }
+
+    [Fact]
+    public void DeMorganRelationshipsHold()
+    {
+        foreach (var row in TruthTable)
+        {
+            Assert.Equal(LogicGates.Nand(row.A, row.B), LogicGates.Or(LogicGates.Not(row.A), LogicGates.Not(row.B)));
+            Assert.Equal(LogicGates.Nor(row.A, row.B), LogicGates.And(LogicGates.Not(row.A), LogicGates.Not(row.B)));
+            Assert.Equal(LogicGates.Xnor(row.A, row.B), LogicGates.Not(LogicGates.Xor(row.A, row.B)));
+        }
+    }
+}

--- a/code/packages/fsharp/logic-gates/BUILD
+++ b/code/packages/fsharp/logic-gates/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/logic-gates/BUILD_windows
+++ b/code/packages/fsharp/logic-gates/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/logic-gates/CHANGELOG.md
+++ b/code/packages/fsharp/logic-gates/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# implementation of core logic gates, NAND-derived gates, and multi-input variants.

--- a/code/packages/fsharp/logic-gates/CodingAdventures.LogicGates.fsproj
+++ b/code/packages/fsharp/logic-gates/CodingAdventures.LogicGates.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LogicGates.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Core digital logic gates and NAND-derived variants</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LogicGates.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/logic-gates/LogicGates.fs
+++ b/code/packages/fsharp/logic-gates/LogicGates.fs
@@ -1,0 +1,67 @@
+namespace CodingAdventures.LogicGates
+
+open System
+
+/// Core digital logic gates over integer bits.
+[<RequireQualifiedAccess>]
+module LogicGates =
+    let private validateBit name value =
+        if value <> 0 && value <> 1 then
+            raise (ArgumentOutOfRangeException(name, value, "Bit values must be 0 or 1."))
+
+    let notGate a =
+        validateBit (nameof a) a
+        if a = 0 then 1 else 0
+
+    let andGate a b =
+        validateBit (nameof a) a
+        validateBit (nameof b) b
+        if a = 1 && b = 1 then 1 else 0
+
+    let orGate a b =
+        validateBit (nameof a) a
+        validateBit (nameof b) b
+        if a = 1 || b = 1 then 1 else 0
+
+    let xorGate a b =
+        validateBit (nameof a) a
+        validateBit (nameof b) b
+        if a <> b then 1 else 0
+
+    let nand a b = notGate (andGate a b)
+
+    let nor a b = notGate (orGate a b)
+
+    let xnor a b = notGate (xorGate a b)
+
+    let nandNot a = nand a a
+
+    let nandAnd a b = nandNot (nand a b)
+
+    let nandOr a b = nand (nandNot a) (nandNot b)
+
+    let nandXor a b =
+        let nandValue = nand a b
+        nand (nand a nandValue) (nand b nandValue)
+
+    let andN (inputs: int list) =
+        if isNull (box inputs) then
+            nullArg (nameof inputs)
+
+        match inputs with
+        | first :: second :: rest -> rest |> List.fold andGate (andGate first second)
+        | _ -> invalidArg (nameof inputs) "andN requires at least two inputs."
+
+    let orN (inputs: int list) =
+        if isNull (box inputs) then
+            nullArg (nameof inputs)
+
+        match inputs with
+        | first :: second :: rest -> rest |> List.fold orGate (orGate first second)
+        | _ -> invalidArg (nameof inputs) "orN requires at least two inputs."
+
+    let xorN (inputs: int list) =
+        if isNull (box inputs) then
+            nullArg (nameof inputs)
+
+        inputs |> List.fold xorGate 0

--- a/code/packages/fsharp/logic-gates/README.md
+++ b/code/packages/fsharp/logic-gates/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.LogicGates.FSharp
+
+Core digital logic gates with validated bit inputs, NAND-derived equivalents,
+and multi-input AND/OR/XOR helpers.

--- a/code/packages/fsharp/logic-gates/required_capabilities.json
+++ b/code/packages/fsharp/logic-gates/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/logic-gates",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.fsproj
+++ b/code/packages/fsharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/CodingAdventures.LogicGates.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.LogicGates.fsproj" />
+    <Compile Include="LogicGatesTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/LogicGatesTests.fs
+++ b/code/packages/fsharp/logic-gates/tests/CodingAdventures.LogicGates.Tests/LogicGatesTests.fs
@@ -1,0 +1,61 @@
+namespace CodingAdventures.LogicGates.Tests
+
+open System
+open Xunit
+open CodingAdventures.LogicGates
+
+type LogicGatesTests() =
+    let truthTable =
+        [|
+            0, 0, 1, 0, 0, 0, 1, 1, 1
+            0, 1, 1, 0, 1, 1, 1, 0, 0
+            1, 0, 0, 0, 1, 1, 1, 0, 0
+            1, 1, 0, 1, 1, 0, 0, 0, 1
+        |]
+
+    [<Fact>]
+    member _.``Fundamental gates match truth tables``() =
+        for a, b, notA, andValue, orValue, xorValue, nandValue, norValue, xnorValue in truthTable do
+            Assert.Equal(notA, LogicGates.notGate a)
+            Assert.Equal(andValue, LogicGates.andGate a b)
+            Assert.Equal(orValue, LogicGates.orGate a b)
+            Assert.Equal(xorValue, LogicGates.xorGate a b)
+            Assert.Equal(nandValue, LogicGates.nand a b)
+            Assert.Equal(norValue, LogicGates.nor a b)
+            Assert.Equal(xnorValue, LogicGates.xnor a b)
+
+    [<Fact>]
+    member _.``NAND derived gates match direct gates``() =
+        for a, b, _, _, _, _, _, _, _ in truthTable do
+            Assert.Equal(LogicGates.notGate a, LogicGates.nandNot a)
+            Assert.Equal(LogicGates.andGate a b, LogicGates.nandAnd a b)
+            Assert.Equal(LogicGates.orGate a b, LogicGates.nandOr a b)
+            Assert.Equal(LogicGates.xorGate a b, LogicGates.nandXor a b)
+
+    [<Fact>]
+    member _.``Multi input gates work``() =
+        Assert.Equal(1, LogicGates.andN [ 1; 1; 1; 1 ])
+        Assert.Equal(0, LogicGates.andN [ 1; 1; 0; 1 ])
+        Assert.Equal(0, LogicGates.orN [ 0; 0; 0 ])
+        Assert.Equal(1, LogicGates.orN [ 0; 0; 1; 0 ])
+        Assert.Equal(0, LogicGates.xorN [])
+        Assert.Equal(1, LogicGates.xorN [ 1 ])
+        Assert.Equal(0, LogicGates.xorN [ 1; 1; 1; 1 ])
+        Assert.Equal(1, LogicGates.xorN [ 1; 1; 1 ])
+
+    [<Fact>]
+    member _.``Invalid inputs are rejected``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LogicGates.notGate -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LogicGates.andGate 2 1 |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LogicGates.orGate 0 -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LogicGates.xorGate 0 2 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LogicGates.andN [ 1 ] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LogicGates.orN [] |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LogicGates.xorN [ 0; 2 ] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``De Morgan relationships hold``() =
+        for a, b, _, _, _, _, _, _, _ in truthTable do
+            Assert.Equal(LogicGates.nand a b, LogicGates.orGate (LogicGates.notGate a) (LogicGates.notGate b))
+            Assert.Equal(LogicGates.nor a b, LogicGates.andGate (LogicGates.notGate a) (LogicGates.notGate b))
+            Assert.Equal(LogicGates.xnor a b, LogicGates.notGate (LogicGates.xorGate a b))


### PR DESCRIPTION
## Summary
- add C# and F# logic-gates packages with core gate truth tables
- include NAND-derived NOT/AND/OR/XOR and multi-input AND/OR/XOR helpers
- add xUnit coverage and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.LogicGates.Tests\\CodingAdventures.LogicGates.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\\CodingAdventures.LogicGates.Tests\\CodingAdventures.LogicGates.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line