### PR TITLE
feat(parity): add dotnet perceptron packages

### DIFF
--- a/code/packages/csharp/perceptron/BUILD
+++ b/code/packages/csharp/perceptron/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/perceptron/BUILD_windows
+++ b/code/packages/csharp/perceptron/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/perceptron/CHANGELOG.md
+++ b/code/packages/csharp/perceptron/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# perceptron classifier package.
+- Include sigmoid/BCE training, prediction, validation, and xUnit coverage.

--- a/code/packages/csharp/perceptron/CodingAdventures.Perceptron.csproj
+++ b/code/packages/csharp/perceptron/CodingAdventures.Perceptron.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Perceptron.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Binary perceptron classifier trained with sigmoid and binary cross-entropy</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../activation-functions/CodingAdventures.ActivationFunctions.csproj" />
+    <ProjectReference Include="../loss-functions/CodingAdventures.LossFunctions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/perceptron/Perceptron.cs
+++ b/code/packages/csharp/perceptron/Perceptron.cs
@@ -1,0 +1,227 @@
+using Activations = CodingAdventures.ActivationFunctions.ActivationFunctions;
+using Losses = CodingAdventures.LossFunctions.LossFunctions;
+
+namespace CodingAdventures.Perceptron;
+
+/// <summary>
+/// Single-neuron binary classifier trained with sigmoid activation and binary cross-entropy.
+/// </summary>
+public sealed class Perceptron
+{
+    private double[]? _weights;
+
+    /// <summary>Create a perceptron trainer.</summary>
+    public Perceptron(double learningRate = 0.1, int epochs = 2000)
+    {
+        if (!double.IsFinite(learningRate))
+        {
+            throw new ArgumentOutOfRangeException(nameof(learningRate), "Learning rate must be finite.");
+        }
+
+        if (epochs < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(epochs), "Epochs must be non-negative.");
+        }
+
+        LearningRate = learningRate;
+        Epochs = epochs;
+    }
+
+    /// <summary>Step size applied to each gradient update.</summary>
+    public double LearningRate { get; }
+
+    /// <summary>Number of training epochs to run.</summary>
+    public int Epochs { get; }
+
+    /// <summary>Current bias term.</summary>
+    public double Bias { get; private set; }
+
+    /// <summary>Current trained weights, or null before fitting.</summary>
+    public IReadOnlyList<double>? Weights => _weights?.ToArray();
+
+    /// <summary>Fit against labels supplied as a single binary value per sample.</summary>
+    public void Fit(
+        IReadOnlyList<IReadOnlyList<double>> features,
+        IReadOnlyList<double> labels,
+        int logSteps = 0)
+    {
+        var x = ValidateFeatures(features);
+        var y = ValidateLabels(labels, x.Length);
+        var featureCount = x[0].Length;
+
+        _weights = new double[featureCount];
+        Bias = 0.0;
+
+        for (var epoch = 0; epoch <= Epochs; epoch++)
+        {
+            var rawScores = new double[x.Length];
+            var predictions = new double[x.Length];
+
+            for (var row = 0; row < x.Length; row++)
+            {
+                rawScores[row] = Score(x[row], _weights, Bias);
+                predictions[row] = Activations.Sigmoid(rawScores[row]);
+            }
+
+            var lossGradient = Losses.BceDerivative(y, predictions);
+            var weightGradient = new double[featureCount];
+            var biasGradient = 0.0;
+
+            for (var row = 0; row < x.Length; row++)
+            {
+                var combined = lossGradient[row] * Activations.SigmoidDerivative(rawScores[row]);
+                for (var col = 0; col < featureCount; col++)
+                {
+                    weightGradient[col] += x[row][col] * combined;
+                }
+
+                biasGradient += combined;
+            }
+
+            for (var col = 0; col < featureCount; col++)
+            {
+                _weights[col] -= LearningRate * weightGradient[col];
+            }
+
+            Bias -= LearningRate * biasGradient;
+
+            if (logSteps > 0 && epoch % logSteps == 0)
+            {
+                var loss = Losses.Bce(y, predictions);
+                Console.WriteLine($"Epoch {epoch,4} | BCE Loss: {loss:F4} | Bias: {Bias:F2}");
+            }
+        }
+    }
+
+    /// <summary>Fit against labels supplied as one-column rows.</summary>
+    public void Fit(
+        IReadOnlyList<IReadOnlyList<double>> features,
+        IReadOnlyList<IReadOnlyList<double>> labels,
+        int logSteps = 0) =>
+        Fit(features, FlattenLabels(labels), logSteps);
+
+    /// <summary>Predict probabilities for each sample.</summary>
+    public double[] Predict(IReadOnlyList<IReadOnlyList<double>> features)
+    {
+        if (_weights is null)
+        {
+            throw new InvalidOperationException("Perceptron has not been trained yet. Call Fit first.");
+        }
+
+        var x = ValidateFeatures(features);
+        if (x[0].Length != _weights.Length)
+        {
+            throw new ArgumentException(
+                $"Feature width {x[0].Length} does not match trained width {_weights.Length}.",
+                nameof(features));
+        }
+
+        var predictions = new double[x.Length];
+        for (var row = 0; row < x.Length; row++)
+        {
+            predictions[row] = Activations.Sigmoid(Score(x[row], _weights, Bias));
+        }
+
+        return predictions;
+    }
+
+    private static double Score(IReadOnlyList<double> row, IReadOnlyList<double> weights, double bias)
+    {
+        var sum = bias;
+        for (var i = 0; i < weights.Count; i++)
+        {
+            sum += row[i] * weights[i];
+        }
+
+        return sum;
+    }
+
+    private static double[][] ValidateFeatures(IReadOnlyList<IReadOnlyList<double>> features)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        if (features.Count == 0)
+        {
+            throw new ArgumentException("Training data must contain at least one sample.", nameof(features));
+        }
+
+        var expectedColumns = -1;
+        var copy = new double[features.Count][];
+        for (var row = 0; row < features.Count; row++)
+        {
+            var values = features[row];
+            ArgumentNullException.ThrowIfNull(values);
+
+            if (row == 0)
+            {
+                if (values.Count == 0)
+                {
+                    throw new ArgumentException("Samples must contain at least one feature.", nameof(features));
+                }
+
+                expectedColumns = values.Count;
+            }
+            else if (values.Count != expectedColumns)
+            {
+                throw new ArgumentException(
+                    $"Sample {row} has {values.Count} features, expected {expectedColumns}.",
+                    nameof(features));
+            }
+
+            copy[row] = new double[expectedColumns];
+            for (var col = 0; col < expectedColumns; col++)
+            {
+                var value = values[col];
+                if (!double.IsFinite(value))
+                {
+                    throw new ArgumentException("Feature values must be finite.", nameof(features));
+                }
+
+                copy[row][col] = value;
+            }
+        }
+
+        return copy;
+    }
+
+    private static double[] ValidateLabels(IReadOnlyList<double> labels, int expectedRows)
+    {
+        ArgumentNullException.ThrowIfNull(labels);
+        if (labels.Count != expectedRows || labels.Count == 0)
+        {
+            throw new ArgumentException("Labels must match the non-zero sample count.", nameof(labels));
+        }
+
+        var copy = new double[labels.Count];
+        for (var i = 0; i < labels.Count; i++)
+        {
+            var value = labels[i];
+            if (!double.IsFinite(value))
+            {
+                throw new ArgumentException("Labels must be finite.", nameof(labels));
+            }
+
+            copy[i] = value;
+        }
+
+        return copy;
+    }
+
+    private static double[] FlattenLabels(IReadOnlyList<IReadOnlyList<double>> labels)
+    {
+        ArgumentNullException.ThrowIfNull(labels);
+        var copy = new double[labels.Count];
+        for (var i = 0; i < labels.Count; i++)
+        {
+            var row = labels[i];
+            ArgumentNullException.ThrowIfNull(row);
+            if (row.Count != 1)
+            {
+                throw new ArgumentException("Column labels must have exactly one value per row.", nameof(labels));
+            }
+
+            copy[i] = row[0];
+        }
+
+        return copy;
+    }
+}

