### PR TITLE
feat(parity): add dotnet point2d packages

### DIFF
--- a/code/packages/csharp/point2d/BUILD
+++ b/code/packages/csharp/point2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/point2d/BUILD_windows
+++ b/code/packages/csharp/point2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/point2d/CHANGELOG.md
+++ b/code/packages/csharp/point2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure C# 2D point/vector and rectangle primitives.

--- a/code/packages/csharp/point2d/CodingAdventures.Point2D.csproj
+++ b/code/packages/csharp/point2d/CodingAdventures.Point2D.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Point2D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# 2D point/vector and axis-aligned rectangle primitives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/point2d/Point2D.cs
+++ b/code/packages/csharp/point2d/Point2D.cs
@@ -1,0 +1,92 @@
+namespace CodingAdventures.Point2D;
+
+public readonly record struct Point(double X, double Y)
+{
+    public static Point Origin() => new(0.0, 0.0);
+
+    public Point Add(Point other) => new(X + other.X, Y + other.Y);
+
+    public Point Subtract(Point other) => new(X - other.X, Y - other.Y);
+
+    public Point Scale(double scalar) => new(X * scalar, Y * scalar);
+
+    public Point Negate() => new(-X, -Y);
+
+    public double Dot(Point other) => X * other.X + Y * other.Y;
+
+    public double Cross(Point other) => X * other.Y - Y * other.X;
+
+    public double Magnitude() => Math.Sqrt(MagnitudeSquared());
+
+    public double MagnitudeSquared() => X * X + Y * Y;
+
+    public Point Normalize()
+    {
+        var magnitude = Magnitude();
+        return magnitude < 1e-12 ? Origin() : new Point(X / magnitude, Y / magnitude);
+    }
+
+    public double Distance(Point other) => Subtract(other).Magnitude();
+
+    public double DistanceSquared(Point other) => Subtract(other).MagnitudeSquared();
+
+    public Point Lerp(Point other, double t) => new(X + (other.X - X) * t, Y + (other.Y - Y) * t);
+
+    public Point Perpendicular() => new(-Y, X);
+
+    public double Angle() => Math.Atan2(Y, X);
+}
+
+public readonly record struct Rect(double X, double Y, double Width, double Height)
+{
+    public static Rect Zero() => new(0.0, 0.0, 0.0, 0.0);
+
+    public static Rect FromPoints(Point min, Point max) => new(min.X, min.Y, max.X - min.X, max.Y - min.Y);
+
+    public Point MinPoint() => new(X, Y);
+
+    public Point MaxPoint() => new(X + Width, Y + Height);
+
+    public Point Center() => new(X + Width * 0.5, Y + Height * 0.5);
+
+    public bool IsEmpty() => Width <= 0.0 || Height <= 0.0;
+
+    public bool ContainsPoint(Point point) =>
+        !IsEmpty()
+        && point.X >= X
+        && point.Y >= Y
+        && point.X < X + Width
+        && point.Y < Y + Height;
+
+    public Rect Union(Rect other)
+    {
+        if (IsEmpty())
+        {
+            return other;
+        }
+
+        if (other.IsEmpty())
+        {
+            return this;
+        }
+
+        var minX = Math.Min(X, other.X);
+        var minY = Math.Min(Y, other.Y);
+        var maxX = Math.Max(X + Width, other.X + other.Width);
+        var maxY = Math.Max(Y + Height, other.Y + other.Height);
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    public Rect? Intersection(Rect other)
+    {
+        var minX = Math.Max(X, other.X);
+        var minY = Math.Max(Y, other.Y);
+        var maxX = Math.Min(X + Width, other.X + other.Width);
+        var maxY = Math.Min(Y + Height, other.Y + other.Height);
+        var width = maxX - minX;
+        var height = maxY - minY;
+        return width <= 0.0 || height <= 0.0 ? null : new Rect(minX, minY, width, height);
+    }
+
+    public Rect ExpandBy(double amount) => new(X - amount, Y - amount, Width + 2.0 * amount, Height + 2.0 * amount);
+}

--- a/code/packages/csharp/point2d/README.md
+++ b/code/packages/csharp/point2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Point2D.CSharp
+
+Pure C# 2D geometry primitives: immutable `Point` values for vector arithmetic and immutable `Rect` values for axis-aligned bounds.

--- a/code/packages/csharp/point2d/required_capabilities.json
+++ b/code/packages/csharp/point2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/point2d",
+  "capabilities": [],
+  "justification": "Pure arithmetic geometry package and tests."
+}

