### PR TITLE
feat(parity): add dotnet sha1 packages

### DIFF
--- a/code/packages/csharp/sha1/BUILD
+++ b/code/packages/csharp/sha1/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha1/BUILD_windows
+++ b/code/packages/csharp/sha1/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha1/CHANGELOG.md
+++ b/code/packages/csharp/sha1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# SHA-1 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha1/CodingAdventures.Sha1.csproj
+++ b/code/packages/csharp/sha1/CodingAdventures.Sha1.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha1.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-1 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha1/README.md
+++ b/code/packages/csharp/sha1/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.Sha1.CSharp
+
+SHA-1 helpers for .NET, backed by `System.Security.Cryptography.SHA1`.
+
+SHA-1 is included for compatibility and learning parity with the repository's hash-function packages. New security-sensitive systems should prefer SHA-256 or stronger hashes.
+
+```csharp
+using CodingAdventures.Sha1;
+
+byte[] digest = Sha1.Hash("abc"u8.ToArray());
+string hex = Sha1.HashHex("abc"u8.ToArray());
+
+var hasher = new Sha1Hasher();
+hasher.Update("ab"u8.ToArray()).Update("c"u8.ToArray());
+string streamed = hasher.HexDigest();
+```

--- a/code/packages/csharp/sha1/Sha1.cs
+++ b/code/packages/csharp/sha1/Sha1.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Sha1;
+
+/// <summary>
+/// SHA-1 one-shot and streaming helpers.
+/// </summary>
+public static class Sha1
+{
+    /// <summary>SHA-1 digest length in bytes.</summary>
+    public const int DigestLength = 20;
+
+    /// <summary>Compute the SHA-1 digest for a complete byte array.</summary>
+    public static byte[] Hash(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        return SHA1.HashData(data);
+    }
+
+    /// <summary>Compute SHA-1 and return a lowercase hexadecimal digest.</summary>
+    public static string HashHex(byte[] data) =>
+        Convert.ToHexString(Hash(data)).ToLowerInvariant();
+}
+
+/// <summary>
+/// Streaming SHA-1 hasher with non-destructive digest snapshots.
+/// </summary>
+public sealed class Sha1Hasher
+{
+    private readonly List<byte> _data = [];
+
+    /// <summary>Append bytes and return this hasher for chaining.</summary>
+    public Sha1Hasher Update(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        _data.AddRange(data);
+        return this;
+    }
+
+    /// <summary>Return the current 20-byte digest without modifying this hasher.</summary>
+    public byte[] Digest() => SHA1.HashData(_data.ToArray());
+
+    /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
+    public string HexDigest() =>
+        Convert.ToHexString(Digest()).ToLowerInvariant();
+
+    /// <summary>Return an independent copy of the current hasher state.</summary>
+    public Sha1Hasher Copy()
+    {
+        var copy = new Sha1Hasher();
+        copy._data.AddRange(_data);
+        return copy;
+    }
+}

