### PR TITLE
feat(parity): add dotnet sha512 packages

### DIFF
--- a/code/packages/csharp/sha512/BUILD
+++ b/code/packages/csharp/sha512/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha512/BUILD_windows
+++ b/code/packages/csharp/sha512/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sha512/CHANGELOG.md
+++ b/code/packages/csharp/sha512/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# SHA-512 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha512/CodingAdventures.Sha512.csproj
+++ b/code/packages/csharp/sha512/CodingAdventures.Sha512.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha512.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-512 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha512/README.md
+++ b/code/packages/csharp/sha512/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.Sha512.CSharp
+
+SHA-512 helpers for .NET, backed by `System.Security.Cryptography.SHA512`.
+
+The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
+
+```csharp
+using CodingAdventures.Sha512;
+
+byte[] digest = Sha512.Hash("abc"u8.ToArray());
+string hex = Sha512.HashHex("abc"u8.ToArray());
+
+var hasher = new Sha512Hasher();
+hasher.Update("ab"u8.ToArray()).Update("c"u8.ToArray());
+string streamed = hasher.HexDigest();
+```

--- a/code/packages/csharp/sha512/Sha512.cs
+++ b/code/packages/csharp/sha512/Sha512.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Sha512;
+
+/// <summary>
+/// SHA-512 one-shot and streaming helpers.
+/// </summary>
+public static class Sha512
+{
+    /// <summary>SHA-512 digest length in bytes.</summary>
+    public const int DigestLength = 64;
+
+    /// <summary>Compute the SHA-512 digest for a complete byte array.</summary>
+    public static byte[] Hash(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        return SHA512.HashData(data);
+    }
+
+    /// <summary>Compute SHA-512 and return a lowercase hexadecimal digest.</summary>
+    public static string HashHex(byte[] data) =>
+        Convert.ToHexString(Hash(data)).ToLowerInvariant();
+}
+
+/// <summary>
+/// Streaming SHA-512 hasher with non-destructive digest snapshots.
+/// </summary>
+public sealed class Sha512Hasher
+{
+    private readonly List<byte> _data = [];
+
+    /// <summary>Append bytes and return this hasher for chaining.</summary>
+    public Sha512Hasher Update(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        _data.AddRange(data);
+        return this;
+    }
+
+    /// <summary>Return the current 64-byte digest without modifying this hasher.</summary>
+    public byte[] Digest() => SHA512.HashData(_data.ToArray());
+
+    /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
+    public string HexDigest() =>
+        Convert.ToHexString(Digest()).ToLowerInvariant();
+
+    /// <summary>Return an independent copy of the current hasher state.</summary>
+    public Sha512Hasher Copy()
+    {
+        var copy = new Sha512Hasher();
+        copy._data.AddRange(_data);
+        return copy;
+    }
+}

