### PR TITLE
feat(parity): add dotnet matrix packages

### DIFF
--- a/code/packages/csharp/matrix/BUILD
+++ b/code/packages/csharp/matrix/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/matrix/BUILD_windows
+++ b/code/packages/csharp/matrix/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/matrix/CHANGELOG.md
+++ b/code/packages/csharp/matrix/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Pure C# immutable matrix type for double-precision values
+- Factory helpers for scalars, row vectors, and zero-filled matrices
+- Element-wise add/subtract, scalar add/subtract/scale, transpose, dot product, indexing, deep-copy access, equality, hashing, and dimension validation
+- xUnit coverage for construction, arithmetic, immutability, equality, and invalid dimensions
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/csharp/matrix/CodingAdventures.Matrix.csproj
+++ b/code/packages/csharp/matrix/CodingAdventures.Matrix.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Matrix.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# immutable matrix mathematics helpers for double-precision values</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/matrix/Matrix.cs
+++ b/code/packages/csharp/matrix/Matrix.cs
@@ -1,0 +1,247 @@
+namespace CodingAdventures.Matrix;
+
+/// <summary>
+/// Immutable matrix of double-precision values.
+/// </summary>
+public sealed class Matrix : IEquatable<Matrix>
+{
+    private readonly double[][] _data;
+
+    /// <summary>Create a matrix from a rectangular 2D array.</summary>
+    public Matrix(double[][] data)
+    {
+        _data = ValidateAndCopy(data);
+        Rows = _data.Length;
+        Cols = _data[0].Length;
+    }
+
+    /// <summary>Number of rows.</summary>
+    public int Rows { get; }
+
+    /// <summary>Number of columns.</summary>
+    public int Cols { get; }
+
+    /// <summary>Create a 1x1 matrix from a scalar.</summary>
+    public static Matrix FromScalar(double value) => new([[value]]);
+
+    /// <summary>Create a 1xN row vector from a one-dimensional array.</summary>
+    public static Matrix FromArray(double[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length == 0)
+        {
+            throw new ArgumentException("Array must not be empty", nameof(values));
+        }
+
+        return new Matrix([values.ToArray()]);
+    }
+
+    /// <summary>Create an MxN zero-filled matrix.</summary>
+    public static Matrix Zeros(int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0)
+        {
+            throw new ArgumentException("Dimensions must be positive");
+        }
+
+        return new Matrix(Enumerable.Range(0, rows).Select(_ => new double[cols]).ToArray());
+    }
+
+    /// <summary>Get an element by row and column.</summary>
+    public double this[int row, int col] => _data[row][col];
+
+    /// <summary>Get an element by row and column.</summary>
+    public double Get(int row, int col) => this[row, col];
+
+    /// <summary>Return a deep copy of the matrix data.</summary>
+    public double[][] GetData() => _data.Select(row => row.ToArray()).ToArray();
+
+    /// <summary>Add another matrix element-wise.</summary>
+    public Matrix Add(Matrix other)
+    {
+        CheckDimensions(other, "add");
+        return Map2(other, static (left, right) => left + right);
+    }
+
+    /// <summary>Subtract another matrix element-wise.</summary>
+    public Matrix Subtract(Matrix other)
+    {
+        CheckDimensions(other, "subtract");
+        return Map2(other, static (left, right) => left - right);
+    }
+
+    /// <summary>Add a scalar to every element.</summary>
+    public Matrix AddScalar(double scalar) => Map(value => value + scalar);
+
+    /// <summary>Subtract a scalar from every element.</summary>
+    public Matrix SubtractScalar(double scalar) => AddScalar(-scalar);
+
+    /// <summary>Multiply every element by a scalar.</summary>
+    public Matrix Scale(double scalar) => Map(value => value * scalar);
+
+    /// <summary>Swap rows and columns.</summary>
+    public Matrix Transpose()
+    {
+        var result = new double[Cols][];
+        for (var col = 0; col < Cols; col++)
+        {
+            result[col] = new double[Rows];
+            for (var row = 0; row < Rows; row++)
+            {
+                result[col][row] = _data[row][col];
+            }
+        }
+
+        return new Matrix(result);
+    }
+
+    /// <summary>Multiply this matrix by another matrix.</summary>
+    public Matrix Dot(Matrix other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        if (Cols != other.Rows)
+        {
+            throw new ArgumentException(
+                $"Dot dimension mismatch: {Rows}x{Cols} dot {other.Rows}x{other.Cols}",
+                nameof(other));
+        }
+
+        var result = new double[Rows][];
+        for (var row = 0; row < Rows; row++)
+        {
+            result[row] = new double[other.Cols];
+            for (var col = 0; col < other.Cols; col++)
+            {
+                var sum = 0.0;
+                for (var k = 0; k < Cols; k++)
+                {
+                    sum += _data[row][k] * other._data[k][col];
+                }
+
+                result[row][col] = sum;
+            }
+        }
+
+        return new Matrix(result);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(Matrix? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other is null || Rows != other.Rows || Cols != other.Cols)
+        {
+            return false;
+        }
+
+        for (var row = 0; row < Rows; row++)
+        {
+            if (!_data[row].SequenceEqual(other._data[row]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Matrix other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Rows);
+        hash.Add(Cols);
+        foreach (var row in _data)
+        {
+            foreach (var value in row)
+            {
+                hash.Add(value);
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"Matrix({Rows}x{Cols})";
+
+    private static double[][] ValidateAndCopy(double[][] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length == 0)
+        {
+            throw new ArgumentException("Matrix must have at least one row and column", nameof(data));
+        }
+
+        ArgumentNullException.ThrowIfNull(data[0]);
+        if (data[0].Length == 0)
+        {
+            throw new ArgumentException("Matrix must have at least one row and column", nameof(data));
+        }
+
+        var cols = data[0].Length;
+        var copy = new double[data.Length][];
+        for (var row = 0; row < data.Length; row++)
+        {
+            ArgumentNullException.ThrowIfNull(data[row]);
+            if (data[row].Length != cols)
+            {
+                throw new ArgumentException(
+                    $"Row {row} has {data[row].Length} columns, expected {cols}",
+                    nameof(data));
+            }
+
+            copy[row] = data[row].ToArray();
+        }
+
+        return copy;
+    }
+
+    private void CheckDimensions(Matrix? other, string operation)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        if (Rows != other.Rows || Cols != other.Cols)
+        {
+            throw new ArgumentException(
+                $"{operation} dimension mismatch: {Rows}x{Cols} vs {other.Rows}x{other.Cols}",
+                nameof(other));
+        }
+    }
+
+    private Matrix Map(Func<double, double> mapper)
+    {
+        var result = new double[Rows][];
+        for (var row = 0; row < Rows; row++)
+        {
+            result[row] = new double[Cols];
+            for (var col = 0; col < Cols; col++)
+            {
+                result[row][col] = mapper(_data[row][col]);
+            }
+        }
+
+        return new Matrix(result);
+    }
+
+    private Matrix Map2(Matrix other, Func<double, double, double> mapper)
+    {
+        var result = new double[Rows][];
+        for (var row = 0; row < Rows; row++)
+        {
+            result[row] = new double[Cols];
+            for (var col = 0; col < Cols; col++)
+            {
+                result[row][col] = mapper(_data[row][col], other._data[row][col]);
+            }
+        }
+
+        return new Matrix(result);
+    }
+}

--- a/code/packages/csharp/matrix/README.md
+++ b/code/packages/csharp/matrix/README.md
@@ -1,0 +1,26 @@
+# matrix
+
+Pure C# immutable matrix mathematics helpers for double-precision values.
+
+## What It Includes
+
+- Construction from rectangular 2D arrays, scalars, row vectors, and zero-filled dimensions
+- Element access with deep-copy data export
+- Element-wise add/subtract, scalar add/subtract/scale, transpose, and dot product
+- Value equality, hashing, and dimension validation
+
+## Example
+
+```csharp
+using CodingAdventures.Matrix;
+
+var a = new Matrix(new[] { new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 } });
+var b = Matrix.FromScalar(2.0);
+var c = a.Scale(b[0, 0]).Transpose();
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/matrix/required_capabilities.json
+++ b/code/packages/csharp/matrix/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/matrix",
+  "capabilities": [],
+  "justification": "Pure in-memory C# matrix mathematics implementation and tests."
+}

--- a/code/packages/csharp/matrix/tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.csproj
+++ b/code/packages/csharp/matrix/tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Matrix.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/matrix/tests/CodingAdventures.Matrix.Tests/MatrixTests.cs
+++ b/code/packages/csharp/matrix/tests/CodingAdventures.Matrix.Tests/MatrixTests.cs
@@ -1,0 +1,167 @@
+namespace CodingAdventures.Matrix.Tests;
+
+public sealed class MatrixTests
+{
+    [Fact]
+    public void FromScalar_CreatesOneByOneMatrix()
+    {
+        var matrix = Matrix.FromScalar(5.0);
+
+        Assert.Equal(1, matrix.Rows);
+        Assert.Equal(1, matrix.Cols);
+        Assert.Equal(5.0, matrix[0, 0]);
+    }
+
+    [Fact]
+    public void FromArray_CreatesRowVector()
+    {
+        var matrix = Matrix.FromArray([1.0, 2.0, 3.0]);
+
+        Assert.Equal(1, matrix.Rows);
+        Assert.Equal(3, matrix.Cols);
+        Assert.Equal(2.0, matrix.Get(0, 1));
+    }
+
+    [Fact]
+    public void Constructor_DeepCopiesRectangularData()
+    {
+        var source = new[] { new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 } };
+        var matrix = new Matrix(source);
+        source[0][0] = 99.0;
+
+        Assert.Equal(2, matrix.Rows);
+        Assert.Equal(2, matrix.Cols);
+        Assert.Equal(1.0, matrix[0, 0]);
+    }
+
+    [Fact]
+    public void Zeros_CreatesZeroFilledMatrix()
+    {
+        var matrix = Matrix.Zeros(3, 2);
+
+        Assert.Equal(3, matrix.Rows);
+        Assert.Equal(2, matrix.Cols);
+        for (var row = 0; row < matrix.Rows; row++)
+        {
+            for (var col = 0; col < matrix.Cols; col++)
+            {
+                Assert.Equal(0.0, matrix[row, col]);
+            }
+        }
+    }
+
+    [Fact]
+    public void InvalidConstruction_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new Matrix([]));
+        Assert.Throws<ArgumentException>(() => new Matrix([[]]));
+        Assert.Throws<ArgumentException>(() => new Matrix([new[] { 1.0, 2.0 }, [3.0]]));
+        Assert.Throws<ArgumentException>(() => Matrix.FromArray([]));
+        Assert.Throws<ArgumentException>(() => Matrix.Zeros(0, 2));
+    }
+
+    [Fact]
+    public void Add_AddsMatricesElementWise()
+    {
+        var a = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+        var b = new Matrix([new[] { 5.0, 6.0 }, new[] { 7.0, 8.0 }]);
+
+        Assert.Equal(new Matrix([new[] { 6.0, 8.0 }, new[] { 10.0, 12.0 }]), a.Add(b));
+    }
+
+    [Fact]
+    public void Subtract_SubtractsMatricesElementWise()
+    {
+        var a = new Matrix([new[] { 5.0, 6.0 }, new[] { 7.0, 8.0 }]);
+        var b = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+
+        Assert.Equal(new Matrix([new[] { 4.0, 4.0 }, new[] { 4.0, 4.0 }]), a.Subtract(b));
+    }
+
+    [Fact]
+    public void ScalarOperations_MapEveryElement()
+    {
+        var matrix = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+
+        Assert.Equal(new Matrix([new[] { 11.0, 12.0 }, new[] { 13.0, 14.0 }]), matrix.AddScalar(10.0));
+        Assert.Equal(new Matrix([new[] { -4.0, -3.0 }, new[] { -2.0, -1.0 }]), matrix.SubtractScalar(5.0));
+        Assert.Equal(new Matrix([new[] { 2.0, 4.0 }, new[] { 6.0, 8.0 }]), matrix.Scale(2.0));
+        Assert.Equal(Matrix.Zeros(2, 2), matrix.Scale(0.0));
+    }
+
+    [Fact]
+    public void DimensionMismatch_ThrowsForElementWiseOperations()
+    {
+        var row = new Matrix([new[] { 1.0, 2.0 }]);
+        var column = new Matrix([new[] { 1.0 }, new[] { 2.0 }]);
+
+        Assert.Throws<ArgumentException>(() => row.Add(column));
+        Assert.Throws<ArgumentException>(() => row.Subtract(column));
+    }
+
+    [Fact]
+    public void Transpose_SwapsRowsAndColumns()
+    {
+        var matrix = new Matrix([new[] { 1.0, 2.0, 3.0 }, new[] { 4.0, 5.0, 6.0 }]);
+        var transposed = matrix.Transpose();
+
+        Assert.Equal(3, transposed.Rows);
+        Assert.Equal(2, transposed.Cols);
+        Assert.Equal(new Matrix([new[] { 1.0, 4.0 }, new[] { 2.0, 5.0 }, new[] { 3.0, 6.0 }]), transposed);
+        Assert.Equal(matrix, transposed.Transpose());
+    }
+
+    [Fact]
+    public void Dot_MultipliesMatrices()
+    {
+        var a = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+        var b = new Matrix([new[] { 5.0, 6.0 }, new[] { 7.0, 8.0 }]);
+
+        Assert.Equal(new Matrix([new[] { 19.0, 22.0 }, new[] { 43.0, 50.0 }]), a.Dot(b));
+    }
+
+    [Fact]
+    public void Dot_HandlesNonSquareAndIdentityMatrices()
+    {
+        var row = new Matrix([new[] { 1.0, 2.0, 3.0 }]);
+        var column = new Matrix([new[] { 4.0 }, new[] { 5.0 }, new[] { 6.0 }]);
+        var identity = new Matrix([new[] { 1.0, 0.0 }, new[] { 0.0, 1.0 }]);
+        var matrix = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+
+        Assert.Equal(Matrix.FromScalar(32.0), row.Dot(column));
+        Assert.Equal(matrix, matrix.Dot(identity));
+        Assert.Equal(matrix, identity.Dot(matrix));
+    }
+
+    [Fact]
+    public void Dot_RejectsDimensionMismatch()
+    {
+        var matrix = new Matrix([new[] { 1.0, 2.0 }]);
+        Assert.Throws<ArgumentException>(() => matrix.Dot(matrix));
+    }
+
+    [Fact]
+    public void EqualityHashCodeAndString_UseMatrixValues()
+    {
+        var a = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+        var b = new Matrix([new[] { 1.0, 2.0 }, new[] { 3.0, 4.0 }]);
+        var c = new Matrix([new[] { 1.0, 3.0 }, new[] { 3.0, 4.0 }]);
+
+        Assert.Equal(a, b);
+        Assert.True(a.Equals((object)b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.NotEqual(a, c);
+        Assert.NotEqual(a, Matrix.FromArray([1.0, 2.0]));
+        Assert.Equal("Matrix(2x2)", a.ToString());
+    }
+
+    [Fact]
+    public void GetData_ReturnsDeepCopy()
+    {
+        var matrix = new Matrix([new[] { 1.0, 2.0 }]);
+        var copy = matrix.GetData();
+        copy[0][0] = 999.0;
+
+        Assert.Equal(1.0, matrix[0, 0]);
+    }
+}

--- a/code/packages/fsharp/matrix/BUILD
+++ b/code/packages/fsharp/matrix/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/matrix/BUILD_windows
+++ b/code/packages/fsharp/matrix/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/matrix/CHANGELOG.md
+++ b/code/packages/fsharp/matrix/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Pure F# immutable matrix type for double-precision values
+- Factory helpers for scalars, row vectors, and zero-filled matrices
+- Element-wise add/subtract, scalar add/subtract/scale, transpose, dot product, indexing, deep-copy access, equality, hashing, and dimension validation
+- xUnit coverage for construction, arithmetic, immutability, equality, and invalid dimensions
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/fsharp/matrix/CodingAdventures.Matrix.fsproj
+++ b/code/packages/fsharp/matrix/CodingAdventures.Matrix.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Matrix.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# immutable matrix mathematics helpers for double-precision values</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Matrix.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/matrix/Matrix.fs
+++ b/code/packages/fsharp/matrix/Matrix.fs
@@ -1,0 +1,118 @@
+namespace CodingAdventures.Matrix.FSharp
+
+open System
+
+[<RequireQualifiedAccess>]
+module private MatrixData =
+    let validateAndCopy (data: float array array) =
+        if isNull data then nullArg "data"
+        if data.Length = 0 then invalidArg "data" "Matrix must have at least one row and column"
+        if isNull data.[0] || data.[0].Length = 0 then invalidArg "data" "Matrix must have at least one row and column"
+
+        let cols = data.[0].Length
+        data
+        |> Array.mapi (fun row values ->
+            if isNull values then nullArg $"data[{row}]"
+            if values.Length <> cols then
+                invalidArg "data" $"Row {row} has {values.Length} columns, expected {cols}"
+            Array.copy values)
+
+[<AllowNullLiteral>]
+type Matrix(input: float array array) =
+    let data = MatrixData.validateAndCopy input
+
+    member _.Rows = data.Length
+    member _.Cols = data.[0].Length
+
+    member _.Get(row: int, col: int) = data.[row].[col]
+
+    member this.Item
+        with get (row: int, col: int) = this.Get(row, col)
+
+    member _.GetData() =
+        data |> Array.map Array.copy
+
+    member this.Add(other: Matrix) =
+        this.CheckDimensions(other, "add")
+        this.Map2(other, fun left right -> left + right)
+
+    member this.Subtract(other: Matrix) =
+        this.CheckDimensions(other, "subtract")
+        this.Map2(other, fun left right -> left - right)
+
+    member this.AddScalar(scalar: float) =
+        this.Map(fun value -> value + scalar)
+
+    member this.SubtractScalar(scalar: float) =
+        this.AddScalar(-scalar)
+
+    member this.Scale(scalar: float) =
+        this.Map(fun value -> value * scalar)
+
+    member this.Transpose() =
+        Array.init this.Cols (fun col ->
+            Array.init this.Rows (fun row -> data.[row].[col]))
+        |> Matrix
+
+    member this.Dot(other: Matrix) =
+        if isNull other then nullArg "other"
+
+        if this.Cols <> other.Rows then
+            invalidArg "other" $"Dot dimension mismatch: {this.Rows}x{this.Cols} dot {other.Rows}x{other.Cols}"
+
+        Array.init this.Rows (fun row ->
+            Array.init other.Cols (fun col ->
+                seq { 0 .. this.Cols - 1 }
+                |> Seq.sumBy (fun k -> data.[row].[k] * other.Get(k, col))))
+        |> Matrix
+
+    member private this.CheckDimensions(other: Matrix, operation: string) =
+        if isNull other then nullArg "other"
+
+        if this.Rows <> other.Rows || this.Cols <> other.Cols then
+            invalidArg "other" $"{operation} dimension mismatch: {this.Rows}x{this.Cols} vs {other.Rows}x{other.Cols}"
+
+    member private this.Map(mapper: float -> float) =
+        Array.init this.Rows (fun row ->
+            Array.init this.Cols (fun col -> mapper data.[row].[col]))
+        |> Matrix
+
+    member private this.Map2(other: Matrix, mapper: float -> float -> float) =
+        Array.init this.Rows (fun row ->
+            Array.init this.Cols (fun col -> mapper data.[row].[col] (other.Get(row, col))))
+        |> Matrix
+
+    override this.Equals(obj: obj) =
+        match obj with
+        | :? Matrix as other when this.Rows = other.Rows && this.Cols = other.Cols ->
+            seq {
+                for row in 0 .. this.Rows - 1 do
+                    for col in 0 .. this.Cols - 1 do
+                        data.[row].[col] = other.Get(row, col)
+            }
+            |> Seq.forall id
+        | _ -> false
+
+    override _.GetHashCode() =
+        let mutable hash = HashCode()
+        hash.Add(data.Length)
+        hash.Add(data.[0].Length)
+        for row in data do
+            for value in row do
+                hash.Add(value)
+        hash.ToHashCode()
+
+    override this.ToString() =
+        $"Matrix({this.Rows}x{this.Cols})"
+
+    static member FromScalar(value: float) =
+        Matrix [| [| value |] |]
+
+    static member FromArray(values: float array) =
+        if isNull values then nullArg "values"
+        if values.Length = 0 then invalidArg "values" "Array must not be empty"
+        Matrix [| Array.copy values |]
+
+    static member Zeros(rows: int, cols: int) =
+        if rows <= 0 || cols <= 0 then invalidArg "rows" "Dimensions must be positive"
+        Matrix(Array.init rows (fun _ -> Array.zeroCreate cols))

--- a/code/packages/fsharp/matrix/README.md
+++ b/code/packages/fsharp/matrix/README.md
@@ -1,0 +1,26 @@
+# matrix
+
+Pure F# immutable matrix mathematics helpers for double-precision values.
+
+## What It Includes
+
+- Construction from rectangular 2D arrays, scalars, row vectors, and zero-filled dimensions
+- Element access with deep-copy data export
+- Element-wise add/subtract, scalar add/subtract/scale, transpose, and dot product
+- Value equality, hashing, and dimension validation
+
+## Example
+
+```fsharp
+open CodingAdventures.Matrix.FSharp
+
+let a = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+let b = Matrix.FromScalar 2.0
+let c = a.Scale(b[0, 0]).Transpose()
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/matrix/required_capabilities.json
+++ b/code/packages/fsharp/matrix/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/matrix",
+  "capabilities": [],
+  "justification": "Pure in-memory F# matrix mathematics implementation and tests."
+}

--- a/code/packages/fsharp/matrix/tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.fsproj
+++ b/code/packages/fsharp/matrix/tests/CodingAdventures.Matrix.Tests/CodingAdventures.Matrix.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Matrix.fsproj" />
+    <Compile Include="MatrixTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/matrix/tests/CodingAdventures.Matrix.Tests/MatrixTests.fs
+++ b/code/packages/fsharp/matrix/tests/CodingAdventures.Matrix.Tests/MatrixTests.fs
@@ -1,0 +1,135 @@
+namespace CodingAdventures.Matrix.FSharp.Tests
+
+open System
+open CodingAdventures.Matrix.FSharp
+open Xunit
+
+type MatrixTests() =
+    [<Fact>]
+    member _.``from scalar creates one by one matrix``() =
+        let matrix = Matrix.FromScalar 5.0
+
+        Assert.Equal(1, matrix.Rows)
+        Assert.Equal(1, matrix.Cols)
+        Assert.Equal(5.0, matrix.[0, 0])
+
+    [<Fact>]
+    member _.``from array creates row vector``() =
+        let matrix = Matrix.FromArray [| 1.0; 2.0; 3.0 |]
+
+        Assert.Equal(1, matrix.Rows)
+        Assert.Equal(3, matrix.Cols)
+        Assert.Equal(2.0, matrix.Get(0, 1))
+
+    [<Fact>]
+    member _.``constructor deep copies rectangular data``() =
+        let source = [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+        let matrix = Matrix source
+        source.[0].[0] <- 99.0
+
+        Assert.Equal(2, matrix.Rows)
+        Assert.Equal(2, matrix.Cols)
+        Assert.Equal(1.0, matrix.[0, 0])
+
+    [<Fact>]
+    member _.``zeros creates zero filled matrix``() =
+        let matrix = Matrix.Zeros(3, 2)
+
+        Assert.Equal(3, matrix.Rows)
+        Assert.Equal(2, matrix.Cols)
+        for row in 0 .. matrix.Rows - 1 do
+            for col in 0 .. matrix.Cols - 1 do
+                Assert.Equal(0.0, matrix.[row, col])
+
+    [<Fact>]
+    member _.``invalid construction throws``() =
+        Assert.Throws<ArgumentException>(fun () -> Matrix [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Matrix [| [||] |] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Matrix [| [| 1.0; 2.0 |]; [| 3.0 |] |] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Matrix.FromArray [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Matrix.Zeros(0, 2) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``add adds matrices element wise``() =
+        let a = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+        let b = Matrix [| [| 5.0; 6.0 |]; [| 7.0; 8.0 |] |]
+
+        Assert.Equal(Matrix [| [| 6.0; 8.0 |]; [| 10.0; 12.0 |] |], a.Add b)
+
+    [<Fact>]
+    member _.``subtract subtracts matrices element wise``() =
+        let a = Matrix [| [| 5.0; 6.0 |]; [| 7.0; 8.0 |] |]
+        let b = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+
+        Assert.Equal(Matrix [| [| 4.0; 4.0 |]; [| 4.0; 4.0 |] |], a.Subtract b)
+
+    [<Fact>]
+    member _.``scalar operations map every element``() =
+        let matrix = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+
+        Assert.Equal(Matrix [| [| 11.0; 12.0 |]; [| 13.0; 14.0 |] |], matrix.AddScalar 10.0)
+        Assert.Equal(Matrix [| [| -4.0; -3.0 |]; [| -2.0; -1.0 |] |], matrix.SubtractScalar 5.0)
+        Assert.Equal(Matrix [| [| 2.0; 4.0 |]; [| 6.0; 8.0 |] |], matrix.Scale 2.0)
+        Assert.Equal(Matrix.Zeros(2, 2), matrix.Scale 0.0)
+
+    [<Fact>]
+    member _.``dimension mismatch throws for element wise operations``() =
+        let row = Matrix [| [| 1.0; 2.0 |] |]
+        let column = Matrix [| [| 1.0 |]; [| 2.0 |] |]
+
+        Assert.Throws<ArgumentException>(fun () -> row.Add column |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> row.Subtract column |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``transpose swaps rows and columns``() =
+        let matrix = Matrix [| [| 1.0; 2.0; 3.0 |]; [| 4.0; 5.0; 6.0 |] |]
+        let transposed = matrix.Transpose()
+
+        Assert.Equal(3, transposed.Rows)
+        Assert.Equal(2, transposed.Cols)
+        Assert.Equal(Matrix [| [| 1.0; 4.0 |]; [| 2.0; 5.0 |]; [| 3.0; 6.0 |] |], transposed)
+        Assert.Equal(matrix, transposed.Transpose())
+
+    [<Fact>]
+    member _.``dot multiplies matrices``() =
+        let a = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+        let b = Matrix [| [| 5.0; 6.0 |]; [| 7.0; 8.0 |] |]
+
+        Assert.Equal(Matrix [| [| 19.0; 22.0 |]; [| 43.0; 50.0 |] |], a.Dot b)
+
+    [<Fact>]
+    member _.``dot handles non square and identity matrices``() =
+        let row = Matrix [| [| 1.0; 2.0; 3.0 |] |]
+        let column = Matrix [| [| 4.0 |]; [| 5.0 |]; [| 6.0 |] |]
+        let identity = Matrix [| [| 1.0; 0.0 |]; [| 0.0; 1.0 |] |]
+        let matrix = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+
+        Assert.Equal(Matrix.FromScalar 32.0, row.Dot column)
+        Assert.Equal(matrix, matrix.Dot identity)
+        Assert.Equal(matrix, identity.Dot matrix)
+
+    [<Fact>]
+    member _.``dot rejects dimension mismatch``() =
+        let matrix = Matrix [| [| 1.0; 2.0 |] |]
+        Assert.Throws<ArgumentException>(fun () -> matrix.Dot matrix |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``equality hash code and string use matrix values``() =
+        let a = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+        let b = Matrix [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |]
+        let c = Matrix [| [| 1.0; 3.0 |]; [| 3.0; 4.0 |] |]
+
+        Assert.Equal(a, b)
+        Assert.True(a.Equals(b :> obj))
+        Assert.Equal(a.GetHashCode(), b.GetHashCode())
+        Assert.NotEqual(a, c)
+        Assert.NotEqual(a, Matrix.FromArray [| 1.0; 2.0 |])
+        Assert.Equal("Matrix(2x2)", a.ToString())
+
+    [<Fact>]
+    member _.``get data returns deep copy``() =
+        let matrix = Matrix [| [| 1.0; 2.0 |] |]
+        let copy = matrix.GetData()
+        copy.[0].[0] <- 999.0
+
+        Assert.Equal(1.0, matrix.[0, 0])


### PR DESCRIPTION
## Summary
- add native C# and F# immutable matrix packages to match the Java/Kotlin matrix surface
- include construction from scalars, row vectors, rectangular arrays, and zero dimensions plus element access and deep-copy export
- support element-wise add/subtract, scalar operations, transpose, dot product, equality, hashing, package metadata, capability manifests, and xUnit coverage

## Verification
- dotnet test tests\CodingAdventures.Matrix.Tests\CodingAdventures.Matrix.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.Matrix.Tests\CodingAdventures.Matrix.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line