### PR TITLE
feat(parity): add dotnet radix tree packages

### DIFF
--- a/code/packages/csharp/radix-tree/BUILD
+++ b/code/packages/csharp/radix-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/radix-tree/BUILD_windows
+++ b/code/packages/csharp/radix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/radix-tree/CHANGELOG.md
+++ b/code/packages/csharp/radix-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a compressed radix tree with insertion, deletion, lookup, prefix queries, and sorted traversal helpers.

--- a/code/packages/csharp/radix-tree/CodingAdventures.RadixTree.csproj
+++ b/code/packages/csharp/radix-tree/CodingAdventures.RadixTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.RadixTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# compressed radix tree with prefix query helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/radix-tree/README.md
+++ b/code/packages/csharp/radix-tree/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.RadixTree
+
+Pure C# compressed radix tree mapping string keys to generic values.
+
+The package supports insertion, exact lookup, deletion with edge merging, prefix searches, longest-prefix matching, sorted key traversal, and dictionary export.

--- a/code/packages/csharp/radix-tree/RadixTree.cs
+++ b/code/packages/csharp/radix-tree/RadixTree.cs
@@ -1,0 +1,419 @@
+using System.Collections;
+
+namespace CodingAdventures.RadixTree;
+
+/// <summary>
+/// A compressed trie mapping string keys to values.
+/// </summary>
+public sealed class RadixTree<TValue> : IReadOnlyCollection<string>
+{
+    private readonly Node _root = new();
+    private int _size;
+
+    public RadixTree()
+    {
+    }
+
+    public RadixTree(IEnumerable<KeyValuePair<string, TValue>> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        foreach (var entry in entries)
+        {
+            Insert(entry.Key, entry.Value);
+        }
+    }
+
+    public int Count => _size;
+
+    public int Size => _size;
+
+    public bool IsEmpty => _size == 0;
+
+    public void Insert(string key, TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (InsertRecursive(_root, key, value))
+        {
+            _size++;
+        }
+    }
+
+    public void Put(string key, TValue value) => Insert(key, value);
+
+    public TValue? Search(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var node = _root;
+        var remaining = key;
+
+        while (remaining.Length > 0)
+        {
+            if (!node.Children.TryGetValue(FirstChar(remaining), out var edge))
+            {
+                return default;
+            }
+
+            var commonLength = CommonPrefixLength(remaining, edge.Label);
+            if (commonLength < edge.Label.Length)
+            {
+                return default;
+            }
+
+            remaining = remaining[commonLength..];
+            node = edge.Child;
+        }
+
+        return node.IsEnd ? node.Value : default;
+    }
+
+    public TValue? Get(string key) => Search(key);
+
+    public bool ContainsKey(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return KeyExists(key);
+    }
+
+    public bool Delete(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var result = DeleteRecursive(_root, key);
+        if (result.Deleted)
+        {
+            _size--;
+        }
+
+        return result.Deleted;
+    }
+
+    public bool StartsWith(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (prefix.Length == 0)
+        {
+            return _size > 0;
+        }
+
+        var node = _root;
+        var remaining = prefix;
+        while (remaining.Length > 0)
+        {
+            if (!node.Children.TryGetValue(FirstChar(remaining), out var edge))
+            {
+                return false;
+            }
+
+            var commonLength = CommonPrefixLength(remaining, edge.Label);
+            if (commonLength == remaining.Length)
+            {
+                return true;
+            }
+
+            if (commonLength < edge.Label.Length)
+            {
+                return false;
+            }
+
+            remaining = remaining[commonLength..];
+            node = edge.Child;
+        }
+
+        return node.IsEnd || node.Children.Count > 0;
+    }
+
+    public List<string> WordsWithPrefix(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (prefix.Length == 0)
+        {
+            return Keys();
+        }
+
+        var node = _root;
+        var remaining = prefix;
+        var path = "";
+
+        while (remaining.Length > 0)
+        {
+            if (!node.Children.TryGetValue(FirstChar(remaining), out var edge))
+            {
+                return [];
+            }
+
+            var commonLength = CommonPrefixLength(remaining, edge.Label);
+            if (commonLength == remaining.Length)
+            {
+                if (commonLength == edge.Label.Length)
+                {
+                    path += edge.Label;
+                    node = edge.Child;
+                    remaining = "";
+                }
+                else
+                {
+                    var results = new List<string>();
+                    CollectKeys(edge.Child, path + edge.Label, results);
+                    return results;
+                }
+            }
+            else if (commonLength < edge.Label.Length)
+            {
+                return [];
+            }
+            else
+            {
+                path += edge.Label;
+                remaining = remaining[commonLength..];
+                node = edge.Child;
+            }
+        }
+
+        var matches = new List<string>();
+        CollectKeys(node, path, matches);
+        return matches;
+    }
+
+    public string? LongestPrefixMatch(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var node = _root;
+        var remaining = key;
+        var consumed = 0;
+        string? best = node.IsEnd ? "" : null;
+
+        while (remaining.Length > 0)
+        {
+            if (!node.Children.TryGetValue(FirstChar(remaining), out var edge))
+            {
+                break;
+            }
+
+            var commonLength = CommonPrefixLength(remaining, edge.Label);
+            if (commonLength < edge.Label.Length)
+            {
+                break;
+            }
+
+            consumed += commonLength;
+            remaining = remaining[commonLength..];
+            node = edge.Child;
+            if (node.IsEnd)
+            {
+                best = key[..consumed];
+            }
+        }
+
+        return best;
+    }
+
+    public List<string> Keys()
+    {
+        var results = new List<string>();
+        CollectKeys(_root, "", results);
+        return results;
+    }
+
+    public List<TValue> Values() => ToDictionary().Values.ToList();
+
+    public SortedDictionary<string, TValue> ToDictionary()
+    {
+        var result = new SortedDictionary<string, TValue>(StringComparer.Ordinal);
+        CollectValues(_root, "", result);
+        return result;
+    }
+
+    public int NodeCount() => CountNodes(_root);
+
+    public IEnumerator<string> GetEnumerator() => Keys().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString()
+    {
+        var preview = string.Join(", ", ToDictionary().Take(5).Select(pair => $"{pair.Key}={pair.Value}"));
+        return $"RadixTree({_size} keys: [{preview}])";
+    }
+
+    private bool KeyExists(string key)
+    {
+        var node = _root;
+        var remaining = key;
+
+        while (remaining.Length > 0)
+        {
+            if (!node.Children.TryGetValue(FirstChar(remaining), out var edge))
+            {
+                return false;
+            }
+
+            var commonLength = CommonPrefixLength(remaining, edge.Label);
+            if (commonLength < edge.Label.Length)
+            {
+                return false;
+            }
+
+            remaining = remaining[commonLength..];
+            node = edge.Child;
+        }
+
+        return node.IsEnd;
+    }
+
+    private static bool InsertRecursive(Node node, string key, TValue value)
+    {
+        if (key.Length == 0)
+        {
+            var added = !node.IsEnd;
+            node.IsEnd = true;
+            node.Value = value;
+            return added;
+        }
+
+        var first = FirstChar(key);
+        if (!node.Children.TryGetValue(first, out var edge))
+        {
+            node.Children[first] = new Edge(key, Node.Leaf(value));
+            return true;
+        }
+
+        var commonLength = CommonPrefixLength(key, edge.Label);
+        if (commonLength == edge.Label.Length)
+        {
+            return InsertRecursive(edge.Child, key[commonLength..], value);
+        }
+
+        var common = edge.Label[..commonLength];
+        var labelRest = edge.Label[commonLength..];
+        var keyRest = key[commonLength..];
+        var splitNode = new Node();
+        splitNode.Children[FirstChar(labelRest)] = new Edge(labelRest, edge.Child);
+
+        if (keyRest.Length == 0)
+        {
+            splitNode.IsEnd = true;
+            splitNode.Value = value;
+        }
+        else
+        {
+            splitNode.Children[FirstChar(keyRest)] = new Edge(keyRest, Node.Leaf(value));
+        }
+
+        node.Children[first] = new Edge(common, splitNode);
+        return true;
+    }
+
+    private static DeleteResult DeleteRecursive(Node node, string key)
+    {
+        if (key.Length == 0)
+        {
+            if (!node.IsEnd)
+            {
+                return new DeleteResult(false, false);
+            }
+
+            node.IsEnd = false;
+            node.Value = default;
+            return new DeleteResult(true, node.Children.Count == 1);
+        }
+
+        var first = FirstChar(key);
+        if (!node.Children.TryGetValue(first, out var edge))
+        {
+            return new DeleteResult(false, false);
+        }
+
+        var commonLength = CommonPrefixLength(key, edge.Label);
+        if (commonLength < edge.Label.Length)
+        {
+            return new DeleteResult(false, false);
+        }
+
+        var result = DeleteRecursive(edge.Child, key[commonLength..]);
+        if (!result.Deleted)
+        {
+            return result;
+        }
+
+        if (result.ChildMergeable)
+        {
+            var grandchild = edge.Child.Children.First().Value;
+            node.Children[first] = new Edge(edge.Label + grandchild.Label, grandchild.Child);
+        }
+        else if (!edge.Child.IsEnd && edge.Child.Children.Count == 0)
+        {
+            node.Children.Remove(first);
+        }
+
+        return new DeleteResult(true, !node.IsEnd && node.Children.Count == 1);
+    }
+
+    private static void CollectKeys(Node node, string current, List<string> results)
+    {
+        if (node.IsEnd)
+        {
+            results.Add(current);
+        }
+
+        foreach (var edge in node.Children.Values)
+        {
+            CollectKeys(edge.Child, current + edge.Label, results);
+        }
+    }
+
+    private static void CollectValues(Node node, string current, SortedDictionary<string, TValue> result)
+    {
+        if (node.IsEnd)
+        {
+            result[current] = node.Value!;
+        }
+
+        foreach (var edge in node.Children.Values)
+        {
+            CollectValues(edge.Child, current + edge.Label, result);
+        }
+    }
+
+    private static int CountNodes(Node node)
+    {
+        var count = 1;
+        foreach (var edge in node.Children.Values)
+        {
+            count += CountNodes(edge.Child);
+        }
+
+        return count;
+    }
+
+    private static int CommonPrefixLength(string left, string right)
+    {
+        var index = 0;
+        var limit = Math.Min(left.Length, right.Length);
+        while (index < limit && left[index] == right[index])
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static char FirstChar(string value) => value[0];
+
+    private sealed class Node
+    {
+        public bool IsEnd { get; set; }
+
+        public TValue? Value { get; set; }
+
+        public SortedDictionary<char, Edge> Children { get; } = new();
+
+        public static Node Leaf(TValue value) => new()
+        {
+            IsEnd = true,
+            Value = value,
+        };
+    }
+
+    private sealed record Edge(string Label, Node Child);
+
+    private readonly record struct DeleteResult(bool Deleted, bool ChildMergeable);
+}

--- a/code/packages/csharp/radix-tree/required_capabilities.json
+++ b/code/packages/csharp/radix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/radix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.csproj
+++ b/code/packages/csharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.RadixTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.RadixTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/RadixTreeTests.cs
+++ b/code/packages/csharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/RadixTreeTests.cs
@@ -1,0 +1,102 @@
+using CodingAdventures.RadixTree;
+
+namespace CodingAdventures.RadixTree.Tests;
+
+public sealed class RadixTreeTests
+{
+    [Fact]
+    public void InsertAndSearchCoverSplitCases()
+    {
+        var tree = new RadixTree<int>();
+
+        tree.Insert("application", 1);
+        tree.Insert("apple", 2);
+        tree.Insert("app", 3);
+        tree.Insert("apt", 4);
+
+        Assert.Equal(1, tree.Search("application"));
+        Assert.Equal(2, tree.Search("apple"));
+        Assert.Equal(3, tree.Search("app"));
+        Assert.Equal(4, tree.Search("apt"));
+        Assert.Equal(default, tree.Search("appl"));
+        Assert.Equal(4, tree.Count);
+    }
+
+    [Fact]
+    public void UpdatingExistingKeyDoesNotChangeCount()
+    {
+        var tree = new RadixTree<string>();
+
+        tree.Insert("alpha", "first");
+        tree.Put("alpha", "second");
+
+        Assert.True(tree.ContainsKey("alpha"));
+        Assert.Equal("second", tree.Get("alpha"));
+        Assert.Single(tree);
+    }
+
+    [Fact]
+    public void DeletePrunesAndMerges()
+    {
+        var tree = new RadixTree<int>();
+        tree.Insert("app", 1);
+        tree.Insert("apple", 2);
+
+        Assert.Equal(3, tree.NodeCount());
+        Assert.True(tree.Delete("app"));
+        Assert.False(tree.ContainsKey("app"));
+        Assert.Equal(2, tree.Search("apple"));
+        Assert.Equal(2, tree.NodeCount());
+        Assert.False(tree.Delete("app"));
+    }
+
+    [Fact]
+    public void SupportsPrefixQueriesAndMatches()
+    {
+        var tree = new RadixTree<int>();
+        tree.Insert("search", 1);
+        tree.Insert("searcher", 2);
+        tree.Insert("searching", 3);
+        tree.Insert("banana", 4);
+
+        Assert.True(tree.StartsWith("sear"));
+        Assert.False(tree.StartsWith("seek"));
+        Assert.Equal(["search", "searcher", "searching"], tree.WordsWithPrefix("search"));
+        Assert.Equal("search", tree.LongestPrefixMatch("search-party"));
+        Assert.Null(tree.LongestPrefixMatch("xyz"));
+    }
+
+    [Fact]
+    public void SupportsEmptyStringAndSortedKeys()
+    {
+        var tree = new RadixTree<int>();
+        tree.Insert("", 1);
+        tree.Insert("banana", 2);
+        tree.Insert("apple", 3);
+        tree.Insert("apricot", 4);
+        tree.Insert("app", 5);
+
+        Assert.Equal(1, tree.Search(""));
+        Assert.Equal("", tree.LongestPrefixMatch("xyz"));
+        Assert.True(tree.Delete(""));
+        Assert.Equal(default, tree.Search(""));
+        Assert.Equal(["app", "apple", "apricot", "banana"], tree.Keys());
+        Assert.Equal([5, 3, 4, 2], tree.Values());
+        Assert.Equal(4, tree.Size);
+        Assert.False(tree.IsEmpty);
+    }
+
+    [Fact]
+    public void ConstructorAndDictionaryExportKeepSortedKeys()
+    {
+        var tree = new RadixTree<int>(
+        [
+            new KeyValuePair<string, int>("delta", 4),
+            new KeyValuePair<string, int>("alpha", 1),
+            new KeyValuePair<string, int>("charlie", 3),
+        ]);
+
+        Assert.Equal(["alpha", "charlie", "delta"], tree.ToDictionary().Keys);
+        Assert.Equal("RadixTree(3 keys: [alpha=1, charlie=3, delta=4])", tree.ToString());
+    }
+}

--- a/code/packages/fsharp/radix-tree/BUILD
+++ b/code/packages/fsharp/radix-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/radix-tree/BUILD_windows
+++ b/code/packages/fsharp/radix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/radix-tree/CHANGELOG.md
+++ b/code/packages/fsharp/radix-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a compressed radix tree with insertion, deletion, lookup, prefix queries, and sorted traversal helpers.

--- a/code/packages/fsharp/radix-tree/CodingAdventures.RadixTree.fsproj
+++ b/code/packages/fsharp/radix-tree/CodingAdventures.RadixTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RadixTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# compressed radix tree with prefix query helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="RadixTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/radix-tree/README.md
+++ b/code/packages/fsharp/radix-tree/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.RadixTree
+
+Pure F# compressed radix tree mapping string keys to generic values.
+
+The package supports insertion, exact lookup, deletion with edge merging, prefix searches, longest-prefix matching, sorted key traversal, and map export.

--- a/code/packages/fsharp/radix-tree/RadixTree.fs
+++ b/code/packages/fsharp/radix-tree/RadixTree.fs
@@ -1,0 +1,333 @@
+namespace CodingAdventures.RadixTree
+
+open System
+open System.Collections
+open System.Collections.Generic
+
+type private Edge<'V>(label: string, child: Node<'V>) =
+    member _.Label = label
+    member _.Child = child
+
+and private Node<'V>() =
+    let children = SortedDictionary<char, Edge<'V>>()
+
+    member val IsEnd = false with get, set
+    member val Value = Unchecked.defaultof<'V> with get, set
+    member _.Children = children
+
+    static member Leaf(value: 'V) =
+        let node = Node<'V>()
+        node.IsEnd <- true
+        node.Value <- value
+        node
+
+type private DeleteResult =
+    { Deleted: bool
+      ChildMergeable: bool }
+
+type RadixTree<'V>(entries: seq<string * 'V>) =
+    let root = Node<'V>()
+    let mutable size = 0
+
+    let firstChar (value: string) = value[0]
+
+    let commonPrefixLength (left: string) (right: string) =
+        let limit = min left.Length right.Length
+        let mutable index = 0
+
+        while index < limit && left[index] = right[index] do
+            index <- index + 1
+
+        index
+
+    let rec insertRecursive (node: Node<'V>) (key: string) (value: 'V) =
+        if key.Length = 0 then
+            let added = not node.IsEnd
+            node.IsEnd <- true
+            node.Value <- value
+            added
+        else
+            let first = firstChar key
+
+            match node.Children.TryGetValue(first) with
+            | false, _ ->
+                node.Children[first] <- Edge(key, Node.Leaf value)
+                true
+            | true, edge ->
+                let commonLength = commonPrefixLength key edge.Label
+
+                if commonLength = edge.Label.Length then
+                    insertRecursive edge.Child (key.Substring commonLength) value
+                else
+                    let common = edge.Label.Substring(0, commonLength)
+                    let labelRest = edge.Label.Substring commonLength
+                    let keyRest = key.Substring commonLength
+                    let splitNode = Node<'V>()
+                    splitNode.Children[firstChar labelRest] <- Edge(labelRest, edge.Child)
+
+                    if keyRest.Length = 0 then
+                        splitNode.IsEnd <- true
+                        splitNode.Value <- value
+                    else
+                        splitNode.Children[firstChar keyRest] <- Edge(keyRest, Node.Leaf value)
+
+                    node.Children[first] <- Edge(common, splitNode)
+                    true
+
+    let rec deleteRecursive (node: Node<'V>) (key: string) =
+        if key.Length = 0 then
+            if not node.IsEnd then
+                { Deleted = false; ChildMergeable = false }
+            else
+                node.IsEnd <- false
+                node.Value <- Unchecked.defaultof<'V>
+                { Deleted = true; ChildMergeable = node.Children.Count = 1 }
+        else
+            let first = firstChar key
+
+            match node.Children.TryGetValue(first) with
+            | false, _ -> { Deleted = false; ChildMergeable = false }
+            | true, edge ->
+                let commonLength = commonPrefixLength key edge.Label
+
+                if commonLength < edge.Label.Length then
+                    { Deleted = false; ChildMergeable = false }
+                else
+                    let result = deleteRecursive edge.Child (key.Substring commonLength)
+
+                    if not result.Deleted then
+                        result
+                    else
+                        if result.ChildMergeable then
+                            let grandchild = edge.Child.Children.Values |> Seq.head
+                            node.Children[first] <- Edge(edge.Label + grandchild.Label, grandchild.Child)
+                        elif not edge.Child.IsEnd && edge.Child.Children.Count = 0 then
+                            node.Children.Remove(first) |> ignore
+
+                        { Deleted = true
+                          ChildMergeable = (not node.IsEnd) && node.Children.Count = 1 }
+
+    let rec collectKeys (node: Node<'V>) (current: string) (results: ResizeArray<string>) =
+        if node.IsEnd then
+            results.Add current
+
+        for edge in node.Children.Values do
+            collectKeys edge.Child (current + edge.Label) results
+
+    let rec collectValues (node: Node<'V>) current (results: ResizeArray<string * 'V>) =
+        if node.IsEnd then
+            results.Add(current, node.Value)
+
+        for edge in node.Children.Values do
+            collectValues edge.Child (current + edge.Label) results
+
+    let rec countNodes (node: Node<'V>) =
+        let mutable count = 1
+
+        for edge in node.Children.Values do
+            count <- count + countNodes edge.Child
+
+        count
+
+    let keyExists (key: string) =
+        let mutable node = root
+        let mutable remaining = key
+        let mutable matched = true
+
+        while matched && remaining.Length > 0 do
+            match node.Children.TryGetValue(firstChar remaining) with
+            | false, _ -> matched <- false
+            | true, edge ->
+                let commonLength = commonPrefixLength remaining edge.Label
+
+                if commonLength < edge.Label.Length then
+                    matched <- false
+                else
+                    remaining <- remaining.Substring commonLength
+                    node <- edge.Child
+
+        matched && node.IsEnd
+
+    do
+        if isNull (box entries) then
+            nullArg (nameof entries)
+
+        for key, value in entries do
+            if insertRecursive root key value then
+                size <- size + 1
+
+    new() = RadixTree<'V>(Seq.empty)
+
+    member _.Count = size
+    member _.Size = size
+    member _.IsEmpty = size = 0
+
+    member _.Insert(key: string, value: 'V) =
+        if isNull key then
+            nullArg (nameof key)
+
+        if insertRecursive root key value then
+            size <- size + 1
+
+    member this.Put(key: string, value: 'V) = this.Insert(key, value)
+
+    member _.Search(key: string) =
+        if isNull key then
+            nullArg (nameof key)
+
+        let mutable node = root
+        let mutable remaining = key
+        let mutable matched = true
+
+        while matched && remaining.Length > 0 do
+            match node.Children.TryGetValue(firstChar remaining) with
+            | false, _ -> matched <- false
+            | true, edge ->
+                let commonLength = commonPrefixLength remaining edge.Label
+
+                if commonLength < edge.Label.Length then
+                    matched <- false
+                else
+                    remaining <- remaining.Substring commonLength
+                    node <- edge.Child
+
+        if matched && node.IsEnd then
+            Some node.Value
+        else
+            None
+
+    member this.Get(key: string) = this.Search key
+
+    member _.ContainsKey(key: string) =
+        if isNull key then
+            nullArg (nameof key)
+
+        keyExists key
+
+    member _.Delete(key: string) =
+        if isNull key then
+            nullArg (nameof key)
+
+        let result = deleteRecursive root key
+
+        if result.Deleted then
+            size <- size - 1
+
+        result.Deleted
+
+    member _.StartsWith(prefix: string) =
+        if isNull prefix then
+            nullArg (nameof prefix)
+
+        if prefix.Length = 0 then
+            size > 0
+        else
+            let mutable node = root
+            let mutable remaining = prefix
+            let mutable matched = true
+            let mutable answer = false
+
+            while matched && not answer && remaining.Length > 0 do
+                match node.Children.TryGetValue(firstChar remaining) with
+                | false, _ -> matched <- false
+                | true, edge ->
+                    let commonLength = commonPrefixLength remaining edge.Label
+
+                    if commonLength = remaining.Length then
+                        answer <- true
+                    elif commonLength < edge.Label.Length then
+                        matched <- false
+                    else
+                        remaining <- remaining.Substring commonLength
+                        node <- edge.Child
+
+            answer || (matched && (node.IsEnd || node.Children.Count > 0))
+
+    member this.WordsWithPrefix(prefix: string) =
+        if isNull prefix then
+            nullArg (nameof prefix)
+
+        if prefix.Length = 0 then
+            this.Keys()
+        else
+            let mutable node = root
+            let mutable remaining = prefix
+            let mutable path = ""
+            let mutable matched = true
+            let mutable finished = false
+            let results = ResizeArray<string>()
+
+            while matched && not finished && remaining.Length > 0 do
+                match node.Children.TryGetValue(firstChar remaining) with
+                | false, _ -> matched <- false
+                | true, edge ->
+                    let commonLength = commonPrefixLength remaining edge.Label
+
+                    if commonLength = remaining.Length then
+                        if commonLength = edge.Label.Length then
+                            path <- path + edge.Label
+                            node <- edge.Child
+                            remaining <- ""
+                        else
+                            collectKeys edge.Child (path + edge.Label) results
+                            finished <- true
+                    elif commonLength < edge.Label.Length then
+                        matched <- false
+                    else
+                        path <- path + edge.Label
+                        remaining <- remaining.Substring commonLength
+                        node <- edge.Child
+
+            if matched && not finished then
+                collectKeys node path results
+
+            List.ofSeq results
+
+    member _.LongestPrefixMatch(key: string) =
+        if isNull key then
+            nullArg (nameof key)
+
+        let mutable node = root
+        let mutable remaining = key
+        let mutable consumed = 0
+        let mutable best = if node.IsEnd then Some "" else None
+        let mutable keepGoing = true
+
+        while keepGoing && remaining.Length > 0 do
+            match node.Children.TryGetValue(firstChar remaining) with
+            | false, _ -> keepGoing <- false
+            | true, edge ->
+                let commonLength = commonPrefixLength remaining edge.Label
+
+                if commonLength < edge.Label.Length then
+                    keepGoing <- false
+                else
+                    consumed <- consumed + commonLength
+                    remaining <- remaining.Substring commonLength
+                    node <- edge.Child
+
+                    if node.IsEnd then
+                        best <- Some(key.Substring(0, consumed))
+
+        best
+
+    member _.Keys() =
+        let results = ResizeArray<string>()
+        collectKeys root "" results
+        List.ofSeq results
+
+    member this.Values() =
+        this.ToMap() |> Map.toList |> List.map snd
+
+    member _.ToMap() =
+        let results = ResizeArray<string * 'V>()
+        collectValues root "" results
+        results |> Seq.sortBy fst |> Map.ofSeq
+
+    member _.NodeCount() = countNodes root
+
+    interface IEnumerable<string> with
+        member this.GetEnumerator() = (this.Keys() :> seq<string>).GetEnumerator()
+
+    interface IEnumerable with
+        member this.GetEnumerator() = (this.Keys() :> IEnumerable).GetEnumerator()

--- a/code/packages/fsharp/radix-tree/required_capabilities.json
+++ b/code/packages/fsharp/radix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/radix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.fsproj
+++ b/code/packages/fsharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/CodingAdventures.RadixTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.RadixTree.fsproj" />
+    <Compile Include="RadixTreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/RadixTreeTests.fs
+++ b/code/packages/fsharp/radix-tree/tests/CodingAdventures.RadixTree.Tests/RadixTreeTests.fs
@@ -1,0 +1,88 @@
+namespace CodingAdventures.RadixTree.Tests
+
+open CodingAdventures.RadixTree
+open Xunit
+
+type RadixTreeTests() =
+    [<Fact>]
+    member _.InsertAndSearchCoverSplitCases() =
+        let tree = RadixTree<int>()
+
+        tree.Insert("application", 1)
+        tree.Insert("apple", 2)
+        tree.Insert("app", 3)
+        tree.Insert("apt", 4)
+
+        Assert.Equal(Some 1, tree.Search "application")
+        Assert.Equal(Some 2, tree.Search "apple")
+        Assert.Equal(Some 3, tree.Search "app")
+        Assert.Equal(Some 4, tree.Search "apt")
+        Assert.Equal(None, tree.Search "appl")
+        Assert.Equal(4, tree.Count)
+
+    [<Fact>]
+    member _.UpdatingExistingKeyDoesNotChangeCount() =
+        let tree = RadixTree<string>()
+
+        tree.Insert("alpha", "first")
+        tree.Put("alpha", "second")
+
+        Assert.True(tree.ContainsKey "alpha")
+        Assert.Equal(Some "second", tree.Get "alpha")
+        Assert.Equal(1, tree.Count)
+
+    [<Fact>]
+    member _.DeletePrunesAndMerges() =
+        let tree = RadixTree<int>()
+        tree.Insert("app", 1)
+        tree.Insert("apple", 2)
+
+        Assert.Equal(3, tree.NodeCount())
+        Assert.True(tree.Delete "app")
+        Assert.False(tree.ContainsKey "app")
+        Assert.Equal(Some 2, tree.Search "apple")
+        Assert.Equal(2, tree.NodeCount())
+        Assert.False(tree.Delete "app")
+
+    [<Fact>]
+    member _.SupportsPrefixQueriesAndMatches() =
+        let tree = RadixTree<int>()
+        tree.Insert("search", 1)
+        tree.Insert("searcher", 2)
+        tree.Insert("searching", 3)
+        tree.Insert("banana", 4)
+
+        Assert.True(tree.StartsWith "sear")
+        Assert.False(tree.StartsWith "seek")
+        Assert.Equal<string>([ "search"; "searcher"; "searching" ], tree.WordsWithPrefix "search")
+        Assert.Equal(Some "search", tree.LongestPrefixMatch "search-party")
+        Assert.Equal(None, tree.LongestPrefixMatch "xyz")
+
+    [<Fact>]
+    member _.SupportsEmptyStringAndSortedKeys() =
+        let tree = RadixTree<int>()
+        tree.Insert("", 1)
+        tree.Insert("banana", 2)
+        tree.Insert("apple", 3)
+        tree.Insert("apricot", 4)
+        tree.Insert("app", 5)
+
+        Assert.Equal(Some 1, tree.Search "")
+        Assert.Equal(Some "", tree.LongestPrefixMatch "xyz")
+        Assert.True(tree.Delete "")
+        Assert.Equal(None, tree.Search "")
+        Assert.Equal<string>([ "app"; "apple"; "apricot"; "banana" ], tree.Keys())
+        Assert.Equal<int>([ 5; 3; 4; 2 ], tree.Values())
+        Assert.Equal(4, tree.Size)
+        Assert.False(tree.IsEmpty)
+
+    [<Fact>]
+    member _.ConstructorAndMapExportKeepSortedKeys() =
+        let tree =
+            RadixTree<int>(
+                [ "delta", 4
+                  "alpha", 1
+                  "charlie", 3 ]
+            )
+
+        Assert.Equal<string>([ "alpha"; "charlie"; "delta" ], tree.ToMap() |> Map.toList |> List.map fst)


### PR DESCRIPTION
## Summary
- add C# and F# radix-tree packages with compressed-edge insertion, lookup, delete/merge, and prefix helpers
- include sorted key/value traversal, dictionary/map export, node counts, and constructor/update coverage
- wire package metadata, capability manifests, and BUILD commands for both runtimes

## Verification
- dotnet test tests\CodingAdventures.RadixTree.Tests\CodingAdventures.RadixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.RadixTree.Tests\CodingAdventures.RadixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line