### PR TITLE
feat(parity): add dotnet language lexer parser stubs

### DIFF
--- a/code/packages/csharp/csharp-lexer/BUILD
+++ b/code/packages/csharp/csharp-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csharp-lexer/BUILD_windows
+++ b/code/packages/csharp/csharp-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csharp-lexer/CHANGELOG.md
+++ b/code/packages/csharp/csharp-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for csharp-lexer.

--- a/code/packages/csharp/csharp-lexer/CSharpLexer.cs
+++ b/code/packages/csharp/csharp-lexer/CSharpLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.CSharpLexer;
+
+/// <summary>
+/// C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class CSharpLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "csharp-lexer";
+}

--- a/code/packages/csharp/csharp-lexer/CodingAdventures.CSharpLexer.csproj
+++ b/code/packages/csharp/csharp-lexer/CodingAdventures.CSharpLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CSharpLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csharp-lexer/README.md
+++ b/code/packages/csharp/csharp-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/csharp-lexer
+
+C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin csharp-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new CSharpLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/csharp-lexer/required_capabilities.json
+++ b/code/packages/csharp/csharp-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/csharp-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CSharpLexerTests.cs
+++ b/code/packages/csharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CSharpLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.CSharpLexer.Tests;
+
+public sealed class CSharpLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("csharp-lexer", new CodingAdventures.CSharpLexer.CSharpLexer().Ping());
+    }
+}

--- a/code/packages/csharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.csproj
+++ b/code/packages/csharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CSharpLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csharp-parser/BUILD
+++ b/code/packages/csharp/csharp-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csharp-parser/BUILD_windows
+++ b/code/packages/csharp/csharp-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csharp-parser/CHANGELOG.md
+++ b/code/packages/csharp/csharp-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for csharp-parser.

--- a/code/packages/csharp/csharp-parser/CSharpParser.cs
+++ b/code/packages/csharp/csharp-parser/CSharpParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.CSharpParser;
+
+/// <summary>
+/// C# parser - parses C# source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class CSharpParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "csharp-parser";
+}

--- a/code/packages/csharp/csharp-parser/CodingAdventures.CSharpParser.csproj
+++ b/code/packages/csharp/csharp-parser/CodingAdventures.CSharpParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CSharpParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>C# parser - parses C# source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../csharp-lexer/CodingAdventures.CSharpLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csharp-parser/README.md
+++ b/code/packages/csharp/csharp-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/csharp-parser
+
+C# parser - parses C# source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin csharp-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new CSharpParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/csharp-parser/required_capabilities.json
+++ b/code/packages/csharp/csharp-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/csharp-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CSharpParserTests.cs
+++ b/code/packages/csharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CSharpParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.CSharpParser.Tests;
+
+public sealed class CSharpParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("csharp-parser", new CodingAdventures.CSharpParser.CSharpParser().Ping());
+    }
+}

--- a/code/packages/csharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.csproj
+++ b/code/packages/csharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CSharpParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/excel-lexer/BUILD
+++ b/code/packages/csharp/excel-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/excel-lexer/BUILD_windows
+++ b/code/packages/csharp/excel-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/excel-lexer/CHANGELOG.md
+++ b/code/packages/csharp/excel-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for excel-lexer.

--- a/code/packages/csharp/excel-lexer/CodingAdventures.ExcelLexer.csproj
+++ b/code/packages/csharp/excel-lexer/CodingAdventures.ExcelLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ExcelLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/excel-lexer/ExcelLexer.cs
+++ b/code/packages/csharp/excel-lexer/ExcelLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.ExcelLexer;
+
+/// <summary>
+/// Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class ExcelLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "excel-lexer";
+}

--- a/code/packages/csharp/excel-lexer/README.md
+++ b/code/packages/csharp/excel-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/excel-lexer
+
+Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin excel-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new ExcelLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/excel-lexer/required_capabilities.json
+++ b/code/packages/csharp/excel-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/excel-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.csproj
+++ b/code/packages/csharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ExcelLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/ExcelLexerTests.cs
+++ b/code/packages/csharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/ExcelLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.ExcelLexer.Tests;
+
+public sealed class ExcelLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("excel-lexer", new CodingAdventures.ExcelLexer.ExcelLexer().Ping());
+    }
+}

--- a/code/packages/csharp/excel-parser/BUILD
+++ b/code/packages/csharp/excel-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/excel-parser/BUILD_windows
+++ b/code/packages/csharp/excel-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/excel-parser/CHANGELOG.md
+++ b/code/packages/csharp/excel-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for excel-parser.

--- a/code/packages/csharp/excel-parser/CodingAdventures.ExcelParser.csproj
+++ b/code/packages/csharp/excel-parser/CodingAdventures.ExcelParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ExcelParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Excel parser - parses Excel source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../excel-lexer/CodingAdventures.ExcelLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/excel-parser/ExcelParser.cs
+++ b/code/packages/csharp/excel-parser/ExcelParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.ExcelParser;
+
+/// <summary>
+/// Excel parser - parses Excel source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class ExcelParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "excel-parser";
+}

--- a/code/packages/csharp/excel-parser/README.md
+++ b/code/packages/csharp/excel-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/excel-parser
+
+Excel parser - parses Excel source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin excel-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new ExcelParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/excel-parser/required_capabilities.json
+++ b/code/packages/csharp/excel-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/excel-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.csproj
+++ b/code/packages/csharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ExcelParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/ExcelParserTests.cs
+++ b/code/packages/csharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/ExcelParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.ExcelParser.Tests;
+
+public sealed class ExcelParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("excel-parser", new CodingAdventures.ExcelParser.ExcelParser().Ping());
+    }
+}

--- a/code/packages/csharp/java-lexer/BUILD
+++ b/code/packages/csharp/java-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/java-lexer/BUILD_windows
+++ b/code/packages/csharp/java-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/java-lexer/CHANGELOG.md
+++ b/code/packages/csharp/java-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for java-lexer.

--- a/code/packages/csharp/java-lexer/CodingAdventures.JavaLexer.csproj
+++ b/code/packages/csharp/java-lexer/CodingAdventures.JavaLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/java-lexer/JavaLexer.cs
+++ b/code/packages/csharp/java-lexer/JavaLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaLexer;
+
+/// <summary>
+/// Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class JavaLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "java-lexer";
+}

--- a/code/packages/csharp/java-lexer/README.md
+++ b/code/packages/csharp/java-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/java-lexer
+
+Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin java-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JavaLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/java-lexer/required_capabilities.json
+++ b/code/packages/csharp/java-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/java-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.csproj
+++ b/code/packages/csharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JavaLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/JavaLexerTests.cs
+++ b/code/packages/csharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/JavaLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaLexer.Tests;
+
+public sealed class JavaLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("java-lexer", new CodingAdventures.JavaLexer.JavaLexer().Ping());
+    }
+}

--- a/code/packages/csharp/java-parser/BUILD
+++ b/code/packages/csharp/java-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/java-parser/BUILD_windows
+++ b/code/packages/csharp/java-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/java-parser/CHANGELOG.md
+++ b/code/packages/csharp/java-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for java-parser.

--- a/code/packages/csharp/java-parser/CodingAdventures.JavaParser.csproj
+++ b/code/packages/csharp/java-parser/CodingAdventures.JavaParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Java parser - parses Java source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../java-lexer/CodingAdventures.JavaLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/java-parser/JavaParser.cs
+++ b/code/packages/csharp/java-parser/JavaParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaParser;
+
+/// <summary>
+/// Java parser - parses Java source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class JavaParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "java-parser";
+}

--- a/code/packages/csharp/java-parser/README.md
+++ b/code/packages/csharp/java-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/java-parser
+
+Java parser - parses Java source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin java-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JavaParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/java-parser/required_capabilities.json
+++ b/code/packages/csharp/java-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/java-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/java-parser/tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.csproj
+++ b/code/packages/csharp/java-parser/tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JavaParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/java-parser/tests/CodingAdventures.JavaParser.Tests/JavaParserTests.cs
+++ b/code/packages/csharp/java-parser/tests/CodingAdventures.JavaParser.Tests/JavaParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaParser.Tests;
+
+public sealed class JavaParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("java-parser", new CodingAdventures.JavaParser.JavaParser().Ping());
+    }
+}

--- a/code/packages/csharp/javascript-lexer/BUILD
+++ b/code/packages/csharp/javascript-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/javascript-lexer/BUILD_windows
+++ b/code/packages/csharp/javascript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/javascript-lexer/CHANGELOG.md
+++ b/code/packages/csharp/javascript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for javascript-lexer.

--- a/code/packages/csharp/javascript-lexer/CodingAdventures.JavaScriptLexer.csproj
+++ b/code/packages/csharp/javascript-lexer/CodingAdventures.JavaScriptLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaScriptLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/javascript-lexer/JavaScriptLexer.cs
+++ b/code/packages/csharp/javascript-lexer/JavaScriptLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaScriptLexer;
+
+/// <summary>
+/// JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class JavaScriptLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "javascript-lexer";
+}

--- a/code/packages/csharp/javascript-lexer/README.md
+++ b/code/packages/csharp/javascript-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/javascript-lexer
+
+JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin javascript-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JavaScriptLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/javascript-lexer/required_capabilities.json
+++ b/code/packages/csharp/javascript-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/javascript-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.csproj
+++ b/code/packages/csharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JavaScriptLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/JavaScriptLexerTests.cs
+++ b/code/packages/csharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/JavaScriptLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaScriptLexer.Tests;
+
+public sealed class JavaScriptLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("javascript-lexer", new CodingAdventures.JavaScriptLexer.JavaScriptLexer().Ping());
+    }
+}

--- a/code/packages/csharp/javascript-parser/BUILD
+++ b/code/packages/csharp/javascript-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/javascript-parser/BUILD_windows
+++ b/code/packages/csharp/javascript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/javascript-parser/CHANGELOG.md
+++ b/code/packages/csharp/javascript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for javascript-parser.

