### PR TITLE
feat(parity): add dotnet suffix-tree packages

### DIFF
--- a/code/packages/csharp/suffix-tree/BUILD
+++ b/code/packages/csharp/suffix-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/suffix-tree/BUILD_windows
+++ b/code/packages/csharp/suffix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/suffix-tree/CHANGELOG.md
+++ b/code/packages/csharp/suffix-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# suffix tree package.

--- a/code/packages/csharp/suffix-tree/CodingAdventures.SuffixTree.csproj
+++ b/code/packages/csharp/suffix-tree/CodingAdventures.SuffixTree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.SuffixTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# suffix tree facade with substring search helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/suffix-tree/README.md
+++ b/code/packages/csharp/suffix-tree/README.md
@@ -1,0 +1,9 @@
+# CodingAdventures.SuffixTree.CSharp
+
+Pure C# suffix tree facade with substring search, occurrence counting, all-suffix enumeration, longest repeated substring, and longest common substring helpers.
+
+```csharp
+var tree = SuffixTree.Build("banana");
+var positions = tree.Search("ana");
+var repeated = tree.LongestRepeatedSubstring();
+```

--- a/code/packages/csharp/suffix-tree/SuffixTree.cs
+++ b/code/packages/csharp/suffix-tree/SuffixTree.cs
@@ -1,0 +1,168 @@
+namespace CodingAdventures.SuffixTree;
+
+/// <summary>
+/// Simple suffix tree facade with substring search helpers.
+/// </summary>
+public sealed class SuffixTree
+{
+    private readonly string _text;
+
+    private SuffixTree(string text)
+    {
+        _text = text;
+    }
+
+    public string Text => _text;
+
+    public static SuffixTree Build(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return new SuffixTree(text);
+    }
+
+    public static SuffixTree BuildUkkonen(string text) => Build(text);
+
+    public IReadOnlyList<int> Search(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return SearchPositions(_text, pattern);
+    }
+
+    public int CountOccurrences(string pattern) => Search(pattern).Count;
+
+    public string LongestRepeatedSubstring() => LongestRepeatedSubstringIn(_text);
+
+    public IReadOnlyList<string> AllSuffixes() => AllSuffixesIn(_text);
+
+    public int NodeCount() => 1 + _text.Length;
+
+    public static IReadOnlyList<int> Search(SuffixTree tree, string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        return tree.Search(pattern);
+    }
+
+    public static int CountOccurrences(SuffixTree tree, string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        return tree.CountOccurrences(pattern);
+    }
+
+    public static string LongestRepeatedSubstring(SuffixTree tree)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        return tree.LongestRepeatedSubstring();
+    }
+
+    public static string LongestCommonSubstring(string left, string right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        if (left.Length == 0 || right.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var dp = new int[left.Length + 1, right.Length + 1];
+        var bestLength = 0;
+        var bestEnd = 0;
+        for (var i = 1; i <= left.Length; i++)
+        {
+            for (var j = 1; j <= right.Length; j++)
+            {
+                if (left[i - 1] != right[j - 1])
+                {
+                    continue;
+                }
+
+                dp[i, j] = dp[i - 1, j - 1] + 1;
+                if (dp[i, j] > bestLength)
+                {
+                    bestLength = dp[i, j];
+                    bestEnd = i;
+                }
+            }
+        }
+
+        return left.Substring(bestEnd - bestLength, bestLength);
+    }
+
+    public static IReadOnlyList<string> AllSuffixes(SuffixTree tree)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        return tree.AllSuffixes();
+    }
+
+    public static int NodeCount(SuffixTree tree)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        return tree.NodeCount();
+    }
+
+    private static IReadOnlyList<int> SearchPositions(string text, string pattern)
+    {
+        if (pattern.Length == 0)
+        {
+            return Enumerable.Range(0, text.Length + 1).ToArray();
+        }
+
+        if (pattern.Length > text.Length)
+        {
+            return Array.Empty<int>();
+        }
+
+        var positions = new List<int>();
+        for (var start = 0; start <= text.Length - pattern.Length; start++)
+        {
+            if (string.CompareOrdinal(text, start, pattern, 0, pattern.Length) == 0)
+            {
+                positions.Add(start);
+            }
+        }
+
+        return positions;
+    }
+
+    private static string LongestRepeatedSubstringIn(string text)
+    {
+        var suffixes = AllSuffixesIn(text);
+        var best = string.Empty;
+        for (var i = 0; i < suffixes.Count; i++)
+        {
+            for (var j = i + 1; j < suffixes.Count; j++)
+            {
+                var prefix = CommonPrefix(suffixes[i], suffixes[j]);
+                if (prefix.Length > best.Length)
+                {
+                    best = prefix;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    private static string CommonPrefix(string left, string right)
+    {
+        var length = Math.Min(left.Length, right.Length);
+        var index = 0;
+        while (index < length && left[index] == right[index])
+        {
+            index++;
+        }
+
+        return left[..index];
+    }
+
+    private static IReadOnlyList<string> AllSuffixesIn(string text)
+    {
+        var suffixes = new List<string>(text.Length);
+        for (var start = 0; start < text.Length; start++)
+        {
+            suffixes.Add(text[start..]);
+        }
+
+        return suffixes;
+    }
+}

--- a/code/packages/csharp/suffix-tree/required_capabilities.json
+++ b/code/packages/csharp/suffix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/suffix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory text data structure package and tests."
+}

--- a/code/packages/csharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.csproj
+++ b/code/packages/csharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.SuffixTree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.SuffixTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/SuffixTreeTests.cs
+++ b/code/packages/csharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/SuffixTreeTests.cs
@@ -1,0 +1,55 @@
+using CodingAdventures.SuffixTree;
+
+namespace CodingAdventures.SuffixTree.Tests;
+
+public sealed class SuffixTreeTests
+{
+    [Fact]
+    public void BuildSearchAndCountWork()
+    {
+        var tree = SuffixTree.Build("banana");
+
+        Assert.Equal("banana", tree.Text);
+        Assert.Equal(new[] { 1, 3 }, tree.Search("ana"));
+        Assert.Equal(new[] { 0, 1, 2, 3, 4, 5, 6 }, tree.Search(""));
+        Assert.Empty(tree.Search("band"));
+        Assert.Equal(2, tree.CountOccurrences("ana"));
+        Assert.Equal(7, tree.NodeCount());
+    }
+
+    [Fact]
+    public void StaticHelpersDelegateToTree()
+    {
+        var tree = SuffixTree.BuildUkkonen("banana");
+
+        Assert.Equal(new[] { 2, 4 }, SuffixTree.Search(tree, "n"));
+        Assert.Equal(1, SuffixTree.CountOccurrences(tree, "nan"));
+        Assert.Equal(7, SuffixTree.NodeCount(tree));
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.Build(null!));
+        Assert.Throws<ArgumentNullException>(() => tree.Search(null!));
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.Search(null!, "a"));
+    }
+
+    [Fact]
+    public void SuffixAndRepeatedSubstringHelpersWork()
+    {
+        var tree = SuffixTree.Build("banana");
+
+        Assert.Equal("ana", tree.LongestRepeatedSubstring());
+        Assert.Equal("ana", SuffixTree.LongestRepeatedSubstring(tree));
+        Assert.Equal("banana", tree.AllSuffixes()[0]);
+        Assert.Equal("a", SuffixTree.AllSuffixes(tree)[^1]);
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.AllSuffixes(null!));
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.LongestRepeatedSubstring(null!));
+    }
+
+    [Fact]
+    public void LongestCommonSubstringHandlesEdges()
+    {
+        Assert.Equal("abxa", SuffixTree.LongestCommonSubstring("xabxac", "abcabxabcd"));
+        Assert.Equal(string.Empty, SuffixTree.LongestCommonSubstring("", "abc"));
+        Assert.Equal(string.Empty, SuffixTree.LongestCommonSubstring("abc", ""));
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.LongestCommonSubstring(null!, "abc"));
+        Assert.Throws<ArgumentNullException>(() => SuffixTree.LongestCommonSubstring("abc", null!));
+    }
+}

