### PR TITLE
feat(parity): add dotnet rope packages

### DIFF
--- a/code/packages/csharp/rope/BUILD
+++ b/code/packages/csharp/rope/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/rope/BUILD_windows
+++ b/code/packages/csharp/rope/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/rope/CHANGELOG.md
+++ b/code/packages/csharp/rope/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# immutable rope package.

--- a/code/packages/csharp/rope/CodingAdventures.Rope.csproj
+++ b/code/packages/csharp/rope/CodingAdventures.Rope.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Rope.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# immutable rope for text concat, split, insert, delete, and substring operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/rope/README.md
+++ b/code/packages/csharp/rope/README.md
@@ -1,0 +1,9 @@
+# CodingAdventures.Rope.CSharp
+
+Pure C# immutable rope for text concat, split, insert, delete, indexing, substring, depth, and rebalance operations.
+
+```csharp
+var rope = Rope.FromString("hello").Concat(Rope.FromString(" world"));
+var edited = rope.Insert(5, ",");
+var text = edited.ToString();
+```

--- a/code/packages/csharp/rope/Rope.cs
+++ b/code/packages/csharp/rope/Rope.cs
@@ -1,0 +1,166 @@
+using System.Text;
+
+namespace CodingAdventures.Rope;
+
+/// <summary>
+/// Immutable rope for efficient text composition and slicing.
+/// </summary>
+public sealed class Rope
+{
+    private readonly RopeNode? _root;
+
+    private Rope(RopeNode? root, int length)
+    {
+        _root = root;
+        Length = length;
+    }
+
+    public int Length { get; }
+
+    public int Count => Length;
+
+    public bool IsEmpty => Length == 0;
+
+    public static Rope Empty() => new(null, 0);
+
+    public static Rope FromString(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return text.Length == 0 ? Empty() : new Rope(new LeafNode(text), text.Length);
+    }
+
+    public static Rope RopeFromString(string text) => FromString(text);
+
+    public static Rope Concat(Rope left, Rope right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        if (left._root is null)
+        {
+            return right;
+        }
+
+        if (right._root is null)
+        {
+            return left;
+        }
+
+        return new Rope(new InternalNode(left.Length, left._root, right._root), left.Length + right.Length);
+    }
+
+    public Rope Concat(Rope right) => Concat(this, right);
+
+    public (Rope Left, Rope Right) Split(int index)
+    {
+        var chars = ToString().ToCharArray();
+        var splitAt = Math.Clamp(index, 0, chars.Length);
+        return (
+            FromString(new string(chars[..splitAt])),
+            FromString(new string(chars[splitAt..])));
+    }
+
+    public Rope Insert(int index, string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var (left, right) = Split(index);
+        return Concat(Concat(left, FromString(text)), right);
+    }
+
+    public Rope Delete(int start, int length)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        }
+
+        var chars = ToString().ToCharArray();
+        var safeStart = Math.Clamp(start, 0, chars.Length);
+        var end = Math.Min(safeStart + length, chars.Length);
+        return Concat(
+            FromString(new string(chars[..safeStart])),
+            FromString(new string(chars[end..])));
+    }
+
+    public char? Index(int index)
+    {
+        var text = ToString();
+        return index >= 0 && index < text.Length ? text[index] : null;
+    }
+
+    public string Substring(int start, int end)
+    {
+        var chars = ToString().ToCharArray();
+        var safeStart = Math.Clamp(start, 0, chars.Length);
+        var safeEnd = Math.Clamp(end, 0, chars.Length);
+        return safeStart >= safeEnd ? string.Empty : new string(chars[safeStart..safeEnd]);
+    }
+
+    public int Depth() => _root?.Depth() ?? 0;
+
+    public bool IsBalanced() => _root?.IsBalanced() ?? true;
+
+    public Rope Rebalance() => BuildBalanced(ToString());
+
+    public override string ToString()
+    {
+        var builder = new StringBuilder(Length);
+        _root?.AppendTo(builder);
+        return builder.ToString();
+    }
+
+    private static Rope BuildBalanced(string text)
+    {
+        if (text.Length == 0)
+        {
+            return Empty();
+        }
+
+        if (text.Length == 1)
+        {
+            return FromString(text);
+        }
+
+        var midpoint = text.Length / 2;
+        return Concat(BuildBalanced(text[..midpoint]), BuildBalanced(text[midpoint..]));
+    }
+
+    private abstract class RopeNode
+    {
+        public abstract int Depth();
+
+        public abstract bool IsBalanced();
+
+        public abstract void AppendTo(StringBuilder builder);
+    }
+
+    private sealed class LeafNode(string chunk) : RopeNode
+    {
+        public override int Depth() => 0;
+
+        public override bool IsBalanced() => true;
+
+        public override void AppendTo(StringBuilder builder) => builder.Append(chunk);
+    }
+
+    private sealed class InternalNode(int weight, RopeNode left, RopeNode right) : RopeNode
+    {
+        public int Weight => weight;
+
+        public override int Depth() => 1 + Math.Max(left.Depth(), right.Depth());
+
+        public override bool IsBalanced()
+        {
+            var leftDepth = left.Depth();
+            var rightDepth = right.Depth();
+            return Math.Abs(leftDepth - rightDepth) <= 1 && left.IsBalanced() && right.IsBalanced();
+        }
+
+        public override void AppendTo(StringBuilder builder)
+        {
+            left.AppendTo(builder);
+            right.AppendTo(builder);
+        }
+    }
+}

