### PR TITLE
feat(parity): add dotnet immutable-list packages

### DIFF
--- a/code/packages/csharp/immutable-list/BUILD
+++ b/code/packages/csharp/immutable-list/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/immutable-list/BUILD_windows
+++ b/code/packages/csharp/immutable-list/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/immutable-list/CHANGELOG.md
+++ b/code/packages/csharp/immutable-list/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# persistent immutable list package.

--- a/code/packages/csharp/immutable-list/CodingAdventures.ImmutableList.csproj
+++ b/code/packages/csharp/immutable-list/CodingAdventures.ImmutableList.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.ImmutableList.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# persistent list where updates return new immutable snapshots</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/immutable-list/ImmutableList.cs
+++ b/code/packages/csharp/immutable-list/ImmutableList.cs
@@ -1,0 +1,125 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CodingAdventures.ImmutableList;
+
+/// <summary>
+/// A persistent list where updates return new list instances and leave prior versions unchanged.
+/// </summary>
+public sealed class ImmutableList<T> : IReadOnlyList<T>
+{
+    private static readonly T[] EmptyItems = [];
+    private readonly T[] _items;
+
+    public ImmutableList()
+        : this(EmptyItems)
+    {
+    }
+
+    private ImmutableList(T[] items)
+    {
+        _items = items;
+    }
+
+    public static ImmutableList<T> Empty { get; } = new(EmptyItems);
+
+    public static ImmutableList<T> FromEnumerable(IEnumerable<T> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        var array = items.ToArray();
+        return array.Length == 0 ? Empty : new ImmutableList<T>(array);
+    }
+
+    public static ImmutableList<T> FromSlice(IEnumerable<T> items) => FromEnumerable(items);
+
+    public int Count => _items.Length;
+
+    public int Length => _items.Length;
+
+    public bool IsEmpty => _items.Length == 0;
+
+    public T this[int index]
+    {
+        get
+        {
+            EnsureIndex(index);
+            return _items[index];
+        }
+    }
+
+    [return: MaybeNull]
+    public T Get(int index) => IsIndexInRange(index) ? _items[index] : default;
+
+    public bool TryGet(int index, [MaybeNullWhen(false)] out T value)
+    {
+        if (IsIndexInRange(index))
+        {
+            value = _items[index];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public ImmutableList<T> Push(T value)
+    {
+        var next = new T[_items.Length + 1];
+        Array.Copy(_items, next, _items.Length);
+        next[^1] = value;
+        return new ImmutableList<T>(next);
+    }
+
+    public ImmutableList<T> Set(int index, T value)
+    {
+        EnsureIndex(index);
+
+        var next = ToArray();
+        next[index] = value;
+        return new ImmutableList<T>(next);
+    }
+
+    public (ImmutableList<T> List, T Value) Pop()
+    {
+        if (_items.Length == 0)
+        {
+            throw new InvalidOperationException("Cannot pop from an empty list.");
+        }
+
+        var value = _items[^1];
+        if (_items.Length == 1)
+        {
+            return (Empty, value);
+        }
+
+        var next = new T[_items.Length - 1];
+        Array.Copy(_items, next, next.Length);
+        return (new ImmutableList<T>(next), value);
+    }
+
+    public T[] ToArray()
+    {
+        var copy = new T[_items.Length];
+        Array.Copy(_items, copy, _items.Length);
+        return copy;
+    }
+
+    public List<T> ToList() => new(_items);
+
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)_items).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public override string ToString() => $"ImmutableList(count={_items.Length})";
+
+    private void EnsureIndex(int index)
+    {
+        if (!IsIndexInRange(index))
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), "Index is outside the bounds of the list.");
+        }
+    }
+
+    private bool IsIndexInRange(int index) => index >= 0 && index < _items.Length;
+}

--- a/code/packages/csharp/immutable-list/README.md
+++ b/code/packages/csharp/immutable-list/README.md
@@ -1,0 +1,11 @@
+# CodingAdventures.ImmutableList.CSharp
+
+Pure C# persistent list. `Push`, `Set`, and `Pop` return new list instances while the original list remains unchanged.
+
+```csharp
+var empty = ImmutableList<string>.Empty;
+var one = empty.Push("hello");
+var two = one.Push("world");
+
+var updated = two.Set(0, "hi");
+```