--- a/code/packages/csharp/perceptron/README.md
+++ b/code/packages/csharp/perceptron/README.md
@@ -1,0 +1,22 @@
+# CodingAdventures.Perceptron.CSharp
+
+Binary perceptron classifier for small in-memory datasets.
+
+The model trains one sigmoid neuron with binary cross-entropy. `Fit` accepts either a flat label vector or one-column label rows, then `Predict` returns a probability for each input sample.
+
+```csharp
+using CodingAdventures.Perceptron;
+
+var model = new Perceptron(learningRate: 0.8, epochs: 5000);
+model.Fit(
+    new[]
+    {
+        new[] { 0.0, 0.0 },
+        new[] { 0.0, 1.0 },
+        new[] { 1.0, 0.0 },
+        new[] { 1.0, 1.0 },
+    },
+    new[] { 0.0, 0.0, 0.0, 1.0 });
+
+double[] probabilities = model.Predict(new[] { new[] { 1.0, 1.0 } });
+```

--- a/code/packages/csharp/perceptron/required_capabilities.json
+++ b/code/packages/csharp/perceptron/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/perceptron",
+  "capabilities": [],
+  "justification": "Pure in-memory computation and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/perceptron/tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.csproj
+++ b/code/packages/csharp/perceptron/tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.ActivationFunctions]*,[CodingAdventures.LossFunctions]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Perceptron.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/perceptron/tests/CodingAdventures.Perceptron.Tests/PerceptronTests.cs
+++ b/code/packages/csharp/perceptron/tests/CodingAdventures.Perceptron.Tests/PerceptronTests.cs
@@ -1,0 +1,54 @@
+namespace CodingAdventures.Perceptron.Tests;
+
+public sealed class PerceptronTests
+{
+    private static readonly double[][] AndFeatures =
+    [
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 0.0],
+        [1.0, 1.0],
+    ];
+
+    [Fact]
+    public void FitLearnsAndGate()
+    {
+        var model = new Perceptron(learningRate: 0.8, epochs: 5_000);
+
+        model.Fit(AndFeatures, [0.0, 0.0, 0.0, 1.0]);
+
+        var predictions = model.Predict(AndFeatures);
+        Assert.All(predictions.Take(3), value => Assert.True(value < 0.2, $"Expected negative class below 0.2, got {value}."));
+        Assert.True(predictions[3] > 0.7, $"Expected positive class above 0.7, got {predictions[3]}.");
+        Assert.Equal(2, model.Weights!.Count);
+    }
+
+    [Fact]
+    public void FitAcceptsColumnLabels()
+    {
+        var model = new Perceptron(learningRate: 0.8, epochs: 5_000);
+
+        model.Fit(AndFeatures, [[0.0], [0.0], [0.0], [1.0]]);
+
+        Assert.True(model.Predict([[1.0, 1.0]])[0] > 0.7);
+    }
+
+    [Fact]
+    public void PredictRequiresFit()
+    {
+        var model = new Perceptron();
+
+        Assert.Throws<InvalidOperationException>(() => model.Predict(AndFeatures));
+    }
+
+    [Fact]
+    public void FitValidatesTrainingData()
+    {
+        var model = new Perceptron();
+
+        Assert.Throws<ArgumentException>(() => model.Fit(Array.Empty<IReadOnlyList<double>>(), [0.0]));
+        Assert.Throws<ArgumentException>(() => model.Fit([[0.0], [1.0, 2.0]], [0.0, 1.0]));
+        Assert.Throws<ArgumentException>(() => model.Fit([[0.0]], [0.0, 1.0]));
+        Assert.Throws<ArgumentException>(() => model.Fit([[0.0]], [[0.0, 1.0]]));
+    }
+}

