### PR TITLE
feat(parity): add dotnet sha256 packages

### DIFF
--- a/code/packages/csharp/sha256/BUILD
+++ b/code/packages/csharp/sha256/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha256/BUILD_windows
+++ b/code/packages/csharp/sha256/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha256/CHANGELOG.md
+++ b/code/packages/csharp/sha256/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# SHA-256 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha256/CodingAdventures.Sha256.csproj
+++ b/code/packages/csharp/sha256/CodingAdventures.Sha256.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha256.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-256 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha256/README.md
+++ b/code/packages/csharp/sha256/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.Sha256.CSharp
+
+SHA-256 helpers for .NET, backed by `System.Security.Cryptography.SHA256`.
+
+The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
+
+```csharp
+using CodingAdventures.Sha256;
+
+byte[] digest = Sha256.Hash("abc"u8.ToArray());
+string hex = Sha256.HashHex("abc"u8.ToArray());
+
+var hasher = new Sha256Hasher();
+hasher.Update("ab"u8.ToArray()).Update("c"u8.ToArray());
+string streamed = hasher.HexDigest();
+```

--- a/code/packages/csharp/sha256/Sha256.cs
+++ b/code/packages/csharp/sha256/Sha256.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Sha256;
+
+/// <summary>
+/// SHA-256 one-shot and streaming helpers.
+/// </summary>
+public static class Sha256
+{
+    /// <summary>SHA-256 digest length in bytes.</summary>
+    public const int DigestLength = 32;
+
+    /// <summary>Compute the SHA-256 digest for a complete byte array.</summary>
+    public static byte[] Hash(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        return SHA256.HashData(data);
+    }
+
+    /// <summary>Compute SHA-256 and return a lowercase hexadecimal digest.</summary>
+    public static string HashHex(byte[] data) =>
+        Convert.ToHexString(Hash(data)).ToLowerInvariant();
+}
+
+/// <summary>
+/// Streaming SHA-256 hasher with non-destructive digest snapshots.
+/// </summary>
+public sealed class Sha256Hasher
+{
+    private readonly List<byte> _data = [];
+
+    /// <summary>Append bytes and return this hasher for chaining.</summary>
+    public Sha256Hasher Update(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        _data.AddRange(data);
+        return this;
+    }
+
+    /// <summary>Return the current 32-byte digest without modifying this hasher.</summary>
+    public byte[] Digest() => SHA256.HashData(_data.ToArray());
+
+    /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
+    public string HexDigest() =>
+        Convert.ToHexString(Digest()).ToLowerInvariant();
+
+    /// <summary>Return an independent copy of the current hasher state.</summary>
+    public Sha256Hasher Copy()
+    {
+        var copy = new Sha256Hasher();
+        copy._data.AddRange(_data);
+        return copy;
+    }
+}

