### PR TITLE
feat(parity): add dotnet gradient-descent packages

### DIFF
--- a/code/packages/csharp/gradient-descent/BUILD
+++ b/code/packages/csharp/gradient-descent/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/gradient-descent/BUILD_windows
+++ b/code/packages/csharp/gradient-descent/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/gradient-descent/CHANGELOG.md
+++ b/code/packages/csharp/gradient-descent/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# stochastic gradient descent update helper.

--- a/code/packages/csharp/gradient-descent/CodingAdventures.GradientDescent.csproj
+++ b/code/packages/csharp/gradient-descent/CodingAdventures.GradientDescent.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.GradientDescent.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# stochastic gradient descent weight update helper</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/gradient-descent/GradientDescent.cs
+++ b/code/packages/csharp/gradient-descent/GradientDescent.cs
@@ -1,0 +1,23 @@
+namespace CodingAdventures.GradientDescent;
+
+public static class GradientDescent
+{
+    public static IReadOnlyList<double> Sgd(IReadOnlyList<double> weights, IReadOnlyList<double> gradients, double learningRate)
+    {
+        ArgumentNullException.ThrowIfNull(weights);
+        ArgumentNullException.ThrowIfNull(gradients);
+
+        if (weights.Count == 0 || weights.Count != gradients.Count)
+        {
+            throw new ArgumentException("Weights and gradients must have the same non-zero length.");
+        }
+
+        var updated = new double[weights.Count];
+        for (var index = 0; index < weights.Count; index++)
+        {
+            updated[index] = weights[index] - learningRate * gradients[index];
+        }
+
+        return updated;
+    }
+}

--- a/code/packages/csharp/gradient-descent/README.md
+++ b/code/packages/csharp/gradient-descent/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.GradientDescent.CSharp
+
+Pure C# stochastic gradient descent helper for applying `weight - learningRate * gradient` updates.

--- a/code/packages/csharp/gradient-descent/required_capabilities.json
+++ b/code/packages/csharp/gradient-descent/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/gradient-descent",
+  "capabilities": [],
+  "justification": "Pure arithmetic package and tests."
+}

--- a/code/packages/csharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.csproj
+++ b/code/packages/csharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.GradientDescent]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.GradientDescent.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/GradientDescentTests.cs
+++ b/code/packages/csharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/GradientDescentTests.cs
@@ -1,0 +1,25 @@
+using CodingAdventures.GradientDescent;
+
+namespace CodingAdventures.GradientDescent.Tests;
+
+public sealed class GradientDescentTests
+{
+    [Fact]
+    public void SgdAppliesWeightUpdates()
+    {
+        var updated = GradientDescent.Sgd([1.0, -0.5, 2.0], [0.1, -0.2, 0.0], 0.1);
+
+        Assert.Equal(0.99, updated[0], 9);
+        Assert.Equal(-0.48, updated[1], 9);
+        Assert.Equal(2.0, updated[2], 9);
+    }
+
+    [Fact]
+    public void SgdRejectsInvalidInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => GradientDescent.Sgd(null!, [1.0], 0.1));
+        Assert.Throws<ArgumentNullException>(() => GradientDescent.Sgd([1.0], null!, 0.1));
+        Assert.Throws<ArgumentException>(() => GradientDescent.Sgd([], [], 0.1));
+        Assert.Throws<ArgumentException>(() => GradientDescent.Sgd([1.0], [], 0.1));
+    }
+}

--- a/code/packages/fsharp/gradient-descent/BUILD
+++ b/code/packages/fsharp/gradient-descent/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/gradient-descent/BUILD_windows
+++ b/code/packages/fsharp/gradient-descent/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/gradient-descent/CHANGELOG.md
+++ b/code/packages/fsharp/gradient-descent/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# stochastic gradient descent update helper.

--- a/code/packages/fsharp/gradient-descent/CodingAdventures.GradientDescent.fsproj
+++ b/code/packages/fsharp/gradient-descent/CodingAdventures.GradientDescent.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CodingAdventures.GradientDescent.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.GradientDescent</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# stochastic gradient descent weight update helper</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GradientDescent.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/gradient-descent/GradientDescent.fs
+++ b/code/packages/fsharp/gradient-descent/GradientDescent.fs
@@ -1,0 +1,16 @@
+namespace CodingAdventures.GradientDescent
+
+open System
+
+type GradientDescent private () =
+    static member Sgd(weights: float list, gradients: float list, learningRate: float) =
+        if isNull (box weights) then
+            nullArg (nameof weights)
+
+        if isNull (box gradients) then
+            nullArg (nameof gradients)
+
+        if List.isEmpty weights || weights.Length <> gradients.Length then
+            invalidArg (nameof gradients) "Weights and gradients must have the same non-zero length."
+
+        List.map2 (fun weight gradient -> weight - learningRate * gradient) weights gradients

--- a/code/packages/fsharp/gradient-descent/README.md
+++ b/code/packages/fsharp/gradient-descent/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.GradientDescent
+
+Pure F# stochastic gradient descent helper for applying `weight - learningRate * gradient` updates.

--- a/code/packages/fsharp/gradient-descent/required_capabilities.json
+++ b/code/packages/fsharp/gradient-descent/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/gradient-descent",
+  "capabilities": [],
+  "justification": "Pure arithmetic package and tests."
+}

--- a/code/packages/fsharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.fsproj
+++ b/code/packages/fsharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/CodingAdventures.GradientDescent.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.GradientDescent.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.GradientDescent.fsproj" />
+    <Compile Include="GradientDescentTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/GradientDescentTests.fs
+++ b/code/packages/fsharp/gradient-descent/tests/CodingAdventures.GradientDescent.Tests/GradientDescentTests.fs
@@ -1,0 +1,21 @@
+namespace CodingAdventures.GradientDescent.Tests
+
+open System
+open CodingAdventures.GradientDescent
+open Xunit
+
+type GradientDescentTests() =
+    [<Fact>]
+    member _.SgdAppliesWeightUpdates() =
+        let updated = GradientDescent.Sgd([ 1.0; -0.5; 2.0 ], [ 0.1; -0.2; 0.0 ], 0.1)
+
+        Assert.Equal(0.99, updated[0], 9)
+        Assert.Equal(-0.48, updated[1], 9)
+        Assert.Equal(2.0, updated[2], 9)
+
+    [<Fact>]
+    member _.SgdRejectsInvalidInputs() =
+        Assert.Throws<ArgumentNullException>(fun () -> GradientDescent.Sgd(Unchecked.defaultof<float list>, [ 1.0 ], 0.1) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> GradientDescent.Sgd([ 1.0 ], Unchecked.defaultof<float list>, 0.1) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> GradientDescent.Sgd([], [], 0.1) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> GradientDescent.Sgd([ 1.0 ], [], 0.1) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# gradient-descent packages with stochastic gradient descent weight updates
- validate null, empty, and mismatched input vectors before applying `weight - learningRate * gradient`
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\gradient-descent\tests\CodingAdventures.GradientDescent.Tests\CodingAdventures.GradientDescent.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\gradient-descent\tests\CodingAdventures.GradientDescent.Tests\CodingAdventures.GradientDescent.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line