--- a/code/packages/csharp/javascript-parser/CodingAdventures.JavaScriptParser.csproj
+++ b/code/packages/csharp/javascript-parser/CodingAdventures.JavaScriptParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaScriptParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../javascript-lexer/CodingAdventures.JavaScriptLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/javascript-parser/JavaScriptParser.cs
+++ b/code/packages/csharp/javascript-parser/JavaScriptParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaScriptParser;
+
+/// <summary>
+/// JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class JavaScriptParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "javascript-parser";
+}

--- a/code/packages/csharp/javascript-parser/README.md
+++ b/code/packages/csharp/javascript-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/javascript-parser
+
+JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin javascript-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JavaScriptParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/javascript-parser/required_capabilities.json
+++ b/code/packages/csharp/javascript-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/javascript-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.csproj
+++ b/code/packages/csharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JavaScriptParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/JavaScriptParserTests.cs
+++ b/code/packages/csharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/JavaScriptParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JavaScriptParser.Tests;
+
+public sealed class JavaScriptParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("javascript-parser", new CodingAdventures.JavaScriptParser.JavaScriptParser().Ping());
+    }
+}

--- a/code/packages/csharp/json-lexer/BUILD
+++ b/code/packages/csharp/json-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-lexer/BUILD_windows
+++ b/code/packages/csharp/json-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-lexer/CHANGELOG.md
+++ b/code/packages/csharp/json-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for json-lexer.

--- a/code/packages/csharp/json-lexer/CodingAdventures.JsonLexer.csproj
+++ b/code/packages/csharp/json-lexer/CodingAdventures.JsonLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JsonLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-lexer/JsonLexer.cs
+++ b/code/packages/csharp/json-lexer/JsonLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JsonLexer;
+
+/// <summary>
+/// JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class JsonLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "json-lexer";
+}

--- a/code/packages/csharp/json-lexer/README.md
+++ b/code/packages/csharp/json-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/json-lexer
+
+JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin json-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JsonLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/json-lexer/required_capabilities.json
+++ b/code/packages/csharp/json-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/json-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.csproj
+++ b/code/packages/csharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JsonLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/JsonLexerTests.cs
+++ b/code/packages/csharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/JsonLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JsonLexer.Tests;
+
+public sealed class JsonLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("json-lexer", new CodingAdventures.JsonLexer.JsonLexer().Ping());
+    }
+}

--- a/code/packages/csharp/json-parser/BUILD
+++ b/code/packages/csharp/json-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-parser/BUILD_windows
+++ b/code/packages/csharp/json-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-parser/CHANGELOG.md
+++ b/code/packages/csharp/json-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for json-parser.

--- a/code/packages/csharp/json-parser/CodingAdventures.JsonParser.csproj
+++ b/code/packages/csharp/json-parser/CodingAdventures.JsonParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JsonParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON parser - parses JSON source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../json-lexer/CodingAdventures.JsonLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-parser/JsonParser.cs
+++ b/code/packages/csharp/json-parser/JsonParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JsonParser;
+
+/// <summary>
+/// JSON parser - parses JSON source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class JsonParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "json-parser";
+}

--- a/code/packages/csharp/json-parser/README.md
+++ b/code/packages/csharp/json-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/json-parser
+
+JSON parser - parses JSON source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin json-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new JsonParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/json-parser/required_capabilities.json
+++ b/code/packages/csharp/json-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/json-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/json-parser/tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.csproj
+++ b/code/packages/csharp/json-parser/tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JsonParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-parser/tests/CodingAdventures.JsonParser.Tests/JsonParserTests.cs
+++ b/code/packages/csharp/json-parser/tests/CodingAdventures.JsonParser.Tests/JsonParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.JsonParser.Tests;
+
+public sealed class JsonParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("json-parser", new CodingAdventures.JsonParser.JsonParser().Ping());
+    }
+}

--- a/code/packages/csharp/lattice-lexer/BUILD
+++ b/code/packages/csharp/lattice-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lattice-lexer/BUILD_windows
+++ b/code/packages/csharp/lattice-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lattice-lexer/CHANGELOG.md
+++ b/code/packages/csharp/lattice-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for lattice-lexer.

--- a/code/packages/csharp/lattice-lexer/CodingAdventures.LatticeLexer.csproj
+++ b/code/packages/csharp/lattice-lexer/CodingAdventures.LatticeLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LatticeLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lattice-lexer/LatticeLexer.cs
+++ b/code/packages/csharp/lattice-lexer/LatticeLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.LatticeLexer;
+
+/// <summary>
+/// Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class LatticeLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "lattice-lexer";
+}

--- a/code/packages/csharp/lattice-lexer/README.md
+++ b/code/packages/csharp/lattice-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/lattice-lexer
+
+Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin lattice-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new LatticeLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/lattice-lexer/required_capabilities.json
+++ b/code/packages/csharp/lattice-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lattice-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.csproj
+++ b/code/packages/csharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.LatticeLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/LatticeLexerTests.cs
+++ b/code/packages/csharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/LatticeLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.LatticeLexer.Tests;
+
+public sealed class LatticeLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("lattice-lexer", new CodingAdventures.LatticeLexer.LatticeLexer().Ping());
+    }
+}

--- a/code/packages/csharp/lattice-parser/BUILD
+++ b/code/packages/csharp/lattice-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lattice-parser/BUILD_windows
+++ b/code/packages/csharp/lattice-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lattice-parser/CHANGELOG.md
+++ b/code/packages/csharp/lattice-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for lattice-parser.

--- a/code/packages/csharp/lattice-parser/CodingAdventures.LatticeParser.csproj
+++ b/code/packages/csharp/lattice-parser/CodingAdventures.LatticeParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LatticeParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../lattice-lexer/CodingAdventures.LatticeLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lattice-parser/LatticeParser.cs
+++ b/code/packages/csharp/lattice-parser/LatticeParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.LatticeParser;
+
+/// <summary>
+/// Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class LatticeParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "lattice-parser";
+}

--- a/code/packages/csharp/lattice-parser/README.md
+++ b/code/packages/csharp/lattice-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/lattice-parser
+
+Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin lattice-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new LatticeParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/lattice-parser/required_capabilities.json
+++ b/code/packages/csharp/lattice-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lattice-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.csproj
+++ b/code/packages/csharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.LatticeParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/LatticeParserTests.cs
+++ b/code/packages/csharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/LatticeParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.LatticeParser.Tests;
+
+public sealed class LatticeParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("lattice-parser", new CodingAdventures.LatticeParser.LatticeParser().Ping());
+    }
+}

--- a/code/packages/csharp/mosaic-lexer/BUILD
+++ b/code/packages/csharp/mosaic-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/mosaic-lexer/BUILD_windows
+++ b/code/packages/csharp/mosaic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/mosaic-lexer/CHANGELOG.md
+++ b/code/packages/csharp/mosaic-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for mosaic-lexer.

--- a/code/packages/csharp/mosaic-lexer/CodingAdventures.MosaicLexer.csproj
+++ b/code/packages/csharp/mosaic-lexer/CodingAdventures.MosaicLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.MosaicLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/mosaic-lexer/MosaicLexer.cs
+++ b/code/packages/csharp/mosaic-lexer/MosaicLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.MosaicLexer;
+
+/// <summary>
+/// Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class MosaicLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "mosaic-lexer";
+}

--- a/code/packages/csharp/mosaic-lexer/README.md
+++ b/code/packages/csharp/mosaic-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/mosaic-lexer
+
+Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin mosaic-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new MosaicLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/mosaic-lexer/required_capabilities.json
+++ b/code/packages/csharp/mosaic-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/mosaic-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.csproj
+++ b/code/packages/csharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.MosaicLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/MosaicLexerTests.cs
+++ b/code/packages/csharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/MosaicLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.MosaicLexer.Tests;
+
+public sealed class MosaicLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("mosaic-lexer", new CodingAdventures.MosaicLexer.MosaicLexer().Ping());
+    }
+}

--- a/code/packages/csharp/mosaic-parser/BUILD
+++ b/code/packages/csharp/mosaic-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/mosaic-parser/BUILD_windows
+++ b/code/packages/csharp/mosaic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/mosaic-parser/CHANGELOG.md
+++ b/code/packages/csharp/mosaic-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for mosaic-parser.

--- a/code/packages/csharp/mosaic-parser/CodingAdventures.MosaicParser.csproj
+++ b/code/packages/csharp/mosaic-parser/CodingAdventures.MosaicParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.MosaicParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../mosaic-lexer/CodingAdventures.MosaicLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/mosaic-parser/MosaicParser.cs
+++ b/code/packages/csharp/mosaic-parser/MosaicParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.MosaicParser;
+
+/// <summary>
+/// Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class MosaicParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "mosaic-parser";
+}

--- a/code/packages/csharp/mosaic-parser/README.md
+++ b/code/packages/csharp/mosaic-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/mosaic-parser
+
+Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin mosaic-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new MosaicParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/mosaic-parser/required_capabilities.json
+++ b/code/packages/csharp/mosaic-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/mosaic-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.csproj
+++ b/code/packages/csharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.MosaicParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/MosaicParserTests.cs
+++ b/code/packages/csharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/MosaicParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.MosaicParser.Tests;
+
+public sealed class MosaicParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("mosaic-parser", new CodingAdventures.MosaicParser.MosaicParser().Ping());
+    }
+}

--- a/code/packages/csharp/python-lexer/BUILD
+++ b/code/packages/csharp/python-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/python-lexer/BUILD_windows
+++ b/code/packages/csharp/python-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/python-lexer/CHANGELOG.md
+++ b/code/packages/csharp/python-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for python-lexer.

--- a/code/packages/csharp/python-lexer/CodingAdventures.PythonLexer.csproj
+++ b/code/packages/csharp/python-lexer/CodingAdventures.PythonLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.PythonLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/python-lexer/PythonLexer.cs
+++ b/code/packages/csharp/python-lexer/PythonLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.PythonLexer;
+
+/// <summary>
+/// Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class PythonLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "python-lexer";
+}