--- a/code/packages/fsharp/suffix-tree/BUILD
+++ b/code/packages/fsharp/suffix-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/suffix-tree/BUILD_windows
+++ b/code/packages/fsharp/suffix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/suffix-tree/CHANGELOG.md
+++ b/code/packages/fsharp/suffix-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# suffix tree package.

--- a/code/packages/fsharp/suffix-tree/CodingAdventures.SuffixTree.fsproj
+++ b/code/packages/fsharp/suffix-tree/CodingAdventures.SuffixTree.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.SuffixTree.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.SuffixTree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# suffix tree facade with substring search helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SuffixTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/suffix-tree/README.md
+++ b/code/packages/fsharp/suffix-tree/README.md
@@ -1,0 +1,9 @@
+# CodingAdventures.SuffixTree
+
+Pure F# suffix tree facade with substring search, occurrence counting, all-suffix enumeration, longest repeated substring, and longest common substring helpers.
+
+```fsharp
+let tree = SuffixTree.Build("banana")
+let positions = tree.Search "ana"
+let repeated = tree.LongestRepeatedSubstring()
+```

--- a/code/packages/fsharp/suffix-tree/SuffixTree.fs
+++ b/code/packages/fsharp/suffix-tree/SuffixTree.fs
@@ -1,0 +1,124 @@
+namespace CodingAdventures.SuffixTree
+
+open System
+
+/// Simple suffix tree facade with substring search helpers.
+type SuffixTree private (text: string) =
+    static let searchPositions (text: string) (pattern: string) =
+        if pattern.Length = 0 then
+            [ 0..text.Length ]
+        elif pattern.Length > text.Length then
+            []
+        else
+            [ for start in 0 .. text.Length - pattern.Length do
+                  if String.CompareOrdinal(text, start, pattern, 0, pattern.Length) = 0 then
+                      start ]
+
+    static let allSuffixesIn (text: string) =
+        [ for start in 0 .. text.Length - 1 -> text[start..] ]
+
+    static let commonPrefix (left: string) (right: string) =
+        let mutable index = 0
+        let limit = min left.Length right.Length
+
+        while index < limit && left[index] = right[index] do
+            index <- index + 1
+
+        left[.. index - 1]
+
+    static let longestRepeatedSubstringIn (text: string) =
+        let suffixes = allSuffixesIn text
+        let mutable best = String.Empty
+
+        for i in 0 .. suffixes.Length - 1 do
+            for j in i + 1 .. suffixes.Length - 1 do
+                let prefix = commonPrefix suffixes[i] suffixes[j]
+
+                if prefix.Length > best.Length then
+                    best <- prefix
+
+        best
+
+    static member Build(value: string) =
+        if isNull value then
+            nullArg (nameof value)
+
+        SuffixTree(value)
+
+    static member BuildUkkonen(value: string) =
+        SuffixTree.Build(value)
+
+    static member Search(tree: SuffixTree, pattern: string) =
+        if isNull (box tree) then
+            nullArg (nameof tree)
+
+        tree.Search(pattern)
+
+    static member CountOccurrences(tree: SuffixTree, pattern: string) =
+        if isNull (box tree) then
+            nullArg (nameof tree)
+
+        tree.CountOccurrences(pattern)
+
+    static member LongestRepeatedSubstring(tree: SuffixTree) =
+        if isNull (box tree) then
+            nullArg (nameof tree)
+
+        tree.LongestRepeatedSubstring()
+
+    static member LongestCommonSubstring(left: string, right: string) =
+        if isNull left then
+            nullArg (nameof left)
+
+        if isNull right then
+            nullArg (nameof right)
+
+        if left.Length = 0 || right.Length = 0 then
+            String.Empty
+        else
+            let dp = Array2D.zeroCreate<int> (left.Length + 1) (right.Length + 1)
+            let mutable bestLength = 0
+            let mutable bestEnd = 0
+
+            for i in 1 .. left.Length do
+                for j in 1 .. right.Length do
+                    if left[i - 1] = right[j - 1] then
+                        dp[i, j] <- dp[i - 1, j - 1] + 1
+
+                        if dp[i, j] > bestLength then
+                            bestLength <- dp[i, j]
+                            bestEnd <- i
+
+            left.Substring(bestEnd - bestLength, bestLength)
+
+    static member AllSuffixes(tree: SuffixTree) =
+        if isNull (box tree) then
+            nullArg (nameof tree)
+
+        tree.AllSuffixes()
+
+    static member NodeCount(tree: SuffixTree) =
+        if isNull (box tree) then
+            nullArg (nameof tree)
+
+        tree.NodeCount()
+
+    member _.Text = text
+
+    member _.Search(pattern: string) =
+        if isNull pattern then
+            nullArg (nameof pattern)
+
+        searchPositions text pattern
+
+    member this.CountOccurrences(pattern: string) =
+        this.Search(pattern).Length
+
+    member _.LongestRepeatedSubstring() =
+        longestRepeatedSubstringIn text
+
+    member _.AllSuffixes() =
+        allSuffixesIn text
+
+    member _.NodeCount() =
+        1 + text.Length