--- a/code/packages/csharp/sha256/required_capabilities.json
+++ b/code/packages/csharp/sha256/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sha256",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sha256/tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.csproj
+++ b/code/packages/csharp/sha256/tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Sha256.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha256/tests/CodingAdventures.Sha256.Tests/Sha256Tests.cs
+++ b/code/packages/csharp/sha256/tests/CodingAdventures.Sha256.Tests/Sha256Tests.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using Sha256Algorithm = CodingAdventures.Sha256.Sha256;
+
+namespace CodingAdventures.Sha256.Tests;
+
+public sealed class Sha256Tests
+{
+    [Theory]
+    [InlineData("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")]
+    [InlineData("abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")]
+    [InlineData("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")]
+    public void HashMatchesFipsVectors(string input, string expected)
+    {
+        var data = Encoding.ASCII.GetBytes(input);
+
+        Assert.Equal(Sha256Algorithm.DigestLength, Sha256Algorithm.Hash(data).Length);
+        Assert.Equal(expected, Sha256Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HashHandlesLargeInput()
+    {
+        var data = Enumerable.Repeat((byte)'a', 1_000_000).ToArray();
+
+        Assert.Equal(
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+            Sha256Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HexDigestIsLowercase()
+    {
+        var hex = Sha256Algorithm.HashHex(Encoding.ASCII.GetBytes("abc"));
+
+        Assert.Equal(64, hex.Length);
+        Assert.Equal(hex.ToLowerInvariant(), hex);
+    }
+
+    [Fact]
+    public void HashRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Sha256Algorithm.Hash(null!));
+        Assert.Throws<ArgumentNullException>(() => Sha256Algorithm.HashHex(null!));
+    }
+
+    [Fact]
+    public void StreamingMatchesOneShotAcrossChunking()
+    {
+        var data = Enumerable.Range(0, 200).Select(value => (byte)value).ToArray();
+
+        foreach (var chunkSize in new[] { 1, 7, 13, 32, 63, 64, 65, 100, 200 })
+        {
+            var hasher = new Sha256Hasher();
+            for (var offset = 0; offset < data.Length; offset += chunkSize)
+            {
+                hasher.Update(data.Skip(offset).Take(chunkSize).ToArray());
+            }
+
+            Assert.Equal(Sha256Algorithm.Hash(data), hasher.Digest());
+        }
+    }
+
+    [Fact]
+    public void StreamingDigestIsNonDestructiveAndChainable()
+    {
+        var hasher = new Sha256Hasher();
+
+        var result = hasher.Update("a"u8.ToArray()).Update("b"u8.ToArray()).Update("c"u8.ToArray());
+
+        Assert.Same(hasher, result);
+        Assert.Equal(hasher.Digest(), hasher.Digest());
+        Assert.Equal(Sha256Algorithm.HashHex("abc"u8.ToArray()), hasher.HexDigest());
+    }
+
+    [Fact]
+    public void StreamingCanContinueAfterDigest()
+    {
+        var hasher = new Sha256Hasher();
+
+        hasher.Update("ab"u8.ToArray());
+        _ = hasher.Digest();
+        hasher.Update("c"u8.ToArray());
+
+        Assert.Equal(Sha256Algorithm.Hash("abc"u8.ToArray()), hasher.Digest());
+    }
+
+    [Fact]
+    public void CopyIsIndependent()
+    {
+        var baseHasher = new Sha256Hasher();
+        baseHasher.Update("ab"u8.ToArray());
+
+        var copy = baseHasher.Copy();
+        copy.Update("c"u8.ToArray());
+        baseHasher.Update("x"u8.ToArray());
+
+        Assert.Equal(Sha256Algorithm.Hash("abc"u8.ToArray()), copy.Digest());
+        Assert.Equal(Sha256Algorithm.Hash("abx"u8.ToArray()), baseHasher.Digest());
+    }
+
+    [Fact]
+    public void UpdateRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sha256Hasher().Update(null!));
+    }
+}

--- a/code/packages/fsharp/sha256/BUILD
+++ b/code/packages/fsharp/sha256/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha256/BUILD_windows
+++ b/code/packages/fsharp/sha256/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha256/CHANGELOG.md
+++ b/code/packages/fsharp/sha256/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# SHA-256 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha256/CodingAdventures.Sha256.fsproj
+++ b/code/packages/fsharp/sha256/CodingAdventures.Sha256.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha256.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-256 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Sha256.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha256/README.md
+++ b/code/packages/fsharp/sha256/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Sha256.FSharp
+
+SHA-256 helpers for .NET, backed by `System.Security.Cryptography.SHA256`.
+
+The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
+
+```fsharp
+open System.Text
+open CodingAdventures.Sha256.FSharp
+
+let digest = Sha256.hash (Encoding.ASCII.GetBytes "abc")
+let hex = Sha256.hashHex (Encoding.ASCII.GetBytes "abc")
+
+let hasher = Sha256Hasher()
+hasher.Update(Encoding.ASCII.GetBytes "ab").Update(Encoding.ASCII.GetBytes "c") |> ignore
+let streamed = hasher.HexDigest()
+```

--- a/code/packages/fsharp/sha256/Sha256.fs
+++ b/code/packages/fsharp/sha256/Sha256.fs
@@ -1,0 +1,36 @@
+namespace CodingAdventures.Sha256.FSharp
+
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Sha256 =
+    [<Literal>]
+    let DigestLength = 32
+
+    let hash (data: byte array) =
+        if isNull data then nullArg "data"
+        SHA256.HashData(data)
+
+    let hashHex (data: byte array) =
+        hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+type Sha256Hasher() =
+    let data = List<byte>()
+
+    member this.Update(bytes: byte array) =
+        if isNull bytes then nullArg "bytes"
+        data.AddRange(bytes)
+        this
+
+    member _.Digest() =
+        data.ToArray() |> SHA256.HashData
+
+    member this.HexDigest() =
+        this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+    member _.Copy() =
+        let copy = Sha256Hasher()
+        copy.Update(data.ToArray()) |> ignore
+        copy

