### PR TITLE
feat(parity): add dotnet treap packages

### DIFF
--- a/code/packages/csharp/treap/BUILD
+++ b/code/packages/csharp/treap/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/treap/BUILD_windows
+++ b/code/packages/csharp/treap/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/treap/CHANGELOG.md
+++ b/code/packages/csharp/treap/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure functional integer treap with split, merge, insert, delete, traversal, and validation helpers.

--- a/code/packages/csharp/treap/CodingAdventures.Treap.csproj
+++ b/code/packages/csharp/treap/CodingAdventures.Treap.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Treap.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# randomized treap with split/merge operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/treap/README.md
+++ b/code/packages/csharp/treap/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Treap
+
+Pure C# integer treap: a binary search tree ordered by key and heap-ordered by randomized priority.
+
+All update operations return new treap instances. The package includes split, merge, insert, delete, sorted traversal, min/max, predecessor/successor, kth-smallest, size, height, and invariant validation.

--- a/code/packages/csharp/treap/Treap.cs
+++ b/code/packages/csharp/treap/Treap.cs
@@ -1,0 +1,286 @@
+namespace CodingAdventures.Treap;
+
+/// <summary>
+/// Pure functional randomized treap for integer keys.
+/// </summary>
+public sealed class Treap
+{
+    private readonly Random _random;
+
+    private Treap(Node? root, Random random)
+    {
+        Root = root;
+        _random = random;
+    }
+
+    public Node? Root { get; }
+
+    public bool IsEmpty => Root is null;
+
+    public int Size => CountNodes(Root);
+
+    public int Height => HeightOf(Root);
+
+    public static Treap Empty() => new(null, new Random());
+
+    public static Treap Empty(Random random)
+    {
+        ArgumentNullException.ThrowIfNull(random);
+        return new Treap(null, random);
+    }
+
+    public static Treap WithSeed(int seed) => new(null, new Random(seed));
+
+    public static Treap FromRoot(Node? root, Random? random = null) => new(root, random ?? new Random());
+
+    public Treap Insert(int key) => Contains(key) ? this : InsertWithPriority(key, _random.NextDouble());
+
+    public Treap InsertWithPriority(int key, double priority)
+    {
+        if (Contains(key))
+        {
+            return this;
+        }
+
+        var (left, right) = SplitStrict(Root, key);
+        var singleton = new Node(key, priority);
+        return new Treap(MergeNodes(MergeNodes(left, singleton), right), _random);
+    }
+
+    public Treap Delete(int key)
+    {
+        if (!Contains(key))
+        {
+            return this;
+        }
+
+        var (left, rest) = SplitStrict(Root, key);
+        var (_, right) = SplitNode(rest, key);
+        return new Treap(MergeNodes(left, right), _random);
+    }
+
+    public SplitResult Split(int key)
+    {
+        var (left, right) = SplitNode(Root, key);
+        return new SplitResult(left, right);
+    }
+
+    public static Treap Merge(Treap left, Treap right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        return new Treap(MergeNodes(left.Root, right.Root), new Random());
+    }
+
+    public bool Contains(int key)
+    {
+        var node = Root;
+        while (node is not null)
+        {
+            if (key < node.Key)
+            {
+                node = node.Left;
+            }
+            else if (key > node.Key)
+            {
+                node = node.Right;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public int? Min()
+    {
+        var node = Root;
+        if (node is null)
+        {
+            return null;
+        }
+
+        while (node.Left is not null)
+        {
+            node = node.Left;
+        }
+
+        return node.Key;
+    }
+
+    public int? Max()
+    {
+        var node = Root;
+        if (node is null)
+        {
+            return null;
+        }
+
+        while (node.Right is not null)
+        {
+            node = node.Right;
+        }
+
+        return node.Key;
+    }
+
+    public int? Predecessor(int key)
+    {
+        int? best = null;
+        var node = Root;
+        while (node is not null)
+        {
+            if (key > node.Key)
+            {
+                best = node.Key;
+                node = node.Right;
+            }
+            else
+            {
+                node = node.Left;
+            }
+        }
+
+        return best;
+    }
+
+    public int? Successor(int key)
+    {
+        int? best = null;
+        var node = Root;
+        while (node is not null)
+        {
+            if (key < node.Key)
+            {
+                best = node.Key;
+                node = node.Left;
+            }
+            else
+            {
+                node = node.Right;
+            }
+        }
+
+        return best;
+    }
+
+    public int KthSmallest(int k)
+    {
+        var sorted = ToSortedList();
+        if (k < 1 || k > sorted.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(k), $"k={k} out of range; treap has {sorted.Count} elements.");
+        }
+
+        return sorted[k - 1];
+    }
+
+    public List<int> ToSortedList()
+    {
+        var result = new List<int>();
+        InOrder(Root, result);
+        return result;
+    }
+
+    public bool IsValidTreap() => CheckNode(Root, null, null, double.MaxValue);
+
+    public override string ToString() => $"Treap(size={Size}, height={Height})";
+
+    internal static (Node? Left, Node? Right) SplitNode(Node? node, int key)
+    {
+        if (node is null)
+        {
+            return (null, null);
+        }
+
+        if (node.Key <= key)
+        {
+            var (leftPart, rightPart) = SplitNode(node.Right, key);
+            return (node with { Right = leftPart }, rightPart);
+        }
+        else
+        {
+            var (leftPart, rightPart) = SplitNode(node.Left, key);
+            return (leftPart, node with { Left = rightPart });
+        }
+    }
+
+    internal static (Node? Left, Node? Right) SplitStrict(Node? node, int key)
+    {
+        if (node is null)
+        {
+            return (null, null);
+        }
+
+        if (node.Key < key)
+        {
+            var (leftPart, rightPart) = SplitStrict(node.Right, key);
+            return (node with { Right = leftPart }, rightPart);
+        }
+        else
+        {
+            var (leftPart, rightPart) = SplitStrict(node.Left, key);
+            return (leftPart, node with { Left = rightPart });
+        }
+    }
+
+    internal static Node? MergeNodes(Node? left, Node? right)
+    {
+        if (left is null)
+        {
+            return right;
+        }
+
+        if (right is null)
+        {
+            return left;
+        }
+
+        return left.Priority > right.Priority
+            ? left with { Right = MergeNodes(left.Right, right) }
+            : right with { Left = MergeNodes(left, right.Left) };
+    }
+
+    private static void InOrder(Node? node, List<int> result)
+    {
+        if (node is null)
+        {
+            return;
+        }
+
+        InOrder(node.Left, result);
+        result.Add(node.Key);
+        InOrder(node.Right, result);
+    }
+
+    private static bool CheckNode(Node? node, int? minKey, int? maxKey, double maxPriority)
+    {
+        if (node is null)
+        {
+            return true;
+        }
+
+        if ((minKey is not null && node.Key <= minKey) || (maxKey is not null && node.Key >= maxKey))
+        {
+            return false;
+        }
+
+        if (node.Priority > maxPriority)
+        {
+            return false;
+        }
+
+        return CheckNode(node.Left, minKey, node.Key, node.Priority)
+            && CheckNode(node.Right, node.Key, maxKey, node.Priority);
+    }
+
+    private static int CountNodes(Node? node) => node is null ? 0 : 1 + CountNodes(node.Left) + CountNodes(node.Right);
+
+    private static int HeightOf(Node? node) => node is null ? 0 : 1 + Math.Max(HeightOf(node.Left), HeightOf(node.Right));
+
+    public sealed record Node(int Key, double Priority, Node? Left = null, Node? Right = null);
+
+    public sealed record SplitResult(Node? Left, Node? Right);
+}

--- a/code/packages/csharp/treap/required_capabilities.json
+++ b/code/packages/csharp/treap/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/treap",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/treap/tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.csproj
+++ b/code/packages/csharp/treap/tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Treap]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Treap.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/treap/tests/CodingAdventures.Treap.Tests/TreapTests.cs
+++ b/code/packages/csharp/treap/tests/CodingAdventures.Treap.Tests/TreapTests.cs
@@ -1,0 +1,150 @@
+using CodingAdventures.Treap;
+
+namespace CodingAdventures.Treap.Tests;
+
+public sealed class TreapTests
+{
+    private static Treap Build(params int[] keys)
+    {
+        var treap = Treap.WithSeed(42);
+        foreach (var key in keys)
+        {
+            treap = treap.Insert(key);
+        }
+
+        return treap;
+    }
+
+    [Fact]
+    public void EmptyAndSingleTreapsExposeMetrics()
+    {
+        var empty = Treap.WithSeed(1);
+
+        Assert.True(empty.IsValidTreap());
+        Assert.True(empty.IsEmpty);
+        Assert.Equal(0, empty.Size);
+        Assert.Equal(0, empty.Height);
+        Assert.Null(empty.Min());
+        Assert.Null(empty.Max());
+        Assert.Throws<ArgumentOutOfRangeException>(() => empty.KthSmallest(1));
+
+        var single = empty.Insert(10);
+        Assert.False(single.IsEmpty);
+        Assert.Equal(1, single.Size);
+        Assert.Equal(1, single.Height);
+        Assert.Equal(10, single.Root?.Key);
+        Assert.Equal(10, single.Min());
+        Assert.Equal(10, single.Max());
+        Assert.True(single.IsValidTreap());
+    }
+
+    [Fact]
+    public void ExplicitPrioritiesShapeTreapDeterministically()
+    {
+        var treap = Treap.WithSeed(0)
+            .InsertWithPriority(5, 0.91)
+            .InsertWithPriority(3, 0.53)
+            .InsertWithPriority(7, 0.75)
+            .InsertWithPriority(1, 0.22)
+            .InsertWithPriority(4, 0.68);
+
+        Assert.True(treap.IsValidTreap());
+        Assert.Equal(5, treap.Root?.Key);
+        Assert.Equal(0.91, treap.Root?.Priority);
+        Assert.Equal([1, 3, 4, 5, 7], treap.ToSortedList());
+    }
+
+    [Fact]
+    public void InsertIgnoresDuplicatesAndPreservesOriginal()
+    {
+        var original = Build(5, 3, 7);
+        var modified = original.Insert(1).Insert(9).Insert(5);
+
+        Assert.Equal([3, 5, 7], original.ToSortedList());
+        Assert.Equal([1, 3, 5, 7, 9], modified.ToSortedList());
+        Assert.Equal(5, modified.Size);
+        Assert.True(modified.IsValidTreap());
+    }
+
+    [Fact]
+    public void ContainsMinMaxPredecessorSuccessorAndKthWork()
+    {
+        var treap = Build(10, 5, 15, 3, 7, 12, 20);
+
+        Assert.True(treap.Contains(10));
+        Assert.False(treap.Contains(11));
+        Assert.Equal(3, treap.Min());
+        Assert.Equal(20, treap.Max());
+        Assert.Null(treap.Predecessor(3));
+        Assert.Equal(7, treap.Predecessor(10));
+        Assert.Equal(12, treap.Successor(10));
+        Assert.Null(treap.Successor(20));
+        Assert.Equal(3, treap.KthSmallest(1));
+        Assert.Equal(10, treap.KthSmallest(4));
+        Assert.Throws<ArgumentOutOfRangeException>(() => treap.KthSmallest(0));
+    }
+
+    [Fact]
+    public void SplitAndMergePartitionAndReconstruct()
+    {
+        var original = Build(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var parts = original.Split(5);
+        var left = Treap.FromRoot(parts.Left);
+        var right = Treap.FromRoot(parts.Right);
+
+        Assert.Equal([1, 2, 3, 4, 5], left.ToSortedList());
+        Assert.Equal([6, 7, 8, 9, 10], right.ToSortedList());
+
+        var merged = Treap.Merge(left, right);
+        Assert.True(merged.IsValidTreap());
+        Assert.Equal(original.ToSortedList(), merged.ToSortedList());
+    }
+
+    [Fact]
+    public void DeleteHandlesAbsentLeafRootAndAllKeys()
+    {
+        var treap = Treap.WithSeed(0)
+            .InsertWithPriority(5, 0.9)
+            .InsertWithPriority(3, 0.5)
+            .InsertWithPriority(7, 0.6);
+
+        Assert.Same(treap, treap.Delete(99));
+        var withoutRoot = treap.Delete(5);
+        Assert.True(withoutRoot.IsValidTreap());
+        Assert.Equal([3, 7], withoutRoot.ToSortedList());
+
+        var all = Build(10, 5, 15, 3, 7, 12, 20);
+        foreach (var key in all.ToSortedList())
+        {
+            all = all.Delete(key);
+            Assert.True(all.IsValidTreap());
+            Assert.False(all.Contains(key));
+        }
+
+        Assert.True(all.IsEmpty);
+    }
+
+    [Fact]
+    public void RandomStressPreservesSortedSetContents()
+    {
+        var random = new Random(7);
+        var treap = Treap.WithSeed(55);
+        var reference = new SortedSet<int>();
+
+        for (var i = 0; i < 200; i++)
+        {
+            var key = random.Next(100);
+            treap = treap.Insert(key);
+            reference.Add(key);
+            Assert.True(treap.IsValidTreap());
+        }
+
+        foreach (var key in reference.OrderBy(_ => random.Next()).ToList())
+        {
+            treap = treap.Delete(key);
+            Assert.True(treap.IsValidTreap());
+        }
+
+        Assert.True(treap.IsEmpty);
+    }
+}

--- a/code/packages/fsharp/treap/BUILD
+++ b/code/packages/fsharp/treap/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/treap/BUILD_windows
+++ b/code/packages/fsharp/treap/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/treap/CHANGELOG.md
+++ b/code/packages/fsharp/treap/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure functional integer treap with split, merge, insert, delete, traversal, and validation helpers.

--- a/code/packages/fsharp/treap/CodingAdventures.Treap.fsproj
+++ b/code/packages/fsharp/treap/CodingAdventures.Treap.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Treap</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# randomized treap with split/merge operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Treap.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/treap/README.md
+++ b/code/packages/fsharp/treap/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Treap
+
+Pure F# integer treap: a binary search tree ordered by key and heap-ordered by randomized priority.
+
+All update operations return new treap instances. The package includes split, merge, insert, delete, sorted traversal, min/max, predecessor/successor, kth-smallest, size, height, and invariant validation.

--- a/code/packages/fsharp/treap/Treap.fs
+++ b/code/packages/fsharp/treap/Treap.fs
@@ -1,0 +1,192 @@
+namespace CodingAdventures.Treap
+
+open System
+
+type Node =
+    { Key: int
+      Priority: double
+      Left: Node option
+      Right: Node option }
+
+type SplitResult =
+    { Left: Node option
+      Right: Node option }
+
+type Treap private (root: Node option, random: Random) =
+    static let rec splitNode (node: Node option) (key: int) : SplitResult =
+        match node with
+        | None -> { Left = None; Right = None }
+        | Some current when current.Key <= key ->
+            let parts = splitNode current.Right key
+            { Left = Some { current with Right = parts.Left }
+              Right = parts.Right }
+        | Some current ->
+            let parts = splitNode current.Left key
+            { Left = parts.Left
+              Right = Some { current with Left = parts.Right } }
+
+    static let rec splitStrict (node: Node option) (key: int) : SplitResult =
+        match node with
+        | None -> { Left = None; Right = None }
+        | Some current when current.Key < key ->
+            let parts = splitStrict current.Right key
+            { Left = Some { current with Right = parts.Left }
+              Right = parts.Right }
+        | Some current ->
+            let parts = splitStrict current.Left key
+            { Left = parts.Left
+              Right = Some { current with Left = parts.Right } }
+
+    static let rec mergeNodes (left: Node option) (right: Node option) : Node option =
+        match left, right with
+        | None, other -> other
+        | other, None -> other
+        | Some l, Some r when l.Priority > r.Priority ->
+            Some { l with Right = mergeNodes l.Right right }
+        | Some l, Some r ->
+            Some { r with Left = mergeNodes left r.Left }
+
+    static let rec inOrder (node: Node option) : int list =
+        match node with
+        | None -> []
+        | Some current -> inOrder current.Left @ [ current.Key ] @ inOrder current.Right
+
+    static let rec checkNode (node: Node option) (minKey: int option) (maxKey: int option) (maxPriority: double) : bool =
+        match node with
+        | None -> true
+        | Some current ->
+            let aboveMin =
+                match minKey with
+                | None -> true
+                | Some low -> current.Key > low
+
+            let belowMax =
+                match maxKey with
+                | None -> true
+                | Some high -> current.Key < high
+
+            aboveMin
+            && belowMax
+            && current.Priority <= maxPriority
+            && checkNode current.Left minKey (Some current.Key) current.Priority
+            && checkNode current.Right (Some current.Key) maxKey current.Priority
+
+    static let rec countNodes (node: Node option) : int =
+        match node with
+        | None -> 0
+        | Some current -> 1 + countNodes current.Left + countNodes current.Right
+
+    static let rec heightOf (node: Node option) : int =
+        match node with
+        | None -> 0
+        | Some current -> 1 + max (heightOf current.Left) (heightOf current.Right)
+
+    static member Empty() = Treap(None, Random())
+    static member Empty(random: Random) = Treap(None, random)
+    static member WithSeed(seed: int) = Treap(None, Random seed)
+    static member FromRoot(root: Node option, ?random: Random) = Treap(root, defaultArg random (Random()))
+
+    static member Merge(left: Treap, right: Treap) =
+        ArgumentNullException.ThrowIfNull(left)
+        ArgumentNullException.ThrowIfNull(right)
+        Treap(mergeNodes left.Root right.Root, Random())
+
+    member _.Root = root
+    member _.IsEmpty = root.IsNone
+    member _.Size = countNodes root
+    member _.Height = heightOf root
+
+    member this.Insert(key: int) =
+        if this.Contains key then
+            this
+        else
+            this.InsertWithPriority(key, random.NextDouble())
+
+    member this.InsertWithPriority(key: int, priority: double) =
+        if this.Contains key then
+            this
+        else
+            let parts = splitStrict root key
+            let singleton: Node option =
+                Some
+                    { Key = key
+                      Priority = priority
+                      Left = None
+                      Right = None }
+
+            Treap(mergeNodes (mergeNodes parts.Left singleton) parts.Right, random)
+
+    member this.Delete(key: int) =
+        if not (this.Contains key) then
+            this
+        else
+            let leftPart = splitStrict root key
+            let rightPart = splitNode leftPart.Right key
+            Treap(mergeNodes leftPart.Left rightPart.Right, random)
+
+    member _.Split(key: int) : SplitResult = splitNode root key
+
+    member _.Contains(key: int) =
+        let rec loop (node: Node option) =
+            match node with
+            | None -> false
+            | Some current when key < current.Key -> loop current.Left
+            | Some current when key > current.Key -> loop current.Right
+            | Some _ -> true
+
+        loop root
+
+    member _.Min() =
+        let rec loop (node: Node option) =
+            match node with
+            | None -> None
+            | Some current ->
+                match current.Left with
+                | None -> Some current.Key
+                | child -> loop child
+
+        loop root
+
+    member _.Max() =
+        let rec loop (node: Node option) =
+            match node with
+            | None -> None
+            | Some current ->
+                match current.Right with
+                | None -> Some current.Key
+                | child -> loop child
+
+        loop root
+
+    member _.Predecessor(key: int) =
+        let rec loop (best: int option) (node: Node option) =
+            match node with
+            | None -> best
+            | Some current when key > current.Key -> loop (Some current.Key) current.Right
+            | Some current -> loop best current.Left
+
+        loop None root
+
+    member _.Successor(key: int) =
+        let rec loop (best: int option) (node: Node option) =
+            match node with
+            | None -> best
+            | Some current when key < current.Key -> loop (Some current.Key) current.Left
+            | Some current -> loop best current.Right
+
+        loop None root
+
+    member this.KthSmallest(k: int) =
+        let sorted = this.ToSortedList()
+
+        if k < 1 || k > sorted.Length then
+            invalidArg (nameof k) $"k={k} out of range; treap has {sorted.Length} elements."
+
+        sorted[k - 1]
+
+    member _.ToSortedList() : int list = inOrder root
+
+    member _.IsValidTreap() = checkNode root None None Double.MaxValue
+
+    override this.ToString() =
+        $"Treap(size={this.Size}, height={this.Height})"

--- a/code/packages/fsharp/treap/required_capabilities.json
+++ b/code/packages/fsharp/treap/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/treap",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/treap/tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.fsproj
+++ b/code/packages/fsharp/treap/tests/CodingAdventures.Treap.Tests/CodingAdventures.Treap.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Treap.fsproj" />
+    <Compile Include="TreapTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/treap/tests/CodingAdventures.Treap.Tests/TreapTests.fs
+++ b/code/packages/fsharp/treap/tests/CodingAdventures.Treap.Tests/TreapTests.fs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.Treap.Tests
+
+open System
+open CodingAdventures.Treap
+open Xunit
+
+type TreapTests() =
+    let build keys =
+        keys |> Seq.fold (fun (treap: Treap) key -> treap.Insert key) (Treap.WithSeed 42)
+
+    [<Fact>]
+    member _.EmptyAndSingleTreapsExposeMetrics() =
+        let empty = Treap.WithSeed 1
+
+        Assert.True(empty.IsValidTreap())
+        Assert.True(empty.IsEmpty)
+        Assert.Equal(0, empty.Size)
+        Assert.Equal(0, empty.Height)
+        Assert.Equal(None, empty.Min())
+        Assert.Equal(None, empty.Max())
+        Assert.Throws<ArgumentException>(fun () -> empty.KthSmallest 1 |> ignore) |> ignore
+
+        let single = empty.Insert 10
+        Assert.False(single.IsEmpty)
+        Assert.Equal(1, single.Size)
+        Assert.Equal(1, single.Height)
+        Assert.Equal(Some 10, single.Min())
+        Assert.Equal(Some 10, single.Max())
+        Assert.True(single.IsValidTreap())
+
+    [<Fact>]
+    member _.ExplicitPrioritiesShapeTreapDeterministically() =
+        let treap =
+            (Treap.WithSeed 0)
+                .InsertWithPriority(5, 0.91)
+                .InsertWithPriority(3, 0.53)
+                .InsertWithPriority(7, 0.75)
+                .InsertWithPriority(1, 0.22)
+                .InsertWithPriority(4, 0.68)
+
+        Assert.True(treap.IsValidTreap())
+        Assert.Equal(Some 5, treap.Root |> Option.map _.Key)
+        Assert.Equal<int>([ 1; 3; 4; 5; 7 ], treap.ToSortedList())
+
+    [<Fact>]
+    member _.InsertIgnoresDuplicatesAndPreservesOriginal() =
+        let original = build [ 5; 3; 7 ]
+        let modified = original.Insert(1).Insert(9).Insert(5)
+
+        Assert.Equal<int>([ 3; 5; 7 ], original.ToSortedList())
+        Assert.Equal<int>([ 1; 3; 5; 7; 9 ], modified.ToSortedList())
+        Assert.Equal(5, modified.Size)
+        Assert.True(modified.IsValidTreap())
+
+    [<Fact>]
+    member _.ContainsMinMaxPredecessorSuccessorAndKthWork() =
+        let treap = build [ 10; 5; 15; 3; 7; 12; 20 ]
+
+        Assert.True(treap.Contains 10)
+        Assert.False(treap.Contains 11)
+        Assert.Equal(Some 3, treap.Min())
+        Assert.Equal(Some 20, treap.Max())
+        Assert.Equal(None, treap.Predecessor 3)
+        Assert.Equal(Some 7, treap.Predecessor 10)
+        Assert.Equal(Some 12, treap.Successor 10)
+        Assert.Equal(None, treap.Successor 20)
+        Assert.Equal(3, treap.KthSmallest 1)
+        Assert.Equal(10, treap.KthSmallest 4)
+        Assert.Throws<ArgumentException>(fun () -> treap.KthSmallest 0 |> ignore) |> ignore
+
+    [<Fact>]
+    member _.SplitAndMergePartitionAndReconstruct() =
+        let original = build [ 1..10 ]
+        let parts = original.Split 5
+        let left = Treap.FromRoot parts.Left
+        let right = Treap.FromRoot parts.Right
+
+        Assert.Equal<int>([ 1; 2; 3; 4; 5 ], left.ToSortedList())
+        Assert.Equal<int>([ 6; 7; 8; 9; 10 ], right.ToSortedList())
+
+        let merged = Treap.Merge(left, right)
+        Assert.True(merged.IsValidTreap())
+        Assert.Equal<int>(original.ToSortedList(), merged.ToSortedList())
+
+    [<Fact>]
+    member _.DeleteHandlesAbsentRootAndAllKeys() =
+        let treap =
+            (Treap.WithSeed 0)
+                .InsertWithPriority(5, 0.9)
+                .InsertWithPriority(3, 0.5)
+                .InsertWithPriority(7, 0.6)
+
+        Assert.Same(treap, treap.Delete 99)
+        let withoutRoot = treap.Delete 5
+        Assert.True(withoutRoot.IsValidTreap())
+        Assert.Equal<int>([ 3; 7 ], withoutRoot.ToSortedList())
+
+        let mutable all = build [ 10; 5; 15; 3; 7; 12; 20 ]
+        for key in all.ToSortedList() do
+            all <- all.Delete key
+            Assert.True(all.IsValidTreap())
+            Assert.False(all.Contains key)
+
+        Assert.True(all.IsEmpty)
+
+    [<Fact>]
+    member _.RandomStressPreservesSortedSetContents() =
+        let random = Random 7
+        let mutable treap = Treap.WithSeed 55
+        let mutable reference = Set.empty<int>
+
+        for _ in 1 .. 200 do
+            let key = random.Next 100
+            treap <- treap.Insert key
+            reference <- reference.Add key
+            Assert.True(treap.IsValidTreap())
+
+        for key in reference |> Seq.toList |> List.sortBy (fun _ -> random.Next()) do
+            treap <- treap.Delete key
+            Assert.True(treap.IsValidTreap())
+
+        Assert.True(treap.IsEmpty)


### PR DESCRIPTION
## Summary
- add C# and F# pure functional treap packages with seeded factories, explicit priorities, split/merge, insert/delete, traversal, min/max, predecessor/successor, kth-smallest, size/height, and validation
- include deterministic structure tests, split/merge reconstruction, immutability checks, delete coverage, and random invariant stress tests
- wire package metadata, capability manifests, and BUILD commands for both runtimes

## Verification
- dotnet test tests\CodingAdventures.Treap.Tests\CodingAdventures.Treap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.Treap.Tests\CodingAdventures.Treap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line