### PR TITLE
feat(cmp): add LZ77, LZSS, and LZW compression in Java and Kotlin

### DIFF
--- a/code/packages/java/lz77/.gitignore
+++ b/code/packages/java/lz77/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/lz77/BUILD
+++ b/code/packages/java/lz77/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lz77/BUILD_windows
+++ b/code/packages/java/lz77/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lz77/CHANGELOG.md
+++ b/code/packages/java/lz77/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — lz77 (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZ77.compress(byte[])` / `decompress(byte[])` — one-shot CMP00 wire format.
+- `LZ77.encode(byte[])` — encode to `List<Token>` with configurable
+  `windowSize`, `maxMatch`, `minMatch` (defaults: 4096 / 255 / 3).
+- `LZ77.decode(List<Token>)` — decode token stream; optional `initialBuffer`
+  seed for streaming decompression.
+- `LZ77.Token` record `(offset, length, nextChar)` with `isLiteral()`,
+  `literal(int)`, `match(int,int,int)` factory methods.
+- `serialiseTokens` / `deserialiseTokens` for the CMP00 wire format.
+- `findLongestMatch` — greedy O(n × window) search with overlapping-match
+  support and one-byte next_char reservation.
+- 38 unit tests covering round-trip, token stream, wire format, edge cases,
+  overlapping matches, compression effectiveness, and determinism.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.

--- a/code/packages/java/lz77/README.md
+++ b/code/packages/java/lz77/README.md
@@ -1,0 +1,60 @@
+# lz77 (Java) — CMP00
+
+LZ77 lossless compression for Java.  The foundational sliding-window algorithm
+(Lempel & Ziv, 1977) that is the ancestor of LZSS, LZW, DEFLATE, zstd, LZ4,
+and virtually every compressor used in ZIP, gzip, PNG, and zlib.
+
+## What it does
+
+`LZ77` exposes:
+
+| Method | Description |
+|--------|-------------|
+| `compress(byte[])` | Encode bytes into CMP00 wire format |
+| `decompress(byte[])` | Decode CMP00 wire format back to original bytes |
+| `encode(byte[])` | Encode to `List<Token>` (token stream) |
+| `decode(List<Token>)` | Decode token stream back to bytes |
+
+Tokens are `LZ77.Token` records: `(offset, length, nextChar)`.
+
+## The algorithm
+
+```
+┌─────────────────────────────────┬──────────────────┐
+│         SEARCH BUFFER           │ LOOKAHEAD BUFFER  │
+│  (last window_size bytes)       │  (next max_match) │
+└─────────────────────────────────┴──────────────────┘
+                                  ↑ cursor
+```
+
+At each cursor position: search for the longest match in the search buffer.
+- Match ≥ `min_match`: emit `Token(offset, length, next_char)`; advance `length+1`.
+- No match: emit `Token(0, 0, byte)`; advance 1.
+
+## Wire format (CMP00)
+
+```
+Bytes 0–3:  token_count  (big-endian uint32)
+Bytes 4+:   token_count × 4 bytes:
+              [0–1] offset    (big-endian uint16)
+              [2]   length    (uint8)
+              [3]   next_char (uint8)
+```
+
+## Quick start
+
+```java
+byte[] original   = "hello hello hello".getBytes();
+byte[] compressed = LZ77.compress(original);
+byte[] recovered  = LZ77.decompress(compressed);
+assert Arrays.equals(original, recovered);
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+38 tests covering round-trip fidelity, token correctness, wire format,
+edge cases, overlapping matches, compression effectiveness, and determinism.

--- a/code/packages/java/lz77/build.gradle.kts
+++ b/code/packages/java/lz77/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/lz77/settings.gradle.kts
+++ b/code/packages/java/lz77/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lz77"

--- a/code/packages/java/lz77/src/main/java/com/codingadventures/lz77/LZ77.java
+++ b/code/packages/java/lz77/src/main/java/com/codingadventures/lz77/LZ77.java
@@ -1,0 +1,438 @@
+// ============================================================================
+// LZ77.java — CMP00: LZ77 Lossless Compression Algorithm (1977)
+// ============================================================================
+//
+// LZ77 is the foundational sliding-window compression algorithm published by
+// Abraham Lempel and Jacob Ziv in 1977.  It is the direct ancestor of LZSS,
+// LZW, DEFLATE, zstd, LZ4, and virtually every modern compressor used in
+// ZIP, gzip, PNG, and zlib.
+//
+// The core idea: instead of storing every byte verbatim, notice when a
+// sequence of bytes has appeared recently.  Replace that sequence with a
+// cheap back-reference: (offset, length).  This exploits locality of real
+// data — repeated words, duplicate instructions, adjacent colour runs.
+//
+// ============================================================================
+// The Sliding Window Model
+// ============================================================================
+//
+//   ┌─────────────────────────────────┬──────────────────┐
+//   │         SEARCH BUFFER           │ LOOKAHEAD BUFFER  │
+//   │  (already processed — the       │  (not yet seen —  │
+//   │   last window_size bytes)       │  next max_match)  │
+//   └─────────────────────────────────┴──────────────────┘
+//                                     ↑
+//                                 cursor (current position)
+//
+// At each step the encoder searches the search buffer for the longest prefix
+// of the lookahead buffer.  If it finds a match long enough (≥ min_match),
+// it emits a back-reference token; otherwise it emits a literal token for
+// the current byte.
+//
+// ============================================================================
+// Token: (offset, length, next_char)
+// ============================================================================
+//
+//   offset    (uint16, 0–65535): distance back to the match start, or 0.
+//   length    (uint8,  0–255):   number of bytes in the match, or 0.
+//   next_char (uint8,  0–255):   the literal byte after the match.
+//
+// A "literal" token has offset=0, length=0; the payload is just next_char.
+// The decoder always appends next_char after copying length bytes.
+//
+// ============================================================================
+// Overlapping Matches
+// ============================================================================
+//
+// A match may extend into output bytes not yet written (when offset < length).
+// This naturally encodes runs.  Example: if output so far is [A,B] and we
+// emit Token(2, 5, 'Z'), the decoder copies byte-by-byte:
+//
+//   1. copy output[0]='A' → [A,B,A]
+//   2. copy output[1]='B' → [A,B,A,B]
+//   3. copy output[2]='A' (just written) → [A,B,A,B,A]
+//   4–5. continues → [A,B,A,B,A,B,A]
+//   finally append 'Z' → [A,B,A,B,A,B,A,Z]
+//
+// Bulk memmove would be wrong here; byte-by-byte copy handles the overlap.
+//
+// ============================================================================
+// Wire Format (CMP00)
+// ============================================================================
+//
+//   Bytes 0–3:    token_count  (big-endian uint32)
+//   Bytes 4+:     token_count × 4 bytes:
+//                   [0–1] offset    (big-endian uint16)
+//                   [2]   length    (uint8)
+//                   [3]   next_char (uint8)
+//
+// This is a teaching format.  Production compressors use variable-width
+// bit-packing (DEFLATE, zstd) for further size reduction.
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.  (this)
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+// Reference
+// ============================================================================
+//
+//   Lempel, A., & Ziv, J. (1977). "A Universal Algorithm for Sequential Data
+//   Compression". IEEE Transactions on Information Theory, 23(3), 337–343.
+//
+// ============================================================================
+
+package com.codingadventures.lz77;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CMP00: LZ77 lossless compression.
+ *
+ * <p>Provides {@link #compress(byte[])} and {@link #decompress(byte[])} for
+ * one-shot compression/decompression, and {@link #encode(byte[])}/
+ * {@link #decode(List)} for working with the intermediate token stream.
+ *
+ * <pre>{@code
+ * byte[] original   = "AAABBC hello hello".getBytes();
+ * byte[] compressed = LZ77.compress(original);
+ * byte[] recovered  = LZ77.decompress(compressed);
+ * assert Arrays.equals(original, recovered);
+ * }</pre>
+ */
+public final class LZ77 {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Default sliding-window size (maximum back-reference distance). */
+    public static final int DEFAULT_WINDOW_SIZE = 4096;
+
+    /** Default maximum match length (fits in one uint8). */
+    public static final int DEFAULT_MAX_MATCH = 255;
+
+    /**
+     * Default minimum match length for a back-reference to be emitted.
+     *
+     * <p>A match of length 3 in LZ77 costs exactly 4 bytes (offset=2 + length=1
+     * + next_char=1).  Three literals also cost 3×1+3×overhead = 4 bytes in
+     * this wire format (a token per literal still costs 4 bytes), so length=3
+     * is the break-even point.
+     */
+    public static final int DEFAULT_MIN_MATCH = 3;
+
+    /** Wire-format header size in bytes (token_count). */
+    private static final int HEADER_SIZE = 4;
+
+    /** Wire-format bytes per token (offset=2, length=1, next_char=1). */
+    private static final int TOKEN_SIZE = 4;
+
+    /** Utility class — no instances. */
+    private LZ77() {}
+
+    // =========================================================================
+    // Token record
+    // =========================================================================
+
+    /**
+     * A single LZ77 token: (offset, length, next_char).
+     *
+     * <p>Represents one unit of the compressed stream.
+     *
+     * <ul>
+     *   <li>{@code offset=0, length=0} → pure literal; payload is next_char.</li>
+     *   <li>{@code offset>0, length>0} → back-reference: copy {@code length}
+     *       bytes from {@code offset} positions back, then emit next_char.</li>
+     * </ul>
+     *
+     * @param offset    distance back the match starts (1..window_size), or 0
+     * @param length    number of matched bytes (0 = no match)
+     * @param nextChar  literal byte immediately after the match (0..255)
+     */
+    public record Token(int offset, int length, int nextChar) {
+
+        /** Create a literal token for a single byte {@code b}. */
+        public static Token literal(int b) {
+            return new Token(0, 0, b & 0xFF);
+        }
+
+        /** Create a back-reference token. */
+        public static Token match(int offset, int length, int nextChar) {
+            return new Token(offset, length, nextChar & 0xFF);
+        }
+
+        /** Return true if this token is a pure literal (no back-reference). */
+        public boolean isLiteral() { return length == 0; }
+    }
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * Encode {@code data} into an LZ77 token stream using the default parameters.
+     *
+     * @param data the bytes to encode
+     * @return token stream suitable for passing to {@link #decode(List)}
+     */
+    public static List<Token> encode(byte[] data) {
+        return encode(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH);
+    }
+
+    /**
+     * Encode {@code data} into an LZ77 token stream with custom parameters.
+     *
+     * <p>Algorithm (greedy O(n × window)):
+     * <ol>
+     *   <li>For each cursor position, scan the last {@code windowSize} bytes for
+     *       the longest match prefix of the lookahead.</li>
+     *   <li>If the best match is ≥ {@code minMatch}, emit a back-reference token
+     *       and advance cursor by {@code length + 1}.</li>
+     *   <li>Otherwise emit a literal token and advance cursor by 1.</li>
+     * </ol>
+     *
+     * <p>Note: one byte is always reserved for next_char, so the lookahead can
+     * extend at most to {@code data.length - 1}.
+     *
+     * @param data       the bytes to encode
+     * @param windowSize maximum back-reference distance (search buffer size)
+     * @param maxMatch   maximum match length
+     * @param minMatch   minimum match length to emit a back-reference
+     * @return token stream
+     */
+    public static List<Token> encode(byte[] data, int windowSize, int maxMatch, int minMatch) {
+        List<Token> tokens = new ArrayList<>();
+        int cursor = 0;
+
+        while (cursor < data.length) {
+            int[] best = findLongestMatch(data, cursor, windowSize, maxMatch);
+            int bestOffset = best[0];
+            int bestLength = best[1];
+
+            if (bestLength >= minMatch) {
+                // Back-reference token: next_char is the byte after the match.
+                int nextChar = data[cursor + bestLength] & 0xFF;
+                tokens.add(Token.match(bestOffset, bestLength, nextChar));
+                cursor += bestLength + 1;
+            } else {
+                // Literal token.
+                tokens.add(Token.literal(data[cursor] & 0xFF));
+                cursor += 1;
+            }
+        }
+
+        return tokens;
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode an LZ77 token stream back into the original bytes.
+     *
+     * <p>For each token:
+     * <ul>
+     *   <li>If {@code length > 0}: copy {@code length} bytes one-at-a-time from
+     *       position {@code output.size() - offset}.  Byte-by-byte copy handles
+     *       overlapping matches (offset &lt; length).</li>
+     *   <li>Always append {@code next_char}.</li>
+     * </ul>
+     *
+     * @param tokens the token stream from {@link #encode(byte[])}
+     * @return the reconstructed bytes
+     */
+    public static byte[] decode(List<Token> tokens) {
+        return decode(tokens, new byte[0]);
+    }
+
+    /**
+     * Decode with an optional pre-seeded output buffer (for streaming use).
+     *
+     * @param tokens        the token stream
+     * @param initialBuffer optional seed for the search buffer
+     * @return the reconstructed bytes (includes the seed)
+     */
+    public static byte[] decode(List<Token> tokens, byte[] initialBuffer) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            out.write(initialBuffer);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        for (Token token : tokens) {
+            if (token.length() > 0) {
+                // Back-reference: copy byte-by-byte for overlap safety.
+                int start = out.size() - token.offset();
+                // Guard: offset must not exceed what has already been written.
+                // A crafted stream with offset > out.size() would produce a
+                // negative start index and cause ArrayIndexOutOfBoundsException.
+                if (start < 0) {
+                    throw new IllegalArgumentException(
+                        "LZ77: back-reference offset " + token.offset() +
+                        " exceeds output buffer size " + out.size());
+                }
+                for (int i = 0; i < token.length(); i++) {
+                    // Re-read each time: if offset < length, we read bytes
+                    // written during this very loop iteration.
+                    out.write(out.toByteArray()[start + i]);
+                }
+            }
+            // Always append next_char.
+            out.write(token.nextChar());
+        }
+
+        return out.toByteArray();
+    }
+
+    // =========================================================================
+    // One-shot compress / decompress
+    // =========================================================================
+
+    /**
+     * Compress {@code data} using LZ77 with default parameters and return
+     * the CMP00 wire-format bytes.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP00 wire format
+     */
+    public static byte[] compress(byte[] data) {
+        return compress(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH);
+    }
+
+    /**
+     * Compress {@code data} with custom parameters.
+     *
+     * @param data       the bytes to compress
+     * @param windowSize maximum back-reference distance
+     * @param maxMatch   maximum match length
+     * @param minMatch   minimum match length for a back-reference
+     * @return compressed bytes in CMP00 wire format
+     */
+    public static byte[] compress(byte[] data, int windowSize, int maxMatch, int minMatch) {
+        if (data == null) data = new byte[0];
+        List<Token> tokens = encode(data, windowSize, maxMatch, minMatch);
+        return serialiseTokens(tokens);
+    }
+
+    /**
+     * Decompress CMP00 wire-format bytes back to the original data.
+     *
+     * @param data compressed bytes (null treated as empty)
+     * @return the original, uncompressed bytes
+     */
+    public static byte[] decompress(byte[] data) {
+        if (data == null || data.length < HEADER_SIZE) return new byte[0];
+        List<Token> tokens = deserialiseTokens(data);
+        return decode(tokens);
+    }
+
+    // =========================================================================
+    // Serialisation helpers
+    // =========================================================================
+
+    /**
+     * Serialise a token list to the CMP00 wire format.
+     *
+     * <p>Format: {@code [token_count (4B BE)] [N × (offset BE uint16, length uint8, next_char uint8)]}
+     *
+     * @param tokens the token list
+     * @return the serialised bytes
+     */
+    static byte[] serialiseTokens(List<Token> tokens) {
+        int n = tokens.size();
+        ByteBuffer buf = ByteBuffer.allocate(HEADER_SIZE + n * TOKEN_SIZE)
+            .order(ByteOrder.BIG_ENDIAN);
+        buf.putInt(n);
+        for (Token t : tokens) {
+            buf.putShort((short) t.offset());  // uint16
+            buf.put((byte) t.length());         // uint8
+            buf.put((byte) t.nextChar());       // uint8
+        }
+        return buf.array();
+    }
+
+    /**
+     * Deserialise CMP00 wire-format bytes into a token list.
+     *
+     * @param data the serialised bytes
+     * @return the token list
+     */
+    static List<Token> deserialiseTokens(byte[] data) {
+        if (data == null || data.length < HEADER_SIZE) return new ArrayList<>();
+        ByteBuffer buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN);
+        int tokenCount = buf.getInt();
+
+        // Cap against payload size to prevent DoS from crafted headers.
+        int maxTokens = (data.length - HEADER_SIZE) / TOKEN_SIZE;
+        int safeCount = Math.min(tokenCount, maxTokens);
+
+        List<Token> tokens = new ArrayList<>(safeCount);
+        for (int i = 0; i < safeCount && buf.remaining() >= TOKEN_SIZE; i++) {
+            int offset   = buf.getShort() & 0xFFFF;  // uint16
+            int length   = buf.get() & 0xFF;          // uint8
+            int nextChar = buf.get() & 0xFF;          // uint8
+            tokens.add(new Token(offset, length, nextChar));
+        }
+        return tokens;
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Find the longest match for {@code data[cursor:]} in the search buffer.
+     *
+     * <p>Scans the {@code window_size} bytes before {@code cursor} for the
+     * longest prefix of {@code data[cursor:]} that also appears there.
+     * Matches may overlap the lookahead region (extend past cursor) — the
+     * decoder handles this correctly by copying byte-by-byte.
+     *
+     * <p>One byte is always reserved for next_char, so the lookahead can
+     * match at most to {@code data.length - 1}.
+     *
+     * @param data       full input bytes
+     * @param cursor     current encode position (start of lookahead)
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @return {@code {bestOffset, bestLength}}; both 0 if no match found
+     */
+    private static int[] findLongestMatch(byte[] data, int cursor, int windowSize, int maxMatch) {
+        int bestOffset = 0;
+        int bestLength = 0;
+
+        int searchStart  = Math.max(0, cursor - windowSize);
+        // One byte reserved for next_char → lookahead ends at data.length - 1.
+        int lookaheadEnd = Math.min(cursor + maxMatch, data.length - 1);
+
+        for (int pos = searchStart; pos < cursor; pos++) {
+            int length = 0;
+            while (cursor + length < lookaheadEnd
+                && data[pos + length] == data[cursor + length]) {
+                length++;
+            }
+            if (length > bestLength) {
+                bestLength = length;
+                bestOffset = cursor - pos;  // distance back from cursor
+            }
+        }
+
+        return new int[]{bestOffset, bestLength};
+    }
+}

--- a/code/packages/java/lz77/src/test/java/com/codingadventures/lz77/LZ77Test.java
+++ b/code/packages/java/lz77/src/test/java/com/codingadventures/lz77/LZ77Test.java
@@ -1,0 +1,345 @@
+// ============================================================================
+// LZ77Test.java — CMP00: LZ77 Compression Tests
+// ============================================================================
+//
+// Test organisation:
+//  1. Round-trip (compress → decompress = original)
+//  2. Token stream correctness
+//  3. Wire format
+//  4. Edge cases (empty, null, single byte, repeated byte)
+//  5. Overlapping matches (run-length encoding degenerate case)
+//  6. Compression effectiveness
+//  7. Decode with initial buffer (streaming seed)
+//  8. Determinism
+// ============================================================================
+
+package com.codingadventures.lz77;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LZ77Test {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test void roundTrip_helloWorld() {
+        roundTrip("hello world".getBytes());
+    }
+
+    @Test void roundTrip_aaabbc() {
+        roundTrip("AAABBC".getBytes());
+    }
+
+    @Test void roundTrip_repeatedPattern() {
+        roundTrip(repeat("ABCABC".getBytes(), 100));
+    }
+
+    @Test void roundTrip_loremIpsum() {
+        roundTrip(("Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                   "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.").getBytes());
+    }
+
+    @Test void roundTrip_all256Bytes() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        roundTrip(data);
+    }
+
+    @Test void roundTrip_binaryData() {
+        roundTrip(new byte[]{0, 1, 2, 3, (byte)255, (byte)254, (byte)253, (byte)128, 64, 32});
+    }
+
+    @Test void roundTrip_longInput() {
+        roundTrip(repeat("the quick brown fox jumps over the lazy dog ".getBytes(), 200));
+    }
+
+    @Test void roundTrip_singleByte() {
+        roundTrip(new byte[]{(byte)'A'});
+    }
+
+    @Test void roundTrip_twoBytes() {
+        roundTrip(new byte[]{(byte)'A', (byte)'B'});
+    }
+
+    @Test void roundTrip_singleRepeatedByte() {
+        byte[] data = new byte[100];
+        Arrays.fill(data, (byte)'A');
+        roundTrip(data);
+    }
+
+    @Test void roundTrip_newlineHeavyText() {
+        roundTrip(repeat("line\n".getBytes(), 200));
+    }
+
+    // =========================================================================
+    // 2. Token stream correctness
+    // =========================================================================
+
+    @Test void encode_simpleABABAB_producesExpectedTokens() {
+        // "ABABABAB" (8 bytes): A literal, B literal, then a 6-byte match
+        // that self-overlaps (offset=2 covers ABABAB, next_char=last byte)
+        byte[] data = "ABABABAB".getBytes();
+        List<LZ77.Token> tokens = LZ77.encode(data);
+        // Decode must give back the original
+        assertArrayEquals(data, LZ77.decode(tokens));
+    }
+
+    @Test void encode_noRepetition_allLiterals() {
+        // A 3-byte non-repeating sequence — all three tokens should be literals
+        // (no sequence of length ≥ minMatch=3 repeats)
+        byte[] data = new byte[]{1, 2, 3};
+        List<LZ77.Token> tokens = LZ77.encode(data);
+        assertTrue(tokens.stream().allMatch(LZ77.Token::isLiteral),
+            "Non-repeating 3-byte input should produce only literals");
+    }
+
+    @Test void encode_AAAAAAA_producesBackRef() {
+        // "AAAAAAA" (7 bytes): literal 'A', then a back-reference token
+        byte[] data = "AAAAAAA".getBytes();
+        List<LZ77.Token> tokens = LZ77.encode(data);
+        long backRefs = tokens.stream().filter(t -> !t.isLiteral()).count();
+        assertTrue(backRefs > 0, "Repeated 'A' bytes should produce at least one back-reference");
+        assertArrayEquals(data, LZ77.decode(tokens));
+    }
+
+    @Test void token_isLiteral() {
+        LZ77.Token lit = LZ77.Token.literal(65);
+        assertTrue(lit.isLiteral());
+        assertEquals(0, lit.offset());
+        assertEquals(0, lit.length());
+        assertEquals(65, lit.nextChar());
+    }
+
+    @Test void token_isMatch() {
+        LZ77.Token match = LZ77.Token.match(4, 5, 90);
+        assertFalse(match.isLiteral());
+        assertEquals(4, match.offset());
+        assertEquals(5, match.length());
+        assertEquals(90, match.nextChar());
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test void wireFormat_empty() {
+        byte[] result = LZ77.compress(new byte[0]);
+        // 4-byte header with count=0
+        assertEquals(4, result.length);
+        int tokenCount = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN).getInt();
+        assertEquals(0, tokenCount);
+    }
+
+    @Test void wireFormat_tokenCountField() {
+        // "A" encodes to 1 token (literal)
+        byte[] compressed = LZ77.compress(new byte[]{(byte)'A'});
+        int tokenCount = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt();
+        assertEquals(1, tokenCount);
+    }
+
+    @Test void wireFormat_eachTokenIs4Bytes() {
+        // For 2 tokens: header(4) + 2×4 = 12 bytes
+        byte[] compressed = LZ77.compress("AB".getBytes()); // 2 literal tokens
+        List<LZ77.Token> tokens = LZ77.encode("AB".getBytes());
+        int expected = 4 + tokens.size() * 4;
+        assertEquals(expected, compressed.length);
+    }
+
+    @Test void wireFormat_offsetBigEndian() {
+        // Build a 2-token stream manually: Token(offset=1000, length=5, next=65)
+        LZ77.Token t = LZ77.Token.match(1000, 5, 65);
+        byte[] wire = LZ77.serialiseTokens(List.of(t));
+        // Header: token_count = 1 (bytes 0-3)
+        assertEquals(1, ByteBuffer.wrap(wire, 0, 4).order(ByteOrder.BIG_ENDIAN).getInt());
+        // Token bytes 4-7: offset big-endian uint16
+        int offset = ((wire[4] & 0xFF) << 8) | (wire[5] & 0xFF);
+        assertEquals(1000, offset);
+        assertEquals(5, wire[6] & 0xFF);   // length
+        assertEquals(65, wire[7] & 0xFF);  // next_char
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test void compress_null() {
+        assertArrayEquals(new byte[0], LZ77.decompress(LZ77.compress(null)));
+    }
+
+    @Test void compress_empty() {
+        assertArrayEquals(new byte[0], LZ77.decompress(LZ77.compress(new byte[0])));
+    }
+
+    @Test void decompress_null() {
+        assertArrayEquals(new byte[0], LZ77.decompress(null));
+    }
+
+    @Test void decompress_tooShort() {
+        assertArrayEquals(new byte[0], LZ77.decompress(new byte[]{0, 0, 0}));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65, 127, 255})
+    void roundTrip_singleSymbol(int sym) {
+        roundTrip(new byte[]{(byte) sym});
+    }
+
+    @Test void roundTrip_nullBytes() {
+        byte[] data = new byte[100]; // all zeros
+        roundTrip(data);
+    }
+
+    @Test void roundTrip_highByteValues() {
+        byte[] data = new byte[128];
+        for (int i = 0; i < 128; i++) data[i] = (byte)(128 + i);
+        roundTrip(data);
+    }
+
+    // =========================================================================
+    // 5. Overlapping matches
+    // =========================================================================
+
+    @Test void decode_overlappingMatch_runsCorrectly() {
+        // Token(offset=1, length=6, next_char='Z'): starting from "A",
+        // copy 6 bytes with offset=1 → produces "AAAAAAAZ"... wait:
+        // more precisely, the initial output would be [A] from a literal first.
+        // Let's build manually: literal(65) then match(1, 6, 90).
+        // Decode: output=[A], then copy 6 bytes from pos 0 (1 back):
+        //   step 1: output[0]='A' → [A,A]
+        //   step 2: output[1]='A' → [A,A,A]
+        //   ... all 6 → [A,A,A,A,A,A,A]
+        //   then next_char='Z' → [A,A,A,A,A,A,A,Z]
+        List<LZ77.Token> tokens = List.of(
+            LZ77.Token.literal(65),          // 'A'
+            LZ77.Token.match(1, 6, 90)       // 6 copies of 'A', then 'Z'
+        );
+        byte[] result = LZ77.decode(tokens);
+        assertArrayEquals("AAAAAAAZ".getBytes(), result);
+    }
+
+    @Test void decode_abOverlap_ABABAB() {
+        // literal(65)='A', literal(66)='B', match(2,4,'B') → ABABAB + B = ABABAB
+        // Actually: output=[A,B], then copy 4 from pos 0 (2 back):
+        //   output[0]='A' → [A,B,A]
+        //   output[1]='B' → [A,B,A,B]
+        //   output[2]='A' (just written) → [A,B,A,B,A]
+        //   output[3]='B' (just written) → [A,B,A,B,A,B]
+        //   then next_char='B' → [A,B,A,B,A,B,B]
+        List<LZ77.Token> tokens = List.of(
+            LZ77.Token.literal(65),
+            LZ77.Token.literal(66),
+            LZ77.Token.match(2, 4, 66)
+        );
+        byte[] result = LZ77.decode(tokens);
+        assertArrayEquals("ABABABB".getBytes(), result);
+    }
+
+    // =========================================================================
+    // 6. Compression effectiveness
+    // =========================================================================
+
+    @Test void effectiveness_repeatedPattern_shrinks() {
+        // A highly repetitive pattern should compress significantly
+        byte[] data = repeat("ABCABCABC".getBytes(), 100);
+        byte[] compressed = LZ77.compress(data);
+        assertTrue(compressed.length < data.length,
+            "Repetitive data should compress below raw size");
+    }
+
+    @Test void effectiveness_repeatedByte_shrinks() {
+        byte[] data = new byte[1000];
+        Arrays.fill(data, (byte)'X');
+        byte[] compressed = LZ77.compress(data);
+        assertTrue(compressed.length < data.length);
+    }
+
+    @Test void effectiveness_uniformRandom_notLargerThan4x() {
+        // Truly random-ish data (all 256 bytes once) should not expand beyond reason
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        byte[] compressed = LZ77.compress(data);
+        // Each byte becomes a literal token (4 bytes), so 256*4 + 4 = 1028
+        assertTrue(compressed.length <= data.length * 4 + 8,
+            "Incompressible data should not expand beyond token overhead");
+    }
+
+    // =========================================================================
+    // 7. Decode with initial buffer
+    // =========================================================================
+
+    @Test void decode_withInitialBuffer_includedInOutput() {
+        // Seed the decoder with some context
+        byte[] seed = "ABCD".getBytes();
+        // A token referencing bytes in the seed (offset=4 → 4 bytes back)
+        List<LZ77.Token> tokens = List.of(LZ77.Token.match(4, 3, 90)); // 'Z'
+        byte[] result = LZ77.decode(tokens, seed);
+        // Output starts with seed, then copies 3 bytes from offset 4 = "ABC", then 'Z'
+        // seed=[A,B,C,D], copy 3 from pos 0 (seed[0..2]) → [A,B,C], then 'Z'
+        byte[] expected = "ABCDABCZ".getBytes();
+        assertArrayEquals(expected, result);
+    }
+
+    // =========================================================================
+    // 8. Security / robustness
+    // =========================================================================
+
+    @Test void decode_craftedOffset_throwsOnOOB() {
+        // A Match token whose offset exceeds the current output buffer size
+        // must throw IllegalArgumentException, not ArrayIndexOutOfBoundsException.
+        List<LZ77.Token> tokens = List.of(
+            LZ77.Token.match(65535, 1, 0) // offset 65535, but output is empty
+        );
+        assertThrows(IllegalArgumentException.class, () -> LZ77.decode(tokens));
+    }
+
+    @Test void decompress_craftedOffset_doesNotCrash() {
+        // 4-byte header: token_count=1, then 1 token: offset=0xFFFF, length=1, nextChar=0
+        byte[] crafted = new byte[]{
+            0, 0, 0, 1,           // token_count = 1
+            (byte)0xFF, (byte)0xFF, // offset = 65535
+            1,                     // length = 1
+            0                      // nextChar = 0
+        };
+        assertThrows(IllegalArgumentException.class, () -> LZ77.decompress(crafted));
+    }
+
+    // =========================================================================
+    // 9. Determinism
+    // =========================================================================
+
+    @Test void deterministicCompression() {
+        byte[] data = "the quick brown fox jumps over the lazy dog".getBytes();
+        assertArrayEquals(LZ77.compress(data), LZ77.compress(data));
+    }
+
+    @Test void deterministicDecompression() {
+        byte[] data = "hello world hello world".getBytes();
+        byte[] compressed = LZ77.compress(data);
+        assertArrayEquals(LZ77.decompress(compressed), LZ77.decompress(compressed));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static void roundTrip(byte[] data) {
+        assertArrayEquals(data, LZ77.decompress(LZ77.compress(data)),
+            "Round-trip failed for " + data.length + " bytes");
+    }
+
+    private static byte[] repeat(byte[] src, int times) {
+        byte[] out = new byte[src.length * times];
+        for (int i = 0; i < times; i++) System.arraycopy(src, 0, out, i * src.length, src.length);
+        return out;
+    }
+}

--- a/code/packages/java/lzss/.gitignore
+++ b/code/packages/java/lzss/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/lzss/BUILD
+++ b/code/packages/java/lzss/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lzss/BUILD_windows
+++ b/code/packages/java/lzss/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lzss/CHANGELOG.md
+++ b/code/packages/java/lzss/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog — lzss (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZSS` class with `compress`, `decompress`, `encode`, `decode`,
+  `serialiseTokens`, `deserialiseTokens`.
+- Sealed `Token` interface with `Literal` record and `Match` record
+  (Java 21 sealed hierarchy + pattern matching).
+- Flag-byte scheme: 8 symbols per block; bit i=0 → Literal (1B),
+  bit i=1 → Match (3B: offset BE uint16 + length uint8).
+- CMP02 wire format: `original_length(4B) + block_count(4B) + blocks`.
+- `original_length` stored in header (no sentinel in pure flag-bit stream).
+- Overlapping-match support: byte-by-byte copy in `decode`.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.
+- 35+ unit tests covering round-trip, token stream, wire format, edge cases,
+  overlapping matches, effectiveness, and determinism.

--- a/code/packages/java/lzss/README.md
+++ b/code/packages/java/lzss/README.md
@@ -1,0 +1,57 @@
+# lzss (Java) — CMP02
+
+LZSS lossless compression for Java.  LZSS (Lempel-Ziv-Storer-Szymanski, 1982)
+is a refinement of LZ77 that eliminates the wasted literal byte present in every
+LZ77 token by replacing the fixed `(offset, length, next_char)` triple with a
+flag-bit scheme: each symbol is either a bare literal byte or a bare
+back-reference, never both.
+
+## What it does
+
+`LZSS` provides:
+
+| Method | Description |
+|--------|-------------|
+| `compress(byte[])` | Encode bytes into CMP02 wire format |
+| `decompress(byte[])` | Decode CMP02 wire format |
+| `encode(byte[])` | Encode to `List<Token>` |
+| `decode(List<Token>, int)` | Decode token stream |
+
+## Token types
+
+| Type | Fields | Wire size |
+|------|--------|-----------|
+| `Literal` | `value` (0–255) | 1 byte |
+| `Match` | `offset` (1..4096), `length` (3..255) | 3 bytes |
+
+## Quick start
+
+```java
+byte[] original   = "hello hello hello".getBytes();
+byte[] compressed = LZSS.compress(original);
+byte[] recovered  = LZSS.decompress(compressed);
+assert Arrays.equals(original, recovered);
+```
+
+## Wire format (CMP02)
+
+```
+Bytes 0–3:  original_length  (big-endian uint32)
+Bytes 4–7:  block_count      (big-endian uint32)
+Bytes 8+:   blocks
+
+Each block:
+  [1 byte]  flag_byte (bit i → 0=Literal, 1=Match)
+  [variable] symbol data:
+      Literal: 1 byte  (byte value)
+      Match:   3 bytes (offset BE uint16 + length uint8)
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+35+ tests covering round-trip, token stream, wire format, edge cases,
+overlapping matches, effectiveness, and determinism.

--- a/code/packages/java/lzss/build.gradle.kts
+++ b/code/packages/java/lzss/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/lzss/settings.gradle.kts
+++ b/code/packages/java/lzss/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lzss"

--- a/code/packages/java/lzss/src/main/java/com/codingadventures/lzss/LZSS.java
+++ b/code/packages/java/lzss/src/main/java/com/codingadventures/lzss/LZSS.java
@@ -1,0 +1,472 @@
+// ============================================================================
+// LZSS.java — CMP02: LZSS Lossless Compression Algorithm (1982)
+// ============================================================================
+//
+// LZSS (Lempel-Ziv-Storer-Szymanski, 1982) is a refinement of LZ77 (CMP00)
+// that eliminates a systematic waste: in LZ77, every token emits a trailing
+// `next_char` byte even after a long back-reference.  LZSS replaces the fixed
+// (offset, length, next_char) triple with a flag-bit scheme where each symbol
+// is either a bare literal byte or a bare back-reference — never both.
+//
+// ============================================================================
+// The Improvement Over LZ77
+// ============================================================================
+//
+//   LZ77:  every token = 4 bytes  (offset=2 + length=1 + next_char=1)
+//   LZSS:  literal   = 1 byte     (just the byte value)
+//           match    = 3 bytes     (offset=2 + length=1)
+//
+// A flag byte precedes every group of 8 symbols to tell the decoder which are
+// literals and which are matches.
+//
+// ============================================================================
+// The Flag-Byte Scheme
+// ============================================================================
+//
+// Symbols are grouped in chunks of 8.  Each chunk is preceded by one flag byte:
+//
+//   bit 0 (LSB) = type of symbol 0 in this chunk
+//   bit 1       = type of symbol 1
+//   ...
+//   bit 7       = type of symbol 7
+//
+//   0 = Literal   → 1 byte  (the actual byte value)
+//   1 = Match     → 3 bytes (offset as big-endian uint16 + length as uint8)
+//
+// The last block may have < 8 symbols; unused flag bits are 0.
+//
+// ============================================================================
+// Break-Even Point
+// ============================================================================
+//
+// A match costs 3 bytes.  Three literals also cost 3 bytes (1 each).  So a
+// match of length ≥ 3 breaks even or saves space.  Traditionally `min_match=3`
+// is used — the same break-even threshold as LZ77.
+//
+// ============================================================================
+// Overlapping Matches
+// ============================================================================
+//
+// LZSS inherits LZ77's self-referential matches (offset < length).  Decoding
+// must copy byte-by-byte, not with a bulk memmove.
+//
+// ============================================================================
+// Wire Format (CMP02)
+// ============================================================================
+//
+//   Bytes 0–3:  original_length  (big-endian uint32)
+//   Bytes 4–7:  block_count      (big-endian uint32)
+//   Bytes 8+:   blocks
+//
+//   Each block:
+//     [1 byte]    flag_byte (bit i → 0=Literal, 1=Match for symbol i)
+//     [variable]  symbol data:
+//         Literal: 1 byte  (byte value)
+//         Match:   3 bytes (offset big-endian uint16 + length uint8)
+//
+// `original_length` is stored because LZSS has no sentinel — the decoder
+// needs the exact count to know when to stop.
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals. (this)
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+// References
+// ============================================================================
+//
+//   Storer, J.A., & Szymanski, T.G. (1982). "Data Compression via Textual
+//   Substitution". Journal of the ACM, 29(4), 928–951.
+//
+//   Lempel, A., & Ziv, J. (1977). "A Universal Algorithm for Sequential Data
+//   Compression". IEEE Transactions on Information Theory, 23(3), 337–343.
+//
+// ============================================================================
+
+package com.codingadventures.lzss;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CMP02: LZSS lossless compression.
+ *
+ * <p>Provides {@link #compress(byte[])} and {@link #decompress(byte[])} for
+ * one-shot compression, and {@link #encode(byte[])}/{@link #decode(List,int)}
+ * for working with the intermediate token stream.
+ *
+ * <pre>{@code
+ * byte[] original   = "hello hello hello".getBytes();
+ * byte[] compressed = LZSS.compress(original);
+ * byte[] recovered  = LZSS.decompress(compressed);
+ * assert Arrays.equals(original, recovered);
+ * }</pre>
+ */
+public final class LZSS {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Default sliding-window size (maximum back-reference distance). */
+    public static final int DEFAULT_WINDOW_SIZE = 4096;
+
+    /** Default maximum match length (fits in uint8). */
+    public static final int DEFAULT_MAX_MATCH = 255;
+
+    /** Default minimum match length for a back-reference to be worthwhile. */
+    public static final int DEFAULT_MIN_MATCH = 3;
+
+    /** Symbols per flag-byte group. */
+    private static final int BLOCK_SIZE = 8;
+
+    /** Wire-format header size: original_length(4) + block_count(4). */
+    private static final int HEADER_SIZE = 8;
+
+    /** Utility class — no instances. */
+    private LZSS() {}
+
+    // =========================================================================
+    // Token types
+    // =========================================================================
+
+    /**
+     * A single LZSS token — either a bare literal byte or a bare back-reference.
+     *
+     * <p>LZSS uses a sealed hierarchy: each token is one of:
+     * <ul>
+     *   <li>{@link Literal} — a single raw byte.</li>
+     *   <li>{@link Match}   — a (offset, length) back-reference.</li>
+     * </ul>
+     */
+    public sealed interface Token permits LZSS.Literal, LZSS.Match {
+        /** True if this is a literal token. */
+        boolean isLiteral();
+    }
+
+    /**
+     * A single literal byte in the LZSS token stream.
+     *
+     * @param value the byte value (0–255)
+     */
+    public record Literal(int value) implements Token {
+        @Override public boolean isLiteral() { return true; }
+    }
+
+    /**
+     * A back-reference match in the LZSS token stream.
+     *
+     * @param offset distance back in the output where the match begins (1..window_size)
+     * @param length number of bytes to copy (min_match..max_match)
+     */
+    public record Match(int offset, int length) implements Token {
+        @Override public boolean isLiteral() { return false; }
+    }
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * Encode {@code data} into an LZSS token stream using default parameters.
+     *
+     * @param data the bytes to encode
+     * @return token stream (mix of {@link Literal} and {@link Match})
+     */
+    public static List<Token> encode(byte[] data) {
+        return encode(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH);
+    }
+
+    /**
+     * Encode {@code data} into an LZSS token stream with custom parameters.
+     *
+     * <p>Key difference from LZ77: on a match, the cursor advances by exactly
+     * {@code length} (not {@code length + 1}).  There is no trailing next_char.
+     *
+     * @param data       the bytes to encode
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @param minMatch   minimum match length for a Match token
+     * @return list of {@link Literal} and {@link Match} tokens
+     */
+    public static List<Token> encode(byte[] data, int windowSize, int maxMatch, int minMatch) {
+        List<Token> tokens = new ArrayList<>();
+        int cursor = 0;
+
+        while (cursor < data.length) {
+            int[] best = findLongestMatch(data, cursor, windowSize, maxMatch);
+            int bestOffset = best[0];
+            int bestLength = best[1];
+
+            if (bestLength >= minMatch) {
+                // Emit bare back-reference; cursor advances by length only.
+                tokens.add(new Match(bestOffset, bestLength));
+                cursor += bestLength;
+            } else {
+                // Emit bare literal; cursor advances by 1.
+                tokens.add(new Literal(data[cursor] & 0xFF));
+                cursor += 1;
+            }
+        }
+
+        return tokens;
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode an LZSS token stream back into the original bytes.
+     *
+     * <p>Processes each token:
+     * <ul>
+     *   <li>{@link Literal}: append the byte to output.</li>
+     *   <li>{@link Match}: copy {@code length} bytes one-at-a-time from
+     *       {@code output.size - offset}.  Byte-by-byte handles overlapping.</li>
+     * </ul>
+     *
+     * @param tokens         the token stream from {@link #encode(byte[])}
+     * @param originalLength if ≥ 0, truncate to this length; pass -1 for no truncation
+     * @return the reconstructed bytes
+     */
+    public static byte[] decode(List<Token> tokens, int originalLength) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        for (Token token : tokens) {
+            if (token instanceof Literal lit) {
+                out.write(lit.value());
+            } else {
+                Match m   = (Match) token;
+                int start = out.size() - m.offset();
+                // Guard: offset must not exceed what has already been written.
+                // A crafted stream with offset > out.size() would produce a
+                // negative start index and cause ArrayIndexOutOfBoundsException.
+                if (start < 0) {
+                    throw new IllegalArgumentException(
+                        "LZSS: back-reference offset " + m.offset() +
+                        " exceeds output buffer size " + out.size());
+                }
+                for (int i = 0; i < m.length(); i++) {
+                    out.write(out.toByteArray()[start + i]);
+                }
+            }
+        }
+
+        byte[] result = out.toByteArray();
+        // originalLength must be non-negative; negative values (from crafted headers)
+        // are treated as "no truncation" to avoid NegativeArraySizeException.
+        if (originalLength >= 0 && originalLength < result.length) {
+            byte[] trimmed = new byte[originalLength];
+            System.arraycopy(result, 0, trimmed, 0, originalLength);
+            return trimmed;
+        }
+        return result;
+    }
+
+    // =========================================================================
+    // One-shot compress / decompress
+    // =========================================================================
+
+    /**
+     * Compress {@code data} using LZSS and return CMP02 wire-format bytes.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP02 wire format
+     */
+    public static byte[] compress(byte[] data) {
+        return compress(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH);
+    }
+
+    /**
+     * Compress with custom parameters.
+     *
+     * @param data       the bytes to compress
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @param minMatch   minimum match length for a back-reference
+     * @return compressed bytes in CMP02 wire format
+     */
+    public static byte[] compress(byte[] data, int windowSize, int maxMatch, int minMatch) {
+        if (data == null) data = new byte[0];
+        List<Token> tokens = encode(data, windowSize, maxMatch, minMatch);
+        return serialiseTokens(tokens, data.length);
+    }
+
+    /**
+     * Decompress CMP02 wire-format bytes back to the original data.
+     *
+     * @param data compressed bytes (null treated as empty)
+     * @return the original, uncompressed bytes
+     */
+    public static byte[] decompress(byte[] data) {
+        if (data == null || data.length < HEADER_SIZE) return new byte[0];
+        int[] header = parseHeader(data);
+        int originalLength = header[0];
+        List<Token> tokens = deserialiseTokens(data);
+        return decode(tokens, originalLength);
+    }
+
+    // =========================================================================
+    // Serialisation helpers
+    // =========================================================================
+
+    /**
+     * Serialise an LZSS token list to the CMP02 wire format.
+     *
+     * <p>Groups tokens into blocks of up to 8.  Each block is preceded by a
+     * flag byte (bit i → 0=Literal, 1=Match), followed by the token data:
+     * <ul>
+     *   <li>Literal: 1 byte</li>
+     *   <li>Match: 3 bytes (offset big-endian uint16 + length uint8)</li>
+     * </ul>
+     *
+     * @param tokens         the token list
+     * @param originalLength length of the original uncompressed data
+     * @return the CMP02 wire-format bytes
+     */
+    static byte[] serialiseTokens(List<Token> tokens, int originalLength) {
+        List<byte[]> blocks = new ArrayList<>();
+        int i = 0;
+        while (i < tokens.size()) {
+            List<Token> chunk = tokens.subList(i, Math.min(i + BLOCK_SIZE, tokens.size()));
+            int flag = 0;
+            ByteArrayOutputStream blockData = new ByteArrayOutputStream();
+
+            for (int bit = 0; bit < chunk.size(); bit++) {
+                Token tok = chunk.get(bit);
+                if (tok instanceof Match m) {
+                    flag |= (1 << bit);
+                    try {
+                        blockData.write(new byte[]{
+                            (byte)(m.offset() >> 8),   // offset high byte
+                            (byte)(m.offset() & 0xFF), // offset low byte
+                            (byte) m.length()           // length
+                        });
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                } else {
+                    blockData.write(((Literal) tok).value());
+                }
+            }
+
+            ByteArrayOutputStream block = new ByteArrayOutputStream();
+            block.write(flag);
+            try { block.write(blockData.toByteArray()); }
+            catch (IOException e) { throw new UncheckedIOException(e); }
+            blocks.add(block.toByteArray());
+            i += BLOCK_SIZE;
+        }
+
+        // Header: original_length(4B) + block_count(4B)
+        ByteBuffer header = ByteBuffer.allocate(HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        header.putInt(originalLength).putInt(blocks.size());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            out.write(header.array());
+            for (byte[] b : blocks) out.write(b);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Deserialise CMP02 wire-format bytes into a token list.
+     *
+     * @param data the CMP02 bytes
+     * @return list of {@link Literal} and {@link Match} tokens
+     */
+    static List<Token> deserialiseTokens(byte[] data) {
+        if (data == null || data.length < HEADER_SIZE) return new ArrayList<>();
+        ByteBuffer header = ByteBuffer.wrap(data, 0, HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        /* originalLength = */ header.getInt();
+        int blockCount = header.getInt();
+
+        // Cap block count against actual payload to prevent DoS.
+        int maxBlocks = data.length - HEADER_SIZE; // at least 1 byte per block
+        int safeCount = Math.min(blockCount, maxBlocks);
+
+        List<Token> tokens = new ArrayList<>();
+        int pos = HEADER_SIZE;
+
+        for (int b = 0; b < safeCount && pos < data.length; b++) {
+            int flag = data[pos++] & 0xFF;
+
+            for (int bit = 0; bit < BLOCK_SIZE && pos < data.length; bit++) {
+                if ((flag & (1 << bit)) != 0) {
+                    // Match: 3 bytes
+                    if (pos + 3 > data.length) break;
+                    int offset = ((data[pos] & 0xFF) << 8) | (data[pos + 1] & 0xFF);
+                    int length = data[pos + 2] & 0xFF;
+                    tokens.add(new Match(offset, length));
+                    pos += 3;
+                } else {
+                    // Literal: 1 byte
+                    tokens.add(new Literal(data[pos++] & 0xFF));
+                }
+            }
+        }
+
+        return tokens;
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /** Parse the 8-byte header; returns [original_length, block_count]. */
+    private static int[] parseHeader(byte[] data) {
+        ByteBuffer buf = ByteBuffer.wrap(data, 0, HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        return new int[]{buf.getInt(), buf.getInt()};
+    }
+
+    /**
+     * Find the longest match for {@code data[cursor:]} in the search buffer.
+     *
+     * <p>Unlike LZ77's implementation, the lookahead may extend all the way to
+     * {@code data.length} — there is no next_char reservation in LZSS.
+     *
+     * @param data       full input bytes
+     * @param cursor     current encode position
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @return {@code {bestOffset, bestLength}}; both 0 if no match found
+     */
+    private static int[] findLongestMatch(byte[] data, int cursor, int windowSize, int maxMatch) {
+        int bestOffset = 0;
+        int bestLength = 0;
+
+        int searchStart  = Math.max(0, cursor - windowSize);
+        // No next_char reservation: lookahead extends to end of input.
+        int lookaheadEnd = Math.min(cursor + maxMatch, data.length);
+
+        for (int pos = searchStart; pos < cursor; pos++) {
+            int length = 0;
+            while (cursor + length < lookaheadEnd
+                && data[pos + length] == data[cursor + length]) {
+                length++;
+            }
+            if (length > bestLength) {
+                bestLength = length;
+                bestOffset = cursor - pos;
+            }
+        }
+
+        return new int[]{bestOffset, bestLength};
+    }
+}

--- a/code/packages/java/lzss/src/test/java/com/codingadventures/lzss/LZSSTest.java
+++ b/code/packages/java/lzss/src/test/java/com/codingadventures/lzss/LZSSTest.java
@@ -1,0 +1,218 @@
+// ============================================================================
+// LZSSTest.java — CMP02: LZSS Compression Tests
+// ============================================================================
+
+package com.codingadventures.lzss;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LZSSTest {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test void roundTrip_helloWorld()      { roundTrip("hello world".getBytes()); }
+    @Test void roundTrip_aaabbc()          { roundTrip("AAABBC".getBytes()); }
+    @Test void roundTrip_repeatedPattern() { roundTrip(repeat("ABCABC".getBytes(), 100)); }
+    @Test void roundTrip_loremIpsum()      { roundTrip(("Lorem ipsum dolor sit amet, consectetur " +
+        "adipiscing elit.").getBytes()); }
+    @Test void roundTrip_all256Bytes()     {
+        byte[] d = new byte[256]; for (int i=0;i<256;i++) d[i]=(byte)i; roundTrip(d); }
+    @Test void roundTrip_binaryData()      { roundTrip(new byte[]{0,1,2,3,(byte)255,(byte)128,64}); }
+    @Test void roundTrip_longInput()       { roundTrip(repeat(
+        "the quick brown fox jumps over the lazy dog ".getBytes(), 200)); }
+    @Test void roundTrip_singleByte()      { roundTrip(new byte[]{(byte)'A'}); }
+    @Test void roundTrip_twoBytes()        { roundTrip(new byte[]{(byte)'A',(byte)'B'}); }
+    @Test void roundTrip_singleRepeated()  { byte[] d=new byte[100]; Arrays.fill(d,(byte)'A'); roundTrip(d); }
+    @Test void roundTrip_newlineHeavy()    { roundTrip(repeat("line\n".getBytes(), 200)); }
+    @Test void roundTrip_nullBytes()       { roundTrip(new byte[100]); }
+    @Test void roundTrip_highBytes()       {
+        byte[] d=new byte[128]; for(int i=0;i<128;i++) d[i]=(byte)(128+i); roundTrip(d); }
+
+    // =========================================================================
+    // 2. Token stream correctness
+    // =========================================================================
+
+    @Test void encode_ABABABAB_hasMatch() {
+        byte[] data = "ABABABAB".getBytes();
+        List<LZSS.Token> tokens = LZSS.encode(data);
+        assertTrue(tokens.stream().anyMatch(t -> !t.isLiteral()),
+            "Repeating AB pattern should produce at least one Match token");
+        assertArrayEquals(data, LZSS.decode(tokens, -1));
+    }
+
+    @Test void encode_shortNonRepeat_allLiterals() {
+        byte[] data = new byte[]{1, 2, 3};
+        List<LZSS.Token> tokens = LZSS.encode(data);
+        assertTrue(tokens.stream().allMatch(LZSS.Token::isLiteral),
+            "3-byte non-repeating input should produce only literals");
+    }
+
+    @Test void encode_AAAAAAA_producesMatch() {
+        byte[] data = "AAAAAAA".getBytes();
+        List<LZSS.Token> tokens = LZSS.encode(data);
+        assertTrue(tokens.stream().anyMatch(t -> t instanceof LZSS.Match));
+        assertArrayEquals(data, LZSS.decode(tokens, -1));
+    }
+
+    @Test void literal_properties() {
+        LZSS.Literal lit = new LZSS.Literal(65);
+        assertTrue(lit.isLiteral());
+        assertEquals(65, lit.value());
+    }
+
+    @Test void match_properties() {
+        LZSS.Match m = new LZSS.Match(10, 5);
+        assertFalse(m.isLiteral());
+        assertEquals(10, m.offset());
+        assertEquals(5,  m.length());
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test void wireFormat_emptyInput() {
+        byte[] result = LZSS.compress(new byte[0]);
+        assertEquals(8, result.length);
+        ByteBuffer buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN);
+        assertEquals(0, buf.getInt()); // original_length
+        assertEquals(0, buf.getInt()); // block_count
+    }
+
+    @Test void wireFormat_originalLengthStored() {
+        for (int len : new int[]{1, 5, 100}) {
+            byte[] data = new byte[len]; Arrays.fill(data, (byte)'A');
+            byte[] compressed = LZSS.compress(data);
+            int stored = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt();
+            assertEquals(len, stored);
+        }
+    }
+
+    @Test void wireFormat_blockCountField() {
+        // 1 byte → 1 token → 1 block
+        byte[] compressed = LZSS.compress("A".getBytes());
+        ByteBuffer buf = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN);
+        buf.getInt(); // skip original_length
+        int blockCount = buf.getInt();
+        assertEquals(1, blockCount);
+    }
+
+    @Test void wireFormat_flagByteIsFirstByteOfBlock() {
+        // "A" → 1 Literal token → flag_byte = 0 (bit 0 = 0 = Literal)
+        byte[] compressed = LZSS.compress("A".getBytes());
+        int flagByte = compressed[8] & 0xFF;
+        assertEquals(0, flagByte, "Single literal → flag_byte should be 0");
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test void compress_null()        { assertArrayEquals(new byte[0], LZSS.decompress(LZSS.compress(null))); }
+    @Test void compress_empty()       { assertArrayEquals(new byte[0], LZSS.decompress(LZSS.compress(new byte[0]))); }
+    @Test void decompress_null()      { assertArrayEquals(new byte[0], LZSS.decompress(null)); }
+    @Test void decompress_tooShort()  { assertArrayEquals(new byte[0], LZSS.decompress(new byte[4])); }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65, 127, 255})
+    void roundTrip_singleSymbol(int sym) { roundTrip(new byte[]{(byte) sym}); }
+
+    // =========================================================================
+    // 5. Overlapping matches
+    // =========================================================================
+
+    @Test void decode_overlappingMatch_runs() {
+        // literal('A') → [A]; match(offset=1, length=6) → [A,A,A,A,A,A,A]
+        List<LZSS.Token> tokens = List.of(
+            new LZSS.Literal(65),
+            new LZSS.Match(1, 6)
+        );
+        byte[] result = LZSS.decode(tokens, -1);
+        assertArrayEquals("AAAAAAA".getBytes(), result);
+    }
+
+    @Test void decode_abOverlap() {
+        // [A,B] then match(2,4) → [A,B,A,B,A,B]
+        List<LZSS.Token> tokens = List.of(
+            new LZSS.Literal(65),
+            new LZSS.Literal(66),
+            new LZSS.Match(2, 4)
+        );
+        byte[] result = LZSS.decode(tokens, -1);
+        assertArrayEquals("ABABAB".getBytes(), result);
+    }
+
+    // =========================================================================
+    // 6. Compression effectiveness
+    // =========================================================================
+
+    @Test void effectiveness_repeatedPattern_shrinks() {
+        byte[] data = repeat("ABCABCABC".getBytes(), 100);
+        assertTrue(LZSS.compress(data).length < data.length);
+    }
+
+    @Test void effectiveness_repeatedByte_shrinks() {
+        byte[] data = new byte[1000]; Arrays.fill(data, (byte)'X');
+        assertTrue(LZSS.compress(data).length < data.length);
+    }
+
+    @Test void effectiveness_vsLz77_noBloat() {
+        // LZSS should not produce more output than raw input for all-unique data
+        byte[] data = new byte[256]; for (int i=0;i<256;i++) data[i]=(byte)i;
+        byte[] compressed = LZSS.compress(data);
+        // Each byte → 1 Literal token (1 byte payload) + flag byte per 8 = 288+8 header
+        assertTrue(compressed.length < data.length * 3,
+            "LZSS should not expand incompressible data by more than 3x");
+    }
+
+    // =========================================================================
+    // 7. Security / robustness
+    // =========================================================================
+
+    @Test void decode_craftedOffset_throwsOnOOB() {
+        // A Match token whose offset exceeds the current output buffer size
+        // must throw IllegalArgumentException, not ArrayIndexOutOfBoundsException.
+        List<LZSS.Token> tokens = List.of(new LZSS.Match(65535, 3));
+        assertThrows(IllegalArgumentException.class, () -> LZSS.decode(tokens, -1));
+    }
+
+    // =========================================================================
+    // 8. Determinism
+    // =========================================================================
+
+    @Test void deterministicCompression() {
+        byte[] data = "the quick brown fox jumps over the lazy dog".getBytes();
+        assertArrayEquals(LZSS.compress(data), LZSS.compress(data));
+    }
+
+    @Test void deterministicDecompression() {
+        byte[] compressed = LZSS.compress("hello world hello world".getBytes());
+        assertArrayEquals(LZSS.decompress(compressed), LZSS.decompress(compressed));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static void roundTrip(byte[] data) {
+        assertArrayEquals(data, LZSS.decompress(LZSS.compress(data)),
+            "Round-trip failed for " + data.length + " bytes");
+    }
+
+    private static byte[] repeat(byte[] src, int times) {
+        byte[] out = new byte[src.length * times];
+        for (int i = 0; i < times; i++) System.arraycopy(src, 0, out, i*src.length, src.length);
+        return out;
+    }
+}

--- a/code/packages/java/lzw/.gitignore
+++ b/code/packages/java/lzw/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/lzw/BUILD
+++ b/code/packages/java/lzw/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lzw/BUILD_windows
+++ b/code/packages/java/lzw/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lzw/CHANGELOG.md
+++ b/code/packages/java/lzw/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog — lzw (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZW` class with `compress`, `decompress`, `encodeCodes`, `decodeCodes`,
+  `packCodes`, `unpackCodes`.
+- `BitWriter` inner class: LSB-first variable-width bit packing.
+- `BitReader` inner class: LSB-first variable-width bit reading.
+- `ByteKey` inner class: value-based byte-array HashMap key.
+- Pre-seeded 256-entry dictionary (codes 0–255 = single bytes).
+- CLEAR_CODE(256) and STOP_CODE(257) control codes.
+- Variable-width codes starting at 9 bits; grows at power-of-2 boundaries;
+  max 16 bits (65536 entries).
+- Tricky-token handling: `code == next_code` → entry from prev + prev[0].
+- Dictionary reset on CLEAR_CODE and when dictionary is full.
+- CMP03 wire format: `original_length(4B BE) + LSB-first bit-packed codes`.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.
+- 38+ unit tests covering round-trip, code stream, wire format, edge cases,
+  tricky token, bit I/O, effectiveness, and determinism.

--- a/code/packages/java/lzw/README.md
+++ b/code/packages/java/lzw/README.md
@@ -1,0 +1,51 @@
+# lzw (Java) — CMP03
+
+LZW lossless compression for Java.  LZW (Lempel-Ziv-Welch, 1984) is LZ78
+with a pre-seeded 256-entry dictionary, variable-width LSB-first bit-packed
+codes, CLEAR/STOP control codes, and the tricky-token edge case handled.
+This is the algorithm that powers GIF compression.
+
+## What it does
+
+`LZW` provides:
+
+| Method | Description |
+|--------|-------------|
+| `compress(byte[])` | Encode bytes into CMP03 wire format |
+| `decompress(byte[])` | Decode CMP03 wire format |
+
+## Quick start
+
+```java
+byte[] original   = "hello hello hello".getBytes();
+byte[] compressed = LZW.compress(original);
+byte[] recovered  = LZW.decompress(compressed);
+assert Arrays.equals(original, recovered);
+```
+
+## Wire format (CMP03)
+
+```
+Bytes 0–3:  original_length  (big-endian uint32)
+Bytes 4+:   variable-width codes, LSB-first bit-packed
+
+  Code sizes:
+    Start at 9 bits (covers codes 0–511)
+    Grow when next_code exceeds current power-of-2 boundary
+    Maximum 16 bits (dictionary capped at 65536 entries)
+
+  Reserved codes:
+    0–255:  Pre-seeded single bytes
+    256:    CLEAR_CODE (reset dictionary)
+    257:    STOP_CODE  (end of stream)
+    258+:   Dynamic entries
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+38+ tests covering round-trip, code stream structure, wire format, edge cases,
+tricky token, bit I/O, effectiveness, and determinism.

--- a/code/packages/java/lzw/build.gradle.kts
+++ b/code/packages/java/lzw/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/lzw/settings.gradle.kts
+++ b/code/packages/java/lzw/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lzw"

--- a/code/packages/java/lzw/src/main/java/com/codingadventures/lzw/LZW.java
+++ b/code/packages/java/lzw/src/main/java/com/codingadventures/lzw/LZW.java
@@ -1,0 +1,593 @@
+// ============================================================================
+// LZW.java — CMP03: LZW Lossless Compression Algorithm (1984)
+// ============================================================================
+//
+// LZW (Lempel-Ziv-Welch, 1984) is LZ78 with one key change: the dictionary is
+// pre-seeded with all 256 single-byte sequences before encoding begins.  This
+// means:
+//
+//   1. The encoder never needs to emit a raw byte outside the code stream —
+//      every byte already has a code (0–255).
+//   2. Tokens are just codes (unsigned integers), not (dict_index, next_char)
+//      tuples like LZ78.
+//   3. With only codes to transmit, the stream can be bit-packed at variable
+//      width — codes start at 9 bits and grow as the dictionary expands.
+//      This is exactly how GIF compression works.
+//
+// ============================================================================
+// Reserved Codes
+// ============================================================================
+//
+//   0–255:  Pre-seeded. Code c decodes to the single byte c.
+//   256:    CLEAR_CODE. Reset the dictionary and code_size.
+//   257:    STOP_CODE.  End of stream.
+//   258+:   Dynamic entries built during encoding.
+//
+// ============================================================================
+// Variable-Width Bit-Packing (LSB-first)
+// ============================================================================
+//
+// Codes are packed bit-by-bit, LSB-first, into a byte stream.  The code_size
+// starts at 9 bits and grows when next_code crosses the next power-of-2
+// boundary.  This matches GIF and Unix compress conventions.
+//
+//   Example: writing code 421 (0b110100101, 9 bits) then code 2 (0b10, 2 bits):
+//
+//     buffer = 0b110100101          (9 bits)
+//     byte 0 = 0b10100101           (low 8 bits)
+//     buffer = 0b1                  (1 bit remaining)
+//     write 2 = 0b10 → buffer = 0b101
+//     (flush) byte 1 = 0b101
+//
+// Maximum code_size = 16 (dictionary capped at 65536 entries).
+//
+// ============================================================================
+// The Tricky Token
+// ============================================================================
+//
+// During decoding there is a classic edge case: the decoder may receive a code
+// equal to next_code — a code it has not yet added to its dictionary.  This
+// happens when the encoded sequence has the form xyx...x (the new entry starts
+// with the same byte as the previous entry).  In that case:
+//
+//   entry = dict[prev_code] + byte { dict[prev_code][0] }
+//
+// This always produces the correct sequence because the encoder only emits such
+// a code when the new entry equals the previous entry extended by its own first
+// byte.
+//
+// ============================================================================
+// Wire Format (CMP03)
+// ============================================================================
+//
+//   Bytes 0–3:  original_length  (big-endian uint32)
+//   Bytes 4+:   bit-packed variable-width codes, LSB-first within each byte
+//
+//     - Starts at code_size = 9 bits
+//     - Grows when next_code crosses the next power-of-2 boundary
+//     - Maximum code_size = 16 (up to 65536 dictionary entries)
+//     - Stream always begins with CLEAR_CODE and ends with STOP_CODE
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF. (this)
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+// References
+// ============================================================================
+//
+//   Welch, T.A. (1984). "A Technique for High-Performance Data Compression".
+//   Computer, 17(6), 8–19. doi:10.1109/MC.1984.1659158
+//
+//   Ziv, J., & Lempel, A. (1978). "Compression of Individual Sequences via
+//   Variable-Rate Coding". IEEE Transactions on Information Theory, 24(5),
+//   530–536.
+//
+// ============================================================================
+
+package com.codingadventures.lzw;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CMP03: LZW lossless compression.
+ *
+ * <p>Provides {@link #compress(byte[])} and {@link #decompress(byte[])} for
+ * one-shot compression.
+ *
+ * <pre>{@code
+ * byte[] original   = "hello hello hello".getBytes();
+ * byte[] compressed = LZW.compress(original);
+ * byte[] recovered  = LZW.decompress(compressed);
+ * assert Arrays.equals(original, recovered);
+ * }</pre>
+ */
+public final class LZW {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Reset code — instructs the decoder to clear its dictionary and restart. */
+    public static final int CLEAR_CODE = 256;
+
+    /** End-of-stream code — the decoder stops reading after this code. */
+    public static final int STOP_CODE = 257;
+
+    /** First dynamically assigned dictionary code. */
+    public static final int INITIAL_NEXT_CODE = 258;
+
+    /** Starting bit-width for codes (covers 0–511, more than enough for 258). */
+    public static final int INITIAL_CODE_SIZE = 9;
+
+    /** Maximum bit-width; dictionary caps at 2^16 = 65536 entries. */
+    public static final int MAX_CODE_SIZE = 16;
+
+    /**
+     * Maximum decompressed output size (64 MiB by default).
+     *
+     * <p>A fully-saturated LZW dictionary (65536 entries, each one byte longer
+     * than the last) can theoretically require ~2 GB of heap.  This limit caps
+     * the output to prevent heap exhaustion from crafted streams.  Call
+     * {@link #decodeCodes(List, int)} directly with a higher limit when needed.
+     */
+    public static final int DEFAULT_MAX_OUTPUT = 64 * 1024 * 1024; // 64 MiB
+
+    /** Wire-format header size: original_length(4). */
+    private static final int HEADER_SIZE = 4;
+
+    /** Utility class — no instances. */
+    private LZW() {}
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Compress {@code data} using LZW and return CMP03 wire-format bytes.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP03 wire format
+     */
+    public static byte[] compress(byte[] data) {
+        if (data == null) data = new byte[0];
+        List<Integer> codes = encodeCodes(data);
+        return packCodes(codes, data.length);
+    }
+
+    /**
+     * Decompress CMP03 wire-format bytes back to the original data.
+     *
+     * <p>Output is capped at {@link #DEFAULT_MAX_OUTPUT} bytes to prevent heap
+     * exhaustion from crafted streams.
+     *
+     * @param data compressed bytes (null treated as empty)
+     * @return the original, uncompressed bytes
+     */
+    public static byte[] decompress(byte[] data) {
+        if (data == null || data.length < HEADER_SIZE) return new byte[0];
+        int originalLength = ByteBuffer.wrap(data, 0, HEADER_SIZE)
+            .order(ByteOrder.BIG_ENDIAN).getInt();
+        List<Integer> codes = unpackCodes(data);
+        byte[] result = decodeCodes(codes, DEFAULT_MAX_OUTPUT);
+        // Trim to original length to remove bit-padding artefacts.
+        if (originalLength >= 0 && originalLength <= result.length) {
+            return Arrays.copyOf(result, originalLength);
+        }
+        return result;
+    }
+
+    // =========================================================================
+    // Encoder
+    // =========================================================================
+
+    /**
+     * Encode {@code data} into a list of LZW codes (including CLEAR and STOP).
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Initialise the encode dictionary: byte → code for all 256 bytes.</li>
+     *   <li>Emit CLEAR_CODE to mark the start of the stream.</li>
+     *   <li>Walk the input byte-by-byte, extending the current prefix {@code w}:
+     *       <ul>
+     *         <li>If {@code w + b} is already in the dictionary, extend {@code w}.</li>
+     *         <li>Otherwise, emit code_for({@code w}), add {@code w + b} as a new
+     *             entry, reset {@code w} to just {@code b}.</li>
+     *         <li>When the dictionary is full, emit CLEAR_CODE and re-initialise.</li>
+     *       </ul>
+     *   </li>
+     *   <li>Flush the remaining prefix and emit STOP_CODE.</li>
+     * </ol>
+     *
+     * @param data the bytes to encode
+     * @return list of LZW codes
+     */
+    static List<Integer> encodeCodes(byte[] data) {
+        List<Integer> codes = new ArrayList<>();
+        int maxEntries = 1 << MAX_CODE_SIZE; // 65536
+
+        // Build encode dictionary: byte[] → code (using ByteKey wrapper).
+        Map<ByteKey, Integer> encodeDict = new HashMap<>(512);
+        for (int b = 0; b < 256; b++) {
+            encodeDict.put(new ByteKey(new byte[]{(byte) b}), b);
+        }
+        int nextCode = INITIAL_NEXT_CODE;
+
+        codes.add(CLEAR_CODE);
+
+        byte[] w = new byte[0]; // current working prefix
+
+        for (byte rawByte : data) {
+            byte[] wb = append(w, rawByte);
+            if (encodeDict.containsKey(new ByteKey(wb))) {
+                w = wb; // extend the prefix
+            } else {
+                // Emit code for the current prefix.
+                codes.add(encodeDict.get(new ByteKey(w)));
+
+                if (nextCode < maxEntries) {
+                    encodeDict.put(new ByteKey(wb), nextCode);
+                    nextCode++;
+                } else {
+                    // Dictionary full — emit CLEAR and reset.
+                    codes.add(CLEAR_CODE);
+                    encodeDict.clear();
+                    for (int b = 0; b < 256; b++) {
+                        encodeDict.put(new ByteKey(new byte[]{(byte) b}), b);
+                    }
+                    nextCode = INITIAL_NEXT_CODE;
+                }
+
+                w = new byte[]{rawByte}; // restart with the unmatched byte
+            }
+        }
+
+        // Flush remaining prefix.
+        if (w.length > 0) {
+            codes.add(encodeDict.get(new ByteKey(w)));
+        }
+
+        codes.add(STOP_CODE);
+        return codes;
+    }
+
+    // =========================================================================
+    // Decoder
+    // =========================================================================
+
+    /**
+     * Decode a list of LZW codes back to the original bytes.
+     *
+     * <p>Uses {@link #DEFAULT_MAX_OUTPUT} as the output size limit.
+     *
+     * @param codes the code list from {@link #encodeCodes(byte[])}
+     * @return the decoded bytes
+     * @throws IllegalArgumentException if the code stream is corrupt or too large
+     */
+    static byte[] decodeCodes(List<Integer> codes) {
+        return decodeCodes(codes, DEFAULT_MAX_OUTPUT);
+    }
+
+    /**
+     * Decode a list of LZW codes back to the original bytes, with an output cap.
+     *
+     * <p>Handles:
+     * <ul>
+     *   <li>CLEAR_CODE: reset dictionary and code_size.</li>
+     *   <li>STOP_CODE: stop decoding.</li>
+     *   <li>Tricky token (code == next_code): construct the entry as
+     *       {@code dict[prev_code] + byte{dict[prev_code][0]}}.</li>
+     * </ul>
+     *
+     * <p>Security: without a size cap, a crafted stream that never emits
+     * CLEAR_CODE can force the decoder to build up to 65278 dictionary entries,
+     * each growing by 1 byte.  Total worst-case allocation ≈ 2 GB.  The
+     * {@code maxOutput} limit stops decoding before heap exhaustion occurs.
+     *
+     * @param codes     the code list from {@link #encodeCodes(byte[])}
+     * @param maxOutput maximum bytes to emit; throw if exceeded
+     * @return the decoded bytes
+     * @throws IllegalArgumentException if the code stream is corrupt or output exceeds maxOutput
+     */
+    static byte[] decodeCodes(List<Integer> codes, int maxOutput) {
+        // Decode dictionary: code → byte sequence.
+        List<byte[]> decodeDict = new ArrayList<>(512);
+        for (int b = 0; b < 256; b++) {
+            decodeDict.add(new byte[]{(byte) b});
+        }
+        decodeDict.add(new byte[0]); // 256 = CLEAR_CODE placeholder
+        decodeDict.add(new byte[0]); // 257 = STOP_CODE  placeholder
+        int nextCode = INITIAL_NEXT_CODE;
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Integer prevCode = null;
+
+        for (int code : codes) {
+            if (code == CLEAR_CODE) {
+                // Reset dictionary to 256 single-byte entries.
+                decodeDict.clear();
+                for (int b = 0; b < 256; b++) {
+                    decodeDict.add(new byte[]{(byte) b});
+                }
+                decodeDict.add(new byte[0]); // 256
+                decodeDict.add(new byte[0]); // 257
+                nextCode = INITIAL_NEXT_CODE;
+                prevCode = null;
+                continue;
+            }
+
+            if (code == STOP_CODE) {
+                break;
+            }
+
+            byte[] entry;
+            if (code < decodeDict.size()) {
+                entry = decodeDict.get(code);
+            } else if (code == nextCode) {
+                // Tricky token: code not yet in dict.
+                // Only valid when prev_code exists; entry = dict[prev] + dict[prev][0].
+                if (prevCode == null) {
+                    throw new IllegalArgumentException(
+                        "Invalid LZW stream: tricky token with no previous code");
+                }
+                byte[] prevEntry = decodeDict.get(prevCode);
+                entry = append(prevEntry, prevEntry[0]);
+            } else {
+                throw new IllegalArgumentException(
+                    "Invalid LZW code: exceeds expected next code");
+            }
+
+            // Guard against heap exhaustion from crafted streams.
+            if (out.size() + entry.length > maxOutput) {
+                throw new IllegalArgumentException(
+                    "LZW: decompressed output exceeds limit of " + maxOutput + " bytes");
+            }
+
+            try { out.write(entry); } catch (Exception e) { throw new RuntimeException(e); }
+
+            // Add new entry to the decode dictionary.
+            if (prevCode != null && nextCode < (1 << MAX_CODE_SIZE)) {
+                byte[] prevEntry = decodeDict.get(prevCode);
+                decodeDict.add(append(prevEntry, entry[0]));
+                nextCode++;
+            }
+
+            prevCode = code;
+        }
+
+        return out.toByteArray();
+    }
+
+    // =========================================================================
+    // Serialisation
+    // =========================================================================
+
+    /**
+     * Pack a list of LZW codes into the CMP03 wire format.
+     *
+     * <p>Wire format:
+     * <ul>
+     *   <li>Bytes 0–3: original_length (big-endian uint32)</li>
+     *   <li>Bytes 4+: codes as variable-width LSB-first bit-packed integers</li>
+     * </ul>
+     *
+     * <p>The code size starts at {@link #INITIAL_CODE_SIZE} (9) and grows each
+     * time next_code crosses the next power-of-2 boundary.  CLEAR_CODE resets
+     * the code size back to {@link #INITIAL_CODE_SIZE}.
+     *
+     * @param codes          the code list
+     * @param originalLength length of the original uncompressed data
+     * @return CMP03 wire-format bytes
+     */
+    static byte[] packCodes(List<Integer> codes, int originalLength) {
+        BitWriter writer = new BitWriter();
+        int codeSize = INITIAL_CODE_SIZE;
+        int nextCode = INITIAL_NEXT_CODE;
+
+        for (int code : codes) {
+            writer.write(code, codeSize);
+
+            if (code == CLEAR_CODE) {
+                codeSize = INITIAL_CODE_SIZE;
+                nextCode = INITIAL_NEXT_CODE;
+            } else if (code != STOP_CODE) {
+                if (nextCode < (1 << MAX_CODE_SIZE)) {
+                    nextCode++;
+                    if (nextCode > (1 << codeSize) && codeSize < MAX_CODE_SIZE) {
+                        codeSize++;
+                    }
+                }
+            }
+        }
+        writer.flush();
+
+        ByteBuffer header = ByteBuffer.allocate(HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        header.putInt(originalLength);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            out.write(header.array());
+            out.write(writer.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Unpack CMP03 wire-format bytes into a list of LZW codes.
+     *
+     * <p>The decoder stops on STOP_CODE or stream exhaustion, so a crafted
+     * stream cannot cause unbounded iteration.
+     *
+     * @param data the CMP03 bytes
+     * @return list of LZW codes
+     */
+    static List<Integer> unpackCodes(byte[] data) {
+        if (data.length < HEADER_SIZE) {
+            return List.of(CLEAR_CODE, STOP_CODE);
+        }
+
+        BitReader reader = new BitReader(data, HEADER_SIZE);
+        List<Integer> codes = new ArrayList<>();
+        int codeSize = INITIAL_CODE_SIZE;
+        int nextCode = INITIAL_NEXT_CODE;
+
+        while (!reader.exhausted()) {
+            if (!reader.hasEnough(codeSize)) break;
+            int code = reader.read(codeSize);
+            codes.add(code);
+
+            if (code == STOP_CODE) {
+                break;
+            } else if (code == CLEAR_CODE) {
+                codeSize = INITIAL_CODE_SIZE;
+                nextCode = INITIAL_NEXT_CODE;
+            } else {
+                if (nextCode < (1 << MAX_CODE_SIZE)) {
+                    nextCode++;
+                    if (nextCode > (1 << codeSize) && codeSize < MAX_CODE_SIZE) {
+                        codeSize++;
+                    }
+                }
+            }
+        }
+
+        return codes;
+    }
+
+    // =========================================================================
+    // Bit I/O
+    // =========================================================================
+
+    /**
+     * Accumulates variable-width codes into a byte buffer, LSB-first.
+     *
+     * <p>LSB-first packing: the first code written occupies bits 0..N-1 of the
+     * first byte, spilling into subsequent bytes as necessary.  This matches the
+     * GIF and Unix compress conventions.
+     */
+    static final class BitWriter {
+        private long buffer = 0L;
+        private int  bitPos = 0;
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        /**
+         * Write {@code code} using exactly {@code codeSize} bits.
+         *
+         * @param code     the value to write
+         * @param codeSize number of bits to write (1..24)
+         */
+        void write(int code, int codeSize) {
+            buffer |= ((long) code) << bitPos;
+            bitPos += codeSize;
+            while (bitPos >= 8) {
+                out.write((int)(buffer & 0xFF));
+                buffer >>>= 8;
+                bitPos -= 8;
+            }
+        }
+
+        /** Flush any remaining bits as a final partial byte. */
+        void flush() {
+            if (bitPos > 0) {
+                out.write((int)(buffer & 0xFF));
+                buffer = 0;
+                bitPos = 0;
+            }
+        }
+
+        /** Return the accumulated output. */
+        byte[] toByteArray() { return out.toByteArray(); }
+    }
+
+    /**
+     * Reads variable-width codes from a byte buffer, LSB-first.
+     *
+     * <p>Mirrors {@link BitWriter} exactly: bits within each byte are consumed
+     * from the least-significant end first.
+     */
+    static final class BitReader {
+        private final byte[] data;
+        private int  pos;     // next byte index
+        private long buffer = 0L;
+        private int  bitPos = 0; // number of valid bits in buffer
+
+        BitReader(byte[] data, int startPos) {
+            this.data = data;
+            this.pos  = startPos;
+        }
+
+        /**
+         * Read and return the next {@code codeSize}-bit code.
+         *
+         * @param codeSize number of bits to read
+         * @return the decoded code value
+         */
+        int read(int codeSize) {
+            while (bitPos < codeSize) {
+                buffer |= ((long)(data[pos++] & 0xFF)) << bitPos;
+                bitPos += 8;
+            }
+            int code = (int)(buffer & ((1L << codeSize) - 1));
+            buffer >>>= codeSize;
+            bitPos -= codeSize;
+            return code;
+        }
+
+        /** True when the byte stream is exhausted and no buffered bits remain. */
+        boolean exhausted() { return pos >= data.length && bitPos == 0; }
+
+        /** True when at least {@code n} bits can still be read. */
+        boolean hasEnough(int n) {
+            int available = bitPos + (data.length - pos) * 8;
+            return available >= n;
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /** Append a single byte to the end of an array. */
+    private static byte[] append(byte[] arr, byte b) {
+        byte[] result = Arrays.copyOf(arr, arr.length + 1);
+        result[arr.length] = b;
+        return result;
+    }
+
+    /**
+     * A byte-array wrapper with value-based equals/hashCode.
+     *
+     * <p>Used as a HashMap key because raw {@code byte[]} uses identity equality.
+     */
+    static final class ByteKey {
+        private final byte[] data;
+
+        ByteKey(byte[] data) { this.data = data; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ByteKey bk)) return false;
+            return Arrays.equals(data, bk.data);
+        }
+
+        @Override
+        public int hashCode() { return Arrays.hashCode(data); }
+    }
+}

--- a/code/packages/java/lzw/src/test/java/com/codingadventures/lzw/LZWTest.java
+++ b/code/packages/java/lzw/src/test/java/com/codingadventures/lzw/LZWTest.java
@@ -1,0 +1,235 @@
+// ============================================================================
+// LZWTest.java — CMP03: LZW Compression Tests
+// ============================================================================
+
+package com.codingadventures.lzw;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LZWTest {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test void roundTrip_helloWorld()      { roundTrip("hello world".getBytes()); }
+    @Test void roundTrip_helloHello()      { roundTrip("hello hello hello".getBytes()); }
+    @Test void roundTrip_aaabbc()          { roundTrip("AAABBC".getBytes()); }
+    @Test void roundTrip_repeatedPattern() { roundTrip(repeat("ABCABC".getBytes(), 100)); }
+    @Test void roundTrip_loremIpsum()      {
+        roundTrip(("Lorem ipsum dolor sit amet, consectetur adipiscing elit.").getBytes()); }
+    @Test void roundTrip_all256Bytes()     {
+        byte[] d = new byte[256]; for (int i=0;i<256;i++) d[i]=(byte)i; roundTrip(d); }
+    @Test void roundTrip_binaryData()      {
+        roundTrip(new byte[]{0,1,2,3,(byte)255,(byte)128,64}); }
+    @Test void roundTrip_longInput()       {
+        roundTrip(repeat("the quick brown fox jumps over the lazy dog ".getBytes(), 200)); }
+    @Test void roundTrip_singleByte()      { roundTrip(new byte[]{(byte)'A'}); }
+    @Test void roundTrip_twoBytes()        { roundTrip(new byte[]{(byte)'A',(byte)'B'}); }
+    @Test void roundTrip_singleRepeated()  {
+        byte[] d=new byte[100]; Arrays.fill(d,(byte)'A'); roundTrip(d); }
+    @Test void roundTrip_newlineHeavy()    { roundTrip(repeat("line\n".getBytes(), 200)); }
+    @Test void roundTrip_nullBytes()       { roundTrip(new byte[100]); }
+    @Test void roundTrip_highBytes()       {
+        byte[] d=new byte[128]; for(int i=0;i<128;i++) d[i]=(byte)(128+i); roundTrip(d); }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 65, 127, 255})
+    void roundTrip_singleSymbol(int sym)   { roundTrip(new byte[]{(byte) sym}); }
+
+    // =========================================================================
+    // 2. Code stream structure
+    // =========================================================================
+
+    @Test void codes_startWithClearCode() {
+        List<Integer> codes = LZW.encodeCodes("hello".getBytes());
+        assertEquals(LZW.CLEAR_CODE, codes.get(0),
+            "First code should always be CLEAR_CODE");
+    }
+
+    @Test void codes_endWithStopCode() {
+        List<Integer> codes = LZW.encodeCodes("hello".getBytes());
+        assertEquals(LZW.STOP_CODE, codes.get(codes.size() - 1),
+            "Last code should always be STOP_CODE");
+    }
+
+    @Test void codes_repeatedInput_hasCodesAbove257() {
+        // A repeated pattern must produce at least one multi-byte dictionary entry.
+        List<Integer> codes = LZW.encodeCodes("ABABABABAB".getBytes());
+        assertTrue(codes.stream().anyMatch(c -> c >= LZW.INITIAL_NEXT_CODE),
+            "Repeated input should produce codes above 257");
+    }
+
+    @Test void codes_singleByte_roundTrips() {
+        List<Integer> codes = LZW.encodeCodes(new byte[]{'X'});
+        byte[] result = LZW.decodeCodes(codes);
+        assertArrayEquals(new byte[]{'X'}, result);
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test void wireFormat_originalLengthStoredInHeader() {
+        for (int len : new int[]{1, 5, 100}) {
+            byte[] data = new byte[len]; Arrays.fill(data, (byte)'A');
+            byte[] compressed = LZW.compress(data);
+            int stored = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt();
+            assertEquals(len, stored);
+        }
+    }
+
+    @Test void wireFormat_headerIs4Bytes() {
+        // Minimum: 4-byte header + at least one bit-packed byte
+        byte[] compressed = LZW.compress("A".getBytes());
+        assertTrue(compressed.length > 4, "Compressed output must exceed the 4-byte header");
+    }
+
+    @Test void wireFormat_emptyInput_producesHeaderOnly() {
+        byte[] compressed = LZW.compress(new byte[0]);
+        // Header (4B) + CLEAR_CODE (9b) + STOP_CODE (9b) = 18 bits = 3 bytes bit-packed
+        // Total should be 7 bytes
+        assertTrue(compressed.length >= 4, "Empty input should at least have a header");
+        int stored = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt();
+        assertEquals(0, stored, "original_length should be 0 for empty input");
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test void compress_null()       { assertArrayEquals(new byte[0], LZW.decompress(LZW.compress(null))); }
+    @Test void compress_empty()      { assertArrayEquals(new byte[0], LZW.decompress(LZW.compress(new byte[0]))); }
+    @Test void decompress_null()     { assertArrayEquals(new byte[0], LZW.decompress(null)); }
+    @Test void decompress_tooShort() { assertArrayEquals(new byte[0], LZW.decompress(new byte[2])); }
+
+    // =========================================================================
+    // 5. Tricky token (code == next_code)
+    // =========================================================================
+
+    @Test void trickyToken_aaaa() {
+        // "AAAA" triggers the tricky token scenario in LZW decoding.
+        // After emitting A(65) twice, the new entry "AA" gets code 258.
+        // The third A extends "AA" → the encoder emits code 258 (AA) before
+        // adding "AAA" as 259.  The decoder receives code 258 = next_code at that
+        // moment — the classic tricky token.
+        roundTrip("AAAA".getBytes());
+    }
+
+    @Test void trickyToken_longRun() {
+        // A long run of identical bytes repeatedly hits the tricky token.
+        byte[] data = new byte[200]; Arrays.fill(data, (byte)'Z');
+        roundTrip(data);
+    }
+
+    @Test void trickyToken_ababab() {
+        // "ABABAB..." where new entries immediately match next_code.
+        roundTrip(repeat("AB".getBytes(), 50));
+    }
+
+    // =========================================================================
+    // 6. Bit I/O round-trip
+    // =========================================================================
+
+    @Test void bitWriter_bitReader_roundTrip() {
+        LZW.BitWriter w = new LZW.BitWriter();
+        w.write(421, 9);  // 9-bit code
+        w.write(258, 9);  // another 9-bit code
+        w.write(1023, 10); // 10-bit code
+        w.flush();
+        byte[] packed = w.toByteArray();
+
+        LZW.BitReader r = new LZW.BitReader(packed, 0);
+        assertEquals(421,  r.read(9));
+        assertEquals(258,  r.read(9));
+        assertEquals(1023, r.read(10));
+    }
+
+    @Test void bitWriter_singleBit() {
+        LZW.BitWriter w = new LZW.BitWriter();
+        w.write(1, 1);
+        w.flush();
+        byte[] packed = w.toByteArray();
+        assertEquals(1, packed[0] & 0xFF);
+    }
+
+    @Test void bitWriter_exactlyOneByte() {
+        LZW.BitWriter w = new LZW.BitWriter();
+        w.write(0b10110101, 8);
+        w.flush();
+        byte[] packed = w.toByteArray();
+        assertEquals(1, packed.length);
+        assertEquals(0b10110101, packed[0] & 0xFF);
+    }
+
+    // =========================================================================
+    // 7. Compression effectiveness
+    // =========================================================================
+
+    @Test void effectiveness_repeatedPattern_shrinks() {
+        byte[] data = repeat("ABCABCABC".getBytes(), 100);
+        assertTrue(LZW.compress(data).length < data.length);
+    }
+
+    @Test void effectiveness_repeatedByte_shrinks() {
+        byte[] data = new byte[1000]; Arrays.fill(data, (byte)'X');
+        assertTrue(LZW.compress(data).length < data.length);
+    }
+
+    // =========================================================================
+    // 8. Security / robustness
+    // =========================================================================
+
+    @Test void decodeCodes_outputLimit_throwsWhenExceeded() {
+        // Encode a large repeated pattern, then try to decode with a tiny limit.
+        byte[] data = repeat("ABCDEFGH".getBytes(), 100);
+        List<Integer> codes = LZW.encodeCodes(data);
+        // 1-byte limit should immediately trigger the guard.
+        assertThrows(IllegalArgumentException.class,
+            () -> LZW.decodeCodes(codes, 1));
+    }
+
+    @Test void decodeCodes_invalidCode_throwsIllegalArgument() {
+        // A code far beyond next_code should throw IllegalArgumentException.
+        List<Integer> codes = List.of(LZW.CLEAR_CODE, 65 /* 'A' */, 9999);
+        assertThrows(IllegalArgumentException.class, () -> LZW.decodeCodes(codes));
+    }
+
+    // =========================================================================
+    // 9. Determinism
+    // =========================================================================
+
+    @Test void deterministicCompression() {
+        byte[] data = "the quick brown fox jumps over the lazy dog".getBytes();
+        assertArrayEquals(LZW.compress(data), LZW.compress(data));
+    }
+
+    @Test void deterministicDecompression() {
+        byte[] compressed = LZW.compress("hello world hello world".getBytes());
+        assertArrayEquals(LZW.decompress(compressed), LZW.decompress(compressed));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static void roundTrip(byte[] data) {
+        assertArrayEquals(data, LZW.decompress(LZW.compress(data)),
+            "Round-trip failed for " + data.length + " bytes");
+    }
+
+    private static byte[] repeat(byte[] src, int times) {
+        byte[] out = new byte[src.length * times];
+        for (int i = 0; i < times; i++) System.arraycopy(src, 0, out, i*src.length, src.length);
+        return out;
+    }
+}

--- a/code/packages/kotlin/lz77/.gitignore
+++ b/code/packages/kotlin/lz77/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/lz77/BUILD
+++ b/code/packages/kotlin/lz77/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lz77/BUILD_windows
+++ b/code/packages/kotlin/lz77/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lz77/CHANGELOG.md
+++ b/code/packages/kotlin/lz77/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — lz77 (Kotlin)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZ77` object with `compress`, `decompress`, `encode`, `decode`,
+  `serialiseTokens`, `deserialiseTokens`.
+- `Token` data class with `isLiteral` property and `literal`/`match`
+  companion factory functions.
+- Idiomatic Kotlin: `Pair<Int,Int>` from `findLongestMatch`, `buildList{}`,
+  `ByteArrayOutputStream`, `minOf`/`maxOf`.
+- `decode` accepts optional `initialBuffer` seed for streaming use.
+- 38 unit tests mirroring the Java suite.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.

--- a/code/packages/kotlin/lz77/README.md
+++ b/code/packages/kotlin/lz77/README.md
@@ -1,0 +1,34 @@
+# lz77 (Kotlin) — CMP00
+
+LZ77 lossless compression for Kotlin.  Idiomatic Kotlin port of the Java
+CMP00 implementation using `data class Token`, Kotlin pairs, `buildList{}`,
+and `ByteArrayOutputStream`.
+
+## What it does
+
+`LZ77` object exposes:
+
+| Function | Description |
+|----------|-------------|
+| `compress(ByteArray?)` | Encode bytes into CMP00 wire format |
+| `decompress(ByteArray?)` | Decode CMP00 wire format |
+| `encode(ByteArray, ...)` | Encode to `List<Token>` |
+| `decode(List<Token>, ...)` | Decode token stream |
+
+## Quick start
+
+```kotlin
+val original   = "hello hello hello".toByteArray()
+val compressed = LZ77.compress(original)
+val recovered  = LZ77.decompress(compressed)
+check(original.contentEquals(recovered))
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+38 tests covering round-trip, token stream, wire format, edge cases,
+overlapping matches, effectiveness, initial-buffer seed, and determinism.

--- a/code/packages/kotlin/lz77/build.gradle.kts
+++ b/code/packages/kotlin/lz77/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/lz77/settings.gradle.kts
+++ b/code/packages/kotlin/lz77/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lz77"

--- a/code/packages/kotlin/lz77/src/main/kotlin/com/codingadventures/lz77/LZ77.kt
+++ b/code/packages/kotlin/lz77/src/main/kotlin/com/codingadventures/lz77/LZ77.kt
@@ -1,0 +1,332 @@
+// ============================================================================
+// LZ77.kt — CMP00: LZ77 Lossless Compression Algorithm (1977)
+// ============================================================================
+//
+// LZ77 is the foundational sliding-window compression algorithm published by
+// Abraham Lempel and Jacob Ziv in 1977.  It is the direct ancestor of LZSS,
+// LZW, DEFLATE, zstd, LZ4, and virtually every modern compressor.
+//
+// The core idea: instead of storing every byte verbatim, notice when a
+// sequence of bytes has appeared recently.  Replace that sequence with a
+// cheap back-reference: (offset, length).  This exploits locality of real
+// data — repeated words, duplicate instructions, adjacent colour runs.
+//
+// ============================================================================
+// The Sliding Window Model
+// ============================================================================
+//
+//   ┌─────────────────────────────────┬──────────────────┐
+//   │         SEARCH BUFFER           │ LOOKAHEAD BUFFER  │
+//   │  (last window_size bytes)       │  (next max_match) │
+//   └─────────────────────────────────┴──────────────────┘
+//                                     ↑ cursor
+//
+// ============================================================================
+// Token: (offset, length, nextChar)
+// ============================================================================
+//
+//   offset=0, length=0 → pure literal; payload is nextChar.
+//   offset>0, length>0 → back-reference: copy length bytes from offset
+//                         positions back, then emit nextChar.
+//
+// ============================================================================
+// Overlapping Matches
+// ============================================================================
+//
+// A match may extend into output bytes not yet written (offset < length).
+// This naturally encodes runs.  The decoder must copy byte-by-byte.
+//
+// ============================================================================
+// Wire Format (CMP00)
+// ============================================================================
+//
+//   Bytes 0–3:    token_count  (big-endian uint32)
+//   Bytes 4+:     token_count × 4 bytes:
+//                   [0–1] offset    (big-endian uint16)
+//                   [2]   length    (uint8)
+//                   [3]   next_char (uint8)
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.  (this)
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+
+package com.codingadventures.lz77
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+// ============================================================================
+// Token
+// ============================================================================
+
+/**
+ * A single LZ77 token: (offset, length, nextChar).
+ *
+ * - `offset=0, length=0` → pure literal; payload is [nextChar].
+ * - `offset>0, length>0` → back-reference: copy [length] bytes from
+ *   [offset] positions back in the output, then emit [nextChar].
+ *
+ * @param offset   distance back the match starts (1..windowSize), or 0
+ * @param length   number of matched bytes (0 = no match)
+ * @param nextChar literal byte after the match (0–255)
+ */
+data class Token(val offset: Int, val length: Int, val nextChar: Int) {
+
+    /** True if this token is a pure literal (no back-reference). */
+    val isLiteral: Boolean get() = length == 0
+
+    companion object {
+        /** Create a literal token for a single byte value. */
+        fun literal(b: Int) = Token(0, 0, b and 0xFF)
+
+        /** Create a back-reference token. */
+        fun match(offset: Int, length: Int, nextChar: Int) =
+            Token(offset, length, nextChar and 0xFF)
+    }
+}
+
+// ============================================================================
+// LZ77
+// ============================================================================
+
+/**
+ * CMP00: LZ77 lossless compression.
+ *
+ * ```kotlin
+ * val original   = "hello hello hello".toByteArray()
+ * val compressed = LZ77.compress(original)
+ * val recovered  = LZ77.decompress(compressed)
+ * check(original.contentEquals(recovered))
+ * ```
+ */
+object LZ77 {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Default sliding-window size (maximum back-reference distance). */
+    const val DEFAULT_WINDOW_SIZE = 4096
+
+    /** Default maximum match length (fits in one uint8). */
+    const val DEFAULT_MAX_MATCH = 255
+
+    /**
+     * Default minimum match length for a back-reference to be emitted.
+     *
+     * A match of length 3 costs 4 bytes (offset=2 + length=1 + next_char=1).
+     * Three literals each as tokens also cost 4 bytes each in this format, so
+     * 3 is the natural break-even point.
+     */
+    const val DEFAULT_MIN_MATCH = 3
+
+    private const val HEADER_SIZE = 4
+    private const val TOKEN_SIZE  = 4
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * Encode [data] into an LZ77 token stream using default parameters.
+     *
+     * @param data the bytes to encode
+     * @return token stream suitable for [decode]
+     */
+    fun encode(data: ByteArray): List<Token> =
+        encode(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH)
+
+    /**
+     * Encode [data] into an LZ77 token stream with custom parameters.
+     *
+     * Greedy O(n × window) algorithm:
+     * 1. For each cursor, scan the last [windowSize] bytes for the longest
+     *    match of the lookahead.
+     * 2. If best match length ≥ [minMatch], emit a back-reference token and
+     *    advance cursor by `length + 1`.
+     * 3. Otherwise emit a literal token and advance by 1.
+     *
+     * One byte is always reserved for nextChar, so the lookahead extends at
+     * most to `data.size - 1`.
+     */
+    fun encode(
+        data: ByteArray,
+        windowSize: Int = DEFAULT_WINDOW_SIZE,
+        maxMatch:   Int = DEFAULT_MAX_MATCH,
+        minMatch:   Int = DEFAULT_MIN_MATCH
+    ): List<Token> {
+        val tokens  = mutableListOf<Token>()
+        var cursor  = 0
+
+        while (cursor < data.size) {
+            val (bestOffset, bestLength) = findLongestMatch(data, cursor, windowSize, maxMatch)
+
+            if (bestLength >= minMatch) {
+                val nextChar = data[cursor + bestLength].toInt() and 0xFF
+                tokens.add(Token.match(bestOffset, bestLength, nextChar))
+                cursor += bestLength + 1
+            } else {
+                tokens.add(Token.literal(data[cursor].toInt() and 0xFF))
+                cursor += 1
+            }
+        }
+        return tokens
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode an LZ77 token stream back into the original bytes.
+     *
+     * For each token:
+     * - If `length > 0`: copy [Token.length] bytes one-at-a-time from position
+     *   `output.size - offset`.  Byte-by-byte copy handles overlapping matches.
+     * - Always append [Token.nextChar].
+     */
+    fun decode(tokens: List<Token>, initialBuffer: ByteArray = ByteArray(0)): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write(initialBuffer)
+
+        for (token in tokens) {
+            if (token.length > 0) {
+                val startPos = out.size() - token.offset
+                // Guard: offset must not exceed what has already been written.
+                // A crafted stream with offset > out.size() produces a negative
+                // startPos and causes ArrayIndexOutOfBoundsException.
+                require(startPos >= 0) {
+                    "LZ77: back-reference offset ${token.offset} exceeds output buffer size ${out.size()}"
+                }
+                repeat(token.length) { i ->
+                    // Re-read live output each step: handles overlapping matches
+                    // where the source overlaps the destination being written.
+                    out.write(out.toByteArray()[startPos + i].toInt() and 0xFF)
+                }
+            }
+            out.write(token.nextChar)
+        }
+        return out.toByteArray()
+    }
+
+    // =========================================================================
+    // One-shot compress / decompress
+    // =========================================================================
+
+    /**
+     * Compress [data] using LZ77 and return CMP00 wire-format bytes.
+     *
+     * @param data bytes to compress (null treated as empty)
+     */
+    fun compress(
+        data:       ByteArray?,
+        windowSize: Int = DEFAULT_WINDOW_SIZE,
+        maxMatch:   Int = DEFAULT_MAX_MATCH,
+        minMatch:   Int = DEFAULT_MIN_MATCH
+    ): ByteArray {
+        val bytes  = data ?: ByteArray(0)
+        val tokens = encode(bytes, windowSize, maxMatch, minMatch)
+        return serialiseTokens(tokens)
+    }
+
+    /**
+     * Decompress CMP00 wire-format bytes back to the original data.
+     *
+     * @param data compressed bytes (null treated as empty)
+     */
+    fun decompress(data: ByteArray?): ByteArray {
+        if (data == null || data.size < HEADER_SIZE) return ByteArray(0)
+        val tokens = deserialiseTokens(data)
+        return decode(tokens)
+    }
+
+    // =========================================================================
+    // Serialisation helpers
+    // =========================================================================
+
+    /**
+     * Serialise a token list to the CMP00 wire format.
+     *
+     * `[token_count (4B BE)] [N × (offset BE uint16, length uint8, nextChar uint8)]`
+     */
+    fun serialiseTokens(tokens: List<Token>): ByteArray {
+        val buf = ByteBuffer.allocate(HEADER_SIZE + tokens.size * TOKEN_SIZE)
+            .order(ByteOrder.BIG_ENDIAN)
+        buf.putInt(tokens.size)
+        for (t in tokens) {
+            buf.putShort(t.offset.toShort())
+            buf.put(t.length.toByte())
+            buf.put(t.nextChar.toByte())
+        }
+        return buf.array()
+    }
+
+    /**
+     * Deserialise CMP00 wire-format bytes into a token list.
+     */
+    fun deserialiseTokens(data: ByteArray): List<Token> {
+        if (data.size < HEADER_SIZE) return emptyList()
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
+        val tokenCount = buf.getInt()
+        val maxTokens  = (data.size - HEADER_SIZE) / TOKEN_SIZE
+        val safeCount  = minOf(tokenCount, maxTokens)
+
+        return buildList {
+            repeat(safeCount) {
+                if (buf.remaining() >= TOKEN_SIZE) {
+                    val offset   = buf.getShort().toInt() and 0xFFFF
+                    val length   = buf.get().toInt()      and 0xFF
+                    val nextChar = buf.get().toInt()      and 0xFF
+                    add(Token(offset, length, nextChar))
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Find the longest match for `data[cursor:]` in the search buffer.
+     *
+     * Returns `Pair(bestOffset, bestLength)` where both are 0 if no match
+     * meeting [minMatch] length was found.  One byte is always reserved for
+     * nextChar, so lookahead ends at `data.size - 1`.
+     */
+    private fun findLongestMatch(
+        data:       ByteArray,
+        cursor:     Int,
+        windowSize: Int,
+        maxMatch:   Int
+    ): Pair<Int, Int> {
+        var bestOffset = 0
+        var bestLength = 0
+
+        val searchStart  = maxOf(0, cursor - windowSize)
+        val lookaheadEnd = minOf(cursor + maxMatch, data.size - 1)
+
+        for (pos in searchStart until cursor) {
+            var length = 0
+            while (cursor + length < lookaheadEnd &&
+                   data[pos + length] == data[cursor + length]) {
+                length++
+            }
+            if (length > bestLength) {
+                bestLength = length
+                bestOffset = cursor - pos
+            }
+        }
+        return Pair(bestOffset, bestLength)
+    }
+}

--- a/code/packages/kotlin/lz77/src/test/kotlin/com/codingadventures/lz77/LZ77Test.kt
+++ b/code/packages/kotlin/lz77/src/test/kotlin/com/codingadventures/lz77/LZ77Test.kt
@@ -1,0 +1,211 @@
+// ============================================================================
+// LZ77Test.kt — CMP00: LZ77 Compression Tests
+// ============================================================================
+
+package com.codingadventures.lz77
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertThrows
+
+class LZ77Test {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test fun roundTrip_helloWorld()       = roundTrip("hello world".toByteArray())
+    @Test fun roundTrip_aaabbc()           = roundTrip("AAABBC".toByteArray())
+    @Test fun roundTrip_repeatedPattern()  = roundTrip(repeat("ABCABC".toByteArray(), 100))
+    @Test fun roundTrip_loremIpsum()       = roundTrip(("Lorem ipsum dolor sit amet, " +
+        "consectetur adipiscing elit. Sed do eiusmod tempor.").toByteArray())
+    @Test fun roundTrip_all256Bytes()      = roundTrip(ByteArray(256) { it.toByte() })
+    @Test fun roundTrip_binaryData()       = roundTrip(byteArrayOf(0, 1, 2, 3,
+        255.toByte(), 254.toByte(), 253.toByte(), 128.toByte(), 64, 32))
+    @Test fun roundTrip_longInput()        = roundTrip(repeat(
+        "the quick brown fox jumps over the lazy dog ".toByteArray(), 200))
+    @Test fun roundTrip_singleByte()       = roundTrip(byteArrayOf('A'.code.toByte()))
+    @Test fun roundTrip_twoBytes()         = roundTrip(byteArrayOf('A'.code.toByte(), 'B'.code.toByte()))
+    @Test fun roundTrip_singleRepeated()   = roundTrip(ByteArray(100) { 'A'.code.toByte() })
+    @Test fun roundTrip_newlineHeavy()     = roundTrip(repeat("line\n".toByteArray(), 200))
+    @Test fun roundTrip_nullBytes()        = roundTrip(ByteArray(100))
+
+    // =========================================================================
+    // 2. Token stream correctness
+    // =========================================================================
+
+    @Test fun encode_simpleABABAB() {
+        val data   = "ABABABAB".toByteArray()
+        val tokens = LZ77.encode(data)
+        assertContentEquals(data, LZ77.decode(tokens))
+    }
+
+    @Test fun encode_noRepetition_allLiterals() {
+        val tokens = LZ77.encode(byteArrayOf(1, 2, 3))
+        assertTrue(tokens.all { it.isLiteral }, "Non-repeating 3-byte input should be all literals")
+    }
+
+    @Test fun encode_AAAAAAA_hasBackRef() {
+        val data = "AAAAAAA".toByteArray()
+        val tokens = LZ77.encode(data)
+        assertTrue(tokens.any { !it.isLiteral }, "Repeated 'A' bytes should produce at least one back-reference")
+        assertContentEquals(data, LZ77.decode(tokens))
+    }
+
+    @Test fun token_literal() {
+        val t = Token.literal(65)
+        assertTrue(t.isLiteral)
+        assertEquals(0,  t.offset)
+        assertEquals(0,  t.length)
+        assertEquals(65, t.nextChar)
+    }
+
+    @Test fun token_match() {
+        val t = Token.match(4, 5, 90)
+        assertFalse(t.isLiteral)
+        assertEquals(4,  t.offset)
+        assertEquals(5,  t.length)
+        assertEquals(90, t.nextChar)
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test fun wireFormat_empty() {
+        val result = LZ77.compress(ByteArray(0))
+        assertEquals(4, result.size)
+        assertEquals(0, ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN).getInt())
+    }
+
+    @Test fun wireFormat_tokenCountField() {
+        val compressed = LZ77.compress(byteArrayOf('A'.code.toByte()))
+        val tokenCount = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt()
+        assertEquals(1, tokenCount)
+    }
+
+    @Test fun wireFormat_offsetBigEndian() {
+        val t    = Token.match(1000, 5, 65)
+        val wire = LZ77.serialiseTokens(listOf(t))
+        assertEquals(1, ByteBuffer.wrap(wire, 0, 4).order(ByteOrder.BIG_ENDIAN).getInt())
+        val offset = ((wire[4].toInt() and 0xFF) shl 8) or (wire[5].toInt() and 0xFF)
+        assertEquals(1000, offset)
+        assertEquals(5,   wire[6].toInt() and 0xFF)
+        assertEquals(65,  wire[7].toInt() and 0xFF)
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test fun compress_null()        = assertContentEquals(ByteArray(0), LZ77.decompress(LZ77.compress(null)))
+    @Test fun compress_empty()       = assertContentEquals(ByteArray(0), LZ77.decompress(LZ77.compress(ByteArray(0))))
+    @Test fun decompress_null()      = assertContentEquals(ByteArray(0), LZ77.decompress(null))
+    @Test fun decompress_tooShort()  = assertContentEquals(ByteArray(0), LZ77.decompress(byteArrayOf(0, 0, 0)))
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 65, 127, 255])
+    fun roundTrip_singleSymbol(sym: Int) = roundTrip(byteArrayOf(sym.toByte()))
+
+    @Test fun roundTrip_highByteValues() = roundTrip(ByteArray(128) { (128 + it).toByte() })
+
+    // =========================================================================
+    // 5. Overlapping matches
+    // =========================================================================
+
+    @Test fun decode_overlappingMatch_runs() {
+        // literal('A'), match(offset=1, length=6, nextChar='Z') → "AAAAAAAZ"
+        val tokens = listOf(Token.literal(65), Token.match(1, 6, 90))
+        assertContentEquals("AAAAAAAZ".toByteArray(), LZ77.decode(tokens))
+    }
+
+    @Test fun decode_abOverlap() {
+        // literal('A'), literal('B'), match(2, 4, 'B') → "ABABABB"
+        val tokens = listOf(
+            Token.literal(65),
+            Token.literal(66),
+            Token.match(2, 4, 66)
+        )
+        assertContentEquals("ABABABB".toByteArray(), LZ77.decode(tokens))
+    }
+
+    // =========================================================================
+    // 6. Compression effectiveness
+    // =========================================================================
+
+    @Test fun effectiveness_repeatedPattern_shrinks() {
+        val data = repeat("ABCABCABC".toByteArray(), 100)
+        assertTrue(LZ77.compress(data).size < data.size)
+    }
+
+    @Test fun effectiveness_repeatedByte_shrinks() {
+        val data = ByteArray(1000) { 'X'.code.toByte() }
+        assertTrue(LZ77.compress(data).size < data.size)
+    }
+
+    // =========================================================================
+    // 7. Decode with initial buffer
+    // =========================================================================
+
+    @Test fun decode_withInitialBuffer() {
+        val seed = "ABCD".toByteArray()
+        val tokens = listOf(Token.match(4, 3, 90))  // 'Z'
+        val result = LZ77.decode(tokens, seed)
+        assertContentEquals("ABCDABCZ".toByteArray(), result)
+    }
+
+    // =========================================================================
+    // 8. Security / robustness
+    // =========================================================================
+
+    @Test fun decode_craftedOffset_throwsOnOOB() {
+        // A Match token whose offset exceeds the current output buffer size
+        // must throw IllegalArgumentException, not ArrayIndexOutOfBoundsException.
+        val tokens = listOf(Token.match(65535, 1, 0))
+        assertThrows<IllegalArgumentException> { LZ77.decode(tokens) }
+    }
+
+    @Test fun decompress_craftedOffset_doesNotCrash() {
+        val crafted = byteArrayOf(
+            0, 0, 0, 1,                          // token_count = 1
+            0xFF.toByte(), 0xFF.toByte(),         // offset = 65535
+            1,                                    // length = 1
+            0                                     // nextChar = 0
+        )
+        assertThrows<IllegalArgumentException> { LZ77.decompress(crafted) }
+    }
+
+    // =========================================================================
+    // 9. Determinism
+    // =========================================================================
+
+    @Test fun deterministicCompression() {
+        val data = "the quick brown fox jumps over the lazy dog".toByteArray()
+        assertContentEquals(LZ77.compress(data), LZ77.compress(data))
+    }
+
+    @Test fun deterministicDecompression() {
+        val compressed = LZ77.compress("hello world hello world".toByteArray())
+        assertContentEquals(LZ77.decompress(compressed), LZ77.decompress(compressed))
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun roundTrip(data: ByteArray) =
+        assertContentEquals(data, LZ77.decompress(LZ77.compress(data)))
+
+    private fun repeat(src: ByteArray, times: Int): ByteArray {
+        val out = ByteArray(src.size * times)
+        repeat(times) { i -> src.copyInto(out, i * src.size) }
+        return out
+    }
+}

--- a/code/packages/kotlin/lzss/.gitignore
+++ b/code/packages/kotlin/lzss/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/lzss/BUILD
+++ b/code/packages/kotlin/lzss/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lzss/BUILD_windows
+++ b/code/packages/kotlin/lzss/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lzss/CHANGELOG.md
+++ b/code/packages/kotlin/lzss/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog — lzss (Kotlin)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZSS` object with `compress`, `decompress`, `encode`, `decode`,
+  `serialiseTokens`, `deserialiseTokens`.
+- Sealed `Token` interface with `Literal` and `Match` data classes.
+- Flag-byte scheme: 8 symbols per block; bit i=0 → Literal (1B),
+  bit i=1 → Match (3B: offset BE uint16 + length uint8).
+- CMP02 wire format: `original_length(4B) + block_count(4B) + blocks`.
+- Overlapping-match support: byte-by-byte copy in `decode`.
+- Idiomatic Kotlin: `sealed interface`, `when` expressions, `shl`/`shr`/`and`,
+  `minOf`/`maxOf`, `toInt() and 0xFF` for unsigned byte handling.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.
+- 37 unit tests mirroring the Java suite.

--- a/code/packages/kotlin/lzss/README.md
+++ b/code/packages/kotlin/lzss/README.md
@@ -1,0 +1,34 @@
+# lzss (Kotlin) — CMP02
+
+LZSS lossless compression for Kotlin.  Idiomatic Kotlin port of the Java
+CMP02 implementation using a sealed `Token` interface, `data class` for
+`Literal` and `Match`, `when` expressions, and `ByteArrayOutputStream`.
+
+## What it does
+
+`LZSS` object exposes:
+
+| Function | Description |
+|----------|-------------|
+| `compress(ByteArray?)` | Encode bytes into CMP02 wire format |
+| `decompress(ByteArray?)` | Decode CMP02 wire format |
+| `encode(ByteArray, ...)` | Encode to `List<Token>` |
+| `decode(List<Token>, Int)` | Decode token stream |
+
+## Quick start
+
+```kotlin
+val original   = "hello hello hello".toByteArray()
+val compressed = LZSS.compress(original)
+val recovered  = LZSS.decompress(compressed)
+check(original.contentEquals(recovered))
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+37 tests covering round-trip, token stream, wire format, edge cases,
+overlapping matches, effectiveness, and determinism.

--- a/code/packages/kotlin/lzss/build.gradle.kts
+++ b/code/packages/kotlin/lzss/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/lzss/settings.gradle.kts
+++ b/code/packages/kotlin/lzss/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lzss"

--- a/code/packages/kotlin/lzss/src/main/kotlin/com/codingadventures/lzss/LZSS.kt
+++ b/code/packages/kotlin/lzss/src/main/kotlin/com/codingadventures/lzss/LZSS.kt
@@ -1,0 +1,429 @@
+// ============================================================================
+// LZSS.kt — CMP02: LZSS Lossless Compression Algorithm (1982)
+// ============================================================================
+//
+// LZSS (Lempel-Ziv-Storer-Szymanski, 1982) is a refinement of LZ77 (CMP00)
+// that eliminates the wasted `next_char` byte present in every LZ77 token.
+// Instead of the fixed (offset, length, next_char) triple, LZSS uses a
+// flag-bit scheme: each symbol is either a bare literal byte or a bare
+// back-reference — never both.
+//
+// ============================================================================
+// The Improvement Over LZ77
+// ============================================================================
+//
+//   LZ77:  every token = 4 bytes  (offset=2 + length=1 + next_char=1)
+//   LZSS:  literal   = 1 byte     (just the byte value)
+//           match    = 3 bytes     (offset=2 + length=1)
+//
+// A flag byte precedes every group of 8 symbols to tell the decoder which are
+// literals (bit=0) and which are matches (bit=1).
+//
+// ============================================================================
+// Break-Even Point
+// ============================================================================
+//
+// A match costs 3 bytes.  Three literals also cost 3 bytes (1 each).  So a
+// match of length ≥ 3 breaks even or saves space — `minMatch=3` is standard.
+//
+// ============================================================================
+// Overlapping Matches
+// ============================================================================
+//
+// LZSS inherits LZ77's self-referential matches (offset < length).  For
+// example, a literal 'A' followed by Match(offset=1, length=6) decodes to
+// "AAAAAAA".  Decoding must copy byte-by-byte, not via a bulk memmove.
+//
+// ============================================================================
+// Wire Format (CMP02)
+// ============================================================================
+//
+//   Bytes 0–3:  original_length  (big-endian uint32)
+//   Bytes 4–7:  block_count      (big-endian uint32)
+//   Bytes 8+:   blocks
+//
+//   Each block:
+//     [1 byte]    flag_byte (bit i → 0=Literal, 1=Match for symbol i)
+//     [variable]  symbol data:
+//         Literal: 1 byte  (byte value)
+//         Match:   3 bytes (offset big-endian uint16 + length uint8)
+//
+// `original_length` is stored because LZSS has no sentinel — the decoder
+// needs the exact count to know when to stop.
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals. (this)
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF.
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+// References
+// ============================================================================
+//
+//   Storer, J.A., & Szymanski, T.G. (1982). "Data Compression via Textual
+//   Substitution". Journal of the ACM, 29(4), 928–951.
+//
+//   Lempel, A., & Ziv, J. (1977). "A Universal Algorithm for Sequential Data
+//   Compression". IEEE Transactions on Information Theory, 23(3), 337–343.
+//
+// ============================================================================
+
+package com.codingadventures.lzss
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+// ============================================================================
+// Token types
+// ============================================================================
+
+/**
+ * A single LZSS token — either a bare literal byte or a bare back-reference.
+ *
+ * LZSS's key insight is that every symbol is *either* a literal *or* a match,
+ * never both.  The type is signalled by a dedicated flag bit — one flag byte
+ * covers 8 symbols — so neither representation wastes a next_char field.
+ */
+sealed interface Token {
+    /** True if this token is a literal (no back-reference). */
+    val isLiteral: Boolean
+}
+
+/**
+ * A single literal byte in the LZSS token stream.
+ *
+ * @param value the byte value (0–255)
+ */
+data class Literal(val value: Int) : Token {
+    override val isLiteral: Boolean get() = true
+}
+
+/**
+ * A back-reference match in the LZSS token stream.
+ *
+ * Matches may overlap (offset < length), encoding run-length behaviour.
+ * For example, Literal('A') + Match(offset=1, length=6) → "AAAAAAA".
+ *
+ * @param offset distance back in the output where the match begins (1..window_size)
+ * @param length number of bytes to copy (min_match..max_match)
+ */
+data class Match(val offset: Int, val length: Int) : Token {
+    override val isLiteral: Boolean get() = false
+}
+
+// ============================================================================
+// LZSS
+// ============================================================================
+
+/**
+ * CMP02: LZSS lossless compression.
+ *
+ * ```kotlin
+ * val original   = "hello hello hello".toByteArray()
+ * val compressed = LZSS.compress(original)
+ * val recovered  = LZSS.decompress(compressed)
+ * check(original.contentEquals(recovered))
+ * ```
+ */
+object LZSS {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Default sliding-window size (maximum back-reference distance). */
+    const val DEFAULT_WINDOW_SIZE = 4096
+
+    /** Default maximum match length (fits in uint8). */
+    const val DEFAULT_MAX_MATCH = 255
+
+    /**
+     * Default minimum match length for a back-reference to be worthwhile.
+     *
+     * Break-even analysis: a Match costs 3 bytes (offset=2 + length=1), and
+     * three Literals also cost 3 bytes (1 each).  So `minMatch=3` is optimal.
+     */
+    const val DEFAULT_MIN_MATCH = 3
+
+    /** Symbols per flag-byte group. */
+    private const val BLOCK_SIZE = 8
+
+    /** Wire-format header size: original_length(4) + block_count(4). */
+    private const val HEADER_SIZE = 8
+
+    // =========================================================================
+    // Encoding
+    // =========================================================================
+
+    /**
+     * Encode [data] into an LZSS token stream using default parameters.
+     *
+     * @param data the bytes to encode
+     * @return token stream (mix of [Literal] and [Match])
+     */
+    fun encode(data: ByteArray): List<Token> =
+        encode(data, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MATCH, DEFAULT_MIN_MATCH)
+
+    /**
+     * Encode [data] into an LZSS token stream with custom parameters.
+     *
+     * Key difference from LZ77: on a match, the cursor advances by exactly
+     * [length] (not `length + 1`).  There is no trailing next_char field.
+     *
+     * @param data       the bytes to encode
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @param minMatch   minimum match length for a [Match] token
+     * @return list of [Literal] and [Match] tokens
+     */
+    fun encode(
+        data:       ByteArray,
+        windowSize: Int = DEFAULT_WINDOW_SIZE,
+        maxMatch:   Int = DEFAULT_MAX_MATCH,
+        minMatch:   Int = DEFAULT_MIN_MATCH
+    ): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var cursor = 0
+
+        while (cursor < data.size) {
+            val (bestOffset, bestLength) = findLongestMatch(data, cursor, windowSize, maxMatch)
+
+            if (bestLength >= minMatch) {
+                // Emit bare back-reference; cursor advances by length only.
+                tokens.add(Match(bestOffset, bestLength))
+                cursor += bestLength
+            } else {
+                // Emit bare literal; cursor advances by 1.
+                tokens.add(Literal(data[cursor].toInt() and 0xFF))
+                cursor += 1
+            }
+        }
+
+        return tokens
+    }
+
+    // =========================================================================
+    // Decoding
+    // =========================================================================
+
+    /**
+     * Decode an LZSS token stream back into the original bytes.
+     *
+     * Processes each token:
+     * - [Literal]: append the byte to output.
+     * - [Match]: copy [Match.length] bytes **one-at-a-time** from
+     *   `output.size - offset`.  Byte-by-byte copy handles overlapping
+     *   matches where the source overlaps the destination being written.
+     *
+     * @param tokens         the token stream from [encode]
+     * @param originalLength if ≥ 0, truncate to this length; pass -1 for no truncation
+     * @return the reconstructed bytes
+     */
+    fun decode(tokens: List<Token>, originalLength: Int = -1): ByteArray {
+        val out = ByteArrayOutputStream()
+
+        for (token in tokens) {
+            when (token) {
+                is Literal -> out.write(token.value)
+                is Match   -> {
+                    val startPos = out.size() - token.offset
+                    // Guard: offset must not exceed what has already been written.
+                    // A crafted stream with offset > out.size() produces a negative
+                    // startPos and causes ArrayIndexOutOfBoundsException.
+                    require(startPos >= 0) {
+                        "LZSS: back-reference offset ${token.offset} exceeds output buffer size ${out.size()}"
+                    }
+                    repeat(token.length) { i ->
+                        // Re-read live output each step: handles overlapping matches
+                        // where the source overlaps the destination being written.
+                        out.write(out.toByteArray()[startPos + i].toInt() and 0xFF)
+                    }
+                }
+            }
+        }
+
+        val result = out.toByteArray()
+        return if (originalLength in 0 until result.size) result.copyOf(originalLength) else result
+    }
+
+    // =========================================================================
+    // One-shot compress / decompress
+    // =========================================================================
+
+    /**
+     * Compress [data] using LZSS and return CMP02 wire-format bytes.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP02 wire format
+     */
+    fun compress(
+        data:       ByteArray?,
+        windowSize: Int = DEFAULT_WINDOW_SIZE,
+        maxMatch:   Int = DEFAULT_MAX_MATCH,
+        minMatch:   Int = DEFAULT_MIN_MATCH
+    ): ByteArray {
+        val bytes  = data ?: ByteArray(0)
+        val tokens = encode(bytes, windowSize, maxMatch, minMatch)
+        return serialiseTokens(tokens, bytes.size)
+    }
+
+    /**
+     * Decompress CMP02 wire-format bytes back to the original data.
+     *
+     * @param data compressed bytes (null treated as empty)
+     * @return the original, uncompressed bytes
+     */
+    fun decompress(data: ByteArray?): ByteArray {
+        if (data == null || data.size < HEADER_SIZE) return ByteArray(0)
+        val buf             = ByteBuffer.wrap(data, 0, HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        val originalLength  = buf.getInt()
+        val tokens          = deserialiseTokens(data)
+        return decode(tokens, originalLength)
+    }
+
+    // =========================================================================
+    // Serialisation helpers
+    // =========================================================================
+
+    /**
+     * Serialise an LZSS token list to the CMP02 wire format.
+     *
+     * Groups tokens into blocks of up to 8.  Each block is preceded by a
+     * flag byte (bit i → 0=Literal, 1=Match), followed by the token data:
+     * - Literal: 1 byte
+     * - Match: 3 bytes (offset big-endian uint16 + length uint8)
+     *
+     * @param tokens         the token list
+     * @param originalLength length of the original uncompressed data
+     * @return the CMP02 wire-format bytes
+     */
+    fun serialiseTokens(tokens: List<Token>, originalLength: Int): ByteArray {
+        val blocks = mutableListOf<ByteArray>()
+        var i = 0
+
+        while (i < tokens.size) {
+            val chunk     = tokens.subList(i, minOf(i + BLOCK_SIZE, tokens.size))
+            var flag      = 0
+            val blockData = ByteArrayOutputStream()
+
+            for ((bit, tok) in chunk.withIndex()) {
+                when (tok) {
+                    is Match -> {
+                        flag = flag or (1 shl bit)
+                        blockData.write(tok.offset shr 8)          // offset high byte
+                        blockData.write(tok.offset and 0xFF)       // offset low byte
+                        blockData.write(tok.length)                // length
+                    }
+                    is Literal -> blockData.write(tok.value)
+                }
+            }
+
+            val block = ByteArrayOutputStream()
+            block.write(flag)
+            block.write(blockData.toByteArray())
+            blocks.add(block.toByteArray())
+            i += BLOCK_SIZE
+        }
+
+        // Header: original_length(4B) + block_count(4B)
+        val header = ByteBuffer.allocate(HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        header.putInt(originalLength).putInt(blocks.size)
+
+        val out = ByteArrayOutputStream()
+        out.write(header.array())
+        for (b in blocks) out.write(b)
+        return out.toByteArray()
+    }
+
+    /**
+     * Deserialise CMP02 wire-format bytes into a token list.
+     *
+     * @param data the CMP02 bytes
+     * @return list of [Literal] and [Match] tokens
+     */
+    fun deserialiseTokens(data: ByteArray): List<Token> {
+        if (data.size < HEADER_SIZE) return emptyList()
+
+        val header     = ByteBuffer.wrap(data, 0, HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        /* originalLength = */ header.getInt()
+        val blockCount = header.getInt()
+
+        // Cap block count against actual payload to prevent DoS.
+        val safeCount = minOf(blockCount, data.size - HEADER_SIZE)
+        val tokens    = mutableListOf<Token>()
+        var pos       = HEADER_SIZE
+
+        for (b in 0 until safeCount) {
+            if (pos >= data.size) break
+            val flag = data[pos++].toInt() and 0xFF
+
+            for (bit in 0 until BLOCK_SIZE) {
+                if (pos >= data.size) break
+                if (flag and (1 shl bit) != 0) {
+                    // Match: 3 bytes
+                    if (pos + 3 > data.size) break
+                    val offset = ((data[pos].toInt() and 0xFF) shl 8) or (data[pos + 1].toInt() and 0xFF)
+                    val length = data[pos + 2].toInt() and 0xFF
+                    tokens.add(Match(offset, length))
+                    pos += 3
+                } else {
+                    // Literal: 1 byte
+                    tokens.add(Literal(data[pos++].toInt() and 0xFF))
+                }
+            }
+        }
+
+        return tokens
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Find the longest match for `data[cursor:]` in the search buffer.
+     *
+     * Unlike LZ77's implementation, the lookahead may extend all the way to
+     * `data.size` — there is no next_char reservation in LZSS.
+     *
+     * @param data       full input bytes
+     * @param cursor     current encode position
+     * @param windowSize maximum lookback distance
+     * @param maxMatch   maximum match length
+     * @return `Pair(bestOffset, bestLength)`; both 0 if no match found
+     */
+    private fun findLongestMatch(
+        data:       ByteArray,
+        cursor:     Int,
+        windowSize: Int,
+        maxMatch:   Int
+    ): Pair<Int, Int> {
+        var bestOffset = 0
+        var bestLength = 0
+
+        val searchStart  = maxOf(0, cursor - windowSize)
+        // No next_char reservation: lookahead extends to end of input.
+        val lookaheadEnd = minOf(cursor + maxMatch, data.size)
+
+        for (pos in searchStart until cursor) {
+            var length = 0
+            while (cursor + length < lookaheadEnd &&
+                   data[pos + length] == data[cursor + length]) {
+                length++
+            }
+            if (length > bestLength) {
+                bestLength = length
+                bestOffset = cursor - pos
+            }
+        }
+
+        return Pair(bestOffset, bestLength)
+    }
+}

--- a/code/packages/kotlin/lzss/src/test/kotlin/com/codingadventures/lzss/LZSSTest.kt
+++ b/code/packages/kotlin/lzss/src/test/kotlin/com/codingadventures/lzss/LZSSTest.kt
@@ -1,0 +1,219 @@
+// ============================================================================
+// LZSSTest.kt — CMP02: LZSS Compression Tests
+// ============================================================================
+
+package com.codingadventures.lzss
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertThrows
+
+class LZSSTest {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test fun roundTrip_helloWorld()      { roundTrip("hello world".toByteArray()) }
+    @Test fun roundTrip_aaabbc()          { roundTrip("AAABBC".toByteArray()) }
+    @Test fun roundTrip_repeatedPattern() { roundTrip(repeat("ABCABC".toByteArray(), 100)) }
+    @Test fun roundTrip_loremIpsum()      { roundTrip(("Lorem ipsum dolor sit amet, consectetur " +
+        "adipiscing elit.").toByteArray()) }
+    @Test fun roundTrip_all256Bytes()     {
+        val d = ByteArray(256) { it.toByte() }; roundTrip(d) }
+    @Test fun roundTrip_binaryData()      {
+        roundTrip(byteArrayOf(0, 1, 2, 3, 255.toByte(), 128.toByte(), 64)) }
+    @Test fun roundTrip_longInput()       { roundTrip(repeat(
+        "the quick brown fox jumps over the lazy dog ".toByteArray(), 200)) }
+    @Test fun roundTrip_singleByte()      { roundTrip(byteArrayOf('A'.code.toByte())) }
+    @Test fun roundTrip_twoBytes()        { roundTrip(byteArrayOf('A'.code.toByte(), 'B'.code.toByte())) }
+    @Test fun roundTrip_singleRepeated()  { roundTrip(ByteArray(100) { 'A'.code.toByte() }) }
+    @Test fun roundTrip_newlineHeavy()    { roundTrip(repeat("line\n".toByteArray(), 200)) }
+    @Test fun roundTrip_nullBytes()       { roundTrip(ByteArray(100)) }
+    @Test fun roundTrip_highBytes()       {
+        val d = ByteArray(128) { (128 + it).toByte() }; roundTrip(d) }
+
+    // =========================================================================
+    // 2. Token stream correctness
+    // =========================================================================
+
+    @Test fun encode_ABABABAB_hasMatch() {
+        val data   = "ABABABAB".toByteArray()
+        val tokens = LZSS.encode(data)
+        assertTrue(tokens.any { !it.isLiteral },
+            "Repeating AB pattern should produce at least one Match token")
+        assertContentEquals(data, LZSS.decode(tokens, -1))
+    }
+
+    @Test fun encode_shortNonRepeat_allLiterals() {
+        val data   = byteArrayOf(1, 2, 3)
+        val tokens = LZSS.encode(data)
+        assertTrue(tokens.all { it.isLiteral },
+            "3-byte non-repeating input should produce only literals")
+    }
+
+    @Test fun encode_AAAAAAA_producesMatch() {
+        val data   = "AAAAAAA".toByteArray()
+        val tokens = LZSS.encode(data)
+        assertTrue(tokens.any { it is Match })
+        assertContentEquals(data, LZSS.decode(tokens, -1))
+    }
+
+    @Test fun literal_properties() {
+        val lit = Literal(65)
+        assertTrue(lit.isLiteral)
+        assertEquals(65, lit.value)
+    }
+
+    @Test fun match_properties() {
+        val m = Match(10, 5)
+        assertFalse(m.isLiteral)
+        assertEquals(10, m.offset)
+        assertEquals(5,  m.length)
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test fun wireFormat_emptyInput() {
+        val result = LZSS.compress(ByteArray(0))
+        assertEquals(8, result.size)
+        val buf = ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        assertEquals(0, buf.getInt()) // original_length
+        assertEquals(0, buf.getInt()) // block_count
+    }
+
+    @Test fun wireFormat_originalLengthStored() {
+        for (len in intArrayOf(1, 5, 100)) {
+            val data       = ByteArray(len) { 'A'.code.toByte() }
+            val compressed = LZSS.compress(data)
+            val stored     = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt()
+            assertEquals(len, stored)
+        }
+    }
+
+    @Test fun wireFormat_blockCountField() {
+        // 1 byte → 1 token → 1 block
+        val compressed = LZSS.compress("A".toByteArray())
+        val buf = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN)
+        buf.getInt() // skip original_length
+        val blockCount = buf.getInt()
+        assertEquals(1, blockCount)
+    }
+
+    @Test fun wireFormat_flagByteIsFirstByteOfBlock() {
+        // "A" → 1 Literal token → flag_byte = 0 (bit 0 = 0 = Literal)
+        val compressed = LZSS.compress("A".toByteArray())
+        val flagByte   = compressed[8].toInt() and 0xFF
+        assertEquals(0, flagByte, "Single literal → flag_byte should be 0")
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test fun compress_null()       { assertContentEquals(ByteArray(0), LZSS.decompress(LZSS.compress(null))) }
+    @Test fun compress_empty()      { assertContentEquals(ByteArray(0), LZSS.decompress(LZSS.compress(ByteArray(0)))) }
+    @Test fun decompress_null()     { assertContentEquals(ByteArray(0), LZSS.decompress(null)) }
+    @Test fun decompress_tooShort() { assertContentEquals(ByteArray(0), LZSS.decompress(ByteArray(4))) }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 65, 127, 255])
+    fun roundTrip_singleSymbol(sym: Int) { roundTrip(byteArrayOf(sym.toByte())) }
+
+    // =========================================================================
+    // 5. Overlapping matches
+    // =========================================================================
+
+    @Test fun decode_overlappingMatch_runs() {
+        // literal('A') → [A]; match(offset=1, length=6) → [A,A,A,A,A,A,A]
+        val tokens = listOf(
+            Literal(65),
+            Match(1, 6)
+        )
+        val result = LZSS.decode(tokens, -1)
+        assertContentEquals("AAAAAAA".toByteArray(), result)
+    }
+
+    @Test fun decode_abOverlap() {
+        // [A,B] then match(2,4) → [A,B,A,B,A,B]
+        val tokens = listOf(
+            Literal(65),
+            Literal(66),
+            Match(2, 4)
+        )
+        val result = LZSS.decode(tokens, -1)
+        assertContentEquals("ABABAB".toByteArray(), result)
+    }
+
+    // =========================================================================
+    // 6. Compression effectiveness
+    // =========================================================================
+
+    @Test fun effectiveness_repeatedPattern_shrinks() {
+        val data = repeat("ABCABCABC".toByteArray(), 100)
+        assertTrue(LZSS.compress(data).size < data.size)
+    }
+
+    @Test fun effectiveness_repeatedByte_shrinks() {
+        val data = ByteArray(1000) { 'X'.code.toByte() }
+        assertTrue(LZSS.compress(data).size < data.size)
+    }
+
+    @Test fun effectiveness_vsLz77_noBloat() {
+        // LZSS should not produce more output than raw input for all-unique data
+        val data       = ByteArray(256) { it.toByte() }
+        val compressed = LZSS.compress(data)
+        // Each byte → 1 Literal token (1 byte payload) + flag byte per 8 = 288+8 header
+        assertTrue(compressed.size < data.size * 3,
+            "LZSS should not expand incompressible data by more than 3x")
+    }
+
+    // =========================================================================
+    // 7. Security / robustness
+    // =========================================================================
+
+    @Test fun decode_craftedOffset_throwsOnOOB() {
+        // A Match token whose offset exceeds the current output buffer size
+        // must throw IllegalArgumentException, not ArrayIndexOutOfBoundsException.
+        val tokens = listOf(Match(65535, 3))
+        assertThrows<IllegalArgumentException> { LZSS.decode(tokens, -1) }
+    }
+
+    // =========================================================================
+    // 8. Determinism
+    // =========================================================================
+
+    @Test fun deterministicCompression() {
+        val data = "the quick brown fox jumps over the lazy dog".toByteArray()
+        assertContentEquals(LZSS.compress(data), LZSS.compress(data))
+    }
+
+    @Test fun deterministicDecompression() {
+        val compressed = LZSS.compress("hello world hello world".toByteArray())
+        assertContentEquals(LZSS.decompress(compressed), LZSS.decompress(compressed))
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun roundTrip(data: ByteArray) {
+        assertContentEquals(data, LZSS.decompress(LZSS.compress(data)),
+            "Round-trip failed for ${data.size} bytes")
+    }
+
+    private fun repeat(src: ByteArray, times: Int): ByteArray {
+        val out = ByteArray(src.size * times)
+        for (i in 0 until times) System.arraycopy(src, 0, out, i * src.size, src.size)
+        return out
+    }
+}

--- a/code/packages/kotlin/lzw/.gitignore
+++ b/code/packages/kotlin/lzw/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/lzw/BUILD
+++ b/code/packages/kotlin/lzw/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lzw/BUILD_windows
+++ b/code/packages/kotlin/lzw/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lzw/CHANGELOG.md
+++ b/code/packages/kotlin/lzw/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — lzw (Kotlin)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-25
+
+### Added
+- `LZW` object with `compress`, `decompress`, `encodeCodes`, `decodeCodes`,
+  `packCodes`, `unpackCodes`.
+- `BitWriter` inner class: LSB-first variable-width bit packing.
+- `BitReader` inner class: LSB-first variable-width bit reading.
+- `List<Byte>` used as dictionary keys (value-equality without wrapper class).
+- Pre-seeded 256-entry dictionary (codes 0–255 = single bytes).
+- CLEAR_CODE(256) and STOP_CODE(257) control codes.
+- Variable-width codes starting at 9 bits; grows at power-of-2 boundaries;
+  max 16 bits (65536 entries).
+- Tricky-token handling: `code == next_code` → entry from prev + prev[0].
+- Dictionary reset on CLEAR_CODE and when dictionary is full.
+- CMP03 wire format: `original_length(4B BE) + LSB-first bit-packed codes`.
+- Idiomatic Kotlin: `shl`/`shr`/`ushr`/`and`/`or`, `toLong() and 0xFFL`,
+  `when` expressions, `isEmpty`/`isNotEmpty`, `mutableListOf`, `buildList`.
+- `build.gradle.kts`, `settings.gradle.kts`, `BUILD`, `BUILD_windows`,
+  `README.md`, `.gitignore`.
+- 39 unit tests mirroring the Java suite.

--- a/code/packages/kotlin/lzw/README.md
+++ b/code/packages/kotlin/lzw/README.md
@@ -1,0 +1,33 @@
+# lzw (Kotlin) — CMP03
+
+LZW lossless compression for Kotlin.  Idiomatic Kotlin port of the Java
+CMP03 implementation using `object` singleton, `List<Byte>` dictionary keys,
+`when` expressions, Kotlin's `shl`/`shr`/`ushr`/`and`/`or` operators, and
+`ByteArrayOutputStream`.
+
+## What it does
+
+`LZW` object exposes:
+
+| Function | Description |
+|----------|-------------|
+| `compress(ByteArray?)` | Encode bytes into CMP03 wire format |
+| `decompress(ByteArray?)` | Decode CMP03 wire format |
+
+## Quick start
+
+```kotlin
+val original   = "hello hello hello".toByteArray()
+val compressed = LZW.compress(original)
+val recovered  = LZW.decompress(compressed)
+check(original.contentEquals(recovered))
+```
+
+## Running tests
+
+```
+gradle test
+```
+
+39 tests covering round-trip, code stream structure, wire format, edge cases,
+tricky token, bit I/O, effectiveness, and determinism.

--- a/code/packages/kotlin/lzw/build.gradle.kts
+++ b/code/packages/kotlin/lzw/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/lzw/settings.gradle.kts
+++ b/code/packages/kotlin/lzw/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lzw"

--- a/code/packages/kotlin/lzw/src/main/kotlin/com/codingadventures/lzw/LZW.kt
+++ b/code/packages/kotlin/lzw/src/main/kotlin/com/codingadventures/lzw/LZW.kt
@@ -1,0 +1,507 @@
+// ============================================================================
+// LZW.kt — CMP03: LZW Lossless Compression Algorithm (1984)
+// ============================================================================
+//
+// LZW (Lempel-Ziv-Welch, 1984) is LZ78 with one key change: the dictionary is
+// pre-seeded with all 256 single-byte sequences before encoding begins.  This
+// means:
+//
+//   1. The encoder never needs to emit a raw byte outside the code stream —
+//      every byte already has a code (0–255).
+//   2. Tokens are just codes (unsigned integers), not (dict_index, next_char)
+//      tuples like LZ78.
+//   3. With only codes to transmit, the stream can be bit-packed at variable
+//      width — codes start at 9 bits and grow as the dictionary expands.
+//      This is exactly how GIF compression works.
+//
+// ============================================================================
+// Reserved Codes
+// ============================================================================
+//
+//   0–255:  Pre-seeded. Code c decodes to the single byte c.
+//   256:    CLEAR_CODE. Reset the dictionary and code_size.
+//   257:    STOP_CODE.  End of stream.
+//   258+:   Dynamic entries built during encoding.
+//
+// ============================================================================
+// Variable-Width Bit-Packing (LSB-first)
+// ============================================================================
+//
+// Codes are packed bit-by-bit, LSB-first, into a byte stream.  The code_size
+// starts at 9 bits and grows when next_code crosses the next power-of-2
+// boundary.  This matches GIF and Unix compress conventions.
+//
+//   Example: writing code 421 (0b110100101, 9 bits) then code 2 (0b10, 2 bits):
+//
+//     buffer = 0b110100101          (9 bits)
+//     byte 0 = 0b10100101           (low 8 bits)
+//     buffer = 0b1                  (1 bit remaining)
+//     write 2 = 0b10 → buffer = 0b101
+//     (flush) byte 1 = 0b101
+//
+// ============================================================================
+// The Tricky Token
+// ============================================================================
+//
+// During decoding there is a classic edge case: the decoder may receive a code
+// equal to next_code — a code it has not yet added to its dictionary.  This
+// happens when the encoded sequence has the form xyx...x (the new entry starts
+// with the same byte as the previous entry).  In that case:
+//
+//   entry = dict[prev_code] + byte { dict[prev_code][0] }
+//
+// This always produces the correct sequence because the encoder only emits such
+// a code when the new entry equals the previous entry extended by its own first
+// byte.
+//
+// ============================================================================
+// Wire Format (CMP03)
+// ============================================================================
+//
+//   Bytes 0–3:  original_length  (big-endian uint32)
+//   Bytes 4+:   bit-packed variable-width codes, LSB-first within each byte
+//
+//     - Starts at code_size = 9 bits
+//     - Grows when next_code crosses the next power-of-2 boundary
+//     - Maximum code_size = 16 (up to 65536 dictionary entries)
+//     - Stream always begins with CLEAR_CODE and ends with STOP_CODE
+//
+// ============================================================================
+// The CMP Series
+// ============================================================================
+//
+//   CMP00 (LZ77,    1977) — Sliding-window back-references.
+//   CMP01 (LZ78,    1978) — Explicit dictionary (trie), no sliding window.
+//   CMP02 (LZSS,    1982) — LZ77 + flag bits; eliminates wasted literals.
+//   CMP03 (LZW,     1984) — LZ78 + pre-initialized dict; powers GIF. (this)
+//   CMP04 (Huffman, 1952) — Entropy coding; prerequisite for DEFLATE.
+//   CMP05 (DEFLATE, 1996) — LZ77 + Huffman; ZIP/gzip/PNG/zlib standard.
+//
+// ============================================================================
+// References
+// ============================================================================
+//
+//   Welch, T.A. (1984). "A Technique for High-Performance Data Compression".
+//   Computer, 17(6), 8–19. doi:10.1109/MC.1984.1659158
+//
+//   Ziv, J., & Lempel, A. (1978). "Compression of Individual Sequences via
+//   Variable-Rate Coding". IEEE Transactions on Information Theory, 24(5),
+//   530–536.
+//
+// ============================================================================
+
+package com.codingadventures.lzw
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+// ============================================================================
+// LZW
+// ============================================================================
+
+/**
+ * CMP03: LZW lossless compression.
+ *
+ * ```kotlin
+ * val original   = "hello hello hello".toByteArray()
+ * val compressed = LZW.compress(original)
+ * val recovered  = LZW.decompress(compressed)
+ * check(original.contentEquals(recovered))
+ * ```
+ */
+object LZW {
+
+    // =========================================================================
+    // Constants
+    // =========================================================================
+
+    /** Reset code — instructs the decoder to clear its dictionary and restart. */
+    const val CLEAR_CODE = 256
+
+    /** End-of-stream code — the decoder stops reading after this code. */
+    const val STOP_CODE = 257
+
+    /** First dynamically assigned dictionary code. */
+    const val INITIAL_NEXT_CODE = 258
+
+    /** Starting bit-width for codes (covers 0–511, more than enough for 258). */
+    const val INITIAL_CODE_SIZE = 9
+
+    /** Maximum bit-width; dictionary caps at 2^16 = 65536 entries. */
+    const val MAX_CODE_SIZE = 16
+
+    /**
+     * Maximum decompressed output size (64 MiB by default).
+     *
+     * A fully-saturated LZW dictionary (65536 entries, each one byte longer
+     * than the last) can theoretically require ~2 GB of heap.  This limit caps
+     * the output to prevent heap exhaustion from crafted streams.  Call
+     * [decodeCodes] directly with a higher limit when needed.
+     */
+    const val DEFAULT_MAX_OUTPUT = 64 * 1024 * 1024 // 64 MiB
+
+    /** Wire-format header size: original_length(4). */
+    private const val HEADER_SIZE = 4
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Compress [data] using LZW and return CMP03 wire-format bytes.
+     *
+     * @param data the bytes to compress (null treated as empty)
+     * @return compressed bytes in CMP03 wire format
+     */
+    fun compress(data: ByteArray?): ByteArray {
+        val bytes  = data ?: ByteArray(0)
+        val codes  = encodeCodes(bytes)
+        return packCodes(codes, bytes.size)
+    }
+
+    /**
+     * Decompress CMP03 wire-format bytes back to the original data.
+     *
+     * Output is capped at [DEFAULT_MAX_OUTPUT] bytes to prevent heap exhaustion
+     * from crafted streams.
+     *
+     * @param data compressed bytes (null treated as empty)
+     * @return the original, uncompressed bytes
+     */
+    fun decompress(data: ByteArray?): ByteArray {
+        if (data == null || data.size < HEADER_SIZE) return ByteArray(0)
+        val originalLength = ByteBuffer.wrap(data, 0, HEADER_SIZE)
+            .order(ByteOrder.BIG_ENDIAN).getInt()
+        val codes  = unpackCodes(data)
+        val result = decodeCodes(codes, DEFAULT_MAX_OUTPUT)
+        // Trim to original length to remove bit-padding artefacts.
+        return if (originalLength in 0..result.size) result.copyOf(originalLength) else result
+    }
+
+    // =========================================================================
+    // Encoder
+    // =========================================================================
+
+    /**
+     * Encode [data] into a list of LZW codes (including CLEAR and STOP).
+     *
+     * Algorithm:
+     * 1. Initialise the encode dictionary: byte → code for all 256 bytes.
+     * 2. Emit CLEAR_CODE to mark the start of the stream.
+     * 3. Walk the input byte-by-byte, extending the current prefix *w*:
+     *    - If *w + b* is already in the dictionary, extend *w*.
+     *    - Otherwise, emit code_for(*w*), add *w + b* as a new entry,
+     *      reset *w* to just *b*.
+     *    - When the dictionary is full, emit CLEAR_CODE and re-initialise.
+     * 4. Flush the remaining prefix and emit STOP_CODE.
+     */
+    internal fun encodeCodes(data: ByteArray): List<Int> {
+        val codes      = mutableListOf<Int>()
+        val maxEntries = 1 shl MAX_CODE_SIZE // 65536
+
+        // Encode dictionary: ByteList → code.
+        // Using List<Byte> as key (value-equal, unlike ByteArray).
+        var encodeDict = HashMap<List<Byte>, Int>(512)
+        for (b in 0 until 256) {
+            encodeDict[listOf(b.toByte())] = b
+        }
+        var nextCode = INITIAL_NEXT_CODE
+
+        codes.add(CLEAR_CODE)
+
+        var w = emptyList<Byte>() // current working prefix
+
+        for (rawByte in data) {
+            val wb = w + rawByte
+            if (encodeDict.containsKey(wb)) {
+                w = wb // extend the prefix
+            } else {
+                // Emit code for the current prefix.
+                codes.add(encodeDict[w]!!)
+
+                if (nextCode < maxEntries) {
+                    encodeDict[wb] = nextCode
+                    nextCode++
+                } else {
+                    // Dictionary full — emit CLEAR and reset.
+                    codes.add(CLEAR_CODE)
+                    encodeDict = HashMap(512)
+                    for (b in 0 until 256) {
+                        encodeDict[listOf(b.toByte())] = b
+                    }
+                    nextCode = INITIAL_NEXT_CODE
+                }
+
+                w = listOf(rawByte) // restart with the unmatched byte
+            }
+        }
+
+        // Flush remaining prefix.
+        if (w.isNotEmpty()) {
+            codes.add(encodeDict[w]!!)
+        }
+
+        codes.add(STOP_CODE)
+        return codes
+    }
+
+    // =========================================================================
+    // Decoder
+    // =========================================================================
+
+    /**
+     * Decode a list of LZW codes back to the original bytes.
+     *
+     * Uses [DEFAULT_MAX_OUTPUT] as the output size limit.
+     *
+     * @param codes the code list from [encodeCodes]
+     * @return the decoded bytes
+     * @throws IllegalArgumentException if the code stream is corrupt or too large
+     */
+    internal fun decodeCodes(codes: List<Int>): ByteArray =
+        decodeCodes(codes, DEFAULT_MAX_OUTPUT)
+
+    /**
+     * Decode a list of LZW codes back to the original bytes, with an output cap.
+     *
+     * Handles:
+     * - [CLEAR_CODE]: reset dictionary and code_size.
+     * - [STOP_CODE]: stop decoding.
+     * - Tricky token (code == next_code): construct the entry as
+     *   `dict[prev_code] + byteArrayOf(dict[prev_code][0])`.
+     *
+     * Security: without a size cap, a crafted stream that never emits
+     * CLEAR_CODE can force the decoder to build up to 65278 dictionary entries,
+     * each growing by 1 byte.  Total worst-case allocation ≈ 2 GB.  The
+     * [maxOutput] limit stops decoding before heap exhaustion occurs.
+     *
+     * @param codes     the code list from [encodeCodes]
+     * @param maxOutput maximum bytes to emit; throw if exceeded
+     * @return the decoded bytes
+     * @throws IllegalArgumentException if the code stream is corrupt or output exceeds maxOutput
+     */
+    internal fun decodeCodes(codes: List<Int>, maxOutput: Int): ByteArray {
+        // Decode dictionary: code → byte sequence.
+        val decodeDict = ArrayList<ByteArray>(512)
+        for (b in 0 until 256) decodeDict.add(byteArrayOf(b.toByte()))
+        decodeDict.add(ByteArray(0)) // 256 = CLEAR_CODE placeholder
+        decodeDict.add(ByteArray(0)) // 257 = STOP_CODE  placeholder
+        var nextCode = INITIAL_NEXT_CODE
+
+        val out      = ByteArrayOutputStream()
+        var prevCode: Int? = null
+
+        for (code in codes) {
+            if (code == CLEAR_CODE) {
+                // Reset dictionary to 256 single-byte entries.
+                decodeDict.clear()
+                for (b in 0 until 256) decodeDict.add(byteArrayOf(b.toByte()))
+                decodeDict.add(ByteArray(0)) // 256
+                decodeDict.add(ByteArray(0)) // 257
+                nextCode = INITIAL_NEXT_CODE
+                prevCode = null
+                continue
+            }
+
+            if (code == STOP_CODE) break
+
+            val entry: ByteArray = when {
+                code < decodeDict.size -> decodeDict[code]
+                code == nextCode -> {
+                    // Tricky token: code not yet in dict.
+                    // Only valid when prevCode exists.
+                    val pc = prevCode ?: throw IllegalArgumentException(
+                        "Invalid LZW stream: tricky token with no previous code")
+                    val prevEntry = decodeDict[pc]
+                    prevEntry + byteArrayOf(prevEntry[0])
+                }
+                else -> throw IllegalArgumentException(
+                    "Invalid LZW code: exceeds expected next code")
+            }
+
+            // Guard against heap exhaustion from crafted streams.
+            require(out.size() + entry.size <= maxOutput) {
+                "LZW: decompressed output exceeds limit of $maxOutput bytes"
+            }
+
+            out.write(entry)
+
+            // Add new entry to the decode dictionary.
+            if (prevCode != null && nextCode < (1 shl MAX_CODE_SIZE)) {
+                val prevEntry = decodeDict[prevCode!!]
+                decodeDict.add(prevEntry + byteArrayOf(entry[0]))
+                nextCode++
+            }
+
+            prevCode = code
+        }
+
+        return out.toByteArray()
+    }
+
+    // =========================================================================
+    // Serialisation
+    // =========================================================================
+
+    /**
+     * Pack a list of LZW codes into the CMP03 wire format.
+     *
+     * Wire format:
+     * - Bytes 0–3: original_length (big-endian uint32)
+     * - Bytes 4+: codes as variable-width LSB-first bit-packed integers
+     *
+     * The code size starts at [INITIAL_CODE_SIZE] (9) and grows each time
+     * next_code crosses the next power-of-2 boundary.  CLEAR_CODE resets the
+     * code size back to [INITIAL_CODE_SIZE].
+     */
+    internal fun packCodes(codes: List<Int>, originalLength: Int): ByteArray {
+        val writer   = BitWriter()
+        var codeSize = INITIAL_CODE_SIZE
+        var nextCode = INITIAL_NEXT_CODE
+
+        for (code in codes) {
+            writer.write(code, codeSize)
+
+            when {
+                code == CLEAR_CODE -> {
+                    codeSize = INITIAL_CODE_SIZE
+                    nextCode = INITIAL_NEXT_CODE
+                }
+                code != STOP_CODE -> {
+                    if (nextCode < (1 shl MAX_CODE_SIZE)) {
+                        nextCode++
+                        if (nextCode > (1 shl codeSize) && codeSize < MAX_CODE_SIZE) {
+                            codeSize++
+                        }
+                    }
+                }
+            }
+        }
+        writer.flush()
+
+        val header = ByteBuffer.allocate(HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        header.putInt(originalLength)
+
+        val out = ByteArrayOutputStream()
+        out.write(header.array())
+        out.write(writer.toByteArray())
+        return out.toByteArray()
+    }
+
+    /**
+     * Unpack CMP03 wire-format bytes into a list of LZW codes.
+     *
+     * The decoder stops on STOP_CODE or stream exhaustion, so a crafted stream
+     * cannot cause unbounded iteration.
+     */
+    internal fun unpackCodes(data: ByteArray): List<Int> {
+        if (data.size < HEADER_SIZE) return listOf(CLEAR_CODE, STOP_CODE)
+
+        val reader   = BitReader(data, HEADER_SIZE)
+        val codes    = mutableListOf<Int>()
+        var codeSize = INITIAL_CODE_SIZE
+        var nextCode = INITIAL_NEXT_CODE
+
+        while (!reader.exhausted()) {
+            if (!reader.hasEnough(codeSize)) break
+            val code = reader.read(codeSize)
+            codes.add(code)
+
+            when {
+                code == STOP_CODE  -> break
+                code == CLEAR_CODE -> {
+                    codeSize = INITIAL_CODE_SIZE
+                    nextCode = INITIAL_NEXT_CODE
+                }
+                else -> {
+                    if (nextCode < (1 shl MAX_CODE_SIZE)) {
+                        nextCode++
+                        if (nextCode > (1 shl codeSize) && codeSize < MAX_CODE_SIZE) {
+                            codeSize++
+                        }
+                    }
+                }
+            }
+        }
+
+        return codes
+    }
+
+    // =========================================================================
+    // Bit I/O
+    // =========================================================================
+
+    /**
+     * Accumulates variable-width codes into a byte buffer, LSB-first.
+     *
+     * LSB-first packing: the first code written occupies bits 0..N-1 of the
+     * first byte, spilling into subsequent bytes as necessary.  This matches the
+     * GIF and Unix compress conventions.
+     */
+    class BitWriter {
+        private var buffer = 0L
+        private var bitPos = 0
+        private val out    = ByteArrayOutputStream()
+
+        /**
+         * Write [code] using exactly [codeSize] bits.
+         */
+        fun write(code: Int, codeSize: Int) {
+            buffer = buffer or (code.toLong() shl bitPos)
+            bitPos += codeSize
+            while (bitPos >= 8) {
+                out.write((buffer and 0xFF).toInt())
+                buffer = buffer ushr 8
+                bitPos -= 8
+            }
+        }
+
+        /** Flush any remaining bits as a final partial byte. */
+        fun flush() {
+            if (bitPos > 0) {
+                out.write((buffer and 0xFF).toInt())
+                buffer = 0L
+                bitPos = 0
+            }
+        }
+
+        /** Return the accumulated output. */
+        fun toByteArray(): ByteArray = out.toByteArray()
+    }
+
+    /**
+     * Reads variable-width codes from a byte buffer, LSB-first.
+     *
+     * Mirrors [BitWriter] exactly: bits within each byte are consumed from the
+     * least-significant end first.
+     */
+    class BitReader(private val data: ByteArray, startPos: Int) {
+        private var pos    = startPos
+        private var buffer = 0L
+        private var bitPos = 0
+
+        /**
+         * Read and return the next [codeSize]-bit code.
+         */
+        fun read(codeSize: Int): Int {
+            while (bitPos < codeSize) {
+                buffer = buffer or ((data[pos++].toLong() and 0xFFL) shl bitPos)
+                bitPos += 8
+            }
+            val code = (buffer and ((1L shl codeSize) - 1L)).toInt()
+            buffer = buffer ushr codeSize
+            bitPos -= codeSize
+            return code
+        }
+
+        /** True when the byte stream is exhausted and no buffered bits remain. */
+        fun exhausted(): Boolean = pos >= data.size && bitPos == 0
+
+        /** True when at least [n] bits can still be read. */
+        fun hasEnough(n: Int): Boolean {
+            val available = bitPos + (data.size - pos) * 8
+            return available >= n
+        }
+    }
+}

--- a/code/packages/kotlin/lzw/src/test/kotlin/com/codingadventures/lzw/LZWTest.kt
+++ b/code/packages/kotlin/lzw/src/test/kotlin/com/codingadventures/lzw/LZWTest.kt
@@ -1,0 +1,223 @@
+// ============================================================================
+// LZWTest.kt — CMP03: LZW Compression Tests
+// ============================================================================
+
+package com.codingadventures.lzw
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertThrows
+
+class LZWTest {
+
+    // =========================================================================
+    // 1. Round-trip
+    // =========================================================================
+
+    @Test fun roundTrip_helloWorld()      { roundTrip("hello world".toByteArray()) }
+    @Test fun roundTrip_helloHello()      { roundTrip("hello hello hello".toByteArray()) }
+    @Test fun roundTrip_aaabbc()          { roundTrip("AAABBC".toByteArray()) }
+    @Test fun roundTrip_repeatedPattern() { roundTrip(repeat("ABCABC".toByteArray(), 100)) }
+    @Test fun roundTrip_loremIpsum()      {
+        roundTrip("Lorem ipsum dolor sit amet, consectetur adipiscing elit.".toByteArray()) }
+    @Test fun roundTrip_all256Bytes()     {
+        roundTrip(ByteArray(256) { it.toByte() }) }
+    @Test fun roundTrip_binaryData()      {
+        roundTrip(byteArrayOf(0, 1, 2, 3, 255.toByte(), 128.toByte(), 64)) }
+    @Test fun roundTrip_longInput()       {
+        roundTrip(repeat("the quick brown fox jumps over the lazy dog ".toByteArray(), 200)) }
+    @Test fun roundTrip_singleByte()      { roundTrip(byteArrayOf('A'.code.toByte())) }
+    @Test fun roundTrip_twoBytes()        { roundTrip(byteArrayOf('A'.code.toByte(), 'B'.code.toByte())) }
+    @Test fun roundTrip_singleRepeated()  { roundTrip(ByteArray(100) { 'A'.code.toByte() }) }
+    @Test fun roundTrip_newlineHeavy()    { roundTrip(repeat("line\n".toByteArray(), 200)) }
+    @Test fun roundTrip_nullBytes()       { roundTrip(ByteArray(100)) }
+    @Test fun roundTrip_highBytes()       {
+        roundTrip(ByteArray(128) { (128 + it).toByte() }) }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 65, 127, 255])
+    fun roundTrip_singleSymbol(sym: Int)  { roundTrip(byteArrayOf(sym.toByte())) }
+
+    // =========================================================================
+    // 2. Code stream structure
+    // =========================================================================
+
+    @Test fun codes_startWithClearCode() {
+        val codes = LZW.encodeCodes("hello".toByteArray())
+        assertEquals(LZW.CLEAR_CODE, codes.first(),
+            "First code should always be CLEAR_CODE")
+    }
+
+    @Test fun codes_endWithStopCode() {
+        val codes = LZW.encodeCodes("hello".toByteArray())
+        assertEquals(LZW.STOP_CODE, codes.last(),
+            "Last code should always be STOP_CODE")
+    }
+
+    @Test fun codes_repeatedInput_hasCodesAbove257() {
+        // A repeated pattern must produce at least one multi-byte dictionary entry.
+        val codes = LZW.encodeCodes("ABABABABAB".toByteArray())
+        assertTrue(codes.any { it >= LZW.INITIAL_NEXT_CODE },
+            "Repeated input should produce codes above 257")
+    }
+
+    @Test fun codes_singleByte_roundTrips() {
+        val codes  = LZW.encodeCodes(byteArrayOf('X'.code.toByte()))
+        val result = LZW.decodeCodes(codes)
+        assertContentEquals(byteArrayOf('X'.code.toByte()), result)
+    }
+
+    // =========================================================================
+    // 3. Wire format
+    // =========================================================================
+
+    @Test fun wireFormat_originalLengthStoredInHeader() {
+        for (len in intArrayOf(1, 5, 100)) {
+            val data       = ByteArray(len) { 'A'.code.toByte() }
+            val compressed = LZW.compress(data)
+            val stored     = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt()
+            assertEquals(len, stored)
+        }
+    }
+
+    @Test fun wireFormat_headerIs4Bytes() {
+        val compressed = LZW.compress("A".toByteArray())
+        assertTrue(compressed.size > 4, "Compressed output must exceed the 4-byte header")
+    }
+
+    @Test fun wireFormat_emptyInput_producesHeaderOnly() {
+        val compressed = LZW.compress(ByteArray(0))
+        assertTrue(compressed.size >= 4, "Empty input should at least have a header")
+        val stored = ByteBuffer.wrap(compressed).order(ByteOrder.BIG_ENDIAN).getInt()
+        assertEquals(0, stored, "original_length should be 0 for empty input")
+    }
+
+    // =========================================================================
+    // 4. Edge cases
+    // =========================================================================
+
+    @Test fun compress_null()       { assertContentEquals(ByteArray(0), LZW.decompress(LZW.compress(null))) }
+    @Test fun compress_empty()      { assertContentEquals(ByteArray(0), LZW.decompress(LZW.compress(ByteArray(0)))) }
+    @Test fun decompress_null()     { assertContentEquals(ByteArray(0), LZW.decompress(null)) }
+    @Test fun decompress_tooShort() { assertContentEquals(ByteArray(0), LZW.decompress(ByteArray(2))) }
+
+    // =========================================================================
+    // 5. Tricky token (code == next_code)
+    // =========================================================================
+
+    @Test fun trickyToken_aaaa() {
+        // "AAAA" triggers the tricky token scenario in LZW decoding.
+        roundTrip("AAAA".toByteArray())
+    }
+
+    @Test fun trickyToken_longRun() {
+        val data = ByteArray(200) { 'Z'.code.toByte() }
+        roundTrip(data)
+    }
+
+    @Test fun trickyToken_ababab() {
+        roundTrip(repeat("AB".toByteArray(), 50))
+    }
+
+    // =========================================================================
+    // 6. Bit I/O round-trip
+    // =========================================================================
+
+    @Test fun bitWriter_bitReader_roundTrip() {
+        val w = LZW.BitWriter()
+        w.write(421,  9)   // 9-bit code
+        w.write(258,  9)   // another 9-bit code
+        w.write(1023, 10)  // 10-bit code
+        w.flush()
+        val packed = w.toByteArray()
+
+        val r = LZW.BitReader(packed, 0)
+        assertEquals(421,  r.read(9))
+        assertEquals(258,  r.read(9))
+        assertEquals(1023, r.read(10))
+    }
+
+    @Test fun bitWriter_singleBit() {
+        val w = LZW.BitWriter()
+        w.write(1, 1)
+        w.flush()
+        val packed = w.toByteArray()
+        assertEquals(1, packed[0].toInt() and 0xFF)
+    }
+
+    @Test fun bitWriter_exactlyOneByte() {
+        val w = LZW.BitWriter()
+        w.write(0b10110101, 8)
+        w.flush()
+        val packed = w.toByteArray()
+        assertEquals(1, packed.size)
+        assertEquals(0b10110101, packed[0].toInt() and 0xFF)
+    }
+
+    // =========================================================================
+    // 7. Compression effectiveness
+    // =========================================================================
+
+    @Test fun effectiveness_repeatedPattern_shrinks() {
+        val data = repeat("ABCABCABC".toByteArray(), 100)
+        assertTrue(LZW.compress(data).size < data.size)
+    }
+
+    @Test fun effectiveness_repeatedByte_shrinks() {
+        val data = ByteArray(1000) { 'X'.code.toByte() }
+        assertTrue(LZW.compress(data).size < data.size)
+    }
+
+    // =========================================================================
+    // 8. Security / robustness
+    // =========================================================================
+
+    @Test fun decodeCodes_outputLimit_throwsWhenExceeded() {
+        // Encode a large repeated pattern, then try to decode with a tiny limit.
+        val data  = repeat("ABCDEFGH".toByteArray(), 100)
+        val codes = LZW.encodeCodes(data)
+        // 1-byte limit should immediately trigger the guard.
+        assertThrows<IllegalArgumentException> { LZW.decodeCodes(codes, 1) }
+    }
+
+    @Test fun decodeCodes_invalidCode_throwsIllegalArgument() {
+        // A code far beyond next_code should throw IllegalArgumentException.
+        val codes = listOf(LZW.CLEAR_CODE, 65, 9999)
+        assertThrows<IllegalArgumentException> { LZW.decodeCodes(codes) }
+    }
+
+    // =========================================================================
+    // 9. Determinism
+    // =========================================================================
+
+    @Test fun deterministicCompression() {
+        val data = "the quick brown fox jumps over the lazy dog".toByteArray()
+        assertContentEquals(LZW.compress(data), LZW.compress(data))
+    }
+
+    @Test fun deterministicDecompression() {
+        val compressed = LZW.compress("hello world hello world".toByteArray())
+        assertContentEquals(LZW.decompress(compressed), LZW.decompress(compressed))
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun roundTrip(data: ByteArray) {
+        assertContentEquals(data, LZW.decompress(LZW.compress(data)),
+            "Round-trip failed for ${data.size} bytes")
+    }
+
+    private fun repeat(src: ByteArray, times: Int): ByteArray {
+        val out = ByteArray(src.size * times)
+        for (i in 0 until times) System.arraycopy(src, 0, out, i * src.size, src.size)
+        return out
+    }
+}


### PR DESCRIPTION
## Summary

- **java/lz77 (CMP00)**: LZ77 sliding-window compression. Token record `(offset, length, nextChar)`; greedy O(n×window) encoder; byte-by-byte overlapping-match decoder. CMP00 wire format. 40 tests.
- **kotlin/lz77 (CMP00)**: Idiomatic Kotlin port using `data class Token`, `Pair<Int,Int>`, optional `initialBuffer` seed for streaming decode. 38 tests.
- **java/lzss (CMP02)**: LZSS refinement of LZ77. Java 21 sealed interface with `Literal` and `Match` records. Flag-byte scheme (8 symbols per block). CMP02 wire format with `original_length` header. 38 tests.
- **kotlin/lzss (CMP02)**: Idiomatic Kotlin port using `sealed interface Token`, `when` expressions. 38 tests.
- **java/lzw (CMP03)**: LZW variable-width bit-packed compression. Pre-seeded 256-entry dictionary, CLEAR/STOP codes, `BitWriter`/`BitReader` with 64-bit accumulator, tricky-token edge case. 41 tests.
- **kotlin/lzw (CMP03)**: Idiomatic Kotlin port using `List<Byte>` dictionary keys (value equality built-in). 41 tests.

**Total: 236 tests, all passing.**

## Security

Two-round security review conducted. Three findings addressed:

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | OOB array access in LZ77/LZSS decode when `offset > out.size()` | Explicit bounds check throwing `IllegalArgumentException` before array access |
| HIGH | LZW heap exhaustion: fully-saturated dictionary (no CLEAR) can allocate ~2 GB | `DEFAULT_MAX_OUTPUT = 64 MiB` cap in `decodeCodes`; public constant for callers who need larger limit |
| MEDIUM | Negative `originalLength` from crafted LZSS header | Existing `originalLength >= 0` guard confirmed correct; clarifying comment added |

## Test plan
- [x] All 236 unit tests pass locally
- [x] Security review passed (2 rounds)
- [x] Round-trip, wire format, edge cases, overlapping matches, effectiveness, determinism all covered
- [x] Crafted-input tests verify security guards throw `IllegalArgumentException` (not `ArrayIndexOutOfBoundsException`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)