--- a/code/packages/csharp/sha512/required_capabilities.json
+++ b/code/packages/csharp/sha512/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sha512",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sha512/tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.csproj
+++ b/code/packages/csharp/sha512/tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Sha512.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sha512/tests/CodingAdventures.Sha512.Tests/Sha512Tests.cs
+++ b/code/packages/csharp/sha512/tests/CodingAdventures.Sha512.Tests/Sha512Tests.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
+
+namespace CodingAdventures.Sha512.Tests;
+
+public sealed class Sha512Tests
+{
+    [Theory]
+    [InlineData("", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")]
+    [InlineData("abc", "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f")]
+    [InlineData("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909")]
+    public void HashMatchesFipsVectors(string input, string expected)
+    {
+        var data = Encoding.ASCII.GetBytes(input);
+
+        Assert.Equal(Sha512Algorithm.DigestLength, Sha512Algorithm.Hash(data).Length);
+        Assert.Equal(expected, Sha512Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HashHandlesLargeInput()
+    {
+        var data = Enumerable.Repeat((byte)'a', 1_000_000).ToArray();
+
+        Assert.Equal(
+            "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b",
+            Sha512Algorithm.HashHex(data));
+    }
+
+    [Fact]
+    public void HexDigestIsLowercase()
+    {
+        var hex = Sha512Algorithm.HashHex(Encoding.ASCII.GetBytes("abc"));
+
+        Assert.Equal(128, hex.Length);
+        Assert.Equal(hex.ToLowerInvariant(), hex);
+    }
+
+    [Fact]
+    public void HashRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Sha512Algorithm.Hash(null!));
+        Assert.Throws<ArgumentNullException>(() => Sha512Algorithm.HashHex(null!));
+    }
+
+    [Fact]
+    public void StreamingMatchesOneShotAcrossChunking()
+    {
+        var data = Enumerable.Range(0, 256).Select(value => (byte)value).ToArray();
+
+        foreach (var chunkSize in new[] { 1, 7, 13, 32, 63, 64, 65, 100, 128, 256 })
+        {
+            var hasher = new Sha512Hasher();
+            for (var offset = 0; offset < data.Length; offset += chunkSize)
+            {
+                hasher.Update(data.Skip(offset).Take(chunkSize).ToArray());
+            }
+
+            Assert.Equal(Sha512Algorithm.Hash(data), hasher.Digest());
+        }
+    }
+
+    [Fact]
+    public void StreamingDigestIsNonDestructiveAndChainable()
+    {
+        var hasher = new Sha512Hasher();
+
+        var result = hasher.Update("a"u8.ToArray()).Update("b"u8.ToArray()).Update("c"u8.ToArray());
+
+        Assert.Same(hasher, result);
+        Assert.Equal(hasher.Digest(), hasher.Digest());
+        Assert.Equal(Sha512Algorithm.HashHex("abc"u8.ToArray()), hasher.HexDigest());
+    }
+
+    [Fact]
+    public void StreamingCanContinueAfterDigest()
+    {
+        var hasher = new Sha512Hasher();
+
+        hasher.Update("ab"u8.ToArray());
+        _ = hasher.Digest();
+        hasher.Update("c"u8.ToArray());
+
+        Assert.Equal(Sha512Algorithm.Hash("abc"u8.ToArray()), hasher.Digest());
+    }
+
+    [Fact]
+    public void CopyIsIndependent()
+    {
+        var baseHasher = new Sha512Hasher();
+        baseHasher.Update("ab"u8.ToArray());
+
+        var copy = baseHasher.Copy();
+        copy.Update("c"u8.ToArray());
+        baseHasher.Update("x"u8.ToArray());
+
+        Assert.Equal(Sha512Algorithm.Hash("abc"u8.ToArray()), copy.Digest());
+        Assert.Equal(Sha512Algorithm.Hash("abx"u8.ToArray()), baseHasher.Digest());
+    }
+
+    [Fact]
+    public void UpdateRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sha512Hasher().Update(null!));
+    }
+}

--- a/code/packages/fsharp/sha512/BUILD
+++ b/code/packages/fsharp/sha512/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha512/BUILD_windows
+++ b/code/packages/fsharp/sha512/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sha512/CHANGELOG.md
+++ b/code/packages/fsharp/sha512/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# SHA-512 package backed by `System.Security.Cryptography`.
+- Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha512/CodingAdventures.Sha512.fsproj
+++ b/code/packages/fsharp/sha512/CodingAdventures.Sha512.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Sha512.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SHA-512 one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Sha512.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha512/README.md
+++ b/code/packages/fsharp/sha512/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Sha512.FSharp
+
+SHA-512 helpers for .NET, backed by `System.Security.Cryptography.SHA512`.
+
+The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
+
+```fsharp
+open System.Text
+open CodingAdventures.Sha512.FSharp
+
+let digest = Sha512.hash (Encoding.ASCII.GetBytes "abc")
+let hex = Sha512.hashHex (Encoding.ASCII.GetBytes "abc")
+
+let hasher = Sha512Hasher()
+hasher.Update(Encoding.ASCII.GetBytes "ab").Update(Encoding.ASCII.GetBytes "c") |> ignore
+let streamed = hasher.HexDigest()
+```

--- a/code/packages/fsharp/sha512/Sha512.fs
+++ b/code/packages/fsharp/sha512/Sha512.fs
@@ -1,0 +1,36 @@
+namespace CodingAdventures.Sha512.FSharp
+
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Sha512 =
+    [<Literal>]
+    let DigestLength = 64
+
+    let hash (data: byte array) =
+        if isNull data then nullArg "data"
+        SHA512.HashData(data)
+
+    let hashHex (data: byte array) =
+        hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+type Sha512Hasher() =
+    let data = List<byte>()
+
+    member this.Update(bytes: byte array) =
+        if isNull bytes then nullArg "bytes"
+        data.AddRange(bytes)
+        this
+
+    member _.Digest() =
+        data.ToArray() |> SHA512.HashData
+
+    member this.HexDigest() =
+        this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+    member _.Copy() =
+        let copy = Sha512Hasher()
+        copy.Update(data.ToArray()) |> ignore
+        copy

