### PR TITLE
feat(parity): add dotnet segment tree packages

### DIFF
--- a/code/packages/csharp/segment-tree/BUILD
+++ b/code/packages/csharp/segment-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/segment-tree/BUILD_windows
+++ b/code/packages/csharp/segment-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/segment-tree/CHANGELOG.md
+++ b/code/packages/csharp/segment-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# segment tree package.

--- a/code/packages/csharp/segment-tree/CodingAdventures.SegmentTree.csproj
+++ b/code/packages/csharp/segment-tree/CodingAdventures.SegmentTree.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SegmentTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Generic segment tree for range queries and point updates</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/segment-tree/README.md
+++ b/code/packages/csharp/segment-tree/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.SegmentTree.CSharp
+
+Generic segment tree for monoid-based range queries and point updates, with
+integer sum, min, max, and GCD factory helpers.

--- a/code/packages/csharp/segment-tree/SegmentTree.cs
+++ b/code/packages/csharp/segment-tree/SegmentTree.cs
@@ -1,0 +1,199 @@
+namespace CodingAdventures.SegmentTree;
+
+/// <summary>
+/// A generic segment tree supporting range queries and point updates in O(log n).
+/// </summary>
+public sealed class SegmentTree<T>
+{
+    /// <summary>
+    /// Package version.
+    /// </summary>
+    public const string VERSION = "0.1.0";
+
+    private readonly T[] _tree;
+    private readonly Func<T, T, T> _combine;
+    private readonly T _identity;
+    private readonly int _size;
+
+    /// <summary>
+    /// Build a segment tree over the provided values.
+    /// </summary>
+    public SegmentTree(IReadOnlyList<T> values, Func<T, T, T> combine, T identity)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        ArgumentNullException.ThrowIfNull(combine);
+
+        _size = values.Count;
+        _combine = combine;
+        _identity = identity;
+        _tree = new T[Math.Max(4, 4 * _size)];
+        Array.Fill(_tree, identity);
+
+        if (_size > 0)
+        {
+            Build(values, node: 1, left: 0, right: _size - 1);
+        }
+    }
+
+    /// <summary>
+    /// Length of the source array.
+    /// </summary>
+    public int Size => _size;
+
+    /// <summary>
+    /// Length of the source array.
+    /// </summary>
+    public int Count => _size;
+
+    /// <summary>
+    /// True when the source array is empty.
+    /// </summary>
+    public bool IsEmpty => _size == 0;
+
+    /// <summary>
+    /// Return the aggregate over values[queryLeft..queryRight], inclusive.
+    /// </summary>
+    public T Query(int queryLeft, int queryRight)
+    {
+        if (queryLeft < 0 || queryRight >= _size || queryLeft > queryRight)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(queryLeft),
+                $"Invalid query range [{queryLeft}, {queryRight}] for array of size {_size}.");
+        }
+
+        return QueryHelper(node: 1, left: 0, right: _size - 1, queryLeft, queryRight);
+    }
+
+    /// <summary>
+    /// Replace values[index] and recompute affected ancestors.
+    /// </summary>
+    public void Update(int index, T value)
+    {
+        if (index < 0 || index >= _size)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), $"Index {index} out of range for array of size {_size}.");
+        }
+
+        UpdateHelper(node: 1, left: 0, right: _size - 1, index, value);
+    }
+
+    /// <summary>
+    /// Reconstruct the current values from the leaf nodes.
+    /// </summary>
+    public IReadOnlyList<T> ToList()
+    {
+        var result = new List<T>(_size);
+        if (_size > 0)
+        {
+            CollectLeaves(node: 1, left: 0, right: _size - 1, result);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Build a range-sum segment tree.
+    /// </summary>
+    public static SegmentTree<int> SumTree(IReadOnlyList<int> values) => new(values, static (a, b) => a + b, 0);
+
+    /// <summary>
+    /// Build a range-minimum segment tree.
+    /// </summary>
+    public static SegmentTree<int> MinTree(IReadOnlyList<int> values) => new(values, Math.Min, int.MaxValue);
+
+    /// <summary>
+    /// Build a range-maximum segment tree.
+    /// </summary>
+    public static SegmentTree<int> MaxTree(IReadOnlyList<int> values) => new(values, Math.Max, int.MinValue);
+
+    /// <summary>
+    /// Build a range-GCD segment tree.
+    /// </summary>
+    public static SegmentTree<int> GcdTree(IReadOnlyList<int> values) => new(values, Gcd, 0);
+
+    /// <summary>
+    /// Return a compact description of the tree metadata.
+    /// </summary>
+    public override string ToString() => $"SegmentTree{{n={_size}, identity={_identity}}}";
+
+    private void Build(IReadOnlyList<T> values, int node, int left, int right)
+    {
+        if (left == right)
+        {
+            _tree[node] = values[left];
+            return;
+        }
+
+        var mid = (left + right) / 2;
+        Build(values, 2 * node, left, mid);
+        Build(values, 2 * node + 1, mid + 1, right);
+        _tree[node] = _combine(_tree[2 * node], _tree[2 * node + 1]);
+    }
+
+    private T QueryHelper(int node, int left, int right, int queryLeft, int queryRight)
+    {
+        if (right < queryLeft || left > queryRight)
+        {
+            return _identity;
+        }
+
+        if (queryLeft <= left && right <= queryRight)
+        {
+            return _tree[node];
+        }
+
+        var mid = (left + right) / 2;
+        var leftResult = QueryHelper(2 * node, left, mid, queryLeft, queryRight);
+        var rightResult = QueryHelper(2 * node + 1, mid + 1, right, queryLeft, queryRight);
+        return _combine(leftResult, rightResult);
+    }
+
+    private void UpdateHelper(int node, int left, int right, int index, T value)
+    {
+        if (left == right)
+        {
+            _tree[node] = value;
+            return;
+        }
+
+        var mid = (left + right) / 2;
+        if (index <= mid)
+        {
+            UpdateHelper(2 * node, left, mid, index, value);
+        }
+        else
+        {
+            UpdateHelper(2 * node + 1, mid + 1, right, index, value);
+        }
+
+        _tree[node] = _combine(_tree[2 * node], _tree[2 * node + 1]);
+    }
+
+    private void CollectLeaves(int node, int left, int right, List<T> values)
+    {
+        if (left == right)
+        {
+            values.Add(_tree[node]);
+            return;
+        }
+
+        var mid = (left + right) / 2;
+        CollectLeaves(2 * node, left, mid, values);
+        CollectLeaves(2 * node + 1, mid + 1, right, values);
+    }
+
+    private static int Gcd(int a, int b)
+    {
+        a = Math.Abs(a);
+        b = Math.Abs(b);
+        while (b != 0)
+        {
+            var next = a % b;
+            a = b;
+            b = next;
+        }
+
+        return a;
+    }
+}

--- a/code/packages/csharp/segment-tree/required_capabilities.json
+++ b/code/packages/csharp/segment-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/segment-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.csproj
+++ b/code/packages/csharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.SegmentTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/SegmentTreeTests.cs
+++ b/code/packages/csharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/SegmentTreeTests.cs
@@ -1,0 +1,256 @@
+using CodingAdventures.SegmentTree;
+
+namespace CodingAdventures.SegmentTree.Tests;
+
+public sealed class SegmentTreeTests
+{
+    [Fact]
+    public void EmptyTreeHasMetadataAndRejectsOperations()
+    {
+        var tree = SegmentTree<int>.SumTree(Array.Empty<int>());
+
+        Assert.Equal(0, tree.Size);
+        Assert.Equal(0, tree.Count);
+        Assert.True(tree.IsEmpty);
+        Assert.Empty(tree.ToList());
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Query(0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Update(0, 1));
+    }
+
+    [Fact]
+    public void SingleElementTreesQueryAndUpdate()
+    {
+        var sum = SegmentTree<int>.SumTree(new[] { 42 });
+        var min = SegmentTree<int>.MinTree(new[] { -7 });
+        var max = SegmentTree<int>.MaxTree(new[] { 99 });
+
+        Assert.Equal(42, sum.Query(0, 0));
+        Assert.Equal(-7, min.Query(0, 0));
+        Assert.Equal(99, max.Query(0, 0));
+        sum.Update(0, 55);
+        Assert.Equal(55, sum.Query(0, 0));
+    }
+
+    [Fact]
+    public void SumTreeMatchesSpecExampleAndUpdates()
+    {
+        var values = new[] { 2, 1, 5, 3, 4 };
+        var tree = SegmentTree<int>.SumTree(values);
+
+        Assert.Equal(15, tree.Query(0, 4));
+        Assert.Equal(9, tree.Query(1, 3));
+        Assert.Equal(3, tree.Query(0, 1));
+        Assert.Equal(7, tree.Query(3, 4));
+        Assert.Equal(5, tree.Query(2, 2));
+
+        tree.Update(2, 7);
+
+        Assert.Equal(11, tree.Query(1, 3));
+        Assert.Equal(17, tree.Query(0, 4));
+        Assert.Equal(new[] { 2, 1, 7, 3, 4 }, tree.ToList());
+    }
+
+    [Fact]
+    public void SumTreeAllRangesMatchBruteForce()
+    {
+        var values = new[] { -3, 1, -4, 1, 5, -9, 2, 6 };
+        var tree = SegmentTree<int>.SumTree(values);
+
+        AssertAllRanges(values, tree, BruteSum);
+    }
+
+    [Fact]
+    public void MinTreeAllRangesAndUpdatesMatchBruteForce()
+    {
+        var values = new[] { 5, 3, 7, 1, 9, 2 };
+        var tree = SegmentTree<int>.MinTree(values);
+
+        AssertAllRanges(values, tree, BruteMin);
+        values[3] = 10;
+        tree.Update(3, 10);
+        Assert.Equal(2, tree.Query(0, 5));
+        AssertAllRanges(values, tree, BruteMin);
+    }
+
+    [Fact]
+    public void MaxTreeAllRangesAndUpdatesMatchBruteForce()
+    {
+        var values = new[] { 3, -1, 4, 1, 5, 9, 2, 6 };
+        var tree = SegmentTree<int>.MaxTree(values);
+
+        AssertAllRanges(values, tree, BruteMax);
+        values[2] = 100;
+        tree.Update(2, 100);
+        Assert.Equal(100, tree.Query(0, 7));
+        Assert.Equal(100, tree.Query(1, 3));
+        AssertAllRanges(values, tree, BruteMax);
+    }
+
+    [Fact]
+    public void GcdTreeAllRangesMatchBruteForce()
+    {
+        var values = new[] { 12, 8, 6, 4, 9 };
+        var tree = SegmentTree<int>.GcdTree(values);
+
+        Assert.Equal(2, tree.Query(0, 2));
+        Assert.Equal(1, tree.Query(1, 4));
+        Assert.Equal(4, tree.Query(0, 1));
+        AssertAllRanges(values, tree, BruteGcd);
+    }
+
+    [Fact]
+    public void NonPowerOfTwoAndMultipleUpdatesStayConsistent()
+    {
+        var values = new[] { 1, 2, 3, 4, 5, 6, 7 };
+        var tree = SegmentTree<int>.SumTree(values);
+
+        Assert.Equal(28, tree.Query(0, 6));
+        Assert.Equal(9, tree.Query(1, 3));
+        values[0] = 10;
+        values[6] = 20;
+        values[2] = 0;
+        tree.Update(0, 10);
+        tree.Update(6, 20);
+        tree.Update(2, 0);
+        Assert.Equal(values, tree.ToList());
+        AssertAllRanges(values, tree, BruteSum);
+    }
+
+    [Fact]
+    public void InvalidRangesAndIndicesThrow()
+    {
+        var tree = SegmentTree<int>.SumTree(new[] { 1, 2, 3 });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Query(2, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Query(-1, 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Query(0, 3));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Update(-1, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tree.Update(3, 5));
+    }
+
+    [Fact]
+    public void CustomCombineSupportsProductAndBitwiseOr()
+    {
+        var product = new SegmentTree<int>(new[] { 2, 3, 4, 5 }, static (a, b) => a * b, 1);
+        Assert.Equal(120, product.Query(0, 3));
+        Assert.Equal(24, product.Query(0, 2));
+        Assert.Equal(20, product.Query(2, 3));
+
+        var bitwiseOr = new SegmentTree<int>(new[] { 0b0001, 0b0010, 0b0100, 0b1000 }, static (a, b) => a | b, 0);
+        Assert.Equal(0b1111, bitwiseOr.Query(0, 3));
+        Assert.Equal(0b0011, bitwiseOr.Query(0, 1));
+        Assert.Equal(0b0110, bitwiseOr.Query(1, 2));
+    }
+
+    [Fact]
+    public void RandomStressMatchesReferenceArray()
+    {
+        var random = new Random(12345);
+        var values = Enumerable.Range(0, 200).Select(_ => random.Next(1000) - 500).ToArray();
+        var sum = SegmentTree<int>.SumTree(values);
+        var min = SegmentTree<int>.MinTree(values);
+        var max = SegmentTree<int>.MaxTree(values);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var left = random.Next(values.Length);
+            var right = left + random.Next(values.Length - left);
+            Assert.Equal(BruteSum(values, left, right), sum.Query(left, right));
+            Assert.Equal(BruteMin(values, left, right), min.Query(left, right));
+            Assert.Equal(BruteMax(values, left, right), max.Query(left, right));
+        }
+
+        for (var i = 0; i < 200; i++)
+        {
+            var index = random.Next(values.Length);
+            var value = random.Next(1000) - 500;
+            values[index] = value;
+            sum.Update(index, value);
+            min.Update(index, value);
+            max.Update(index, value);
+
+            var left = random.Next(values.Length);
+            var right = left + random.Next(values.Length - left);
+            Assert.Equal(BruteSum(values, left, right), sum.Query(left, right));
+            Assert.Equal(BruteMin(values, left, right), min.Query(left, right));
+            Assert.Equal(BruteMax(values, left, right), max.Query(left, right));
+        }
+    }
+
+    [Fact]
+    public void ConstructorsValidateNullArgumentsAndToStringReportsMetadata()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SegmentTree<int>(null!, static (a, b) => a + b, 0));
+        Assert.Throws<ArgumentNullException>(() => new SegmentTree<int>(new[] { 1 }, null!, 0));
+        Assert.Equal("SegmentTree{n=3, identity=0}", SegmentTree<int>.SumTree(new[] { 1, 2, 3 }).ToString());
+    }
+
+    private static void AssertAllRanges(int[] values, SegmentTree<int> tree, Func<int[], int, int, int> reference)
+    {
+        for (var left = 0; left < values.Length; left++)
+        {
+            for (var right = left; right < values.Length; right++)
+            {
+                Assert.Equal(reference(values, left, right), tree.Query(left, right));
+            }
+        }
+    }
+
+    private static int BruteSum(int[] values, int left, int right)
+    {
+        var sum = 0;
+        for (var i = left; i <= right; i++)
+        {
+            sum += values[i];
+        }
+
+        return sum;
+    }
+
+    private static int BruteMin(int[] values, int left, int right)
+    {
+        var min = values[left];
+        for (var i = left + 1; i <= right; i++)
+        {
+            min = Math.Min(min, values[i]);
+        }
+
+        return min;
+    }
+
+    private static int BruteMax(int[] values, int left, int right)
+    {
+        var max = values[left];
+        for (var i = left + 1; i <= right; i++)
+        {
+            max = Math.Max(max, values[i]);
+        }
+
+        return max;
+    }
+
+    private static int BruteGcd(int[] values, int left, int right)
+    {
+        var gcd = Math.Abs(values[left]);
+        for (var i = left + 1; i <= right; i++)
+        {
+            gcd = Gcd(gcd, values[i]);
+        }
+
+        return gcd;
+    }
+
+    private static int Gcd(int a, int b)
+    {
+        a = Math.Abs(a);
+        b = Math.Abs(b);
+        while (b != 0)
+        {
+            var next = a % b;
+            a = b;
+            b = next;
+        }
+
+        return a;
+    }
+}

