### PR TITLE
feat(parity): add pdf417 capability manifests

### DIFF
--- a/code/packages/csharp/pdf417/required_capabilities.json
+++ b/code/packages/csharp/pdf417/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/pdf417",
+  "capabilities": [],
+  "justification": "Pure in-memory PDF417 encoder. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/pdf417/required_capabilities.json
+++ b/code/packages/fsharp/pdf417/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/pdf417",
+  "capabilities": [],
+  "justification": "Pure in-memory PDF417 encoder. No filesystem, process, environment, or network access needed."
+}


### PR DESCRIPTION
## Summary
- Adds the missing `required_capabilities.json` for `csharp/pdf417` and `fsharp/pdf417`. Every other csharp/fsharp package on main has this manifest; these two were the gap.
- Both packages do pure in-memory PDF417 encoding — no filesystem, process, environment, or network access — so `capabilities: []`.
- The pure-F# standalone implementation on main is preserved as-is. (An earlier version of this PR rewrote it into a thin facade over the C# package; that rewrite has been dropped.)

## Files
- `code/packages/csharp/pdf417/required_capabilities.json` (new, 7 lines)
- `code/packages/fsharp/pdf417/required_capabilities.json` (new, 7 lines)