--- a/code/packages/csharp/immutable-list/required_capabilities.json
+++ b/code/packages/csharp/immutable-list/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/immutable-list",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/csharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.csproj
+++ b/code/packages/csharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.ImmutableList]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ImmutableList.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/ImmutableListTests.cs
+++ b/code/packages/csharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/ImmutableListTests.cs
@@ -1,0 +1,98 @@
+using CodingAdventures.ImmutableList;
+
+namespace CodingAdventures.ImmutableList.Tests;
+
+public sealed class ImmutableListTests
+{
+    [Fact]
+    public void EmptyListHasExpectedShape()
+    {
+        var list = ImmutableList<string>.Empty;
+
+        Assert.True(list.IsEmpty);
+        Assert.True(list.Count == 0);
+        Assert.Equal(0, list.Length);
+        Assert.Null(list.Get(0));
+        Assert.False(list.TryGet(0, out string? value));
+        Assert.Null(value);
+        Assert.Empty(list);
+        Assert.Equal("ImmutableList(count=0)", list.ToString());
+    }
+
+    [Fact]
+    public void PushReturnsNewListAndLeavesOriginalUnchanged()
+    {
+        var empty = ImmutableList<string>.Empty;
+        var one = empty.Push("hello");
+        var two = one.Push("world");
+
+        Assert.Empty(empty);
+        Assert.Equal(new[] { "hello" }, one.ToArray());
+        Assert.Equal(new[] { "hello", "world" }, two.ToList());
+        Assert.Equal("world", two[1]);
+    }
+
+    [Fact]
+    public void FromEnumerableAndFromSlicePreserveOrder()
+    {
+        var list = ImmutableList<int>.FromEnumerable(new[] { 3, 1, 4 });
+        var slice = ImmutableList<int>.FromSlice(new[] { 1, 5, 9 });
+
+        Assert.Equal(new[] { 3, 1, 4 }, list.ToArray());
+        Assert.Equal(new[] { 1, 5, 9 }, slice.ToArray());
+        Assert.Same(ImmutableList<int>.Empty, ImmutableList<int>.FromEnumerable(Array.Empty<int>()));
+        Assert.Throws<ArgumentNullException>(() => ImmutableList<int>.FromEnumerable(null!));
+    }
+
+    [Fact]
+    public void SetReturnsChangedCopy()
+    {
+        var list = ImmutableList<string>.FromSlice(new[] { "a", "b", "c" });
+        var updated = list.Set(1, "B");
+
+        Assert.Equal(new[] { "a", "b", "c" }, list.ToArray());
+        Assert.Equal(new[] { "a", "B", "c" }, updated.ToArray());
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Set(-1, "x"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Set(3, "x"));
+    }
+
+    [Fact]
+    public void PopReturnsRemainderAndRemovedValue()
+    {
+        var list = ImmutableList<int>.FromSlice(new[] { 1, 2, 3 });
+        var (two, removed) = list.Pop();
+        var (one, secondRemoved) = two.Pop();
+        var (empty, firstRemoved) = one.Pop();
+
+        Assert.Equal(3, removed);
+        Assert.Equal(2, secondRemoved);
+        Assert.Equal(1, firstRemoved);
+        Assert.Equal(new[] { 1, 2 }, two.ToArray());
+        Assert.Same(ImmutableList<int>.Empty, empty);
+        Assert.Throws<InvalidOperationException>(() => empty.Pop());
+    }
+
+    [Fact]
+    public void GetTryGetAndIndexerHandleBounds()
+    {
+        var list = ImmutableList<int>.FromSlice(new[] { 10, 20 });
+
+        Assert.Equal(10, list.Get(0));
+        Assert.Equal(0, list.Get(20));
+        Assert.True(list.TryGet(1, out var value));
+        Assert.Equal(20, value);
+        Assert.False(list.TryGet(-1, out value));
+        Assert.Equal(0, value);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[2]);
+    }
+
+    [Fact]
+    public void EnumerationUsesSnapshotOrder()
+    {
+        var list = new ImmutableList<string>().Push("a").Push("b").Push("c");
+
+        Assert.Equal(new[] { "a", "b", "c" }, list.Select(item => item));
+        Assert.Equal("ImmutableList(count=3)", list.ToString());
+    }
+}

--- a/code/packages/fsharp/immutable-list/BUILD
+++ b/code/packages/fsharp/immutable-list/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/immutable-list/BUILD_windows
+++ b/code/packages/fsharp/immutable-list/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/immutable-list/CHANGELOG.md
+++ b/code/packages/fsharp/immutable-list/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# persistent immutable list package.