--- a/code/packages/fsharp/sha256/required_capabilities.json
+++ b/code/packages/fsharp/sha256/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sha256",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sha256/tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.fsproj
+++ b/code/packages/fsharp/sha256/tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Sha256.fsproj" />
+    <Compile Include="Sha256Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha256/tests/CodingAdventures.Sha256.Tests/Sha256Tests.fs
+++ b/code/packages/fsharp/sha256/tests/CodingAdventures.Sha256.Tests/Sha256Tests.fs
@@ -1,0 +1,90 @@
+namespace CodingAdventures.Sha256.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.Sha256.FSharp
+
+module Sha256Tests =
+    [<Theory>]
+    [<InlineData("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")>]
+    [<InlineData("abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")>]
+    [<InlineData("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")>]
+    let ``hash matches FIPS vectors`` (input: string) (expected: string) =
+        let data = Encoding.ASCII.GetBytes input
+
+        Assert.Equal(Sha256.DigestLength, (Sha256.hash data).Length)
+        Assert.Equal(expected, Sha256.hashHex data)
+
+    [<Fact>]
+    let ``hash handles large input`` () =
+        let data = Array.create 1_000_000 (byte 'a')
+
+        Assert.Equal(
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+            Sha256.hashHex data)
+
+    [<Fact>]
+    let ``hex digest is lowercase`` () =
+        let hex = Sha256.hashHex (Encoding.ASCII.GetBytes "abc")
+
+        Assert.Equal(64, hex.Length)
+        Assert.Equal(hex.ToLowerInvariant(), hex)
+
+    [<Fact>]
+    let ``hash rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha256.hash null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Sha256.hashHex null |> ignore) |> ignore
+
+    [<Fact>]
+    let ``streaming matches one shot across chunking`` () =
+        let data = [| 0 .. 199 |] |> Array.map byte
+
+        for chunkSize in [ 1; 7; 13; 32; 63; 64; 65; 100; 200 ] do
+            let hasher = Sha256Hasher()
+            for offset in 0 .. chunkSize .. data.Length - 1 do
+                data.[offset .. min (offset + chunkSize - 1) (data.Length - 1)]
+                |> hasher.Update
+                |> ignore
+
+            Assert.Equal<byte array>(Sha256.hash data, hasher.Digest())
+
+    [<Fact>]
+    let ``streaming digest is nondestructive and chainable`` () =
+        let hasher = Sha256Hasher()
+
+        let result =
+            hasher
+                .Update("a"B)
+                .Update("b"B)
+                .Update("c"B)
+
+        Assert.Same(hasher, result)
+        Assert.Equal<byte array>(hasher.Digest(), hasher.Digest())
+        Assert.Equal(Sha256.hashHex "abc"B, hasher.HexDigest())
+
+    [<Fact>]
+    let ``streaming can continue after digest`` () =
+        let hasher = Sha256Hasher()
+
+        hasher.Update("ab"B) |> ignore
+        hasher.Digest() |> ignore
+        hasher.Update("c"B) |> ignore
+
+        Assert.Equal<byte array>(Sha256.hash "abc"B, hasher.Digest())
+
+    [<Fact>]
+    let ``copy is independent`` () =
+        let baseHasher = Sha256Hasher()
+        baseHasher.Update("ab"B) |> ignore
+
+        let copy = baseHasher.Copy()
+        copy.Update("c"B) |> ignore
+        baseHasher.Update("x"B) |> ignore
+
+        Assert.Equal<byte array>(Sha256.hash "abc"B, copy.Digest())
+        Assert.Equal<byte array>(Sha256.hash "abx"B, baseHasher.Digest())
+
+    [<Fact>]
+    let ``update rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha256Hasher().Update(null) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# SHA-256 packages backed by `System.Security.Cryptography.SHA256`
- expose one-shot byte hashing, lowercase hex output, and streaming-style hashers with non-destructive snapshots and copy support
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\sha256\tests\CodingAdventures.Sha256.Tests\CodingAdventures.Sha256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\sha256\tests\CodingAdventures.Sha256.Tests\CodingAdventures.Sha256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line