--- a/code/packages/csharp/rope/required_capabilities.json
+++ b/code/packages/csharp/rope/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/rope",
+  "capabilities": [],
+  "justification": "Pure in-memory text data structure package and tests."
+}

--- a/code/packages/csharp/rope/tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.csproj
+++ b/code/packages/csharp/rope/tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Rope]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Rope.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/rope/tests/CodingAdventures.Rope.Tests/RopeTests.cs
+++ b/code/packages/csharp/rope/tests/CodingAdventures.Rope.Tests/RopeTests.cs
@@ -1,0 +1,86 @@
+using CodingAdventures.Rope;
+
+namespace CodingAdventures.Rope.Tests;
+
+public sealed class RopeTests
+{
+    [Fact]
+    public void EmptyAndFromStringExposeLength()
+    {
+        var empty = Rope.Empty();
+        var rope = Rope.FromString("hello");
+
+        Assert.True(empty.IsEmpty);
+        Assert.Equal(0, empty.Length);
+        Assert.Equal(0, empty.Count);
+        Assert.Equal(string.Empty, empty.ToString());
+        Assert.True(empty.IsBalanced());
+        Assert.Equal(0, empty.Depth());
+        Assert.Equal("hello", Rope.RopeFromString("hello").ToString());
+        Assert.Equal(5, rope.Length);
+        Assert.Throws<ArgumentNullException>(() => Rope.FromString(null!));
+    }
+
+    [Fact]
+    public void ConcatSplitAndIndexWork()
+    {
+        var rope = Rope.Concat(Rope.FromString("hello"), Rope.FromString(" world"));
+
+        Assert.Equal(11, rope.Length);
+        Assert.Equal("hello world", rope.ToString());
+        Assert.Equal('e', rope.Index(1));
+        Assert.Null(rope.Index(-1));
+        Assert.Null(rope.Index(11));
+
+        var (left, right) = rope.Split(5);
+        Assert.Equal("hello", left.ToString());
+        Assert.Equal(" world", right.ToString());
+    }
+
+    [Fact]
+    public void InstanceConcatPreservesEmptyIdentities()
+    {
+        var left = Rope.Empty().Concat(Rope.FromString("a"));
+        var right = Rope.FromString("b").Concat(Rope.Empty());
+
+        Assert.Equal("a", left.ToString());
+        Assert.Equal("b", right.ToString());
+        Assert.Throws<ArgumentNullException>(() => Rope.Concat(null!, Rope.Empty()));
+        Assert.Throws<ArgumentNullException>(() => Rope.Concat(Rope.Empty(), null!));
+    }
+
+    [Fact]
+    public void InsertDeleteAndSubstringClampLikeRust()
+    {
+        var rope = Rope.FromString("ace").Insert(1, "b").Insert(3, "d");
+
+        Assert.Equal("abcde", rope.ToString());
+        Assert.Equal("bcd", rope.Substring(1, 4));
+        Assert.Equal(string.Empty, rope.Substring(4, 1));
+        Assert.Equal("abcde", rope.Substring(-20, 20));
+        Assert.Equal("ade", rope.Delete(1, 2).ToString());
+        Assert.Equal("abcde!", rope.Insert(99, "!").ToString());
+        Assert.Equal("bcde", rope.Delete(-10, 1).ToString());
+        Assert.Throws<ArgumentNullException>(() => rope.Insert(0, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => rope.Delete(0, -1));
+    }
+
+    [Fact]
+    public void RebalanceProducesBalancedTreeWithSameText()
+    {
+        var rope = Rope.FromString("a")
+            .Concat(Rope.FromString("b"))
+            .Concat(Rope.FromString("c"))
+            .Concat(Rope.FromString("d"))
+            .Concat(Rope.FromString("e"))
+            .Concat(Rope.FromString("f"));
+
+        Assert.False(rope.IsBalanced());
+
+        var balanced = rope.Rebalance();
+
+        Assert.Equal("abcdef", balanced.ToString());
+        Assert.True(balanced.IsBalanced());
+        Assert.True(balanced.Depth() <= 3);
+    }
+}

--- a/code/packages/fsharp/rope/BUILD
+++ b/code/packages/fsharp/rope/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/rope/BUILD_windows
+++ b/code/packages/fsharp/rope/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/rope/CHANGELOG.md
+++ b/code/packages/fsharp/rope/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# immutable rope package.

--- a/code/packages/fsharp/rope/CodingAdventures.Rope.fsproj
+++ b/code/packages/fsharp/rope/CodingAdventures.Rope.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.Rope.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Rope</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# immutable rope for text concat, split, insert, delete, and substring operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Rope.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/rope/README.md
+++ b/code/packages/fsharp/rope/README.md
@@ -1,0 +1,9 @@
+# CodingAdventures.Rope
+
+Pure F# immutable rope for text concat, split, insert, delete, indexing, substring, depth, and rebalance operations.
+
+```fsharp
+let rope = Rope.FromString("hello").Concat(Rope.FromString(" world"))
+let edited = rope.Insert(5, ",")
+let text = edited.ToString()
+```

--- a/code/packages/fsharp/rope/Rope.fs
+++ b/code/packages/fsharp/rope/Rope.fs
@@ -1,0 +1,135 @@
+namespace CodingAdventures.Rope
+
+open System
+open System.Text
+
+type private RopeNode =
+    | Leaf of string
+    | Internal of int * RopeNode * RopeNode
+
+type Rope private (root: RopeNode option, length: int) =
+    let rec appendTo (builder: StringBuilder) node =
+        match node with
+        | Leaf chunk -> builder.Append(chunk) |> ignore
+        | Internal(_, left, right) ->
+            appendTo builder left
+            appendTo builder right
+
+    let rec depth node =
+        match node with
+        | Leaf _ -> 0
+        | Internal(_, left, right) -> 1 + max (depth left) (depth right)
+
+    let rec isBalanced node =
+        match node with
+        | Leaf _ -> true
+        | Internal(_, left, right) ->
+            abs (depth left - depth right) <= 1 && isBalanced left && isBalanced right
+
+    let text () =
+        let builder = StringBuilder(length)
+
+        match root with
+        | Some node -> appendTo builder node
+        | None -> ()
+
+        builder.ToString()
+
+    static member Empty() = Rope(None, 0)
+
+    static member FromString(value: string) =
+        if isNull value then
+            nullArg (nameof value)
+
+        if value.Length = 0 then
+            Rope.Empty()
+        else
+            Rope(Some(Leaf value), value.Length)
+
+    static member RopeFromString(value: string) =
+        Rope.FromString(value)
+
+    static member Concat(left: Rope, right: Rope) =
+        if isNull (box left) then
+            nullArg (nameof left)
+
+        if isNull (box right) then
+            nullArg (nameof right)
+
+        match left.Root, right.Root with
+        | None, _ -> right
+        | _, None -> left
+        | Some leftRoot, Some rightRoot ->
+            Rope(Some(Internal(left.Length, leftRoot, rightRoot)), left.Length + right.Length)
+
+    member private _.Root = root
+    member _.Length = length
+    member _.Count = length
+    member _.IsEmpty = length = 0
+
+    member this.Concat(right: Rope) =
+        Rope.Concat(this, right)
+
+    member this.Split(index: int) =
+        let chars = this.ToString().ToCharArray()
+        let splitAt = Math.Clamp(index, 0, chars.Length)
+        let left = String(chars[0.. splitAt - 1])
+        let right = String(chars[splitAt ..])
+        Rope.FromString(left), Rope.FromString(right)
+
+    member this.Insert(index: int, value: string) =
+        if isNull value then
+            nullArg (nameof value)
+
+        let left, right = this.Split index
+        Rope.Concat(Rope.Concat(left, Rope.FromString(value)), right)
+
+    member this.Delete(start: int, deleteLength: int) =
+        if deleteLength < 0 then
+            raise (ArgumentOutOfRangeException(nameof deleteLength, "Length must be non-negative."))
+
+        let chars = this.ToString().ToCharArray()
+        let safeStart = Math.Clamp(start, 0, chars.Length)
+        let finish = Math.Min(safeStart + deleteLength, chars.Length)
+        let left = String(chars[0.. safeStart - 1])
+        let right = String(chars[finish ..])
+        Rope.Concat(Rope.FromString(left), Rope.FromString(right))
+
+    member this.Index(index: int) =
+        let value = this.ToString()
+
+        if index >= 0 && index < value.Length then
+            Some value[index]
+        else
+            None
+
+    member this.Substring(start: int, finish: int) =
+        let chars = this.ToString().ToCharArray()
+        let safeStart = Math.Clamp(start, 0, chars.Length)
+        let safeEnd = Math.Clamp(finish, 0, chars.Length)
+
+        if safeStart >= safeEnd then
+            String.Empty
+        else
+            String(chars[safeStart .. safeEnd - 1])
+
+    member _.Depth() =
+        root |> Option.map depth |> Option.defaultValue 0
+
+    member _.IsBalanced() =
+        root |> Option.map isBalanced |> Option.defaultValue true
+
+    member this.Rebalance() =
+        let rec buildBalanced (value: string) =
+            if value.Length = 0 then
+                Rope.Empty()
+            elif value.Length = 1 then
+                Rope.FromString(value)
+            else
+                let midpoint = value.Length / 2
+                Rope.Concat(buildBalanced value[.. midpoint - 1], buildBalanced value[midpoint ..])
+
+        buildBalanced (this.ToString())
+
+    override _.ToString() =
+        text ()

--- a/code/packages/fsharp/rope/required_capabilities.json
+++ b/code/packages/fsharp/rope/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/rope",
+  "capabilities": [],
+  "justification": "Pure in-memory text data structure package and tests."
+}

