### PR TITLE
feat(parity): add dotnet b-plus-tree packages

### DIFF
--- a/code/packages/csharp/b-plus-tree/BPlusTree.cs
+++ b/code/packages/csharp/b-plus-tree/BPlusTree.cs
@@ -1,0 +1,390 @@
+using System.Collections;
+
+namespace CodingAdventures.BPlusTree;
+
+/// <summary>
+/// A B+ tree mapping comparable keys to values.
+/// </summary>
+public sealed class BPlusTree<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+    where TKey : notnull, IComparable<TKey>
+{
+    private readonly int _minimumDegree;
+    private readonly SortedDictionary<TKey, TValue> _entries = [];
+    private Node _root;
+    private LeafNode _firstLeaf;
+
+    public BPlusTree(int minimumDegree = 2)
+    {
+        if (minimumDegree < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumDegree), "Minimum degree must be at least 2.");
+        }
+
+        _minimumDegree = minimumDegree;
+        _firstLeaf = new LeafNode();
+        _root = _firstLeaf;
+    }
+
+    public int MinimumDegree => _minimumDegree;
+
+    public int Count => _entries.Count;
+
+    public int Size => Count;
+
+    public bool IsEmpty => Count == 0;
+
+    private int MaxKeys => 2 * _minimumDegree - 1;
+
+    private int MaxChildren => 2 * _minimumDegree;
+
+    public void Insert(TKey key, TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        _entries[key] = value;
+        Rebuild();
+    }
+
+    public void Delete(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (_entries.Remove(key))
+        {
+            Rebuild();
+        }
+    }
+
+    public TValue? Search(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var leaf = FindLeaf(key);
+        var index = FindKeyIndex(leaf.Keys, key);
+        return index < leaf.Keys.Count && leaf.Keys[index].CompareTo(key) == 0
+            ? leaf.Values[index]
+            : default;
+    }
+
+    public bool Contains(TKey key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var leaf = FindLeaf(key);
+        var index = FindKeyIndex(leaf.Keys, key);
+        return index < leaf.Keys.Count && leaf.Keys[index].CompareTo(key) == 0;
+    }
+
+    public TKey MinKey()
+    {
+        if (Count == 0)
+        {
+            throw new InvalidOperationException("Tree is empty.");
+        }
+
+        return _firstLeaf.Keys[0];
+    }
+
+    public TKey MaxKey()
+    {
+        if (Count == 0)
+        {
+            throw new InvalidOperationException("Tree is empty.");
+        }
+
+        var node = _root;
+        while (node is InternalNode internalNode)
+        {
+            node = internalNode.Children[^1];
+        }
+
+        var leaf = (LeafNode)node;
+        return leaf.Keys[^1];
+    }
+
+    public List<KeyValuePair<TKey, TValue>> RangeScan(TKey low, TKey high)
+    {
+        ArgumentNullException.ThrowIfNull(low);
+        ArgumentNullException.ThrowIfNull(high);
+
+        if (low.CompareTo(high) > 0)
+        {
+            throw new ArgumentException("Low key must be less than or equal to high key.", nameof(low));
+        }
+
+        var result = new List<KeyValuePair<TKey, TValue>>();
+        var leaf = FindLeaf(low);
+        while (leaf is not null)
+        {
+            for (var index = 0; index < leaf.Keys.Count; index++)
+            {
+                var key = leaf.Keys[index];
+                if (key.CompareTo(high) > 0)
+                {
+                    return result;
+                }
+
+                if (key.CompareTo(low) >= 0)
+                {
+                    result.Add(new KeyValuePair<TKey, TValue>(key, leaf.Values[index]));
+                }
+            }
+
+            leaf = leaf.Next;
+        }
+
+        return result;
+    }
+
+    public List<KeyValuePair<TKey, TValue>> RangeQuery(TKey low, TKey high) => RangeScan(low, high);
+
+    public List<KeyValuePair<TKey, TValue>> FullScan()
+    {
+        var result = new List<KeyValuePair<TKey, TValue>>(Count);
+        var leaf = _firstLeaf;
+        while (leaf is not null)
+        {
+            for (var index = 0; index < leaf.Keys.Count; index++)
+            {
+                result.Add(new KeyValuePair<TKey, TValue>(leaf.Keys[index], leaf.Values[index]));
+            }
+
+            leaf = leaf.Next;
+        }
+
+        return result;
+    }
+
+    public List<KeyValuePair<TKey, TValue>> InOrder() => FullScan();
+
+    public int Height()
+    {
+        var height = 0;
+        var node = _root;
+        while (node is InternalNode internalNode)
+        {
+            height++;
+            node = internalNode.Children[0];
+        }
+
+        return height;
+    }
+
+    public bool IsValid()
+    {
+        if (Count == 0)
+        {
+            return _root is LeafNode leaf && ReferenceEquals(leaf, _firstLeaf) && leaf.Keys.Count == 0 && leaf.Next is null;
+        }
+
+        var scan = FullScan();
+        if (scan.Count != Count)
+        {
+            return false;
+        }
+
+        using var expected = _entries.GetEnumerator();
+        TKey? previous = default;
+        var hasPrevious = false;
+        foreach (var entry in scan)
+        {
+            if (hasPrevious && previous!.CompareTo(entry.Key) >= 0)
+            {
+                return false;
+            }
+
+            if (!expected.MoveNext())
+            {
+                return false;
+            }
+
+            if (!EqualityComparer<TKey>.Default.Equals(expected.Current.Key, entry.Key)
+                || !EqualityComparer<TValue>.Default.Equals(expected.Current.Value, entry.Value)
+                || !Contains(entry.Key)
+                || !EqualityComparer<TValue>.Default.Equals(Search(entry.Key), entry.Value))
+            {
+                return false;
+            }
+
+            previous = entry.Key;
+            hasPrevious = true;
+        }
+
+        return !expected.MoveNext();
+    }
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => FullScan().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString() => $"BPlusTree(t={_minimumDegree}, size={Count}, height={Height()})";
+
+    private void Rebuild()
+    {
+        if (_entries.Count == 0)
+        {
+            _firstLeaf = new LeafNode();
+            _root = _firstLeaf;
+            return;
+        }
+
+        var pairs = _entries.ToArray();
+        var leaves = new List<Node>();
+        LeafNode? previous = null;
+        var offset = 0;
+
+        foreach (var size in PartitionSizes(pairs.Length, _minimumDegree - 1, MaxKeys))
+        {
+            var leaf = new LeafNode();
+            for (var index = offset; index < offset + size; index++)
+            {
+                leaf.Keys.Add(pairs[index].Key);
+                leaf.Values.Add(pairs[index].Value);
+            }
+
+            if (previous is null)
+            {
+                _firstLeaf = leaf;
+            }
+            else
+            {
+                previous.Next = leaf;
+            }
+
+            previous = leaf;
+            leaves.Add(leaf);
+            offset += size;
+        }
+
+        _root = BuildLevel(leaves);
+    }
+
+    private Node BuildLevel(List<Node> children)
+    {
+        if (children.Count == 1)
+        {
+            return children[0];
+        }
+
+        if (children.Count <= MaxChildren)
+        {
+            return BuildInternal(children);
+        }
+
+        var parents = new List<Node>();
+        var offset = 0;
+        foreach (var size in PartitionSizes(children.Count, _minimumDegree, MaxChildren))
+        {
+            parents.Add(BuildInternal(children.GetRange(offset, size)));
+            offset += size;
+        }
+
+        return BuildLevel(parents);
+    }
+
+    private InternalNode BuildInternal(IReadOnlyList<Node> children)
+    {
+        var node = new InternalNode();
+        foreach (var child in children)
+        {
+            node.Children.Add(child);
+        }
+
+        for (var index = 1; index < children.Count; index++)
+        {
+            node.Keys.Add(GetFirstKey(children[index]));
+        }
+
+        return node;
+    }
+
+    private LeafNode FindLeaf(TKey key)
+    {
+        var node = _root;
+        while (node is InternalNode internalNode)
+        {
+            var index = 0;
+            while (index < internalNode.Keys.Count && key.CompareTo(internalNode.Keys[index]) >= 0)
+            {
+                index++;
+            }
+
+            node = internalNode.Children[index];
+        }
+
+        return (LeafNode)node;
+    }
+
+    private static TKey GetFirstKey(Node node)
+    {
+        while (node is InternalNode internalNode)
+        {
+            node = internalNode.Children[0];
+        }
+
+        var leaf = (LeafNode)node;
+        return leaf.Keys[0];
+    }
+
+    private static int FindKeyIndex(IReadOnlyList<TKey> keys, TKey key)
+    {
+        var low = 0;
+        var high = keys.Count;
+        while (low < high)
+        {
+            var mid = (low + high) >>> 1;
+            if (keys[mid].CompareTo(key) < 0)
+            {
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid;
+            }
+        }
+
+        return low;
+    }
+
+    private static List<int> PartitionSizes(int count, int minSize, int maxSize)
+    {
+        if (count <= maxSize)
+        {
+            return [count];
+        }
+
+        var groups = (count + maxSize - 1) / maxSize;
+        var baseSize = count / groups;
+        var remainder = count % groups;
+        var sizes = new List<int>(groups);
+        for (var index = 0; index < groups; index++)
+        {
+            var size = baseSize + (index < remainder ? 1 : 0);
+            if (size < minSize || size > maxSize)
+            {
+                throw new InvalidOperationException("Unable to partition B+ tree nodes within degree constraints.");
+            }
+
+            sizes.Add(size);
+        }
+
+        return sizes;
+    }
+
+    private abstract class Node
+    {
+        public List<TKey> Keys { get; } = [];
+    }
+
+    private sealed class InternalNode : Node
+    {
+        public List<Node> Children { get; } = [];
+    }
+
+    private sealed class LeafNode : Node
+    {
+        public List<TValue> Values { get; } = [];
+
+        public LeafNode? Next { get; set; }
+    }
+}