--- a/code/packages/csharp/point2d/tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.csproj
+++ b/code/packages/csharp/point2d/tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Point2D]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Point2D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/point2d/tests/CodingAdventures.Point2D.Tests/Point2DTests.cs
+++ b/code/packages/csharp/point2d/tests/CodingAdventures.Point2D.Tests/Point2DTests.cs
@@ -1,0 +1,67 @@
+using CodingAdventures.Point2D;
+
+namespace CodingAdventures.Point2D.Tests;
+
+public sealed class Point2DTests
+{
+    [Fact]
+    public void PointArithmeticAndVectorOperationsWork()
+    {
+        var point = new Point(3, 4);
+        var other = new Point(1, 2);
+
+        Assert.Equal(new Point(4, 6), point.Add(other));
+        Assert.Equal(new Point(2, 2), point.Subtract(other));
+        Assert.Equal(new Point(6, 8), point.Scale(2));
+        Assert.Equal(new Point(-3, -4), point.Negate());
+        Assert.Equal(11, point.Dot(other));
+        Assert.Equal(2, point.Cross(other));
+        Assert.Equal(5, point.Magnitude(), 9);
+        Assert.Equal(25, point.MagnitudeSquared(), 9);
+    }
+
+    [Fact]
+    public void PointDerivedOperationsWork()
+    {
+        var point = new Point(3, 4);
+
+        Assert.Equal(new Point(0, 0), Point.Origin());
+        Assert.Equal(new Point(0.6, 0.8), point.Normalize());
+        Assert.Equal(Point.Origin(), Point.Origin().Normalize());
+        Assert.Equal(5, point.Distance(Point.Origin()), 9);
+        Assert.Equal(25, point.DistanceSquared(Point.Origin()), 9);
+        Assert.Equal(new Point(5, 5), Point.Origin().Lerp(new Point(10, 10), 0.5));
+        Assert.Equal(new Point(-4, 3), point.Perpendicular());
+        Assert.Equal(Math.Atan2(4, 3), point.Angle(), 9);
+    }
+
+    [Fact]
+    public void RectAccessorsAndContainmentWork()
+    {
+        var rect = new Rect(10, 20, 30, 40);
+
+        Assert.Equal(Rect.Zero(), new Rect(0, 0, 0, 0));
+        Assert.Equal(new Rect(10, 20, 30, 40), Rect.FromPoints(new Point(10, 20), new Point(40, 60)));
+        Assert.Equal(new Point(10, 20), rect.MinPoint());
+        Assert.Equal(new Point(40, 60), rect.MaxPoint());
+        Assert.Equal(new Point(25, 40), rect.Center());
+        Assert.False(rect.IsEmpty());
+        Assert.True(new Rect(0, 0, 0, 5).IsEmpty());
+        Assert.True(rect.ContainsPoint(new Point(10, 20)));
+        Assert.False(rect.ContainsPoint(new Point(40, 60)));
+    }
+
+    [Fact]
+    public void RectUnionIntersectionAndExpansionWork()
+    {
+        var left = new Rect(0, 0, 10, 10);
+        var right = new Rect(5, 5, 10, 10);
+
+        Assert.Equal(new Rect(0, 0, 15, 15), left.Union(right));
+        Assert.Equal(right, Rect.Zero().Union(right));
+        Assert.Equal(left, left.Union(Rect.Zero()));
+        Assert.Equal(new Rect(5, 5, 5, 5), left.Intersection(right));
+        Assert.Null(left.Intersection(new Rect(20, 20, 2, 2)));
+        Assert.Equal(new Rect(-2, -2, 14, 14), left.ExpandBy(2));
+    }
+}

--- a/code/packages/fsharp/point2d/BUILD
+++ b/code/packages/fsharp/point2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/point2d/BUILD_windows
+++ b/code/packages/fsharp/point2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/point2d/CHANGELOG.md
+++ b/code/packages/fsharp/point2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure F# 2D point/vector and rectangle primitives.

