### PR TITLE
feat(parity): add dotnet tree set packages

### DIFF
--- a/code/packages/csharp/tree-set/BUILD
+++ b/code/packages/csharp/tree-set/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/tree-set/BUILD_windows
+++ b/code/packages/csharp/tree-set/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/tree-set/CHANGELOG.md
+++ b/code/packages/csharp/tree-set/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a sorted tree-backed set with range queries, order statistics, set algebra, predicates, and sorted traversal.

--- a/code/packages/csharp/tree-set/CodingAdventures.TreeSet.csproj
+++ b/code/packages/csharp/tree-set/CodingAdventures.TreeSet.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.TreeSet.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# sorted tree set with range queries, set algebra, and order helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/tree-set/README.md
+++ b/code/packages/csharp/tree-set/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.TreeSet
+
+Pure C# sorted set backed by `SortedSet<T>`.
+
+The package supports add/remove, sorted traversal, min/max, predecessor/successor, rank, range queries, set algebra, and subset/superset/disjoint predicates.

--- a/code/packages/csharp/tree-set/TreeSet.cs
+++ b/code/packages/csharp/tree-set/TreeSet.cs
@@ -1,0 +1,247 @@
+using System.Collections;
+
+namespace CodingAdventures.TreeSet;
+
+/// <summary>
+/// Sorted set with range queries, order helpers, and set algebra.
+/// </summary>
+public sealed class TreeSet<T> : IReadOnlyCollection<T>, IEquatable<TreeSet<T>>
+    where T : IComparable<T>
+{
+    private readonly SortedSet<T> _values;
+
+    public TreeSet()
+    {
+        _values = new SortedSet<T>();
+    }
+
+    public TreeSet(IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        _values = new SortedSet<T>(values);
+    }
+
+    public TreeSet(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        _values = new SortedSet<T>(other._values);
+    }
+
+    public int Count => _values.Count;
+
+    public int Size => _values.Count;
+
+    public bool IsEmpty => _values.Count == 0;
+
+    public TreeSet<T> Add(T value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        _values.Add(value);
+        return this;
+    }
+
+    public bool Remove(T value) => value is not null && _values.Remove(value);
+
+    public bool Delete(T value) => Remove(value);
+
+    public bool Discard(T value) => Remove(value);
+
+    public bool Contains(T value) => value is not null && _values.Contains(value);
+
+    public bool Has(T value) => Contains(value);
+
+    public T? Min() => _values.Count == 0 ? default : _values.Min;
+
+    public T? Max() => _values.Count == 0 ? default : _values.Max;
+
+    public T? First() => Min();
+
+    public T? Last() => Max();
+
+    public T? Predecessor(T value)
+    {
+        if (value is null)
+        {
+            return default;
+        }
+
+        T? candidate = default;
+        foreach (var current in _values)
+        {
+            if (current.CompareTo(value) >= 0)
+            {
+                break;
+            }
+
+            candidate = current;
+        }
+
+        return candidate;
+    }
+
+    public T? Successor(T value)
+    {
+        if (value is null)
+        {
+            return default;
+        }
+
+        foreach (var current in _values)
+        {
+            if (current.CompareTo(value) > 0)
+            {
+                return current;
+            }
+        }
+
+        return default;
+    }
+
+    public int Rank(T value)
+    {
+        if (value is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var current in _values)
+        {
+            if (current.CompareTo(value) >= 0)
+            {
+                break;
+            }
+
+            count++;
+        }
+
+        return count;
+    }
+
+    public T? ByRank(int rank)
+    {
+        if (rank < 0 || rank >= _values.Count)
+        {
+            return default;
+        }
+
+        var index = 0;
+        foreach (var value in _values)
+        {
+            if (index == rank)
+            {
+                return value;
+            }
+
+            index++;
+        }
+
+        return default;
+    }
+
+    public T? KthSmallest(int k) => k <= 0 ? default : ByRank(k - 1);
+
+    public List<T> Range(T low, T high, bool inclusive = true)
+    {
+        ArgumentNullException.ThrowIfNull(low);
+        ArgumentNullException.ThrowIfNull(high);
+
+        if (low.CompareTo(high) > 0)
+        {
+            return [];
+        }
+
+        var result = new List<T>();
+        foreach (var value in _values)
+        {
+            var lower = value.CompareTo(low);
+            var upper = value.CompareTo(high);
+            var inRange = inclusive ? lower >= 0 && upper <= 0 : lower > 0 && upper < 0;
+            if (inRange)
+            {
+                result.Add(value);
+            }
+            else if (upper > 0)
+            {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    public List<T> ToList() => [.. _values];
+
+    public List<T> ToSortedArray() => ToList();
+
+    public TreeSet<T> Union(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        var result = new TreeSet<T>(this);
+        result._values.UnionWith(other._values);
+        return result;
+    }
+
+    public TreeSet<T> Intersection(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        var result = new TreeSet<T>(this);
+        result._values.IntersectWith(other._values);
+        return result;
+    }
+
+    public TreeSet<T> Difference(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        var result = new TreeSet<T>(this);
+        result._values.ExceptWith(other._values);
+        return result;
+    }
+
+    public TreeSet<T> SymmetricDifference(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        var result = new TreeSet<T>(this);
+        result._values.SymmetricExceptWith(other._values);
+        return result;
+    }
+
+    public bool IsSubset(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return _values.IsSubsetOf(other._values);
+    }
+
+    public bool IsSuperset(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return _values.IsSupersetOf(other._values);
+    }
+
+    public bool IsDisjoint(TreeSet<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return !_values.Overlaps(other._values);
+    }
+
+    public bool Equals(TreeSet<T>? other) => other is not null && _values.SetEquals(other._values);
+
+    public override bool Equals(object? obj) => obj is TreeSet<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var value in _values)
+        {
+            hash.Add(value);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    public IEnumerator<T> GetEnumerator() => _values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString() => $"TreeSet([{string.Join(", ", _values)}])";
+}

--- a/code/packages/csharp/tree-set/required_capabilities.json
+++ b/code/packages/csharp/tree-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/tree-set",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/tree-set/tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.csproj
+++ b/code/packages/csharp/tree-set/tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.TreeSet]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TreeSet.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/tree-set/tests/CodingAdventures.TreeSet.Tests/TreeSetTests.cs
+++ b/code/packages/csharp/tree-set/tests/CodingAdventures.TreeSet.Tests/TreeSetTests.cs
@@ -1,0 +1,139 @@
+using CodingAdventures.TreeSet;
+
+namespace CodingAdventures.TreeSet.Tests;
+
+public sealed class TreeSetTests
+{
+    [Fact]
+    public void ConstructionAndMutationCollapseDuplicates()
+    {
+        var set = new TreeSet<int>([3, 1, 4, 1, 5]);
+
+        set.Add(9).Add(2).Add(6).Add(5);
+
+        Assert.Equal(7, set.Count);
+        Assert.Equal(7, set.Size);
+        Assert.False(set.IsEmpty);
+        Assert.True(set.Contains(9));
+        Assert.True(set.Has(3));
+        Assert.False(set.Contains(8));
+        Assert.True(set.Remove(4));
+        Assert.True(set.Delete(9));
+        Assert.False(set.Discard(99));
+        Assert.Equal([1, 2, 3, 5, 6], set.ToList());
+    }
+
+    [Fact]
+    public void MinMaxPredecessorSuccessorAndRankWork()
+    {
+        var set = new TreeSet<int>([10, 20, 30, 40, 50]);
+
+        Assert.Equal(10, set.Min());
+        Assert.Equal(50, set.Max());
+        Assert.Equal(10, set.First());
+        Assert.Equal(50, set.Last());
+        Assert.Null(new TreeSet<string>().Min());
+        Assert.Null(new TreeSet<string>(["alpha"]).Predecessor("alpha"));
+        Assert.Equal(20, set.Predecessor(25));
+        Assert.Equal(30, set.Successor(25));
+        Assert.Null(new TreeSet<string>(["alpha"]).Successor("alpha"));
+        Assert.Equal(2, set.Rank(30));
+        Assert.Equal(1, set.Rank(15));
+    }
+
+    [Fact]
+    public void ByRankKthAndRangeReturnSortedResults()
+    {
+        var set = new TreeSet<int>(Enumerable.Range(1, 10));
+
+        Assert.Equal(1, set.ByRank(0));
+        Assert.Equal(10, set.ByRank(9));
+        var words = new TreeSet<string>(["alpha", "beta"]);
+        Assert.Null(words.ByRank(-1));
+        Assert.Null(words.ByRank(2));
+        Assert.Equal(3, set.KthSmallest(3));
+        Assert.Null(words.KthSmallest(0));
+        Assert.Equal([3, 4, 5, 6, 7], set.Range(3, 7));
+        Assert.Equal([4, 5, 6], set.Range(3, 7, inclusive: false));
+        Assert.Empty(set.Range(7, 3));
+        Assert.Equal(set.ToList(), set.ToSortedArray());
+    }
+
+    [Fact]
+    public void SetAlgebraDoesNotMutateInputs()
+    {
+        var a = new TreeSet<int>([1, 2, 3, 4]);
+        var b = new TreeSet<int>([3, 4, 5, 6]);
+
+        Assert.Equal([1, 2, 3, 4, 5, 6], a.Union(b).ToList());
+        Assert.Equal([3, 4], a.Intersection(b).ToList());
+        Assert.Equal([1, 2], a.Difference(b).ToList());
+        Assert.Equal([1, 2, 5, 6], a.SymmetricDifference(b).ToList());
+        Assert.Equal([1, 2, 3, 4], a.ToList());
+        Assert.Equal([3, 4, 5, 6], b.ToList());
+    }
+
+    [Fact]
+    public void PredicatesAndEqualityCompareSetContents()
+    {
+        var small = new TreeSet<int>([2, 3]);
+        var large = new TreeSet<int>([1, 2, 3, 4]);
+        var disjoint = new TreeSet<int>([8, 9]);
+        var same = new TreeSet<int>([3, 2]);
+
+        Assert.True(small.IsSubset(large));
+        Assert.True(large.IsSuperset(small));
+        Assert.True(small.IsDisjoint(disjoint));
+        Assert.False(small.IsDisjoint(large));
+        Assert.Equal(small, same);
+        Assert.Equal(small.GetHashCode(), same.GetHashCode());
+        Assert.NotEqual(small, large);
+    }
+
+    [Fact]
+    public void IterationAndToStringUseSortedOrder()
+    {
+        var set = new TreeSet<int>([5, 2, 8, 1, 9, 3]);
+
+        Assert.Equal([1, 2, 3, 5, 8, 9], set.ToArray());
+        Assert.Equal("TreeSet([1, 2, 3, 5, 8, 9])", set.ToString());
+    }
+
+    [Fact]
+    public void StressMatchesFrameworkSortedSet()
+    {
+        var ours = new TreeSet<int>();
+        var reference = new SortedSet<int>();
+        var random = new Random(314);
+
+        for (var i = 0; i < 500; i++)
+        {
+            var key = random.Next(300);
+            ours.Add(key);
+            reference.Add(key);
+        }
+
+        foreach (var key in reference.Take(200).ToList())
+        {
+            Assert.Equal(reference.Remove(key), ours.Remove(key));
+        }
+
+        for (var i = 0; i < 300; i++)
+        {
+            var key = random.Next(600);
+            if (random.Next(2) == 0)
+            {
+                ours.Add(key);
+                reference.Add(key);
+            }
+            else
+            {
+                Assert.Equal(reference.Remove(key), ours.Remove(key));
+            }
+        }
+
+        Assert.Equal(reference, ours.ToList());
+        Assert.Equal(reference.Min, ours.Min());
+        Assert.Equal(reference.Max, ours.Max());
+    }
+}

--- a/code/packages/fsharp/tree-set/BUILD
+++ b/code/packages/fsharp/tree-set/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/tree-set/BUILD_windows
+++ b/code/packages/fsharp/tree-set/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/tree-set/CHANGELOG.md
+++ b/code/packages/fsharp/tree-set/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a sorted tree-backed set with range queries, order statistics, set algebra, predicates, and sorted traversal.

--- a/code/packages/fsharp/tree-set/CodingAdventures.TreeSet.fsproj
+++ b/code/packages/fsharp/tree-set/CodingAdventures.TreeSet.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TreeSet</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# sorted tree set with range queries, set algebra, and order helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TreeSet.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/tree-set/README.md
+++ b/code/packages/fsharp/tree-set/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.TreeSet
+
+Pure F# sorted set backed by F# `Set`.
+
+The package supports add/remove, sorted traversal, min/max, predecessor/successor, rank, range queries, set algebra, and subset/superset/disjoint predicates.

--- a/code/packages/fsharp/tree-set/TreeSet.fs
+++ b/code/packages/fsharp/tree-set/TreeSet.fs
@@ -1,0 +1,145 @@
+namespace CodingAdventures.TreeSet
+
+open System
+open System.Collections
+open System.Collections.Generic
+
+type TreeSet<'T when 'T: comparison>(values: seq<'T>) =
+    let mutable items = Set.ofSeq values
+
+    let throwIfNull name value =
+        if isNull (box value) then
+            nullArg name
+
+    new() = TreeSet<'T>(Seq.empty)
+
+    member _.Count = items.Count
+    member _.Size = items.Count
+    member _.IsEmpty = items.IsEmpty
+
+    member this.Add(value: 'T) =
+        throwIfNull (nameof value) value
+        items <- items.Add value
+        this
+
+    member _.Remove(value: 'T) =
+        if isNull (box value) then
+            false
+        else
+            let present = items.Contains value
+            items <- items.Remove value
+            present
+
+    member this.Delete(value: 'T) = this.Remove value
+    member this.Discard(value: 'T) = this.Remove value
+
+    member _.Contains(value: 'T) =
+        not (isNull (box value)) && items.Contains value
+
+    member this.Has(value: 'T) = this.Contains value
+
+    member _.Min() =
+        if items.IsEmpty then None else Some items.MinimumElement
+
+    member _.Max() =
+        if items.IsEmpty then None else Some items.MaximumElement
+
+    member this.First() = this.Min()
+    member this.Last() = this.Max()
+
+    member _.Predecessor(value: 'T) =
+        if isNull (box value) then
+            None
+        else
+            items |> Seq.filter (fun current -> current < value) |> Seq.tryLast
+
+    member _.Successor(value: 'T) =
+        if isNull (box value) then
+            None
+        else
+            items |> Seq.tryFind (fun current -> current > value)
+
+    member _.Rank(value: 'T) =
+        if isNull (box value) then
+            0
+        else
+            items |> Seq.takeWhile (fun current -> current < value) |> Seq.length
+
+    member _.ByRank(rank: int) =
+        if rank < 0 || rank >= items.Count then
+            None
+        else
+            items |> Seq.item rank |> Some
+
+    member this.KthSmallest(k: int) =
+        if k <= 0 then None else this.ByRank(k - 1)
+
+    member _.Range(low: 'T, high: 'T, ?inclusive: bool) =
+        throwIfNull (nameof low) low
+        throwIfNull (nameof high) high
+
+        if low > high then
+            []
+        else
+            let includeBounds = defaultArg inclusive true
+
+            items
+            |> Seq.filter (fun value ->
+                if includeBounds then
+                    value >= low && value <= high
+                else
+                    value > low && value < high)
+            |> List.ofSeq
+
+    member _.ToList() = List.ofSeq items
+    member this.ToSortedArray() = this.ToList()
+
+    member _.Union(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        TreeSet<'T>(Seq.append items other.Values)
+
+    member _.Intersection(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        TreeSet<'T>(Set.intersect items other.Values)
+
+    member _.Difference(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        TreeSet<'T>(Set.difference items other.Values)
+
+    member _.SymmetricDifference(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        let left = Set.difference items other.Values
+        let right = Set.difference other.Values items
+        TreeSet<'T>(Set.union left right)
+
+    member _.IsSubset(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        Set.isSubset items other.Values
+
+    member _.IsSuperset(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        Set.isSuperset items other.Values
+
+    member _.IsDisjoint(other: TreeSet<'T>) =
+        ArgumentNullException.ThrowIfNull(other)
+        Set.intersect items other.Values |> Set.isEmpty
+
+    member internal _.Values = items
+
+    override _.Equals(other: obj) =
+        match other with
+        | :? TreeSet<'T> as tree -> items = tree.Values
+        | _ -> false
+
+    override _.GetHashCode() =
+        hash items
+
+    override this.ToString() =
+        let body = this.ToList() |> List.map string |> String.concat ", "
+        $"TreeSet([{body}])"
+
+    interface IEnumerable<'T> with
+        member _.GetEnumerator() = (items :> seq<'T>).GetEnumerator()
+
+    interface IEnumerable with
+        member _.GetEnumerator() = (items :> IEnumerable).GetEnumerator()

--- a/code/packages/fsharp/tree-set/required_capabilities.json
+++ b/code/packages/fsharp/tree-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/tree-set",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/tree-set/tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.fsproj
+++ b/code/packages/fsharp/tree-set/tests/CodingAdventures.TreeSet.Tests/CodingAdventures.TreeSet.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TreeSet.fsproj" />
+    <Compile Include="TreeSetTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/tree-set/tests/CodingAdventures.TreeSet.Tests/TreeSetTests.fs
+++ b/code/packages/fsharp/tree-set/tests/CodingAdventures.TreeSet.Tests/TreeSetTests.fs
@@ -1,0 +1,117 @@
+namespace CodingAdventures.TreeSet.Tests
+
+open System
+open CodingAdventures.TreeSet
+open Xunit
+
+type TreeSetTests() =
+    [<Fact>]
+    member _.ConstructionAndMutationCollapseDuplicates() =
+        let set = TreeSet<int>([ 3; 1; 4; 1; 5 ])
+
+        set.Add(9).Add(2).Add(6).Add(5) |> ignore
+
+        Assert.Equal(7, set.Count)
+        Assert.Equal(7, set.Size)
+        Assert.False(set.IsEmpty)
+        Assert.True(set.Contains 9)
+        Assert.True(set.Has 3)
+        Assert.False(set.Contains 8)
+        Assert.True(set.Remove 4)
+        Assert.True(set.Delete 9)
+        Assert.False(set.Discard 99)
+        Assert.Equal<int>([ 1; 2; 3; 5; 6 ], set.ToList())
+
+    [<Fact>]
+    member _.MinMaxPredecessorSuccessorAndRankWork() =
+        let set = TreeSet<int>([ 10; 20; 30; 40; 50 ])
+
+        Assert.Equal(Some 10, set.Min())
+        Assert.Equal(Some 50, set.Max())
+        Assert.Equal(Some 10, set.First())
+        Assert.Equal(Some 50, set.Last())
+        Assert.Equal(None, TreeSet<int>().Min())
+        Assert.Equal(None, set.Predecessor 10)
+        Assert.Equal(Some 20, set.Predecessor 25)
+        Assert.Equal(Some 30, set.Successor 25)
+        Assert.Equal(None, set.Successor 50)
+        Assert.Equal(2, set.Rank 30)
+        Assert.Equal(1, set.Rank 15)
+
+    [<Fact>]
+    member _.ByRankKthAndRangeReturnSortedResults() =
+        let set = TreeSet<int>([ 1..10 ])
+
+        Assert.Equal(Some 1, set.ByRank 0)
+        Assert.Equal(Some 10, set.ByRank 9)
+        Assert.Equal(None, set.ByRank -1)
+        Assert.Equal(None, set.ByRank 10)
+        Assert.Equal(Some 3, set.KthSmallest 3)
+        Assert.Equal(None, set.KthSmallest 0)
+        Assert.Equal<int>([ 3; 4; 5; 6; 7 ], set.Range(3, 7))
+        Assert.Equal<int>([ 4; 5; 6 ], set.Range(3, 7, inclusive = false))
+        Assert.Empty(set.Range(7, 3))
+        Assert.Equal<int>(set.ToList(), set.ToSortedArray())
+
+    [<Fact>]
+    member _.SetAlgebraDoesNotMutateInputs() =
+        let a = TreeSet<int>([ 1; 2; 3; 4 ])
+        let b = TreeSet<int>([ 3; 4; 5; 6 ])
+
+        Assert.Equal<int>([ 1; 2; 3; 4; 5; 6 ], a.Union(b).ToList())
+        Assert.Equal<int>([ 3; 4 ], a.Intersection(b).ToList())
+        Assert.Equal<int>([ 1; 2 ], a.Difference(b).ToList())
+        Assert.Equal<int>([ 1; 2; 5; 6 ], a.SymmetricDifference(b).ToList())
+        Assert.Equal<int>([ 1; 2; 3; 4 ], a.ToList())
+        Assert.Equal<int>([ 3; 4; 5; 6 ], b.ToList())
+
+    [<Fact>]
+    member _.PredicatesAndEqualityCompareSetContents() =
+        let small = TreeSet<int>([ 2; 3 ])
+        let large = TreeSet<int>([ 1; 2; 3; 4 ])
+        let disjoint = TreeSet<int>([ 8; 9 ])
+        let same = TreeSet<int>([ 3; 2 ])
+
+        Assert.True(small.IsSubset large)
+        Assert.True(large.IsSuperset small)
+        Assert.True(small.IsDisjoint disjoint)
+        Assert.False(small.IsDisjoint large)
+        Assert.True(small.Equals same)
+        Assert.Equal(small.GetHashCode(), same.GetHashCode())
+        Assert.False(small.Equals large)
+
+    [<Fact>]
+    member _.IterationAndToStringUseSortedOrder() =
+        let set = TreeSet<int>([ 5; 2; 8; 1; 9; 3 ])
+
+        Assert.Equal<int>([ 1; 2; 3; 5; 8; 9 ], set |> Seq.toList)
+        Assert.Equal("TreeSet([1, 2, 3, 5, 8, 9])", set.ToString())
+
+    [<Fact>]
+    member _.StressMatchesFrameworkSet() =
+        let ours = TreeSet<int>()
+        let mutable reference = Set.empty<int>
+        let random = Random(314)
+
+        for _ in 1 .. 500 do
+            let key = random.Next 300
+            ours.Add key |> ignore
+            reference <- reference.Add key
+
+        for key in reference |> Seq.take 200 |> Seq.toList do
+            Assert.Equal(reference.Contains key, ours.Remove key)
+            reference <- reference.Remove key
+
+        for _ in 1 .. 300 do
+            let key = random.Next 600
+
+            if random.Next(2) = 0 then
+                ours.Add key |> ignore
+                reference <- reference.Add key
+            else
+                Assert.Equal(reference.Contains key, ours.Remove key)
+                reference <- reference.Remove key
+
+        Assert.Equal<int>(Set.toList reference, ours.ToList())
+        Assert.Equal(Some reference.MinimumElement, ours.Min())
+        Assert.Equal(Some reference.MaximumElement, ours.Max())


### PR DESCRIPTION
## Summary
- add C# and F# tree-set packages backed by native sorted tree collections
- include sorted traversal, min/max, predecessor/successor, rank, by-rank/kth helpers, ranges, set algebra, predicates, equality, and stress coverage
- wire package metadata, capability manifests, and BUILD commands for both runtimes

## Verification
- dotnet test tests\CodingAdventures.TreeSet.Tests\CodingAdventures.TreeSet.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.TreeSet.Tests\CodingAdventures.TreeSet.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line