### PR TITLE
feat(parity): add fsharp rng package

### DIFF
--- a/code/packages/fsharp/rng/BUILD
+++ b/code/packages/fsharp/rng/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rng.Tests/CodingAdventures.Rng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/rng/BUILD_windows
+++ b/code/packages/fsharp/rng/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rng.Tests/CodingAdventures.Rng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/rng/CHANGELOG.md
+++ b/code/packages/fsharp/rng/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# RNG package.

--- a/code/packages/fsharp/rng/CodingAdventures.Rng.fsproj
+++ b/code/packages/fsharp/rng/CodingAdventures.Rng.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Rng.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Classic deterministic pseudorandom number generators</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Rng.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/rng/README.md
+++ b/code/packages/fsharp/rng/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.Rng.FSharp
+
+Classic deterministic pseudorandom number generators: LCG, Xorshift64, and
+PCG32, each with unsigned integer, float, and inclusive range helpers.

--- a/code/packages/fsharp/rng/Rng.fs
+++ b/code/packages/fsharp/rng/Rng.fs
@@ -1,0 +1,130 @@
+namespace CodingAdventures.Rng
+
+open System
+open System.Numerics
+
+module private Constants =
+    [<Literal>]
+    let LcgMultiplier = 6364136223846793005UL
+
+    [<Literal>]
+    let LcgIncrement = 1442695040888963407UL
+
+    [<Literal>]
+    let FloatDiv = 4294967296.0
+
+[<AutoOpen>]
+module private Helpers =
+    let rangeThreshold (rangeSize: uint64) =
+        (UInt64.MaxValue - rangeSize + 1UL) % rangeSize
+
+    let validateRange min max =
+        if min > max then
+            invalidArg (nameof min) $"NextIntInRange requires min <= max, got {min} > {max}"
+
+[<Sealed>]
+type Lcg(seed: uint64) =
+    let mutable state = seed
+
+    member _.NextU32() =
+        state <- state * Constants.LcgMultiplier + Constants.LcgIncrement
+        uint32 (state >>> 32)
+
+    member this.NextU64() =
+        let hi = uint64 (this.NextU32())
+        let lo = uint64 (this.NextU32())
+        (hi <<< 32) ||| lo
+
+    member this.NextFloat() =
+        double (this.NextU32()) / Constants.FloatDiv
+
+    member this.NextIntInRange(min: int64, max: int64) =
+        validateRange min max
+        let rangeSize = uint64 (max - min + 1L)
+        let threshold = rangeThreshold rangeSize
+        let mutable result = None
+
+        while result.IsNone do
+            let r = uint64 (this.NextU32())
+
+            if r >= threshold then
+                result <- Some(min + int64 (r % rangeSize))
+
+        result.Value
+
+[<Sealed>]
+type Xorshift64(seed: uint64) =
+    let mutable state =
+        if seed = 0UL then
+            1UL
+        else
+            seed
+
+    member _.NextU32() =
+        let mutable x = state
+        x <- x ^^^ (x <<< 13)
+        x <- x ^^^ (x >>> 7)
+        x <- x ^^^ (x <<< 17)
+        state <- x
+        uint32 x
+
+    member this.NextU64() =
+        let hi = uint64 (this.NextU32())
+        let lo = uint64 (this.NextU32())
+        (hi <<< 32) ||| lo
+
+    member this.NextFloat() =
+        double (this.NextU32()) / Constants.FloatDiv
+
+    member this.NextIntInRange(min: int64, max: int64) =
+        validateRange min max
+        let rangeSize = uint64 (max - min + 1L)
+        let threshold = rangeThreshold rangeSize
+        let mutable result = None
+
+        while result.IsNone do
+            let r = uint64 (this.NextU32())
+
+            if r >= threshold then
+                result <- Some(min + int64 (r % rangeSize))
+
+        result.Value
+
+[<Sealed>]
+type Pcg32(seed: uint64) =
+    let increment = Constants.LcgIncrement ||| 1UL
+    let mutable state = 0UL
+
+    do
+        state <- state * Constants.LcgMultiplier + increment
+        state <- state + seed
+        state <- state * Constants.LcgMultiplier + increment
+
+    member _.NextU32() =
+        let oldState = state
+        state <- oldState * Constants.LcgMultiplier + increment
+        let xorshifted = uint32 (((oldState >>> 18) ^^^ oldState) >>> 27)
+        let rotation = int (oldState >>> 59)
+        BitOperations.RotateRight(xorshifted, rotation)
+
+    member this.NextU64() =
+        let hi = uint64 (this.NextU32())
+        let lo = uint64 (this.NextU32())
+        (hi <<< 32) ||| lo
+
+    member this.NextFloat() =
+        double (this.NextU32()) / Constants.FloatDiv
+
+    member this.NextIntInRange(min: int64, max: int64) =
+        validateRange min max
+        let rangeSize = uint64 (max - min + 1L)
+        let threshold = rangeThreshold rangeSize
+        let mutable result = None
+
+        while result.IsNone do
+            let r = uint64 (this.NextU32())
+
+            if r >= threshold then
+                result <- Some(min + int64 (r % rangeSize))
+
+        result.Value