--- a/code/packages/fsharp/point2d/CodingAdventures.Point2D.fsproj
+++ b/code/packages/fsharp/point2d/CodingAdventures.Point2D.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.Point2D.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Point2D</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# 2D point/vector and axis-aligned rectangle primitives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Point2D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/point2d/Point2D.fs
+++ b/code/packages/fsharp/point2d/Point2D.fs
@@ -1,0 +1,84 @@
+namespace CodingAdventures.Point2D
+
+open System
+
+[<Struct>]
+type Point =
+    {
+        X: float
+        Y: float
+    }
+
+    static member New(x: float, y: float) = { X = x; Y = y }
+    static member Origin() = Point.New(0.0, 0.0)
+
+    member this.Add(other: Point) = Point.New(this.X + other.X, this.Y + other.Y)
+    member this.Subtract(other: Point) = Point.New(this.X - other.X, this.Y - other.Y)
+    member this.Scale(scalar: float) = Point.New(this.X * scalar, this.Y * scalar)
+    member this.Negate() = Point.New(-this.X, -this.Y)
+    member this.Dot(other: Point) = this.X * other.X + this.Y * other.Y
+    member this.Cross(other: Point) = this.X * other.Y - this.Y * other.X
+    member this.MagnitudeSquared() = this.X * this.X + this.Y * this.Y
+    member this.Magnitude() = Math.Sqrt(this.MagnitudeSquared())
+
+    member this.Normalize() =
+        let magnitude = this.Magnitude()
+        if magnitude < 1e-12 then Point.Origin() else Point.New(this.X / magnitude, this.Y / magnitude)
+
+    member this.Distance(other: Point) = this.Subtract(other).Magnitude()
+    member this.DistanceSquared(other: Point) = this.Subtract(other).MagnitudeSquared()
+    member this.Lerp(other: Point, t: float) = Point.New(this.X + (other.X - this.X) * t, this.Y + (other.Y - this.Y) * t)
+    member this.Perpendicular() = Point.New(-this.Y, this.X)
+    member this.Angle() = Math.Atan2(this.Y, this.X)
+
+[<Struct>]
+type Rect =
+    {
+        X: float
+        Y: float
+        Width: float
+        Height: float
+    }
+
+    static member New(x: float, y: float, width: float, height: float) =
+        { X = x; Y = y; Width = width; Height = height }
+
+    static member Zero() = Rect.New(0.0, 0.0, 0.0, 0.0)
+    static member FromPoints(minimum: Point, maximum: Point) =
+        Rect.New(minimum.X, minimum.Y, maximum.X - minimum.X, maximum.Y - minimum.Y)
+
+    member this.MinPoint() = Point.New(this.X, this.Y)
+    member this.MaxPoint() = Point.New(this.X + this.Width, this.Y + this.Height)
+    member this.Center() = Point.New(this.X + this.Width * 0.5, this.Y + this.Height * 0.5)
+    member this.IsEmpty() = this.Width <= 0.0 || this.Height <= 0.0
+
+    member this.ContainsPoint(point: Point) =
+        not (this.IsEmpty())
+        && point.X >= this.X
+        && point.Y >= this.Y
+        && point.X < this.X + this.Width
+        && point.Y < this.Y + this.Height
+
+    member this.Union(other: Rect) =
+        if this.IsEmpty() then
+            other
+        elif other.IsEmpty() then
+            this
+        else
+            let minX = min this.X other.X
+            let minY = min this.Y other.Y
+            let maxX = max (this.X + this.Width) (other.X + other.Width)
+            let maxY = max (this.Y + this.Height) (other.Y + other.Height)
+            Rect.New(minX, minY, maxX - minX, maxY - minY)
+
+    member this.Intersection(other: Rect) =
+        let minX = max this.X other.X
+        let minY = max this.Y other.Y
+        let maxX = min (this.X + this.Width) (other.X + other.Width)
+        let maxY = min (this.Y + this.Height) (other.Y + other.Height)
+        let width = maxX - minX
+        let height = maxY - minY
+        if width <= 0.0 || height <= 0.0 then None else Some(Rect.New(minX, minY, width, height))
+
+    member this.ExpandBy(amount: float) =
+        Rect.New(this.X - amount, this.Y - amount, this.Width + 2.0 * amount, this.Height + 2.0 * amount)

--- a/code/packages/fsharp/point2d/README.md
+++ b/code/packages/fsharp/point2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Point2D
+
+Pure F# 2D geometry primitives: immutable `Point` values for vector arithmetic and immutable `Rect` values for axis-aligned bounds.

--- a/code/packages/fsharp/point2d/required_capabilities.json
+++ b/code/packages/fsharp/point2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/point2d",
+  "capabilities": [],
+  "justification": "Pure arithmetic geometry package and tests."
+}

