### PR TITLE
feat(parity): add dotnet wave packages

### DIFF
--- a/code/packages/csharp/wave/BUILD
+++ b/code/packages/csharp/wave/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/wave/BUILD_windows
+++ b/code/packages/csharp/wave/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/wave/CHANGELOG.md
+++ b/code/packages/csharp/wave/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Pure C# immutable sinusoidal wave model with amplitude, frequency, and phase
+- Period, angular-frequency, and time-domain evaluation helpers
+- Validation for non-negative amplitudes and positive frequencies
+- xUnit coverage for construction, phase, extrema, periodicity, invalid input, and high-frequency behavior
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/csharp/wave/CodingAdventures.Wave.csproj
+++ b/code/packages/csharp/wave/CodingAdventures.Wave.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Wave.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# immutable sinusoidal wave model for signal-processing foundations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/wave/README.md
+++ b/code/packages/csharp/wave/README.md
@@ -1,0 +1,24 @@
+# wave
+
+Pure C# immutable sinusoidal wave model for signal-processing foundations.
+
+## What It Includes
+
+- Amplitude, frequency, and phase validation
+- Period and angular-frequency helpers
+- Time-domain evaluation with `y(t) = A * sin(2*pi*f*t + phase)`
+
+## Example
+
+```csharp
+using CodingAdventures.Wave;
+
+var wave = new Wave(amplitude: 1.0, frequency: 440.0);
+var sample = wave.Evaluate(0.001);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/wave/Wave.cs
+++ b/code/packages/csharp/wave/Wave.cs
@@ -1,0 +1,43 @@
+namespace CodingAdventures.Wave;
+
+/// <summary>
+/// Immutable sinusoidal wave: y(t) = A * sin(2*pi*f*t + phase).
+/// </summary>
+public sealed class Wave
+{
+    /// <summary>Create a wave with optional phase in radians.</summary>
+    public Wave(double amplitude, double frequency, double phase = 0.0)
+    {
+        if (amplitude < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amplitude), "Amplitude must be non-negative");
+        }
+
+        if (frequency <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frequency), "Frequency must be positive");
+        }
+
+        Amplitude = amplitude;
+        Frequency = frequency;
+        Phase = phase;
+    }
+
+    /// <summary>Peak displacement.</summary>
+    public double Amplitude { get; }
+
+    /// <summary>Cycles per second in hertz.</summary>
+    public double Frequency { get; }
+
+    /// <summary>Starting offset in radians.</summary>
+    public double Phase { get; }
+
+    /// <summary>Time for one complete cycle, in seconds.</summary>
+    public double Period => 1.0 / Frequency;
+
+    /// <summary>Angular frequency in radians per second.</summary>
+    public double AngularFrequency => 2.0 * Math.PI * Frequency;
+
+    /// <summary>Evaluate the wave at time <paramref name="time"/> in seconds.</summary>
+    public double Evaluate(double time) => Amplitude * Math.Sin(AngularFrequency * time + Phase);
+}

--- a/code/packages/csharp/wave/required_capabilities.json
+++ b/code/packages/csharp/wave/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/wave",
+  "capabilities": [],
+  "justification": "Pure in-memory C# sinusoidal wave implementation and tests."
+}

--- a/code/packages/csharp/wave/tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.csproj
+++ b/code/packages/csharp/wave/tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Wave.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/wave/tests/CodingAdventures.Wave.Tests/WaveTests.cs
+++ b/code/packages/csharp/wave/tests/CodingAdventures.Wave.Tests/WaveTests.cs
@@ -1,0 +1,86 @@
+namespace CodingAdventures.Wave.Tests;
+
+public sealed class WaveTests
+{
+    private const double Epsilon = 1e-10;
+
+    [Fact]
+    public void Constructor_StoresAmplitudeFrequencyAndDefaultPhase()
+    {
+        var wave = new Wave(1.0, 440.0);
+
+        Assert.Equal(1.0, wave.Amplitude);
+        Assert.Equal(440.0, wave.Frequency);
+        Assert.Equal(0.0, wave.Phase);
+    }
+
+    [Fact]
+    public void Constructor_StoresExplicitPhase()
+    {
+        var wave = new Wave(2.0, 100.0, Math.PI / 2.0);
+
+        Assert.Equal(Math.PI / 2.0, wave.Phase, Epsilon);
+    }
+
+    [Fact]
+    public void Period_IsInverseFrequency()
+    {
+        Assert.Equal(0.25, new Wave(1.0, 4.0).Period, Epsilon);
+    }
+
+    [Fact]
+    public void AngularFrequency_IsTwoPiTimesFrequency()
+    {
+        Assert.Equal(2.0 * Math.PI, new Wave(1.0, 1.0).AngularFrequency, Epsilon);
+    }
+
+    [Fact]
+    public void Evaluate_HandlesZeroCrossingPeakAndTrough()
+    {
+        Assert.Equal(0.0, new Wave(1.0, 1.0).Evaluate(0.0), Epsilon);
+        Assert.Equal(3.0, new Wave(3.0, 1.0).Evaluate(0.25), 1e-9);
+        Assert.Equal(-2.0, new Wave(2.0, 1.0).Evaluate(0.75), 1e-9);
+    }
+
+    [Fact]
+    public void Evaluate_IsPeriodic()
+    {
+        var wave = new Wave(2.0, 5.0);
+        const double time = 0.123;
+
+        Assert.Equal(wave.Evaluate(time), wave.Evaluate(time + wave.Period), 1e-9);
+    }
+
+    [Fact]
+    public void Phase_ShiftsWave()
+    {
+        Assert.Equal(1.0, new Wave(1.0, 1.0, Math.PI / 2.0).Evaluate(0.0), 1e-9);
+
+        var wave = new Wave(1.0, 1.0, 0.0);
+        var opposite = new Wave(1.0, 1.0, Math.PI);
+        Assert.Equal(0.0, wave.Evaluate(0.3) + opposite.Evaluate(0.3), 1e-9);
+    }
+
+    [Fact]
+    public void ZeroAmplitude_AlwaysEvaluatesToZero()
+    {
+        Assert.Equal(0.0, new Wave(0.0, 1.0).Evaluate(0.5), Epsilon);
+    }
+
+    [Fact]
+    public void InvalidParameters_Throw()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Wave(-1.0, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Wave(1.0, 0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Wave(1.0, -1.0));
+    }
+
+    [Fact]
+    public void HighFrequency_HasExpectedPeriodAndQuarterCyclePeak()
+    {
+        var wave = new Wave(1.0, 1000.0);
+
+        Assert.Equal(0.001, wave.Period, Epsilon);
+        Assert.Equal(1.0, wave.Evaluate(0.00025), 1e-8);
+    }
+}

--- a/code/packages/fsharp/wave/BUILD
+++ b/code/packages/fsharp/wave/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/wave/BUILD_windows
+++ b/code/packages/fsharp/wave/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/wave/CHANGELOG.md
+++ b/code/packages/fsharp/wave/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-26
+
+### Added
+
+- Pure F# immutable sinusoidal wave model with amplitude, frequency, and phase
+- Period, angular-frequency, and time-domain evaluation helpers
+- Validation for non-negative amplitudes and positive frequencies
+- xUnit coverage for construction, phase, extrema, periodicity, invalid input, and high-frequency behavior
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/fsharp/wave/CodingAdventures.Wave.fsproj
+++ b/code/packages/fsharp/wave/CodingAdventures.Wave.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Wave.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# immutable sinusoidal wave model for signal-processing foundations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Wave.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/wave/README.md
+++ b/code/packages/fsharp/wave/README.md
@@ -1,0 +1,24 @@
+# wave
+
+Pure F# immutable sinusoidal wave model for signal-processing foundations.
+
+## What It Includes
+
+- Amplitude, frequency, and phase validation
+- Period and angular-frequency helpers
+- Time-domain evaluation with `y(t) = A * sin(2*pi*f*t + phase)`
+
+## Example
+
+```fsharp
+open CodingAdventures.Wave.FSharp
+
+let wave = Wave(amplitude = 1.0, frequency = 440.0)
+let sample = wave.Evaluate 0.001
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/wave/Wave.fs
+++ b/code/packages/fsharp/wave/Wave.fs
@@ -1,0 +1,20 @@
+namespace CodingAdventures.Wave.FSharp
+
+open System
+
+type Wave(amplitude: float, frequency: float, ?phase: float) =
+    let phase = defaultArg phase 0.0
+
+    do
+        if amplitude < 0.0 then invalidArg "amplitude" "Amplitude must be non-negative"
+        if frequency <= 0.0 then invalidArg "frequency" "Frequency must be positive"
+
+    member _.Amplitude = amplitude
+    member _.Frequency = frequency
+    member _.Phase = phase
+
+    member _.Period = 1.0 / frequency
+    member _.AngularFrequency = 2.0 * Math.PI * frequency
+
+    member this.Evaluate(time: float) =
+        amplitude * sin (this.AngularFrequency * time + phase)

