### PR TITLE
feat(parity): add dotnet grammar language packages

### DIFF
--- a/code/packages/csharp/algol-lexer/AlgolLexer.cs
+++ b/code/packages/csharp/algol-lexer/AlgolLexer.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.AlgolLexer;
+
+/// <summary>
+/// ALGOL lexer backed by shared grammar token definitions.
+/// </summary>
+public static class AlgolLexer
+{
+    public const string DefaultVersion = "algol60";
+    public static IReadOnlyList<string> SupportedVersions { get; } = new[] { "algol60" };
+
+    private static readonly ConcurrentDictionary<string, TokenGrammar> TokenGrammars = new();
+
+    public static GrammarLexer CreateAlgolLexer() => CreateAlgolLexer(DefaultVersion);
+
+    public static GrammarLexer CreateAlgolLexer(string? version) => new(LoadTokenGrammar(version));
+
+    public static IReadOnlyList<Token> TokenizeAlgol(string source) => TokenizeAlgol(source, DefaultVersion);
+
+    public static IReadOnlyList<Token> TokenizeAlgol(string source, string? version)
+    {
+        try
+        {
+            return CreateAlgolLexer(version).Tokenize(source);
+        }
+        catch (LexerError error)
+        {
+            throw new ArgumentException("ALGOL tokenization failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static TokenGrammar LoadTokenGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return TokenGrammars.GetOrAdd(validated, ParseTokenGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown ALGOL version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static TokenGrammar ParseTokenGrammarResource(string version)
+    {
+        try
+        {
+            return TokenGrammarParser.Parse(ReadResource(version + ".tokens"));
+        }
+        catch (TokenGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled ALGOL token grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(AlgolLexer).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/algol-lexer/BUILD
+++ b/code/packages/csharp/algol-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/algol-lexer/BUILD_windows
+++ b/code/packages/csharp/algol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/algol-lexer/CHANGELOG.md
+++ b/code/packages/csharp/algol-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for algol-lexer.

--- a/code/packages/csharp/algol-lexer/CodingAdventures.AlgolLexer.csproj
+++ b/code/packages/csharp/algol-lexer/CodingAdventures.AlgolLexer.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AlgolLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ALGOL lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/algol/*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/algol-lexer/README.md
+++ b/code/packages/csharp/algol-lexer/README.md
@@ -1,0 +1,13 @@
+# csharp/algol-lexer
+
+ALGOL lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin algol-lexer API shape and embeds the shared grammar resources from `code/grammars/algol`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/algol-lexer/required_capabilities.json
+++ b/code/packages/csharp/algol-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/algol-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/AlgolLexerTests.cs
+++ b/code/packages/csharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/AlgolLexerTests.cs
@@ -1,0 +1,32 @@
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.AlgolLexer.Tests;
+
+public sealed class AlgolLexerTests
+{
+    [Fact]
+    public void TokenizesSample()
+    {
+        var tokens = CodingAdventures.AlgolLexer.AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end");
+
+        Assert.Equal(TokenType.Keyword, tokens[0].Type);
+        Assert.Equal("begin", tokens[0].Value);
+        Assert.Equal("NAME", tokens[2].EffectiveTypeName);
+        Assert.Equal("x", tokens[2].Value);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.AlgolLexer.AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end"),
+            CodingAdventures.AlgolLexer.AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end", CodingAdventures.AlgolLexer.AlgolLexer.DefaultVersion));
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.AlgolLexer.AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end", "algol68"));
+        Assert.Contains("Unknown ALGOL version", error.Message);
+    }
+}

--- a/code/packages/csharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.csproj
+++ b/code/packages/csharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AlgolLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/algol-parser/AlgolParser.cs
+++ b/code/packages/csharp/algol-parser/AlgolParser.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Parser;
+
+namespace CodingAdventures.AlgolParser;
+
+/// <summary>
+/// ALGOL parser backed by shared grammar definitions.
+/// </summary>
+public static class AlgolParser
+{
+    public static string DefaultVersion => CodingAdventures.AlgolLexer.AlgolLexer.DefaultVersion;
+    public static IReadOnlyList<string> SupportedVersions => CodingAdventures.AlgolLexer.AlgolLexer.SupportedVersions;
+
+    private static readonly ConcurrentDictionary<string, ParserGrammar> ParserGrammars = new();
+
+    public static GrammarParser CreateAlgolParser() => CreateAlgolParser(DefaultVersion);
+
+    public static GrammarParser CreateAlgolParser(string? version) => new(LoadParserGrammar(version));
+
+    public static ASTNode ParseAlgol(string source) => ParseAlgol(source, DefaultVersion);
+
+    public static ASTNode ParseAlgol(string source, string? version)
+    {
+        try
+        {
+            return CreateAlgolParser(version).Parse(CodingAdventures.AlgolLexer.AlgolLexer.TokenizeAlgol(source, version));
+        }
+        catch (GrammarParseError error)
+        {
+            throw new ArgumentException("ALGOL parse failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static ParserGrammar LoadParserGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return ParserGrammars.GetOrAdd(validated, ParseParserGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown ALGOL version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static ParserGrammar ParseParserGrammarResource(string version)
+    {
+        try
+        {
+            return ParserGrammarParser.Parse(ReadResource(version + ".grammar"));
+        }
+        catch (ParserGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled ALGOL parser grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(AlgolParser).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/algol-parser/BUILD
+++ b/code/packages/csharp/algol-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/algol-parser/BUILD_windows
+++ b/code/packages/csharp/algol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/algol-parser/CHANGELOG.md
+++ b/code/packages/csharp/algol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for algol-parser.

--- a/code/packages/csharp/algol-parser/CodingAdventures.AlgolParser.csproj
+++ b/code/packages/csharp/algol-parser/CodingAdventures.AlgolParser.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AlgolParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ALGOL parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/algol/*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../algol-lexer/CodingAdventures.AlgolLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/algol-parser/README.md
+++ b/code/packages/csharp/algol-parser/README.md
@@ -1,0 +1,13 @@
+# csharp/algol-parser
+
+ALGOL parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin algol-parser API shape and embeds the shared grammar resources from `code/grammars/algol`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/algol-parser/required_capabilities.json
+++ b/code/packages/csharp/algol-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/algol-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/AlgolParserTests.cs
+++ b/code/packages/csharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/AlgolParserTests.cs
@@ -1,0 +1,28 @@
+namespace CodingAdventures.AlgolParser.Tests;
+
+public sealed class AlgolParserTests
+{
+    [Fact]
+    public void ParsesSample()
+    {
+        var ast = CodingAdventures.AlgolParser.AlgolParser.ParseAlgol("begin integer x; x := 42 end");
+
+        Assert.Equal("program", ast.RuleName);
+        Assert.True(ast.DescendantCount() > 0);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.AlgolParser.AlgolParser.ParseAlgol("begin integer x; x := 42 end").RuleName,
+            CodingAdventures.AlgolParser.AlgolParser.ParseAlgol("begin integer x; x := 42 end", CodingAdventures.AlgolParser.AlgolParser.DefaultVersion).RuleName);
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.AlgolParser.AlgolParser.ParseAlgol("begin integer x; x := 42 end", "algol68"));
+        Assert.Contains("Unknown ALGOL version", error.Message);
+    }
+}

--- a/code/packages/csharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.csproj
+++ b/code/packages/csharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AlgolParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/grammar-tools/GrammarTools.cs
+++ b/code/packages/csharp/grammar-tools/GrammarTools.cs
@@ -131,6 +131,22 @@ public static class TokenGrammarParser
                 continue;
             }
 
+            if (trimmed.StartsWith("escapes:", StringComparison.Ordinal))
+            {
+                escapeMode = trimmed["escapes:".Length..].Trim();
+                continue;
+            }
+
+            if (trimmed.StartsWith("case_sensitive:", StringComparison.Ordinal))
+            {
+                if (bool.TryParse(trimmed["case_sensitive:".Length..].Trim(), out var parsedBool))
+                {
+                    caseInsensitive = !parsedBool;
+                }
+
+                continue;
+            }
+
             if (trimmed == "keywords:" || trimmed == "reserved:" || trimmed == "context_keywords:" || trimmed == "soft_keywords:" || trimmed == "skip:" || trimmed == "errors:")
             {
                 section = trimmed[..^1];
@@ -149,6 +165,14 @@ public static class TokenGrammarParser
                 section = "group";
                 groupDefinitions[currentGroup] = new List<TokenDefinition>();
                 continue;
+            }
+
+            if ((section == "skip" || section == "errors" || section == "group")
+                && !char.IsWhiteSpace(rawLine[0])
+                && trimmed.Contains('='))
+            {
+                section = "definitions";
+                currentGroup = null;
             }
 
             switch (section)
@@ -247,7 +271,7 @@ public static class TokenGrammarParser
         var rhs = line[(equalsIndex + 1)..].Trim();
         string? alias = null;
 
-        var aliasIndex = rhs.IndexOf("->", StringComparison.Ordinal);
+        var aliasIndex = FindAliasMarker(rhs);
         if (aliasIndex >= 0)
         {
             alias = rhs[(aliasIndex + 2)..].Trim();
@@ -265,6 +289,48 @@ public static class TokenGrammarParser
         }
 
         throw new TokenGrammarError("Pattern must be /regex/ or \"literal\"", lineNumber);
+    }
+
+    private static int FindAliasMarker(string rhs)
+    {
+        var inRegex = false;
+        var inString = false;
+        var escaped = false;
+
+        for (var index = 0; index < rhs.Length - 1; index++)
+        {
+            var ch = rhs[index];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (ch == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (ch == '"' && !inRegex)
+            {
+                inString = !inString;
+                continue;
+            }
+
+            if (ch == '/' && !inString)
+            {
+                inRegex = !inRegex;
+                continue;
+            }
+
+            if (!inRegex && !inString && ch == '-' && rhs[index + 1] == '>')
+            {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     private static string UnescapeQuoted(string text)

--- a/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.cs
+++ b/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.cs
@@ -28,6 +28,27 @@ public class GrammarToolsTests
     }
 
     [Fact]
+    public void TokenGrammarParser_AllowsArrowLiteral()
+    {
+        var grammar = TokenGrammarParser.Parse("""
+            escapes: none
+            case_sensitive: false
+            skip:
+              WS = /[ \t]+/
+            TRIGGER = "->"
+            NAME = /[a-z]+/ -> IDENT
+            """);
+
+        Assert.Equal("none", grammar.EscapeMode);
+        Assert.False(grammar.CaseSensitive);
+        Assert.True(grammar.CaseInsensitive);
+        Assert.Single(grammar.SkipDefinitions!);
+        Assert.Equal("->", grammar.Definitions[0].Pattern);
+        Assert.Null(grammar.Definitions[0].Alias);
+        Assert.Equal("IDENT", grammar.Definitions[1].Alias);
+    }
+
+    [Fact]
     public void ParserGrammarParser_ParsesCoreForms()
     {
         var grammar = ParserGrammarParser.Parse("""

--- a/code/packages/csharp/verilog-lexer/BUILD
+++ b/code/packages/csharp/verilog-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/verilog-lexer/BUILD_windows
+++ b/code/packages/csharp/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/verilog-lexer/CHANGELOG.md
+++ b/code/packages/csharp/verilog-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for verilog-lexer.

--- a/code/packages/csharp/verilog-lexer/CodingAdventures.VerilogLexer.csproj
+++ b/code/packages/csharp/verilog-lexer/CodingAdventures.VerilogLexer.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VerilogLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Verilog lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/verilog/verilog*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/verilog-lexer/README.md
+++ b/code/packages/csharp/verilog-lexer/README.md
@@ -1,0 +1,13 @@
+# csharp/verilog-lexer
+
+Verilog lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin verilog-lexer API shape and embeds the shared grammar resources from `code/grammars/verilog`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/verilog-lexer/VerilogLexer.cs
+++ b/code/packages/csharp/verilog-lexer/VerilogLexer.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.VerilogLexer;
+
+/// <summary>
+/// Verilog lexer backed by shared grammar token definitions.
+/// </summary>
+public static class VerilogLexer
+{
+    public const string DefaultVersion = "2005";
+    public static IReadOnlyList<string> SupportedVersions { get; } = new[] { "1995", "2001", "2005" };
+
+    private static readonly ConcurrentDictionary<string, TokenGrammar> TokenGrammars = new();
+
+    public static GrammarLexer CreateVerilogLexer() => CreateVerilogLexer(DefaultVersion);
+
+    public static GrammarLexer CreateVerilogLexer(string? version) => new(LoadTokenGrammar(version));
+
+    public static IReadOnlyList<Token> TokenizeVerilog(string source) => TokenizeVerilog(source, DefaultVersion);
+
+    public static IReadOnlyList<Token> TokenizeVerilog(string source, string? version)
+    {
+        try
+        {
+            return CreateVerilogLexer(version).Tokenize(source);
+        }
+        catch (LexerError error)
+        {
+            throw new ArgumentException("Verilog tokenization failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static TokenGrammar LoadTokenGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return TokenGrammars.GetOrAdd(validated, ParseTokenGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown Verilog version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static TokenGrammar ParseTokenGrammarResource(string version)
+    {
+        try
+        {
+            return TokenGrammarParser.Parse(ReadResource("verilog" + version + ".tokens"));
+        }
+        catch (TokenGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled Verilog token grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(VerilogLexer).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/verilog-lexer/required_capabilities.json
+++ b/code/packages/csharp/verilog-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/verilog-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.csproj
+++ b/code/packages/csharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.VerilogLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/VerilogLexerTests.cs
+++ b/code/packages/csharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/VerilogLexerTests.cs
@@ -1,0 +1,32 @@
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.VerilogLexer.Tests;
+
+public sealed class VerilogLexerTests
+{
+    [Fact]
+    public void TokenizesSample()
+    {
+        var tokens = CodingAdventures.VerilogLexer.VerilogLexer.TokenizeVerilog("module top; endmodule");
+
+        Assert.Equal(TokenType.Keyword, tokens[0].Type);
+        Assert.Equal("module", tokens[0].Value);
+        Assert.Equal("NAME", tokens[1].EffectiveTypeName);
+        Assert.Equal("top", tokens[1].Value);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.VerilogLexer.VerilogLexer.TokenizeVerilog("module top; endmodule"),
+            CodingAdventures.VerilogLexer.VerilogLexer.TokenizeVerilog("module top; endmodule", CodingAdventures.VerilogLexer.VerilogLexer.DefaultVersion));
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.VerilogLexer.VerilogLexer.TokenizeVerilog("module top; endmodule", "2099"));
+        Assert.Contains("Unknown Verilog version", error.Message);
+    }
+}

--- a/code/packages/csharp/verilog-parser/BUILD
+++ b/code/packages/csharp/verilog-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/verilog-parser/BUILD_windows
+++ b/code/packages/csharp/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/verilog-parser/CHANGELOG.md
+++ b/code/packages/csharp/verilog-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for verilog-parser.

--- a/code/packages/csharp/verilog-parser/CodingAdventures.VerilogParser.csproj
+++ b/code/packages/csharp/verilog-parser/CodingAdventures.VerilogParser.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VerilogParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Verilog parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/verilog/verilog*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../verilog-lexer/CodingAdventures.VerilogLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/verilog-parser/README.md
+++ b/code/packages/csharp/verilog-parser/README.md
@@ -1,0 +1,13 @@
+# csharp/verilog-parser
+
+Verilog parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin verilog-parser API shape and embeds the shared grammar resources from `code/grammars/verilog`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/verilog-parser/VerilogParser.cs
+++ b/code/packages/csharp/verilog-parser/VerilogParser.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Parser;
+
+namespace CodingAdventures.VerilogParser;
+
+/// <summary>
+/// Verilog parser backed by shared grammar definitions.
+/// </summary>
+public static class VerilogParser
+{
+    public static string DefaultVersion => CodingAdventures.VerilogLexer.VerilogLexer.DefaultVersion;
+    public static IReadOnlyList<string> SupportedVersions => CodingAdventures.VerilogLexer.VerilogLexer.SupportedVersions;
+
+    private static readonly ConcurrentDictionary<string, ParserGrammar> ParserGrammars = new();
+
+    public static GrammarParser CreateVerilogParser() => CreateVerilogParser(DefaultVersion);
+
+    public static GrammarParser CreateVerilogParser(string? version) => new(LoadParserGrammar(version));
+
+    public static ASTNode ParseVerilog(string source) => ParseVerilog(source, DefaultVersion);
+
+    public static ASTNode ParseVerilog(string source, string? version)
+    {
+        try
+        {
+            return CreateVerilogParser(version).Parse(CodingAdventures.VerilogLexer.VerilogLexer.TokenizeVerilog(source, version));
+        }
+        catch (GrammarParseError error)
+        {
+            throw new ArgumentException("Verilog parse failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static ParserGrammar LoadParserGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return ParserGrammars.GetOrAdd(validated, ParseParserGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown Verilog version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static ParserGrammar ParseParserGrammarResource(string version)
+    {
+        try
+        {
+            return ParserGrammarParser.Parse(ReadResource("verilog" + version + ".grammar"));
+        }
+        catch (ParserGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled Verilog parser grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(VerilogParser).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/verilog-parser/required_capabilities.json
+++ b/code/packages/csharp/verilog-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/verilog-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.csproj
+++ b/code/packages/csharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.VerilogParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/VerilogParserTests.cs
+++ b/code/packages/csharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/VerilogParserTests.cs
@@ -1,0 +1,28 @@
+namespace CodingAdventures.VerilogParser.Tests;
+
+public sealed class VerilogParserTests
+{
+    [Fact]
+    public void ParsesSample()
+    {
+        var ast = CodingAdventures.VerilogParser.VerilogParser.ParseVerilog("module top; endmodule");
+
+        Assert.Equal("source_text", ast.RuleName);
+        Assert.True(ast.DescendantCount() > 0);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.VerilogParser.VerilogParser.ParseVerilog("module top; endmodule").RuleName,
+            CodingAdventures.VerilogParser.VerilogParser.ParseVerilog("module top; endmodule", CodingAdventures.VerilogParser.VerilogParser.DefaultVersion).RuleName);
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.VerilogParser.VerilogParser.ParseVerilog("module top; endmodule", "2099"));
+        Assert.Contains("Unknown Verilog version", error.Message);
+    }
+}

--- a/code/packages/csharp/vhdl-lexer/BUILD
+++ b/code/packages/csharp/vhdl-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vhdl-lexer/BUILD_windows
+++ b/code/packages/csharp/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vhdl-lexer/CHANGELOG.md
+++ b/code/packages/csharp/vhdl-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for vhdl-lexer.

--- a/code/packages/csharp/vhdl-lexer/CodingAdventures.VhdlLexer.csproj
+++ b/code/packages/csharp/vhdl-lexer/CodingAdventures.VhdlLexer.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VhdlLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>VHDL lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/vhdl/vhdl*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vhdl-lexer/README.md
+++ b/code/packages/csharp/vhdl-lexer/README.md
@@ -1,0 +1,13 @@
+# csharp/vhdl-lexer
+
+VHDL lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin vhdl-lexer API shape and embeds the shared grammar resources from `code/grammars/vhdl`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/vhdl-lexer/VhdlLexer.cs
+++ b/code/packages/csharp/vhdl-lexer/VhdlLexer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.VhdlLexer;
+
+/// <summary>
+/// VHDL lexer backed by shared grammar token definitions.
+/// </summary>
+public static class VhdlLexer
+{
+    public const string DefaultVersion = "2008";
+    public static IReadOnlyList<string> SupportedVersions { get; } = new[] { "1987", "1993", "2002", "2008", "2019" };
+
+    private static readonly ConcurrentDictionary<string, TokenGrammar> TokenGrammars = new();
+
+    public static GrammarLexer CreateVhdlLexer() => CreateVhdlLexer(DefaultVersion);
+
+    public static GrammarLexer CreateVhdlLexer(string? version) => new(LoadTokenGrammar(version));
+
+    public static IReadOnlyList<Token> TokenizeVhdl(string source) => TokenizeVhdl(source, DefaultVersion);
+
+    public static IReadOnlyList<Token> TokenizeVhdl(string source, string? version)
+    {
+        var grammar = LoadTokenGrammar(version);
+        try
+        {
+            var tokens = new GrammarLexer(grammar).Tokenize(source);
+            return NormalizeCase(tokens, new HashSet<string>(grammar.Keywords, StringComparer.Ordinal));
+        }
+        catch (LexerError error)
+        {
+            throw new ArgumentException("VHDL tokenization failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static IReadOnlyList<Token> NormalizeCase(IReadOnlyList<Token> tokens, ISet<string> keywords)
+    {
+        var normalized = new List<Token>(tokens.Count);
+        foreach (var token in tokens)
+        {
+            var normalizeKeyword = token.Type == TokenType.Keyword;
+            var normalizeName = token.Type == TokenType.Grammar && token.TypeName == "NAME";
+            if (!normalizeKeyword && !normalizeName)
+            {
+                normalized.Add(token);
+                continue;
+            }
+
+            var lowered = token.Value.ToLowerInvariant();
+            var normalizedType = normalizeKeyword ? TokenType.Keyword : token.Type;
+            var normalizedTypeName = normalizeKeyword ? "KEYWORD" : token.TypeName;
+            if (normalizeName && keywords.Contains(lowered))
+            {
+                normalizedType = TokenType.Keyword;
+                normalizedTypeName = "KEYWORD";
+            }
+
+            normalized.Add(token with { Type = normalizedType, Value = lowered, TypeName = normalizedTypeName });
+        }
+
+        return normalized;
+    }
+
+    private static TokenGrammar LoadTokenGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return TokenGrammars.GetOrAdd(validated, ParseTokenGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown VHDL version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static TokenGrammar ParseTokenGrammarResource(string version)
+    {
+        try
+        {
+            return TokenGrammarParser.Parse(ReadResource("vhdl" + version + ".tokens"));
+        }
+        catch (TokenGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled VHDL token grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(VhdlLexer).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/vhdl-lexer/required_capabilities.json
+++ b/code/packages/csharp/vhdl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/vhdl-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.csproj
+++ b/code/packages/csharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.VhdlLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/VhdlLexerTests.cs
+++ b/code/packages/csharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/VhdlLexerTests.cs
@@ -1,0 +1,32 @@
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.VhdlLexer.Tests;
+
+public sealed class VhdlLexerTests
+{
+    [Fact]
+    public void TokenizesSample()
+    {
+        var tokens = CodingAdventures.VhdlLexer.VhdlLexer.TokenizeVhdl("ENTITY TOP IS END ENTITY TOP;");
+
+        Assert.Equal(TokenType.Keyword, tokens[0].Type);
+        Assert.Equal("entity", tokens[0].Value);
+        Assert.Equal("NAME", tokens[1].EffectiveTypeName);
+        Assert.Equal("top", tokens[1].Value);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.VhdlLexer.VhdlLexer.TokenizeVhdl("entity top is end entity top;"),
+            CodingAdventures.VhdlLexer.VhdlLexer.TokenizeVhdl("entity top is end entity top;", CodingAdventures.VhdlLexer.VhdlLexer.DefaultVersion));
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.VhdlLexer.VhdlLexer.TokenizeVhdl("entity top is end entity top;", "2099"));
+        Assert.Contains("Unknown VHDL version", error.Message);
+    }
+}

--- a/code/packages/csharp/vhdl-parser/BUILD
+++ b/code/packages/csharp/vhdl-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vhdl-parser/BUILD_windows
+++ b/code/packages/csharp/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/vhdl-parser/CHANGELOG.md
+++ b/code/packages/csharp/vhdl-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial csharp package for vhdl-parser.

--- a/code/packages/csharp/vhdl-parser/CodingAdventures.VhdlParser.csproj
+++ b/code/packages/csharp/vhdl-parser/CodingAdventures.VhdlParser.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VhdlParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>VHDL parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/vhdl/vhdl*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../vhdl-lexer/CodingAdventures.VhdlLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vhdl-parser/README.md
+++ b/code/packages/csharp/vhdl-parser/README.md
@@ -1,0 +1,13 @@
+# csharp/vhdl-parser
+
+VHDL parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin vhdl-parser API shape and embeds the shared grammar resources from `code/grammars/vhdl`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/vhdl-parser/VhdlParser.cs
+++ b/code/packages/csharp/vhdl-parser/VhdlParser.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Parser;
+
+namespace CodingAdventures.VhdlParser;
+
+/// <summary>
+/// VHDL parser backed by shared grammar definitions.
+/// </summary>
+public static class VhdlParser
+{
+    public static string DefaultVersion => CodingAdventures.VhdlLexer.VhdlLexer.DefaultVersion;
+    public static IReadOnlyList<string> SupportedVersions => CodingAdventures.VhdlLexer.VhdlLexer.SupportedVersions;
+
+    private static readonly ConcurrentDictionary<string, ParserGrammar> ParserGrammars = new();
+
+    public static GrammarParser CreateVhdlParser() => CreateVhdlParser(DefaultVersion);
+
+    public static GrammarParser CreateVhdlParser(string? version) => new(LoadParserGrammar(version));
+
+    public static ASTNode ParseVhdl(string source) => ParseVhdl(source, DefaultVersion);
+
+    public static ASTNode ParseVhdl(string source, string? version)
+    {
+        try
+        {
+            return CreateVhdlParser(version).Parse(CodingAdventures.VhdlLexer.VhdlLexer.TokenizeVhdl(source, version));
+        }
+        catch (GrammarParseError error)
+        {
+            throw new ArgumentException("VHDL parse failed: " + error.Message, nameof(source), error);
+        }
+    }
+
+    private static ParserGrammar LoadParserGrammar(string? version)
+    {
+        var validated = ValidateVersion(version);
+        return ParserGrammars.GetOrAdd(validated, ParseParserGrammarResource);
+    }
+
+    private static string ValidateVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        if (!SupportedVersions.Contains(version))
+        {
+            throw new ArgumentException("Unknown VHDL version '" + version + "'. Valid values: " + string.Join(", ", SupportedVersions), nameof(version));
+        }
+
+        return version;
+    }
+
+    private static ParserGrammar ParseParserGrammarResource(string version)
+    {
+        try
+        {
+            return ParserGrammarParser.Parse(ReadResource("vhdl" + version + ".grammar"));
+        }
+        catch (ParserGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled VHDL parser grammar for version " + version, error);
+        }
+    }
+
+    private static string ReadResource(string resourceName)
+    {
+        var assembly = typeof(VhdlParser).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException("Missing bundled resource: " + resourceName);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/code/packages/csharp/vhdl-parser/required_capabilities.json
+++ b/code/packages/csharp/vhdl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/vhdl-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/csharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.csproj
+++ b/code/packages/csharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.VhdlParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/VhdlParserTests.cs
+++ b/code/packages/csharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/VhdlParserTests.cs
@@ -1,0 +1,28 @@
+namespace CodingAdventures.VhdlParser.Tests;
+
+public sealed class VhdlParserTests
+{
+    [Fact]
+    public void ParsesSample()
+    {
+        var ast = CodingAdventures.VhdlParser.VhdlParser.ParseVhdl("entity top is end entity top;");
+
+        Assert.Equal("design_file", ast.RuleName);
+        Assert.True(ast.DescendantCount() > 0);
+    }
+
+    [Fact]
+    public void DefaultVersionMatchesExplicitVersion()
+    {
+        Assert.Equal(
+            CodingAdventures.VhdlParser.VhdlParser.ParseVhdl("entity top is end entity top;").RuleName,
+            CodingAdventures.VhdlParser.VhdlParser.ParseVhdl("entity top is end entity top;", CodingAdventures.VhdlParser.VhdlParser.DefaultVersion).RuleName);
+    }
+
+    [Fact]
+    public void RejectsUnknownVersion()
+    {
+        var error = Assert.Throws<ArgumentException>(() => CodingAdventures.VhdlParser.VhdlParser.ParseVhdl("entity top is end entity top;", "2099"));
+        Assert.Contains("Unknown VHDL version", error.Message);
+    }
+}

--- a/code/packages/fsharp/algol-lexer/AlgolLexer.fs
+++ b/code/packages/fsharp/algol-lexer/AlgolLexer.fs
@@ -1,0 +1,56 @@
+namespace CodingAdventures.AlgolLexer.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Lexer.FSharp
+
+/// ALGOL lexer backed by shared grammar token definitions.
+type AlgolLexer private () =
+    static let defaultVersion = "algol60"
+    static let supportedVersions = [| "algol60" |]
+    static let tokenGrammars = ConcurrentDictionary<string, TokenGrammar>()
+
+    static member DefaultVersion = defaultVersion
+    static member SupportedVersions = supportedVersions :> IReadOnlyList<string>
+
+    static member CreateAlgolLexer() = AlgolLexer.CreateAlgolLexer(defaultVersion)
+    static member CreateAlgolLexer(version: string) = GrammarLexer(AlgolLexer.LoadTokenGrammar(version))
+
+    static member TokenizeAlgol(source: string) = AlgolLexer.TokenizeAlgol(source, defaultVersion)
+    static member TokenizeAlgol(source: string, version: string) =
+        try
+            AlgolLexer.CreateAlgolLexer(version).Tokenize(source)
+        with
+        | :? LexerError as error ->
+            raise (ArgumentException(sprintf "ALGOL tokenization failed: %s" error.Message, "source", error))
+
+    static member private LoadTokenGrammar(version: string) =
+        let validated = AlgolLexer.ValidateVersion(version)
+        tokenGrammars.GetOrAdd(validated, Func<string, TokenGrammar>(AlgolLexer.ParseTokenGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            defaultVersion
+        elif Array.exists ((=) version) supportedVersions then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown ALGOL version '%s'. Valid values: %s" version (String.Join(", ", supportedVersions)))
+
+    static member private ParseTokenGrammarResource(version: string) =
+        try
+            TokenGrammarParser.Parse(AlgolLexer.ReadResource(version + ".tokens"))
+        with
+        | :? TokenGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled ALGOL token grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<AlgolLexer>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/algol-lexer/BUILD
+++ b/code/packages/fsharp/algol-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/algol-lexer/BUILD_windows
+++ b/code/packages/fsharp/algol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/algol-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/algol-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for algol-lexer.

--- a/code/packages/fsharp/algol-lexer/CodingAdventures.AlgolLexer.fsproj
+++ b/code/packages/fsharp/algol-lexer/CodingAdventures.AlgolLexer.fsproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AlgolLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ALGOL lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="AlgolLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/algol/*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/algol-lexer/README.md
+++ b/code/packages/fsharp/algol-lexer/README.md
@@ -1,0 +1,13 @@
+# fsharp/algol-lexer
+
+ALGOL lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin algol-lexer API shape and embeds the shared grammar resources from `code/grammars/algol`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/algol-lexer/required_capabilities.json
+++ b/code/packages/fsharp/algol-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/algol-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/AlgolLexerTests.fs
+++ b/code/packages/fsharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/AlgolLexerTests.fs
@@ -1,0 +1,27 @@
+namespace CodingAdventures.AlgolLexer.Tests
+
+open CodingAdventures.Lexer.FSharp
+open CodingAdventures.AlgolLexer.FSharp
+open Xunit
+
+module AlgolLexerTests =
+    [<Fact>]
+    let tokenizesSample () =
+        let tokens = AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end")
+
+        Assert.Equal(TokenType.Keyword, tokens.[0].Type)
+        Assert.Equal("begin", tokens.[0].Value)
+        Assert.Equal("NAME", tokens.[2].EffectiveTypeName)
+        Assert.Equal("x", tokens.[2].Value)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        let defaultTokens = AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end")
+        let explicitTokens = AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end", AlgolLexer.DefaultVersion)
+        Assert.Equal(Seq.length defaultTokens, Seq.length explicitTokens)
+        Assert.Equal(defaultTokens.[0].Value, explicitTokens.[0].Value)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> AlgolLexer.TokenizeAlgol("begin integer x; x := 42 end", "algol68") |> ignore)
+        Assert.Contains("Unknown ALGOL version", error.Message)

--- a/code/packages/fsharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.fsproj
+++ b/code/packages/fsharp/algol-lexer/tests/CodingAdventures.AlgolLexer.Tests/CodingAdventures.AlgolLexer.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.AlgolLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AlgolLexer.fsproj" />
+    <Compile Include="AlgolLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/algol-parser/AlgolParser.fs
+++ b/code/packages/fsharp/algol-parser/AlgolParser.fs
@@ -1,0 +1,54 @@
+namespace CodingAdventures.AlgolParser.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Parser.FSharp
+open CodingAdventures.AlgolLexer.FSharp
+
+/// ALGOL parser backed by shared grammar definitions.
+type AlgolParser private () =
+    static let parserGrammars = ConcurrentDictionary<string, ParserGrammar>()
+
+    static member DefaultVersion = AlgolLexer.DefaultVersion
+    static member SupportedVersions = AlgolLexer.SupportedVersions
+
+    static member CreateAlgolParser() = AlgolParser.CreateAlgolParser(AlgolParser.DefaultVersion)
+    static member CreateAlgolParser(version: string) = GrammarParser(AlgolParser.LoadParserGrammar(version))
+
+    static member ParseAlgol(source: string) = AlgolParser.ParseAlgol(source, AlgolParser.DefaultVersion)
+    static member ParseAlgol(source: string, version: string) =
+        try
+            AlgolParser.CreateAlgolParser(version).Parse(AlgolLexer.TokenizeAlgol(source, version))
+        with
+        | :? GrammarParseError as error ->
+            raise (ArgumentException(sprintf "ALGOL parse failed: %s" error.Message, "source", error))
+
+    static member private LoadParserGrammar(version: string) =
+        let validated = AlgolParser.ValidateVersion(version)
+        parserGrammars.GetOrAdd(validated, Func<string, ParserGrammar>(AlgolParser.ParseParserGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            AlgolParser.DefaultVersion
+        elif AlgolParser.SupportedVersions |> Seq.exists ((=) version) then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown ALGOL version '%s'. Valid values: %s" version (String.Join(", ", AlgolParser.SupportedVersions)))
+
+    static member private ParseParserGrammarResource(version: string) =
+        try
+            ParserGrammarParser.Parse(AlgolParser.ReadResource(version + ".grammar"))
+        with
+        | :? ParserGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled ALGOL parser grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<AlgolParser>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/algol-parser/BUILD
+++ b/code/packages/fsharp/algol-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/algol-parser/BUILD_windows
+++ b/code/packages/fsharp/algol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/algol-parser/CHANGELOG.md
+++ b/code/packages/fsharp/algol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for algol-parser.

--- a/code/packages/fsharp/algol-parser/CodingAdventures.AlgolParser.fsproj
+++ b/code/packages/fsharp/algol-parser/CodingAdventures.AlgolParser.fsproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AlgolParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ALGOL parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="AlgolParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/algol/*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../algol-lexer/CodingAdventures.AlgolLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/algol-parser/README.md
+++ b/code/packages/fsharp/algol-parser/README.md
@@ -1,0 +1,13 @@
+# fsharp/algol-parser
+
+ALGOL parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin algol-parser API shape and embeds the shared grammar resources from `code/grammars/algol`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/algol-parser/required_capabilities.json
+++ b/code/packages/fsharp/algol-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/algol-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/AlgolParserTests.fs
+++ b/code/packages/fsharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/AlgolParserTests.fs
@@ -1,0 +1,23 @@
+namespace CodingAdventures.AlgolParser.Tests
+
+open CodingAdventures.AlgolParser.FSharp
+open Xunit
+
+module AlgolParserTests =
+    [<Fact>]
+    let parsesSample () =
+        let ast = AlgolParser.ParseAlgol("begin integer x; x := 42 end")
+
+        Assert.Equal("program", ast.RuleName)
+        Assert.True(ast.DescendantCount() > 0)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        Assert.Equal(
+            AlgolParser.ParseAlgol("begin integer x; x := 42 end").RuleName,
+            AlgolParser.ParseAlgol("begin integer x; x := 42 end", AlgolParser.DefaultVersion).RuleName)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> AlgolParser.ParseAlgol("begin integer x; x := 42 end", "algol68") |> ignore)
+        Assert.Contains("Unknown ALGOL version", error.Message)

--- a/code/packages/fsharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.fsproj
+++ b/code/packages/fsharp/algol-parser/tests/CodingAdventures.AlgolParser.Tests/CodingAdventures.AlgolParser.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.AlgolParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AlgolParser.fsproj" />
+    <Compile Include="AlgolParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/grammar-tools/GrammarTools.fs
+++ b/code/packages/fsharp/grammar-tools/GrammarTools.fs
@@ -168,6 +168,31 @@ module private TokenGrammarParsing =
 
         result.ToString()
 
+    let findAliasMarker (rhs: string) =
+        let mutable inRegex = false
+        let mutable inString = false
+        let mutable escaped = false
+        let mutable found = -1
+        let mutable index = 0
+
+        while found < 0 && index < rhs.Length - 1 do
+            let ch = rhs[index]
+
+            if escaped then
+                escaped <- false
+            elif ch = '\\' then
+                escaped <- true
+            elif ch = '"' && not inRegex then
+                inString <- not inString
+            elif ch = '/' && not inString then
+                inRegex <- not inRegex
+            elif not inRegex && not inString && ch = '-' && rhs[index + 1] = '>' then
+                found <- index
+
+            index <- index + 1
+
+        found
+
     let parseDefinition (line: string) lineNumber =
         let equalsIndex = line.IndexOf('=')
         if equalsIndex < 1 then
@@ -176,7 +201,7 @@ module private TokenGrammarParsing =
         let name = line.Substring(0, equalsIndex).Trim()
         let mutable rhs = line.Substring(equalsIndex + 1).Trim()
         let mutable alias = None
-        let aliasIndex = rhs.IndexOf("->", StringComparison.Ordinal)
+        let aliasIndex = findAliasMarker rhs
 
         if aliasIndex >= 0 then
             alias <- Some(rhs.Substring(aliasIndex + 2).Trim())
@@ -231,6 +256,12 @@ type TokenGrammarParser =
                     mode <- Some(trimmed.Substring("mode:".Length).Trim())
                 elif trimmed.StartsWith("escape_mode:", StringComparison.Ordinal) then
                     escapeMode <- Some(trimmed.Substring("escape_mode:".Length).Trim())
+                elif trimmed.StartsWith("escapes:", StringComparison.Ordinal) then
+                    escapeMode <- Some(trimmed.Substring("escapes:".Length).Trim())
+                elif trimmed.StartsWith("case_sensitive:", StringComparison.Ordinal) then
+                    match Boolean.TryParse(trimmed.Substring("case_sensitive:".Length).Trim()) with
+                    | true, parsedBool -> caseInsensitive <- not parsedBool
+                    | _ -> ()
                 elif
                     trimmed = "keywords:"
                     || trimmed = "reserved:"
@@ -251,6 +282,14 @@ type TokenGrammarParser =
                     currentGroup <- Some groupName
                     groupDefinitions[groupName] <- ResizeArray<TokenDefinition>()
                 else
+                    if
+                        (section = "skip" || section = "errors" || section = "group")
+                        && not (Char.IsWhiteSpace(lines[index][0]))
+                        && trimmed.Contains("=")
+                    then
+                        section <- "definitions"
+                        currentGroup <- None
+
                     match section with
                     | "keywords" -> keywords.Add(trimmed)
                     | "reserved" -> reserved.Add(trimmed)

--- a/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.fs
+++ b/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.fs
@@ -48,6 +48,19 @@ module GrammarToolsTests =
         Assert.True(grammar.Groups.ContainsKey("punctuation"))
 
     [<Fact>]
+    let ``token grammar parser allows arrow literal`` () =
+        let grammar =
+            TokenGrammarParser.Parse "escapes: none\ncase_sensitive: false\nskip:\n  WS = /[ \t]+/\nTRIGGER = \"->\"\nNAME = /[a-z]+/ -> IDENT"
+
+        Assert.Equal("none", grammar.EscapeMode)
+        Assert.False(grammar.CaseSensitive)
+        Assert.True(grammar.CaseInsensitive)
+        Assert.Single(grammar.SkipDefinitions) |> ignore
+        Assert.Equal("->", grammar.Definitions[0].Pattern)
+        Assert.Null(grammar.Definitions[0].Alias)
+        Assert.Equal("IDENT", grammar.Definitions[1].Alias)
+
+    [<Fact>]
     let ``token grammar parser rejects malformed definitions`` () =
         let error =
             Assert.Throws<TokenGrammarError>(fun () ->

--- a/code/packages/fsharp/verilog-lexer/BUILD
+++ b/code/packages/fsharp/verilog-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/verilog-lexer/BUILD_windows
+++ b/code/packages/fsharp/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/verilog-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/verilog-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for verilog-lexer.

--- a/code/packages/fsharp/verilog-lexer/CodingAdventures.VerilogLexer.fsproj
+++ b/code/packages/fsharp/verilog-lexer/CodingAdventures.VerilogLexer.fsproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VerilogLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Verilog lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="VerilogLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/verilog/verilog*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/verilog-lexer/README.md
+++ b/code/packages/fsharp/verilog-lexer/README.md
@@ -1,0 +1,13 @@
+# fsharp/verilog-lexer
+
+Verilog lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin verilog-lexer API shape and embeds the shared grammar resources from `code/grammars/verilog`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/verilog-lexer/VerilogLexer.fs
+++ b/code/packages/fsharp/verilog-lexer/VerilogLexer.fs
@@ -1,0 +1,56 @@
+namespace CodingAdventures.VerilogLexer.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Lexer.FSharp
+
+/// Verilog lexer backed by shared grammar token definitions.
+type VerilogLexer private () =
+    static let defaultVersion = "2005"
+    static let supportedVersions = [| "1995"; "2001"; "2005" |]
+    static let tokenGrammars = ConcurrentDictionary<string, TokenGrammar>()
+
+    static member DefaultVersion = defaultVersion
+    static member SupportedVersions = supportedVersions :> IReadOnlyList<string>
+
+    static member CreateVerilogLexer() = VerilogLexer.CreateVerilogLexer(defaultVersion)
+    static member CreateVerilogLexer(version: string) = GrammarLexer(VerilogLexer.LoadTokenGrammar(version))
+
+    static member TokenizeVerilog(source: string) = VerilogLexer.TokenizeVerilog(source, defaultVersion)
+    static member TokenizeVerilog(source: string, version: string) =
+        try
+            VerilogLexer.CreateVerilogLexer(version).Tokenize(source)
+        with
+        | :? LexerError as error ->
+            raise (ArgumentException(sprintf "Verilog tokenization failed: %s" error.Message, "source", error))
+
+    static member private LoadTokenGrammar(version: string) =
+        let validated = VerilogLexer.ValidateVersion(version)
+        tokenGrammars.GetOrAdd(validated, Func<string, TokenGrammar>(VerilogLexer.ParseTokenGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            defaultVersion
+        elif Array.exists ((=) version) supportedVersions then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown Verilog version '%s'. Valid values: %s" version (String.Join(", ", supportedVersions)))
+
+    static member private ParseTokenGrammarResource(version: string) =
+        try
+            TokenGrammarParser.Parse(VerilogLexer.ReadResource("verilog" + version + ".tokens"))
+        with
+        | :? TokenGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled Verilog token grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<VerilogLexer>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/verilog-lexer/required_capabilities.json
+++ b/code/packages/fsharp/verilog-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/verilog-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.fsproj
+++ b/code/packages/fsharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/CodingAdventures.VerilogLexer.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.VerilogLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.VerilogLexer.fsproj" />
+    <Compile Include="VerilogLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/VerilogLexerTests.fs
+++ b/code/packages/fsharp/verilog-lexer/tests/CodingAdventures.VerilogLexer.Tests/VerilogLexerTests.fs
@@ -1,0 +1,27 @@
+namespace CodingAdventures.VerilogLexer.Tests
+
+open CodingAdventures.Lexer.FSharp
+open CodingAdventures.VerilogLexer.FSharp
+open Xunit
+
+module VerilogLexerTests =
+    [<Fact>]
+    let tokenizesSample () =
+        let tokens = VerilogLexer.TokenizeVerilog("module top; endmodule")
+
+        Assert.Equal(TokenType.Keyword, tokens.[0].Type)
+        Assert.Equal("module", tokens.[0].Value)
+        Assert.Equal("NAME", tokens.[1].EffectiveTypeName)
+        Assert.Equal("top", tokens.[1].Value)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        let defaultTokens = VerilogLexer.TokenizeVerilog("module top; endmodule")
+        let explicitTokens = VerilogLexer.TokenizeVerilog("module top; endmodule", VerilogLexer.DefaultVersion)
+        Assert.Equal(Seq.length defaultTokens, Seq.length explicitTokens)
+        Assert.Equal(defaultTokens.[0].Value, explicitTokens.[0].Value)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> VerilogLexer.TokenizeVerilog("module top; endmodule", "2099") |> ignore)
+        Assert.Contains("Unknown Verilog version", error.Message)

--- a/code/packages/fsharp/verilog-parser/BUILD
+++ b/code/packages/fsharp/verilog-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/verilog-parser/BUILD_windows
+++ b/code/packages/fsharp/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/verilog-parser/CHANGELOG.md
+++ b/code/packages/fsharp/verilog-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for verilog-parser.

--- a/code/packages/fsharp/verilog-parser/CodingAdventures.VerilogParser.fsproj
+++ b/code/packages/fsharp/verilog-parser/CodingAdventures.VerilogParser.fsproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VerilogParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Verilog parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="VerilogParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/verilog/verilog*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../verilog-lexer/CodingAdventures.VerilogLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/verilog-parser/README.md
+++ b/code/packages/fsharp/verilog-parser/README.md
@@ -1,0 +1,13 @@
+# fsharp/verilog-parser
+
+Verilog parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin verilog-parser API shape and embeds the shared grammar resources from `code/grammars/verilog`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/verilog-parser/VerilogParser.fs
+++ b/code/packages/fsharp/verilog-parser/VerilogParser.fs
@@ -1,0 +1,54 @@
+namespace CodingAdventures.VerilogParser.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Parser.FSharp
+open CodingAdventures.VerilogLexer.FSharp
+
+/// Verilog parser backed by shared grammar definitions.
+type VerilogParser private () =
+    static let parserGrammars = ConcurrentDictionary<string, ParserGrammar>()
+
+    static member DefaultVersion = VerilogLexer.DefaultVersion
+    static member SupportedVersions = VerilogLexer.SupportedVersions
+
+    static member CreateVerilogParser() = VerilogParser.CreateVerilogParser(VerilogParser.DefaultVersion)
+    static member CreateVerilogParser(version: string) = GrammarParser(VerilogParser.LoadParserGrammar(version))
+
+    static member ParseVerilog(source: string) = VerilogParser.ParseVerilog(source, VerilogParser.DefaultVersion)
+    static member ParseVerilog(source: string, version: string) =
+        try
+            VerilogParser.CreateVerilogParser(version).Parse(VerilogLexer.TokenizeVerilog(source, version))
+        with
+        | :? GrammarParseError as error ->
+            raise (ArgumentException(sprintf "Verilog parse failed: %s" error.Message, "source", error))
+
+    static member private LoadParserGrammar(version: string) =
+        let validated = VerilogParser.ValidateVersion(version)
+        parserGrammars.GetOrAdd(validated, Func<string, ParserGrammar>(VerilogParser.ParseParserGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            VerilogParser.DefaultVersion
+        elif VerilogParser.SupportedVersions |> Seq.exists ((=) version) then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown Verilog version '%s'. Valid values: %s" version (String.Join(", ", VerilogParser.SupportedVersions)))
+
+    static member private ParseParserGrammarResource(version: string) =
+        try
+            ParserGrammarParser.Parse(VerilogParser.ReadResource("verilog" + version + ".grammar"))
+        with
+        | :? ParserGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled Verilog parser grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<VerilogParser>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/verilog-parser/required_capabilities.json
+++ b/code/packages/fsharp/verilog-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/verilog-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.fsproj
+++ b/code/packages/fsharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/CodingAdventures.VerilogParser.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.VerilogParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.VerilogParser.fsproj" />
+    <Compile Include="VerilogParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/VerilogParserTests.fs
+++ b/code/packages/fsharp/verilog-parser/tests/CodingAdventures.VerilogParser.Tests/VerilogParserTests.fs
@@ -1,0 +1,23 @@
+namespace CodingAdventures.VerilogParser.Tests
+
+open CodingAdventures.VerilogParser.FSharp
+open Xunit
+
+module VerilogParserTests =
+    [<Fact>]
+    let parsesSample () =
+        let ast = VerilogParser.ParseVerilog("module top; endmodule")
+
+        Assert.Equal("source_text", ast.RuleName)
+        Assert.True(ast.DescendantCount() > 0)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        Assert.Equal(
+            VerilogParser.ParseVerilog("module top; endmodule").RuleName,
+            VerilogParser.ParseVerilog("module top; endmodule", VerilogParser.DefaultVersion).RuleName)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> VerilogParser.ParseVerilog("module top; endmodule", "2099") |> ignore)
+        Assert.Contains("Unknown Verilog version", error.Message)

--- a/code/packages/fsharp/vhdl-lexer/BUILD
+++ b/code/packages/fsharp/vhdl-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vhdl-lexer/BUILD_windows
+++ b/code/packages/fsharp/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vhdl-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/vhdl-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for vhdl-lexer.

--- a/code/packages/fsharp/vhdl-lexer/CodingAdventures.VhdlLexer.fsproj
+++ b/code/packages/fsharp/vhdl-lexer/CodingAdventures.VhdlLexer.fsproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VhdlLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>VHDL lexer backed by shared grammar token definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="VhdlLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/vhdl/vhdl*.tokens" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vhdl-lexer/README.md
+++ b/code/packages/fsharp/vhdl-lexer/README.md
@@ -1,0 +1,13 @@
+# fsharp/vhdl-lexer
+
+VHDL lexer backed by shared grammar token definitions.
+
+The package mirrors the Java and Kotlin vhdl-lexer API shape and embeds the shared grammar resources from `code/grammars/vhdl`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/vhdl-lexer/VhdlLexer.fs
+++ b/code/packages/fsharp/vhdl-lexer/VhdlLexer.fs
@@ -1,0 +1,76 @@
+namespace CodingAdventures.VhdlLexer.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Lexer.FSharp
+
+/// VHDL lexer backed by shared grammar token definitions.
+type VhdlLexer private () =
+    static let defaultVersion = "2008"
+    static let supportedVersions = [| "1987"; "1993"; "2002"; "2008"; "2019" |]
+    static let tokenGrammars = ConcurrentDictionary<string, TokenGrammar>()
+
+    static member DefaultVersion = defaultVersion
+    static member SupportedVersions = supportedVersions :> IReadOnlyList<string>
+
+    static member CreateVhdlLexer() = VhdlLexer.CreateVhdlLexer(defaultVersion)
+    static member CreateVhdlLexer(version: string) = GrammarLexer(VhdlLexer.LoadTokenGrammar(version))
+
+    static member TokenizeVhdl(source: string) = VhdlLexer.TokenizeVhdl(source, defaultVersion)
+    static member TokenizeVhdl(source: string, version: string) =
+        let grammar = VhdlLexer.LoadTokenGrammar(version)
+        try
+            let tokens = GrammarLexer(grammar).Tokenize(source)
+            VhdlLexer.NormalizeCase(tokens, HashSet<string>(grammar.Keywords, StringComparer.Ordinal))
+        with
+        | :? LexerError as error ->
+            raise (ArgumentException(sprintf "VHDL tokenization failed: %s" error.Message, "source", error))
+
+    static member private NormalizeCase(tokens: IReadOnlyList<Token>, keywords: ISet<string>) =
+        tokens
+        |> Seq.map (fun token ->
+            let normalizeKeyword = token.Type = TokenType.Keyword
+            let normalizeName = token.Type = TokenType.Grammar && token.TypeName = "NAME"
+            if not normalizeKeyword && not normalizeName then
+                token
+            else
+                let lowered = token.Value.ToLowerInvariant()
+                let mutable normalizedType = if normalizeKeyword then TokenType.Keyword else token.Type
+                let mutable normalizedTypeName = if normalizeKeyword then "KEYWORD" else token.TypeName
+                if normalizeName && keywords.Contains(lowered) then
+                    normalizedType <- TokenType.Keyword
+                    normalizedTypeName <- "KEYWORD"
+                Token(normalizedType, lowered, token.Line, token.Column, normalizedTypeName, token.Flags))
+        |> ResizeArray<Token>
+        :> IReadOnlyList<Token>
+
+    static member private LoadTokenGrammar(version: string) =
+        let validated = VhdlLexer.ValidateVersion(version)
+        tokenGrammars.GetOrAdd(validated, Func<string, TokenGrammar>(VhdlLexer.ParseTokenGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            defaultVersion
+        elif Array.exists ((=) version) supportedVersions then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown VHDL version '%s'. Valid values: %s" version (String.Join(", ", supportedVersions)))
+
+    static member private ParseTokenGrammarResource(version: string) =
+        try
+            TokenGrammarParser.Parse(VhdlLexer.ReadResource("vhdl" + version + ".tokens"))
+        with
+        | :? TokenGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled VHDL token grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<VhdlLexer>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/vhdl-lexer/required_capabilities.json
+++ b/code/packages/fsharp/vhdl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/vhdl-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.fsproj
+++ b/code/packages/fsharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/CodingAdventures.VhdlLexer.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.VhdlLexer]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.VhdlLexer.fsproj" />
+    <Compile Include="VhdlLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/VhdlLexerTests.fs
+++ b/code/packages/fsharp/vhdl-lexer/tests/CodingAdventures.VhdlLexer.Tests/VhdlLexerTests.fs
@@ -1,0 +1,27 @@
+namespace CodingAdventures.VhdlLexer.Tests
+
+open CodingAdventures.Lexer.FSharp
+open CodingAdventures.VhdlLexer.FSharp
+open Xunit
+
+module VhdlLexerTests =
+    [<Fact>]
+    let tokenizesSample () =
+        let tokens = VhdlLexer.TokenizeVhdl("ENTITY TOP IS END ENTITY TOP;")
+
+        Assert.Equal(TokenType.Keyword, tokens.[0].Type)
+        Assert.Equal("entity", tokens.[0].Value)
+        Assert.Equal("NAME", tokens.[1].EffectiveTypeName)
+        Assert.Equal("top", tokens.[1].Value)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        let defaultTokens = VhdlLexer.TokenizeVhdl("entity top is end entity top;")
+        let explicitTokens = VhdlLexer.TokenizeVhdl("entity top is end entity top;", VhdlLexer.DefaultVersion)
+        Assert.Equal(Seq.length defaultTokens, Seq.length explicitTokens)
+        Assert.Equal(defaultTokens.[0].Value, explicitTokens.[0].Value)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> VhdlLexer.TokenizeVhdl("entity top is end entity top;", "2099") |> ignore)
+        Assert.Contains("Unknown VHDL version", error.Message)

--- a/code/packages/fsharp/vhdl-parser/BUILD
+++ b/code/packages/fsharp/vhdl-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vhdl-parser/BUILD_windows
+++ b/code/packages/fsharp/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/vhdl-parser/CHANGELOG.md
+++ b/code/packages/fsharp/vhdl-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial fsharp package for vhdl-parser.

--- a/code/packages/fsharp/vhdl-parser/CodingAdventures.VhdlParser.fsproj
+++ b/code/packages/fsharp/vhdl-parser/CodingAdventures.VhdlParser.fsproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.VhdlParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>VHDL parser backed by shared grammar definitions</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="VhdlParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/vhdl/vhdl*.grammar" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../vhdl-lexer/CodingAdventures.VhdlLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vhdl-parser/README.md
+++ b/code/packages/fsharp/vhdl-parser/README.md
@@ -1,0 +1,13 @@
+# fsharp/vhdl-parser
+
+VHDL parser backed by shared grammar definitions.
+
+The package mirrors the Java and Kotlin vhdl-parser API shape and embeds the shared grammar resources from `code/grammars/vhdl`.
+
+## Usage
+
+Run the package tests with:
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/vhdl-parser/VhdlParser.fs
+++ b/code/packages/fsharp/vhdl-parser/VhdlParser.fs
@@ -1,0 +1,54 @@
+namespace CodingAdventures.VhdlParser.FSharp
+
+open System
+open System.Collections.Concurrent
+open System.IO
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Parser.FSharp
+open CodingAdventures.VhdlLexer.FSharp
+
+/// VHDL parser backed by shared grammar definitions.
+type VhdlParser private () =
+    static let parserGrammars = ConcurrentDictionary<string, ParserGrammar>()
+
+    static member DefaultVersion = VhdlLexer.DefaultVersion
+    static member SupportedVersions = VhdlLexer.SupportedVersions
+
+    static member CreateVhdlParser() = VhdlParser.CreateVhdlParser(VhdlParser.DefaultVersion)
+    static member CreateVhdlParser(version: string) = GrammarParser(VhdlParser.LoadParserGrammar(version))
+
+    static member ParseVhdl(source: string) = VhdlParser.ParseVhdl(source, VhdlParser.DefaultVersion)
+    static member ParseVhdl(source: string, version: string) =
+        try
+            VhdlParser.CreateVhdlParser(version).Parse(VhdlLexer.TokenizeVhdl(source, version))
+        with
+        | :? GrammarParseError as error ->
+            raise (ArgumentException(sprintf "VHDL parse failed: %s" error.Message, "source", error))
+
+    static member private LoadParserGrammar(version: string) =
+        let validated = VhdlParser.ValidateVersion(version)
+        parserGrammars.GetOrAdd(validated, Func<string, ParserGrammar>(VhdlParser.ParseParserGrammarResource))
+
+    static member private ValidateVersion(version: string) =
+        if String.IsNullOrWhiteSpace(version) then
+            VhdlParser.DefaultVersion
+        elif VhdlParser.SupportedVersions |> Seq.exists ((=) version) then
+            version
+        else
+            invalidArg "version" (sprintf "Unknown VHDL version '%s'. Valid values: %s" version (String.Join(", ", VhdlParser.SupportedVersions)))
+
+    static member private ParseParserGrammarResource(version: string) =
+        try
+            ParserGrammarParser.Parse(VhdlParser.ReadResource("vhdl" + version + ".grammar"))
+        with
+        | :? ParserGrammarError as error ->
+            raise (InvalidOperationException(sprintf "Failed to parse bundled VHDL parser grammar for version %s" version, error))
+
+    static member private ReadResource(resourceName: string) =
+        let assembly = typeof<VhdlParser>.Assembly
+        use stream = assembly.GetManifestResourceStream(resourceName)
+        if isNull stream then
+            invalidOp (sprintf "Missing bundled resource: %s" resourceName)
+        use reader = new StreamReader(stream, Encoding.UTF8)
+        reader.ReadToEnd()

--- a/code/packages/fsharp/vhdl-parser/required_capabilities.json
+++ b/code/packages/fsharp/vhdl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/vhdl-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. Bundled grammar resources are embedded at build time."
+}

--- a/code/packages/fsharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.fsproj
+++ b/code/packages/fsharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/CodingAdventures.VhdlParser.Tests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.VhdlParser]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.VhdlParser.fsproj" />
+    <Compile Include="VhdlParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/VhdlParserTests.fs
+++ b/code/packages/fsharp/vhdl-parser/tests/CodingAdventures.VhdlParser.Tests/VhdlParserTests.fs
@@ -1,0 +1,23 @@
+namespace CodingAdventures.VhdlParser.Tests
+
+open CodingAdventures.VhdlParser.FSharp
+open Xunit
+
+module VhdlParserTests =
+    [<Fact>]
+    let parsesSample () =
+        let ast = VhdlParser.ParseVhdl("entity top is end entity top;")
+
+        Assert.Equal("design_file", ast.RuleName)
+        Assert.True(ast.DescendantCount() > 0)
+
+    [<Fact>]
+    let defaultVersionMatchesExplicitVersion () =
+        Assert.Equal(
+            VhdlParser.ParseVhdl("entity top is end entity top;").RuleName,
+            VhdlParser.ParseVhdl("entity top is end entity top;", VhdlParser.DefaultVersion).RuleName)
+
+    [<Fact>]
+    let rejectsUnknownVersion () =
+        let error = Assert.Throws<System.ArgumentException>(fun () -> VhdlParser.ParseVhdl("entity top is end entity top;", "2099") |> ignore)
+        Assert.Contains("Unknown VHDL version", error.Message)


### PR DESCRIPTION
## Summary
- add C# and F# ALGOL, Verilog, and VHDL lexer/parser packages backed by the shared grammar resources
- wire package metadata, capability manifests, BUILD commands, project references, and xUnit behavior tests for all twelve new packages
- extend C# and F# grammar-tools parsing for shared grammar metadata and literals: `escapes:`, `case_sensitive:`, indented section boundaries, and quoted `->` tokens

## Verification
- dotnet test code\packages\csharp\grammar-tools\tests\CodingAdventures.GrammarTools.Tests\CodingAdventures.GrammarTools.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\grammar-tools\tests\CodingAdventures.GrammarTools.Tests\CodingAdventures.GrammarTools.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\csharp\<algol|verilog|vhdl>-<lexer|parser>\tests\CodingAdventures.<Package>.Tests\CodingAdventures.<Package>.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\<algol|verilog|vhdl>-<lexer|parser>\tests\CodingAdventures.<Package>.Tests\CodingAdventures.<Package>.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line