### PR TITLE
feat(parity): add dotnet trie packages

### DIFF
--- a/code/packages/csharp/trie/BUILD
+++ b/code/packages/csharp/trie/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/trie/BUILD_windows
+++ b/code/packages/csharp/trie/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/trie/CHANGELOG.md
+++ b/code/packages/csharp/trie/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# generic trie implementation with prefix queries.

--- a/code/packages/csharp/trie/CodingAdventures.Trie.csproj
+++ b/code/packages/csharp/trie/CodingAdventures.Trie.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Trie.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Generic prefix tree for string keys</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/trie/README.md
+++ b/code/packages/csharp/trie/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.Trie.CSharp
+
+Generic trie (prefix tree) for mapping string keys to values, with efficient
+prefix checks and key enumeration.

--- a/code/packages/csharp/trie/Trie.cs
+++ b/code/packages/csharp/trie/Trie.cs
@@ -1,0 +1,154 @@
+using System.Text;
+
+namespace CodingAdventures.Trie;
+
+/// <summary>
+/// Generic trie (prefix tree) mapping string keys to values.
+/// </summary>
+public sealed class Trie<T>
+{
+    private sealed class Node
+    {
+        public Dictionary<char, Node> Children { get; } = [];
+        public bool IsEnd { get; set; }
+        public T? Value { get; set; }
+    }
+
+    private readonly Node _root = new();
+    private int _count;
+
+    /// <summary>Number of keys stored in the trie.</summary>
+    public int Count => _count;
+
+    /// <summary>Number of keys stored in the trie.</summary>
+    public int Size => _count;
+
+    /// <summary>True when no keys are stored.</summary>
+    public bool IsEmpty => _count == 0;
+
+    /// <summary>Insert or update a key.</summary>
+    public void Insert(string key, T? value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var node = _root;
+        foreach (var ch in key)
+        {
+            if (!node.Children.TryGetValue(ch, out var child))
+            {
+                child = new Node();
+                node.Children.Add(ch, child);
+            }
+
+            node = child;
+        }
+
+        if (!node.IsEnd)
+        {
+            node.IsEnd = true;
+            _count++;
+        }
+
+        node.Value = value;
+    }
+
+    /// <summary>Return the value for a key, or default when absent.</summary>
+    public T? Get(string key)
+    {
+        var node = FindNode(key);
+        return node is { IsEnd: true } ? node.Value : default;
+    }
+
+    /// <summary>Try to get the value for a key.</summary>
+    public bool TryGetValue(string key, out T? value)
+    {
+        var node = FindNode(key);
+        if (node is { IsEnd: true })
+        {
+            value = node.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>Return true if the complete key exists.</summary>
+    public bool Contains(string key)
+    {
+        var node = FindNode(key);
+        return node is { IsEnd: true };
+    }
+
+    /// <summary>Return true if any key starts with the prefix.</summary>
+    public bool StartsWith(string prefix) => FindNode(prefix) is not null;
+
+    /// <summary>Delete a key if present.</summary>
+    public bool Delete(string key)
+    {
+        var node = FindNode(key);
+        if (node is not { IsEnd: true })
+        {
+            return false;
+        }
+
+        node.IsEnd = false;
+        node.Value = default;
+        _count--;
+        return true;
+    }
+
+    /// <summary>Return all stored keys that start with prefix.</summary>
+    public List<string> KeysWithPrefix(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var results = new List<string>();
+        var node = FindNode(prefix);
+        if (node is not null)
+        {
+            CollectKeys(node, new StringBuilder(prefix), results);
+        }
+
+        return results;
+    }
+
+    /// <summary>Return all stored keys.</summary>
+    public List<string> Keys() => KeysWithPrefix(string.Empty);
+
+    private Node? FindNode(string? key)
+    {
+        if (key is null)
+        {
+            return null;
+        }
+
+        var node = _root;
+        foreach (var ch in key)
+        {
+            if (!node.Children.TryGetValue(ch, out var child))
+            {
+                return null;
+            }
+
+            node = child;
+        }
+
+        return node;
+    }
+
+    private static void CollectKeys(Node node, StringBuilder prefix, List<string> results)
+    {
+        if (node.IsEnd)
+        {
+            results.Add(prefix.ToString());
+        }
+
+        foreach (var (ch, child) in node.Children)
+        {
+            prefix.Append(ch);
+            CollectKeys(child, prefix, results);
+            prefix.Length--;
+        }
+    }
+}

--- a/code/packages/csharp/trie/required_capabilities.json
+++ b/code/packages/csharp/trie/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/trie",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/trie/tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.csproj
+++ b/code/packages/csharp/trie/tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Trie.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/trie/tests/CodingAdventures.Trie.Tests/TrieTests.cs
+++ b/code/packages/csharp/trie/tests/CodingAdventures.Trie.Tests/TrieTests.cs
@@ -1,0 +1,132 @@
+namespace CodingAdventures.Trie.Tests;
+
+public sealed class TrieTests
+{
+    [Fact]
+    public void InsertGetAndOverwrite()
+    {
+        var trie = new Trie<int>();
+        trie.Insert("apple", 1);
+        trie.Insert("app", 2);
+
+        Assert.True(trie.TryGetValue("apple", out var apple));
+        Assert.Equal(1, apple);
+        Assert.Equal(2, trie.Get("app"));
+        Assert.Equal(2, trie.Count);
+
+        trie.Insert("apple", 42);
+        Assert.Equal(42, trie.Get("apple"));
+        Assert.Equal(2, trie.Size);
+    }
+
+    [Fact]
+    public void MissingKeysAndPrefixesAreDistinct()
+    {
+        var trie = new Trie<int>();
+        trie.Insert("apple", 1);
+
+        Assert.False(trie.Contains("app"));
+        Assert.True(trie.StartsWith("app"));
+        Assert.False(trie.TryGetValue("banana", out _));
+        Assert.False(trie.StartsWith("banana"));
+        Assert.Equal(default, trie.Get("apples"));
+    }
+
+    [Fact]
+    public void EmptyKeyAndNullValueAreSupported()
+    {
+        var trie = new Trie<string>();
+        trie.Insert("", "empty");
+        trie.Insert("nullable", null);
+
+        Assert.True(trie.Contains(""));
+        Assert.Equal("empty", trie.Get(""));
+        Assert.True(trie.TryGetValue("nullable", out var value));
+        Assert.Null(value);
+        Assert.Equal(2, trie.Count);
+    }
+
+    [Fact]
+    public void DeleteUnmarksOnlyTheRequestedKey()
+    {
+        var trie = new Trie<int>();
+        trie.Insert("app", 1);
+        trie.Insert("apple", 2);
+        trie.Insert("apply", 3);
+
+        Assert.True(trie.Delete("apple"));
+        Assert.False(trie.Contains("apple"));
+        Assert.True(trie.Contains("app"));
+        Assert.True(trie.Contains("apply"));
+        Assert.False(trie.Delete("apple"));
+        Assert.False(trie.Delete("banana"));
+        Assert.Equal(2, trie.Count);
+    }
+
+    [Fact]
+    public void KeysWithPrefixReturnsMatches()
+    {
+        var trie = new Trie<int>();
+        trie.Insert("app", 1);
+        trie.Insert("apple", 2);
+        trie.Insert("apply", 3);
+        trie.Insert("apt", 4);
+        trie.Insert("banana", 5);
+
+        var appKeys = trie.KeysWithPrefix("app");
+        Assert.Equal(3, appKeys.Count);
+        Assert.Contains("app", appKeys);
+        Assert.Contains("apple", appKeys);
+        Assert.Contains("apply", appKeys);
+        Assert.DoesNotContain("apt", appKeys);
+        Assert.Empty(trie.KeysWithPrefix("z"));
+
+        var allKeys = trie.Keys();
+        Assert.Equal(5, allKeys.Count);
+        Assert.Contains("banana", allKeys);
+    }
+
+    [Fact]
+    public void SizeAndIsEmptyTrackMutations()
+    {
+        var trie = new Trie<int>();
+        Assert.True(trie.IsEmpty);
+        trie.Insert("a", 1);
+        trie.Insert("b", 2);
+        Assert.False(trie.IsEmpty);
+        trie.Delete("a");
+        trie.Delete("b");
+        Assert.True(trie.IsEmpty);
+        Assert.Equal(0, trie.Count);
+    }
+
+    [Fact]
+    public void UnicodeAndLargeDatasetsWork()
+    {
+        var trie = new Trie<int>();
+        trie.Insert("cafe\u0301", 1);
+        trie.Insert("cafe\u0301s", 2);
+        Assert.True(trie.Contains("cafe\u0301"));
+        Assert.Equal(2, trie.KeysWithPrefix("caf").Count);
+
+        for (var i = 0; i < 250; i++)
+        {
+            trie.Insert($"key{i}", i);
+        }
+
+        Assert.Equal(252, trie.Count);
+        Assert.Equal(250, trie.KeysWithPrefix("key").Count);
+    }
+
+    [Fact]
+    public void NullKeysAreRejectedOrTreatedAsAbsent()
+    {
+        var trie = new Trie<int>();
+
+        Assert.Throws<ArgumentNullException>(() => trie.Insert(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => trie.KeysWithPrefix(null!));
+        Assert.False(trie.Contains(null!));
+        Assert.False(trie.StartsWith(null!));
+        Assert.False(trie.Delete(null!));
+    }
+}

--- a/code/packages/fsharp/trie/BUILD
+++ b/code/packages/fsharp/trie/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/trie/BUILD_windows
+++ b/code/packages/fsharp/trie/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/trie/CHANGELOG.md
+++ b/code/packages/fsharp/trie/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# generic trie implementation with prefix queries.

--- a/code/packages/fsharp/trie/CodingAdventures.Trie.fsproj
+++ b/code/packages/fsharp/trie/CodingAdventures.Trie.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Trie.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Generic prefix tree for string keys</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Trie.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/trie/README.md
+++ b/code/packages/fsharp/trie/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.Trie.FSharp
+
+Generic trie (prefix tree) for mapping string keys to values, with efficient
+prefix checks and key enumeration.

--- a/code/packages/fsharp/trie/Trie.fs
+++ b/code/packages/fsharp/trie/Trie.fs
@@ -1,0 +1,112 @@
+namespace CodingAdventures.Trie
+
+open System
+open System.Collections.Generic
+open System.Text
+
+type private Node<'T>() =
+    let children = Dictionary<char, Node<'T>>()
+
+    member _.Children = children
+    member val IsEnd = false with get, set
+    member val Value = Unchecked.defaultof<'T> with get, set
+
+/// Generic trie (prefix tree) mapping string keys to values.
+type Trie<'T>() =
+    let root = Node<'T>()
+    let mutable count = 0
+
+    member _.Count = count
+    member _.Size = count
+    member _.IsEmpty = count = 0
+
+    member private _.FindNode(key: string) =
+        if isNull key then
+            None
+        else
+            let mutable node = root
+            let mutable index = 0
+            let mutable found = true
+
+            while found && index < key.Length do
+                match node.Children.TryGetValue(key[index]) with
+                | true, child ->
+                    node <- child
+                    index <- index + 1
+                | false, _ -> found <- false
+
+            if found then Some node else None
+
+    member _.Insert(key: string, value: 'T) =
+        if isNull key then
+            nullArg (nameof key)
+
+        let mutable node = root
+
+        for ch in key do
+            match node.Children.TryGetValue(ch) with
+            | true, child -> node <- child
+            | false, _ ->
+                let child = Node<'T>()
+                node.Children.Add(ch, child)
+                node <- child
+
+        if not node.IsEnd then
+            node.IsEnd <- true
+            count <- count + 1
+
+        node.Value <- value
+
+    member this.Get(key: string) =
+        match this.FindNode key with
+        | Some node when node.IsEnd -> Some node.Value
+        | _ -> None
+
+    member this.TryGetValue(key: string, value: byref<'T>) =
+        match this.FindNode key with
+        | Some node when node.IsEnd ->
+            value <- node.Value
+            true
+        | _ ->
+            value <- Unchecked.defaultof<'T>
+            false
+
+    member this.Contains(key: string) =
+        match this.FindNode key with
+        | Some node -> node.IsEnd
+        | None -> false
+
+    member this.StartsWith(prefix: string) =
+        this.FindNode prefix |> Option.isSome
+
+    member this.Delete(key: string) =
+        match this.FindNode key with
+        | Some node when node.IsEnd ->
+            node.IsEnd <- false
+            node.Value <- Unchecked.defaultof<'T>
+            count <- count - 1
+            true
+        | _ -> false
+
+    member private this.CollectKeys(node: Node<'T>, prefix: StringBuilder, results: ResizeArray<string>) =
+        if node.IsEnd then
+            results.Add(prefix.ToString())
+
+        for KeyValue(ch, child) in node.Children do
+            prefix.Append(ch) |> ignore
+            this.CollectKeys(child, prefix, results)
+            prefix.Length <- prefix.Length - 1
+
+    member this.KeysWithPrefix(prefix: string) =
+        if isNull prefix then
+            nullArg (nameof prefix)
+
+        let results = ResizeArray<string>()
+
+        match this.FindNode prefix with
+        | Some node -> this.CollectKeys(node, StringBuilder(prefix), results)
+        | None -> ()
+
+        List.ofSeq results
+
+    member this.Keys() = this.KeysWithPrefix("")

--- a/code/packages/fsharp/trie/required_capabilities.json
+++ b/code/packages/fsharp/trie/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/trie",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/trie/tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.fsproj
+++ b/code/packages/fsharp/trie/tests/CodingAdventures.Trie.Tests/CodingAdventures.Trie.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Trie.fsproj" />
+    <Compile Include="TrieTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/trie/tests/CodingAdventures.Trie.Tests/TrieTests.fs
+++ b/code/packages/fsharp/trie/tests/CodingAdventures.Trie.Tests/TrieTests.fs
@@ -1,0 +1,110 @@
+namespace CodingAdventures.Trie.Tests
+
+open System
+open Xunit
+open CodingAdventures.Trie
+
+type TrieTests() =
+    [<Fact>]
+    member _.``Insert get and overwrite``() =
+        let trie = Trie<int>()
+        trie.Insert("apple", 1)
+        trie.Insert("app", 2)
+
+        let mutable apple = 0
+        Assert.True(trie.TryGetValue("apple", &apple))
+        Assert.Equal(1, apple)
+        Assert.Equal(Some 2, trie.Get("app"))
+        Assert.Equal(2, trie.Count)
+
+        trie.Insert("apple", 42)
+        Assert.Equal(Some 42, trie.Get("apple"))
+        Assert.Equal(2, trie.Size)
+
+    [<Fact>]
+    member _.``Missing keys and prefixes are distinct``() =
+        let trie = Trie<int>()
+        trie.Insert("apple", 1)
+        Assert.False(trie.Contains "app")
+        Assert.True(trie.StartsWith "app")
+        Assert.Equal(None, trie.Get "banana")
+        Assert.False(trie.StartsWith "banana")
+
+    [<Fact>]
+    member _.``Empty key is supported``() =
+        let trie = Trie<string>()
+        trie.Insert("", "empty")
+        Assert.True(trie.Contains "")
+        Assert.Equal(Some "empty", trie.Get "")
+        Assert.Equal(1, trie.Count)
+
+    [<Fact>]
+    member _.``Delete unmarks only the requested key``() =
+        let trie = Trie<int>()
+        trie.Insert("app", 1)
+        trie.Insert("apple", 2)
+        trie.Insert("apply", 3)
+
+        Assert.True(trie.Delete "apple")
+        Assert.False(trie.Contains "apple")
+        Assert.True(trie.Contains "app")
+        Assert.True(trie.Contains "apply")
+        Assert.False(trie.Delete "apple")
+        Assert.False(trie.Delete "banana")
+        Assert.Equal(2, trie.Count)
+
+    [<Fact>]
+    member _.``Keys with prefix returns matches``() =
+        let trie = Trie<int>()
+        trie.Insert("app", 1)
+        trie.Insert("apple", 2)
+        trie.Insert("apply", 3)
+        trie.Insert("apt", 4)
+        trie.Insert("banana", 5)
+
+        let appKeys = trie.KeysWithPrefix "app"
+        Assert.Equal(3, List.length appKeys)
+        Assert.Contains("app", appKeys)
+        Assert.Contains("apple", appKeys)
+        Assert.Contains("apply", appKeys)
+        Assert.DoesNotContain("apt", appKeys)
+        Assert.Empty(trie.KeysWithPrefix "z")
+
+        let allKeys = trie.Keys()
+        Assert.Equal(5, List.length allKeys)
+        Assert.Contains("banana", allKeys)
+
+    [<Fact>]
+    member _.``Size and is empty track mutations``() =
+        let trie = Trie<int>()
+        Assert.True(trie.IsEmpty)
+        trie.Insert("a", 1)
+        trie.Insert("b", 2)
+        Assert.False(trie.IsEmpty)
+        trie.Delete("a") |> ignore
+        trie.Delete("b") |> ignore
+        Assert.True(trie.IsEmpty)
+        Assert.Equal(0, trie.Count)
+
+    [<Fact>]
+    member _.``Unicode and large datasets work``() =
+        let trie = Trie<int>()
+        trie.Insert("cafe\u0301", 1)
+        trie.Insert("cafe\u0301s", 2)
+        Assert.True(trie.Contains "cafe\u0301")
+        Assert.Equal(2, trie.KeysWithPrefix("caf").Length)
+
+        for i in 0 .. 249 do
+            trie.Insert($"key{i}", i)
+
+        Assert.Equal(252, trie.Count)
+        Assert.Equal(250, trie.KeysWithPrefix("key").Length)
+
+    [<Fact>]
+    member _.``Null keys are rejected or treated as absent``() =
+        let trie = Trie<int>()
+        Assert.Throws<ArgumentNullException>(fun () -> trie.Insert(null, 1)) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> trie.KeysWithPrefix(null) |> ignore) |> ignore
+        Assert.False(trie.Contains null)
+        Assert.False(trie.StartsWith null)
+        Assert.False(trie.Delete null)


### PR DESCRIPTION
## Summary
- add C# and F# trie packages for generic string-key prefix maps
- support insert/update, get/try-get, contains, startsWith, delete, keys, and keysWithPrefix
- add xUnit coverage and package metadata/build wrappers

## Verification
- dotnet test tests\\CodingAdventures.Trie.Tests\\CodingAdventures.Trie.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\\CodingAdventures.Trie.Tests\\CodingAdventures.Trie.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line