--- a/code/packages/csharp/python-lexer/README.md
+++ b/code/packages/csharp/python-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/python-lexer
+
+Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin python-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new PythonLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/python-lexer/required_capabilities.json
+++ b/code/packages/csharp/python-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/python-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.csproj
+++ b/code/packages/csharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.PythonLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/PythonLexerTests.cs
+++ b/code/packages/csharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/PythonLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.PythonLexer.Tests;
+
+public sealed class PythonLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("python-lexer", new CodingAdventures.PythonLexer.PythonLexer().Ping());
+    }
+}

--- a/code/packages/csharp/python-parser/BUILD
+++ b/code/packages/csharp/python-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/python-parser/BUILD_windows
+++ b/code/packages/csharp/python-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/python-parser/CHANGELOG.md
+++ b/code/packages/csharp/python-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for python-parser.

--- a/code/packages/csharp/python-parser/CodingAdventures.PythonParser.csproj
+++ b/code/packages/csharp/python-parser/CodingAdventures.PythonParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.PythonParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Python parser - parses Python source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../python-lexer/CodingAdventures.PythonLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/python-parser/PythonParser.cs
+++ b/code/packages/csharp/python-parser/PythonParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.PythonParser;
+
+/// <summary>
+/// Python parser - parses Python source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class PythonParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "python-parser";
+}

--- a/code/packages/csharp/python-parser/README.md
+++ b/code/packages/csharp/python-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/python-parser
+
+Python parser - parses Python source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin python-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new PythonParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/python-parser/required_capabilities.json
+++ b/code/packages/csharp/python-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/python-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/python-parser/tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.csproj
+++ b/code/packages/csharp/python-parser/tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.PythonParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/python-parser/tests/CodingAdventures.PythonParser.Tests/PythonParserTests.cs
+++ b/code/packages/csharp/python-parser/tests/CodingAdventures.PythonParser.Tests/PythonParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.PythonParser.Tests;
+
+public sealed class PythonParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("python-parser", new CodingAdventures.PythonParser.PythonParser().Ping());
+    }
+}

--- a/code/packages/csharp/ruby-lexer/BUILD
+++ b/code/packages/csharp/ruby-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ruby-lexer/BUILD_windows
+++ b/code/packages/csharp/ruby-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ruby-lexer/CHANGELOG.md
+++ b/code/packages/csharp/ruby-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for ruby-lexer.

--- a/code/packages/csharp/ruby-lexer/CodingAdventures.RubyLexer.csproj
+++ b/code/packages/csharp/ruby-lexer/CodingAdventures.RubyLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RubyLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ruby-lexer/README.md
+++ b/code/packages/csharp/ruby-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/ruby-lexer
+
+Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin ruby-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new RubyLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/ruby-lexer/RubyLexer.cs
+++ b/code/packages/csharp/ruby-lexer/RubyLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.RubyLexer;
+
+/// <summary>
+/// Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class RubyLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "ruby-lexer";
+}

--- a/code/packages/csharp/ruby-lexer/required_capabilities.json
+++ b/code/packages/csharp/ruby-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/ruby-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.csproj
+++ b/code/packages/csharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.RubyLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/RubyLexerTests.cs
+++ b/code/packages/csharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/RubyLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.RubyLexer.Tests;
+
+public sealed class RubyLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("ruby-lexer", new CodingAdventures.RubyLexer.RubyLexer().Ping());
+    }
+}

--- a/code/packages/csharp/ruby-parser/BUILD
+++ b/code/packages/csharp/ruby-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ruby-parser/BUILD_windows
+++ b/code/packages/csharp/ruby-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ruby-parser/CHANGELOG.md
+++ b/code/packages/csharp/ruby-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for ruby-parser.

--- a/code/packages/csharp/ruby-parser/CodingAdventures.RubyParser.csproj
+++ b/code/packages/csharp/ruby-parser/CodingAdventures.RubyParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RubyParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../ruby-lexer/CodingAdventures.RubyLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ruby-parser/README.md
+++ b/code/packages/csharp/ruby-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/ruby-parser
+
+Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin ruby-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new RubyParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/ruby-parser/RubyParser.cs
+++ b/code/packages/csharp/ruby-parser/RubyParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.RubyParser;
+
+/// <summary>
+/// Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class RubyParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "ruby-parser";
+}

--- a/code/packages/csharp/ruby-parser/required_capabilities.json
+++ b/code/packages/csharp/ruby-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/ruby-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.csproj
+++ b/code/packages/csharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.RubyParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/RubyParserTests.cs
+++ b/code/packages/csharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/RubyParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.RubyParser.Tests;
+
+public sealed class RubyParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("ruby-parser", new CodingAdventures.RubyParser.RubyParser().Ping());
+    }
+}

--- a/code/packages/csharp/sql-lexer/BUILD
+++ b/code/packages/csharp/sql-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-lexer/BUILD_windows
+++ b/code/packages/csharp/sql-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-lexer/CHANGELOG.md
+++ b/code/packages/csharp/sql-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for sql-lexer.

--- a/code/packages/csharp/sql-lexer/CodingAdventures.SqlLexer.csproj
+++ b/code/packages/csharp/sql-lexer/CodingAdventures.SqlLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-lexer/README.md
+++ b/code/packages/csharp/sql-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/sql-lexer
+
+SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin sql-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new SqlLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/sql-lexer/SqlLexer.cs
+++ b/code/packages/csharp/sql-lexer/SqlLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.SqlLexer;
+
+/// <summary>
+/// SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class SqlLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "sql-lexer";
+}

--- a/code/packages/csharp/sql-lexer/required_capabilities.json
+++ b/code/packages/csharp/sql-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sql-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.csproj
+++ b/code/packages/csharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.SqlLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/SqlLexerTests.cs
+++ b/code/packages/csharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/SqlLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.SqlLexer.Tests;
+
+public sealed class SqlLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("sql-lexer", new CodingAdventures.SqlLexer.SqlLexer().Ping());
+    }
+}

--- a/code/packages/csharp/sql-parser/BUILD
+++ b/code/packages/csharp/sql-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-parser/BUILD_windows
+++ b/code/packages/csharp/sql-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-parser/CHANGELOG.md
+++ b/code/packages/csharp/sql-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for sql-parser.

--- a/code/packages/csharp/sql-parser/CodingAdventures.SqlParser.csproj
+++ b/code/packages/csharp/sql-parser/CodingAdventures.SqlParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SQL parser - parses SQL source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../sql-lexer/CodingAdventures.SqlLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-parser/README.md
+++ b/code/packages/csharp/sql-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/sql-parser
+
+SQL parser - parses SQL source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin sql-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new SqlParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/sql-parser/SqlParser.cs
+++ b/code/packages/csharp/sql-parser/SqlParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.SqlParser;
+
+/// <summary>
+/// SQL parser - parses SQL source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class SqlParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "sql-parser";
+}

--- a/code/packages/csharp/sql-parser/required_capabilities.json
+++ b/code/packages/csharp/sql-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sql-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.csproj
+++ b/code/packages/csharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.SqlParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/SqlParserTests.cs
+++ b/code/packages/csharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/SqlParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.SqlParser.Tests;
+
+public sealed class SqlParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("sql-parser", new CodingAdventures.SqlParser.SqlParser().Ping());
+    }
+}

--- a/code/packages/csharp/starlark-lexer/BUILD
+++ b/code/packages/csharp/starlark-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/starlark-lexer/BUILD_windows
+++ b/code/packages/csharp/starlark-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/starlark-lexer/CHANGELOG.md
+++ b/code/packages/csharp/starlark-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for starlark-lexer.

--- a/code/packages/csharp/starlark-lexer/CodingAdventures.StarlarkLexer.csproj
+++ b/code/packages/csharp/starlark-lexer/CodingAdventures.StarlarkLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.StarlarkLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/starlark-lexer/README.md
+++ b/code/packages/csharp/starlark-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/starlark-lexer
+
+Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin starlark-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new StarlarkLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/starlark-lexer/StarlarkLexer.cs
+++ b/code/packages/csharp/starlark-lexer/StarlarkLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.StarlarkLexer;
+
+/// <summary>
+/// Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class StarlarkLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "starlark-lexer";
+}

--- a/code/packages/csharp/starlark-lexer/required_capabilities.json
+++ b/code/packages/csharp/starlark-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/starlark-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.csproj
+++ b/code/packages/csharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.StarlarkLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/StarlarkLexerTests.cs
+++ b/code/packages/csharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/StarlarkLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.StarlarkLexer.Tests;
+
+public sealed class StarlarkLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("starlark-lexer", new CodingAdventures.StarlarkLexer.StarlarkLexer().Ping());
+    }
+}

--- a/code/packages/csharp/starlark-parser/BUILD
+++ b/code/packages/csharp/starlark-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/starlark-parser/BUILD_windows
+++ b/code/packages/csharp/starlark-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/starlark-parser/CHANGELOG.md
+++ b/code/packages/csharp/starlark-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for starlark-parser.

--- a/code/packages/csharp/starlark-parser/CodingAdventures.StarlarkParser.csproj
+++ b/code/packages/csharp/starlark-parser/CodingAdventures.StarlarkParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.StarlarkParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../starlark-lexer/CodingAdventures.StarlarkLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/starlark-parser/README.md
+++ b/code/packages/csharp/starlark-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/starlark-parser
+
+Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin starlark-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new StarlarkParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/starlark-parser/StarlarkParser.cs
+++ b/code/packages/csharp/starlark-parser/StarlarkParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.StarlarkParser;
+
+/// <summary>
+/// Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class StarlarkParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "starlark-parser";
+}

--- a/code/packages/csharp/starlark-parser/required_capabilities.json
+++ b/code/packages/csharp/starlark-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/starlark-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.csproj
+++ b/code/packages/csharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.StarlarkParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/StarlarkParserTests.cs
+++ b/code/packages/csharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/StarlarkParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.StarlarkParser.Tests;
+
+public sealed class StarlarkParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("starlark-parser", new CodingAdventures.StarlarkParser.StarlarkParser().Ping());
+    }
+}