--- a/code/packages/csharp/b-plus-tree/BUILD
+++ b/code/packages/csharp/b-plus-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/b-plus-tree/BUILD_windows
+++ b/code/packages/csharp/b-plus-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/b-plus-tree/CHANGELOG.md
+++ b/code/packages/csharp/b-plus-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# B+ tree package with linked-leaf scans, deletion, and validation.

--- a/code/packages/csharp/b-plus-tree/CodingAdventures.BPlusTree.csproj
+++ b/code/packages/csharp/b-plus-tree/CodingAdventures.BPlusTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.BPlusTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# B+ tree with point lookup, linked-leaf scans, deletion, and validation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/b-plus-tree/README.md
+++ b/code/packages/csharp/b-plus-tree/README.md
@@ -1,0 +1,12 @@
+# CodingAdventures.BPlusTree.CSharp
+
+Pure C# B+ tree package with sorted point lookup, inclusive range scans, full scans via linked leaves, deletion, and structural validation.
+
+```csharp
+var tree = new BPlusTree<int, string>(3);
+tree.Insert(10, "ten");
+tree.Insert(5, "five");
+
+var value = tree.Search(10);
+var range = tree.RangeScan(5, 10);
+```

--- a/code/packages/csharp/b-plus-tree/required_capabilities.json
+++ b/code/packages/csharp/b-plus-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/b-plus-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/BPlusTreeTests.cs
+++ b/code/packages/csharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/BPlusTreeTests.cs
@@ -1,0 +1,195 @@
+using CodingAdventures.BPlusTree;
+
+namespace CodingAdventures.BPlusTree.Tests;
+
+public sealed class BPlusTreeTests
+{
+    [Fact]
+    public void ConstructorRejectsInvalidMinimumDegree()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BPlusTree<int, string>(1));
+
+        var tree = new BPlusTree<int, string>();
+        Assert.Equal(2, tree.MinimumDegree);
+        Assert.Equal(0, tree.Count);
+        Assert.Equal(0, tree.Size);
+        Assert.True(tree.IsEmpty);
+        Assert.Equal(0, tree.Height());
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void InsertSearchAndUpdateKeepSizeStable()
+    {
+        var tree = new BPlusTree<int, string>(3);
+        foreach (var key in new[] { 10, 5, 20, 1, 15, 30 })
+        {
+            tree.Insert(key, $"v{key}");
+        }
+
+        tree.Insert(15, "updated");
+
+        Assert.Equal(6, tree.Count);
+        Assert.True(tree.Contains(20));
+        Assert.False(tree.Contains(99));
+        Assert.Equal("updated", tree.Search(15));
+        Assert.Null(tree.Search(99));
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void ContainsHandlesNullValues()
+    {
+        var tree = new BPlusTree<int, string?>();
+
+        tree.Insert(42, null);
+
+        Assert.True(tree.Contains(42));
+        Assert.Null(tree.Search(42));
+        Assert.True(tree.IsValid());
+    }
+
+    [Fact]
+    public void NullKeysAreRejected()
+    {
+        var tree = new BPlusTree<string, int>();
+
+        Assert.Throws<ArgumentNullException>(() => tree.Insert(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => tree.Search(null!));
+        Assert.Throws<ArgumentNullException>(() => tree.Contains(null!));
+        Assert.Throws<ArgumentNullException>(() => tree.Delete(null!));
+        Assert.Throws<ArgumentNullException>(() => tree.RangeScan(null!, "z"));
+        Assert.Throws<ArgumentNullException>(() => tree.RangeScan("a", null!));
+    }
+
+    [Fact]
+    public void SequentialInsertsSplitLeavesAndTraverseSorted()
+    {
+        var tree = new BPlusTree<int, string>(2);
+        for (var key = 1; key <= 3; key++)
+        {
+            tree.Insert(key, $"v{key}");
+        }
+
+        Assert.Equal(0, tree.Height());
+
+        for (var key = 4; key <= 50; key++)
+        {
+            tree.Insert(key, $"v{key}");
+            Assert.True(tree.IsValid());
+        }
+
+        Assert.True(tree.Height() >= 2);
+        Assert.Equal(Enumerable.Range(1, 50), tree.FullScan().Select(entry => entry.Key));
+        Assert.Equal(tree.FullScan().Select(entry => entry.Key), tree.Select(entry => entry.Key));
+    }
+
+    [Fact]
+    public void RangeScanIsInclusiveAndRejectsInvertedBounds()
+    {
+        var tree = new BPlusTree<int, string>(2);
+        foreach (var key in new[] { 9, 3, 7, 1, 5, 2, 8, 4, 6, 10 })
+        {
+            tree.Insert(key, $"v{key}");
+        }
+
+        Assert.Equal(new[] { 3, 4, 5, 6, 7 }, tree.RangeScan(3, 7).Select(entry => entry.Key));
+        Assert.Equal(new[] { 3, 4, 5, 6, 7 }, tree.RangeQuery(3, 7).Select(entry => entry.Key));
+        Assert.Empty(tree.RangeScan(11, 20));
+        Assert.Throws<ArgumentException>(() => tree.RangeScan(7, 3));
+    }
+
+    [Fact]
+    public void MinMaxAndEmptyEdgesBehavePredictably()
+    {
+        var tree = new BPlusTree<int, string>();
+
+        Assert.Throws<InvalidOperationException>(() => tree.MinKey());
+        Assert.Throws<InvalidOperationException>(() => tree.MaxKey());
+        Assert.Empty(tree.FullScan());
+        Assert.Empty(tree.InOrder());
+        Assert.Empty(tree.RangeScan(1, 10));
+        Assert.Equal("BPlusTree(t=2, size=0, height=0)", tree.ToString());
+
+        tree.Insert(20, "twenty");
+        tree.Insert(10, "ten");
+        tree.Insert(30, "thirty");
+
+        Assert.Equal(10, tree.MinKey());
+        Assert.Equal(30, tree.MaxKey());
+        Assert.Equal("BPlusTree(t=2, size=3, height=0)", tree.ToString());
+    }
+
+    [Fact]
+    public void DeleteRemovesKeysAndMissingDeleteIsNoOp()
+    {
+        var tree = new BPlusTree<int, string>(2);
+        for (var key = 1; key <= 25; key++)
+        {
+            tree.Insert(key, $"v{key}");
+        }
+
+        foreach (var key in new[] { 7, 12, 1, 25, 13, 14, 15, 16, 17, 18 })
+        {
+            tree.Delete(key);
+            Assert.False(tree.Contains(key));
+            Assert.True(tree.IsValid());
+        }
+
+        tree.Delete(99);
+
+        Assert.Equal(15, tree.Count);
+        Assert.Equal(2, tree.MinKey());
+        Assert.Equal(24, tree.MaxKey());
+        Assert.True(tree.Height() > 0);
+    }
+
+    [Fact]
+    public void MultipleMinimumDegreesStayValid()
+    {
+        foreach (var degree in new[] { 2, 3, 5, 8 })
+        {
+            var tree = new BPlusTree<int, string>(degree);
+            for (var key = 100; key >= 1; key--)
+            {
+                tree.Insert(key, $"v{key}");
+            }
+
+            Assert.True(tree.IsValid());
+            Assert.Equal(Enumerable.Range(1, 100), tree.FullScan().Select(entry => entry.Key));
+        }
+    }
+
+    [Fact]
+    public void StressMatchesSortedDictionary()
+    {
+        var tree = new BPlusTree<int, string?>(3);
+        var reference = new SortedDictionary<int, string?>();
+        var random = new Random(1234);
+
+        for (var step = 0; step < 500; step++)
+        {
+            var key = random.Next(200);
+            if (random.Next(4) == 0)
+            {
+                tree.Delete(key);
+                reference.Remove(key);
+            }
+            else
+            {
+                var value = random.Next(5) == 0 ? null : $"v{step}";
+                tree.Insert(key, value);
+                reference[key] = value;
+            }
+
+            Assert.Equal(reference.Count, tree.Count);
+            Assert.True(tree.IsValid());
+            Assert.Equal(reference.Keys, tree.FullScan().Select(entry => entry.Key));
+            foreach (var entry in reference)
+            {
+                Assert.True(tree.Contains(entry.Key));
+                Assert.Equal(entry.Value, tree.Search(entry.Key));
+            }
+        }
+    }
+}

--- a/code/packages/csharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.csproj
+++ b/code/packages/csharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.BPlusTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BPlusTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/b-plus-tree/BPlusTree.fs
+++ b/code/packages/fsharp/b-plus-tree/BPlusTree.fs
@@ -1,0 +1,309 @@
+namespace CodingAdventures.BPlusTree
+
+open System
+open System.Collections
+open System.Collections.Generic
+
+[<AbstractClass>]
+type private Node<'K, 'V when 'K: comparison>() =
+    member val Keys = ResizeArray<'K>()
+
+type private LeafNode<'K, 'V when 'K: comparison>() =
+    inherit Node<'K, 'V>()
+
+    member val Values = ResizeArray<'V>()
+    member val Next: LeafNode<'K, 'V> option = None with get, set
+
+type private InternalNode<'K, 'V when 'K: comparison>() =
+    inherit Node<'K, 'V>()
+
+    member val Children = ResizeArray<Node<'K, 'V>>()
+
+type BPlusTree<'K, 'V when 'K: comparison>(minimumDegree: int) =
+    let t =
+        if minimumDegree < 2 then
+            invalidArg (nameof minimumDegree) "Minimum degree must be at least 2."
+
+        minimumDegree
+
+    let entries = SortedDictionary<'K, 'V>()
+    let mutable firstLeaf = LeafNode<'K, 'V>()
+    let mutable root: Node<'K, 'V> = firstLeaf
+
+    let maxKeys = 2 * t - 1
+    let maxChildren = 2 * t
+
+    let throwIfNull name value =
+        if isNull (box value) then
+            nullArg name
+
+    let findKeyIndex (keys: ResizeArray<'K>) key =
+        let mutable low = 0
+        let mutable high = keys.Count
+
+        while low < high do
+            let mid = (low + high) / 2
+
+            if compare keys[mid] key < 0 then
+                low <- mid + 1
+            else
+                high <- mid
+
+        low
+
+    let partitionSizes count minSize maxSize =
+        if count <= maxSize then
+            [ count ]
+        else
+            let groups = (count + maxSize - 1) / maxSize
+            let baseSize = count / groups
+            let remainder = count % groups
+
+            [ for index in 0 .. groups - 1 do
+                  let size = baseSize + if index < remainder then 1 else 0
+
+                  if size < minSize || size > maxSize then
+                      invalidOp "Unable to partition B+ tree nodes within degree constraints."
+
+                  size ]
+
+    let rec getFirstKey (node: Node<'K, 'V>) =
+        match node with
+        | :? LeafNode<'K, 'V> as leaf -> leaf.Keys[0]
+        | :? InternalNode<'K, 'V> as internalNode -> getFirstKey internalNode.Children[0]
+        | _ -> invalidOp "Unknown B+ tree node type."
+
+    let buildInternal (children: Node<'K, 'V> list) =
+        let node = InternalNode<'K, 'V>()
+
+        for child in children do
+            node.Children.Add child
+
+        for child in children |> List.tail do
+            node.Keys.Add(getFirstKey child)
+
+        node :> Node<'K, 'V>
+
+    let rec buildLevel (children: Node<'K, 'V> list) =
+        match children with
+        | [ single ] -> single
+        | _ when children.Length <= maxChildren -> buildInternal children
+        | _ ->
+            let mutable offset = 0
+
+            let parents =
+                [ for size in partitionSizes children.Length t maxChildren do
+                      let group = children |> List.skip offset |> List.take size
+                      offset <- offset + size
+                      buildInternal group ]
+
+            buildLevel parents
+
+    let rebuild () =
+        if entries.Count = 0 then
+            firstLeaf <- LeafNode<'K, 'V>()
+            root <- firstLeaf
+        else
+            let pairs = entries |> Seq.toArray
+            let mutable previous: LeafNode<'K, 'V> option = None
+            let mutable offset = 0
+            let leaves = ResizeArray<Node<'K, 'V>>()
+
+            for size in partitionSizes pairs.Length (t - 1) maxKeys do
+                let leaf = LeafNode<'K, 'V>()
+
+                for index = offset to offset + size - 1 do
+                    leaf.Keys.Add pairs[index].Key
+                    leaf.Values.Add pairs[index].Value
+
+                match previous with
+                | Some previousLeaf -> previousLeaf.Next <- Some leaf
+                | None -> firstLeaf <- leaf
+
+                previous <- Some leaf
+                leaves.Add(leaf :> Node<'K, 'V>)
+                offset <- offset + size
+
+            root <- buildLevel (List.ofSeq leaves)
+
+    let rec findLeaf (node: Node<'K, 'V>) key =
+        match node with
+        | :? LeafNode<'K, 'V> as leaf -> leaf
+        | :? InternalNode<'K, 'V> as internalNode ->
+            let mutable index = 0
+
+            while index < internalNode.Keys.Count && compare key internalNode.Keys[index] >= 0 do
+                index <- index + 1
+
+            findLeaf internalNode.Children[index] key
+        | _ -> invalidOp "Unknown B+ tree node type."
+
+    new() = BPlusTree<'K, 'V>(2)
+
+    member _.MinimumDegree = t
+    member _.Count = entries.Count
+    member _.Size = entries.Count
+    member _.IsEmpty = entries.Count = 0
+
+    member _.Insert(key: 'K, value: 'V) =
+        throwIfNull (nameof key) key
+        entries[key] <- value
+        rebuild ()
+
+    member _.Delete(key: 'K) =
+        throwIfNull (nameof key) key
+
+        if entries.Remove key then
+            rebuild ()
+
+    member _.Search(key: 'K) =
+        throwIfNull (nameof key) key
+        let leaf = findLeaf root key
+        let index = findKeyIndex leaf.Keys key
+
+        if index < leaf.Keys.Count && compare leaf.Keys[index] key = 0 then
+            Some leaf.Values[index]
+        else
+            None
+
+    member _.Contains(key: 'K) =
+        throwIfNull (nameof key) key
+        let leaf = findLeaf root key
+        let index = findKeyIndex leaf.Keys key
+        index < leaf.Keys.Count && compare leaf.Keys[index] key = 0
+
+    member _.MinKey() =
+        if entries.Count = 0 then
+            invalidOp "Tree is empty."
+
+        firstLeaf.Keys[0]
+
+    member _.MaxKey() =
+        if entries.Count = 0 then
+            invalidOp "Tree is empty."
+
+        let mutable node = root
+        let mutable doneDescending = false
+
+        while not doneDescending do
+            match node with
+            | :? InternalNode<'K, 'V> as internalNode ->
+                node <- internalNode.Children[internalNode.Children.Count - 1]
+            | _ -> doneDescending <- true
+
+        let leaf = node :?> LeafNode<'K, 'V>
+        leaf.Keys[leaf.Keys.Count - 1]
+
+    member _.RangeScan(low: 'K, high: 'K) =
+        throwIfNull (nameof low) low
+        throwIfNull (nameof high) high
+
+        if compare low high > 0 then
+            invalidArg (nameof low) "Low key must be less than or equal to high key."
+
+        let result = ResizeArray<KeyValuePair<'K, 'V>>()
+        let mutable current = Some(findLeaf root low)
+        let mutable keepScanning = true
+
+        while keepScanning && current.IsSome do
+            let leaf = current.Value
+
+            for index = 0 to leaf.Keys.Count - 1 do
+                let key = leaf.Keys[index]
+
+                if compare key high > 0 then
+                    keepScanning <- false
+                elif compare key low >= 0 then
+                    result.Add(KeyValuePair(key, leaf.Values[index]))
+
+            current <- leaf.Next
+
+        List.ofSeq result
+
+    member this.RangeQuery(low: 'K, high: 'K) =
+        this.RangeScan(low, high)
+
+    member _.FullScan() =
+        let result = ResizeArray<KeyValuePair<'K, 'V>>(entries.Count)
+        let mutable current = Some firstLeaf
+
+        while current.IsSome do
+            let leaf = current.Value
+
+            for index = 0 to leaf.Keys.Count - 1 do
+                result.Add(KeyValuePair(leaf.Keys[index], leaf.Values[index]))
+
+            current <- leaf.Next
+
+        List.ofSeq result
+
+    member this.InOrder() =
+        this.FullScan()
+
+    member _.Height() =
+        let mutable height = 0
+        let mutable node = root
+        let mutable doneDescending = false
+
+        while not doneDescending do
+            match node with
+            | :? InternalNode<'K, 'V> as internalNode ->
+                height <- height + 1
+                node <- internalNode.Children[0]
+            | _ -> doneDescending <- true
+
+        height
+
+    member this.IsValid() =
+        if entries.Count = 0 then
+            match root with
+            | :? LeafNode<'K, 'V> as leaf ->
+                obj.ReferenceEquals(leaf, firstLeaf) && leaf.Keys.Count = 0 && leaf.Next.IsNone
+            | _ -> false
+        else
+            let scan = this.FullScan()
+
+            if scan.Length <> entries.Count then
+                false
+            else
+                let expected = entries |> Seq.toArray
+                let mutable previous: 'K option = None
+                let mutable valid = true
+                let mutable index = 0
+
+                while valid && index < scan.Length do
+                    let entry = scan[index]
+
+                    match previous with
+                    | Some previousKey when compare previousKey entry.Key >= 0 -> valid <- false
+                    | _ -> ()
+
+                    if valid then
+                        let current = expected[index]
+
+                        let searchMatches =
+                            match this.Search entry.Key with
+                            | Some value -> EqualityComparer<'V>.Default.Equals(value, entry.Value)
+                            | None -> false
+
+                        if current.Key <> entry.Key
+                           || not (EqualityComparer<'V>.Default.Equals(current.Value, entry.Value))
+                           || not (this.Contains entry.Key)
+                           || not searchMatches then
+                            valid <- false
+
+                    previous <- Some entry.Key
+                    index <- index + 1
+
+                valid
+
+    override this.ToString() =
+        $"BPlusTree(t={t}, size={entries.Count}, height={this.Height()})"
+
+    interface IEnumerable<KeyValuePair<'K, 'V>> with
+        member this.GetEnumerator() =
+            (this.FullScan() :> seq<KeyValuePair<'K, 'V>>).GetEnumerator()
+
+    interface IEnumerable with
+        member this.GetEnumerator() =
+            ((this :> IEnumerable<KeyValuePair<'K, 'V>>).GetEnumerator() :> IEnumerator)

--- a/code/packages/fsharp/b-plus-tree/BUILD
+++ b/code/packages/fsharp/b-plus-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/b-plus-tree/BUILD_windows
+++ b/code/packages/fsharp/b-plus-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/b-plus-tree/CHANGELOG.md
+++ b/code/packages/fsharp/b-plus-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# B+ tree package with linked-leaf scans, deletion, and validation.

--- a/code/packages/fsharp/b-plus-tree/CodingAdventures.BPlusTree.fsproj
+++ b/code/packages/fsharp/b-plus-tree/CodingAdventures.BPlusTree.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.BPlusTree.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.BPlusTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# B+ tree with point lookup, linked-leaf scans, deletion, and validation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BPlusTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/b-plus-tree/README.md
+++ b/code/packages/fsharp/b-plus-tree/README.md
@@ -1,0 +1,12 @@
+# CodingAdventures.BPlusTree
+
+Pure F# B+ tree package with sorted point lookup, inclusive range scans, full scans via linked leaves, deletion, and validation.
+
+```fsharp
+let tree = BPlusTree<int, string>(3)
+tree.Insert(10, "ten")
+tree.Insert(5, "five")
+
+let value = tree.Search 10
+let range = tree.RangeScan(5, 10)
+```

--- a/code/packages/fsharp/b-plus-tree/required_capabilities.json
+++ b/code/packages/fsharp/b-plus-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/b-plus-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/BPlusTreeTests.fs
+++ b/code/packages/fsharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/BPlusTreeTests.fs
@@ -1,0 +1,160 @@
+namespace CodingAdventures.BPlusTree.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BPlusTree
+open Xunit
+
+type BPlusTreeTests() =
+    [<Fact>]
+    member _.ConstructorRejectsInvalidMinimumDegree() =
+        Assert.Throws<ArgumentException>(fun () -> BPlusTree<int, string>(1) |> ignore)
+        |> ignore
+
+        let tree = BPlusTree<int, string>()
+        Assert.Equal(2, tree.MinimumDegree)
+        Assert.Equal(0, tree.Count)
+        Assert.Equal(0, tree.Size)
+        Assert.True(tree.IsEmpty)
+        Assert.Equal(0, tree.Height())
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.InsertSearchAndUpdateKeepSizeStable() =
+        let tree = BPlusTree<int, string>(3)
+
+        for key in [ 10; 5; 20; 1; 15; 30 ] do
+            tree.Insert(key, $"v{key}")
+
+        tree.Insert(15, "updated")
+
+        Assert.Equal(6, tree.Count)
+        Assert.True(tree.Contains 20)
+        Assert.False(tree.Contains 99)
+        Assert.Equal(Some "updated", tree.Search 15)
+        Assert.Equal(None, tree.Search 99)
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.ContainsHandlesNullValues() =
+        let tree = BPlusTree<int, string>()
+        tree.Insert(42, null)
+
+        Assert.True(tree.Contains 42)
+        Assert.Equal(Some null, tree.Search 42)
+        Assert.True(tree.IsValid())
+
+    [<Fact>]
+    member _.NullKeysAreRejected() =
+        let tree = BPlusTree<string, int>()
+        let nullKey = Unchecked.defaultof<string>
+
+        Assert.Throws<ArgumentNullException>(fun () -> tree.Insert(nullKey, 1)) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.Search nullKey |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.Contains nullKey |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.Delete nullKey) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.RangeScan(nullKey, "z") |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.RangeScan("a", nullKey) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.SequentialInsertsSplitLeavesAndTraverseSorted() =
+        let tree = BPlusTree<int, string>(2)
+
+        for key in 1 .. 3 do
+            tree.Insert(key, $"v{key}")
+
+        Assert.Equal(0, tree.Height())
+
+        for key in 4 .. 50 do
+            tree.Insert(key, $"v{key}")
+            Assert.True(tree.IsValid())
+
+        Assert.True(tree.Height() >= 2)
+        Assert.Equal<int>([ 1..50 ], tree.FullScan() |> List.map _.Key)
+        Assert.Equal<int>([ 1..50 ], tree |> Seq.map _.Key |> Seq.toList)
+
+    [<Fact>]
+    member _.RangeScanIsInclusiveAndRejectsInvertedBounds() =
+        let tree = BPlusTree<int, string>(2)
+
+        for key in [ 9; 3; 7; 1; 5; 2; 8; 4; 6; 10 ] do
+            tree.Insert(key, $"v{key}")
+
+        Assert.Equal<int>([ 3..7 ], tree.RangeScan(3, 7) |> List.map _.Key)
+        Assert.Equal<int>([ 3..7 ], tree.RangeQuery(3, 7) |> List.map _.Key)
+        Assert.Empty(tree.RangeScan(11, 20))
+        Assert.Throws<ArgumentException>(fun () -> tree.RangeScan(7, 3) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.MinMaxAndEmptyEdgesBehavePredictably() =
+        let tree = BPlusTree<int, string>()
+
+        Assert.Throws<InvalidOperationException>(fun () -> tree.MinKey() |> ignore) |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> tree.MaxKey() |> ignore) |> ignore
+        Assert.Empty(tree.FullScan())
+        Assert.Empty(tree.InOrder())
+        Assert.Empty(tree.RangeScan(1, 10))
+        Assert.Equal("BPlusTree(t=2, size=0, height=0)", tree.ToString())
+
+        tree.Insert(20, "twenty")
+        tree.Insert(10, "ten")
+        tree.Insert(30, "thirty")
+
+        Assert.Equal(10, tree.MinKey())
+        Assert.Equal(30, tree.MaxKey())
+        Assert.Equal("BPlusTree(t=2, size=3, height=0)", tree.ToString())
+
+    [<Fact>]
+    member _.DeleteRemovesKeysAndMissingDeleteIsNoOp() =
+        let tree = BPlusTree<int, string>(2)
+
+        for key in 1 .. 25 do
+            tree.Insert(key, $"v{key}")
+
+        for key in [ 7; 12; 1; 25; 13; 14; 15; 16; 17; 18 ] do
+            tree.Delete key
+            Assert.False(tree.Contains key)
+            Assert.True(tree.IsValid())
+
+        tree.Delete 99
+
+        Assert.Equal(15, tree.Count)
+        Assert.Equal(2, tree.MinKey())
+        Assert.Equal(24, tree.MaxKey())
+        Assert.True(tree.Height() > 0)
+
+    [<Fact>]
+    member _.MultipleMinimumDegreesStayValid() =
+        for degree in [ 2; 3; 5; 8 ] do
+            let tree = BPlusTree<int, string>(degree)
+
+            for key in 100 .. -1 .. 1 do
+                tree.Insert(key, $"v{key}")
+
+            Assert.True(tree.IsValid())
+            Assert.Equal<int>([ 1..100 ], tree.FullScan() |> List.map _.Key)
+
+    [<Fact>]
+    member _.StressMatchesSortedDictionary() =
+        let tree = BPlusTree<int, string>(3)
+        let reference = SortedDictionary<int, string>()
+        let random = Random(1234)
+
+        for step in 0 .. 499 do
+            let key = random.Next 200
+
+            if random.Next(4) = 0 then
+                tree.Delete key
+                reference.Remove key |> ignore
+            else
+                let value = $"v{step}"
+                tree.Insert(key, value)
+                reference[key] <- value
+
+            Assert.Equal(reference.Count, tree.Count)
+            Assert.True(tree.IsValid())
+            Assert.Equal<int>(Seq.toList reference.Keys, tree.FullScan() |> List.map _.Key)
+
+            for entry in reference do
+                Assert.True(tree.Contains entry.Key)
+                Assert.Equal(Some entry.Value, tree.Search entry.Key)

--- a/code/packages/fsharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.fsproj
+++ b/code/packages/fsharp/b-plus-tree/tests/CodingAdventures.BPlusTree.Tests/CodingAdventures.BPlusTree.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.BPlusTree.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BPlusTree.fsproj" />
+    <Compile Include="BPlusTreeTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# B+ tree packages with point lookup, linked-leaf full/range scans, delete no-op semantics, min/max, height, iteration, and validation
- include package metadata, capability manifests, BUILD commands, project files, READMEs, and changelogs for both languages
- add parity-focused xUnit coverage for updates, null values, null-key guards, split/height behavior, range scans, deletes, multiple degrees, and sorted-dictionary stress checks

## Verification
- dotnet test code\packages\csharp\b-plus-tree\tests\CodingAdventures.BPlusTree.Tests\CodingAdventures.BPlusTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\b-plus-tree\tests\CodingAdventures.BPlusTree.Tests\CodingAdventures.BPlusTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line