--- a/code/packages/csharp/sha1/required_capabilities.json
+++ b/code/packages/csharp/sha1/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sha1",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sha1/tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.csproj
+++ b/code/packages/csharp/sha1/tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Sha1.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha1/tests/CodingAdventures.Sha1.Tests/Sha1Tests.cs
+++ b/code/packages/csharp/sha1/tests/CodingAdventures.Sha1.Tests/Sha1Tests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
+
+namespace CodingAdventures.Sha1.Tests;
+
+public sealed class Sha1Tests
+{
+    [Theory]
+    [InlineData("", "da39a3ee5e6b4b0d3255bfef95601890afd80709")]
+    [InlineData("abc", "a9993e364706816aba3e25717850c26c9cd0d89d")]
+    [InlineData("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84983e441c3bd26ebaae4aa1f95129e5e54670f1")]
+    public void HashMatchesFipsVectors(string input, string expected)
+    {
+        var data = Encoding.ASCII.GetBytes(input);
+
+        Assert.Equal(Sha1Algorithm.DigestLength, Sha1Algorithm.Hash(data).Length);
+        Assert.Equal(expected, Sha1Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HashHandlesLargeInput()
+    {
+        var data = Enumerable.Repeat((byte)'a', 1_000_000).ToArray();
+
+        Assert.Equal("34aa973cd4c4daa4f61eeb2bdbad27316534016f", Sha1Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HexDigestIsLowercase()
+    {
+        var hex = Sha1Algorithm.HashHex(Encoding.ASCII.GetBytes("abc"));
+
+        Assert.Equal(40, hex.Length);
+        Assert.Equal(hex.ToLowerInvariant(), hex);
+    }
+
+    [Fact]
+    public void HashRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Sha1Algorithm.Hash(null!));
+        Assert.Throws<ArgumentNullException>(() => Sha1Algorithm.HashHex(null!));
+    }
+
+    [Fact]
+    public void StreamingMatchesOneShotAcrossChunking()
+    {
+        var data = Enumerable.Range(0, 200).Select(value => (byte)value).ToArray();
+
+        foreach (var chunkSize in new[] { 1, 7, 13, 32, 63, 64, 65, 100, 200 })
+        {
+            var hasher = new Sha1Hasher();
+            for (var offset = 0; offset < data.Length; offset += chunkSize)
+            {
+                hasher.Update(data.Skip(offset).Take(chunkSize).ToArray());
+            }
+
+            Assert.Equal(Sha1Algorithm.Hash(data), hasher.Digest());
+        }
+    }
+
+    [Fact]
+    public void StreamingDigestIsNonDestructiveAndChainable()
+    {
+        var hasher = new Sha1Hasher();
+
+        var result = hasher.Update("a"u8.ToArray()).Update("b"u8.ToArray()).Update("c"u8.ToArray());
+
+        Assert.Same(hasher, result);
+        Assert.Equal(hasher.Digest(), hasher.Digest());
+        Assert.Equal(Sha1Algorithm.HashHex("abc"u8.ToArray()), hasher.HexDigest());
+    }
+
+    [Fact]
+    public void StreamingCanContinueAfterDigest()
+    {
+        var hasher = new Sha1Hasher();
+
+        hasher.Update("ab"u8.ToArray());
+        _ = hasher.Digest();
+        hasher.Update("c"u8.ToArray());
+
+        Assert.Equal(Sha1Algorithm.Hash("abc"u8.ToArray()), hasher.Digest());
+    }
+
+    [Fact]
+    public void CopyIsIndependent()
+    {
+        var baseHasher = new Sha1Hasher();
+        baseHasher.Update("ab"u8.ToArray());
+
+        var copy = baseHasher.Copy();
+        copy.Update("c"u8.ToArray());
+        baseHasher.Update("x"u8.ToArray());
+
+        Assert.Equal(Sha1Algorithm.Hash("abc"u8.ToArray()), copy.Digest());
+        Assert.Equal(Sha1Algorithm.Hash("abx"u8.ToArray()), baseHasher.Digest());
+    }
+
+    [Fact]
+    public void UpdateRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sha1Hasher().Update(null!));
+    }
+}

--- a/code/packages/fsharp/sha1/BUILD
+++ b/code/packages/fsharp/sha1/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha1/BUILD_windows
+++ b/code/packages/fsharp/sha1/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha1/CHANGELOG.md
+++ b/code/packages/fsharp/sha1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# SHA-1 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha1/CodingAdventures.Sha1.fsproj
+++ b/code/packages/fsharp/sha1/CodingAdventures.Sha1.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha1.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-1 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Sha1.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha1/README.md
+++ b/code/packages/fsharp/sha1/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Sha1.FSharp
+
+SHA-1 helpers for .NET, backed by `System.Security.Cryptography.SHA1`.
+
+SHA-1 is included for compatibility and learning parity with the repository's hash-function packages. New security-sensitive systems should prefer SHA-256 or stronger hashes.
+
+```fsharp
+open System.Text
+open CodingAdventures.Sha1.FSharp
+
+let digest = Sha1.hash (Encoding.ASCII.GetBytes "abc")
+let hex = Sha1.hashHex (Encoding.ASCII.GetBytes "abc")
+
+let hasher = Sha1Hasher()
+hasher.Update(Encoding.ASCII.GetBytes "ab").Update(Encoding.ASCII.GetBytes "c") |> ignore
+let streamed = hasher.HexDigest()
+```

--- a/code/packages/fsharp/sha1/Sha1.fs
+++ b/code/packages/fsharp/sha1/Sha1.fs
@@ -1,0 +1,36 @@
+namespace CodingAdventures.Sha1.FSharp
+
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Sha1 =
+    [<Literal>]
+    let DigestLength = 20
+
+    let hash (data: byte array) =
+        if isNull data then nullArg "data"
+        SHA1.HashData(data)
+
+    let hashHex (data: byte array) =
+        hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+type Sha1Hasher() =
+    let data = List<byte>()
+
+    member this.Update(bytes: byte array) =
+        if isNull bytes then nullArg "bytes"
+        data.AddRange(bytes)
+        this
+
+    member _.Digest() =
+        data.ToArray() |> SHA1.HashData
+
+    member this.HexDigest() =
+        this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+    member _.Copy() =
+        let copy = Sha1Hasher()
+        copy.Update(data.ToArray()) |> ignore
+        copy