--- a/code/packages/csharp/toml-lexer/BUILD
+++ b/code/packages/csharp/toml-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/toml-lexer/BUILD_windows
+++ b/code/packages/csharp/toml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/toml-lexer/CHANGELOG.md
+++ b/code/packages/csharp/toml-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for toml-lexer.

--- a/code/packages/csharp/toml-lexer/CodingAdventures.TomlLexer.csproj
+++ b/code/packages/csharp/toml-lexer/CodingAdventures.TomlLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TomlLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/toml-lexer/README.md
+++ b/code/packages/csharp/toml-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/toml-lexer
+
+TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin toml-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new TomlLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/toml-lexer/TomlLexer.cs
+++ b/code/packages/csharp/toml-lexer/TomlLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TomlLexer;
+
+/// <summary>
+/// TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class TomlLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "toml-lexer";
+}

--- a/code/packages/csharp/toml-lexer/required_capabilities.json
+++ b/code/packages/csharp/toml-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/toml-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.csproj
+++ b/code/packages/csharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TomlLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/TomlLexerTests.cs
+++ b/code/packages/csharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/TomlLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TomlLexer.Tests;
+
+public sealed class TomlLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("toml-lexer", new CodingAdventures.TomlLexer.TomlLexer().Ping());
+    }
+}

--- a/code/packages/csharp/toml-parser/BUILD
+++ b/code/packages/csharp/toml-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/toml-parser/BUILD_windows
+++ b/code/packages/csharp/toml-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/toml-parser/CHANGELOG.md
+++ b/code/packages/csharp/toml-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for toml-parser.

--- a/code/packages/csharp/toml-parser/CodingAdventures.TomlParser.csproj
+++ b/code/packages/csharp/toml-parser/CodingAdventures.TomlParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TomlParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TOML parser - parses TOML source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../toml-lexer/CodingAdventures.TomlLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/toml-parser/README.md
+++ b/code/packages/csharp/toml-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/toml-parser
+
+TOML parser - parses TOML source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin toml-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new TomlParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/toml-parser/TomlParser.cs
+++ b/code/packages/csharp/toml-parser/TomlParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TomlParser;
+
+/// <summary>
+/// TOML parser - parses TOML source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class TomlParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "toml-parser";
+}

--- a/code/packages/csharp/toml-parser/required_capabilities.json
+++ b/code/packages/csharp/toml-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/toml-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.csproj
+++ b/code/packages/csharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TomlParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/TomlParserTests.cs
+++ b/code/packages/csharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/TomlParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TomlParser.Tests;
+
+public sealed class TomlParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("toml-parser", new CodingAdventures.TomlParser.TomlParser().Ping());
+    }
+}

--- a/code/packages/csharp/typescript-lexer/BUILD
+++ b/code/packages/csharp/typescript-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/typescript-lexer/BUILD_windows
+++ b/code/packages/csharp/typescript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/typescript-lexer/CHANGELOG.md
+++ b/code/packages/csharp/typescript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for typescript-lexer.

--- a/code/packages/csharp/typescript-lexer/CodingAdventures.TypeScriptLexer.csproj
+++ b/code/packages/csharp/typescript-lexer/CodingAdventures.TypeScriptLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeScriptLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/typescript-lexer/README.md
+++ b/code/packages/csharp/typescript-lexer/README.md
@@ -1,0 +1,12 @@
+# csharp/typescript-lexer
+
+TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin typescript-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new TypeScriptLexer();
+var id = package.Ping();
+``

--- a/code/packages/csharp/typescript-lexer/TypeScriptLexer.cs
+++ b/code/packages/csharp/typescript-lexer/TypeScriptLexer.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TypeScriptLexer;
+
+/// <summary>
+/// TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure.
+/// </summary>
+public sealed class TypeScriptLexer
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "typescript-lexer";
+}

--- a/code/packages/csharp/typescript-lexer/required_capabilities.json
+++ b/code/packages/csharp/typescript-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/typescript-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.csproj
+++ b/code/packages/csharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TypeScriptLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/TypeScriptLexerTests.cs
+++ b/code/packages/csharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/TypeScriptLexerTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TypeScriptLexer.Tests;
+
+public sealed class TypeScriptLexerTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("typescript-lexer", new CodingAdventures.TypeScriptLexer.TypeScriptLexer().Ping());
+    }
+}

--- a/code/packages/csharp/typescript-parser/BUILD
+++ b/code/packages/csharp/typescript-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/typescript-parser/BUILD_windows
+++ b/code/packages/csharp/typescript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/typescript-parser/CHANGELOG.md
+++ b/code/packages/csharp/typescript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for typescript-parser.

--- a/code/packages/csharp/typescript-parser/CodingAdventures.TypeScriptParser.csproj
+++ b/code/packages/csharp/typescript-parser/CodingAdventures.TypeScriptParser.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeScriptParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../typescript-lexer/CodingAdventures.TypeScriptLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/typescript-parser/README.md
+++ b/code/packages/csharp/typescript-parser/README.md
@@ -1,0 +1,12 @@
+# csharp/typescript-parser
+
+TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin typescript-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``csharp
+var package = new TypeScriptParser();
+var id = package.Ping();
+``

--- a/code/packages/csharp/typescript-parser/TypeScriptParser.cs
+++ b/code/packages/csharp/typescript-parser/TypeScriptParser.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TypeScriptParser;
+
+/// <summary>
+/// TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure.
+/// </summary>
+public sealed class TypeScriptParser
+{
+    /// <summary>Returns the package identifier used by the parity placeholder packages.</summary>
+    public string Ping() => "typescript-parser";
+}

--- a/code/packages/csharp/typescript-parser/required_capabilities.json
+++ b/code/packages/csharp/typescript-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/typescript-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.csproj
+++ b/code/packages/csharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TypeScriptParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/TypeScriptParserTests.cs
+++ b/code/packages/csharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/TypeScriptParserTests.cs
@@ -1,0 +1,10 @@
+namespace CodingAdventures.TypeScriptParser.Tests;
+
+public sealed class TypeScriptParserTests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("typescript-parser", new CodingAdventures.TypeScriptParser.TypeScriptParser().Ping());
+    }
+}

--- a/code/packages/fsharp/csharp-lexer/BUILD
+++ b/code/packages/fsharp/csharp-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csharp-lexer/BUILD_windows
+++ b/code/packages/fsharp/csharp-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csharp-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/csharp-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for csharp-lexer.

--- a/code/packages/fsharp/csharp-lexer/CSharpLexer.fs
+++ b/code/packages/fsharp/csharp-lexer/CSharpLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.CSharpLexer.FSharp
+
+/// C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure.
+type CSharpLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "csharp-lexer"

--- a/code/packages/fsharp/csharp-lexer/CodingAdventures.CSharpLexer.fsproj
+++ b/code/packages/fsharp/csharp-lexer/CodingAdventures.CSharpLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CSharpLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CSharpLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csharp-lexer/README.md
+++ b/code/packages/fsharp/csharp-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/csharp-lexer
+
+C# lexer - tokenizes C# source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin csharp-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = CSharpLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/csharp-lexer/required_capabilities.json
+++ b/code/packages/fsharp/csharp-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/csharp-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CSharpLexerTests.fs
+++ b/code/packages/fsharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CSharpLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.CSharpLexer.Tests
+
+open CodingAdventures.CSharpLexer.FSharp
+open Xunit
+
+module CSharpLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("csharp-lexer", CSharpLexer().Ping())

--- a/code/packages/fsharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.fsproj
+++ b/code/packages/fsharp/csharp-lexer/tests/CodingAdventures.CSharpLexer.Tests/CodingAdventures.CSharpLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.CSharpLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CSharpLexer.fsproj" />
+    <Compile Include="CSharpLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csharp-parser/BUILD
+++ b/code/packages/fsharp/csharp-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csharp-parser/BUILD_windows
+++ b/code/packages/fsharp/csharp-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csharp-parser/CHANGELOG.md
+++ b/code/packages/fsharp/csharp-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for csharp-parser.

--- a/code/packages/fsharp/csharp-parser/CSharpParser.fs
+++ b/code/packages/fsharp/csharp-parser/CSharpParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.CSharpParser.FSharp
+
+/// C# parser - parses C# source text using the grammar-driven parser infrastructure.
+type CSharpParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "csharp-parser"

--- a/code/packages/fsharp/csharp-parser/CodingAdventures.CSharpParser.fsproj
+++ b/code/packages/fsharp/csharp-parser/CodingAdventures.CSharpParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CSharpParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>C# parser - parses C# source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CSharpParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../csharp-lexer/CodingAdventures.CSharpLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csharp-parser/README.md
+++ b/code/packages/fsharp/csharp-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/csharp-parser
+
+C# parser - parses C# source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin csharp-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = CSharpParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/csharp-parser/required_capabilities.json
+++ b/code/packages/fsharp/csharp-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/csharp-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CSharpParserTests.fs
+++ b/code/packages/fsharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CSharpParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.CSharpParser.Tests
+
+open CodingAdventures.CSharpParser.FSharp
+open Xunit
+
+module CSharpParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("csharp-parser", CSharpParser().Ping())

--- a/code/packages/fsharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.fsproj
+++ b/code/packages/fsharp/csharp-parser/tests/CodingAdventures.CSharpParser.Tests/CodingAdventures.CSharpParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.CSharpParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CSharpParser.fsproj" />
+    <Compile Include="CSharpParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/excel-lexer/BUILD
+++ b/code/packages/fsharp/excel-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/excel-lexer/BUILD_windows
+++ b/code/packages/fsharp/excel-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/excel-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/excel-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for excel-lexer.