--- a/code/packages/fsharp/perceptron/BUILD
+++ b/code/packages/fsharp/perceptron/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/perceptron/BUILD_windows
+++ b/code/packages/fsharp/perceptron/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/perceptron/CHANGELOG.md
+++ b/code/packages/fsharp/perceptron/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# perceptron classifier package.
+- Include sigmoid/BCE training, prediction, validation, and xUnit coverage.

--- a/code/packages/fsharp/perceptron/CodingAdventures.Perceptron.fsproj
+++ b/code/packages/fsharp/perceptron/CodingAdventures.Perceptron.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Perceptron.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Binary perceptron classifier trained with sigmoid and binary cross-entropy</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../activation-functions/CodingAdventures.ActivationFunctions.fsproj" />
+    <ProjectReference Include="../loss-functions/CodingAdventures.LossFunctions.fsproj" />
+    <Compile Include="Perceptron.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/perceptron/Perceptron.fs
+++ b/code/packages/fsharp/perceptron/Perceptron.fs
@@ -1,0 +1,139 @@
+namespace CodingAdventures.Perceptron.FSharp
+
+open System
+open CodingAdventures.ActivationFunctions
+open CodingAdventures.LossFunctions
+
+[<RequireQualifiedAccess>]
+module private Validation =
+    let ensureFinite name value =
+        if Double.IsNaN(value) || Double.IsInfinity(value) then
+            invalidArg name "Values must be finite."
+
+    let validateFeatures (features: float array array) =
+        if isNull features then nullArg "features"
+        if features.Length = 0 then invalidArg "features" "Training data must contain at least one sample."
+        if isNull features.[0] || features.[0].Length = 0 then
+            invalidArg "features" "Samples must contain at least one feature."
+
+        let expectedColumns = features.[0].Length
+
+        features
+        |> Array.mapi (fun row values ->
+            if isNull values then nullArg $"features[{row}]"
+            if values.Length <> expectedColumns then
+                invalidArg "features" $"Sample {row} has {values.Length} features, expected {expectedColumns}."
+
+            values
+            |> Array.map (fun value ->
+                ensureFinite "features" value
+                value))
+
+    let validateLabels (labels: float array) expectedRows =
+        if isNull labels then nullArg "labels"
+        if labels.Length <> expectedRows || labels.Length = 0 then
+            invalidArg "labels" "Labels must match the non-zero sample count."
+
+        labels
+        |> Array.map (fun value ->
+            ensureFinite "labels" value
+            value)
+
+    let flattenLabels (labels: float array array) =
+        if isNull labels then nullArg "labels"
+
+        labels
+        |> Array.mapi (fun row values ->
+            if isNull values then nullArg $"labels[{row}]"
+            if values.Length <> 1 then
+                invalidArg "labels" "Column labels must have exactly one value per row."
+            values.[0])
+
+type Perceptron(learningRate: float, epochs: int) =
+    let mutable weights: float array option = None
+    let mutable bias = 0.0
+
+    do
+        Validation.ensureFinite "learningRate" learningRate
+        if epochs < 0 then invalidArg "epochs" "Epochs must be non-negative."
+
+    new() = Perceptron(0.1, 2000)
+
+    new(learningRate: float) = Perceptron(learningRate, 2000)
+
+    member _.LearningRate = learningRate
+
+    member _.Epochs = epochs
+
+    member _.Bias = bias
+
+    member _.Weights = weights |> Option.map Array.copy
+
+    member this.Fit(features: float array array, labels: float array) =
+        this.Fit(features, labels, 0)
+
+    member this.Fit(features: float array array, labels: float array array) =
+        this.Fit(features, Validation.flattenLabels labels, 0)
+
+    member _.Fit(features: float array array, labels: float array, logSteps: int) =
+        let x = Validation.validateFeatures features
+        let y = Validation.validateLabels labels x.Length
+        let featureCount = x.[0].Length
+        let currentWeights = Array.zeroCreate<float> featureCount
+        weights <- Some currentWeights
+        bias <- 0.0
+
+        for epoch in 0 .. epochs do
+            let rawScores =
+                x
+                |> Array.map (fun row ->
+                    let weighted =
+                        row
+                        |> Array.mapi (fun index value -> value * currentWeights.[index])
+                        |> Array.sum
+
+                    weighted + bias)
+
+            let predictions = rawScores |> Array.map ActivationFunctions.sigmoid
+            let lossGradient = LossFunctions.bceDerivative y predictions
+            let weightGradient = Array.zeroCreate<float> featureCount
+            let mutable biasGradient = 0.0
+
+            for row in 0 .. x.Length - 1 do
+                let combined = lossGradient.[row] * ActivationFunctions.sigmoidDerivative rawScores.[row]
+                for col in 0 .. featureCount - 1 do
+                    weightGradient.[col] <- weightGradient.[col] + (x.[row].[col] * combined)
+
+                biasGradient <- biasGradient + combined
+
+            for col in 0 .. featureCount - 1 do
+                currentWeights.[col] <- currentWeights.[col] - (learningRate * weightGradient.[col])
+
+            bias <- bias - (learningRate * biasGradient)
+
+            if logSteps > 0 && epoch % logSteps = 0 then
+                let loss = LossFunctions.bce y predictions
+                printfn "Epoch %4d | BCE Loss: %.4f | Bias: %.2f" epoch loss bias
+
+        weights <- Some(Array.copy currentWeights)
+
+    member this.Fit(features: float array array, labels: float array array, logSteps: int) =
+        this.Fit(features, Validation.flattenLabels labels, logSteps)
+
+    member _.Predict(features: float array array) =
+        match weights with
+        | None -> invalidOp "Perceptron has not been trained yet. Call Fit first."
+        | Some currentWeights ->
+            let x = Validation.validateFeatures features
+            if x.[0].Length <> currentWeights.Length then
+                invalidArg "features" $"Feature width {x.[0].Length} does not match trained width {currentWeights.Length}."
+
+            x
+            |> Array.map (fun row ->
+                let raw =
+                    row
+                    |> Array.mapi (fun index value -> value * currentWeights.[index])
+                    |> Array.sum
+                    |> fun value -> value + bias
+
+                ActivationFunctions.sigmoid raw)