--- a/code/packages/fsharp/sha1/required_capabilities.json
+++ b/code/packages/fsharp/sha1/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sha1",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sha1/tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.fsproj
+++ b/code/packages/fsharp/sha1/tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Sha1.fsproj" />
+    <Compile Include="Sha1Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha1/tests/CodingAdventures.Sha1.Tests/Sha1Tests.fs
+++ b/code/packages/fsharp/sha1/tests/CodingAdventures.Sha1.Tests/Sha1Tests.fs
@@ -1,0 +1,88 @@
+namespace CodingAdventures.Sha1.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.Sha1.FSharp
+
+module Sha1Tests =
+    [<Theory>]
+    [<InlineData("", "da39a3ee5e6b4b0d3255bfef95601890afd80709")>]
+    [<InlineData("abc", "a9993e364706816aba3e25717850c26c9cd0d89d")>]
+    [<InlineData("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84983e441c3bd26ebaae4aa1f95129e5e54670f1")>]
+    let ``hash matches FIPS vectors`` (input: string) (expected: string) =
+        let data = Encoding.ASCII.GetBytes input
+
+        Assert.Equal(Sha1.DigestLength, (Sha1.hash data).Length)
+        Assert.Equal(expected, Sha1.hashHex data)
+
+    [<Fact>]
+    let ``hash handles large input`` () =
+        let data = Array.create 1_000_000 (byte 'a')
+
+        Assert.Equal("34aa973cd4c4daa4f61eeb2bdbad27316534016f", Sha1.hashHex data)
+
+    [<Fact>]
+    let ``hex digest is lowercase`` () =
+        let hex = Sha1.hashHex (Encoding.ASCII.GetBytes "abc")
+
+        Assert.Equal(40, hex.Length)
+        Assert.Equal(hex.ToLowerInvariant(), hex)
+
+    [<Fact>]
+    let ``hash rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha1.hash null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Sha1.hashHex null |> ignore) |> ignore
+
+    [<Fact>]
+    let ``streaming matches one shot across chunking`` () =
+        let data = [| 0 .. 199 |] |> Array.map byte
+
+        for chunkSize in [ 1; 7; 13; 32; 63; 64; 65; 100; 200 ] do
+            let hasher = Sha1Hasher()
+            for offset in 0 .. chunkSize .. data.Length - 1 do
+                data.[offset .. min (offset + chunkSize - 1) (data.Length - 1)]
+                |> hasher.Update
+                |> ignore
+
+            Assert.Equal<byte array>(Sha1.hash data, hasher.Digest())
+
+    [<Fact>]
+    let ``streaming digest is nondestructive and chainable`` () =
+        let hasher = Sha1Hasher()
+
+        let result =
+            hasher
+                .Update("a"B)
+                .Update("b"B)
+                .Update("c"B)
+
+        Assert.Same(hasher, result)
+        Assert.Equal<byte array>(hasher.Digest(), hasher.Digest())
+        Assert.Equal(Sha1.hashHex "abc"B, hasher.HexDigest())
+
+    [<Fact>]
+    let ``streaming can continue after digest`` () =
+        let hasher = Sha1Hasher()
+
+        hasher.Update("ab"B) |> ignore
+        hasher.Digest() |> ignore
+        hasher.Update("c"B) |> ignore
+
+        Assert.Equal<byte array>(Sha1.hash "abc"B, hasher.Digest())
+
+    [<Fact>]
+    let ``copy is independent`` () =
+        let baseHasher = Sha1Hasher()
+        baseHasher.Update("ab"B) |> ignore
+
+        let copy = baseHasher.Copy()
+        copy.Update("c"B) |> ignore
+        baseHasher.Update("x"B) |> ignore
+
+        Assert.Equal<byte array>(Sha1.hash "abc"B, copy.Digest())
+        Assert.Equal<byte array>(Sha1.hash "abx"B, baseHasher.Digest())
+
+    [<Fact>]
+    let ``update rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha1Hasher().Update(null) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# SHA-1 packages backed by `System.Security.Cryptography.SHA1`
- expose one-shot byte hashing, lowercase hex output, and streaming-style hashers with non-destructive snapshots and copy support
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\sha1\tests\CodingAdventures.Sha1.Tests\CodingAdventures.Sha1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\sha1\tests\CodingAdventures.Sha1.Tests\CodingAdventures.Sha1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line