--- a/code/packages/fsharp/excel-lexer/CodingAdventures.ExcelLexer.fsproj
+++ b/code/packages/fsharp/excel-lexer/CodingAdventures.ExcelLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ExcelLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ExcelLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/excel-lexer/ExcelLexer.fs
+++ b/code/packages/fsharp/excel-lexer/ExcelLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.ExcelLexer.FSharp
+
+/// Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure.
+type ExcelLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "excel-lexer"

--- a/code/packages/fsharp/excel-lexer/README.md
+++ b/code/packages/fsharp/excel-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/excel-lexer
+
+Excel lexer - tokenizes Excel source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin excel-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = ExcelLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/excel-lexer/required_capabilities.json
+++ b/code/packages/fsharp/excel-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/excel-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.fsproj
+++ b/code/packages/fsharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/CodingAdventures.ExcelLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.ExcelLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ExcelLexer.fsproj" />
+    <Compile Include="ExcelLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/ExcelLexerTests.fs
+++ b/code/packages/fsharp/excel-lexer/tests/CodingAdventures.ExcelLexer.Tests/ExcelLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.ExcelLexer.Tests
+
+open CodingAdventures.ExcelLexer.FSharp
+open Xunit
+
+module ExcelLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("excel-lexer", ExcelLexer().Ping())

--- a/code/packages/fsharp/excel-parser/BUILD
+++ b/code/packages/fsharp/excel-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/excel-parser/BUILD_windows
+++ b/code/packages/fsharp/excel-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/excel-parser/CHANGELOG.md
+++ b/code/packages/fsharp/excel-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for excel-parser.

--- a/code/packages/fsharp/excel-parser/CodingAdventures.ExcelParser.fsproj
+++ b/code/packages/fsharp/excel-parser/CodingAdventures.ExcelParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ExcelParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Excel parser - parses Excel source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ExcelParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../excel-lexer/CodingAdventures.ExcelLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/excel-parser/ExcelParser.fs
+++ b/code/packages/fsharp/excel-parser/ExcelParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.ExcelParser.FSharp
+
+/// Excel parser - parses Excel source text using the grammar-driven parser infrastructure.
+type ExcelParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "excel-parser"

--- a/code/packages/fsharp/excel-parser/README.md
+++ b/code/packages/fsharp/excel-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/excel-parser
+
+Excel parser - parses Excel source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin excel-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = ExcelParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/excel-parser/required_capabilities.json
+++ b/code/packages/fsharp/excel-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/excel-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.fsproj
+++ b/code/packages/fsharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/CodingAdventures.ExcelParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.ExcelParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ExcelParser.fsproj" />
+    <Compile Include="ExcelParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/ExcelParserTests.fs
+++ b/code/packages/fsharp/excel-parser/tests/CodingAdventures.ExcelParser.Tests/ExcelParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.ExcelParser.Tests
+
+open CodingAdventures.ExcelParser.FSharp
+open Xunit
+
+module ExcelParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("excel-parser", ExcelParser().Ping())

--- a/code/packages/fsharp/java-lexer/BUILD
+++ b/code/packages/fsharp/java-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/java-lexer/BUILD_windows
+++ b/code/packages/fsharp/java-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/java-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/java-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for java-lexer.

--- a/code/packages/fsharp/java-lexer/CodingAdventures.JavaLexer.fsproj
+++ b/code/packages/fsharp/java-lexer/CodingAdventures.JavaLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JavaLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/java-lexer/JavaLexer.fs
+++ b/code/packages/fsharp/java-lexer/JavaLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JavaLexer.FSharp
+
+/// Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure.
+type JavaLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "java-lexer"

--- a/code/packages/fsharp/java-lexer/README.md
+++ b/code/packages/fsharp/java-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/java-lexer
+
+Java lexer - tokenizes Java source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin java-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JavaLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/java-lexer/required_capabilities.json
+++ b/code/packages/fsharp/java-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/java-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.fsproj
+++ b/code/packages/fsharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/CodingAdventures.JavaLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JavaLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JavaLexer.fsproj" />
+    <Compile Include="JavaLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/JavaLexerTests.fs
+++ b/code/packages/fsharp/java-lexer/tests/CodingAdventures.JavaLexer.Tests/JavaLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JavaLexer.Tests
+
+open CodingAdventures.JavaLexer.FSharp
+open Xunit
+
+module JavaLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("java-lexer", JavaLexer().Ping())

--- a/code/packages/fsharp/java-parser/BUILD
+++ b/code/packages/fsharp/java-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/java-parser/BUILD_windows
+++ b/code/packages/fsharp/java-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/java-parser/CHANGELOG.md
+++ b/code/packages/fsharp/java-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for java-parser.

--- a/code/packages/fsharp/java-parser/CodingAdventures.JavaParser.fsproj
+++ b/code/packages/fsharp/java-parser/CodingAdventures.JavaParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Java parser - parses Java source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JavaParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../java-lexer/CodingAdventures.JavaLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/java-parser/JavaParser.fs
+++ b/code/packages/fsharp/java-parser/JavaParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JavaParser.FSharp
+
+/// Java parser - parses Java source text using the grammar-driven parser infrastructure.
+type JavaParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "java-parser"

--- a/code/packages/fsharp/java-parser/README.md
+++ b/code/packages/fsharp/java-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/java-parser
+
+Java parser - parses Java source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin java-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JavaParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/java-parser/required_capabilities.json
+++ b/code/packages/fsharp/java-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/java-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/java-parser/tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.fsproj
+++ b/code/packages/fsharp/java-parser/tests/CodingAdventures.JavaParser.Tests/CodingAdventures.JavaParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JavaParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JavaParser.fsproj" />
+    <Compile Include="JavaParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/java-parser/tests/CodingAdventures.JavaParser.Tests/JavaParserTests.fs
+++ b/code/packages/fsharp/java-parser/tests/CodingAdventures.JavaParser.Tests/JavaParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JavaParser.Tests
+
+open CodingAdventures.JavaParser.FSharp
+open Xunit
+
+module JavaParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("java-parser", JavaParser().Ping())

--- a/code/packages/fsharp/javascript-lexer/BUILD
+++ b/code/packages/fsharp/javascript-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/javascript-lexer/BUILD_windows
+++ b/code/packages/fsharp/javascript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/javascript-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/javascript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for javascript-lexer.

--- a/code/packages/fsharp/javascript-lexer/CodingAdventures.JavaScriptLexer.fsproj
+++ b/code/packages/fsharp/javascript-lexer/CodingAdventures.JavaScriptLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaScriptLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JavaScriptLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/javascript-lexer/JavaScriptLexer.fs
+++ b/code/packages/fsharp/javascript-lexer/JavaScriptLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JavaScriptLexer.FSharp
+
+/// JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure.
+type JavaScriptLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "javascript-lexer"

--- a/code/packages/fsharp/javascript-lexer/README.md
+++ b/code/packages/fsharp/javascript-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/javascript-lexer
+
+JavaScript lexer - tokenizes JavaScript source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin javascript-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JavaScriptLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/javascript-lexer/required_capabilities.json
+++ b/code/packages/fsharp/javascript-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/javascript-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.fsproj
+++ b/code/packages/fsharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/CodingAdventures.JavaScriptLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JavaScriptLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JavaScriptLexer.fsproj" />
+    <Compile Include="JavaScriptLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/JavaScriptLexerTests.fs
+++ b/code/packages/fsharp/javascript-lexer/tests/CodingAdventures.JavaScriptLexer.Tests/JavaScriptLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JavaScriptLexer.Tests
+
+open CodingAdventures.JavaScriptLexer.FSharp
+open Xunit
+
+module JavaScriptLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("javascript-lexer", JavaScriptLexer().Ping())

--- a/code/packages/fsharp/javascript-parser/BUILD
+++ b/code/packages/fsharp/javascript-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/javascript-parser/BUILD_windows
+++ b/code/packages/fsharp/javascript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/javascript-parser/CHANGELOG.md
+++ b/code/packages/fsharp/javascript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for javascript-parser.

--- a/code/packages/fsharp/javascript-parser/CodingAdventures.JavaScriptParser.fsproj
+++ b/code/packages/fsharp/javascript-parser/CodingAdventures.JavaScriptParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JavaScriptParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JavaScriptParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../javascript-lexer/CodingAdventures.JavaScriptLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/javascript-parser/JavaScriptParser.fs
+++ b/code/packages/fsharp/javascript-parser/JavaScriptParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JavaScriptParser.FSharp
+
+/// JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure.
+type JavaScriptParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "javascript-parser"

--- a/code/packages/fsharp/javascript-parser/README.md
+++ b/code/packages/fsharp/javascript-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/javascript-parser
+
+JavaScript parser - parses JavaScript source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin javascript-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JavaScriptParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/javascript-parser/required_capabilities.json
+++ b/code/packages/fsharp/javascript-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/javascript-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.fsproj
+++ b/code/packages/fsharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/CodingAdventures.JavaScriptParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JavaScriptParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JavaScriptParser.fsproj" />
+    <Compile Include="JavaScriptParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/JavaScriptParserTests.fs
+++ b/code/packages/fsharp/javascript-parser/tests/CodingAdventures.JavaScriptParser.Tests/JavaScriptParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JavaScriptParser.Tests
+
+open CodingAdventures.JavaScriptParser.FSharp
+open Xunit
+
+module JavaScriptParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("javascript-parser", JavaScriptParser().Ping())

--- a/code/packages/fsharp/json-lexer/BUILD
+++ b/code/packages/fsharp/json-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-lexer/BUILD_windows
+++ b/code/packages/fsharp/json-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/json-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for json-lexer.

--- a/code/packages/fsharp/json-lexer/CodingAdventures.JsonLexer.fsproj
+++ b/code/packages/fsharp/json-lexer/CodingAdventures.JsonLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JsonLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JsonLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-lexer/JsonLexer.fs
+++ b/code/packages/fsharp/json-lexer/JsonLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JsonLexer.FSharp
+
+/// JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure.
+type JsonLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "json-lexer"

