### PR TITLE
feat(parity): add dotnet red-black tree packages

### DIFF
--- a/code/packages/csharp/red-black-tree/BUILD
+++ b/code/packages/csharp/red-black-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/red-black-tree/BUILD_windows
+++ b/code/packages/csharp/red-black-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/red-black-tree/CHANGELOG.md
+++ b/code/packages/csharp/red-black-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# red-black tree package.

--- a/code/packages/csharp/red-black-tree/CodingAdventures.RedBlackTree.csproj
+++ b/code/packages/csharp/red-black-tree/CodingAdventures.RedBlackTree.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RedBlackTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Purely functional left-leaning red-black tree for integers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/red-black-tree/RBTree.cs
+++ b/code/packages/csharp/red-black-tree/RBTree.cs
@@ -1,0 +1,471 @@
+namespace CodingAdventures.RedBlackTree;
+
+/// <summary>
+/// Node color for a red-black tree.
+/// </summary>
+public enum Color
+{
+    /// <summary>Red node/link.</summary>
+    Red,
+
+    /// <summary>Black node/link.</summary>
+    Black,
+}
+
+/// <summary>
+/// A purely functional left-leaning red-black tree over integers.
+/// </summary>
+public sealed class RBTree
+{
+    /// <summary>
+    /// Package version.
+    /// </summary>
+    public const string VERSION = "0.1.0";
+
+    private readonly Node? _root;
+
+    private RBTree(Node? root)
+    {
+        _root = root;
+    }
+
+    /// <summary>
+    /// Immutable tree node.
+    /// </summary>
+    public sealed record Node(int Value, Color Color, Node? Left = null, Node? Right = null)
+    {
+        /// <summary>
+        /// True when this node is red.
+        /// </summary>
+        public bool IsRed => Color == Color.Red;
+
+        internal Node WithColor(Color color) => color == Color ? this : this with { Color = color };
+    }
+
+    /// <summary>
+    /// Return an empty tree.
+    /// </summary>
+    public static RBTree Empty() => new(null);
+
+    /// <summary>
+    /// Return a new tree with value inserted. Duplicates are ignored.
+    /// </summary>
+    public RBTree Insert(int value)
+    {
+        var newRoot = InsertHelper(_root, value).WithColor(Color.Black);
+        return new RBTree(newRoot);
+    }
+
+    /// <summary>
+    /// Return a new tree with value removed. Missing values leave the tree unchanged.
+    /// </summary>
+    public RBTree Delete(int value)
+    {
+        if (!Contains(value))
+        {
+            return this;
+        }
+
+        var newRoot = _root is null ? null : DeleteHelper(_root, value);
+        return new RBTree(newRoot?.WithColor(Color.Black));
+    }
+
+    /// <summary>
+    /// Return true if value is present.
+    /// </summary>
+    public bool Contains(int value)
+    {
+        var node = _root;
+        while (node is not null)
+        {
+            if (value < node.Value)
+            {
+                node = node.Left;
+            }
+            else if (value > node.Value)
+            {
+                node = node.Right;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Return the minimum value, or null for an empty tree.
+    /// </summary>
+    public int? Min()
+    {
+        var node = _root;
+        if (node is null)
+        {
+            return null;
+        }
+
+        while (node.Left is not null)
+        {
+            node = node.Left;
+        }
+
+        return node.Value;
+    }
+
+    /// <summary>
+    /// Return the maximum value, or null for an empty tree.
+    /// </summary>
+    public int? Max()
+    {
+        var node = _root;
+        if (node is null)
+        {
+            return null;
+        }
+
+        while (node.Right is not null)
+        {
+            node = node.Right;
+        }
+
+        return node.Value;
+    }
+
+    /// <summary>
+    /// Return the largest value strictly less than value, or null.
+    /// </summary>
+    public int? Predecessor(int value)
+    {
+        int? best = null;
+        var node = _root;
+        while (node is not null)
+        {
+            if (value > node.Value)
+            {
+                best = node.Value;
+                node = node.Right;
+            }
+            else
+            {
+                node = node.Left;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Return the smallest value strictly greater than value, or null.
+    /// </summary>
+    public int? Successor(int value)
+    {
+        int? best = null;
+        var node = _root;
+        while (node is not null)
+        {
+            if (value < node.Value)
+            {
+                best = node.Value;
+                node = node.Left;
+            }
+            else
+            {
+                node = node.Right;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Return the 1-indexed kth smallest value.
+    /// </summary>
+    public int KthSmallest(int k)
+    {
+        var sorted = ToSortedList();
+        if (k < 1 || k > sorted.Count)
+        {
+            throw new InvalidOperationException($"k={k} out of range; tree has {sorted.Count} elements");
+        }
+
+        return sorted[k - 1];
+    }
+
+    /// <summary>
+    /// Return all values in ascending order.
+    /// </summary>
+    public IReadOnlyList<int> ToSortedList()
+    {
+        var result = new List<int>();
+        InOrder(_root, result);
+        return result;
+    }
+
+    /// <summary>
+    /// Verify the red-black invariants.
+    /// </summary>
+    public bool IsValidRB()
+    {
+        if (_root is null)
+        {
+            return true;
+        }
+
+        return _root.Color == Color.Black && CheckNode(_root) != -1;
+    }
+
+    /// <summary>
+    /// Return the root black-height, or 0 for an empty tree.
+    /// </summary>
+    public int BlackHeight() => BlackHeightHelper(_root);
+
+    /// <summary>
+    /// Return the number of values in the tree.
+    /// </summary>
+    public int Size() => SizeHelper(_root);
+
+    /// <summary>
+    /// Return the tree height, or 0 for an empty tree.
+    /// </summary>
+    public int Height() => HeightHelper(_root);
+
+    /// <summary>
+    /// True when the tree is empty.
+    /// </summary>
+    public bool IsEmpty => _root is null;
+
+    /// <summary>
+    /// Return the root node, or null when empty.
+    /// </summary>
+    public Node? Root => _root;
+
+    /// <summary>
+    /// Return the root node, or null when empty.
+    /// </summary>
+    public Node? GetRoot() => _root;
+
+    /// <summary>
+    /// Return tree metadata.
+    /// </summary>
+    public override string ToString() => $"RBTree{{size={Size()}, height={Height()}, blackHeight={BlackHeight()}}}";
+
+    private static Node InsertHelper(Node? node, int value)
+    {
+        if (node is null)
+        {
+            return new Node(value, Color.Red);
+        }
+
+        if (value < node.Value)
+        {
+            return FixUp(node with { Left = InsertHelper(node.Left, value) });
+        }
+
+        if (value > node.Value)
+        {
+            return FixUp(node with { Right = InsertHelper(node.Right, value) });
+        }
+
+        return node;
+    }
+
+    private static Node? DeleteHelper(Node node, int value)
+    {
+        if (value < node.Value)
+        {
+            var current = node;
+            if (!IsRed(current.Left) && !IsRed(current.Left?.Left))
+            {
+                current = MoveRedLeft(current);
+            }
+
+            var newLeft = current.Left is null ? null : DeleteHelper(current.Left, value);
+            return FixUp(current with { Left = newLeft });
+        }
+
+        var n = node;
+        if (IsRed(n.Left))
+        {
+            n = RotateRight(n);
+        }
+
+        if (value == n.Value && n.Right is null)
+        {
+            return null;
+        }
+
+        if (!IsRed(n.Right) && !IsRed(n.Right?.Left))
+        {
+            n = MoveRedRight(n);
+        }
+
+        if (value == n.Value)
+        {
+            var successor = MinValue(n.Right!);
+            var newRight = DeleteMin(n.Right!);
+            return FixUp(new Node(successor, n.Color, n.Left, newRight));
+        }
+
+        var right = n.Right is null ? null : DeleteHelper(n.Right, value);
+        return FixUp(n with { Right = right });
+    }
+
+    private static Node? DeleteMin(Node node)
+    {
+        if (node.Left is null)
+        {
+            return null;
+        }
+
+        var current = node;
+        if (!IsRed(current.Left) && !IsRed(current.Left?.Left))
+        {
+            current = MoveRedLeft(current);
+        }
+
+        return FixUp(current with { Left = DeleteMin(current.Left!) });
+    }
+
+    private static Node RotateLeft(Node node)
+    {
+        var right = node.Right!;
+        return new Node(
+            right.Value,
+            node.Color,
+            new Node(node.Value, Color.Red, node.Left, right.Left),
+            right.Right);
+    }
+
+    private static Node RotateRight(Node node)
+    {
+        var left = node.Left!;
+        return new Node(
+            left.Value,
+            node.Color,
+            left.Left,
+            new Node(node.Value, Color.Red, left.Right, node.Right));
+    }
+
+    private static Node FlipColors(Node node)
+    {
+        return new Node(
+            node.Value,
+            Toggle(node.Color),
+            node.Left?.WithColor(Toggle(node.Left.Color)),
+            node.Right?.WithColor(Toggle(node.Right.Color)));
+    }
+
+    private static Node FixUp(Node node)
+    {
+        var current = node;
+        if (IsRed(current.Right) && !IsRed(current.Left))
+        {
+            current = RotateLeft(current);
+        }
+
+        if (IsRed(current.Left) && IsRed(current.Left?.Left))
+        {
+            current = RotateRight(current);
+        }
+
+        if (IsRed(current.Left) && IsRed(current.Right))
+        {
+            current = FlipColors(current);
+        }
+
+        return current;
+    }
+
+    private static Node MoveRedLeft(Node node)
+    {
+        var current = FlipColors(node);
+        if (IsRed(current.Right?.Left))
+        {
+            current = current with { Right = RotateRight(current.Right!) };
+            current = RotateLeft(current);
+            current = FlipColors(current);
+        }
+
+        return current;
+    }
+
+    private static Node MoveRedRight(Node node)
+    {
+        var current = FlipColors(node);
+        if (IsRed(current.Left?.Left))
+        {
+            current = RotateRight(current);
+            current = FlipColors(current);
+        }
+
+        return current;
+    }
+
+    private static bool IsRed(Node? node) => node?.Color == Color.Red;
+
+    private static Color Toggle(Color color) => color == Color.Red ? Color.Black : Color.Red;
+
+    private static int MinValue(Node node)
+    {
+        var current = node;
+        while (current.Left is not null)
+        {
+            current = current.Left;
+        }
+
+        return current.Value;
+    }
+
+    private static void InOrder(Node? node, List<int> values)
+    {
+        if (node is null)
+        {
+            return;
+        }
+
+        InOrder(node.Left, values);
+        values.Add(node.Value);
+        InOrder(node.Right, values);
+    }
+
+    private static int CheckNode(Node? node)
+    {
+        if (node is null)
+        {
+            return 1;
+        }
+
+        if (node.Color == Color.Red && (IsRed(node.Left) || IsRed(node.Right)))
+        {
+            return -1;
+        }
+
+        var leftBlackHeight = CheckNode(node.Left);
+        var rightBlackHeight = CheckNode(node.Right);
+
+        if (leftBlackHeight == -1 || rightBlackHeight == -1 || leftBlackHeight != rightBlackHeight)
+        {
+            return -1;
+        }
+
+        return leftBlackHeight + (node.Color == Color.Black ? 1 : 0);
+    }
+
+    private static int BlackHeightHelper(Node? node)
+    {
+        if (node is null)
+        {
+            return 0;
+        }
+
+        return BlackHeightHelper(node.Left) + (node.Color == Color.Black ? 1 : 0);
+    }
+
+    private static int SizeHelper(Node? node) =>
+        node is null ? 0 : 1 + SizeHelper(node.Left) + SizeHelper(node.Right);
+
+    private static int HeightHelper(Node? node) =>
+        node is null ? 0 : 1 + Math.Max(HeightHelper(node.Left), HeightHelper(node.Right));
+}

--- a/code/packages/csharp/red-black-tree/README.md
+++ b/code/packages/csharp/red-black-tree/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.RedBlackTree.CSharp
+
+Purely functional left-leaning red-black tree for integers, with immutable
+insert/delete operations, sorted traversal, search helpers, and invariant checks.

--- a/code/packages/csharp/red-black-tree/required_capabilities.json
+++ b/code/packages/csharp/red-black-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/red-black-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.csproj
+++ b/code/packages/csharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.RedBlackTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/RBTreeTests.cs
+++ b/code/packages/csharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/RBTreeTests.cs
@@ -1,0 +1,227 @@
+using CodingAdventures.RedBlackTree;
+
+namespace CodingAdventures.RedBlackTree.Tests;
+
+public sealed class RBTreeTests
+{
+    [Fact]
+    public void EmptyTreeReportsMetadataAndMissingValues()
+    {
+        var tree = RBTree.Empty();
+
+        Assert.True(tree.IsValidRB());
+        Assert.True(tree.IsEmpty);
+        Assert.Equal(0, tree.Size());
+        Assert.Equal(0, tree.Height());
+        Assert.Equal(0, tree.BlackHeight());
+        Assert.False(tree.Contains(42));
+        Assert.Null(tree.Min());
+        Assert.Null(tree.Max());
+        Assert.Empty(tree.ToSortedList());
+        Assert.Throws<InvalidOperationException>(() => tree.KthSmallest(1));
+    }
+
+    [Fact]
+    public void SingleInsertCreatesBlackRoot()
+    {
+        var tree = Build(10);
+
+        Assert.True(tree.IsValidRB());
+        Assert.Equal(Color.Black, tree.GetRoot()!.Color);
+        Assert.Equal(tree.Root, tree.GetRoot());
+        Assert.Equal(1, tree.Size());
+        Assert.True(tree.Contains(10));
+        Assert.False(tree.Contains(11));
+        Assert.Equal(10, tree.Min());
+        Assert.Equal(10, tree.Max());
+    }
+
+    [Fact]
+    public void InsertSequencesStayValidAndSorted()
+    {
+        var ascending = RBTree.Empty();
+        for (var i = 1; i <= 40; i++)
+        {
+            ascending = ascending.Insert(i);
+            Assert.True(ascending.IsValidRB(), $"after inserting {i}");
+        }
+
+        Assert.Equal(Enumerable.Range(1, 40), ascending.ToSortedList());
+
+        var descending = RBTree.Empty();
+        for (var i = 40; i >= 1; i--)
+        {
+            descending = descending.Insert(i);
+            Assert.True(descending.IsValidRB(), $"after inserting {i}");
+        }
+
+        Assert.Equal(Enumerable.Range(1, 40), descending.ToSortedList());
+    }
+
+    [Fact]
+    public void DuplicatesAreIgnored()
+    {
+        var tree = Build(5, 5, 5, 3, 3, 7);
+
+        Assert.True(tree.IsValidRB());
+        Assert.Equal(3, tree.Size());
+        Assert.Equal(new[] { 3, 5, 7 }, tree.ToSortedList());
+    }
+
+    [Fact]
+    public void SearchMinMaxPredecessorSuccessorWork()
+    {
+        var tree = Build(10, 5, 15, 3, 7, 12, 20);
+
+        Assert.True(tree.Contains(10));
+        Assert.True(tree.Contains(20));
+        Assert.False(tree.Contains(11));
+        Assert.Equal(3, tree.Min());
+        Assert.Equal(20, tree.Max());
+        Assert.Equal(10, tree.Predecessor(12));
+        Assert.Equal(7, tree.Predecessor(10));
+        Assert.Null(tree.Predecessor(3));
+        Assert.Equal(12, tree.Successor(10));
+        Assert.Equal(10, tree.Successor(7));
+        Assert.Null(tree.Successor(20));
+    }
+
+    [Fact]
+    public void KthSmallestUsesSortedOrder()
+    {
+        var tree = Build(5, 3, 8, 1, 9, 4);
+
+        Assert.Equal(1, tree.KthSmallest(1));
+        Assert.Equal(3, tree.KthSmallest(2));
+        Assert.Equal(4, tree.KthSmallest(3));
+        Assert.Equal(5, tree.KthSmallest(4));
+        Assert.Equal(8, tree.KthSmallest(5));
+        Assert.Equal(9, tree.KthSmallest(6));
+        Assert.Throws<InvalidOperationException>(() => tree.KthSmallest(0));
+        Assert.Throws<InvalidOperationException>(() => tree.KthSmallest(7));
+    }
+
+    [Fact]
+    public void DeleteCasesPreserveInvariants()
+    {
+        var absent = Build(5, 3, 7).Delete(99);
+        Assert.True(absent.IsValidRB());
+        Assert.Equal(new[] { 3, 5, 7 }, absent.ToSortedList());
+
+        Assert.True(Build(42).Delete(42).IsEmpty);
+
+        var rootDeleted = Build(5, 3).Delete(5);
+        Assert.True(rootDeleted.IsValidRB());
+        Assert.Equal(new[] { 3 }, rootDeleted.ToSortedList());
+
+        var leafDeleted = Build(5, 3, 7).Delete(3);
+        Assert.True(leafDeleted.IsValidRB());
+        Assert.Equal(new[] { 5, 7 }, leafDeleted.ToSortedList());
+
+        var internalDeleted = Build(10, 5, 15, 3, 7, 12, 20).Delete(5);
+        Assert.True(internalDeleted.IsValidRB());
+        Assert.Equal(new[] { 3, 7, 10, 12, 15, 20 }, internalDeleted.ToSortedList());
+    }
+
+    [Fact]
+    public void DeleteAllElementsInSeveralOrders()
+    {
+        var values = new[] { 10, 5, 15, 3, 7, 12, 20 };
+        var tree = Build(values);
+
+        foreach (var value in values)
+        {
+            tree = tree.Delete(value);
+            Assert.True(tree.IsValidRB(), $"after deleting {value}");
+            Assert.False(tree.Contains(value));
+        }
+
+        Assert.True(tree.IsEmpty);
+
+        var minOrder = Build(1, 2, 3, 4, 5);
+        for (var i = 1; i <= 5; i++)
+        {
+            minOrder = minOrder.Delete(i);
+            Assert.True(minOrder.IsValidRB());
+        }
+
+        var maxOrder = Build(1, 2, 3, 4, 5);
+        for (var i = 5; i >= 1; i--)
+        {
+            maxOrder = maxOrder.Delete(i);
+            Assert.True(maxOrder.IsValidRB());
+        }
+    }
+
+    [Fact]
+    public void ImmutabilityKeepsOldTreeUnchanged()
+    {
+        var original = Build(5, 3, 7);
+        var modified = original.Insert(1).Insert(9).Delete(3);
+
+        Assert.Equal(new[] { 3, 5, 7 }, original.ToSortedList());
+        Assert.Equal(new[] { 1, 5, 7, 9 }, modified.ToSortedList());
+        Assert.True(modified.IsValidRB());
+    }
+
+    [Fact]
+    public void HeightBlackHeightAndToStringAreConsistent()
+    {
+        var tree = Build(Enumerable.Range(1, 100).ToArray());
+        var maxAllowedHeight = (int)(2 * Math.Ceiling(Math.Log2(101)));
+
+        Assert.True(tree.IsValidRB());
+        Assert.True(tree.Height() <= maxAllowedHeight);
+        Assert.True(tree.BlackHeight() > 0);
+        Assert.Equal($"RBTree{{size={tree.Size()}, height={tree.Height()}, blackHeight={tree.BlackHeight()}}}", tree.ToString());
+    }
+
+    [Fact]
+    public void RandomStressMatchesSortedSet()
+    {
+        var random = new Random(42);
+        var tree = RBTree.Empty();
+        var reference = new SortedSet<int>();
+
+        for (var i = 0; i < 200; i++)
+        {
+            var value = random.Next(100);
+            tree = tree.Insert(value);
+            reference.Add(value);
+            Assert.True(tree.IsValidRB());
+            Assert.Equal(reference, tree.ToSortedList());
+        }
+
+        foreach (var value in reference.OrderBy(_ => random.Next()).ToArray())
+        {
+            tree = tree.Delete(value);
+            reference.Remove(value);
+            Assert.True(tree.IsValidRB());
+            Assert.Equal(reference, tree.ToSortedList());
+        }
+
+        Assert.True(tree.IsEmpty);
+    }
+
+    [Fact]
+    public void NodeRecordsExposeColorAndIsRed()
+    {
+        var red = new RBTree.Node(5, Color.Red);
+        var black = red with { Color = Color.Black };
+
+        Assert.True(red.IsRed);
+        Assert.False(black.IsRed);
+        Assert.Equal(5, red.Value);
+    }
+
+    private static RBTree Build(params int[] values)
+    {
+        var tree = RBTree.Empty();
+        foreach (var value in values)
+        {
+            tree = tree.Insert(value);
+        }
+
+        return tree;
+    }
+}

--- a/code/packages/fsharp/red-black-tree/BUILD
+++ b/code/packages/fsharp/red-black-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/red-black-tree/BUILD_windows
+++ b/code/packages/fsharp/red-black-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/red-black-tree/CHANGELOG.md
+++ b/code/packages/fsharp/red-black-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# red-black tree package.

--- a/code/packages/fsharp/red-black-tree/CodingAdventures.RedBlackTree.fsproj
+++ b/code/packages/fsharp/red-black-tree/CodingAdventures.RedBlackTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RedBlackTree.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Purely functional left-leaning red-black tree for integers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="RBTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/red-black-tree/RBTree.fs
+++ b/code/packages/fsharp/red-black-tree/RBTree.fs
@@ -1,0 +1,324 @@
+namespace CodingAdventures.RedBlackTree
+
+open System
+
+type Color =
+    | Red
+    | Black
+
+type Node =
+    { Value: int
+      Color: Color
+      Left: Node option
+      Right: Node option }
+
+    member this.IsRed = this.Color = Red
+
+module private Core =
+    let isRed =
+        function
+        | Some node -> node.Color = Red
+        | None -> false
+
+    let toggle =
+        function
+        | Red -> Black
+        | Black -> Red
+
+    let withColor color node =
+        if color = node.Color then
+            node
+        else
+            { node with Color = color }
+
+    let rotateLeft node =
+        let right = Option.get node.Right
+
+        { Value = right.Value
+          Color = node.Color
+          Left =
+            Some
+                { Value = node.Value
+                  Color = Red
+                  Left = node.Left
+                  Right = right.Left }
+          Right = right.Right }
+
+    let rotateRight node =
+        let left = Option.get node.Left
+
+        { Value = left.Value
+          Color = node.Color
+          Left = left.Left
+          Right =
+            Some
+                { Value = node.Value
+                  Color = Red
+                  Left = left.Right
+                  Right = node.Right } }
+
+    let flipOption =
+        function
+        | Some node -> Some(withColor (toggle node.Color) node)
+        | None -> None
+
+    let flipColors node =
+        { Value = node.Value
+          Color = toggle node.Color
+          Left = flipOption node.Left
+          Right = flipOption node.Right }
+
+    let fixUp node =
+        let mutable current = node
+
+        if isRed current.Right && not (isRed current.Left) then
+            current <- rotateLeft current
+
+        let leftLeft =
+            current.Left
+            |> Option.bind _.Left
+
+        if isRed current.Left && isRed leftLeft then
+            current <- rotateRight current
+
+        if isRed current.Left && isRed current.Right then
+            current <- flipColors current
+
+        current
+
+    let moveRedLeft node =
+        let mutable current = flipColors node
+        let rightLeft = current.Right |> Option.bind _.Left
+
+        if isRed rightLeft then
+            current <- { current with Right = current.Right |> Option.map rotateRight }
+            current <- rotateLeft current
+            current <- flipColors current
+
+        current
+
+    let moveRedRight node =
+        let mutable current = flipColors node
+        let leftLeft = current.Left |> Option.bind _.Left
+
+        if isRed leftLeft then
+            current <- rotateRight current
+            current <- flipColors current
+
+        current
+
+    let rec insertHelper node value =
+        match node with
+        | None ->
+            { Value = value
+              Color = Red
+              Left = None
+              Right = None }
+        | Some h when value < h.Value -> fixUp { h with Left = Some(insertHelper h.Left value) }
+        | Some h when value > h.Value -> fixUp { h with Right = Some(insertHelper h.Right value) }
+        | Some h -> h
+
+    let minValue node =
+        let mutable current = node
+
+        while current.Left.IsSome do
+            current <- Option.get current.Left
+
+        current.Value
+
+    let rec deleteMin node =
+        if node.Left.IsNone then
+            None
+        else
+            let mutable current = node
+            let leftLeft = current.Left |> Option.bind _.Left
+
+            if not (isRed current.Left) && not (isRed leftLeft) then
+                current <- moveRedLeft current
+
+            Some(fixUp { current with Left = current.Left |> Option.bind deleteMin })
+
+    let rec deleteHelper node value =
+        if value < node.Value then
+            let mutable current = node
+            let leftLeft = current.Left |> Option.bind _.Left
+
+            if not (isRed current.Left) && not (isRed leftLeft) then
+                current <- moveRedLeft current
+
+            Some(fixUp { current with Left = current.Left |> Option.bind (fun left -> deleteHelper left value) })
+        else
+            let mutable current = node
+
+            if isRed current.Left then
+                current <- rotateRight current
+
+            if value = current.Value && current.Right.IsNone then
+                None
+            else
+                let rightLeft = current.Right |> Option.bind _.Left
+
+                if not (isRed current.Right) && not (isRed rightLeft) then
+                    current <- moveRedRight current
+
+                if value = current.Value then
+                    let right = Option.get current.Right
+                    let successor = minValue right
+                    let newRight = deleteMin right
+
+                    Some(
+                        fixUp
+                            { Value = successor
+                              Color = current.Color
+                              Left = current.Left
+                              Right = newRight }
+                    )
+                else
+                    Some(fixUp { current with Right = current.Right |> Option.bind (fun right -> deleteHelper right value) })
+
+    let rec inOrder node acc =
+        match node with
+        | None -> acc
+        | Some n ->
+            let withLeft = inOrder n.Left acc
+            let withCurrent = n.Value :: withLeft
+            inOrder n.Right withCurrent
+
+    let toSortedList root =
+        inOrder root [] |> List.rev
+
+    let rec checkNode node =
+        match node with
+        | None -> 1
+        | Some n ->
+            if n.Color = Red && (isRed n.Left || isRed n.Right) then
+                -1
+            else
+                let leftBlackHeight = checkNode n.Left
+                let rightBlackHeight = checkNode n.Right
+
+                if leftBlackHeight = -1 || rightBlackHeight = -1 || leftBlackHeight <> rightBlackHeight then
+                    -1
+                else
+                    leftBlackHeight + if n.Color = Black then 1 else 0
+
+    let rec blackHeight node =
+        match node with
+        | None -> 0
+        | Some n -> blackHeight n.Left + if n.Color = Black then 1 else 0
+
+    let rec size node =
+        match node with
+        | None -> 0
+        | Some n -> 1 + size n.Left + size n.Right
+
+    let rec height node =
+        match node with
+        | None -> 0
+        | Some n -> 1 + max (height n.Left) (height n.Right)
+
+type RBTree private (root: Node option) =
+    member _.Root = root
+
+    static member Empty() = RBTree None
+
+    member _.Insert(value: int) =
+        Core.insertHelper root value
+        |> Core.withColor Black
+        |> Some
+        |> RBTree
+
+    member this.Delete(value: int) =
+        if not (this.Contains value) then
+            this
+        else
+            let newRoot = root |> Option.bind (fun node -> Core.deleteHelper node value)
+            RBTree(newRoot |> Option.map (Core.withColor Black))
+
+    member _.Contains(value: int) =
+        let mutable node = root
+        let mutable found = false
+
+        while node.IsSome && not found do
+            let current = Option.get node
+
+            if value < current.Value then
+                node <- current.Left
+            elif value > current.Value then
+                node <- current.Right
+            else
+                found <- true
+
+        found
+
+    member _.Min() =
+        match root with
+        | None -> None
+        | Some node -> Some(Core.minValue node)
+
+    member _.Max() =
+        let mutable node = root
+
+        match node with
+        | None -> None
+        | Some _ ->
+            while (Option.get node).Right.IsSome do
+                node <- (Option.get node).Right
+
+            Some((Option.get node).Value)
+
+    member _.Predecessor(value: int) =
+        let mutable best = None
+        let mutable node = root
+
+        while node.IsSome do
+            let current = Option.get node
+
+            if value > current.Value then
+                best <- Some current.Value
+                node <- current.Right
+            else
+                node <- current.Left
+
+        best
+
+    member _.Successor(value: int) =
+        let mutable best = None
+        let mutable node = root
+
+        while node.IsSome do
+            let current = Option.get node
+
+            if value < current.Value then
+                best <- Some current.Value
+                node <- current.Left
+            else
+                node <- current.Right
+
+        best
+
+    member _.ToSortedList() = Core.toSortedList root
+
+    member this.KthSmallest(k: int) =
+        let sorted: int list = this.ToSortedList()
+
+        if k < 1 || k > sorted.Length then
+            invalidOp $"k={k} out of range; tree has {sorted.Length} elements"
+
+        sorted[k - 1]
+
+    member _.IsValidRB() =
+        match root with
+        | None -> true
+        | Some node -> node.Color = Black && Core.checkNode root <> -1
+
+    member _.BlackHeight() = Core.blackHeight root
+
+    member _.Size() = Core.size root
+
+    member _.Height() = Core.height root
+
+    member _.IsEmpty = root.IsNone
+
+    override this.ToString() =
+        $"RBTree{{size={this.Size()}, height={this.Height()}, blackHeight={this.BlackHeight()}}}"

--- a/code/packages/fsharp/red-black-tree/README.md
+++ b/code/packages/fsharp/red-black-tree/README.md
@@ -1,0 +1,4 @@
+# CodingAdventures.RedBlackTree.FSharp
+
+Purely functional left-leaning red-black tree for integers, with immutable
+insert/delete operations, sorted traversal, search helpers, and invariant checks.

--- a/code/packages/fsharp/red-black-tree/required_capabilities.json
+++ b/code/packages/fsharp/red-black-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/red-black-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.fsproj
+++ b/code/packages/fsharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/CodingAdventures.RedBlackTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.RedBlackTree.fsproj" />
+    <Compile Include="RBTreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/RBTreeTests.fs
+++ b/code/packages/fsharp/red-black-tree/tests/CodingAdventures.RedBlackTree.Tests/RBTreeTests.fs
@@ -1,0 +1,184 @@
+namespace CodingAdventures.RedBlackTree.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.RedBlackTree
+open Xunit
+
+type RBTreeTests() =
+    let build values =
+        values |> Seq.fold (fun (tree: RBTree) value -> tree.Insert value) (RBTree.Empty())
+
+    [<Fact>]
+    member _.EmptyTreeReportsMetadataAndMissingValues() =
+        let tree = RBTree.Empty()
+
+        Assert.True(tree.IsValidRB())
+        Assert.True(tree.IsEmpty)
+        Assert.Equal(0, tree.Size())
+        Assert.Equal(0, tree.Height())
+        Assert.Equal(0, tree.BlackHeight())
+        Assert.False(tree.Contains 42)
+        Assert.Equal(None, tree.Min())
+        Assert.Equal(None, tree.Max())
+        Assert.Empty(tree.ToSortedList())
+        Assert.Throws<InvalidOperationException>(fun () -> tree.KthSmallest 1 |> ignore) |> ignore
+
+    [<Fact>]
+    member _.SingleInsertCreatesBlackRoot() =
+        let tree = build [ 10 ]
+
+        Assert.True(tree.IsValidRB())
+        Assert.Equal(Some Black, tree.Root |> Option.map _.Color)
+        Assert.Equal(1, tree.Size())
+        Assert.True(tree.Contains 10)
+        Assert.False(tree.Contains 11)
+        Assert.Equal(Some 10, tree.Min())
+        Assert.Equal(Some 10, tree.Max())
+
+    [<Fact>]
+    member _.InsertSequencesStayValidAndSorted() =
+        let mutable ascending = RBTree.Empty()
+
+        for value in 1 .. 40 do
+            ascending <- ascending.Insert value
+            Assert.True(ascending.IsValidRB())
+
+        Assert.Equal<int list>([ 1..40 ], ascending.ToSortedList())
+
+        let mutable descending = RBTree.Empty()
+
+        for value in 40 .. -1 .. 1 do
+            descending <- descending.Insert value
+            Assert.True(descending.IsValidRB())
+
+        Assert.Equal<int list>([ 1..40 ], descending.ToSortedList())
+
+    [<Fact>]
+    member _.DuplicatesAreIgnored() =
+        let tree = build [ 5; 5; 5; 3; 3; 7 ]
+
+        Assert.True(tree.IsValidRB())
+        Assert.Equal(3, tree.Size())
+        Assert.Equal<int list>([ 3; 5; 7 ], tree.ToSortedList())
+
+    [<Fact>]
+    member _.SearchMinMaxPredecessorSuccessorWork() =
+        let tree = build [ 10; 5; 15; 3; 7; 12; 20 ]
+
+        Assert.True(tree.Contains 10)
+        Assert.True(tree.Contains 20)
+        Assert.False(tree.Contains 11)
+        Assert.Equal(Some 3, tree.Min())
+        Assert.Equal(Some 20, tree.Max())
+        Assert.Equal(Some 10, tree.Predecessor 12)
+        Assert.Equal(Some 7, tree.Predecessor 10)
+        Assert.Equal(None, tree.Predecessor 3)
+        Assert.Equal(Some 12, tree.Successor 10)
+        Assert.Equal(Some 10, tree.Successor 7)
+        Assert.Equal(None, tree.Successor 20)
+
+    [<Fact>]
+    member _.KthSmallestUsesSortedOrder() =
+        let tree = build [ 5; 3; 8; 1; 9; 4 ]
+
+        Assert.Equal(1, tree.KthSmallest 1)
+        Assert.Equal(3, tree.KthSmallest 2)
+        Assert.Equal(4, tree.KthSmallest 3)
+        Assert.Equal(5, tree.KthSmallest 4)
+        Assert.Equal(8, tree.KthSmallest 5)
+        Assert.Equal(9, tree.KthSmallest 6)
+        Assert.Throws<InvalidOperationException>(fun () -> tree.KthSmallest 0 |> ignore) |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> tree.KthSmallest 7 |> ignore) |> ignore
+
+    [<Fact>]
+    member _.DeleteCasesPreserveInvariants() =
+        let absent = (build [ 5; 3; 7 ]).Delete 99
+        Assert.True(absent.IsValidRB())
+        Assert.Equal<int list>([ 3; 5; 7 ], absent.ToSortedList())
+
+        Assert.True((build [ 42 ]).Delete(42).IsEmpty)
+        Assert.Equal<int list>([ 3 ], (build [ 5; 3 ]).Delete(5).ToSortedList())
+        Assert.Equal<int list>([ 5; 7 ], (build [ 5; 3; 7 ]).Delete(3).ToSortedList())
+
+        let internalDeleted = (build [ 10; 5; 15; 3; 7; 12; 20 ]).Delete 5
+        Assert.True(internalDeleted.IsValidRB())
+        Assert.Equal<int list>([ 3; 7; 10; 12; 15; 20 ], internalDeleted.ToSortedList())
+
+    [<Fact>]
+    member _.DeleteAllElementsInSeveralOrders() =
+        let values = [ 10; 5; 15; 3; 7; 12; 20 ]
+        let mutable tree = build values
+
+        for value in values do
+            tree <- tree.Delete value
+            Assert.True(tree.IsValidRB())
+            Assert.False(tree.Contains value)
+
+        Assert.True(tree.IsEmpty)
+
+        let mutable minOrder = build [ 1; 2; 3; 4; 5 ]
+
+        for value in 1 .. 5 do
+            minOrder <- minOrder.Delete value
+            Assert.True(minOrder.IsValidRB())
+
+        let mutable maxOrder = build [ 1; 2; 3; 4; 5 ]
+
+        for value in 5 .. -1 .. 1 do
+            maxOrder <- maxOrder.Delete value
+            Assert.True(maxOrder.IsValidRB())
+
+    [<Fact>]
+    member _.ImmutabilityKeepsOldTreeUnchanged() =
+        let original = build [ 5; 3; 7 ]
+        let modified = original.Insert(1).Insert(9).Delete 3
+
+        Assert.Equal<int list>([ 3; 5; 7 ], original.ToSortedList())
+        Assert.Equal<int list>([ 1; 5; 7; 9 ], modified.ToSortedList())
+        Assert.True(modified.IsValidRB())
+
+    [<Fact>]
+    member _.HeightBlackHeightAndToStringAreConsistent() =
+        let tree = build [ 1..100 ]
+        let maxAllowedHeight = int (2.0 * Math.Ceiling(Math.Log2 101.0))
+
+        Assert.True(tree.IsValidRB())
+        Assert.True(tree.Height() <= maxAllowedHeight)
+        Assert.True(tree.BlackHeight() > 0)
+        Assert.Equal($"RBTree{{size={tree.Size()}, height={tree.Height()}, blackHeight={tree.BlackHeight()}}}", tree.ToString())
+
+    [<Fact>]
+    member _.RandomStressMatchesSortedSet() =
+        let random = Random 42
+        let reference = SortedSet<int>()
+        let mutable tree = RBTree.Empty()
+
+        for _ in 1 .. 200 do
+            let value = random.Next 100
+            tree <- tree.Insert value
+            reference.Add value |> ignore
+            Assert.True(tree.IsValidRB())
+            Assert.Equal<int list>(reference |> Seq.toList, tree.ToSortedList())
+
+        for value in reference |> Seq.sortBy (fun _ -> random.Next()) |> Seq.toArray do
+            tree <- tree.Delete value
+            reference.Remove value |> ignore
+            Assert.True(tree.IsValidRB())
+            Assert.Equal<int list>(reference |> Seq.toList, tree.ToSortedList())
+
+        Assert.True(tree.IsEmpty)
+
+    [<Fact>]
+    member _.NodeRecordsExposeColorAndIsRed() =
+        let red =
+            { Value = 5
+              Color = Red
+              Left = None
+              Right = None }
+
+        let black = { red with Color = Black }
+
+        Assert.True(red.IsRed)
+        Assert.False(black.IsRed)
+        Assert.Equal(5, red.Value)


### PR DESCRIPTION
## Summary
- add C# and F# purely functional left-leaning red-black tree packages for integers
- include immutable insert/delete, contains, min/max, predecessor/successor, kth-smallest, sorted traversal, root/metadata, black-height, and invariant validation
- add package metadata, capability manifests, BUILD commands, and invariant/stress xUnit coverage for both runtimes

## Verification
- dotnet test tests\CodingAdventures.RedBlackTree.Tests\CodingAdventures.RedBlackTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.RedBlackTree.Tests\CodingAdventures.RedBlackTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line