--- a/code/packages/fsharp/wave/required_capabilities.json
+++ b/code/packages/fsharp/wave/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/wave",
+  "capabilities": [],
+  "justification": "Pure in-memory F# sinusoidal wave implementation and tests."
+}

--- a/code/packages/fsharp/wave/tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.fsproj
+++ b/code/packages/fsharp/wave/tests/CodingAdventures.Wave.Tests/CodingAdventures.Wave.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Wave.fsproj" />
+    <Compile Include="WaveTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/wave/tests/CodingAdventures.Wave.Tests/WaveTests.fs
+++ b/code/packages/fsharp/wave/tests/CodingAdventures.Wave.Tests/WaveTests.fs
@@ -1,0 +1,68 @@
+namespace CodingAdventures.Wave.FSharp.Tests
+
+open System
+open CodingAdventures.Wave.FSharp
+open Xunit
+
+type WaveTests() =
+    let epsilon = 1e-10
+
+    [<Fact>]
+    member _.``constructor stores amplitude frequency and default phase``() =
+        let wave = Wave(1.0, 440.0)
+
+        Assert.Equal(1.0, wave.Amplitude)
+        Assert.Equal(440.0, wave.Frequency)
+        Assert.Equal(0.0, wave.Phase)
+
+    [<Fact>]
+    member _.``constructor stores explicit phase``() =
+        let wave = Wave(2.0, 100.0, Math.PI / 2.0)
+
+        Assert.Equal(Math.PI / 2.0, wave.Phase, epsilon)
+
+    [<Fact>]
+    member _.``period is inverse frequency``() =
+        Assert.Equal(0.25, Wave(1.0, 4.0).Period, epsilon)
+
+    [<Fact>]
+    member _.``angular frequency is two pi times frequency``() =
+        Assert.Equal(2.0 * Math.PI, Wave(1.0, 1.0).AngularFrequency, epsilon)
+
+    [<Fact>]
+    member _.``evaluate handles zero crossing peak and trough``() =
+        Assert.Equal(0.0, Wave(1.0, 1.0).Evaluate 0.0, epsilon)
+        Assert.Equal(3.0, Wave(3.0, 1.0).Evaluate 0.25, 1e-9)
+        Assert.Equal(-2.0, Wave(2.0, 1.0).Evaluate 0.75, 1e-9)
+
+    [<Fact>]
+    member _.``evaluate is periodic``() =
+        let wave = Wave(2.0, 5.0)
+        let time = 0.123
+
+        Assert.Equal(wave.Evaluate time, wave.Evaluate(time + wave.Period), 1e-9)
+
+    [<Fact>]
+    member _.``phase shifts wave``() =
+        Assert.Equal(1.0, Wave(1.0, 1.0, Math.PI / 2.0).Evaluate 0.0, 1e-9)
+
+        let wave = Wave(1.0, 1.0, 0.0)
+        let opposite = Wave(1.0, 1.0, Math.PI)
+        Assert.Equal(0.0, wave.Evaluate 0.3 + opposite.Evaluate 0.3, 1e-9)
+
+    [<Fact>]
+    member _.``zero amplitude always evaluates to zero``() =
+        Assert.Equal(0.0, Wave(0.0, 1.0).Evaluate 0.5, epsilon)
+
+    [<Fact>]
+    member _.``invalid parameters throw``() =
+        Assert.Throws<ArgumentException>(fun () -> Wave(-1.0, 1.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Wave(1.0, 0.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Wave(1.0, -1.0) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``high frequency has expected period and quarter cycle peak``() =
+        let wave = Wave(1.0, 1000.0)
+
+        Assert.Equal(0.001, wave.Period, epsilon)
+        Assert.Equal(1.0, wave.Evaluate 0.00025, 1e-8)


### PR DESCRIPTION
## Summary
- add native C# and F# immutable sinusoidal wave packages matching the Java/Kotlin wave surface
- expose amplitude, frequency, phase, period, angular frequency, and time-domain evaluation with validation
- include package metadata, capability manifests, BUILD commands, and xUnit coverage for both runtimes

## Verification
- dotnet test tests\CodingAdventures.Wave.Tests\CodingAdventures.Wave.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests\CodingAdventures.Wave.Tests\CodingAdventures.Wave.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line