--- a/code/packages/fsharp/perceptron/README.md
+++ b/code/packages/fsharp/perceptron/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Perceptron.FSharp
+
+Binary perceptron classifier for small in-memory datasets.
+
+The model trains one sigmoid neuron with binary cross-entropy. `Fit` accepts either a flat label vector or one-column label rows, then `Predict` returns a probability for each input sample.
+
+```fsharp
+open CodingAdventures.Perceptron.FSharp
+
+let model = Perceptron(0.8, 5000)
+
+model.Fit(
+    [| [| 0.0; 0.0 |]; [| 0.0; 1.0 |]; [| 1.0; 0.0 |]; [| 1.0; 1.0 |] |],
+    [| 0.0; 0.0; 0.0; 1.0 |])
+
+let probabilities = model.Predict [| [| 1.0; 1.0 |] |]
+```

--- a/code/packages/fsharp/perceptron/required_capabilities.json
+++ b/code/packages/fsharp/perceptron/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/perceptron",
+  "capabilities": [],
+  "justification": "Pure in-memory computation and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/perceptron/tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.fsproj
+++ b/code/packages/fsharp/perceptron/tests/CodingAdventures.Perceptron.Tests/CodingAdventures.Perceptron.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.ActivationFunctions]*,[CodingAdventures.LossFunctions]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Perceptron.fsproj" />
+    <Compile Include="PerceptronTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/perceptron/tests/CodingAdventures.Perceptron.Tests/PerceptronTests.fs
+++ b/code/packages/fsharp/perceptron/tests/CodingAdventures.Perceptron.Tests/PerceptronTests.fs
@@ -1,0 +1,51 @@
+namespace CodingAdventures.Perceptron.Tests
+
+open System
+open Xunit
+open CodingAdventures.Perceptron.FSharp
+
+module PerceptronTests =
+    let private andFeatures =
+        [|
+            [| 0.0; 0.0 |]
+            [| 0.0; 1.0 |]
+            [| 1.0; 0.0 |]
+            [| 1.0; 1.0 |]
+        |]
+
+    [<Fact>]
+    let ``fit learns AND gate`` () =
+        let model = Perceptron(0.8, 5000)
+
+        model.Fit(andFeatures, [| 0.0; 0.0; 0.0; 1.0 |])
+
+        let predictions = model.Predict andFeatures
+        predictions.[0..2]
+        |> Array.iter (fun value -> Assert.True(value < 0.2, $"Expected negative class below 0.2, got {value}."))
+        Assert.True(predictions.[3] > 0.7, $"Expected positive class above 0.7, got {predictions.[3]}.")
+        Assert.Equal(2, model.Weights.Value.Length)
+
+    [<Fact>]
+    let ``fit accepts column labels`` () =
+        let model = Perceptron(0.8, 5000)
+
+        model.Fit(andFeatures, [| [| 0.0 |]; [| 0.0 |]; [| 0.0 |]; [| 1.0 |] |])
+
+        Assert.True((model.Predict [| [| 1.0; 1.0 |] |]).[0] > 0.7)
+
+    [<Fact>]
+    let ``predict requires fit`` () =
+        let model = Perceptron()
+
+        Assert.Throws<InvalidOperationException>(fun () -> model.Predict(andFeatures) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``fit validates training data`` () =
+        let model = Perceptron()
+        let emptyFeatures: float array array = [||]
+
+        Assert.Throws<ArgumentException>(fun () -> model.Fit(emptyFeatures, [| 0.0 |])) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> model.Fit([| [| 0.0 |]; [| 1.0; 2.0 |] |], [| 0.0; 1.0 |])) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> model.Fit([| [| 0.0 |] |], [| 0.0; 1.0 |])) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> model.Fit([| [| 0.0 |] |], [| [| 0.0; 1.0 |] |])) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# perceptron packages for sigmoid/BCE binary classification
- support flat label vectors and one-column label rows, with validation for feature shape and trained prediction width
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\perceptron\tests\CodingAdventures.Perceptron.Tests\CodingAdventures.Perceptron.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\perceptron\tests\CodingAdventures.Perceptron.Tests\CodingAdventures.Perceptron.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line