--- a/code/packages/fsharp/json-lexer/README.md
+++ b/code/packages/fsharp/json-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/json-lexer
+
+JSON lexer - tokenizes JSON source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin json-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JsonLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/json-lexer/required_capabilities.json
+++ b/code/packages/fsharp/json-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/json-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.fsproj
+++ b/code/packages/fsharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/CodingAdventures.JsonLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JsonLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JsonLexer.fsproj" />
+    <Compile Include="JsonLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/JsonLexerTests.fs
+++ b/code/packages/fsharp/json-lexer/tests/CodingAdventures.JsonLexer.Tests/JsonLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JsonLexer.Tests
+
+open CodingAdventures.JsonLexer.FSharp
+open Xunit
+
+module JsonLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("json-lexer", JsonLexer().Ping())

--- a/code/packages/fsharp/json-parser/BUILD
+++ b/code/packages/fsharp/json-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-parser/BUILD_windows
+++ b/code/packages/fsharp/json-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-parser/CHANGELOG.md
+++ b/code/packages/fsharp/json-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for json-parser.

--- a/code/packages/fsharp/json-parser/CodingAdventures.JsonParser.fsproj
+++ b/code/packages/fsharp/json-parser/CodingAdventures.JsonParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JsonParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON parser - parses JSON source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JsonParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../json-lexer/CodingAdventures.JsonLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-parser/JsonParser.fs
+++ b/code/packages/fsharp/json-parser/JsonParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.JsonParser.FSharp
+
+/// JSON parser - parses JSON source text using the grammar-driven parser infrastructure.
+type JsonParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "json-parser"

--- a/code/packages/fsharp/json-parser/README.md
+++ b/code/packages/fsharp/json-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/json-parser
+
+JSON parser - parses JSON source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin json-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = JsonParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/json-parser/required_capabilities.json
+++ b/code/packages/fsharp/json-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/json-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/json-parser/tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.fsproj
+++ b/code/packages/fsharp/json-parser/tests/CodingAdventures.JsonParser.Tests/CodingAdventures.JsonParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JsonParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JsonParser.fsproj" />
+    <Compile Include="JsonParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-parser/tests/CodingAdventures.JsonParser.Tests/JsonParserTests.fs
+++ b/code/packages/fsharp/json-parser/tests/CodingAdventures.JsonParser.Tests/JsonParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.JsonParser.Tests
+
+open CodingAdventures.JsonParser.FSharp
+open Xunit
+
+module JsonParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("json-parser", JsonParser().Ping())

--- a/code/packages/fsharp/lattice-lexer/BUILD
+++ b/code/packages/fsharp/lattice-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lattice-lexer/BUILD_windows
+++ b/code/packages/fsharp/lattice-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lattice-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/lattice-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for lattice-lexer.

--- a/code/packages/fsharp/lattice-lexer/CodingAdventures.LatticeLexer.fsproj
+++ b/code/packages/fsharp/lattice-lexer/CodingAdventures.LatticeLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LatticeLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="LatticeLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lattice-lexer/LatticeLexer.fs
+++ b/code/packages/fsharp/lattice-lexer/LatticeLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.LatticeLexer.FSharp
+
+/// Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure.
+type LatticeLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "lattice-lexer"

--- a/code/packages/fsharp/lattice-lexer/README.md
+++ b/code/packages/fsharp/lattice-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/lattice-lexer
+
+Lattice lexer - tokenizes Lattice source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin lattice-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = LatticeLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/lattice-lexer/required_capabilities.json
+++ b/code/packages/fsharp/lattice-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lattice-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.fsproj
+++ b/code/packages/fsharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/CodingAdventures.LatticeLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.LatticeLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.LatticeLexer.fsproj" />
+    <Compile Include="LatticeLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/LatticeLexerTests.fs
+++ b/code/packages/fsharp/lattice-lexer/tests/CodingAdventures.LatticeLexer.Tests/LatticeLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.LatticeLexer.Tests
+
+open CodingAdventures.LatticeLexer.FSharp
+open Xunit
+
+module LatticeLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("lattice-lexer", LatticeLexer().Ping())

--- a/code/packages/fsharp/lattice-parser/BUILD
+++ b/code/packages/fsharp/lattice-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lattice-parser/BUILD_windows
+++ b/code/packages/fsharp/lattice-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lattice-parser/CHANGELOG.md
+++ b/code/packages/fsharp/lattice-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for lattice-parser.

--- a/code/packages/fsharp/lattice-parser/CodingAdventures.LatticeParser.fsproj
+++ b/code/packages/fsharp/lattice-parser/CodingAdventures.LatticeParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LatticeParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="LatticeParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../lattice-lexer/CodingAdventures.LatticeLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lattice-parser/LatticeParser.fs
+++ b/code/packages/fsharp/lattice-parser/LatticeParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.LatticeParser.FSharp
+
+/// Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure.
+type LatticeParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "lattice-parser"

--- a/code/packages/fsharp/lattice-parser/README.md
+++ b/code/packages/fsharp/lattice-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/lattice-parser
+
+Lattice parser - parses Lattice source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin lattice-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = LatticeParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/lattice-parser/required_capabilities.json
+++ b/code/packages/fsharp/lattice-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lattice-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.fsproj
+++ b/code/packages/fsharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/CodingAdventures.LatticeParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.LatticeParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.LatticeParser.fsproj" />
+    <Compile Include="LatticeParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/LatticeParserTests.fs
+++ b/code/packages/fsharp/lattice-parser/tests/CodingAdventures.LatticeParser.Tests/LatticeParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.LatticeParser.Tests
+
+open CodingAdventures.LatticeParser.FSharp
+open Xunit
+
+module LatticeParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("lattice-parser", LatticeParser().Ping())

--- a/code/packages/fsharp/mosaic-lexer/BUILD
+++ b/code/packages/fsharp/mosaic-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/mosaic-lexer/BUILD_windows
+++ b/code/packages/fsharp/mosaic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/mosaic-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/mosaic-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for mosaic-lexer.

--- a/code/packages/fsharp/mosaic-lexer/CodingAdventures.MosaicLexer.fsproj
+++ b/code/packages/fsharp/mosaic-lexer/CodingAdventures.MosaicLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.MosaicLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="MosaicLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/mosaic-lexer/MosaicLexer.fs
+++ b/code/packages/fsharp/mosaic-lexer/MosaicLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.MosaicLexer.FSharp
+
+/// Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure.
+type MosaicLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "mosaic-lexer"

--- a/code/packages/fsharp/mosaic-lexer/README.md
+++ b/code/packages/fsharp/mosaic-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/mosaic-lexer
+
+Mosaic lexer - tokenizes Mosaic source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin mosaic-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = MosaicLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/mosaic-lexer/required_capabilities.json
+++ b/code/packages/fsharp/mosaic-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/mosaic-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.fsproj
+++ b/code/packages/fsharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/CodingAdventures.MosaicLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.MosaicLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.MosaicLexer.fsproj" />
+    <Compile Include="MosaicLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/MosaicLexerTests.fs
+++ b/code/packages/fsharp/mosaic-lexer/tests/CodingAdventures.MosaicLexer.Tests/MosaicLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.MosaicLexer.Tests
+
+open CodingAdventures.MosaicLexer.FSharp
+open Xunit
+
+module MosaicLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("mosaic-lexer", MosaicLexer().Ping())

--- a/code/packages/fsharp/mosaic-parser/BUILD
+++ b/code/packages/fsharp/mosaic-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/mosaic-parser/BUILD_windows
+++ b/code/packages/fsharp/mosaic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/mosaic-parser/CHANGELOG.md
+++ b/code/packages/fsharp/mosaic-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for mosaic-parser.

--- a/code/packages/fsharp/mosaic-parser/CodingAdventures.MosaicParser.fsproj
+++ b/code/packages/fsharp/mosaic-parser/CodingAdventures.MosaicParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.MosaicParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="MosaicParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../mosaic-lexer/CodingAdventures.MosaicLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/mosaic-parser/MosaicParser.fs
+++ b/code/packages/fsharp/mosaic-parser/MosaicParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.MosaicParser.FSharp
+
+/// Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure.
+type MosaicParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "mosaic-parser"

--- a/code/packages/fsharp/mosaic-parser/README.md
+++ b/code/packages/fsharp/mosaic-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/mosaic-parser
+
+Mosaic parser - parses Mosaic source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin mosaic-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = MosaicParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/mosaic-parser/required_capabilities.json
+++ b/code/packages/fsharp/mosaic-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/mosaic-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.fsproj
+++ b/code/packages/fsharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/CodingAdventures.MosaicParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.MosaicParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.MosaicParser.fsproj" />
+    <Compile Include="MosaicParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/MosaicParserTests.fs
+++ b/code/packages/fsharp/mosaic-parser/tests/CodingAdventures.MosaicParser.Tests/MosaicParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.MosaicParser.Tests
+
+open CodingAdventures.MosaicParser.FSharp
+open Xunit
+
+module MosaicParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("mosaic-parser", MosaicParser().Ping())

--- a/code/packages/fsharp/python-lexer/BUILD
+++ b/code/packages/fsharp/python-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/python-lexer/BUILD_windows
+++ b/code/packages/fsharp/python-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/python-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/python-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for python-lexer.

--- a/code/packages/fsharp/python-lexer/CodingAdventures.PythonLexer.fsproj
+++ b/code/packages/fsharp/python-lexer/CodingAdventures.PythonLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.PythonLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="PythonLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/python-lexer/PythonLexer.fs
+++ b/code/packages/fsharp/python-lexer/PythonLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.PythonLexer.FSharp
+
+/// Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure.
+type PythonLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "python-lexer"

--- a/code/packages/fsharp/python-lexer/README.md
+++ b/code/packages/fsharp/python-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/python-lexer
+
+Python lexer - tokenizes Python source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin python-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = PythonLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/python-lexer/required_capabilities.json
+++ b/code/packages/fsharp/python-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/python-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.fsproj
+++ b/code/packages/fsharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/CodingAdventures.PythonLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.PythonLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.PythonLexer.fsproj" />
+    <Compile Include="PythonLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/PythonLexerTests.fs
+++ b/code/packages/fsharp/python-lexer/tests/CodingAdventures.PythonLexer.Tests/PythonLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.PythonLexer.Tests
+
+open CodingAdventures.PythonLexer.FSharp
+open Xunit
+
+module PythonLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("python-lexer", PythonLexer().Ping())