--- a/code/packages/fsharp/immutable-list/CodingAdventures.ImmutableList.fsproj
+++ b/code/packages/fsharp/immutable-list/CodingAdventures.ImmutableList.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.ImmutableList.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.ImmutableList</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# persistent list where updates return new immutable snapshots</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ImmutableList.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/immutable-list/ImmutableList.fs
+++ b/code/packages/fsharp/immutable-list/ImmutableList.fs
@@ -1,0 +1,92 @@
+namespace CodingAdventures.ImmutableList
+
+open System
+open System.Collections
+open System.Collections.Generic
+
+/// Persistent list where updates return new list instances and leave prior versions unchanged.
+type ImmutableList<'T> private (items: 'T array) =
+    static let empty = ImmutableList<'T>(Array.empty)
+
+    new() = ImmutableList<'T>(Array.empty)
+
+    static member Empty = empty
+
+    static member FromSeq(values: seq<'T>) =
+        if isNull (box values) then
+            nullArg (nameof values)
+
+        let array = Seq.toArray values
+        if Array.isEmpty array then empty else ImmutableList<'T>(array)
+
+    static member FromSlice(values: seq<'T>) =
+        ImmutableList<'T>.FromSeq(values)
+
+    member _.Count = items.Length
+    member _.Length = items.Length
+    member _.IsEmpty = items.Length = 0
+
+    member _.Item
+        with get index =
+            if index < 0 || index >= items.Length then
+                raise (ArgumentOutOfRangeException(nameof index, "Index is outside the bounds of the list."))
+
+            items[index]
+
+    member _.Get(index: int) =
+        if index >= 0 && index < items.Length then
+            Some items[index]
+        else
+            None
+
+    member _.TryGet(index: int, value: byref<'T>) =
+        if index >= 0 && index < items.Length then
+            value <- items[index]
+            true
+        else
+            value <- Unchecked.defaultof<'T>
+            false
+
+    member _.Push(value: 'T) =
+        let next = Array.zeroCreate<'T> (items.Length + 1)
+        Array.Copy(items, next, items.Length)
+        next[next.Length - 1] <- value
+        ImmutableList<'T>(next)
+
+    member _.Set(index: int, value: 'T) =
+        if index < 0 || index >= items.Length then
+            raise (ArgumentOutOfRangeException(nameof index, "Index is outside the bounds of the list."))
+
+        let next = Array.copy items
+        next[index] <- value
+        ImmutableList<'T>(next)
+
+    member _.Pop() =
+        if items.Length = 0 then
+            invalidOp "Cannot pop from an empty list."
+
+        let value = items[items.Length - 1]
+
+        if items.Length = 1 then
+            empty, value
+        else
+            let next = Array.zeroCreate<'T> (items.Length - 1)
+            Array.Copy(items, next, next.Length)
+            ImmutableList<'T>(next), value
+
+    member _.ToArray() =
+        Array.copy items
+
+    member _.ToList() =
+        Array.toList items
+
+    override _.ToString() =
+        $"ImmutableList(count={items.Length})"
+
+    interface IEnumerable<'T> with
+        member _.GetEnumerator() =
+            ((items :> seq<'T>).GetEnumerator())
+
+    interface IEnumerable with
+        member _.GetEnumerator() =
+            ((items :> IEnumerable).GetEnumerator())

--- a/code/packages/fsharp/immutable-list/README.md
+++ b/code/packages/fsharp/immutable-list/README.md
@@ -1,0 +1,11 @@
+# CodingAdventures.ImmutableList
+
+Pure F# persistent list. `Push`, `Set`, and `Pop` return new list instances while the original list remains unchanged.
+
+```fsharp
+let empty = ImmutableList<string>.Empty
+let one = empty.Push "hello"
+let two = one.Push "world"
+
+let updated = two.Set(0, "hi")
+```

--- a/code/packages/fsharp/immutable-list/required_capabilities.json
+++ b/code/packages/fsharp/immutable-list/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/immutable-list",
+  "capabilities": [],
+  "justification": "Pure in-memory collection package and tests."
+}

--- a/code/packages/fsharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.fsproj
+++ b/code/packages/fsharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/CodingAdventures.ImmutableList.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.ImmutableList.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ImmutableList.fsproj" />
+    <Compile Include="ImmutableListTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/ImmutableListTests.fs
+++ b/code/packages/fsharp/immutable-list/tests/CodingAdventures.ImmutableList.Tests/ImmutableListTests.fs
@@ -1,0 +1,86 @@
+namespace CodingAdventures.ImmutableList.Tests
+
+open System
+open CodingAdventures.ImmutableList
+open Xunit
+
+type ImmutableListTests() =
+    [<Fact>]
+    member _.EmptyListHasExpectedShape() =
+        let list = ImmutableList<string>.Empty
+        let mutable value = ""
+
+        Assert.True(list.IsEmpty)
+        Assert.Equal(0, list.Count)
+        Assert.Equal(0, list.Length)
+        Assert.Equal(None, list.Get 0)
+        Assert.False(list.TryGet(0, &value))
+        Assert.Null(value)
+        Assert.Empty(list)
+        Assert.Equal("ImmutableList(count=0)", list.ToString())
+
+    [<Fact>]
+    member _.PushReturnsNewListAndLeavesOriginalUnchanged() =
+        let empty = ImmutableList<string>.Empty
+        let one = empty.Push "hello"
+        let two = one.Push "world"
+
+        Assert.Empty(empty)
+        Assert.Equal<string>([ "hello" ], one.ToArray())
+        Assert.Equal<string>([ "hello"; "world" ], two.ToList())
+        Assert.Equal("world", two[1])
+
+    [<Fact>]
+    member _.FromSeqAndFromSlicePreserveOrder() =
+        let list = ImmutableList<int>.FromSeq([ 3; 1; 4 ])
+        let slice = ImmutableList<int>.FromSlice([ 1; 5; 9 ])
+
+        Assert.Equal<int>([ 3; 1; 4 ], list.ToArray())
+        Assert.Equal<int>([ 1; 5; 9 ], slice.ToArray())
+        Assert.Same(ImmutableList<int>.Empty, ImmutableList<int>.FromSeq([]))
+        Assert.Throws<ArgumentNullException>(fun () -> ImmutableList<int>.FromSeq(Unchecked.defaultof<seq<int>>) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.SetReturnsChangedCopy() =
+        let list = ImmutableList<string>.FromSlice([ "a"; "b"; "c" ])
+        let updated = list.Set(1, "B")
+
+        Assert.Equal<string>([ "a"; "b"; "c" ], list.ToArray())
+        Assert.Equal<string>([ "a"; "B"; "c" ], updated.ToArray())
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> list.Set(-1, "x") |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> list.Set(3, "x") |> ignore) |> ignore
+
+    [<Fact>]
+    member _.PopReturnsRemainderAndRemovedValue() =
+        let list = ImmutableList<int>.FromSlice([ 1; 2; 3 ])
+        let two, removed = list.Pop()
+        let one, secondRemoved = two.Pop()
+        let empty, firstRemoved = one.Pop()
+
+        Assert.Equal(3, removed)
+        Assert.Equal(2, secondRemoved)
+        Assert.Equal(1, firstRemoved)
+        Assert.Equal<int>([ 1; 2 ], two.ToArray())
+        Assert.Same(ImmutableList<int>.Empty, empty)
+        Assert.Throws<InvalidOperationException>(fun () -> empty.Pop() |> ignore) |> ignore
+
+    [<Fact>]
+    member _.GetTryGetAndIndexerHandleBounds() =
+        let list = ImmutableList<int>.FromSlice([ 10; 20 ])
+        let mutable value = 0
+
+        Assert.Equal(Some 10, list.Get 0)
+        Assert.Equal(None, list.Get 20)
+        Assert.True(list.TryGet(1, &value))
+        Assert.Equal(20, value)
+        Assert.False(list.TryGet(-1, &value))
+        Assert.Equal(0, value)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> list[-1] |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> list[2] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.EnumerationUsesSnapshotOrder() =
+        let list = ImmutableList<string>().Push("a").Push("b").Push("c")
+
+        Assert.Equal<string>([ "a"; "b"; "c" ], list |> Seq.toList)
+        Assert.Equal("ImmutableList(count=3)", list.ToString())


### PR DESCRIPTION
## Summary
- add native C# and F# immutable-list packages with persistent Push, Set, and Pop operations
- include package metadata, capability manifests, BUILD commands, project files, READMEs, and changelogs for both languages
- add xUnit coverage for empty lists, snapshot immutability, construction helpers, bounds behavior, pop semantics, and enumeration

## Verification
- dotnet test code\packages\csharp\immutable-list\tests\CodingAdventures.ImmutableList.Tests\CodingAdventures.ImmutableList.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\immutable-list\tests\CodingAdventures.ImmutableList.Tests\CodingAdventures.ImmutableList.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line