--- a/code/packages/fsharp/sha512/required_capabilities.json
+++ b/code/packages/fsharp/sha512/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sha512",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sha512/tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.fsproj
+++ b/code/packages/fsharp/sha512/tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Sha512.fsproj" />
+    <Compile Include="Sha512Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sha512/tests/CodingAdventures.Sha512.Tests/Sha512Tests.fs
+++ b/code/packages/fsharp/sha512/tests/CodingAdventures.Sha512.Tests/Sha512Tests.fs
@@ -1,0 +1,90 @@
+namespace CodingAdventures.Sha512.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.Sha512.FSharp
+
+module Sha512Tests =
+    [<Theory>]
+    [<InlineData("", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")>]
+    [<InlineData("abc", "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f")>]
+    [<InlineData("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909")>]
+    let ``hash matches FIPS vectors`` (input: string) (expected: string) =
+        let data = Encoding.ASCII.GetBytes input
+
+        Assert.Equal(Sha512.DigestLength, (Sha512.hash data).Length)
+        Assert.Equal(expected, Sha512.hashHex data)
+
+    [<Fact>]
+    let ``hash handles large input`` () =
+        let data = Array.create 1_000_000 (byte 'a')
+
+        Assert.Equal(
+            "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b",
+            Sha512.hashHex data)
+
+    [<Fact>]
+    let ``hex digest is lowercase`` () =
+        let hex = Sha512.hashHex (Encoding.ASCII.GetBytes "abc")
+
+        Assert.Equal(128, hex.Length)
+        Assert.Equal(hex.ToLowerInvariant(), hex)
+
+    [<Fact>]
+    let ``hash rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha512.hash null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Sha512.hashHex null |> ignore) |> ignore
+
+    [<Fact>]
+    let ``streaming matches one shot across chunking`` () =
+        let data = [| 0 .. 255 |] |> Array.map byte
+
+        for chunkSize in [ 1; 7; 13; 32; 63; 64; 65; 100; 128; 256 ] do
+            let hasher = Sha512Hasher()
+            for offset in 0 .. chunkSize .. data.Length - 1 do
+                data.[offset .. min (offset + chunkSize - 1) (data.Length - 1)]
+                |> hasher.Update
+                |> ignore
+
+            Assert.Equal<byte array>(Sha512.hash data, hasher.Digest())
+
+    [<Fact>]
+    let ``streaming digest is nondestructive and chainable`` () =
+        let hasher = Sha512Hasher()
+
+        let result =
+            hasher
+                .Update("a"B)
+                .Update("b"B)
+                .Update("c"B)
+
+        Assert.Same(hasher, result)
+        Assert.Equal<byte array>(hasher.Digest(), hasher.Digest())
+        Assert.Equal(Sha512.hashHex "abc"B, hasher.HexDigest())
+
+    [<Fact>]
+    let ``streaming can continue after digest`` () =
+        let hasher = Sha512Hasher()
+
+        hasher.Update("ab"B) |> ignore
+        hasher.Digest() |> ignore
+        hasher.Update("c"B) |> ignore
+
+        Assert.Equal<byte array>(Sha512.hash "abc"B, hasher.Digest())
+
+    [<Fact>]
+    let ``copy is independent`` () =
+        let baseHasher = Sha512Hasher()
+        baseHasher.Update("ab"B) |> ignore
+
+        let copy = baseHasher.Copy()
+        copy.Update("c"B) |> ignore
+        baseHasher.Update("x"B) |> ignore
+
+        Assert.Equal<byte array>(Sha512.hash "abc"B, copy.Digest())
+        Assert.Equal<byte array>(Sha512.hash "abx"B, baseHasher.Digest())
+
+    [<Fact>]
+    let ``update rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Sha512Hasher().Update(null) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# SHA-512 packages backed by `System.Security.Cryptography.SHA512`
- expose one-shot byte hashing, lowercase hex output, and streaming-style hashers with non-destructive snapshots and copy support
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\sha512\tests\CodingAdventures.Sha512.Tests\CodingAdventures.Sha512.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\sha512\tests\CodingAdventures.Sha512.Tests\CodingAdventures.Sha512.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line