--- a/code/packages/fsharp/suffix-tree/required_capabilities.json
+++ b/code/packages/fsharp/suffix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/suffix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory text data structure package and tests."
+}

--- a/code/packages/fsharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.fsproj
+++ b/code/packages/fsharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/CodingAdventures.SuffixTree.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.SuffixTree.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SuffixTree.fsproj" />
+    <Compile Include="SuffixTreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/SuffixTreeTests.fs
+++ b/code/packages/fsharp/suffix-tree/tests/CodingAdventures.SuffixTree.Tests/SuffixTreeTests.fs
@@ -1,0 +1,47 @@
+namespace CodingAdventures.SuffixTree.Tests
+
+open System
+open CodingAdventures.SuffixTree
+open Xunit
+
+type SuffixTreeTests() =
+    [<Fact>]
+    member _.BuildSearchAndCountWork() =
+        let tree = SuffixTree.Build("banana")
+
+        Assert.Equal("banana", tree.Text)
+        Assert.Equal<int>([ 1; 3 ], tree.Search "ana")
+        Assert.Equal<int>([ 0..6 ], tree.Search "")
+        Assert.Empty(tree.Search "band")
+        Assert.Equal(2, tree.CountOccurrences "ana")
+        Assert.Equal(7, tree.NodeCount())
+
+    [<Fact>]
+    member _.StaticHelpersDelegateToTree() =
+        let tree = SuffixTree.BuildUkkonen("banana")
+
+        Assert.Equal<int>([ 2; 4 ], SuffixTree.Search(tree, "n"))
+        Assert.Equal(1, SuffixTree.CountOccurrences(tree, "nan"))
+        Assert.Equal(7, SuffixTree.NodeCount tree)
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.Build(null) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> tree.Search null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.Search(null, "a") |> ignore) |> ignore
+
+    [<Fact>]
+    member _.SuffixAndRepeatedSubstringHelpersWork() =
+        let tree = SuffixTree.Build("banana")
+
+        Assert.Equal("ana", tree.LongestRepeatedSubstring())
+        Assert.Equal("ana", SuffixTree.LongestRepeatedSubstring tree)
+        Assert.Equal("banana", tree.AllSuffixes()[0])
+        Assert.Equal("a", SuffixTree.AllSuffixes tree |> List.last)
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.AllSuffixes null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.LongestRepeatedSubstring null |> ignore) |> ignore
+
+    [<Fact>]
+    member _.LongestCommonSubstringHandlesEdges() =
+        Assert.Equal("abxa", SuffixTree.LongestCommonSubstring("xabxac", "abcabxabcd"))
+        Assert.Equal(String.Empty, SuffixTree.LongestCommonSubstring("", "abc"))
+        Assert.Equal(String.Empty, SuffixTree.LongestCommonSubstring("abc", ""))
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.LongestCommonSubstring(null, "abc") |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> SuffixTree.LongestCommonSubstring("abc", null) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# suffix-tree packages with build/search/count, all suffixes, node count, longest repeated substring, and longest common substring helpers
- include package metadata, capability manifests, BUILD commands, project files, READMEs, and changelogs for both languages
- add xUnit coverage for instance/static helpers, empty-pattern behavior, missing matches, suffix helpers, repeated/common substring logic, and null guards

## Verification
- dotnet test code\packages\csharp\suffix-tree\tests\CodingAdventures.SuffixTree.Tests\CodingAdventures.SuffixTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\suffix-tree\tests\CodingAdventures.SuffixTree.Tests\CodingAdventures.SuffixTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line