### PR TITLE
feat(parity): add dotnet uuid packages

### DIFF
--- a/code/packages/csharp/uuid/BUILD
+++ b/code/packages/csharp/uuid/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/uuid/BUILD_windows
+++ b/code/packages/csharp/uuid/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/uuid/CHANGELOG.md
+++ b/code/packages/csharp/uuid/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# UUID package with RFC 4122 and RFC 9562 helpers.

--- a/code/packages/csharp/uuid/CodingAdventures.Uuid.csproj
+++ b/code/packages/csharp/uuid/CodingAdventures.Uuid.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Uuid.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>RFC 4122 and RFC 9562 UUID parsing, formatting, and generation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/uuid/README.md
+++ b/code/packages/csharp/uuid/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.Uuid.CSharp
+
+RFC 4122 and RFC 9562 UUID parsing, formatting, byte conversion, comparison,
+namespace constants, and v1/v3/v4/v5/v7 generation helpers.

--- a/code/packages/csharp/uuid/Uuid.cs
+++ b/code/packages/csharp/uuid/Uuid.cs
@@ -1,0 +1,282 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CodingAdventures.Uuid;
+
+/// <summary>
+/// A 128-bit universally unique identifier per RFC 4122 and RFC 9562.
+/// </summary>
+public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
+{
+    /// <summary>
+    /// Package version.
+    /// </summary>
+    public const string VERSION = "0.1.0";
+
+    private const ulong GregorianOffset = 122_192_928_000_000_000UL;
+    private static readonly Regex UuidPattern = new(
+        "^\\s*(?:urn:uuid:)?\\{?"
+        + "([0-9a-fA-F]{8})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{12})"
+        + "\\}?\\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly int ClockSequence = CreateClockSequence();
+
+    /// <summary>
+    /// The nil UUID: all 128 bits are zero.
+    /// </summary>
+    public static readonly Uuid NIL = new(0UL, 0UL);
+
+    /// <summary>
+    /// The max UUID: all 128 bits are one.
+    /// </summary>
+    public static readonly Uuid MAX = new(ulong.MaxValue, ulong.MaxValue);
+
+    /// <summary>
+    /// RFC 4122 namespace for fully-qualified domain names.
+    /// </summary>
+    public static readonly Uuid NAMESPACE_DNS = FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// RFC 4122 namespace for URLs.
+    /// </summary>
+    public static readonly Uuid NAMESPACE_URL = FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// RFC 4122 namespace for ISO OIDs.
+    /// </summary>
+    public static readonly Uuid NAMESPACE_OID = FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// RFC 4122 namespace for X.500 distinguished names.
+    /// </summary>
+    public static readonly Uuid NAMESPACE_X500 = FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// Version field stored in the high nibble of byte 6.
+    /// </summary>
+    public int Version => (int)((Msb >> 12) & 0xFUL);
+
+    /// <summary>
+    /// Variant field rendered as ncs, rfc4122, microsoft, or reserved.
+    /// </summary>
+    public string Variant
+    {
+        get
+        {
+            var top = (int)((Lsb >> 62) & 0x3UL);
+            if (top <= 1)
+            {
+                return "ncs";
+            }
+
+            if (top == 2)
+            {
+                return "rfc4122";
+            }
+
+            return ((Lsb >> 61) & 0x7UL) == 7UL ? "reserved" : "microsoft";
+        }
+    }
+
+    /// <summary>
+    /// True when all bits are zero.
+    /// </summary>
+    public bool IsNil => Msb == 0UL && Lsb == 0UL;
+
+    /// <summary>
+    /// True when all bits are one.
+    /// </summary>
+    public bool IsMax => Msb == ulong.MaxValue && Lsb == ulong.MaxValue;
+
+    /// <summary>
+    /// Parse a UUID from standard, compact, braced, or URN text.
+    /// </summary>
+    public static Uuid FromString(string? text)
+    {
+        if (text is null)
+        {
+            throw new UuidException("UUID string must not be null");
+        }
+
+        var match = UuidPattern.Match(text.Trim());
+        if (!match.Success)
+        {
+            throw new UuidException($"Invalid UUID string: '{text}'");
+        }
+
+        var hex = string.Concat(
+            match.Groups[1].Value,
+            match.Groups[2].Value,
+            match.Groups[3].Value,
+            match.Groups[4].Value,
+            match.Groups[5].Value);
+        var msb = ulong.Parse(hex[..16], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+        var lsb = ulong.Parse(hex[16..], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+        return new Uuid(msb, lsb);
+    }
+
+    /// <summary>
+    /// Construct a UUID from exactly 16 bytes in network byte order.
+    /// </summary>
+    public static Uuid FromBytes(byte[]? bytes)
+    {
+        if (bytes is null)
+        {
+            throw new UuidException("UUID bytes must be exactly 16, got null");
+        }
+
+        return FromBytes((ReadOnlySpan<byte>)bytes);
+    }
+
+    /// <summary>
+    /// Construct a UUID from exactly 16 bytes in network byte order.
+    /// </summary>
+    public static Uuid FromBytes(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != 16)
+        {
+            throw new UuidException($"UUID bytes must be exactly 16, got {bytes.Length}");
+        }
+
+        return new Uuid(
+            BinaryPrimitives.ReadUInt64BigEndian(bytes[..8]),
+            BinaryPrimitives.ReadUInt64BigEndian(bytes[8..]));
+    }
+
+    /// <summary>
+    /// Return true when the text is a UUID in one of the supported forms.
+    /// </summary>
+    public static bool IsValid(string? text) => text is not null && UuidPattern.IsMatch(text.Trim());
+
+    /// <summary>
+    /// Return the 16 bytes of this UUID in network byte order.
+    /// </summary>
+    public byte[] ToBytes()
+    {
+        var bytes = new byte[16];
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(0, 8), Msb);
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(8, 8), Lsb);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Return the standard lowercase 8-4-4-4-12 UUID string.
+    /// </summary>
+    public override string ToString()
+    {
+        var hex = string.Create(CultureInfo.InvariantCulture, $"{Msb:x16}{Lsb:x16}");
+        return $"{hex[..8]}-{hex[8..12]}-{hex[12..16]}-{hex[16..20]}-{hex[20..]}";
+    }
+
+    /// <summary>
+    /// Compare UUIDs by unsigned byte order.
+    /// </summary>
+    public int CompareTo(Uuid other)
+    {
+        var compareMsb = Msb.CompareTo(other.Msb);
+        return compareMsb != 0 ? compareMsb : Lsb.CompareTo(other.Lsb);
+    }
+
+    /// <summary>
+    /// Generate a random UUID v4.
+    /// </summary>
+    public static Uuid V4()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(16);
+        return StampVersionVariant(bytes, 4);
+    }
+
+    /// <summary>
+    /// Generate a time-ordered random UUID v7.
+    /// </summary>
+    public static Uuid V7()
+    {
+        var timestampMs = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var random = RandomNumberGenerator.GetBytes(10);
+        var raw = new byte[16];
+        raw[0] = (byte)((timestampMs >> 40) & 0xFFUL);
+        raw[1] = (byte)((timestampMs >> 32) & 0xFFUL);
+        raw[2] = (byte)((timestampMs >> 24) & 0xFFUL);
+        raw[3] = (byte)((timestampMs >> 16) & 0xFFUL);
+        raw[4] = (byte)((timestampMs >> 8) & 0xFFUL);
+        raw[5] = (byte)(timestampMs & 0xFFUL);
+        raw[6] = (byte)(0x70 | (random[0] & 0x0F));
+        raw[7] = random[1];
+        raw[8] = (byte)(0x80 | (random[2] & 0x3F));
+        random.AsSpan(3, 7).CopyTo(raw.AsSpan(9));
+        return FromBytes(raw);
+    }
+
+    /// <summary>
+    /// Generate a time-based UUID v1 with a random node id.
+    /// </summary>
+    public static Uuid V1()
+    {
+        var timestamp = ((ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 10_000UL) + GregorianOffset;
+        var timeLow = timestamp & 0xFFFFFFFFUL;
+        var timeMid = (timestamp >> 32) & 0xFFFFUL;
+        var timeHi = (timestamp >> 48) & 0x0FFFUL;
+        var msb = (timeLow << 32) | (timeMid << 16) | (0x1000UL | timeHi);
+
+        var clockSeqHi = 0x80UL | ((uint)ClockSequence >> 8);
+        var clockSeqLow = (uint)ClockSequence & 0xFFU;
+        var nodeBytes = RandomNumberGenerator.GetBytes(6);
+        nodeBytes[0] = (byte)(nodeBytes[0] | 0x01);
+
+        var node = 0UL;
+        foreach (var value in nodeBytes)
+        {
+            node = (node << 8) | value;
+        }
+
+        var lsb = (clockSeqHi << 56) | ((ulong)clockSeqLow << 48) | node;
+        return new Uuid(msb, lsb);
+    }
+
+    /// <summary>
+    /// Generate a name-based UUID v5 using SHA-1.
+    /// </summary>
+    public static Uuid V5(Uuid namespaceId, string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        var digest = SHA1.HashData(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name)));
+        var raw = new byte[16];
+        digest.AsSpan(0, 16).CopyTo(raw);
+        return StampVersionVariant(raw, 5);
+    }
+
+    /// <summary>
+    /// Generate a name-based UUID v3 using MD5.
+    /// </summary>
+    public static Uuid V3(Uuid namespaceId, string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return StampVersionVariant(MD5.HashData(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name))), 3);
+    }
+
+    private static Uuid StampVersionVariant(byte[] bytes, int version)
+    {
+        bytes[6] = (byte)((bytes[6] & 0x0F) | (version << 4));
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+        return FromBytes(bytes);
+    }
+
+    private static byte[] Concat(byte[] left, byte[] right)
+    {
+        var result = new byte[left.Length + right.Length];
+        Buffer.BlockCopy(left, 0, result, 0, left.Length);
+        Buffer.BlockCopy(right, 0, result, left.Length, right.Length);
+        return result;
+    }
+
+    private static int CreateClockSequence()
+    {
+        Span<byte> bytes = stackalloc byte[2];
+        RandomNumberGenerator.Fill(bytes);
+        return (((bytes[0] << 8) | bytes[1]) & 0x3FFF);
+    }
+}

