### PR TITLE
feat(parity): add managed ct compare packages

### DIFF
--- a/code/packages/csharp/ct-compare/BUILD
+++ b/code/packages/csharp/ct-compare/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ct-compare/BUILD_windows
+++ b/code/packages/csharp/ct-compare/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ct-compare/CHANGELOG.md
+++ b/code/packages/csharp/ct-compare/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# constant-time byte comparison helpers.

--- a/code/packages/csharp/ct-compare/CodingAdventures.CtCompare.csproj
+++ b/code/packages/csharp/ct-compare/CodingAdventures.CtCompare.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CtCompare.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Constant-time equality and byte selection helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ct-compare/CtCompare.cs
+++ b/code/packages/csharp/ct-compare/CtCompare.cs
@@ -1,0 +1,61 @@
+namespace CodingAdventures.CtCompare;
+
+/// <summary>
+/// Constant-time comparison helpers for public-length byte buffers.
+/// </summary>
+public static class CtCompare
+{
+    /// <summary>
+    /// Compare two byte sequences without short-circuiting on the first differing byte.
+    /// </summary>
+    public static bool CtEq(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        byte accumulator = 0;
+        for (var i = 0; i < left.Length; i++)
+        {
+            accumulator |= (byte)(left[i] ^ right[i]);
+        }
+
+        return accumulator == 0;
+    }
+
+    /// <summary>
+    /// Compare two same-size byte arrays. Runtime length mismatch returns false.
+    /// </summary>
+    public static bool CtEqFixed(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right) => CtEq(left, right);
+
+    /// <summary>
+    /// Select between two same-length byte arrays using a byte mask.
+    /// </summary>
+    public static byte[] CtSelectBytes(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right, bool choice)
+    {
+        if (left.Length != right.Length)
+        {
+            throw new ArgumentException("CtSelectBytes requires equal-length inputs.");
+        }
+
+        var mask = unchecked((byte)(0 - (choice ? 1 : 0)));
+        var output = new byte[left.Length];
+        for (var i = 0; i < left.Length; i++)
+        {
+            output[i] = (byte)(right[i] ^ ((left[i] ^ right[i]) & mask));
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Compare two UInt64 values without data-dependent ordering branches.
+    /// </summary>
+    public static bool CtEqUInt64(ulong left, ulong right)
+    {
+        var diff = left ^ right;
+        var folded = (diff | (0UL - diff)) >> 63;
+        return folded == 0;
+    }
+}

--- a/code/packages/csharp/ct-compare/README.md
+++ b/code/packages/csharp/ct-compare/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.CtCompare.CSharp
+
+Constant-time byte equality, fixed-size equality alias, mask-based byte
+selection, and branch-free 64-bit equality helpers.

--- a/code/packages/csharp/ct-compare/required_capabilities.json
+++ b/code/packages/csharp/ct-compare/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/ct-compare",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.csproj
+++ b/code/packages/csharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CtCompare.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CtCompareTests.cs
+++ b/code/packages/csharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CtCompareTests.cs
@@ -1,0 +1,64 @@
+namespace CodingAdventures.CtCompare.Tests;
+
+public sealed class CtCompareTests
+{
+    [Fact]
+    public void CtEqMatchesByteEquality()
+    {
+        Assert.True(CtCompare.CtEq("abcdef"u8, "abcdef"u8));
+        Assert.True(CtCompare.CtEq(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty));
+        Assert.False(CtCompare.CtEq("abcdef"u8, "abcdeg"u8));
+        Assert.False(CtCompare.CtEq("abcdef"u8, "bbcdef"u8));
+        Assert.False(CtCompare.CtEq("abc"u8, "abcd"u8));
+    }
+
+    [Fact]
+    public void CtEqDetectsEverySingleBitPosition()
+    {
+        var baseline = Enumerable.Repeat((byte)0x42, 32).ToArray();
+        for (var index = 0; index < baseline.Length; index++)
+        {
+            for (var bit = 0; bit < 8; bit++)
+            {
+                var flipped = baseline.ToArray();
+                flipped[index] ^= (byte)(1 << bit);
+                Assert.False(CtCompare.CtEq(baseline, flipped));
+            }
+        }
+    }
+
+    [Fact]
+    public void CtEqFixedIsDynamicAlias()
+    {
+        Assert.True(CtCompare.CtEqFixed(new byte[16], new byte[16]));
+        var different = new byte[16];
+        different[15] = 1;
+        Assert.False(CtCompare.CtEqFixed(new byte[16], different));
+    }
+
+    [Fact]
+    public void CtSelectBytesChoosesWithoutMutatingInputs()
+    {
+        var left = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+        var right = left.Reverse().ToArray();
+
+        Assert.Equal(left, CtCompare.CtSelectBytes(left, right, true));
+        Assert.Equal(right, CtCompare.CtSelectBytes(left, right, false));
+        Assert.Empty(CtCompare.CtSelectBytes([], [], true));
+        Assert.Throws<ArgumentException>(() => CtCompare.CtSelectBytes("abc"u8, "abcd"u8, true));
+    }
+
+    [Fact]
+    public void CtEqUInt64HandlesEdges()
+    {
+        Assert.True(CtCompare.CtEqUInt64(0, 0));
+        Assert.True(CtCompare.CtEqUInt64(ulong.MaxValue, ulong.MaxValue));
+        Assert.False(CtCompare.CtEqUInt64(0, 1UL << 63));
+
+        const ulong baseline = 0x1234_5678_9ABC_DEF0;
+        for (var bit = 0; bit < 64; bit++)
+        {
+            Assert.False(CtCompare.CtEqUInt64(baseline, baseline ^ (1UL << bit)));
+        }
+    }
+}

--- a/code/packages/fsharp/ct-compare/BUILD
+++ b/code/packages/fsharp/ct-compare/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ct-compare/BUILD_windows
+++ b/code/packages/fsharp/ct-compare/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ct-compare/CHANGELOG.md
+++ b/code/packages/fsharp/ct-compare/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# constant-time byte comparison helpers.

--- a/code/packages/fsharp/ct-compare/CodingAdventures.CtCompare.fsproj
+++ b/code/packages/fsharp/ct-compare/CodingAdventures.CtCompare.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CtCompare.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Constant-time equality and byte selection helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CtCompare.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ct-compare/CtCompare.fs
+++ b/code/packages/fsharp/ct-compare/CtCompare.fs
@@ -1,0 +1,39 @@
+namespace CodingAdventures.CtCompare
+
+/// Constant-time comparison helpers for public-length byte buffers.
+[<RequireQualifiedAccess>]
+module CtCompare =
+    let ctEq (left: byte array) (right: byte array) =
+        if isNull left then
+            nullArg (nameof left)
+        if isNull right then
+            nullArg (nameof right)
+
+        if left.Length <> right.Length then
+            false
+        else
+            let mutable accumulator = 0uy
+            for index in 0 .. left.Length - 1 do
+                accumulator <- accumulator ||| (left[index] ^^^ right[index])
+            accumulator = 0uy
+
+    let ctEqFixed (left: byte array) (right: byte array) =
+        ctEq left right
+
+    let ctSelectBytes (left: byte array) (right: byte array) choice =
+        if isNull left then
+            nullArg (nameof left)
+        if isNull right then
+            nullArg (nameof right)
+
+        if left.Length <> right.Length then
+            invalidArg (nameof right) "ctSelectBytes requires equal-length inputs."
+
+        let mask = if choice then 0xFFuy else 0uy
+        Array.init left.Length (fun index ->
+            right[index] ^^^ ((left[index] ^^^ right[index]) &&& mask))
+
+    let ctEqUInt64 (left: uint64) (right: uint64) =
+        let diff = left ^^^ right
+        let folded = (diff ||| (0UL - diff)) >>> 63
+        folded = 0UL

--- a/code/packages/fsharp/ct-compare/README.md
+++ b/code/packages/fsharp/ct-compare/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.CtCompare.FSharp
+
+Constant-time byte equality, fixed-size equality alias, mask-based byte
+selection, and branch-free 64-bit equality helpers.

--- a/code/packages/fsharp/ct-compare/required_capabilities.json
+++ b/code/packages/fsharp/ct-compare/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/ct-compare",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.fsproj
+++ b/code/packages/fsharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CodingAdventures.CtCompare.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CtCompare.fsproj" />
+    <Compile Include="CtCompareTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CtCompareTests.fs
+++ b/code/packages/fsharp/ct-compare/tests/CodingAdventures.CtCompare.Tests/CtCompareTests.fs
@@ -1,0 +1,49 @@
+namespace CodingAdventures.CtCompare.Tests
+
+open System
+open Xunit
+open CodingAdventures.CtCompare
+
+type CtCompareTests() =
+    [<Fact>]
+    member _.``ctEq matches byte equality``() =
+        Assert.True(CtCompare.ctEq [| 1uy; 2uy; 3uy |] [| 1uy; 2uy; 3uy |])
+        Assert.True(CtCompare.ctEq [||] [||])
+        Assert.False(CtCompare.ctEq [| 1uy; 2uy; 3uy |] [| 1uy; 2uy; 4uy |])
+        Assert.False(CtCompare.ctEq [| 1uy; 2uy; 3uy |] [| 0uy; 2uy; 3uy |])
+        Assert.False(CtCompare.ctEq [| 1uy; 2uy; 3uy |] [| 1uy; 2uy; 3uy; 4uy |])
+
+    [<Fact>]
+    member _.``ctEq detects every single bit position``() =
+        let baseline = Array.create 32 0x42uy
+        for index in 0 .. baseline.Length - 1 do
+            for bit in 0 .. 7 do
+                let flipped = Array.copy baseline
+                flipped[index] <- flipped[index] ^^^ byte (1 <<< bit)
+                Assert.False(CtCompare.ctEq baseline flipped)
+
+    [<Fact>]
+    member _.``ctEqFixed is dynamic alias``() =
+        Assert.True(CtCompare.ctEqFixed (Array.zeroCreate 16) (Array.zeroCreate 16))
+        let different = Array.zeroCreate<byte> 16
+        different[15] <- 1uy
+        Assert.False(CtCompare.ctEqFixed (Array.zeroCreate 16) different)
+
+    [<Fact>]
+    member _.``ctSelectBytes chooses without mutating inputs``() =
+        let left = [| 0uy .. 255uy |]
+        let right = Array.rev left
+        Assert.Equal<byte array>(left, CtCompare.ctSelectBytes left right true)
+        Assert.Equal<byte array>(right, CtCompare.ctSelectBytes left right false)
+        Assert.Empty(CtCompare.ctSelectBytes [||] [||] true)
+        Assert.Throws<ArgumentException>(fun () -> CtCompare.ctSelectBytes [| 1uy |] [| 1uy; 2uy |] true |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``ctEqUInt64 handles edges``() =
+        Assert.True(CtCompare.ctEqUInt64 0UL 0UL)
+        Assert.True(CtCompare.ctEqUInt64 UInt64.MaxValue UInt64.MaxValue)
+        Assert.False(CtCompare.ctEqUInt64 0UL (1UL <<< 63))
+
+        let baseline = 0x123456789ABCDEF0UL
+        for bit in 0 .. 63 do
+            Assert.False(CtCompare.ctEqUInt64 baseline (baseline ^^^ (1UL <<< bit)))

--- a/code/packages/java/ct-compare/.gitignore
+++ b/code/packages/java/ct-compare/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/ct-compare/BUILD
+++ b/code/packages/java/ct-compare/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/ct-compare/BUILD_windows
+++ b/code/packages/java/ct-compare/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/ct-compare/CHANGELOG.md
+++ b/code/packages/java/ct-compare/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Java constant-time byte comparison helpers.

--- a/code/packages/java/ct-compare/README.md
+++ b/code/packages/java/ct-compare/README.md
@@ -1,0 +1,4 @@
+# ct-compare
+
+Constant-time byte equality, fixed-size equality alias, mask-based byte
+selection, and branch-free 64-bit equality helpers for Java.

--- a/code/packages/java/ct-compare/build.gradle.kts
+++ b/code/packages/java/ct-compare/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/ct-compare/settings.gradle.kts
+++ b/code/packages/java/ct-compare/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "ct-compare"

--- a/code/packages/java/ct-compare/src/main/java/com/codingadventures/ctcompare/CtCompare.java
+++ b/code/packages/java/ct-compare/src/main/java/com/codingadventures/ctcompare/CtCompare.java
@@ -1,0 +1,47 @@
+package com.codingadventures.ctcompare;
+
+import java.util.Objects;
+
+public final class CtCompare {
+    private CtCompare() {
+    }
+
+    public static boolean ctEq(byte[] left, byte[] right) {
+        Objects.requireNonNull(left, "left");
+        Objects.requireNonNull(right, "right");
+        if (left.length != right.length) {
+            return false;
+        }
+
+        int accumulator = 0;
+        for (int i = 0; i < left.length; i++) {
+            accumulator |= (left[i] ^ right[i]) & 0xFF;
+        }
+        return accumulator == 0;
+    }
+
+    public static boolean ctEqFixed(byte[] left, byte[] right) {
+        return ctEq(left, right);
+    }
+
+    public static byte[] ctSelectBytes(byte[] left, byte[] right, boolean choice) {
+        Objects.requireNonNull(left, "left");
+        Objects.requireNonNull(right, "right");
+        if (left.length != right.length) {
+            throw new IllegalArgumentException("ctSelectBytes requires equal-length inputs");
+        }
+
+        int mask = 0 - (choice ? 1 : 0);
+        byte[] output = new byte[left.length];
+        for (int i = 0; i < left.length; i++) {
+            output[i] = (byte) (right[i] ^ ((left[i] ^ right[i]) & mask));
+        }
+        return output;
+    }
+
+    public static boolean ctEqU64(long left, long right) {
+        long diff = left ^ right;
+        long folded = (diff | -diff) >>> 63;
+        return folded == 0L;
+    }
+}

--- a/code/packages/java/ct-compare/src/test/java/com/codingadventures/ctcompare/CtCompareTest.java
+++ b/code/packages/java/ct-compare/src/test/java/com/codingadventures/ctcompare/CtCompareTest.java
@@ -1,0 +1,64 @@
+package com.codingadventures.ctcompare;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CtCompareTest {
+    @Test
+    void ctEqMatchesByteEquality() {
+        assertTrue(CtCompare.ctEq("abcdef".getBytes(), "abcdef".getBytes()));
+        assertTrue(CtCompare.ctEq(new byte[0], new byte[0]));
+        assertFalse(CtCompare.ctEq("abcdef".getBytes(), "abcdeg".getBytes()));
+        assertFalse(CtCompare.ctEq("abcdef".getBytes(), "bbcdef".getBytes()));
+        assertFalse(CtCompare.ctEq("abc".getBytes(), "abcd".getBytes()));
+    }
+
+    @Test
+    void ctEqDetectsEverySingleBitPosition() {
+        byte[] baseline = new byte[32];
+        java.util.Arrays.fill(baseline, (byte) 0x42);
+        for (int index = 0; index < baseline.length; index++) {
+            for (int bit = 0; bit < 8; bit++) {
+                byte[] flipped = baseline.clone();
+                flipped[index] ^= (byte) (1 << bit);
+                assertFalse(CtCompare.ctEq(baseline, flipped));
+            }
+        }
+    }
+
+    @Test
+    void ctEqFixedIsDynamicAlias() {
+        assertTrue(CtCompare.ctEqFixed(new byte[16], new byte[16]));
+        byte[] different = new byte[16];
+        different[15] = 1;
+        assertFalse(CtCompare.ctEqFixed(new byte[16], different));
+    }
+
+    @Test
+    void ctSelectBytesChoosesWithoutMutatingInputs() {
+        byte[] left = new byte[256];
+        byte[] right = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            left[i] = (byte) i;
+            right[i] = (byte) (255 - i);
+        }
+
+        assertArrayEquals(left, CtCompare.ctSelectBytes(left, right, true));
+        assertArrayEquals(right, CtCompare.ctSelectBytes(left, right, false));
+        assertArrayEquals(new byte[0], CtCompare.ctSelectBytes(new byte[0], new byte[0], true));
+        assertThrows(IllegalArgumentException.class, () -> CtCompare.ctSelectBytes(new byte[1], new byte[2], true));
+    }
+
+    @Test
+    void ctEqU64HandlesEdges() {
+        assertTrue(CtCompare.ctEqU64(0L, 0L));
+        assertTrue(CtCompare.ctEqU64(-1L, -1L));
+        assertFalse(CtCompare.ctEqU64(0L, Long.MIN_VALUE));
+
+        long baseline = 0x1234_5678_9ABC_DEF0L;
+        for (int bit = 0; bit < 64; bit++) {
+            assertFalse(CtCompare.ctEqU64(baseline, baseline ^ (1L << bit)));
+        }
+    }
+}

--- a/code/packages/kotlin/ct-compare/.gitignore
+++ b/code/packages/kotlin/ct-compare/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/ct-compare/BUILD
+++ b/code/packages/kotlin/ct-compare/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/ct-compare/BUILD_windows
+++ b/code/packages/kotlin/ct-compare/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/ct-compare/CHANGELOG.md
+++ b/code/packages/kotlin/ct-compare/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Kotlin constant-time byte comparison helpers.

--- a/code/packages/kotlin/ct-compare/README.md
+++ b/code/packages/kotlin/ct-compare/README.md
@@ -1,0 +1,4 @@
+# ct-compare
+
+Constant-time byte equality, fixed-size equality alias, mask-based byte
+selection, and branch-free 64-bit equality helpers for Kotlin.

--- a/code/packages/kotlin/ct-compare/build.gradle.kts
+++ b/code/packages/kotlin/ct-compare/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/ct-compare/settings.gradle.kts
+++ b/code/packages/kotlin/ct-compare/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "ct-compare"

--- a/code/packages/kotlin/ct-compare/src/main/kotlin/com/codingadventures/ctcompare/CtCompare.kt
+++ b/code/packages/kotlin/ct-compare/src/main/kotlin/com/codingadventures/ctcompare/CtCompare.kt
@@ -1,0 +1,30 @@
+package com.codingadventures.ctcompare
+
+object CtCompare {
+    fun ctEq(left: ByteArray, right: ByteArray): Boolean {
+        if (left.size != right.size) return false
+
+        var accumulator = 0
+        for (index in left.indices) {
+            accumulator = accumulator or ((left[index].toInt() xor right[index].toInt()) and 0xFF)
+        }
+        return accumulator == 0
+    }
+
+    fun ctEqFixed(left: ByteArray, right: ByteArray): Boolean = ctEq(left, right)
+
+    fun ctSelectBytes(left: ByteArray, right: ByteArray, choice: Boolean): ByteArray {
+        require(left.size == right.size) { "ctSelectBytes requires equal-length inputs" }
+
+        val mask = 0 - if (choice) 1 else 0
+        return ByteArray(left.size) { index ->
+            (right[index].toInt() xor ((left[index].toInt() xor right[index].toInt()) and mask)).toByte()
+        }
+    }
+
+    fun ctEqU64(left: Long, right: Long): Boolean {
+        val diff = left xor right
+        val folded = (diff or -diff).ushr(63)
+        return folded == 0L
+    }
+}

--- a/code/packages/kotlin/ct-compare/src/test/kotlin/com/codingadventures/ctcompare/CtCompareTest.kt
+++ b/code/packages/kotlin/ct-compare/src/test/kotlin/com/codingadventures/ctcompare/CtCompareTest.kt
@@ -1,0 +1,63 @@
+package com.codingadventures.ctcompare
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CtCompareTest {
+    @Test
+    fun ctEqMatchesByteEquality() {
+        assertTrue(CtCompare.ctEq("abcdef".encodeToByteArray(), "abcdef".encodeToByteArray()))
+        assertTrue(CtCompare.ctEq(ByteArray(0), ByteArray(0)))
+        assertFalse(CtCompare.ctEq("abcdef".encodeToByteArray(), "abcdeg".encodeToByteArray()))
+        assertFalse(CtCompare.ctEq("abcdef".encodeToByteArray(), "bbcdef".encodeToByteArray()))
+        assertFalse(CtCompare.ctEq("abc".encodeToByteArray(), "abcd".encodeToByteArray()))
+    }
+
+    @Test
+    fun ctEqDetectsEverySingleBitPosition() {
+        val baseline = ByteArray(32) { 0x42 }
+        for (index in baseline.indices) {
+            for (bit in 0 until 8) {
+                val flipped = baseline.copyOf()
+                flipped[index] = (flipped[index].toInt() xor (1 shl bit)).toByte()
+                assertFalse(CtCompare.ctEq(baseline, flipped))
+            }
+        }
+    }
+
+    @Test
+    fun ctEqFixedIsDynamicAlias() {
+        assertTrue(CtCompare.ctEqFixed(ByteArray(16), ByteArray(16)))
+        val different = ByteArray(16)
+        different[15] = 1
+        assertFalse(CtCompare.ctEqFixed(ByteArray(16), different))
+    }
+
+    @Test
+    fun ctSelectBytesChoosesWithoutMutatingInputs() {
+        val left = ByteArray(256) { it.toByte() }
+        val right = ByteArray(256) { (255 - it).toByte() }
+
+        assertContentEquals(left, CtCompare.ctSelectBytes(left, right, true))
+        assertContentEquals(right, CtCompare.ctSelectBytes(left, right, false))
+        assertContentEquals(ByteArray(0), CtCompare.ctSelectBytes(ByteArray(0), ByteArray(0), true))
+        assertFailsWith<IllegalArgumentException> {
+            CtCompare.ctSelectBytes(ByteArray(1), ByteArray(2), true)
+        }
+    }
+
+    @Test
+    fun ctEqU64HandlesEdges() {
+        assertTrue(CtCompare.ctEqU64(0L, 0L))
+        assertTrue(CtCompare.ctEqU64(-1L, -1L))
+        assertFalse(CtCompare.ctEqU64(0L, Long.MIN_VALUE))
+
+        val baseline = 0x1234_5678_9ABC_DEF0L
+        for (bit in 0 until 64) {
+            assertFalse(CtCompare.ctEqU64(baseline, baseline xor (1L shl bit)))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add C# and F# ct-compare packages with constant-time byte equality, selection, and UInt64 helpers
- add Java and Kotlin ct-compare packages with matching byte equality, selection, and 64-bit helpers
- include tests and package/build metadata across all four runtimes

## Verification
- dotnet test tests\CodingAdventures.CtCompare.Tests\CodingAdventures.CtCompare.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.CtCompare.Tests\CodingAdventures.CtCompare.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- javac --release 21 -d out src\main\java\com\codingadventures\ctcompare\CtCompare.java
- kotlinc src\main\kotlin\com\codingadventures\ctcompare\CtCompare.kt -d kotlinc-out