--- a/code/packages/fsharp/point2d/tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.fsproj
+++ b/code/packages/fsharp/point2d/tests/CodingAdventures.Point2D.Tests/CodingAdventures.Point2D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Point2D.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Point2D.fsproj" />
+    <Compile Include="Point2DTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/point2d/tests/CodingAdventures.Point2D.Tests/Point2DTests.fs
+++ b/code/packages/fsharp/point2d/tests/CodingAdventures.Point2D.Tests/Point2DTests.fs
@@ -1,0 +1,59 @@
+namespace CodingAdventures.Point2D.Tests
+
+open System
+open CodingAdventures.Point2D
+open Xunit
+
+type Point2DTests() =
+    [<Fact>]
+    member _.PointArithmeticAndVectorOperationsWork() =
+        let point = Point.New(3.0, 4.0)
+        let other = Point.New(1.0, 2.0)
+
+        Assert.Equal(Point.New(4.0, 6.0), point.Add other)
+        Assert.Equal(Point.New(2.0, 2.0), point.Subtract other)
+        Assert.Equal(Point.New(6.0, 8.0), point.Scale 2.0)
+        Assert.Equal(Point.New(-3.0, -4.0), point.Negate())
+        Assert.Equal(11.0, point.Dot other, 9)
+        Assert.Equal(2.0, point.Cross other, 9)
+        Assert.Equal(5.0, point.Magnitude(), 9)
+        Assert.Equal(25.0, point.MagnitudeSquared(), 9)
+
+    [<Fact>]
+    member _.PointDerivedOperationsWork() =
+        let point = Point.New(3.0, 4.0)
+
+        Assert.Equal(Point.New(0.0, 0.0), Point.Origin())
+        Assert.Equal(Point.New(0.6, 0.8), point.Normalize())
+        Assert.Equal(Point.Origin(), Point.Origin().Normalize())
+        Assert.Equal(5.0, point.Distance(Point.Origin()), 9)
+        Assert.Equal(25.0, point.DistanceSquared(Point.Origin()), 9)
+        Assert.Equal(Point.New(5.0, 5.0), Point.Origin().Lerp(Point.New(10.0, 10.0), 0.5))
+        Assert.Equal(Point.New(-4.0, 3.0), point.Perpendicular())
+        Assert.Equal(Math.Atan2(4.0, 3.0), point.Angle(), 9)
+
+    [<Fact>]
+    member _.RectAccessorsAndContainmentWork() =
+        let rect = Rect.New(10.0, 20.0, 30.0, 40.0)
+
+        Assert.Equal(Rect.Zero(), Rect.New(0.0, 0.0, 0.0, 0.0))
+        Assert.Equal(Rect.New(10.0, 20.0, 30.0, 40.0), Rect.FromPoints(Point.New(10.0, 20.0), Point.New(40.0, 60.0)))
+        Assert.Equal(Point.New(10.0, 20.0), rect.MinPoint())
+        Assert.Equal(Point.New(40.0, 60.0), rect.MaxPoint())
+        Assert.Equal(Point.New(25.0, 40.0), rect.Center())
+        Assert.False(rect.IsEmpty())
+        Assert.True(Rect.New(0.0, 0.0, 0.0, 5.0).IsEmpty())
+        Assert.True(rect.ContainsPoint(Point.New(10.0, 20.0)))
+        Assert.False(rect.ContainsPoint(Point.New(40.0, 60.0)))
+
+    [<Fact>]
+    member _.RectUnionIntersectionAndExpansionWork() =
+        let left = Rect.New(0.0, 0.0, 10.0, 10.0)
+        let right = Rect.New(5.0, 5.0, 10.0, 10.0)
+
+        Assert.Equal(Rect.New(0.0, 0.0, 15.0, 15.0), left.Union right)
+        Assert.Equal(right, Rect.Zero().Union right)
+        Assert.Equal(left, left.Union(Rect.Zero()))
+        Assert.Equal(Some(Rect.New(5.0, 5.0, 5.0, 5.0)), left.Intersection right)
+        Assert.Equal(None, left.Intersection(Rect.New(20.0, 20.0, 2.0, 2.0)))
+        Assert.Equal(Rect.New(-2.0, -2.0, 14.0, 14.0), left.ExpandBy(2.0))


### PR DESCRIPTION
## Summary
- add native C# and F# point2d packages with immutable Point and Rect primitives
- support vector arithmetic, dot/cross, magnitude, normalization, distance, interpolation, perpendicular/angle, bounds accessors, containment, union, intersection, and expansion
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\point2d\tests\CodingAdventures.Point2D.Tests\CodingAdventures.Point2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\point2d\tests\CodingAdventures.Point2D.Tests\CodingAdventures.Point2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line