--- a/code/packages/fsharp/rope/tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.fsproj
+++ b/code/packages/fsharp/rope/tests/CodingAdventures.Rope.Tests/CodingAdventures.Rope.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Rope.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Rope.fsproj" />
+    <Compile Include="RopeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/rope/tests/CodingAdventures.Rope.Tests/RopeTests.fs
+++ b/code/packages/fsharp/rope/tests/CodingAdventures.Rope.Tests/RopeTests.fs
@@ -1,0 +1,77 @@
+namespace CodingAdventures.Rope.Tests
+
+open System
+open CodingAdventures.Rope
+open Xunit
+
+type RopeTests() =
+    [<Fact>]
+    member _.EmptyAndFromStringExposeLength() =
+        let empty = Rope.Empty()
+        let rope = Rope.FromString("hello")
+
+        Assert.True(empty.IsEmpty)
+        Assert.Equal(0, empty.Length)
+        Assert.Equal(0, empty.Count)
+        Assert.Equal(String.Empty, empty.ToString())
+        Assert.True(empty.IsBalanced())
+        Assert.Equal(0, empty.Depth())
+        Assert.Equal("hello", Rope.RopeFromString("hello").ToString())
+        Assert.Equal(5, rope.Length)
+        Assert.Throws<ArgumentNullException>(fun () -> Rope.FromString(null) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.ConcatSplitAndIndexWork() =
+        let rope = Rope.Concat(Rope.FromString("hello"), Rope.FromString(" world"))
+
+        Assert.Equal(11, rope.Length)
+        Assert.Equal("hello world", rope.ToString())
+        Assert.Equal(Some 'e', rope.Index 1)
+        Assert.Equal(None, rope.Index -1)
+        Assert.Equal(None, rope.Index 11)
+
+        let left, right = rope.Split 5
+        Assert.Equal("hello", left.ToString())
+        Assert.Equal(" world", right.ToString())
+
+    [<Fact>]
+    member _.InstanceConcatPreservesEmptyIdentities() =
+        let left = Rope.Empty().Concat(Rope.FromString("a"))
+        let right = Rope.FromString("b").Concat(Rope.Empty())
+
+        Assert.Equal("a", left.ToString())
+        Assert.Equal("b", right.ToString())
+        Assert.Throws<ArgumentNullException>(fun () -> Rope.Concat(null, Rope.Empty()) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Rope.Concat(Rope.Empty(), null) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.InsertDeleteAndSubstringClampLikeRust() =
+        let rope = Rope.FromString("ace").Insert(1, "b").Insert(3, "d")
+
+        Assert.Equal("abcde", rope.ToString())
+        Assert.Equal("bcd", rope.Substring(1, 4))
+        Assert.Equal(String.Empty, rope.Substring(4, 1))
+        Assert.Equal("abcde", rope.Substring(-20, 20))
+        Assert.Equal("ade", rope.Delete(1, 2).ToString())
+        Assert.Equal("abcde!", rope.Insert(99, "!").ToString())
+        Assert.Equal("bcde", rope.Delete(-10, 1).ToString())
+        Assert.Throws<ArgumentNullException>(fun () -> rope.Insert(0, null) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> rope.Delete(0, -1) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.RebalanceProducesBalancedTreeWithSameText() =
+        let rope =
+            Rope.FromString("a")
+                .Concat(Rope.FromString("b"))
+                .Concat(Rope.FromString("c"))
+                .Concat(Rope.FromString("d"))
+                .Concat(Rope.FromString("e"))
+                .Concat(Rope.FromString("f"))
+
+        Assert.False(rope.IsBalanced())
+
+        let balanced = rope.Rebalance()
+
+        Assert.Equal("abcdef", balanced.ToString())
+        Assert.True(balanced.IsBalanced())
+        Assert.True(balanced.Depth() <= 3)


### PR DESCRIPTION
## Summary
- add native C# and F# rope packages with concat, split, insert, delete, index, substring, depth, balance checks, and rebalance
- include package metadata, capability manifests, BUILD commands, project files, READMEs, and changelogs for both languages
- add xUnit coverage for empty/text construction, concat/split/index behavior, identity cases, edit clamping, null/negative guards, and rebalance

## Verification
- dotnet test code\packages\csharp\rope\tests\CodingAdventures.Rope.Tests\CodingAdventures.Rope.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\rope\tests\CodingAdventures.Rope.Tests\CodingAdventures.Rope.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line