### PR TITLE
feat(parity): add dotnet tree packages

### DIFF
--- a/code/packages/csharp/tree/BUILD
+++ b/code/packages/csharp/tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/tree/BUILD_windows
+++ b/code/packages/csharp/tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/tree/CHANGELOG.md
+++ b/code/packages/csharp/tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# rooted tree package.

--- a/code/packages/csharp/tree/CodingAdventures.Tree.csproj
+++ b/code/packages/csharp/tree/CodingAdventures.Tree.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Tree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# rooted tree with traversal, query, subtree, and ASCII rendering helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/tree/README.md
+++ b/code/packages/csharp/tree/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Tree.CSharp
+
+Pure C# rooted tree with unique string node names, traversal helpers, parent/child queries, subtree removal/extraction, lowest common ancestor, and ASCII rendering.

--- a/code/packages/csharp/tree/Tree.cs
+++ b/code/packages/csharp/tree/Tree.cs
@@ -1,0 +1,317 @@
+using System.Text;
+
+namespace CodingAdventures.Tree;
+
+public enum TreeErrorKind
+{
+    NodeNotFound,
+    DuplicateNode,
+    RootRemoval,
+}
+
+public sealed class TreeException : InvalidOperationException
+{
+    public TreeException(TreeErrorKind kind, string? node)
+        : base(CreateMessage(kind, node))
+    {
+        Kind = kind;
+        Node = node;
+    }
+
+    public TreeErrorKind Kind { get; }
+
+    public string? Node { get; }
+
+    private static string CreateMessage(TreeErrorKind kind, string? node) =>
+        kind switch
+        {
+            TreeErrorKind.NodeNotFound => $"Node not found in tree: {node}",
+            TreeErrorKind.DuplicateNode => $"Node already exists in tree: {node}",
+            TreeErrorKind.RootRemoval => "Cannot remove the root node.",
+            _ => "Tree operation failed.",
+        };
+}
+
+/// <summary>
+/// A rooted tree with unique string node names.
+/// </summary>
+public sealed class Tree
+{
+    private readonly Dictionary<string, string?> _parents = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, SortedSet<string>> _children = new(StringComparer.Ordinal);
+
+    public Tree(string root)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        Root = root;
+        _parents[root] = null;
+        _children[root] = [];
+    }
+
+    public string Root { get; }
+
+    public int Size => _parents.Count;
+
+    public Tree AddChild(string parent, string child)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(child);
+
+        if (!HasNode(parent))
+        {
+            throw new TreeException(TreeErrorKind.NodeNotFound, parent);
+        }
+
+        if (HasNode(child))
+        {
+            throw new TreeException(TreeErrorKind.DuplicateNode, child);
+        }
+
+        _parents[child] = parent;
+        _children[child] = [];
+        _children[parent].Add(child);
+        return this;
+    }
+
+    public Tree RemoveSubtree(string node)
+    {
+        EnsureNode(node);
+        if (node == Root)
+        {
+            throw new TreeException(TreeErrorKind.RootRemoval, node);
+        }
+
+        var nodes = CollectSubtreeNodes(node);
+        foreach (var current in nodes.AsEnumerable().Reverse())
+        {
+            foreach (var child in _children[current].ToArray())
+            {
+                _children[current].Remove(child);
+            }
+
+            if (_parents[current] is { } parent)
+            {
+                _children[parent].Remove(current);
+            }
+
+            _children.Remove(current);
+            _parents.Remove(current);
+        }
+
+        return this;
+    }
+
+    public string? Parent(string node)
+    {
+        EnsureNode(node);
+        return _parents[node];
+    }
+
+    public IReadOnlyList<string> Children(string node)
+    {
+        EnsureNode(node);
+        return _children[node].ToArray();
+    }
+
+    public IReadOnlyList<string> Siblings(string node)
+    {
+        EnsureNode(node);
+        var parent = _parents[node];
+        return parent is null ? [] : _children[parent].Where(child => child != node).ToArray();
+    }
+
+    public bool IsLeaf(string node)
+    {
+        EnsureNode(node);
+        return _children[node].Count == 0;
+    }
+
+    public bool IsRoot(string node)
+    {
+        EnsureNode(node);
+        return node == Root;
+    }
+
+    public int Depth(string node)
+    {
+        EnsureNode(node);
+        var depth = 0;
+        var current = node;
+        while (_parents[current] is { } parent)
+        {
+            depth++;
+            current = parent;
+        }
+
+        return depth;
+    }
+
+    public int Height() => _parents.Keys.Select(Depth).DefaultIfEmpty(0).Max();
+
+    public IReadOnlyList<string> Nodes() => _parents.Keys.Order(StringComparer.Ordinal).ToArray();
+
+    public IReadOnlyList<string> Leaves() => _parents.Keys.Where(node => _children[node].Count == 0).Order(StringComparer.Ordinal).ToArray();
+
+    public bool HasNode(string node) => _parents.ContainsKey(node);
+
+    public IReadOnlyList<string> Preorder()
+    {
+        var result = new List<string>();
+        VisitPreorder(Root, result);
+        return result;
+    }
+
+    public IReadOnlyList<string> Postorder()
+    {
+        var result = new List<string>();
+        VisitPostorder(Root, result);
+        return result;
+    }
+
+    public IReadOnlyList<string> LevelOrder()
+    {
+        var result = new List<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(Root);
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            result.Add(node);
+            foreach (var child in _children[node])
+            {
+                queue.Enqueue(child);
+            }
+        }
+
+        return result;
+    }
+
+    public IReadOnlyList<string> PathTo(string node)
+    {
+        EnsureNode(node);
+        var path = new List<string>();
+        var current = node;
+        while (true)
+        {
+            path.Add(current);
+            if (_parents[current] is not { } parent)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        path.Reverse();
+        return path;
+    }
+
+    public string LowestCommonAncestor(string left, string right)
+    {
+        EnsureNode(left);
+        EnsureNode(right);
+        var leftPath = PathTo(left);
+        var rightPath = PathTo(right);
+        var limit = Math.Min(leftPath.Count, rightPath.Count);
+        var ancestor = Root;
+        for (var index = 0; index < limit && leftPath[index] == rightPath[index]; index++)
+        {
+            ancestor = leftPath[index];
+        }
+
+        return ancestor;
+    }
+
+    public string Lca(string left, string right) => LowestCommonAncestor(left, right);
+
+    public Tree Subtree(string node)
+    {
+        EnsureNode(node);
+        var tree = new Tree(node);
+        CopyChildrenInto(node, tree);
+        return tree;
+    }
+
+    public string ToAscii()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(Root);
+        var children = _children[Root].ToArray();
+        for (var index = 0; index < children.Length; index++)
+        {
+            AppendAscii(builder, children[index], string.Empty, index == children.Length - 1);
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    public override string ToString() => $"Tree(root={Root}, size={Size}, height={Height()})";
+
+    private void EnsureNode(string node)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(node);
+        if (!HasNode(node))
+        {
+            throw new TreeException(TreeErrorKind.NodeNotFound, node);
+        }
+    }
+
+    private List<string> CollectSubtreeNodes(string node)
+    {
+        var result = new List<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(node);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            result.Add(current);
+            foreach (var child in _children[current])
+            {
+                queue.Enqueue(child);
+            }
+        }
+
+        return result;
+    }
+
+    private void VisitPreorder(string node, List<string> result)
+    {
+        result.Add(node);
+        foreach (var child in _children[node])
+        {
+            VisitPreorder(child, result);
+        }
+    }
+
+    private void VisitPostorder(string node, List<string> result)
+    {
+        foreach (var child in _children[node])
+        {
+            VisitPostorder(child, result);
+        }
+
+        result.Add(node);
+    }
+
+    private void CopyChildrenInto(string node, Tree target)
+    {
+        foreach (var child in _children[node])
+        {
+            target.AddChild(node, child);
+            CopyChildrenInto(child, target);
+        }
+    }
+
+    private void AppendAscii(StringBuilder builder, string node, string prefix, bool isLast)
+    {
+        builder.Append(prefix);
+        builder.Append(isLast ? "`-- " : "|-- ");
+        builder.AppendLine(node);
+
+        var children = _children[node].ToArray();
+        for (var index = 0; index < children.Length; index++)
+        {
+            AppendAscii(builder, children[index], prefix + (isLast ? "    " : "|   "), index == children.Length - 1);
+        }
+    }
+}