--- a/code/packages/csharp/uuid/UuidException.cs
+++ b/code/packages/csharp/uuid/UuidException.cs
@@ -1,0 +1,23 @@
+namespace CodingAdventures.Uuid;
+
+/// <summary>
+/// Thrown when a UUID string or byte sequence cannot be parsed.
+/// </summary>
+public sealed class UuidException : ArgumentException
+{
+    /// <summary>
+    /// Create a UUID exception with a message.
+    /// </summary>
+    public UuidException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Create a UUID exception with a message and inner exception.
+    /// </summary>
+    public UuidException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/code/packages/csharp/uuid/required_capabilities.json
+++ b/code/packages/csharp/uuid/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/uuid",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Uses cryptographic randomness through the runtime; no filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj
+++ b/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Uuid.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/UuidTests.cs
+++ b/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/UuidTests.cs
@@ -1,0 +1,179 @@
+using CodingAdventures.Uuid;
+
+namespace CodingAdventures.Uuid.Tests;
+
+public sealed class UuidTests
+{
+    [Fact]
+    public void FromStringAcceptsSupportedForms()
+    {
+        const string expected = "550e8400-e29b-41d4-a716-446655440000";
+
+        Assert.Equal(expected, Uuid.FromString(expected).ToString());
+        Assert.Equal(expected, Uuid.FromString("550E8400-E29B-41D4-A716-446655440000").ToString());
+        Assert.Equal(expected, Uuid.FromString("550e8400e29b41d4a716446655440000").ToString());
+        Assert.Equal(expected, Uuid.FromString("{550e8400-e29b-41d4-a716-446655440000}").ToString());
+        Assert.Equal(expected, Uuid.FromString("urn:uuid:550e8400-e29b-41d4-a716-446655440000").ToString());
+        Assert.Equal(expected, Uuid.FromString("  550e8400-e29b-41d4-a716-446655440000  ").ToString());
+    }
+
+    [Fact]
+    public void FromStringRejectsInvalidText()
+    {
+        Assert.Throws<UuidException>(() => Uuid.FromString("not-a-uuid"));
+        Assert.Throws<UuidException>(() => Uuid.FromString("550e8400-e29b-41d4-a716-44665544000z"));
+        Assert.Throws<UuidException>(() => Uuid.FromString(""));
+        Assert.Throws<UuidException>(() => Uuid.FromString(null));
+    }
+
+    [Fact]
+    public void FromBytesRoundTripsAndRejectsWrongLength()
+    {
+        var uuid = Uuid.FromString("550e8400-e29b-41d4-a716-446655440000");
+        var bytes = uuid.ToBytes();
+
+        Assert.Equal(16, bytes.Length);
+        Assert.Equal(uuid, Uuid.FromBytes(bytes));
+        Assert.Equal(uuid, Uuid.FromBytes((ReadOnlySpan<byte>)bytes));
+        Assert.Throws<UuidException>(() => Uuid.FromBytes(new byte[15]));
+        Assert.Throws<UuidException>(() => Uuid.FromBytes(new byte[17]));
+        Assert.Throws<UuidException>(() => Uuid.FromBytes(null));
+        Assert.Throws<UuidException>(() => Uuid.FromBytes(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void PropertiesExposeVersionVariantAndExtremes()
+    {
+        Assert.Equal(4, Uuid.FromString("550e8400-e29b-41d4-a716-446655440000").Version);
+        Assert.Equal(1, Uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8").Version);
+        Assert.Equal(5, Uuid.FromString("886313e1-3b8a-5372-9b90-0c9aee199e5d").Version);
+        Assert.True(Uuid.NIL.IsNil);
+        Assert.False(Uuid.V4().IsNil);
+        Assert.True(Uuid.MAX.IsMax);
+        Assert.False(Uuid.V4().IsMax);
+        Assert.Equal("00000000-0000-0000-0000-000000000000", Uuid.NIL.ToString());
+        Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", Uuid.MAX.ToString());
+    }
+
+    [Fact]
+    public void VariantClassifiesAllFamilies()
+    {
+        foreach (var nibble in new[] { "8", "9", "a", "b" })
+        {
+            var uuid = Uuid.FromString($"550e8400-e29b-41d4-{nibble}716-446655440000");
+            Assert.Equal("rfc4122", uuid.Variant);
+        }
+
+        Assert.Equal("ncs", new Uuid(0UL, 0x0000_0000_0000_0000UL).Variant);
+        Assert.Equal("ncs", new Uuid(0UL, 0x4000_0000_0000_0000UL).Variant);
+        Assert.Equal("microsoft", new Uuid(0UL, 0xC000_0000_0000_0000UL).Variant);
+        Assert.Equal("reserved", new Uuid(0UL, 0xE000_0000_0000_0000UL).Variant);
+    }
+
+    [Fact]
+    public void EqualityHashAndOrderingUseUnsignedBytes()
+    {
+        var first = Uuid.FromString("00000000-0000-0000-0000-000000000001");
+        var second = Uuid.FromString("00000000-0000-0000-0000-000000000002");
+        var high = Uuid.FromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        Assert.Equal(first, Uuid.FromString(first.ToString()));
+        Assert.Equal(first.GetHashCode(), Uuid.FromString(first.ToString()).GetHashCode());
+        Assert.True(first.CompareTo(second) < 0);
+        Assert.True(second.CompareTo(first) > 0);
+        Assert.True(first.CompareTo(high) < 0);
+        Assert.Equal(0, first.CompareTo(first));
+        Assert.Single(new HashSet<Uuid> { first, Uuid.FromString(first.ToString()) });
+    }
+
+    [Fact]
+    public void IsValidMatchesParser()
+    {
+        Assert.True(Uuid.IsValid("550e8400-e29b-41d4-a716-446655440000"));
+        Assert.True(Uuid.IsValid("550e8400e29b41d4a716446655440000"));
+        Assert.True(Uuid.IsValid("{550e8400-e29b-41d4-a716-446655440000}"));
+        Assert.True(Uuid.IsValid("urn:uuid:550e8400-e29b-41d4-a716-446655440000"));
+        Assert.False(Uuid.IsValid("not-a-uuid"));
+        Assert.False(Uuid.IsValid(""));
+        Assert.False(Uuid.IsValid(null));
+        Assert.False(Uuid.IsValid("550e8400-e29b-41d4-a716-44665544000z"));
+    }
+
+    [Fact]
+    public void V4HasVersionVariantFormatAndUniqueness()
+    {
+        var value = Uuid.V4();
+        var text = value.ToString();
+
+        Assert.Equal(4, value.Version);
+        Assert.Equal("rfc4122", value.Variant);
+        Assert.Equal('4', text[14]);
+        Assert.Contains(text[19], new[] { '8', '9', 'a', 'b' });
+        Assert.Equal(1000, Enumerable.Range(0, 1000).Select(_ => Uuid.V4()).ToHashSet().Count);
+    }
+
+    [Fact]
+    public void V7HasVersionVariantTimestampAndUniqueness()
+    {
+        var first = Uuid.V7();
+        var second = Uuid.V7();
+        var firstTimestamp = first.Msb >> 16;
+        var secondTimestamp = second.Msb >> 16;
+
+        Assert.Equal(7, first.Version);
+        Assert.Equal("rfc4122", first.Variant);
+        Assert.True(firstTimestamp <= secondTimestamp);
+        Assert.Equal(100, Enumerable.Range(0, 100).Select(_ => Uuid.V7()).ToHashSet().Count);
+    }
+
+    [Fact]
+    public void V1HasVersionVariantAndUniqueness()
+    {
+        var value = Uuid.V1();
+
+        Assert.Equal(1, value.Version);
+        Assert.Equal("rfc4122", value.Variant);
+        Assert.Equal(100, Enumerable.Range(0, 100).Select(_ => Uuid.V1()).ToHashSet().Count);
+    }
+
+    [Fact]
+    public void V5MatchesRfcVectorAndIsDeterministic()
+    {
+        Assert.Equal("886313e1-3b8a-5372-9b90-0c9aee199e5d", Uuid.V5(Uuid.NAMESPACE_DNS, "python.org").ToString());
+        Assert.Equal(Uuid.V5(Uuid.NAMESPACE_DNS, "example.com"), Uuid.V5(Uuid.NAMESPACE_DNS, "example.com"));
+        Assert.NotEqual(Uuid.V5(Uuid.NAMESPACE_DNS, "example.com"), Uuid.V5(Uuid.NAMESPACE_DNS, "example.org"));
+        Assert.NotEqual(Uuid.V5(Uuid.NAMESPACE_DNS, "example.com"), Uuid.V5(Uuid.NAMESPACE_URL, "example.com"));
+        Assert.Equal(5, Uuid.V5(Uuid.NAMESPACE_DNS, "test").Version);
+        Assert.Equal("rfc4122", Uuid.V5(Uuid.NAMESPACE_DNS, "test").Variant);
+        Assert.Throws<ArgumentNullException>(() => Uuid.V5(Uuid.NAMESPACE_DNS, null!));
+    }
+
+    [Fact]
+    public void V3MatchesRfcVectorAndIsDeterministic()
+    {
+        Assert.Equal("6fa459ea-ee8a-3ca4-894e-db77e160355e", Uuid.V3(Uuid.NAMESPACE_DNS, "python.org").ToString());
+        Assert.Equal(Uuid.V3(Uuid.NAMESPACE_DNS, "example.com"), Uuid.V3(Uuid.NAMESPACE_DNS, "example.com"));
+        Assert.NotEqual(Uuid.V3(Uuid.NAMESPACE_DNS, "python.org"), Uuid.V5(Uuid.NAMESPACE_DNS, "python.org"));
+        Assert.Equal(3, Uuid.V3(Uuid.NAMESPACE_DNS, "test").Version);
+        Assert.Throws<ArgumentNullException>(() => Uuid.V3(Uuid.NAMESPACE_DNS, null!));
+    }
+
+    [Fact]
+    public void NamespaceConstantsMatchRfcValues()
+    {
+        Assert.Equal("6ba7b810-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_DNS.ToString());
+        Assert.Equal("6ba7b811-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_URL.ToString());
+        Assert.Equal("6ba7b812-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_OID.ToString());
+        Assert.Equal("6ba7b814-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_X500.ToString());
+    }
+
+    [Fact]
+    public void ExceptionCanWrapCause()
+    {
+        var inner = new InvalidOperationException("boom");
+        var exception = new UuidException("wrapped", inner);
+
+        Assert.Equal("wrapped", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+}

--- a/code/packages/fsharp/uuid/BUILD
+++ b/code/packages/fsharp/uuid/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/uuid/BUILD_windows
+++ b/code/packages/fsharp/uuid/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/uuid/CHANGELOG.md
+++ b/code/packages/fsharp/uuid/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# UUID package with RFC 4122 and RFC 9562 helpers.

--- a/code/packages/fsharp/uuid/CodingAdventures.Uuid.fsproj
+++ b/code/packages/fsharp/uuid/CodingAdventures.Uuid.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Uuid.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>RFC 4122 and RFC 9562 UUID parsing, formatting, and generation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Uuid.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/uuid/README.md
+++ b/code/packages/fsharp/uuid/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.Uuid.FSharp
+
+RFC 4122 and RFC 9562 UUID parsing, formatting, byte conversion, comparison,
+namespace constants, and v1/v3/v4/v5/v7 generation helpers.

--- a/code/packages/fsharp/uuid/Uuid.fs
+++ b/code/packages/fsharp/uuid/Uuid.fs
@@ -1,0 +1,196 @@
+namespace CodingAdventures.Uuid
+
+open System
+open System.Buffers.Binary
+open System.Globalization
+open System.Security.Cryptography
+open System.Text
+open System.Text.RegularExpressions
+
+type UuidException(message: string, innerException: exn) =
+    inherit ArgumentException(message, innerException)
+
+    new(message: string) = UuidException(message, null)
+
+type Uuid =
+    { Msb: uint64
+      Lsb: uint64 }
+
+    member this.Version = int ((this.Msb >>> 12) &&& 0xFUL)
+
+    member this.Variant =
+        let top = int ((this.Lsb >>> 62) &&& 0x3UL)
+
+        if top <= 1 then
+            "ncs"
+        elif top = 2 then
+            "rfc4122"
+        elif ((this.Lsb >>> 61) &&& 0x7UL) = 7UL then
+            "reserved"
+        else
+            "microsoft"
+
+    member this.IsNil = this.Msb = 0UL && this.Lsb = 0UL
+
+    member this.IsMax = this.Msb = UInt64.MaxValue && this.Lsb = UInt64.MaxValue
+
+    member this.ToBytes() =
+        let bytes = Array.zeroCreate<byte> 16
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(0, 8), this.Msb)
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(8, 8), this.Lsb)
+        bytes
+
+    override this.ToString() =
+        let hex =
+            this.Msb.ToString("x16", CultureInfo.InvariantCulture)
+            + this.Lsb.ToString("x16", CultureInfo.InvariantCulture)
+
+        $"{hex.Substring(0, 8)}-{hex.Substring(8, 4)}-{hex.Substring(12, 4)}-{hex.Substring(16, 4)}-{hex.Substring(20)}"
+
+[<RequireQualifiedAccess>]
+module Uuid =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private uuidPattern =
+        Regex(
+            "^\\s*(?:urn:uuid:)?\\{?"
+            + "([0-9a-fA-F]{8})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{4})-?([0-9a-fA-F]{12})"
+            + "\\}?\\s*$",
+            RegexOptions.Compiled ||| RegexOptions.CultureInvariant ||| RegexOptions.IgnoreCase
+        )
+
+    let private gregorianOffset = 122_192_928_000_000_000UL
+
+    let private createClockSequence () =
+        let bytes = Array.zeroCreate<byte> 2
+        RandomNumberGenerator.Fill(bytes)
+        ((int bytes[0] <<< 8) ||| int bytes[1]) &&& 0x3FFF
+
+    let private clockSequence = createClockSequence ()
+
+    let fromString (text: string) =
+        if isNull text then
+            raise (UuidException "UUID string must not be null")
+
+        let matchResult = uuidPattern.Match(text.Trim())
+
+        if not matchResult.Success then
+            raise (UuidException $"Invalid UUID string: '{text}'")
+
+        let hex =
+            matchResult.Groups[1].Value
+            + matchResult.Groups[2].Value
+            + matchResult.Groups[3].Value
+            + matchResult.Groups[4].Value
+            + matchResult.Groups[5].Value
+
+        { Msb = UInt64.Parse(hex.Substring(0, 16), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture)
+          Lsb = UInt64.Parse(hex.Substring(16), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture) }
+
+    let fromBytes (bytes: byte array) =
+        if isNull bytes then
+            raise (UuidException "UUID bytes must be exactly 16, got null")
+
+        if bytes.Length <> 16 then
+            raise (UuidException $"UUID bytes must be exactly 16, got {bytes.Length}")
+
+        { Msb = BinaryPrimitives.ReadUInt64BigEndian(bytes.AsSpan(0, 8))
+          Lsb = BinaryPrimitives.ReadUInt64BigEndian(bytes.AsSpan(8, 8)) }
+
+    let isValid (text: string) =
+        not (isNull text) && uuidPattern.IsMatch(text.Trim())
+
+    let toBytes (uuid: Uuid) = uuid.ToBytes()
+
+    let version (uuid: Uuid) = uuid.Version
+
+    let variant (uuid: Uuid) = uuid.Variant
+
+    let isNil (uuid: Uuid) = uuid.IsNil
+
+    let isMax (uuid: Uuid) = uuid.IsMax
+
+    let NIL = { Msb = 0UL; Lsb = 0UL }
+
+    let MAX = { Msb = UInt64.MaxValue; Lsb = UInt64.MaxValue }
+
+    let NAMESPACE_DNS = fromString "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+    let NAMESPACE_URL = fromString "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+
+    let NAMESPACE_OID = fromString "6ba7b812-9dad-11d1-80b4-00c04fd430c8"
+
+    let NAMESPACE_X500 = fromString "6ba7b814-9dad-11d1-80b4-00c04fd430c8"
+
+    let private stampVersionVariant (bytes: byte array) version =
+        bytes[6] <- byte ((int bytes[6] &&& 0x0F) ||| (version <<< 4))
+        bytes[8] <- byte ((int bytes[8] &&& 0x3F) ||| 0x80)
+        fromBytes bytes
+
+    let v4 () =
+        let bytes = RandomNumberGenerator.GetBytes 16
+        stampVersionVariant bytes 4
+
+    let v7 () =
+        let timestampMs = uint64 (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+        let random = RandomNumberGenerator.GetBytes 10
+        let raw = Array.zeroCreate<byte> 16
+        raw[0] <- byte ((timestampMs >>> 40) &&& 0xFFUL)
+        raw[1] <- byte ((timestampMs >>> 32) &&& 0xFFUL)
+        raw[2] <- byte ((timestampMs >>> 24) &&& 0xFFUL)
+        raw[3] <- byte ((timestampMs >>> 16) &&& 0xFFUL)
+        raw[4] <- byte ((timestampMs >>> 8) &&& 0xFFUL)
+        raw[5] <- byte (timestampMs &&& 0xFFUL)
+        raw[6] <- byte (0x70 ||| (int random[0] &&& 0x0F))
+        raw[7] <- random[1]
+        raw[8] <- byte (0x80 ||| (int random[2] &&& 0x3F))
+        Array.Copy(random, 3, raw, 9, 7)
+        fromBytes raw
+
+    let v1 () =
+        let timestamp =
+            uint64 (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) * 10_000UL
+            + gregorianOffset
+
+        let timeLow = timestamp &&& 0xFFFFFFFFUL
+        let timeMid = (timestamp >>> 32) &&& 0xFFFFUL
+        let timeHi = (timestamp >>> 48) &&& 0x0FFFUL
+        let msb = (timeLow <<< 32) ||| (timeMid <<< 16) ||| (0x1000UL ||| timeHi)
+        let clockSeqHi = 0x80UL ||| (uint64 clockSequence >>> 8)
+        let clockSeqLow = uint64 (clockSequence &&& 0xFF)
+        let nodeBytes = RandomNumberGenerator.GetBytes 6
+        nodeBytes[0] <- byte (int nodeBytes[0] ||| 0x01)
+
+        let mutable node = 0UL
+
+        for value in nodeBytes do
+            node <- (node <<< 8) ||| uint64 value
+
+        { Msb = msb
+          Lsb = (clockSeqHi <<< 56) ||| (clockSeqLow <<< 48) ||| node }
+
+    let private concat (left: byte array) (right: byte array) =
+        let result = Array.zeroCreate<byte> (left.Length + right.Length)
+        Buffer.BlockCopy(left, 0, result, 0, left.Length)
+        Buffer.BlockCopy(right, 0, result, left.Length, right.Length)
+        result
+
+    let v5 (namespaceId: Uuid) (name: string) =
+        if isNull name then
+            nullArg (nameof name)
+
+        let digest =
+            concat (namespaceId.ToBytes()) (Encoding.UTF8.GetBytes name)
+            |> SHA1.HashData
+
+        let raw = digest[..15]
+        stampVersionVariant raw 5
+
+    let v3 (namespaceId: Uuid) (name: string) =
+        if isNull name then
+            nullArg (nameof name)
+
+        concat (namespaceId.ToBytes()) (Encoding.UTF8.GetBytes name)
+        |> MD5.HashData
+        |> fun digest -> stampVersionVariant digest 3

--- a/code/packages/fsharp/uuid/required_capabilities.json
+++ b/code/packages/fsharp/uuid/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/uuid",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Uses cryptographic randomness through the runtime; no filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj
+++ b/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Uuid.fsproj" />
+    <Compile Include="UuidTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/UuidTests.fs
+++ b/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/UuidTests.fs
@@ -1,0 +1,153 @@
+namespace CodingAdventures.Uuid.Tests
+
+open System
+open CodingAdventures.Uuid
+open Xunit
+
+type UuidTests() =
+    [<Fact>]
+    member _.FromStringAcceptsSupportedForms() =
+        let expected = "550e8400-e29b-41d4-a716-446655440000"
+
+        Assert.Equal(expected, Uuid.fromString(expected).ToString())
+        Assert.Equal(expected, Uuid.fromString("550E8400-E29B-41D4-A716-446655440000").ToString())
+        Assert.Equal(expected, Uuid.fromString("550e8400e29b41d4a716446655440000").ToString())
+        Assert.Equal(expected, Uuid.fromString("{550e8400-e29b-41d4-a716-446655440000}").ToString())
+        Assert.Equal(expected, Uuid.fromString("urn:uuid:550e8400-e29b-41d4-a716-446655440000").ToString())
+        Assert.Equal(expected, Uuid.fromString("  550e8400-e29b-41d4-a716-446655440000  ").ToString())
+
+    [<Fact>]
+    member _.FromStringRejectsInvalidText() =
+        Assert.Throws<UuidException>(fun () -> Uuid.fromString "not-a-uuid" |> ignore) |> ignore
+        Assert.Throws<UuidException>(fun () -> Uuid.fromString "550e8400-e29b-41d4-a716-44665544000z" |> ignore) |> ignore
+        Assert.Throws<UuidException>(fun () -> Uuid.fromString "" |> ignore) |> ignore
+        Assert.Throws<UuidException>(fun () -> Uuid.fromString null |> ignore) |> ignore
+
+    [<Fact>]
+    member _.FromBytesRoundTripsAndRejectsWrongLength() =
+        let uuid = Uuid.fromString "550e8400-e29b-41d4-a716-446655440000"
+        let bytes = Uuid.toBytes uuid
+
+        Assert.Equal(16, bytes.Length)
+        Assert.Equal(uuid, Uuid.fromBytes bytes)
+        Assert.Throws<UuidException>(fun () -> Uuid.fromBytes (Array.zeroCreate 15) |> ignore) |> ignore
+        Assert.Throws<UuidException>(fun () -> Uuid.fromBytes (Array.zeroCreate 17) |> ignore) |> ignore
+        Assert.Throws<UuidException>(fun () -> Uuid.fromBytes null |> ignore) |> ignore
+
+    [<Fact>]
+    member _.PropertiesExposeVersionVariantAndExtremes() =
+        Assert.Equal(4, (Uuid.fromString "550e8400-e29b-41d4-a716-446655440000").Version)
+        Assert.Equal(1, (Uuid.fromString "6ba7b810-9dad-11d1-80b4-00c04fd430c8").Version)
+        Assert.Equal(5, (Uuid.fromString "886313e1-3b8a-5372-9b90-0c9aee199e5d").Version)
+        Assert.True(Uuid.NIL.IsNil)
+        Assert.False((Uuid.v4 ()).IsNil)
+        Assert.True(Uuid.MAX.IsMax)
+        Assert.False((Uuid.v4 ()).IsMax)
+        Assert.Equal("00000000-0000-0000-0000-000000000000", Uuid.NIL.ToString())
+        Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", Uuid.MAX.ToString())
+
+    [<Fact>]
+    member _.VariantClassifiesAllFamilies() =
+        for nibble in [ "8"; "9"; "a"; "b" ] do
+            let uuid = Uuid.fromString $"550e8400-e29b-41d4-{nibble}716-446655440000"
+            Assert.Equal("rfc4122", uuid.Variant)
+
+        Assert.Equal("ncs", { Msb = 0UL; Lsb = 0x0000_0000_0000_0000UL }.Variant)
+        Assert.Equal("ncs", { Msb = 0UL; Lsb = 0x4000_0000_0000_0000UL }.Variant)
+        Assert.Equal("microsoft", { Msb = 0UL; Lsb = 0xC000_0000_0000_0000UL }.Variant)
+        Assert.Equal("reserved", { Msb = 0UL; Lsb = 0xE000_0000_0000_0000UL }.Variant)
+
+    [<Fact>]
+    member _.EqualityHashAndOrderingUseUnsignedBytes() =
+        let first = Uuid.fromString "00000000-0000-0000-0000-000000000001"
+        let second = Uuid.fromString "00000000-0000-0000-0000-000000000002"
+        let high = Uuid.fromString "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+        Assert.Equal(first, Uuid.fromString(first.ToString()))
+        Assert.Equal(first.GetHashCode(), (Uuid.fromString(first.ToString())).GetHashCode())
+        Assert.True(compare first second < 0)
+        Assert.True(compare second first > 0)
+        Assert.True(compare first high < 0)
+        Assert.Equal(0, compare first first)
+        Assert.Single(Set.ofList [ first; Uuid.fromString(first.ToString()) ]) |> ignore
+
+    [<Fact>]
+    member _.IsValidMatchesParser() =
+        Assert.True(Uuid.isValid "550e8400-e29b-41d4-a716-446655440000")
+        Assert.True(Uuid.isValid "550e8400e29b41d4a716446655440000")
+        Assert.True(Uuid.isValid "{550e8400-e29b-41d4-a716-446655440000}")
+        Assert.True(Uuid.isValid "urn:uuid:550e8400-e29b-41d4-a716-446655440000")
+        Assert.False(Uuid.isValid "not-a-uuid")
+        Assert.False(Uuid.isValid "")
+        Assert.False(Uuid.isValid null)
+        Assert.False(Uuid.isValid "550e8400-e29b-41d4-a716-44665544000z")
+
+    [<Fact>]
+    member _.V4HasVersionVariantFormatAndUniqueness() =
+        let value = Uuid.v4 ()
+        let text = value.ToString()
+
+        Assert.Equal(4, value.Version)
+        Assert.Equal("rfc4122", value.Variant)
+        Assert.Equal('4', text[14])
+        Assert.Contains(text[19], [| '8'; '9'; 'a'; 'b' |])
+
+        let seen = [ 1..1000 ] |> List.map (fun _ -> Uuid.v4 ()) |> Set.ofList
+        Assert.Equal(1000, seen.Count)
+
+    [<Fact>]
+    member _.V7HasVersionVariantTimestampAndUniqueness() =
+        let first = Uuid.v7 ()
+        let second = Uuid.v7 ()
+        let firstTimestamp = first.Msb >>> 16
+        let secondTimestamp = second.Msb >>> 16
+
+        Assert.Equal(7, first.Version)
+        Assert.Equal("rfc4122", first.Variant)
+        Assert.True(firstTimestamp <= secondTimestamp)
+
+        let seen = [ 1..100 ] |> List.map (fun _ -> Uuid.v7 ()) |> Set.ofList
+        Assert.Equal(100, seen.Count)
+
+    [<Fact>]
+    member _.V1HasVersionVariantAndUniqueness() =
+        let value = Uuid.v1 ()
+
+        Assert.Equal(1, value.Version)
+        Assert.Equal("rfc4122", value.Variant)
+
+        let seen = [ 1..100 ] |> List.map (fun _ -> Uuid.v1 ()) |> Set.ofList
+        Assert.Equal(100, seen.Count)
+
+    [<Fact>]
+    member _.V5MatchesRfcVectorAndIsDeterministic() =
+        Assert.Equal("886313e1-3b8a-5372-9b90-0c9aee199e5d", (Uuid.v5 Uuid.NAMESPACE_DNS "python.org").ToString())
+        Assert.Equal(Uuid.v5 Uuid.NAMESPACE_DNS "example.com", Uuid.v5 Uuid.NAMESPACE_DNS "example.com")
+        Assert.NotEqual(Uuid.v5 Uuid.NAMESPACE_DNS "example.com", Uuid.v5 Uuid.NAMESPACE_DNS "example.org")
+        Assert.NotEqual(Uuid.v5 Uuid.NAMESPACE_DNS "example.com", Uuid.v5 Uuid.NAMESPACE_URL "example.com")
+        Assert.Equal(5, (Uuid.v5 Uuid.NAMESPACE_DNS "test").Version)
+        Assert.Equal("rfc4122", (Uuid.v5 Uuid.NAMESPACE_DNS "test").Variant)
+        Assert.Throws<ArgumentNullException>(fun () -> Uuid.v5 Uuid.NAMESPACE_DNS null |> ignore) |> ignore
+
+    [<Fact>]
+    member _.V3MatchesRfcVectorAndIsDeterministic() =
+        Assert.Equal("6fa459ea-ee8a-3ca4-894e-db77e160355e", (Uuid.v3 Uuid.NAMESPACE_DNS "python.org").ToString())
+        Assert.Equal(Uuid.v3 Uuid.NAMESPACE_DNS "example.com", Uuid.v3 Uuid.NAMESPACE_DNS "example.com")
+        Assert.NotEqual(Uuid.v3 Uuid.NAMESPACE_DNS "python.org", Uuid.v5 Uuid.NAMESPACE_DNS "python.org")
+        Assert.Equal(3, (Uuid.v3 Uuid.NAMESPACE_DNS "test").Version)
+        Assert.Throws<ArgumentNullException>(fun () -> Uuid.v3 Uuid.NAMESPACE_DNS null |> ignore) |> ignore
+
+    [<Fact>]
+    member _.NamespaceConstantsMatchRfcValues() =
+        Assert.Equal("6ba7b810-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_DNS.ToString())
+        Assert.Equal("6ba7b811-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_URL.ToString())
+        Assert.Equal("6ba7b812-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_OID.ToString())
+        Assert.Equal("6ba7b814-9dad-11d1-80b4-00c04fd430c8", Uuid.NAMESPACE_X500.ToString())
+
+    [<Fact>]
+    member _.ExceptionCanWrapCause() =
+        let inner = InvalidOperationException "boom"
+        let exceptionValue = UuidException("wrapped", inner)
+
+        Assert.Equal("wrapped", exceptionValue.Message)
+        Assert.Same(inner, exceptionValue.InnerException)


### PR DESCRIPTION
## Summary
- add C# and F# UUID packages covering parsing, formatting, byte conversion, comparison, namespace constants, and v1/v3/v4/v5/v7 generation
- mirror the Java/Kotlin UUID surface while using idiomatic .NET value types and F# module helpers
- include package metadata, capability manifests, BUILD commands, and xUnit coverage for both runtimes

## Verification
- dotnet test tests\CodingAdventures.Uuid.Tests\CodingAdventures.Uuid.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.Uuid.Tests\CodingAdventures.Uuid.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line