--- a/code/packages/fsharp/python-parser/BUILD
+++ b/code/packages/fsharp/python-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/python-parser/BUILD_windows
+++ b/code/packages/fsharp/python-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/python-parser/CHANGELOG.md
+++ b/code/packages/fsharp/python-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for python-parser.

--- a/code/packages/fsharp/python-parser/CodingAdventures.PythonParser.fsproj
+++ b/code/packages/fsharp/python-parser/CodingAdventures.PythonParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.PythonParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Python parser - parses Python source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="PythonParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../python-lexer/CodingAdventures.PythonLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/python-parser/PythonParser.fs
+++ b/code/packages/fsharp/python-parser/PythonParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.PythonParser.FSharp
+
+/// Python parser - parses Python source text using the grammar-driven parser infrastructure.
+type PythonParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "python-parser"

--- a/code/packages/fsharp/python-parser/README.md
+++ b/code/packages/fsharp/python-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/python-parser
+
+Python parser - parses Python source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin python-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = PythonParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/python-parser/required_capabilities.json
+++ b/code/packages/fsharp/python-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/python-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/python-parser/tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.fsproj
+++ b/code/packages/fsharp/python-parser/tests/CodingAdventures.PythonParser.Tests/CodingAdventures.PythonParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.PythonParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.PythonParser.fsproj" />
+    <Compile Include="PythonParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/python-parser/tests/CodingAdventures.PythonParser.Tests/PythonParserTests.fs
+++ b/code/packages/fsharp/python-parser/tests/CodingAdventures.PythonParser.Tests/PythonParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.PythonParser.Tests
+
+open CodingAdventures.PythonParser.FSharp
+open Xunit
+
+module PythonParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("python-parser", PythonParser().Ping())

--- a/code/packages/fsharp/ruby-lexer/BUILD
+++ b/code/packages/fsharp/ruby-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ruby-lexer/BUILD_windows
+++ b/code/packages/fsharp/ruby-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ruby-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/ruby-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for ruby-lexer.

--- a/code/packages/fsharp/ruby-lexer/CodingAdventures.RubyLexer.fsproj
+++ b/code/packages/fsharp/ruby-lexer/CodingAdventures.RubyLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RubyLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="RubyLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ruby-lexer/README.md
+++ b/code/packages/fsharp/ruby-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/ruby-lexer
+
+Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin ruby-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = RubyLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/ruby-lexer/RubyLexer.fs
+++ b/code/packages/fsharp/ruby-lexer/RubyLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.RubyLexer.FSharp
+
+/// Ruby lexer - tokenizes Ruby source text using the grammar-driven lexer infrastructure.
+type RubyLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "ruby-lexer"

--- a/code/packages/fsharp/ruby-lexer/required_capabilities.json
+++ b/code/packages/fsharp/ruby-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/ruby-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.fsproj
+++ b/code/packages/fsharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/CodingAdventures.RubyLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.RubyLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.RubyLexer.fsproj" />
+    <Compile Include="RubyLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/RubyLexerTests.fs
+++ b/code/packages/fsharp/ruby-lexer/tests/CodingAdventures.RubyLexer.Tests/RubyLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.RubyLexer.Tests
+
+open CodingAdventures.RubyLexer.FSharp
+open Xunit
+
+module RubyLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("ruby-lexer", RubyLexer().Ping())

--- a/code/packages/fsharp/ruby-parser/BUILD
+++ b/code/packages/fsharp/ruby-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ruby-parser/BUILD_windows
+++ b/code/packages/fsharp/ruby-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ruby-parser/CHANGELOG.md
+++ b/code/packages/fsharp/ruby-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for ruby-parser.

--- a/code/packages/fsharp/ruby-parser/CodingAdventures.RubyParser.fsproj
+++ b/code/packages/fsharp/ruby-parser/CodingAdventures.RubyParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.RubyParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="RubyParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../ruby-lexer/CodingAdventures.RubyLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ruby-parser/README.md
+++ b/code/packages/fsharp/ruby-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/ruby-parser
+
+Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin ruby-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = RubyParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/ruby-parser/RubyParser.fs
+++ b/code/packages/fsharp/ruby-parser/RubyParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.RubyParser.FSharp
+
+/// Ruby parser - parses Ruby source text using the grammar-driven parser infrastructure.
+type RubyParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "ruby-parser"

--- a/code/packages/fsharp/ruby-parser/required_capabilities.json
+++ b/code/packages/fsharp/ruby-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/ruby-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.fsproj
+++ b/code/packages/fsharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/CodingAdventures.RubyParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.RubyParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.RubyParser.fsproj" />
+    <Compile Include="RubyParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/RubyParserTests.fs
+++ b/code/packages/fsharp/ruby-parser/tests/CodingAdventures.RubyParser.Tests/RubyParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.RubyParser.Tests
+
+open CodingAdventures.RubyParser.FSharp
+open Xunit
+
+module RubyParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("ruby-parser", RubyParser().Ping())

--- a/code/packages/fsharp/sql-lexer/BUILD
+++ b/code/packages/fsharp/sql-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-lexer/BUILD_windows
+++ b/code/packages/fsharp/sql-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/sql-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for sql-lexer.

--- a/code/packages/fsharp/sql-lexer/CodingAdventures.SqlLexer.fsproj
+++ b/code/packages/fsharp/sql-lexer/CodingAdventures.SqlLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SqlLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-lexer/README.md
+++ b/code/packages/fsharp/sql-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/sql-lexer
+
+SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin sql-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = SqlLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/sql-lexer/SqlLexer.fs
+++ b/code/packages/fsharp/sql-lexer/SqlLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.SqlLexer.FSharp
+
+/// SQL lexer - tokenizes SQL source text using the grammar-driven lexer infrastructure.
+type SqlLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "sql-lexer"

--- a/code/packages/fsharp/sql-lexer/required_capabilities.json
+++ b/code/packages/fsharp/sql-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sql-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.fsproj
+++ b/code/packages/fsharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/CodingAdventures.SqlLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.SqlLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SqlLexer.fsproj" />
+    <Compile Include="SqlLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/SqlLexerTests.fs
+++ b/code/packages/fsharp/sql-lexer/tests/CodingAdventures.SqlLexer.Tests/SqlLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.SqlLexer.Tests
+
+open CodingAdventures.SqlLexer.FSharp
+open Xunit
+
+module SqlLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("sql-lexer", SqlLexer().Ping())

--- a/code/packages/fsharp/sql-parser/BUILD
+++ b/code/packages/fsharp/sql-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-parser/BUILD_windows
+++ b/code/packages/fsharp/sql-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-parser/CHANGELOG.md
+++ b/code/packages/fsharp/sql-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for sql-parser.

--- a/code/packages/fsharp/sql-parser/CodingAdventures.SqlParser.fsproj
+++ b/code/packages/fsharp/sql-parser/CodingAdventures.SqlParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SQL parser - parses SQL source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SqlParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../sql-lexer/CodingAdventures.SqlLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-parser/README.md
+++ b/code/packages/fsharp/sql-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/sql-parser
+
+SQL parser - parses SQL source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin sql-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = SqlParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/sql-parser/SqlParser.fs
+++ b/code/packages/fsharp/sql-parser/SqlParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.SqlParser.FSharp
+
+/// SQL parser - parses SQL source text using the grammar-driven parser infrastructure.
+type SqlParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "sql-parser"

--- a/code/packages/fsharp/sql-parser/required_capabilities.json
+++ b/code/packages/fsharp/sql-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sql-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.fsproj
+++ b/code/packages/fsharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/CodingAdventures.SqlParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.SqlParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SqlParser.fsproj" />
+    <Compile Include="SqlParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/SqlParserTests.fs
+++ b/code/packages/fsharp/sql-parser/tests/CodingAdventures.SqlParser.Tests/SqlParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.SqlParser.Tests
+
+open CodingAdventures.SqlParser.FSharp
+open Xunit
+
+module SqlParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("sql-parser", SqlParser().Ping())

--- a/code/packages/fsharp/starlark-lexer/BUILD
+++ b/code/packages/fsharp/starlark-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/starlark-lexer/BUILD_windows
+++ b/code/packages/fsharp/starlark-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/starlark-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/starlark-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for starlark-lexer.

--- a/code/packages/fsharp/starlark-lexer/CodingAdventures.StarlarkLexer.fsproj
+++ b/code/packages/fsharp/starlark-lexer/CodingAdventures.StarlarkLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.StarlarkLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="StarlarkLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/starlark-lexer/README.md
+++ b/code/packages/fsharp/starlark-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/starlark-lexer
+
+Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin starlark-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = StarlarkLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/starlark-lexer/StarlarkLexer.fs
+++ b/code/packages/fsharp/starlark-lexer/StarlarkLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.StarlarkLexer.FSharp
+
+/// Starlark lexer - tokenizes Starlark source text using the grammar-driven lexer infrastructure.
+type StarlarkLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "starlark-lexer"

--- a/code/packages/fsharp/starlark-lexer/required_capabilities.json
+++ b/code/packages/fsharp/starlark-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/starlark-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.fsproj
+++ b/code/packages/fsharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/CodingAdventures.StarlarkLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.StarlarkLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.StarlarkLexer.fsproj" />
+    <Compile Include="StarlarkLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/StarlarkLexerTests.fs
+++ b/code/packages/fsharp/starlark-lexer/tests/CodingAdventures.StarlarkLexer.Tests/StarlarkLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.StarlarkLexer.Tests
+
+open CodingAdventures.StarlarkLexer.FSharp
+open Xunit
+
+module StarlarkLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("starlark-lexer", StarlarkLexer().Ping())