--- a/code/packages/fsharp/segment-tree/BUILD
+++ b/code/packages/fsharp/segment-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/segment-tree/BUILD_windows
+++ b/code/packages/fsharp/segment-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/segment-tree/CHANGELOG.md
+++ b/code/packages/fsharp/segment-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# segment tree package.

--- a/code/packages/fsharp/segment-tree/CodingAdventures.SegmentTree.fsproj
+++ b/code/packages/fsharp/segment-tree/CodingAdventures.SegmentTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SegmentTree.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Generic segment tree for range queries and point updates</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SegmentTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/segment-tree/README.md
+++ b/code/packages/fsharp/segment-tree/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.SegmentTree.FSharp
+
+Generic segment tree for monoid-based range queries and point updates, with
+integer sum, min, max, and GCD factory helpers.

--- a/code/packages/fsharp/segment-tree/SegmentTree.fs
+++ b/code/packages/fsharp/segment-tree/SegmentTree.fs
@@ -1,0 +1,113 @@
+namespace CodingAdventures.SegmentTree
+
+open System
+open System.Collections.Generic
+
+type SegmentTree<'T>(values: seq<'T>, combine: 'T -> 'T -> 'T, identity: 'T) =
+    do
+        if isNull (box values) then
+            nullArg (nameof values)
+
+        if isNull (box combine) then
+            nullArg (nameof combine)
+
+    let source = Seq.toArray values
+    let size = source.Length
+    let tree = Array.create (max 4 (4 * size)) identity
+
+    let rec build node left right =
+        if left = right then
+            tree[node] <- source[left]
+        else
+            let mid = (left + right) / 2
+            build (2 * node) left mid
+            build (2 * node + 1) (mid + 1) right
+            tree[node] <- combine tree[2 * node] tree[2 * node + 1]
+
+    let rec queryHelper node left right queryLeft queryRight =
+        if right < queryLeft || left > queryRight then
+            identity
+        elif queryLeft <= left && right <= queryRight then
+            tree[node]
+        else
+            let mid = (left + right) / 2
+            let leftResult = queryHelper (2 * node) left mid queryLeft queryRight
+            let rightResult = queryHelper (2 * node + 1) (mid + 1) right queryLeft queryRight
+            combine leftResult rightResult
+
+    let rec updateHelper node left right index value =
+        if left = right then
+            tree[node] <- value
+        else
+            let mid = (left + right) / 2
+
+            if index <= mid then
+                updateHelper (2 * node) left mid index value
+            else
+                updateHelper (2 * node + 1) (mid + 1) right index value
+
+            tree[node] <- combine tree[2 * node] tree[2 * node + 1]
+
+    let rec collectLeaves node left right (acc: ResizeArray<'T>) =
+        if left = right then
+            acc.Add tree[node]
+        else
+            let mid = (left + right) / 2
+            collectLeaves (2 * node) left mid acc
+            collectLeaves (2 * node + 1) (mid + 1) right acc
+
+    do
+        if size > 0 then
+            build 1 0 (size - 1)
+
+    member _.Size = size
+
+    member _.Count = size
+
+    member _.IsEmpty = size = 0
+
+    member _.Query(queryLeft: int, queryRight: int) =
+        if queryLeft < 0 || queryRight >= size || queryLeft > queryRight then
+            raise (ArgumentOutOfRangeException(nameof queryLeft, $"Invalid query range [{queryLeft}, {queryRight}] for array of size {size}."))
+
+        queryHelper 1 0 (size - 1) queryLeft queryRight
+
+    member _.Update(index: int, value: 'T) =
+        if index < 0 || index >= size then
+            raise (ArgumentOutOfRangeException(nameof index, $"Index {index} out of range for array of size {size}."))
+
+        updateHelper 1 0 (size - 1) index value
+
+    member _.ToList() =
+        let result = ResizeArray<'T>(size)
+
+        if size > 0 then
+            collectLeaves 1 0 (size - 1) result
+
+        result |> Seq.toList
+
+    override _.ToString() = $"SegmentTree{{n={size}, identity={identity}}}"
+
+[<RequireQualifiedAccess>]
+module SegmentTree =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private gcd (left: int) (right: int) =
+        let mutable a = Math.Abs left
+        let mutable b = Math.Abs right
+
+        while b <> 0 do
+            let next = a % b
+            a <- b
+            b <- next
+
+        a
+
+    let sumTree (values: seq<int>) = SegmentTree<int>(values, (+), 0)
+
+    let minTree (values: seq<int>) = SegmentTree<int>(values, min, Int32.MaxValue)
+
+    let maxTree (values: seq<int>) = SegmentTree<int>(values, max, Int32.MinValue)
+
+    let gcdTree (values: seq<int>) = SegmentTree<int>(values, gcd, 0)

--- a/code/packages/fsharp/segment-tree/required_capabilities.json
+++ b/code/packages/fsharp/segment-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/segment-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.fsproj
+++ b/code/packages/fsharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/CodingAdventures.SegmentTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SegmentTree.fsproj" />
+    <Compile Include="SegmentTreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/SegmentTreeTests.fs
+++ b/code/packages/fsharp/segment-tree/tests/CodingAdventures.SegmentTree.Tests/SegmentTreeTests.fs
@@ -1,0 +1,185 @@
+namespace CodingAdventures.SegmentTree.Tests
+
+open System
+open CodingAdventures.SegmentTree
+open Xunit
+
+type SegmentTreeTests() =
+    let bruteSum (values: int array) left right =
+        values[left..right] |> Array.sum
+
+    let bruteMin (values: int array) left right =
+        values[left..right] |> Array.min
+
+    let bruteMax (values: int array) left right =
+        values[left..right] |> Array.max
+
+    let gcd (left: int) (right: int) =
+        let mutable a = Math.Abs left
+        let mutable b = Math.Abs right
+
+        while b <> 0 do
+            let next = a % b
+            a <- b
+            b <- next
+
+        a
+
+    let bruteGcd (values: int array) left right =
+        values[left..right] |> Array.reduce gcd
+
+    let assertAllRanges (values: int array) (tree: SegmentTree<int>) (reference: int array -> int -> int -> int) =
+        for left in 0 .. values.Length - 1 do
+            for right in left .. values.Length - 1 do
+                Assert.Equal(reference values left right, tree.Query(left, right))
+
+    [<Fact>]
+    member _.EmptyTreeHasMetadataAndRejectsOperations() =
+        let tree = SegmentTree.sumTree [||]
+
+        Assert.Equal(0, tree.Size)
+        Assert.Equal(0, tree.Count)
+        Assert.True(tree.IsEmpty)
+        Assert.Empty(tree.ToList())
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Query(0, 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Update(0, 1)) |> ignore
+
+    [<Fact>]
+    member _.SingleElementTreesQueryAndUpdate() =
+        let sum = SegmentTree.sumTree [| 42 |]
+        let minimum = SegmentTree.minTree [| -7 |]
+        let maximum = SegmentTree.maxTree [| 99 |]
+
+        Assert.Equal(42, sum.Query(0, 0))
+        Assert.Equal(-7, minimum.Query(0, 0))
+        Assert.Equal(99, maximum.Query(0, 0))
+        sum.Update(0, 55)
+        Assert.Equal(55, sum.Query(0, 0))
+
+    [<Fact>]
+    member _.SumTreeMatchesSpecExampleAndUpdates() =
+        let tree = SegmentTree.sumTree [| 2; 1; 5; 3; 4 |]
+
+        Assert.Equal(15, tree.Query(0, 4))
+        Assert.Equal(9, tree.Query(1, 3))
+        Assert.Equal(3, tree.Query(0, 1))
+        Assert.Equal(7, tree.Query(3, 4))
+        Assert.Equal(5, tree.Query(2, 2))
+        tree.Update(2, 7)
+        Assert.Equal(11, tree.Query(1, 3))
+        Assert.Equal(17, tree.Query(0, 4))
+        Assert.Equal<int list>([ 2; 1; 7; 3; 4 ], tree.ToList())
+
+    [<Fact>]
+    member _.SumTreeAllRangesMatchBruteForce() =
+        let values = [| -3; 1; -4; 1; 5; -9; 2; 6 |]
+        let tree = SegmentTree.sumTree values
+
+        assertAllRanges values tree bruteSum
+
+    [<Fact>]
+    member _.MinTreeAllRangesAndUpdatesMatchBruteForce() =
+        let values = [| 5; 3; 7; 1; 9; 2 |]
+        let tree = SegmentTree.minTree values
+
+        assertAllRanges values tree bruteMin
+        values[3] <- 10
+        tree.Update(3, 10)
+        Assert.Equal(2, tree.Query(0, 5))
+        assertAllRanges values tree bruteMin
+
+    [<Fact>]
+    member _.MaxTreeAllRangesAndUpdatesMatchBruteForce() =
+        let values = [| 3; -1; 4; 1; 5; 9; 2; 6 |]
+        let tree = SegmentTree.maxTree values
+
+        assertAllRanges values tree bruteMax
+        values[2] <- 100
+        tree.Update(2, 100)
+        Assert.Equal(100, tree.Query(0, 7))
+        Assert.Equal(100, tree.Query(1, 3))
+        assertAllRanges values tree bruteMax
+
+    [<Fact>]
+    member _.GcdTreeAllRangesMatchBruteForce() =
+        let values = [| 12; 8; 6; 4; 9 |]
+        let tree = SegmentTree.gcdTree values
+
+        Assert.Equal(2, tree.Query(0, 2))
+        Assert.Equal(1, tree.Query(1, 4))
+        Assert.Equal(4, tree.Query(0, 1))
+        assertAllRanges values tree bruteGcd
+
+    [<Fact>]
+    member _.NonPowerOfTwoAndMultipleUpdatesStayConsistent() =
+        let values = [| 1; 2; 3; 4; 5; 6; 7 |]
+        let tree = SegmentTree.sumTree values
+
+        Assert.Equal(28, tree.Query(0, 6))
+        Assert.Equal(9, tree.Query(1, 3))
+        values[0] <- 10
+        values[6] <- 20
+        values[2] <- 0
+        tree.Update(0, 10)
+        tree.Update(6, 20)
+        tree.Update(2, 0)
+        Assert.Equal<int list>(values |> Array.toList, tree.ToList())
+        assertAllRanges values tree bruteSum
+
+    [<Fact>]
+    member _.InvalidRangesAndIndicesThrow() =
+        let tree = SegmentTree.sumTree [| 1; 2; 3 |]
+
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Query(2, 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Query(-1, 2) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Query(0, 3) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Update(-1, 5)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> tree.Update(3, 5)) |> ignore
+
+    [<Fact>]
+    member _.CustomCombineSupportsProductAndBitwiseOr() =
+        let product = SegmentTree<int>([| 2; 3; 4; 5 |], (*), 1)
+        Assert.Equal(120, product.Query(0, 3))
+        Assert.Equal(24, product.Query(0, 2))
+        Assert.Equal(20, product.Query(2, 3))
+
+        let bitwiseOr = SegmentTree<int>([| 0b0001; 0b0010; 0b0100; 0b1000 |], (|||), 0)
+        Assert.Equal(0b1111, bitwiseOr.Query(0, 3))
+        Assert.Equal(0b0011, bitwiseOr.Query(0, 1))
+        Assert.Equal(0b0110, bitwiseOr.Query(1, 2))
+
+    [<Fact>]
+    member _.RandomStressMatchesReferenceArray() =
+        let random = Random 12345
+        let values = Array.init 200 (fun _ -> random.Next(1000) - 500)
+        let sum = SegmentTree.sumTree values
+        let minimum = SegmentTree.minTree values
+        let maximum = SegmentTree.maxTree values
+
+        for _ in 1 .. 50 do
+            let left = random.Next values.Length
+            let right = left + random.Next(values.Length - left)
+            Assert.Equal(bruteSum values left right, sum.Query(left, right))
+            Assert.Equal(bruteMin values left right, minimum.Query(left, right))
+            Assert.Equal(bruteMax values left right, maximum.Query(left, right))
+
+        for _ in 1 .. 200 do
+            let index = random.Next values.Length
+            let value = random.Next(1000) - 500
+            values[index] <- value
+            sum.Update(index, value)
+            minimum.Update(index, value)
+            maximum.Update(index, value)
+
+            let left = random.Next values.Length
+            let right = left + random.Next(values.Length - left)
+            Assert.Equal(bruteSum values left right, sum.Query(left, right))
+            Assert.Equal(bruteMin values left right, minimum.Query(left, right))
+            Assert.Equal(bruteMax values left right, maximum.Query(left, right))
+
+    [<Fact>]
+    member _.ConstructorsValidateNullArgumentsAndToStringReportsMetadata() =
+        Assert.Throws<ArgumentNullException>(fun () -> SegmentTree<int>(null, (+), 0) |> ignore) |> ignore
+        let missingCombine = Unchecked.defaultof<int -> int -> int>
+        Assert.Throws<ArgumentNullException>(fun () -> SegmentTree<int>([| 1 |], missingCombine, 0) |> ignore) |> ignore
+        Assert.Equal("SegmentTree{n=3, identity=0}", (SegmentTree.sumTree [| 1; 2; 3 |]).ToString())


### PR DESCRIPTION
## Summary
- add C# and F# generic segment tree packages for monoid-based range queries and point updates
- include integer sum, min, max, and GCD factory helpers plus size/is-empty metadata and leaf reconstruction
- wire package metadata, capability manifests, BUILD commands, and xUnit stress/edge coverage for both runtimes

## Verification
- dotnet test tests\CodingAdventures.SegmentTree.Tests\CodingAdventures.SegmentTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.SegmentTree.Tests\CodingAdventures.SegmentTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line