### PR TITLE
feat(interpreter-ir): LANG16 PR1 — heap / GC opcodes and ref<T> type

### DIFF
--- a/code/packages/python/interpreter-ir/CHANGELOG.md
+++ b/code/packages/python/interpreter-ir/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## [Unreleased]
 
+### Added — LANG16 PR1: heap / GC opcodes and ref<T> type encoding
+
+Schema-only foundation for the GC plug-in framework — vm-core, jit-core,
+and the GC packages will fill in the runtime semantics in follow-up
+PRs.  Programs that don't allocate are unaffected: the new opcodes
+never appear in their IIR, and ``IIRInstr.may_alloc`` defaults to
+``False``.
+
+**New opcodes** (in ``HEAP_OPS``):
+
+- ``alloc(size, kind)`` — allocate ``size`` bytes tagged ``kind``;
+  produces ``ref<any>``.  Sets a safepoint.
+- ``box(value)`` — allocate a single-slot heap cell holding ``value``;
+  produces ``ref<typeof(value)>``.  Sets a safepoint.
+- ``unbox(ref)`` — deref a single-slot box; traps on null.
+- ``field_load(ref, offset)`` — read one field from a heap object.
+- ``field_store(ref, offset, value)`` — write one field; emits a
+  write barrier when the active GC requires one.
+- ``is_null(ref)`` — produces ``bool``.
+- ``safepoint()`` — yield to the GC if a collection is pending.
+
+**New opcode-category sets**:
+
+- ``HEAP_OPS`` — the seven opcodes above.
+- ``ALLOCATING_OPS`` — the subset that may trigger a collection
+  (``alloc``, ``box``, ``safepoint``).
+
+``alloc``, ``box``, ``unbox``, ``field_load``, ``is_null`` are added
+to ``VALUE_OPS``.  ``field_store`` and ``safepoint`` are added to
+``SIDE_EFFECT_OPS``.
+
+**``ref<T>`` type encoding**:
+
+Heap pointers use the string form ``"ref<T>"`` where ``T`` is the
+pointee type.  Examples: ``"ref<u8>"``, ``"ref<any>"``,
+``"ref<ref<any>>"``.  Three helpers are exported:
+
+- ``is_ref_type(s) -> bool``
+- ``unwrap_ref_type(s) -> str | None`` (``"ref<u8>"`` → ``"u8"``)
+- ``make_ref_type(t) -> str`` (``"u8"`` → ``"ref<u8>"``)
+
+``IIRInstr.is_typed()`` was updated to recognise ``ref<T>`` as a
+concrete type so the profiler skips them (heap references are not
+profiled the way primitives are).
+
+**``IIRInstr.may_alloc: bool`` field**:
+
+A new optional flag (default ``False``) frontends set on any
+instruction that may trigger a heap allocation — directly via the
+allocating opcodes, or transitively via a ``call`` whose callee
+allocates.  vm-core uses this in PR3 to decide where to insert GC
+safepoints; for now it is metadata.  ``compare=False`` so it does
+not affect ``==``.
+
+**Test coverage**: 140 tests, 100% coverage (was 114, 100%).  Pre-existing
+lint warnings on ``feedback_slots`` and ``source_map`` field declarations
+fixed in passing.
+
 ### Added — LANG17 PR4: optional frontend side tables on IIRFunction
 
 - `IIRFunction.feedback_slots: dict[int, int]` — optional

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
@@ -44,6 +44,7 @@ from interpreter_ir.instr import IIRInstr
 from interpreter_ir.module import IIRModule
 from interpreter_ir.opcodes import (
     ALL_OPS,
+    ALLOCATING_OPS,
     ARITHMETIC_OPS,
     BITWISE_OPS,
     BRANCH_OPS,
@@ -53,11 +54,17 @@ from interpreter_ir.opcodes import (
     CONCRETE_TYPES,
     CONTROL_OPS,
     DYNAMIC_TYPE,
+    HEAP_OPS,
     IO_OPS,
     MEMORY_OPS,
     POLYMORPHIC_TYPE,
+    REF_PREFIX,
+    REF_SUFFIX,
     SIDE_EFFECT_OPS,
     VALUE_OPS,
+    is_ref_type,
+    make_ref_type,
+    unwrap_ref_type,
 )
 from interpreter_ir.serialise import deserialise, serialise
 from interpreter_ir.slot_state import (
@@ -81,6 +88,7 @@ __all__ = [
     "deserialise",
     # Opcode sets
     "ALL_OPS",
+    "ALLOCATING_OPS",
     "ARITHMETIC_OPS",
     "BITWISE_OPS",
     "BRANCH_OPS",
@@ -88,12 +96,18 @@ __all__ = [
     "CMP_OPS",
     "COERCION_OPS",
     "CONTROL_OPS",
+    "HEAP_OPS",
     "IO_OPS",
     "MEMORY_OPS",
     "SIDE_EFFECT_OPS",
     "VALUE_OPS",
-    # Type constants
+    # Type constants and helpers
     "CONCRETE_TYPES",
     "DYNAMIC_TYPE",
     "POLYMORPHIC_TYPE",
+    "REF_PREFIX",
+    "REF_SUFFIX",
+    "is_ref_type",
+    "make_ref_type",
+    "unwrap_ref_type",
 ]

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/function.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/function.py
@@ -101,7 +101,9 @@ class IIRFunction:
     # observation time.
     # ----------------------------------------------------------------------
 
-    feedback_slots: dict[int, int] = field(default_factory=dict, repr=False, compare=False)
+    feedback_slots: dict[int, int] = field(
+        default_factory=dict, repr=False, compare=False
+    )
     """Optional: ``slot_index → iir_instr_index`` mapping.
 
     Frontends that allocate named feedback slots at compile time (Tetrad,
@@ -112,7 +114,9 @@ class IIRFunction:
     returns a list indexed by slot index).
     """
 
-    source_map: list[tuple[int, int, int]] = field(default_factory=list, repr=False, compare=False)
+    source_map: list[tuple[int, int, int]] = field(
+        default_factory=list, repr=False, compare=False
+    )
     """Optional: ``(iir_index, source_a, source_b)`` triples.
 
     Frontends populate this with whatever indexing scheme they need on

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/instr.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/instr.py
@@ -112,14 +112,29 @@ class IIRInstr:
     ``None`` means no guard has been emitted yet.
     """
 
+    may_alloc: bool = field(default=False, repr=False, compare=False)
+    """LANG16 hint: this instruction may trigger a heap allocation.
+
+    Set by language frontends for any instruction that allocates (`alloc`,
+    `box`, `safepoint`) or transitively reaches one through a function
+    call.  vm-core uses this to decide where to insert GC safepoints —
+    a collection cycle can only happen at an instruction whose
+    ``may_alloc`` is True (or at the periodic forced-safepoint interval
+    for tight loops with no allocation).
+
+    Defaults to ``False`` so existing callers see no behaviour change:
+    programs that never allocate pay zero GC overhead because no
+    instruction's ``may_alloc`` ever fires.
+    """
+
     # -----------------------------------------------------------------------
     # Convenience helpers
     # -----------------------------------------------------------------------
 
     def is_typed(self) -> bool:
         """Return True if this instruction has a concrete (non-dynamic) type hint."""
-        from interpreter_ir.opcodes import CONCRETE_TYPES
-        return self.type_hint in CONCRETE_TYPES
+        from interpreter_ir.opcodes import CONCRETE_TYPES, is_ref_type
+        return self.type_hint in CONCRETE_TYPES or is_ref_type(self.type_hint)
 
     def has_observation(self) -> bool:
         """Return True if the profiler has recorded at least one observation."""

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
@@ -1,12 +1,14 @@
-"""Opcode category frozensets for InterpreterIR.
+"""Opcode category frozensets and type-string helpers for InterpreterIR.
 
-These sets let vm-core, jit-core, and passes classify instructions without
-comparing against long lists of mnemonic strings.
+These let vm-core, jit-core, and IR passes classify instructions
+without comparing against long lists of mnemonic strings.
 
 Usage::
 
-    from interpreter_ir.opcodes import ARITHMETIC_OPS, CMP_OPS
+    from interpreter_ir.opcodes import ARITHMETIC_OPS, CMP_OPS, is_ref_type
     if instr.op in ARITHMETIC_OPS:
+        ...
+    if is_ref_type(instr.type_hint):
         ...
 """
 
@@ -25,6 +27,51 @@ DYNAMIC_TYPE = "any"
 
 # Sentinel placed by the vm-core profiler when multiple types are observed.
 POLYMORPHIC_TYPE = "polymorphic"
+
+# ---------------------------------------------------------------------------
+# Reference-type encoding (LANG16)
+# ---------------------------------------------------------------------------
+#
+# Heap pointers are typed as ``"ref<T>"`` where ``T`` is the pointee type.
+# Examples::
+#
+#     "ref<u8>"        → pointer to a heap-allocated u8 (a "boxed" byte)
+#     "ref<any>"       → pointer to a heap object of unknown shape
+#                        (Lisp's default — every cons cell is ref<any>)
+#     "ref<ref<any>>"  → pointer to a pointer (e.g. a cons cell's `cdr` slot)
+#
+# The string-form encoding keeps the rest of the type system unchanged.
+# Anything that needs to recognise ref types calls :func:`is_ref_type` or
+# :func:`unwrap_ref_type`.
+# ---------------------------------------------------------------------------
+
+REF_PREFIX = "ref<"
+REF_SUFFIX = ">"
+
+
+def is_ref_type(type_hint: str) -> bool:
+    """Return True if ``type_hint`` is a heap-reference type ``ref<T>``."""
+    return type_hint.startswith(REF_PREFIX) and type_hint.endswith(REF_SUFFIX)
+
+
+def unwrap_ref_type(type_hint: str) -> str | None:
+    """Return ``T`` for ``ref<T>``, else ``None``.
+
+    Examples::
+
+        unwrap_ref_type("ref<u8>")        == "u8"
+        unwrap_ref_type("ref<ref<any>>")  == "ref<any>"
+        unwrap_ref_type("u8")             is None
+    """
+    if not is_ref_type(type_hint):
+        return None
+    return type_hint[len(REF_PREFIX):-len(REF_SUFFIX)]
+
+
+def make_ref_type(inner: str) -> str:
+    """Wrap ``inner`` as a reference type.  Inverse of :func:`unwrap_ref_type`."""
+    return f"{REF_PREFIX}{inner}{REF_SUFFIX}"
+
 
 # ---------------------------------------------------------------------------
 # Opcode categories
@@ -66,18 +113,53 @@ COERCION_OPS: frozenset[str] = frozenset(
     {"cast", "type_assert"}
 )
 
+# ---------------------------------------------------------------------------
+# Heap / GC opcodes (LANG16)
+# ---------------------------------------------------------------------------
+#
+# Programs that don't allocate ignore this entire set — these opcodes
+# never appear in their IIR and the GC subsystem is never wired in.
+# Programs that DO allocate use these seven opcodes to talk to the
+# heap / GC; everything richer (weak refs, finalizers, generational
+# barriers) builds on top in library code.
+# ---------------------------------------------------------------------------
+
+HEAP_OPS: frozenset[str] = frozenset(
+    {
+        "alloc",        # dest = heap-alloc(size, kind);   may_alloc
+        "box",          # dest = heap-alloc-and-store(value);  may_alloc
+        "unbox",        # dest = *ref;  trap on null
+        "field_load",   # dest = *(ref + offset)
+        "field_store",  # *(ref + offset) = value;  may emit write barrier
+        "is_null",      # dest = (ref == NULL)
+        "safepoint",    # yield to GC if collection pending; may_alloc
+    }
+)
+
 # All ops that produce a value (have a non-None dest).
 _VALUE_EXTRA: frozenset[str] = frozenset(
     {"const", "load_reg", "load_mem", "call", "call_builtin", "io_in", "cast"}
 )
-VALUE_OPS: frozenset[str] = ARITHMETIC_OPS | BITWISE_OPS | CMP_OPS | _VALUE_EXTRA
+_HEAP_VALUE_OPS: frozenset[str] = frozenset(
+    {"alloc", "box", "unbox", "field_load", "is_null"}
+)
+VALUE_OPS: frozenset[str] = (
+    ARITHMETIC_OPS | BITWISE_OPS | CMP_OPS | _VALUE_EXTRA | _HEAP_VALUE_OPS
+)
 
 # All ops that have side effects beyond producing a value.
 SIDE_EFFECT_OPS: frozenset[str] = (
     BRANCH_OPS
     | CONTROL_OPS
     | frozenset({"store_reg", "store_mem", "io_out", "type_assert"})
+    | frozenset({"field_store", "safepoint"})
 )
+
+# Heap ops whose execution may trigger a GC cycle (collection happens
+# at safepoints, and these are the safepoints).  Frontends should set
+# ``IIRInstr.may_alloc=True`` for every emission of these opcodes plus
+# any ``call`` whose callee transitively allocates.
+ALLOCATING_OPS: frozenset[str] = frozenset({"alloc", "box", "safepoint"})
 
 # All known opcodes.
 ALL_OPS: frozenset[str] = (
@@ -90,5 +172,6 @@ ALL_OPS: frozenset[str] = (
     | CALL_OPS
     | IO_OPS
     | COERCION_OPS
+    | HEAP_OPS
     | frozenset({"const"})
 )

--- a/code/packages/python/interpreter-ir/tests/test_heap_opcodes.py
+++ b/code/packages/python/interpreter-ir/tests/test_heap_opcodes.py
@@ -1,0 +1,233 @@
+"""Tests for the LANG16 heap / GC additions to InterpreterIR.
+
+These verify the *schema* contract — the new opcodes appear in the
+right opcode-category sets, ``ref<T>`` types parse and round-trip
+correctly, and the new ``IIRInstr.may_alloc`` field defaults to
+False so existing programs see no behaviour change.
+
+Runtime semantics (when does a collection actually fire, what does
+``alloc`` return, etc.) live in vm-core and the GC algorithms; tests
+for those land in their own packages.
+"""
+
+from __future__ import annotations
+
+from interpreter_ir import (
+    ALL_OPS,
+    ALLOCATING_OPS,
+    HEAP_OPS,
+    SIDE_EFFECT_OPS,
+    VALUE_OPS,
+    IIRInstr,
+    is_ref_type,
+    make_ref_type,
+    unwrap_ref_type,
+)
+
+# ---------------------------------------------------------------------------
+# Heap opcodes — schema membership
+# ---------------------------------------------------------------------------
+
+
+def test_heap_opcodes_are_in_all_ops() -> None:
+    """Every HEAP_OPS member is also in ALL_OPS."""
+    for op in HEAP_OPS:
+        assert op in ALL_OPS
+
+
+def test_heap_ops_canonical_set() -> None:
+    """The seven LANG16 heap opcodes are present and the set is exact."""
+    assert frozenset({
+        "alloc",
+        "box",
+        "unbox",
+        "field_load",
+        "field_store",
+        "is_null",
+        "safepoint",
+    }) == HEAP_OPS
+
+
+def test_value_producing_heap_ops_are_in_value_ops() -> None:
+    """``alloc``, ``box``, ``unbox``, ``field_load``, ``is_null``
+    produce values and so must appear in ``VALUE_OPS``."""
+    for op in ("alloc", "box", "unbox", "field_load", "is_null"):
+        assert op in VALUE_OPS
+
+
+def test_side_effect_heap_ops_are_in_side_effect_ops() -> None:
+    """``field_store`` mutates the heap and ``safepoint`` may yield
+    to the GC; both must appear in ``SIDE_EFFECT_OPS``."""
+    assert "field_store" in SIDE_EFFECT_OPS
+    assert "safepoint" in SIDE_EFFECT_OPS
+
+
+def test_allocating_ops_subset_of_heap_ops() -> None:
+    """``ALLOCATING_OPS`` must be a subset of ``HEAP_OPS``."""
+    assert ALLOCATING_OPS.issubset(HEAP_OPS)
+
+
+def test_allocating_ops_canonical_set() -> None:
+    """Allocations happen at ``alloc``, ``box``, and ``safepoint``."""
+    assert frozenset({"alloc", "box", "safepoint"}) == ALLOCATING_OPS
+
+
+# ---------------------------------------------------------------------------
+# ref<T> type encoding
+# ---------------------------------------------------------------------------
+
+
+def test_is_ref_type_recognises_ref_strings() -> None:
+    assert is_ref_type("ref<u8>") is True
+    assert is_ref_type("ref<any>") is True
+    assert is_ref_type("ref<ref<any>>") is True
+    assert is_ref_type("ref<some-language-type>") is True
+
+
+def test_is_ref_type_rejects_plain_types() -> None:
+    assert is_ref_type("u8") is False
+    assert is_ref_type("any") is False
+    assert is_ref_type("bool") is False
+    assert is_ref_type("") is False
+
+
+def test_unwrap_ref_type_returns_inner() -> None:
+    assert unwrap_ref_type("ref<u8>") == "u8"
+    assert unwrap_ref_type("ref<any>") == "any"
+
+
+def test_unwrap_ref_type_handles_nested_refs() -> None:
+    """``ref<ref<any>>`` unwraps once to ``ref<any>``."""
+    assert unwrap_ref_type("ref<ref<any>>") == "ref<any>"
+    # And once more.
+    assert unwrap_ref_type("ref<any>") == "any"
+
+
+def test_unwrap_ref_type_returns_none_for_non_ref() -> None:
+    assert unwrap_ref_type("u8") is None
+    assert unwrap_ref_type("any") is None
+    assert unwrap_ref_type("ref") is None  # not "ref<...>"
+
+
+def test_make_and_unwrap_round_trip() -> None:
+    """``unwrap(make(t)) == t`` for any base type."""
+    for t in ("u8", "u16", "any", "str", "ref<any>", "cons", "symbol"):
+        assert unwrap_ref_type(make_ref_type(t)) == t
+
+
+def test_make_ref_type_format() -> None:
+    assert make_ref_type("u8") == "ref<u8>"
+    assert make_ref_type("any") == "ref<any>"
+
+
+# ---------------------------------------------------------------------------
+# IIRInstr — may_alloc field
+# ---------------------------------------------------------------------------
+
+
+def test_may_alloc_defaults_to_false() -> None:
+    """Existing callers that don't set ``may_alloc`` see the safe default."""
+    instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+    assert instr.may_alloc is False
+
+
+def test_may_alloc_is_settable() -> None:
+    """Frontends set ``may_alloc=True`` for allocating instructions."""
+    instr = IIRInstr("alloc", "v0", [16, 0], "ref<any>", may_alloc=True)
+    assert instr.may_alloc is True
+
+
+def test_may_alloc_does_not_affect_equality() -> None:
+    """``may_alloc`` is ``compare=False`` so it does not affect ``==``."""
+    a = IIRInstr("add", "v0", ["a", "b"], "u8")
+    b = IIRInstr("add", "v0", ["a", "b"], "u8", may_alloc=True)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# is_typed() recognises ref<T> as typed
+# ---------------------------------------------------------------------------
+
+
+def test_is_typed_true_for_ref_types() -> None:
+    """``ref<T>`` is a concrete type — JITs should not run the
+    profiler on it."""
+    instr = IIRInstr("alloc", "v0", [16, 0], "ref<any>")
+    assert instr.is_typed() is True
+
+
+def test_is_typed_false_for_any() -> None:
+    instr = IIRInstr("add", "v0", ["a", "b"], "any")
+    assert instr.is_typed() is False
+
+
+def test_is_typed_true_for_plain_concrete() -> None:
+    """Sanity: existing concrete types still report typed."""
+    instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+    assert instr.is_typed() is True
+
+
+# ---------------------------------------------------------------------------
+# Heap-opcode IIRInstr smoke tests — construction must not raise
+# ---------------------------------------------------------------------------
+
+
+def test_alloc_instr() -> None:
+    """``alloc size, kind`` produces a ``ref<any>``."""
+    instr = IIRInstr(
+        "alloc",
+        "cell",
+        [16, 0],            # size, kind_id
+        "ref<any>",
+        may_alloc=True,
+    )
+    assert instr.op == "alloc"
+    assert instr.may_alloc is True
+    assert is_ref_type(instr.type_hint)
+
+
+def test_box_instr() -> None:
+    """``box value`` boxes a primitive into a single-slot heap cell."""
+    instr = IIRInstr("box", "p", ["x"], "ref<u8>", may_alloc=True)
+    assert instr.op == "box"
+    assert unwrap_ref_type(instr.type_hint) == "u8"
+
+
+def test_unbox_instr() -> None:
+    """``unbox ref`` derefs a single-slot box."""
+    instr = IIRInstr("unbox", "x", ["p"], "u8")
+    assert instr.op == "unbox"
+    assert instr.may_alloc is False
+
+
+def test_field_load_instr() -> None:
+    """``field_load ref, offset`` reads one field from a heap object."""
+    instr = IIRInstr("field_load", "car", ["cell", 0], "any")
+    assert instr.op == "field_load"
+
+
+def test_field_store_instr() -> None:
+    """``field_store ref, offset, value`` writes one field; the field
+    is in ``srcs`` because ``field_store`` is void."""
+    instr = IIRInstr(
+        "field_store",
+        None,
+        ["cell", 1, "newval"],
+        "void",
+    )
+    assert instr.op == "field_store"
+    assert instr.dest is None
+
+
+def test_is_null_instr() -> None:
+    """``is_null ref`` returns a bool."""
+    instr = IIRInstr("is_null", "empty", ["cell"], "bool")
+    assert instr.op == "is_null"
+
+
+def test_safepoint_instr() -> None:
+    """``safepoint`` is void and may trigger a collection."""
+    instr = IIRInstr("safepoint", None, [], "void", may_alloc=True)
+    assert instr.op == "safepoint"
+    assert instr.dest is None
+    assert instr.may_alloc is True


### PR DESCRIPTION
## Summary

LANG16 PR1 of ~5: schema-only foundation for the GC plug-in framework. vm-core, jit-core, and the GC algorithms add the runtime semantics in follow-up PRs. **Programs that don't allocate are unaffected** — the new opcodes never appear in their IIR, `IIRInstr.may_alloc` defaults to False, and the existing 114 tests still pass unchanged.

## What's new

**HEAP_OPS — seven new opcodes**

| Opcode | Operands | Effect | `may_alloc` |
|---|---|---|---|
| `alloc` | (size, kind) | `dest = ref<any>` | yes |
| `box` | (value,) | `dest = ref<typeof(value)>` | yes |
| `unbox` | (ref,) | `dest = *ref` (trap on null) | no |
| `field_load` | (ref, offset) | `dest = *(ref + offset)` | no |
| `field_store` | (ref, offset, value) | `*(ref + offset) = value` | no* |
| `is_null` | (ref,) | `dest = (ref == NULL)` | no |
| `safepoint` | () | yield to GC if pending | yes |

`alloc`/`box`/`unbox`/`field_load`/`is_null` join `VALUE_OPS`. `field_store`/`safepoint` join `SIDE_EFFECT_OPS`. `ALLOCATING_OPS = {alloc, box, safepoint}` is a new convenience set for the safepoint detection in PR3.

**`ref<T>` type encoding**

Heap pointers use the string form `"ref<T>"`. Examples: `"ref<u8>"`, `"ref<any>"`, `"ref<ref<any>>"`. Three helpers exported: `is_ref_type`, `unwrap_ref_type`, `make_ref_type`.

I picked the string form so the rest of the type system stays unchanged — existing `CONCRETE_TYPES` membership, serialiser, repr, and tests all work without modification. Anything that needs to recognise refs calls a helper; nothing parses type strings character-by-character.

`IIRInstr.is_typed()` was updated to recognise `ref<T>` as concrete so the profiler skips heap references (their type is statically known).

**`IIRInstr.may_alloc: bool` field**

Optional flag (default `False`) frontends set on any instruction that may trigger heap allocation — directly via `HEAP_OPS` or transitively through a `call`. vm-core uses this in PR3 to insert GC safepoints; for now it's metadata. `compare=False` so it doesn't affect `==`.

## Tests

**140 tests, 100% coverage** (was 114 / 100%). New file `test_heap_opcodes.py` (26 tests):
- Schema membership: every heap op in `ALL_OPS`, value-producing in `VALUE_OPS`, side-effect in `SIDE_EFFECT_OPS`, `ALLOCATING_OPS ⊂ HEAP_OPS`
- `ref<T>` recognition (positive + negative), unwrap, make, round-trips, nested refs
- `may_alloc` default (`False`), settable, doesn't affect equality
- `is_typed()` returns True for `ref<T>`, False for `"any"`
- Construction smoke tests for all seven heap-opcode instrs

Two pre-existing `E501` lint warnings on `IIRFunction.feedback_slots` and `source_map` field declarations fixed in passing.

## What this unlocks

- **PR2**: `garbage-collector` ABC additions (`should_collect`, `write_barrier`, no-op defaults preserve back-compat)
- **PR3**: vm-core integration — opcode handlers, `enumerate_roots()`, dispatch-loop safepoints, `gc` config field
- **PR4**: `RefCountingGC` — second algorithm, demonstrates pluggability
- **PR5**: End-to-end demo (cons-cell allocator + traversal) running through both mark-and-sweep and reference counting, asserting same observable output

## Test plan

- [x] interpreter-ir: 140 tests, 100% coverage, ruff clean
- [x] All existing tests still pass (no schema breakage)
- [x] `may_alloc` default preserves behaviour for non-allocating frontends
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)