### PR TITLE
feat(parity): add dotnet b tree packages

### DIFF
--- a/code/packages/csharp/b-tree/BTree.cs
+++ b/code/packages/csharp/b-tree/BTree.cs
@@ -1,0 +1,538 @@
+namespace CodingAdventures.BTree;
+
+/// <summary>
+/// A self-balancing multi-way search tree mapping comparable keys to values.
+/// </summary>
+public sealed class BTree<TKey, TValue>
+    where TKey : IComparable<TKey>
+{
+    private readonly int _minimumDegree;
+    private Node _root;
+    private int _count;
+
+    public BTree(int minimumDegree = 2)
+    {
+        if (minimumDegree < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumDegree), "Minimum degree must be at least 2.");
+        }
+
+        _minimumDegree = minimumDegree;
+        _root = new Node(isLeaf: true);
+    }
+
+    public int MinimumDegree => _minimumDegree;
+
+    public int Count => _count;
+
+    public bool IsEmpty => _count == 0;
+
+    public void Insert(TKey key, TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (_root.IsFull(_minimumDegree))
+        {
+            var newRoot = new Node(isLeaf: false);
+            newRoot.Children.Add(_root);
+            SplitChild(newRoot, 0);
+            _root = newRoot;
+        }
+
+        if (InsertNonFull(_root, key, value))
+        {
+            _count++;
+        }
+    }
+
+    public void Delete(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (!Contains(key))
+        {
+            throw new KeyNotFoundException($"Key not found: {key}");
+        }
+
+        DeleteRecursive(_root, key);
+        _count--;
+
+        if (_root.Keys.Count == 0 && _root.Children.Count > 0)
+        {
+            _root = _root.Children[0];
+        }
+    }
+
+    public TValue? Search(TKey key)
+    {
+        if (key is null)
+        {
+            return default;
+        }
+
+        return SearchRecursive(_root, key);
+    }
+
+    public bool Contains(TKey key)
+    {
+        if (key is null)
+        {
+            return false;
+        }
+
+        return ContainsRecursive(_root, key);
+    }
+
+    public TKey MinKey()
+    {
+        if (_count == 0)
+        {
+            throw new InvalidOperationException("Tree is empty.");
+        }
+
+        return MinNode(_root).Keys[0];
+    }
+
+    public TKey MaxKey()
+    {
+        if (_count == 0)
+        {
+            throw new InvalidOperationException("Tree is empty.");
+        }
+
+        var node = _root;
+        while (!node.IsLeaf)
+        {
+            node = node.Children[^1];
+        }
+
+        return node.Keys[^1];
+    }
+
+    public List<KeyValuePair<TKey, TValue>> RangeQuery(TKey low, TKey high)
+    {
+        ArgumentNullException.ThrowIfNull(low);
+        ArgumentNullException.ThrowIfNull(high);
+
+        var result = new List<KeyValuePair<TKey, TValue>>();
+        foreach (var entry in InOrder())
+        {
+            if (entry.Key.CompareTo(high) > 0)
+            {
+                break;
+            }
+
+            if (entry.Key.CompareTo(low) >= 0)
+            {
+                result.Add(entry);
+            }
+        }
+
+        return result;
+    }
+
+    public List<KeyValuePair<TKey, TValue>> InOrder()
+    {
+        var result = new List<KeyValuePair<TKey, TValue>>(_count);
+        CollectInOrder(_root, result);
+        return result;
+    }
+
+    public int Height()
+    {
+        var node = _root;
+        var height = 0;
+        while (!node.IsLeaf)
+        {
+            node = node.Children[0];
+            height++;
+        }
+
+        return height;
+    }
+
+    public bool IsValid()
+    {
+        if (_count == 0)
+        {
+            return _root.Keys.Count == 0 && _root.IsLeaf;
+        }
+
+        var leafDepth = -1;
+        return Validate(_root, default!, hasMinKey: false, default!, hasMaxKey: false, 0, ref leafDepth, isRoot: true);
+    }
+
+    public override string ToString() => $"BTree(t={_minimumDegree}, size={_count}, height={Height()})";
+
+    private void SplitChild(Node parent, int childIndex)
+    {
+        var child = parent.Children[childIndex];
+        var right = new Node(child.IsLeaf);
+        var mid = _minimumDegree - 1;
+
+        parent.Keys.Insert(childIndex, child.Keys[mid]);
+        parent.Values.Insert(childIndex, child.Values[mid]);
+        parent.Children.Insert(childIndex + 1, right);
+
+        right.Keys.AddRange(child.Keys.GetRange(mid + 1, child.Keys.Count - mid - 1));
+        right.Values.AddRange(child.Values.GetRange(mid + 1, child.Values.Count - mid - 1));
+        if (!child.IsLeaf)
+        {
+            right.Children.AddRange(child.Children.GetRange(_minimumDegree, child.Children.Count - _minimumDegree));
+            child.Children.RemoveRange(_minimumDegree, child.Children.Count - _minimumDegree);
+        }
+
+        child.Keys.RemoveRange(mid, child.Keys.Count - mid);
+        child.Values.RemoveRange(mid, child.Values.Count - mid);
+    }
+
+    private bool InsertNonFull(Node node, TKey key, TValue value)
+    {
+        var index = node.FindKeyIndex(key);
+        if (index < node.Keys.Count && node.Keys[index].CompareTo(key) == 0)
+        {
+            node.Values[index] = value;
+            return false;
+        }
+
+        if (node.IsLeaf)
+        {
+            node.Keys.Insert(index, key);
+            node.Values.Insert(index, value);
+            return true;
+        }
+
+        if (node.Children[index].IsFull(_minimumDegree))
+        {
+            SplitChild(node, index);
+            var comparison = key.CompareTo(node.Keys[index]);
+            if (comparison == 0)
+            {
+                node.Values[index] = value;
+                return false;
+            }
+
+            if (comparison > 0)
+            {
+                index++;
+            }
+        }
+
+        return InsertNonFull(node.Children[index], key, value);
+    }
+
+    private TValue? SearchRecursive(Node node, TKey key)
+    {
+        var index = node.FindKeyIndex(key);
+        if (index < node.Keys.Count && node.Keys[index].CompareTo(key) == 0)
+        {
+            return node.Values[index];
+        }
+
+        return node.IsLeaf ? default : SearchRecursive(node.Children[index], key);
+    }
+
+    private bool ContainsRecursive(Node node, TKey key)
+    {
+        var index = node.FindKeyIndex(key);
+        if (index < node.Keys.Count && node.Keys[index].CompareTo(key) == 0)
+        {
+            return true;
+        }
+
+        return !node.IsLeaf && ContainsRecursive(node.Children[index], key);
+    }
+
+    private Node MinNode(Node node)
+    {
+        while (!node.IsLeaf)
+        {
+            node = node.Children[0];
+        }
+
+        return node;
+    }
+
+    private Node MaxNode(Node node)
+    {
+        while (!node.IsLeaf)
+        {
+            node = node.Children[^1];
+        }
+
+        return node;
+    }
+
+    private void DeleteRecursive(Node node, TKey key)
+    {
+        var index = node.FindKeyIndex(key);
+        var found = index < node.Keys.Count && node.Keys[index].CompareTo(key) == 0;
+
+        if (found)
+        {
+            if (node.IsLeaf)
+            {
+                node.Keys.RemoveAt(index);
+                node.Values.RemoveAt(index);
+                return;
+            }
+
+            var leftChild = node.Children[index];
+            var rightChild = node.Children[index + 1];
+            if (leftChild.Keys.Count >= _minimumDegree)
+            {
+                var predecessor = MaxNode(leftChild);
+                var predecessorKey = predecessor.Keys[^1];
+                var predecessorValue = predecessor.Values[^1];
+                node.Keys[index] = predecessorKey;
+                node.Values[index] = predecessorValue;
+                DeleteRecursive(leftChild, predecessorKey);
+            }
+            else if (rightChild.Keys.Count >= _minimumDegree)
+            {
+                var successor = MinNode(rightChild);
+                var successorKey = successor.Keys[0];
+                var successorValue = successor.Values[0];
+                node.Keys[index] = successorKey;
+                node.Values[index] = successorValue;
+                DeleteRecursive(rightChild, successorKey);
+            }
+            else
+            {
+                var merged = MergeChildren(node, index);
+                DeleteRecursive(merged, key);
+            }
+
+            return;
+        }
+
+        if (node.IsLeaf)
+        {
+            return;
+        }
+
+        var childIndex = EnsureMinKeys(node, index);
+        DeleteRecursive(node.Children[childIndex], key);
+    }
+
+    private Node MergeChildren(Node parent, int leftIndex)
+    {
+        var left = parent.Children[leftIndex];
+        var right = parent.Children[leftIndex + 1];
+
+        left.Keys.Add(parent.Keys[leftIndex]);
+        left.Values.Add(parent.Values[leftIndex]);
+        parent.Keys.RemoveAt(leftIndex);
+        parent.Values.RemoveAt(leftIndex);
+        parent.Children.RemoveAt(leftIndex + 1);
+
+        left.Keys.AddRange(right.Keys);
+        left.Values.AddRange(right.Values);
+        if (!left.IsLeaf)
+        {
+            left.Children.AddRange(right.Children);
+        }
+
+        return left;
+    }
+
+    private int EnsureMinKeys(Node parent, int childIndex)
+    {
+        var child = parent.Children[childIndex];
+        if (child.Keys.Count >= _minimumDegree)
+        {
+            return childIndex;
+        }
+
+        if (childIndex > 0)
+        {
+            var leftSibling = parent.Children[childIndex - 1];
+            if (leftSibling.Keys.Count >= _minimumDegree)
+            {
+                child.Keys.Insert(0, parent.Keys[childIndex - 1]);
+                child.Values.Insert(0, parent.Values[childIndex - 1]);
+
+                var last = leftSibling.Keys.Count - 1;
+                parent.Keys[childIndex - 1] = leftSibling.Keys[last];
+                parent.Values[childIndex - 1] = leftSibling.Values[last];
+                leftSibling.Keys.RemoveAt(last);
+                leftSibling.Values.RemoveAt(last);
+
+                if (!leftSibling.IsLeaf)
+                {
+                    child.Children.Insert(0, leftSibling.Children[^1]);
+                    leftSibling.Children.RemoveAt(leftSibling.Children.Count - 1);
+                }
+
+                return childIndex;
+            }
+        }
+
+        if (childIndex < parent.Children.Count - 1)
+        {
+            var rightSibling = parent.Children[childIndex + 1];
+            if (rightSibling.Keys.Count >= _minimumDegree)
+            {
+                child.Keys.Add(parent.Keys[childIndex]);
+                child.Values.Add(parent.Values[childIndex]);
+
+                parent.Keys[childIndex] = rightSibling.Keys[0];
+                parent.Values[childIndex] = rightSibling.Values[0];
+                rightSibling.Keys.RemoveAt(0);
+                rightSibling.Values.RemoveAt(0);
+
+                if (!rightSibling.IsLeaf)
+                {
+                    child.Children.Add(rightSibling.Children[0]);
+                    rightSibling.Children.RemoveAt(0);
+                }
+
+                return childIndex;
+            }
+        }
+
+        if (childIndex > 0)
+        {
+            MergeChildren(parent, childIndex - 1);
+            return childIndex - 1;
+        }
+
+        MergeChildren(parent, childIndex);
+        return childIndex;
+    }
+
+    private static void CollectInOrder(Node node, List<KeyValuePair<TKey, TValue>> result)
+    {
+        if (node.IsLeaf)
+        {
+            for (var i = 0; i < node.Keys.Count; i++)
+            {
+                result.Add(new KeyValuePair<TKey, TValue>(node.Keys[i], node.Values[i]));
+            }
+
+            return;
+        }
+
+        for (var i = 0; i < node.Keys.Count; i++)
+        {
+            CollectInOrder(node.Children[i], result);
+            result.Add(new KeyValuePair<TKey, TValue>(node.Keys[i], node.Values[i]));
+        }
+
+        CollectInOrder(node.Children[^1], result);
+    }
+
+    private bool Validate(
+        Node node,
+        TKey minKey,
+        bool hasMinKey,
+        TKey maxKey,
+        bool hasMaxKey,
+        int depth,
+        ref int leafDepth,
+        bool isRoot)
+    {
+        var keyCount = node.Keys.Count;
+        if (isRoot)
+        {
+            if (_count > 0 && keyCount < 1)
+            {
+                return false;
+            }
+        }
+        else if (keyCount < _minimumDegree - 1 || keyCount > 2 * _minimumDegree - 1)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < keyCount; i++)
+        {
+            var key = node.Keys[i];
+            if (hasMinKey && key.CompareTo(minKey) <= 0)
+            {
+                return false;
+            }
+
+            if (hasMaxKey && key.CompareTo(maxKey) >= 0)
+            {
+                return false;
+            }
+
+            if (i > 0 && key.CompareTo(node.Keys[i - 1]) <= 0)
+            {
+                return false;
+            }
+        }
+
+        if (node.IsLeaf)
+        {
+            if (node.Children.Count != 0)
+            {
+                return false;
+            }
+
+            if (leafDepth < 0)
+            {
+                leafDepth = depth;
+            }
+
+            return leafDepth == depth;
+        }
+
+        if (node.Children.Count != keyCount + 1)
+        {
+            return false;
+        }
+
+        for (var i = 0; i <= keyCount; i++)
+        {
+            var low = i > 0 ? node.Keys[i - 1] : minKey;
+            var high = i < keyCount ? node.Keys[i] : maxKey;
+            var hasLow = i > 0 || hasMinKey;
+            var hasHigh = i < keyCount || hasMaxKey;
+            if (!Validate(node.Children[i], low, hasLow, high, hasHigh, depth + 1, ref leafDepth, isRoot: false))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed class Node
+    {
+        public Node(bool isLeaf)
+        {
+            IsLeaf = isLeaf;
+        }
+
+        public bool IsLeaf { get; }
+
+        public List<TKey> Keys { get; } = [];
+
+        public List<TValue> Values { get; } = [];
+
+        public List<Node> Children { get; } = [];
+
+        public bool IsFull(int minimumDegree) => Keys.Count == 2 * minimumDegree - 1;
+
+        public int FindKeyIndex(TKey key)
+        {
+            var low = 0;
+            var high = Keys.Count;
+            while (low < high)
+            {
+                var mid = (low + high) >>> 1;
+                if (Keys[mid].CompareTo(key) < 0)
+                {
+                    low = mid + 1;
+                }
+                else
+                {
+                    high = mid;
+                }
+            }
+
+            return low;
+        }
+    }
+}