--- a/code/packages/fsharp/rng/required_capabilities.json
+++ b/code/packages/fsharp/rng/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/rng",
+  "capabilities": [],
+  "justification": "Pure in-memory deterministic PRNG library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/rng/tests/CodingAdventures.Rng.Tests/CodingAdventures.Rng.Tests.fsproj
+++ b/code/packages/fsharp/rng/tests/CodingAdventures.Rng.Tests/CodingAdventures.Rng.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Rng.fsproj" />
+    <Compile Include="RngTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/rng/tests/CodingAdventures.Rng.Tests/RngTests.fs
+++ b/code/packages/fsharp/rng/tests/CodingAdventures.Rng.Tests/RngTests.fs
@@ -1,0 +1,170 @@
+namespace CodingAdventures.Rng.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.Rng
+open Xunit
+
+type LcgTests() =
+    [<Fact>]
+    member _.NextU32MatchesKnownVectorsSeed1() =
+        let generator = Lcg 1UL
+        Assert.Equal(1817669548u, generator.NextU32())
+        Assert.Equal(2187888307u, generator.NextU32())
+        Assert.Equal(2784682393u, generator.NextU32())
+
+    [<Fact>]
+    member _.SameSeedIsDeterministicAndDifferentSeedsDiverge() =
+        let left = Lcg 0UL
+        let right = Lcg 0UL
+
+        for _ in 1 .. 10 do
+            Assert.Equal(left.NextU32(), right.NextU32())
+
+        Assert.NotEqual((Lcg 1UL).NextU32(), (Lcg 2UL).NextU32())
+
+    [<Fact>]
+    member _.NextU64ComposesTwoU32Draws() =
+        let combined = (Lcg 1UL).NextU64()
+        let reference = Lcg 1UL
+        let hi = uint64 (reference.NextU32())
+        let lo = uint64 (reference.NextU32())
+        Assert.Equal((hi <<< 32) ||| lo, combined)
+
+    [<Fact>]
+    member _.FloatAndRangeHelpersRespectBounds() =
+        let floatGenerator = Lcg 42UL
+
+        for _ in 1 .. 1000 do
+            let value = floatGenerator.NextFloat()
+            Assert.True(value >= 0.0 && value < 1.0)
+
+        let rangeGenerator = Lcg 7UL
+        let seen = HashSet<int64>()
+
+        for _ in 1 .. 10000 do
+            let value = rangeGenerator.NextIntInRange(1L, 6L)
+            Assert.InRange(value, 1L, 6L)
+            seen.Add value |> ignore
+
+        for value in 1L .. 6L do
+            Assert.Contains(value, seen)
+
+        Assert.Equal(42L, (Lcg 123UL).NextIntInRange(42L, 42L))
+        Assert.InRange((Lcg 5UL).NextIntInRange(-10L, -1L), -10L, -1L)
+        Assert.Throws<ArgumentException>(fun () -> (Lcg 1UL).NextIntInRange(6L, 1L) |> ignore) |> ignore
+
+type Xorshift64Tests() =
+    [<Fact>]
+    member _.NextU32MatchesKnownVectorsSeed1() =
+        let generator = Xorshift64 1UL
+        Assert.Equal(1082269761u, generator.NextU32())
+        Assert.Equal(201397313u, generator.NextU32())
+        Assert.Equal(1854285353u, generator.NextU32())
+
+    [<Fact>]
+    member _.SeedZeroIsReplacedWithOneAndSequencesAreDeterministic() =
+        let zero = Xorshift64 0UL
+        let one = Xorshift64 1UL
+        Assert.Equal(one.NextU32(), zero.NextU32())
+        Assert.Equal(one.NextU32(), zero.NextU32())
+
+        let left = Xorshift64 99UL
+        let right = Xorshift64 99UL
+
+        for _ in 1 .. 20 do
+            Assert.Equal(left.NextU32(), right.NextU32())
+
+    [<Fact>]
+    member _.NextU64ComposesTwoU32Draws() =
+        let combined = (Xorshift64 17UL).NextU64()
+        let reference = Xorshift64 17UL
+        let hi = uint64 (reference.NextU32())
+        let lo = uint64 (reference.NextU32())
+        Assert.Equal((hi <<< 32) ||| lo, combined)
+
+    [<Fact>]
+    member _.FloatAndRangeHelpersRespectBounds() =
+        let floatGenerator = Xorshift64 42UL
+
+        for _ in 1 .. 1000 do
+            let value = floatGenerator.NextFloat()
+            Assert.True(value >= 0.0 && value < 1.0)
+
+        let rangeGenerator = Xorshift64 3UL
+        let seen = HashSet<int64>()
+
+        for _ in 1 .. 10000 do
+            let value = rangeGenerator.NextIntInRange(1L, 6L)
+            Assert.InRange(value, 1L, 6L)
+            seen.Add value |> ignore
+
+        for value in 1L .. 6L do
+            Assert.Contains(value, seen)
+
+        Assert.Equal(-5L, (Xorshift64 7UL).NextIntInRange(-5L, -5L))
+        Assert.Throws<ArgumentException>(fun () -> (Xorshift64 1UL).NextIntInRange(6L, 1L) |> ignore) |> ignore
+
+type Pcg32Tests() =
+    [<Fact>]
+    member _.NextU32MatchesKnownVectorsSeed1() =
+        let generator = Pcg32 1UL
+        Assert.Equal(1412771199u, generator.NextU32())
+        Assert.Equal(1791099446u, generator.NextU32())
+        Assert.Equal(124312908u, generator.NextU32())
+
+    [<Fact>]
+    member _.SameSeedIsDeterministicAndDifferentSeedsDiverge() =
+        let left = Pcg32 0UL
+        let right = Pcg32 0UL
+
+        for _ in 1 .. 10 do
+            Assert.Equal(left.NextU32(), right.NextU32())
+
+        Assert.NotEqual((Pcg32 1UL).NextU32(), (Pcg32 2UL).NextU32())
+
+    [<Fact>]
+    member _.NextU64ComposesTwoU32Draws() =
+        let combined = (Pcg32 55UL).NextU64()
+        let reference = Pcg32 55UL
+        let hi = uint64 (reference.NextU32())
+        let lo = uint64 (reference.NextU32())
+        Assert.Equal((hi <<< 32) ||| lo, combined)
+
+    [<Fact>]
+    member _.FloatAndRangeHelpersRespectBounds() =
+        let floatGenerator = Pcg32 42UL
+        let mutable sawLow = false
+        let mutable sawHigh = false
+
+        for _ in 1 .. 1000 do
+            let value = floatGenerator.NextFloat()
+            Assert.True(value >= 0.0 && value < 1.0)
+            if value < 0.5 then sawLow <- true else sawHigh <- true
+
+        Assert.True(sawLow && sawHigh)
+
+        let rangeGenerator = Pcg32 9UL
+        let seen = HashSet<int64>()
+
+        for _ in 1 .. 10000 do
+            let value = rangeGenerator.NextIntInRange(1L, 6L)
+            Assert.InRange(value, 1L, 6L)
+            seen.Add value |> ignore
+
+        for value in 1L .. 6L do
+            Assert.Contains(value, seen)
+
+        Assert.Equal(100L, (Pcg32 111UL).NextIntInRange(100L, 100L))
+        Assert.InRange((Pcg32 22UL).NextIntInRange(-20L, -10L), -20L, -10L)
+        Assert.Throws<ArgumentException>(fun () -> (Pcg32 1UL).NextIntInRange(6L, 1L) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.AllThreeGeneratorsProduceDifferentOutputsForSameSeed() =
+        let lcg = (Lcg 1UL).NextU32()
+        let xorshift = (Xorshift64 1UL).NextU32()
+        let pcg = (Pcg32 1UL).NextU32()
+
+        Assert.NotEqual(lcg, xorshift)
+        Assert.NotEqual(xorshift, pcg)
+        Assert.NotEqual(lcg, pcg)


### PR DESCRIPTION
## Summary
- add the missing F# RNG package to match the existing C#/Java/Kotlin implementations
- include LCG, Xorshift64, and PCG32 generators with deterministic U32/U64, float, and inclusive range helpers
- add package metadata, capability manifest, BUILD commands, and xUnit known-vector/property coverage

## Verification
- dotnet test tests\CodingAdventures.Rng.Tests\CodingAdventures.Rng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line