--- a/code/packages/csharp/tree/required_capabilities.json
+++ b/code/packages/csharp/tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure package and tests."
+}

--- a/code/packages/csharp/tree/tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.csproj
+++ b/code/packages/csharp/tree/tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Tree]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Tree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/tree/tests/CodingAdventures.Tree.Tests/TreeTests.cs
+++ b/code/packages/csharp/tree/tests/CodingAdventures.Tree.Tests/TreeTests.cs
@@ -1,0 +1,85 @@
+using CodingAdventures.Tree;
+
+namespace CodingAdventures.Tree.Tests;
+
+public sealed class TreeTests
+{
+    private static Tree Sample() =>
+        new Tree("root")
+            .AddChild("root", "child1")
+            .AddChild("root", "child2")
+            .AddChild("child1", "grandchild");
+
+    [Fact]
+    public void ConstructionAndQueriesWork()
+    {
+        var tree = Sample();
+
+        Assert.Equal("root", tree.Root);
+        Assert.Equal(4, tree.Size);
+        Assert.Equal(2, tree.Height());
+        Assert.Equal("child1", tree.Parent("grandchild"));
+        Assert.Null(tree.Parent("root"));
+        Assert.Equal(new[] { "child1", "child2" }, tree.Children("root"));
+        Assert.Equal(new[] { "child2" }, tree.Siblings("child1"));
+        Assert.True(tree.IsLeaf("grandchild"));
+        Assert.True(tree.IsRoot("root"));
+        Assert.True(tree.HasNode("child2"));
+        Assert.Equal("Tree(root=root, size=4, height=2)", tree.ToString());
+    }
+
+    [Fact]
+    public void TraversalsAndPathsAreDeterministic()
+    {
+        var tree = Sample();
+
+        Assert.Equal(new[] { "child1", "child2", "grandchild", "root" }, tree.Nodes());
+        Assert.Equal(new[] { "child2", "grandchild" }, tree.Leaves());
+        Assert.Equal(new[] { "root", "child1", "grandchild", "child2" }, tree.Preorder());
+        Assert.Equal(new[] { "grandchild", "child1", "child2", "root" }, tree.Postorder());
+        Assert.Equal(new[] { "root", "child1", "child2", "grandchild" }, tree.LevelOrder());
+        Assert.Equal(new[] { "root", "child1", "grandchild" }, tree.PathTo("grandchild"));
+        Assert.Equal("root", tree.LowestCommonAncestor("grandchild", "child2"));
+        Assert.Equal("child1", tree.Lca("child1", "grandchild"));
+    }
+
+    [Fact]
+    public void SubtreeAndRemoveSubtreeWork()
+    {
+        var tree = Sample();
+        var subtree = tree.Subtree("child1");
+
+        Assert.Equal("child1", subtree.Root);
+        Assert.Equal(new[] { "child1", "grandchild" }, subtree.Preorder());
+
+        tree.RemoveSubtree("child1");
+
+        Assert.Equal(new[] { "root", "child2" }, tree.Preorder());
+        Assert.False(tree.HasNode("grandchild"));
+    }
+
+    [Fact]
+    public void ErrorsAreSpecific()
+    {
+        var tree = Sample();
+
+        var missing = Assert.Throws<TreeException>(() => tree.AddChild("missing", "x"));
+        Assert.Equal(TreeErrorKind.NodeNotFound, missing.Kind);
+        var duplicate = Assert.Throws<TreeException>(() => tree.AddChild("root", "child1"));
+        Assert.Equal(TreeErrorKind.DuplicateNode, duplicate.Kind);
+        var rootRemoval = Assert.Throws<TreeException>(() => tree.RemoveSubtree("root"));
+        Assert.Equal(TreeErrorKind.RootRemoval, rootRemoval.Kind);
+        Assert.Throws<TreeException>(() => tree.Depth("missing"));
+        Assert.Throws<ArgumentException>(() => new Tree(""));
+    }
+
+    [Fact]
+    public void AsciiRenderingIncludesShape()
+    {
+        var ascii = Sample().ToAscii();
+
+        Assert.Contains("root", ascii);
+        Assert.Contains("|-- child1", ascii);
+        Assert.Contains("`-- child2", ascii);
+    }
+}