--- a/code/packages/csharp/b-tree/BUILD
+++ b/code/packages/csharp/b-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/b-tree/BUILD_windows
+++ b/code/packages/csharp/b-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/b-tree/CHANGELOG.md
+++ b/code/packages/csharp/b-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a generic minimum-degree B-tree with insert, delete, search, range query, traversal, and validation helpers.

--- a/code/packages/csharp/b-tree/CodingAdventures.BTree.csproj
+++ b/code/packages/csharp/b-tree/CodingAdventures.BTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.BTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# minimum-degree B-tree with search, deletion, range queries, and validation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/b-tree/README.md
+++ b/code/packages/csharp/b-tree/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.BTree
+
+Pure C# minimum-degree B-tree mapping comparable keys to generic values.
+
+The package supports insert, update, search, delete with borrow/merge, min/max, range query, in-order traversal, height, and invariant validation.

--- a/code/packages/csharp/b-tree/required_capabilities.json
+++ b/code/packages/csharp/b-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/b-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/b-tree/tests/CodingAdventures.BTree.Tests/BTreeTests.cs
+++ b/code/packages/csharp/b-tree/tests/CodingAdventures.BTree.Tests/BTreeTests.cs
@@ -1,0 +1,159 @@
+using CodingAdventures.BTree;
+
+namespace CodingAdventures.BTree.Tests;
+
+public sealed class BTreeTests
+{
+    [Fact]
+    public void ConstructorRejectsInvalidMinimumDegree()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BTree<int, string>(1));
+
+        var tree = new BTree<int, string>();
+        Assert.True(tree.IsEmpty);
+        Assert.Equal(0, tree.Height());
+        Assert.True(tree.IsValid());
+        Assert.Equal(2, tree.MinimumDegree);
+    }
+
+    [Fact]
+    public void InsertSearchAndUpdateKeepSizeStable()
+    {
+        var tree = new BTree<int, string>(3);
+        foreach (var key in new[] { 10, 5, 20, 1, 15, 30 })
+        {
+            tree.Insert(key, $"v{key}");
+        }
+
+        tree.Insert(15, "updated");
+
+        Assert.Equal(6, tree.Count);
+        Assert.True(tree.Contains(20));
+        Assert.False(tree.Contains(99));
+        Assert.Equal("updated", tree.Search(15));
+        Assert.Null(tree.Search(99));
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void SequentialInsertsSplitRootAndTraverseSorted()
+    {
+        var tree = new BTree<int, string>(2);
+        for (var i = 0; i < 100; i++)
+        {
+            tree.Insert(i, $"v{i}");
+            Assert.True(tree.IsValid());
+        }
+
+        Assert.Equal(100, tree.Count);
+        Assert.True(tree.Height() > 0);
+        Assert.Equal(Enumerable.Range(0, 100), tree.InOrder().Select(entry => entry.Key));
+    }
+
+    [Fact]
+    public void DeleteHandlesLeafBorrowMergeAndRootShrink()
+    {
+        var tree = new BTree<int, string>(2);
+        for (var i = 1; i <= 25; i++)
+        {
+            tree.Insert(i, $"v{i}");
+        }
+
+        var deletionOrder = new[] { 7, 12, 1, 25, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 2, 3, 4, 5, 6, 8, 9, 10 };
+        foreach (var key in deletionOrder)
+        {
+            tree.Delete(key);
+            Assert.False(tree.Contains(key));
+            Assert.True(tree.IsValid());
+        }
+
+        Assert.Equal(1, tree.Count);
+        Assert.Equal(11, tree.MinKey());
+        Assert.Equal(11, tree.MaxKey());
+        Assert.Equal(0, tree.Height());
+    }
+
+    [Fact]
+    public void DeleteMissingKeyThrows()
+    {
+        var tree = new BTree<int, string>();
+        tree.Insert(10, "ten");
+
+        Assert.Throws<KeyNotFoundException>(() => tree.Delete(99));
+        Assert.True(tree.Contains(10));
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void MinMaxAndRangeQueryWorkAcrossLevels()
+    {
+        var tree = new BTree<int, string>(3);
+        for (var i = 1; i <= 50; i++)
+        {
+            tree.Insert(i, $"v{i}");
+        }
+
+        Assert.Equal(1, tree.MinKey());
+        Assert.Equal(50, tree.MaxKey());
+        Assert.Equal(Enumerable.Range(10, 11), tree.RangeQuery(10, 20).Select(entry => entry.Key));
+        Assert.Empty(tree.RangeQuery(60, 70));
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void EmptyMinMaxThrowAndRangeIsEmpty()
+    {
+        var tree = new BTree<int, string>();
+
+        Assert.Throws<InvalidOperationException>(() => tree.MinKey());
+        Assert.Throws<InvalidOperationException>(() => tree.MaxKey());
+        Assert.Empty(tree.RangeQuery(1, 10));
+        Assert.Empty(tree.InOrder());
+        Assert.Equal("BTree(t=2, size=0, height=0)", tree.ToString());
+    }
+
+    [Fact]
+    public void StressMatchesSortedDictionary()
+    {
+        var tree = new BTree<int, string>(3);
+        var reference = new SortedDictionary<int, string>();
+        var random = new Random(1234);
+        var keys = Enumerable.Range(0, 400).OrderBy(_ => random.Next()).ToList();
+
+        foreach (var key in keys)
+        {
+            var value = $"v{key}";
+            tree.Insert(key, value);
+            reference[key] = value;
+        }
+
+        foreach (var key in keys)
+        {
+            Assert.Equal(reference[key], tree.Search(key));
+        }
+
+        foreach (var key in keys.Take(175))
+        {
+            tree.Delete(key);
+            reference.Remove(key);
+        }
+
+        for (var i = 0; i < 100; i++)
+        {
+            var key = random.Next(600);
+            if (random.Next(2) == 0)
+            {
+                tree.Insert(key, $"v{key}");
+                reference[key] = $"v{key}";
+            }
+            else if (reference.Remove(key))
+            {
+                tree.Delete(key);
+            }
+        }
+
+        Assert.Equal(reference.Count, tree.Count);
+        Assert.True(tree.IsValid());
+        Assert.Equal(reference.Keys, tree.InOrder().Select(entry => entry.Key));
+    }
+}

--- a/code/packages/csharp/b-tree/tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.csproj
+++ b/code/packages/csharp/b-tree/tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.BTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/b-tree/BTree.fs
+++ b/code/packages/fsharp/b-tree/BTree.fs
@@ -1,0 +1,377 @@
+namespace CodingAdventures.BTree
+
+open System
+open System.Collections.Generic
+
+type private Node<'K, 'V when 'K: comparison>(isLeaf: bool) =
+    let keys = ResizeArray<'K>()
+    let values = ResizeArray<'V>()
+    let children = ResizeArray<Node<'K, 'V>>()
+
+    member _.IsLeaf = isLeaf
+    member _.Keys = keys
+    member _.Values = values
+    member _.Children = children
+
+    member _.IsFull(minimumDegree: int) =
+        keys.Count = 2 * minimumDegree - 1
+
+    member _.FindKeyIndex(key: 'K) =
+        let mutable low = 0
+        let mutable high = keys.Count
+
+        while low < high do
+            let mid = (low + high) / 2
+
+            if compare keys[mid] key < 0 then
+                low <- mid + 1
+            else
+                high <- mid
+
+        low
+
+type BTree<'K, 'V when 'K: comparison>(minimumDegree: int) =
+    let t =
+        if minimumDegree < 2 then
+            invalidArg (nameof minimumDegree) "Minimum degree must be at least 2."
+
+        minimumDegree
+
+    let mutable root = Node<'K, 'V>(true)
+    let mutable count = 0
+
+    let throwIfNull name value =
+        if isNull (box value) then
+            nullArg name
+
+    let rec minNode (node: Node<'K, 'V>) =
+        let mutable current = node
+
+        while not current.IsLeaf do
+            current <- current.Children[0]
+
+        current
+
+    let rec maxNode (node: Node<'K, 'V>) =
+        let mutable current = node
+
+        while not current.IsLeaf do
+            current <- current.Children[current.Children.Count - 1]
+
+        current
+
+    let splitChild (parent: Node<'K, 'V>) childIndex =
+        let child = parent.Children[childIndex]
+        let right = Node<'K, 'V>(child.IsLeaf)
+        let mid = t - 1
+
+        parent.Keys.Insert(childIndex, child.Keys[mid])
+        parent.Values.Insert(childIndex, child.Values[mid])
+        parent.Children.Insert(childIndex + 1, right)
+
+        right.Keys.AddRange(child.Keys.GetRange(mid + 1, child.Keys.Count - mid - 1))
+        right.Values.AddRange(child.Values.GetRange(mid + 1, child.Values.Count - mid - 1))
+
+        if not child.IsLeaf then
+            right.Children.AddRange(child.Children.GetRange(t, child.Children.Count - t))
+            child.Children.RemoveRange(t, child.Children.Count - t)
+
+        child.Keys.RemoveRange(mid, child.Keys.Count - mid)
+        child.Values.RemoveRange(mid, child.Values.Count - mid)
+
+    let rec insertNonFull (node: Node<'K, 'V>) key value =
+        let mutable index = node.FindKeyIndex key
+
+        if index < node.Keys.Count && compare node.Keys[index] key = 0 then
+            node.Values[index] <- value
+            false
+        elif node.IsLeaf then
+            node.Keys.Insert(index, key)
+            node.Values.Insert(index, value)
+            true
+        else
+            if node.Children[index].IsFull t then
+                splitChild node index
+                let comparison = compare key node.Keys[index]
+
+                if comparison = 0 then
+                    node.Values[index] <- value
+                    false
+                else
+                    if comparison > 0 then
+                        index <- index + 1
+
+                    insertNonFull node.Children[index] key value
+            else
+                insertNonFull node.Children[index] key value
+
+    let rec searchRecursive (node: Node<'K, 'V>) key =
+        let index = node.FindKeyIndex key
+
+        if index < node.Keys.Count && compare node.Keys[index] key = 0 then
+            Some node.Values[index]
+        elif node.IsLeaf then
+            None
+        else
+            searchRecursive node.Children[index] key
+
+    let rec containsRecursive (node: Node<'K, 'V>) key =
+        let index = node.FindKeyIndex key
+
+        if index < node.Keys.Count && compare node.Keys[index] key = 0 then
+            true
+        elif node.IsLeaf then
+            false
+        else
+            containsRecursive node.Children[index] key
+
+    let mergeChildren (parent: Node<'K, 'V>) leftIndex =
+        let left = parent.Children[leftIndex]
+        let right = parent.Children[leftIndex + 1]
+
+        left.Keys.Add(parent.Keys[leftIndex])
+        left.Values.Add(parent.Values[leftIndex])
+        parent.Keys.RemoveAt leftIndex
+        parent.Values.RemoveAt leftIndex
+        parent.Children.RemoveAt(leftIndex + 1)
+
+        left.Keys.AddRange right.Keys
+        left.Values.AddRange right.Values
+
+        if not left.IsLeaf then
+            left.Children.AddRange right.Children
+
+        left
+
+    let rec deleteRecursive (node: Node<'K, 'V>) key =
+        let mutable index = node.FindKeyIndex key
+        let found = index < node.Keys.Count && compare node.Keys[index] key = 0
+
+        if found then
+            if node.IsLeaf then
+                node.Keys.RemoveAt index
+                node.Values.RemoveAt index
+            else
+                let leftChild = node.Children[index]
+                let rightChild = node.Children[index + 1]
+
+                if leftChild.Keys.Count >= t then
+                    let predecessor = maxNode leftChild
+                    let predecessorKey = predecessor.Keys[predecessor.Keys.Count - 1]
+                    let predecessorValue = predecessor.Values[predecessor.Values.Count - 1]
+                    node.Keys[index] <- predecessorKey
+                    node.Values[index] <- predecessorValue
+                    deleteRecursive leftChild predecessorKey
+                elif rightChild.Keys.Count >= t then
+                    let successor = minNode rightChild
+                    let successorKey = successor.Keys[0]
+                    let successorValue = successor.Values[0]
+                    node.Keys[index] <- successorKey
+                    node.Values[index] <- successorValue
+                    deleteRecursive rightChild successorKey
+                else
+                    let merged = mergeChildren node index
+                    deleteRecursive merged key
+        elif not node.IsLeaf then
+            let ensureMinKeys (parent: Node<'K, 'V>) childIndex =
+                let child = parent.Children[childIndex]
+
+                if child.Keys.Count >= t then
+                    childIndex
+                elif childIndex > 0 && parent.Children[childIndex - 1].Keys.Count >= t then
+                    let leftSibling = parent.Children[childIndex - 1]
+                    child.Keys.Insert(0, parent.Keys[childIndex - 1])
+                    child.Values.Insert(0, parent.Values[childIndex - 1])
+
+                    let last = leftSibling.Keys.Count - 1
+                    parent.Keys[childIndex - 1] <- leftSibling.Keys[last]
+                    parent.Values[childIndex - 1] <- leftSibling.Values[last]
+                    leftSibling.Keys.RemoveAt last
+                    leftSibling.Values.RemoveAt last
+
+                    if not leftSibling.IsLeaf then
+                        child.Children.Insert(0, leftSibling.Children[leftSibling.Children.Count - 1])
+                        leftSibling.Children.RemoveAt(leftSibling.Children.Count - 1)
+
+                    childIndex
+                elif childIndex < parent.Children.Count - 1 && parent.Children[childIndex + 1].Keys.Count >= t then
+                    let rightSibling = parent.Children[childIndex + 1]
+                    child.Keys.Add(parent.Keys[childIndex])
+                    child.Values.Add(parent.Values[childIndex])
+
+                    parent.Keys[childIndex] <- rightSibling.Keys[0]
+                    parent.Values[childIndex] <- rightSibling.Values[0]
+                    rightSibling.Keys.RemoveAt 0
+                    rightSibling.Values.RemoveAt 0
+
+                    if not rightSibling.IsLeaf then
+                        child.Children.Add(rightSibling.Children[0])
+                        rightSibling.Children.RemoveAt 0
+
+                    childIndex
+                elif childIndex > 0 then
+                    mergeChildren parent (childIndex - 1) |> ignore
+                    childIndex - 1
+                else
+                    mergeChildren parent childIndex |> ignore
+                    childIndex
+
+            index <- ensureMinKeys node index
+            deleteRecursive node.Children[index] key
+
+    let rec collectInOrder (node: Node<'K, 'V>) (result: ResizeArray<KeyValuePair<'K, 'V>>) =
+        if node.IsLeaf then
+            for index in 0 .. node.Keys.Count - 1 do
+                result.Add(KeyValuePair(node.Keys[index], node.Values[index]))
+        else
+            for index in 0 .. node.Keys.Count - 1 do
+                collectInOrder node.Children[index] result
+                result.Add(KeyValuePair(node.Keys[index], node.Values[index]))
+
+            collectInOrder node.Children[node.Children.Count - 1] result
+
+    let rec validate (node: Node<'K, 'V>) minKey maxKey depth (leafDepth: int byref) isRoot =
+        let keyCount = node.Keys.Count
+
+        let keyCountValid =
+            if isRoot then
+                count = 0 || keyCount >= 1
+            else
+                keyCount >= t - 1 && keyCount <= 2 * t - 1
+
+        if not keyCountValid then
+            false
+        else
+            let mutable valid = true
+            let mutable index = 0
+
+            while valid && index < keyCount do
+                let key = node.Keys[index]
+
+                match minKey with
+                | Some low when compare key low <= 0 -> valid <- false
+                | _ -> ()
+
+                match maxKey with
+                | Some high when compare key high >= 0 -> valid <- false
+                | _ -> ()
+
+                if index > 0 && compare key node.Keys[index - 1] <= 0 then
+                    valid <- false
+
+                index <- index + 1
+
+            if not valid then
+                false
+            elif node.IsLeaf then
+                if node.Children.Count <> 0 then
+                    false
+                else
+                    if leafDepth < 0 then
+                        leafDepth <- depth
+
+                    leafDepth = depth
+            elif node.Children.Count <> keyCount + 1 then
+                false
+            else
+                let mutable childIndex = 0
+
+                while valid && childIndex <= keyCount do
+                    let low = if childIndex > 0 then Some node.Keys[childIndex - 1] else minKey
+                    let high = if childIndex < keyCount then Some node.Keys[childIndex] else maxKey
+
+                    if not (validate node.Children[childIndex] low high (depth + 1) &leafDepth false) then
+                        valid <- false
+
+                    childIndex <- childIndex + 1
+
+                valid
+
+    new() = BTree<'K, 'V>(2)
+
+    member _.MinimumDegree = t
+    member _.Count = count
+    member _.Size = count
+    member _.IsEmpty = count = 0
+
+    member _.Insert(key: 'K, value: 'V) =
+        throwIfNull (nameof key) key
+
+        if root.IsFull t then
+            let newRoot = Node<'K, 'V>(false)
+            newRoot.Children.Add root
+            splitChild newRoot 0
+            root <- newRoot
+
+        if insertNonFull root key value then
+            count <- count + 1
+
+    member _.Delete(key: 'K) =
+        throwIfNull (nameof key) key
+
+        if not (containsRecursive root key) then
+            raise (KeyNotFoundException($"Key not found: {key}"))
+
+        deleteRecursive root key
+        count <- count - 1
+
+        if root.Keys.Count = 0 && root.Children.Count > 0 then
+            root <- root.Children[0]
+
+    member _.Search(key: 'K) =
+        if isNull (box key) then
+            None
+        else
+            searchRecursive root key
+
+    member _.Contains(key: 'K) =
+        if isNull (box key) then
+            false
+        else
+            containsRecursive root key
+
+    member _.MinKey() =
+        if count = 0 then
+            invalidOp "Tree is empty."
+
+        (minNode root).Keys[0]
+
+    member _.MaxKey() =
+        if count = 0 then
+            invalidOp "Tree is empty."
+
+        let node = maxNode root
+        node.Keys[node.Keys.Count - 1]
+
+    member this.RangeQuery(low: 'K, high: 'K) =
+        throwIfNull (nameof low) low
+        throwIfNull (nameof high) high
+
+        (this.InOrder(): KeyValuePair<'K, 'V> list)
+        |> List.takeWhile (fun (entry: KeyValuePair<'K, 'V>) -> compare entry.Key high <= 0)
+        |> List.filter (fun (entry: KeyValuePair<'K, 'V>) -> compare entry.Key low >= 0)
+
+    member _.InOrder() =
+        let result = ResizeArray<KeyValuePair<'K, 'V>>(count)
+        collectInOrder root result
+        List.ofSeq result
+
+    member _.Height() =
+        let mutable node = root
+        let mutable height = 0
+
+        while not node.IsLeaf do
+            node <- node.Children[0]
+            height <- height + 1
+
+        height
+
+    member _.IsValid() =
+        if count = 0 then
+            root.Keys.Count = 0 && root.IsLeaf
+        else
+            let mutable leafDepth = -1
+            validate root None None 0 &leafDepth true
+
+    override this.ToString() =
+        $"BTree(t={t}, size={count}, height={this.Height()})"

--- a/code/packages/fsharp/b-tree/BUILD
+++ b/code/packages/fsharp/b-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/b-tree/BUILD_windows
+++ b/code/packages/fsharp/b-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/b-tree/CHANGELOG.md
+++ b/code/packages/fsharp/b-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a generic minimum-degree B-tree with insert, delete, search, range query, traversal, and validation helpers.

--- a/code/packages/fsharp/b-tree/CodingAdventures.BTree.fsproj
+++ b/code/packages/fsharp/b-tree/CodingAdventures.BTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# minimum-degree B-tree with search, deletion, range queries, and validation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/b-tree/README.md
+++ b/code/packages/fsharp/b-tree/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.BTree
+
+Pure F# minimum-degree B-tree mapping comparable keys to generic values.
+
+The package supports insert, update, search, delete with borrow/merge, min/max, range query, in-order traversal, height, and invariant validation.

--- a/code/packages/fsharp/b-tree/required_capabilities.json
+++ b/code/packages/fsharp/b-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/b-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/b-tree/tests/CodingAdventures.BTree.Tests/BTreeTests.fs
+++ b/code/packages/fsharp/b-tree/tests/CodingAdventures.BTree.Tests/BTreeTests.fs
@@ -1,0 +1,129 @@
+namespace CodingAdventures.BTree.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BTree
+open Xunit
+
+type BTreeTests() =
+    [<Fact>]
+    member _.ConstructorRejectsInvalidMinimumDegree() =
+        Assert.Throws<ArgumentException>(fun () -> BTree<int, string>(1) |> ignore)
+        |> ignore
+
+        let tree = BTree<int, string>()
+        Assert.True(tree.IsEmpty)
+        Assert.Equal(0, tree.Height())
+        Assert.True(tree.IsValid())
+        Assert.Equal(2, tree.MinimumDegree)
+
+    [<Fact>]
+    member _.InsertSearchAndUpdateKeepSizeStable() =
+        let tree = BTree<int, string>(3)
+
+        for key in [ 10; 5; 20; 1; 15; 30 ] do
+            tree.Insert(key, $"v{key}")
+
+        tree.Insert(15, "updated")
+
+        Assert.Equal(6, tree.Count)
+        Assert.True(tree.Contains 20)
+        Assert.False(tree.Contains 99)
+        Assert.Equal(Some "updated", tree.Search 15)
+        Assert.Equal(None, tree.Search 99)
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.SequentialInsertsSplitRootAndTraverseSorted() =
+        let tree = BTree<int, string>(2)
+
+        for key in 0 .. 99 do
+            tree.Insert(key, $"v{key}")
+            Assert.True(tree.IsValid())
+
+        Assert.Equal(100, tree.Count)
+        Assert.True(tree.Height() > 0)
+        Assert.Equal<int>([ 0..99 ], tree.InOrder() |> List.map _.Key)
+
+    [<Fact>]
+    member _.DeleteHandlesLeafBorrowMergeAndRootShrink() =
+        let tree = BTree<int, string>(2)
+
+        for key in 1 .. 25 do
+            tree.Insert(key, $"v{key}")
+
+        let deletionOrder = [ 7; 12; 1; 25; 13; 14; 15; 16; 17; 18; 19; 20; 21; 22; 23; 24; 2; 3; 4; 5; 6; 8; 9; 10 ]
+
+        for key in deletionOrder do
+            tree.Delete key
+            Assert.False(tree.Contains key)
+            Assert.True(tree.IsValid())
+
+        Assert.Equal(1, tree.Count)
+        Assert.Equal(11, tree.MinKey())
+        Assert.Equal(11, tree.MaxKey())
+        Assert.Equal(0, tree.Height())
+
+    [<Fact>]
+    member _.DeleteMissingKeyThrows() =
+        let tree = BTree<int, string>()
+        tree.Insert(10, "ten")
+
+        Assert.Throws<KeyNotFoundException>(fun () -> tree.Delete 99) |> ignore
+        Assert.True(tree.Contains 10)
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.MinMaxAndRangeQueryWorkAcrossLevels() =
+        let tree = BTree<int, string>(3)
+
+        for key in 1 .. 50 do
+            tree.Insert(key, $"v{key}")
+
+        Assert.Equal(1, tree.MinKey())
+        Assert.Equal(50, tree.MaxKey())
+        Assert.Equal<int>([ 10..20 ], tree.RangeQuery(10, 20) |> List.map _.Key)
+        Assert.Empty(tree.RangeQuery(60, 70))
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.EmptyMinMaxThrowAndRangeIsEmpty() =
+        let tree = BTree<int, string>()
+
+        Assert.Throws<InvalidOperationException>(fun () -> tree.MinKey() |> ignore) |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> tree.MaxKey() |> ignore) |> ignore
+        Assert.Empty(tree.RangeQuery(1, 10))
+        Assert.Empty(tree.InOrder())
+        Assert.Equal("BTree(t=2, size=0, height=0)", tree.ToString())
+
+    [<Fact>]
+    member _.StressMatchesSortedDictionary() =
+        let tree = BTree<int, string>(3)
+        let reference = SortedDictionary<int, string>()
+        let random = Random(1234)
+        let keys = [ 0..399 ] |> List.sortBy (fun _ -> random.Next())
+
+        for key in keys do
+            let value = $"v{key}"
+            tree.Insert(key, value)
+            reference[key] <- value
+
+        for key in keys do
+            Assert.Equal(Some reference[key], tree.Search key)
+
+        for key in keys |> List.take 175 do
+            tree.Delete key
+            reference.Remove key |> ignore
+
+        for _ in 1 .. 100 do
+            let key = random.Next 600
+
+            if random.Next(2) = 0 then
+                tree.Insert(key, $"v{key}")
+                reference[key] <- $"v{key}"
+            elif reference.Remove key then
+                tree.Delete key
+
+        Assert.Equal(reference.Count, tree.Count)
+        Assert.True(tree.IsValid())
+        Assert.Equal<int>(Seq.toList reference.Keys, tree.InOrder() |> List.map _.Key)

--- a/code/packages/fsharp/b-tree/tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.fsproj
+++ b/code/packages/fsharp/b-tree/tests/CodingAdventures.BTree.Tests/CodingAdventures.BTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BTree.fsproj" />
+    <Compile Include="BTreeTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# minimum-degree B-tree packages with insert/update, search, delete borrow/merge, min/max, range query, traversal, height, and validation helpers
- include stress coverage against sorted reference collections and deletion/root-shrink scenarios
- wire package metadata, capability manifests, and BUILD commands for both runtimes

## Verification
- dotnet test tests\CodingAdventures.BTree.Tests\CodingAdventures.BTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.BTree.Tests\CodingAdventures.BTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line