--- a/code/packages/fsharp/starlark-parser/BUILD
+++ b/code/packages/fsharp/starlark-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/starlark-parser/BUILD_windows
+++ b/code/packages/fsharp/starlark-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/starlark-parser/CHANGELOG.md
+++ b/code/packages/fsharp/starlark-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for starlark-parser.

--- a/code/packages/fsharp/starlark-parser/CodingAdventures.StarlarkParser.fsproj
+++ b/code/packages/fsharp/starlark-parser/CodingAdventures.StarlarkParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.StarlarkParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="StarlarkParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../starlark-lexer/CodingAdventures.StarlarkLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/starlark-parser/README.md
+++ b/code/packages/fsharp/starlark-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/starlark-parser
+
+Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin starlark-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = StarlarkParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/starlark-parser/StarlarkParser.fs
+++ b/code/packages/fsharp/starlark-parser/StarlarkParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.StarlarkParser.FSharp
+
+/// Starlark parser - parses Starlark source text using the grammar-driven parser infrastructure.
+type StarlarkParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "starlark-parser"

--- a/code/packages/fsharp/starlark-parser/required_capabilities.json
+++ b/code/packages/fsharp/starlark-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/starlark-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.fsproj
+++ b/code/packages/fsharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/CodingAdventures.StarlarkParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.StarlarkParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.StarlarkParser.fsproj" />
+    <Compile Include="StarlarkParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/StarlarkParserTests.fs
+++ b/code/packages/fsharp/starlark-parser/tests/CodingAdventures.StarlarkParser.Tests/StarlarkParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.StarlarkParser.Tests
+
+open CodingAdventures.StarlarkParser.FSharp
+open Xunit
+
+module StarlarkParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("starlark-parser", StarlarkParser().Ping())

--- a/code/packages/fsharp/toml-lexer/BUILD
+++ b/code/packages/fsharp/toml-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/toml-lexer/BUILD_windows
+++ b/code/packages/fsharp/toml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/toml-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/toml-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for toml-lexer.

--- a/code/packages/fsharp/toml-lexer/CodingAdventures.TomlLexer.fsproj
+++ b/code/packages/fsharp/toml-lexer/CodingAdventures.TomlLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TomlLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TomlLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/toml-lexer/README.md
+++ b/code/packages/fsharp/toml-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/toml-lexer
+
+TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin toml-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = TomlLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/toml-lexer/TomlLexer.fs
+++ b/code/packages/fsharp/toml-lexer/TomlLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.TomlLexer.FSharp
+
+/// TOML lexer - tokenizes TOML source text using the grammar-driven lexer infrastructure.
+type TomlLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "toml-lexer"

--- a/code/packages/fsharp/toml-lexer/required_capabilities.json
+++ b/code/packages/fsharp/toml-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/toml-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.fsproj
+++ b/code/packages/fsharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/CodingAdventures.TomlLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.TomlLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TomlLexer.fsproj" />
+    <Compile Include="TomlLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/TomlLexerTests.fs
+++ b/code/packages/fsharp/toml-lexer/tests/CodingAdventures.TomlLexer.Tests/TomlLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.TomlLexer.Tests
+
+open CodingAdventures.TomlLexer.FSharp
+open Xunit
+
+module TomlLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("toml-lexer", TomlLexer().Ping())

--- a/code/packages/fsharp/toml-parser/BUILD
+++ b/code/packages/fsharp/toml-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/toml-parser/BUILD_windows
+++ b/code/packages/fsharp/toml-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/toml-parser/CHANGELOG.md
+++ b/code/packages/fsharp/toml-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for toml-parser.

--- a/code/packages/fsharp/toml-parser/CodingAdventures.TomlParser.fsproj
+++ b/code/packages/fsharp/toml-parser/CodingAdventures.TomlParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TomlParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TOML parser - parses TOML source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TomlParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../toml-lexer/CodingAdventures.TomlLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/toml-parser/README.md
+++ b/code/packages/fsharp/toml-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/toml-parser
+
+TOML parser - parses TOML source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin toml-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = TomlParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/toml-parser/TomlParser.fs
+++ b/code/packages/fsharp/toml-parser/TomlParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.TomlParser.FSharp
+
+/// TOML parser - parses TOML source text using the grammar-driven parser infrastructure.
+type TomlParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "toml-parser"

--- a/code/packages/fsharp/toml-parser/required_capabilities.json
+++ b/code/packages/fsharp/toml-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/toml-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.fsproj
+++ b/code/packages/fsharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/CodingAdventures.TomlParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.TomlParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TomlParser.fsproj" />
+    <Compile Include="TomlParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/TomlParserTests.fs
+++ b/code/packages/fsharp/toml-parser/tests/CodingAdventures.TomlParser.Tests/TomlParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.TomlParser.Tests
+
+open CodingAdventures.TomlParser.FSharp
+open Xunit
+
+module TomlParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("toml-parser", TomlParser().Ping())

--- a/code/packages/fsharp/typescript-lexer/BUILD
+++ b/code/packages/fsharp/typescript-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/typescript-lexer/BUILD_windows
+++ b/code/packages/fsharp/typescript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/typescript-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/typescript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for typescript-lexer.

--- a/code/packages/fsharp/typescript-lexer/CodingAdventures.TypeScriptLexer.fsproj
+++ b/code/packages/fsharp/typescript-lexer/CodingAdventures.TypeScriptLexer.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeScriptLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TypeScriptLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/typescript-lexer/README.md
+++ b/code/packages/fsharp/typescript-lexer/README.md
@@ -1,0 +1,12 @@
+# fsharp/typescript-lexer
+
+TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure.
+
+This package mirrors the Java and Kotlin typescript-lexer package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = TypeScriptLexer()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/typescript-lexer/TypeScriptLexer.fs
+++ b/code/packages/fsharp/typescript-lexer/TypeScriptLexer.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.TypeScriptLexer.FSharp
+
+/// TypeScript lexer - tokenizes TypeScript source text using the grammar-driven lexer infrastructure.
+type TypeScriptLexer() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "typescript-lexer"

--- a/code/packages/fsharp/typescript-lexer/required_capabilities.json
+++ b/code/packages/fsharp/typescript-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/typescript-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.fsproj
+++ b/code/packages/fsharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/CodingAdventures.TypeScriptLexer.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.TypeScriptLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TypeScriptLexer.fsproj" />
+    <Compile Include="TypeScriptLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/TypeScriptLexerTests.fs
+++ b/code/packages/fsharp/typescript-lexer/tests/CodingAdventures.TypeScriptLexer.Tests/TypeScriptLexerTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.TypeScriptLexer.Tests
+
+open CodingAdventures.TypeScriptLexer.FSharp
+open Xunit
+
+module TypeScriptLexerTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("typescript-lexer", TypeScriptLexer().Ping())

--- a/code/packages/fsharp/typescript-parser/BUILD
+++ b/code/packages/fsharp/typescript-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/typescript-parser/BUILD_windows
+++ b/code/packages/fsharp/typescript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/typescript-parser/CHANGELOG.md
+++ b/code/packages/fsharp/typescript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for typescript-parser.

--- a/code/packages/fsharp/typescript-parser/CodingAdventures.TypeScriptParser.fsproj
+++ b/code/packages/fsharp/typescript-parser/CodingAdventures.TypeScriptParser.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeScriptParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TypeScriptParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../typescript-lexer/CodingAdventures.TypeScriptLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/typescript-parser/README.md
+++ b/code/packages/fsharp/typescript-parser/README.md
@@ -1,0 +1,12 @@
+# fsharp/typescript-parser
+
+TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure.
+
+This package mirrors the Java and Kotlin typescript-parser package surface while reserving the dependency shape for the shared grammar-driven infrastructure.
+
+## Usage
+
+``fsharp
+let package = TypeScriptParser()
+let id = package.Ping()
+``

--- a/code/packages/fsharp/typescript-parser/TypeScriptParser.fs
+++ b/code/packages/fsharp/typescript-parser/TypeScriptParser.fs
@@ -1,0 +1,6 @@
+namespace CodingAdventures.TypeScriptParser.FSharp
+
+/// TypeScript parser - parses TypeScript source text using the grammar-driven parser infrastructure.
+type TypeScriptParser() =
+    /// Returns the package identifier used by the parity placeholder packages.
+    member _.Ping() = "typescript-parser"

--- a/code/packages/fsharp/typescript-parser/required_capabilities.json
+++ b/code/packages/fsharp/typescript-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/typescript-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.fsproj
+++ b/code/packages/fsharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/CodingAdventures.TypeScriptParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.TypeScriptParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TypeScriptParser.fsproj" />
+    <Compile Include="TypeScriptParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/TypeScriptParserTests.fs
+++ b/code/packages/fsharp/typescript-parser/tests/CodingAdventures.TypeScriptParser.Tests/TypeScriptParserTests.fs
@@ -1,0 +1,9 @@
+namespace CodingAdventures.TypeScriptParser.Tests
+
+open CodingAdventures.TypeScriptParser.FSharp
+open Xunit
+
+module TypeScriptParserTests =
+    [<Fact>]
+    let pingReturnsPackageName () =
+        Assert.Equal("typescript-parser", TypeScriptParser().Ping())


### PR DESCRIPTION
## Summary
- add C# and F# parity packages for the lightweight language lexer/parser placeholders currently present in Java/Kotlin
- cover C#, Excel, Java, JavaScript, JSON, Lattice, Mosaic, Python, Ruby, SQL, Starlark, TOML, and TypeScript lexer/parser packages
- preserve grammar/lexer/parser project-reference shape and add package metadata, capability manifests, BUILD commands, and xUnit ping tests

## Verification
- dotnet test code/packages/csharp/<package>/tests/CodingAdventures.<Package>.Tests/CodingAdventures.<Package>.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (all 26 generated C# packages)
- dotnet test code/packages/fsharp/<package>/tests/CodingAdventures.<Package>.Tests/CodingAdventures.<Package>.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (all 26 generated F# packages)