--- a/code/packages/fsharp/tree/BUILD
+++ b/code/packages/fsharp/tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/tree/BUILD_windows
+++ b/code/packages/fsharp/tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/tree/CHANGELOG.md
+++ b/code/packages/fsharp/tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# rooted tree package.

--- a/code/packages/fsharp/tree/CodingAdventures.Tree.fsproj
+++ b/code/packages/fsharp/tree/CodingAdventures.Tree.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.Tree.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Tree</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# rooted tree with traversal, query, subtree, and ASCII rendering helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Tree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/tree/README.md
+++ b/code/packages/fsharp/tree/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Tree
+
+Pure F# rooted tree with unique string node names, traversal helpers, parent/child queries, subtree removal/extraction, lowest common ancestor, and ASCII rendering.

--- a/code/packages/fsharp/tree/Tree.fs
+++ b/code/packages/fsharp/tree/Tree.fs
@@ -1,0 +1,253 @@
+namespace CodingAdventures.Tree
+
+open System
+open System.Collections.Generic
+open System.Text
+
+type TreeErrorKind =
+    | NodeNotFound = 0
+    | DuplicateNode = 1
+    | RootRemoval = 2
+
+type private TreeMessages =
+    static member Create(kind: TreeErrorKind, node: string option) =
+        let nodeText = Option.defaultValue "" node
+
+        match kind with
+        | TreeErrorKind.NodeNotFound -> "Node not found in tree: " + nodeText
+        | TreeErrorKind.DuplicateNode -> "Node already exists in tree: " + nodeText
+        | TreeErrorKind.RootRemoval -> "Cannot remove the root node."
+        | _ -> "Tree operation failed."
+
+type TreeException(kind: TreeErrorKind, node: string option) =
+    inherit InvalidOperationException(TreeMessages.Create(kind, node))
+
+    member _.Kind = kind
+    member _.Node = node
+
+/// A rooted tree with unique string node names.
+type Tree(root: string) =
+    do
+        if String.IsNullOrWhiteSpace(root) then
+            invalidArg (nameof root) "Root must not be empty."
+
+    let parents = Dictionary<string, string option>(StringComparer.Ordinal)
+    let children = Dictionary<string, SortedSet<string>>(StringComparer.Ordinal)
+
+    do
+        parents[root] <- None
+        children[root] <- SortedSet<string>(StringComparer.Ordinal)
+
+    let hasNode node = parents.ContainsKey node
+
+    let ensureNode node =
+        if String.IsNullOrWhiteSpace node then
+            invalidArg (nameof node) "Node must not be empty."
+
+        if not (hasNode node) then
+            raise (TreeException(TreeErrorKind.NodeNotFound, Some node))
+
+    let rec visitPreorder node (result: ResizeArray<string>) =
+        result.Add node
+
+        for child in children[node] do
+            visitPreorder child result
+
+    let rec visitPostorder node (result: ResizeArray<string>) =
+        for child in children[node] do
+            visitPostorder child result
+
+        result.Add node
+
+    let collectSubtreeNodes node =
+        let result = ResizeArray<string>()
+        let queue = Queue<string>()
+        queue.Enqueue node
+
+        while queue.Count > 0 do
+            let current = queue.Dequeue()
+            result.Add current
+
+            for child in children[current] do
+                queue.Enqueue child
+
+        List.ofSeq result
+
+    let rec copyChildrenInto node (target: Tree) =
+        for child in children[node] do
+            target.AddChild(node, child) |> ignore
+            copyChildrenInto child target
+
+    let rec appendAscii (builder: StringBuilder) (node: string) (prefix: string) (isLast: bool) =
+        builder.Append(prefix).Append(if isLast then "`-- " else "|-- ").AppendLine(node) |> ignore
+        let childArray = children[node] |> Seq.toArray
+
+        for index in 0 .. childArray.Length - 1 do
+            appendAscii builder childArray[index] (prefix + (if isLast then "    " else "|   ")) (index = childArray.Length - 1)
+
+    member _.Root = root
+    member _.Size = parents.Count
+
+    member this.AddChild(parent: string, child: string) =
+        if String.IsNullOrWhiteSpace parent then
+            invalidArg (nameof parent) "Parent must not be empty."
+
+        if String.IsNullOrWhiteSpace child then
+            invalidArg (nameof child) "Child must not be empty."
+
+        if not (hasNode parent) then
+            raise (TreeException(TreeErrorKind.NodeNotFound, Some parent))
+
+        if hasNode child then
+            raise (TreeException(TreeErrorKind.DuplicateNode, Some child))
+
+        parents[child] <- Some parent
+        children[child] <- SortedSet<string>(StringComparer.Ordinal)
+        children[parent].Add child |> ignore
+        this
+
+    member this.RemoveSubtree(node: string) =
+        ensureNode node
+
+        if node = root then
+            raise (TreeException(TreeErrorKind.RootRemoval, Some node))
+
+        let nodes = collectSubtreeNodes node
+
+        for current in nodes |> List.rev do
+            for child in children[current] |> Seq.toArray do
+                children[current].Remove child |> ignore
+
+            match parents[current] with
+            | Some parent -> children[parent].Remove current |> ignore
+            | None -> ()
+
+            children.Remove current |> ignore
+            parents.Remove current |> ignore
+
+        this
+
+    member _.Parent(node: string) =
+        ensureNode node
+        parents[node]
+
+    member _.Children(node: string) =
+        ensureNode node
+        children[node] |> Seq.toList
+
+    member this.Siblings(node: string) =
+        ensureNode node
+
+        match parents[node] with
+        | None -> []
+        | Some parent -> this.Children(parent) |> List.filter ((<>) node)
+
+    member _.IsLeaf(node: string) =
+        ensureNode node
+        children[node].Count = 0
+
+    member _.IsRoot(node: string) =
+        ensureNode node
+        node = root
+
+    member _.Depth(node: string) =
+        ensureNode node
+        let mutable depth = 0
+        let mutable current = node
+        let mutable keepGoing = true
+
+        while keepGoing do
+            match parents[current] with
+            | Some parent ->
+                depth <- depth + 1
+                current <- parent
+            | None -> keepGoing <- false
+
+        depth
+
+    member this.Height() =
+        parents.Keys |> Seq.map this.Depth |> Seq.max
+
+    member _.Nodes() =
+        parents.Keys |> Seq.sort |> Seq.toList
+
+    member _.Leaves() =
+        parents.Keys |> Seq.filter (fun node -> children[node].Count = 0) |> Seq.sort |> Seq.toList
+
+    member _.HasNode(node: string) =
+        hasNode node
+
+    member _.Preorder() =
+        let result = ResizeArray<string>()
+        visitPreorder root result
+        List.ofSeq result
+
+    member _.Postorder() =
+        let result = ResizeArray<string>()
+        visitPostorder root result
+        List.ofSeq result
+
+    member _.LevelOrder() =
+        let result = ResizeArray<string>()
+        let queue = Queue<string>()
+        queue.Enqueue root
+
+        while queue.Count > 0 do
+            let node = queue.Dequeue()
+            result.Add node
+
+            for child in children[node] do
+                queue.Enqueue child
+
+        List.ofSeq result
+
+    member _.PathTo(node: string) =
+        ensureNode node
+        let path = ResizeArray<string>()
+        let mutable current = node
+        let mutable keepGoing = true
+
+        while keepGoing do
+            path.Add current
+
+            match parents[current] with
+            | Some parent -> current <- parent
+            | None -> keepGoing <- false
+
+        path |> Seq.rev |> Seq.toList
+
+    member this.LowestCommonAncestor(left: string, right: string) =
+        ensureNode left
+        ensureNode right
+        let leftPath = this.PathTo left
+        let rightPath = this.PathTo right
+        let mutable ancestor = root
+        let mutable index = 0
+
+        while index < min leftPath.Length rightPath.Length && leftPath[index] = rightPath[index] do
+            ancestor <- leftPath[index]
+            index <- index + 1
+
+        ancestor
+
+    member this.Lca(left: string, right: string) =
+        this.LowestCommonAncestor(left, right)
+
+    member _.Subtree(node: string) =
+        ensureNode node
+        let tree = Tree(node)
+        copyChildrenInto node tree
+        tree
+
+    member _.ToAscii() =
+        let builder = StringBuilder()
+        builder.AppendLine(root) |> ignore
+        let childArray = children[root] |> Seq.toArray
+
+        for index in 0 .. childArray.Length - 1 do
+            appendAscii builder childArray[index] "" (index = childArray.Length - 1)
+
+        builder.ToString().TrimEnd()
+
+    override this.ToString() =
+        $"Tree(root={root}, size={parents.Count}, height={this.Height()})"

--- a/code/packages/fsharp/tree/required_capabilities.json
+++ b/code/packages/fsharp/tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure package and tests."
+}

--- a/code/packages/fsharp/tree/tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.fsproj
+++ b/code/packages/fsharp/tree/tests/CodingAdventures.Tree.Tests/CodingAdventures.Tree.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Tree.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Tree.fsproj" />
+    <Compile Include="TreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/tree/tests/CodingAdventures.Tree.Tests/TreeTests.fs
+++ b/code/packages/fsharp/tree/tests/CodingAdventures.Tree.Tests/TreeTests.fs
@@ -1,0 +1,75 @@
+namespace CodingAdventures.Tree.Tests
+
+open System
+open CodingAdventures.Tree
+open Xunit
+
+type TreeTests() =
+    let sample () =
+        Tree("root")
+            .AddChild("root", "child1")
+            .AddChild("root", "child2")
+            .AddChild("child1", "grandchild")
+
+    [<Fact>]
+    member _.ConstructionAndQueriesWork() =
+        let tree = sample ()
+
+        Assert.Equal("root", tree.Root)
+        Assert.Equal(4, tree.Size)
+        Assert.Equal(2, tree.Height())
+        Assert.Equal(Some "child1", tree.Parent "grandchild")
+        Assert.Equal(None, tree.Parent "root")
+        Assert.Equal<string>([ "child1"; "child2" ], tree.Children "root")
+        Assert.Equal<string>([ "child2" ], tree.Siblings "child1")
+        Assert.True(tree.IsLeaf "grandchild")
+        Assert.True(tree.IsRoot "root")
+        Assert.True(tree.HasNode "child2")
+        Assert.Equal("Tree(root=root, size=4, height=2)", tree.ToString())
+
+    [<Fact>]
+    member _.TraversalsAndPathsAreDeterministic() =
+        let tree = sample ()
+
+        Assert.Equal<string>([ "child1"; "child2"; "grandchild"; "root" ], tree.Nodes())
+        Assert.Equal<string>([ "child2"; "grandchild" ], tree.Leaves())
+        Assert.Equal<string>([ "root"; "child1"; "grandchild"; "child2" ], tree.Preorder())
+        Assert.Equal<string>([ "grandchild"; "child1"; "child2"; "root" ], tree.Postorder())
+        Assert.Equal<string>([ "root"; "child1"; "child2"; "grandchild" ], tree.LevelOrder())
+        Assert.Equal<string>([ "root"; "child1"; "grandchild" ], tree.PathTo "grandchild")
+        Assert.Equal("root", tree.LowestCommonAncestor("grandchild", "child2"))
+        Assert.Equal("child1", tree.Lca("child1", "grandchild"))
+
+    [<Fact>]
+    member _.SubtreeAndRemoveSubtreeWork() =
+        let tree = sample ()
+        let subtree = tree.Subtree "child1"
+
+        Assert.Equal("child1", subtree.Root)
+        Assert.Equal<string>([ "child1"; "grandchild" ], subtree.Preorder())
+
+        tree.RemoveSubtree "child1" |> ignore
+
+        Assert.Equal<string>([ "root"; "child2" ], tree.Preorder())
+        Assert.False(tree.HasNode "grandchild")
+
+    [<Fact>]
+    member _.ErrorsAreSpecific() =
+        let tree = sample ()
+
+        let missing = Assert.Throws<TreeException>(fun () -> tree.AddChild("missing", "x") |> ignore)
+        Assert.Equal(TreeErrorKind.NodeNotFound, missing.Kind)
+        let duplicate = Assert.Throws<TreeException>(fun () -> tree.AddChild("root", "child1") |> ignore)
+        Assert.Equal(TreeErrorKind.DuplicateNode, duplicate.Kind)
+        let rootRemoval = Assert.Throws<TreeException>(fun () -> tree.RemoveSubtree "root" |> ignore)
+        Assert.Equal(TreeErrorKind.RootRemoval, rootRemoval.Kind)
+        Assert.Throws<TreeException>(fun () -> tree.Depth "missing" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Tree("") |> ignore) |> ignore
+
+    [<Fact>]
+    member _.AsciiRenderingIncludesShape() =
+        let ascii = (sample ()).ToAscii()
+
+        Assert.Contains("root", ascii)
+        Assert.Contains("|-- child1", ascii)
+        Assert.Contains("`-- child2", ascii)


### PR DESCRIPTION
## Summary
- add native C# and F# rooted tree packages with unique node names and explicit tree errors
- support add/remove subtree, parent/children/siblings, leaf/root/depth/height queries, deterministic traversals, paths, LCA, subtree extraction, and ASCII rendering
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\tree\tests\CodingAdventures.Tree.Tests\CodingAdventures.Tree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\tree\tests\CodingAdventures.Tree.Tests\CodingAdventures.Tree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line