### PR TITLE
feat(parity): add dotnet hmac packages

### DIFF
--- a/code/packages/csharp/hmac/BUILD
+++ b/code/packages/csharp/hmac/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hmac/BUILD_windows
+++ b/code/packages/csharp/hmac/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hmac/CHANGELOG.md
+++ b/code/packages/csharp/hmac/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# HMAC package for MD5, SHA-1, SHA-256, and SHA-512.
+- Include generic RFC 2104 construction, lowercase hex helpers, constant-time verification, and xUnit coverage.

--- a/code/packages/csharp/hmac/CodingAdventures.Hmac.csproj
+++ b/code/packages/csharp/hmac/CodingAdventures.Hmac.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Hmac.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hmac/Hmac.cs
+++ b/code/packages/csharp/hmac/Hmac.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Hmac;
+
+/// <summary>
+/// HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512.
+/// </summary>
+public static class Hmac
+{
+    private const byte Ipad = 0x36;
+    private const byte Opad = 0x5c;
+
+    /// <summary>Compute the RFC 2104 HMAC construction using a supplied hash function.</summary>
+    public static byte[] Compute(Func<byte[], byte[]> hashFunction, int blockSize, byte[] key, byte[] message)
+    {
+        ArgumentNullException.ThrowIfNull(hashFunction);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(message);
+
+        if (blockSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be positive.");
+        }
+
+        EnsureNonEmptyKey(key);
+
+        var keyPrime = NormalizeKey(hashFunction, blockSize, key);
+        var innerKey = new byte[blockSize];
+        var outerKey = new byte[blockSize];
+
+        for (var i = 0; i < blockSize; i++)
+        {
+            innerKey[i] = (byte)(keyPrime[i] ^ Ipad);
+            outerKey[i] = (byte)(keyPrime[i] ^ Opad);
+        }
+
+        var innerInput = Concat(innerKey, message);
+        var inner = hashFunction(innerInput);
+        return hashFunction(Concat(outerKey, inner));
+    }
+
+    /// <summary>Compute HMAC-MD5.</summary>
+    public static byte[] HmacMd5(byte[] key, byte[] message) =>
+        Compute(MD5.HashData, 64, key, message);
+
+    /// <summary>Compute HMAC-SHA1.</summary>
+    public static byte[] HmacSha1(byte[] key, byte[] message) =>
+        Compute(SHA1.HashData, 64, key, message);
+
+    /// <summary>Compute HMAC-SHA256.</summary>
+    public static byte[] HmacSha256(byte[] key, byte[] message) =>
+        Compute(SHA256.HashData, 64, key, message);
+
+    /// <summary>Compute HMAC-SHA512.</summary>
+    public static byte[] HmacSha512(byte[] key, byte[] message) =>
+        Compute(SHA512.HashData, 128, key, message);
+
+    /// <summary>Compute HMAC-MD5 and return lowercase hex.</summary>
+    public static string HmacMd5Hex(byte[] key, byte[] message) =>
+        ToHex(HmacMd5(key, message));
+
+    /// <summary>Compute HMAC-SHA1 and return lowercase hex.</summary>
+    public static string HmacSha1Hex(byte[] key, byte[] message) =>
+        ToHex(HmacSha1(key, message));
+
+    /// <summary>Compute HMAC-SHA256 and return lowercase hex.</summary>
+    public static string HmacSha256Hex(byte[] key, byte[] message) =>
+        ToHex(HmacSha256(key, message));
+
+    /// <summary>Compute HMAC-SHA512 and return lowercase hex.</summary>
+    public static string HmacSha512Hex(byte[] key, byte[] message) =>
+        ToHex(HmacSha512(key, message));
+
+    /// <summary>Compare two tags in constant time.</summary>
+    public static bool Verify(byte[] expected, byte[] actual)
+    {
+        ArgumentNullException.ThrowIfNull(expected);
+        ArgumentNullException.ThrowIfNull(actual);
+        return CryptographicOperations.FixedTimeEquals(expected, actual);
+    }
+
+    private static byte[] NormalizeKey(Func<byte[], byte[]> hashFunction, int blockSize, byte[] key)
+    {
+        var normalized = key.Length > blockSize ? hashFunction(key) : key.ToArray();
+        if (normalized.Length > blockSize)
+        {
+            throw new ArgumentException("Hash output must not exceed the HMAC block size.", nameof(hashFunction));
+        }
+
+        Array.Resize(ref normalized, blockSize);
+        return normalized;
+    }
+
+    private static byte[] Concat(byte[] left, byte[] right)
+    {
+        var result = new byte[left.Length + right.Length];
+        Buffer.BlockCopy(left, 0, result, 0, left.Length);
+        Buffer.BlockCopy(right, 0, result, left.Length, right.Length);
+        return result;
+    }
+
+    private static string ToHex(byte[] data) =>
+        Convert.ToHexString(data).ToLowerInvariant();
+
+    private static void EnsureNonEmptyKey(byte[] key)
+    {
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("HMAC key must not be empty.", nameof(key));
+        }
+    }
+}

--- a/code/packages/csharp/hmac/README.md
+++ b/code/packages/csharp/hmac/README.md
@@ -1,0 +1,14 @@
+# CodingAdventures.Hmac.CSharp
+
+HMAC helpers for .NET.
+
+The package provides named HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512, plus a generic RFC 2104 `Compute` helper and constant-time tag verification.
+
+```csharp
+using CodingAdventures.Hmac;
+
+byte[] tag = Hmac.HmacSha256("key"u8.ToArray(), "message"u8.ToArray());
+string hex = Hmac.HmacSha256Hex("key"u8.ToArray(), "message"u8.ToArray());
+
+bool ok = Hmac.Verify(tag, Hmac.HmacSha256("key"u8.ToArray(), "message"u8.ToArray()));
+```

--- a/code/packages/csharp/hmac/required_capabilities.json
+++ b/code/packages/csharp/hmac/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/hmac",
+  "capabilities": [],
+  "justification": "Pure in-memory message authentication using .NET hash primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj
+++ b/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Hmac.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.cs
+++ b/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.cs
@@ -1,0 +1,99 @@
+using System.Security.Cryptography;
+using System.Text;
+using HmacAlgorithm = CodingAdventures.Hmac.Hmac;
+
+namespace CodingAdventures.Hmac.Tests;
+
+public sealed class HmacTests
+{
+    [Fact]
+    public void HmacSha256MatchesRfc4231Vectors()
+    {
+        Assert.Equal(
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+            HmacAlgorithm.HmacSha256Hex(Enumerable.Repeat((byte)0x0b, 20).ToArray(), "Hi There"u8.ToArray()));
+        Assert.Equal(
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+            HmacAlgorithm.HmacSha256Hex("Jefe"u8.ToArray(), Encoding.ASCII.GetBytes("what do ya want for nothing?")));
+    }
+
+    [Fact]
+    public void HmacSha512MatchesRfc4231Vectors()
+    {
+        Assert.Equal(
+            "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854",
+            HmacAlgorithm.HmacSha512Hex(Enumerable.Repeat((byte)0x0b, 20).ToArray(), "Hi There"u8.ToArray()));
+        Assert.Equal(
+            "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737",
+            HmacAlgorithm.HmacSha512Hex("Jefe"u8.ToArray(), Encoding.ASCII.GetBytes("what do ya want for nothing?")));
+    }
+
+    [Fact]
+    public void LegacyVariantsMatchRfc2202Vectors()
+    {
+        var key = Enumerable.Repeat((byte)0x0b, 16).ToArray();
+        Assert.Equal("9294727a3638bb1c13f48ef8158bfc9d", HmacAlgorithm.HmacMd5Hex(key, "Hi There"u8.ToArray()));
+
+        var sha1Key = Enumerable.Repeat((byte)0x0b, 20).ToArray();
+        Assert.Equal("b617318655057264e28bc0b6fb378c8ef146be00", HmacAlgorithm.HmacSha1Hex(sha1Key, "Hi There"u8.ToArray()));
+        Assert.Equal("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79", HmacAlgorithm.HmacSha1Hex("Jefe"u8.ToArray(), Encoding.ASCII.GetBytes("what do ya want for nothing?")));
+    }
+
+    [Fact]
+    public void ReturnLengthsMatchHashFamilies()
+    {
+        var key = "key"u8.ToArray();
+        var message = "message"u8.ToArray();
+
+        Assert.Equal(16, HmacAlgorithm.HmacMd5(key, message).Length);
+        Assert.Equal(20, HmacAlgorithm.HmacSha1(key, message).Length);
+        Assert.Equal(32, HmacAlgorithm.HmacSha256(key, message).Length);
+        Assert.Equal(64, HmacAlgorithm.HmacSha512(key, message).Length);
+        Assert.Equal(64, HmacAlgorithm.HmacSha256Hex(key, message).Length);
+        Assert.Equal(128, HmacAlgorithm.HmacSha512Hex(key, message).Length);
+    }
+
+    [Fact]
+    public void GenericComputeMatchesNamedVariant()
+    {
+        var key = Enumerable.Repeat((byte)0x01, 100).ToArray();
+        var message = "msg"u8.ToArray();
+
+        Assert.Equal(HmacAlgorithm.HmacSha256(key, message), HmacAlgorithm.Compute(SHA256.HashData, 64, key, message));
+        Assert.Equal(HmacAlgorithm.HmacSha512(key, message), HmacAlgorithm.Compute(SHA512.HashData, 128, key, message));
+    }
+
+    [Fact]
+    public void VerifyUsesConstantTimeComparisonSemantics()
+    {
+        var tag = HmacAlgorithm.HmacSha256("key"u8.ToArray(), "message"u8.ToArray());
+
+        Assert.True(HmacAlgorithm.Verify(tag, tag.ToArray()));
+        Assert.False(HmacAlgorithm.Verify(tag, HmacAlgorithm.HmacSha256("key2"u8.ToArray(), "message"u8.ToArray())));
+        Assert.False(HmacAlgorithm.Verify(tag, tag[..^1]));
+    }
+
+    [Fact]
+    public void EmptyKeyIsRejectedButEmptyMessageIsAllowed()
+    {
+        Assert.Throws<ArgumentException>(() => HmacAlgorithm.HmacSha256([], "message"u8.ToArray()));
+        Assert.Equal(32, HmacAlgorithm.HmacSha256("key"u8.ToArray(), []).Length);
+    }
+
+    [Fact]
+    public void NullInputsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => HmacAlgorithm.Compute(null!, 64, "key"u8.ToArray(), "message"u8.ToArray()));
+        Assert.Throws<ArgumentNullException>(() => HmacAlgorithm.HmacSha256(null!, "message"u8.ToArray()));
+        Assert.Throws<ArgumentNullException>(() => HmacAlgorithm.HmacSha256("key"u8.ToArray(), null!));
+        Assert.Throws<ArgumentNullException>(() => HmacAlgorithm.Verify(null!, []));
+        Assert.Throws<ArgumentNullException>(() => HmacAlgorithm.Verify([], null!));
+    }
+
+    [Fact]
+    public void InvalidBlockSizeIsRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            HmacAlgorithm.Compute(SHA256.HashData, 0, "key"u8.ToArray(), "message"u8.ToArray()));
+    }
+}

--- a/code/packages/fsharp/hmac/BUILD
+++ b/code/packages/fsharp/hmac/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hmac/BUILD_windows
+++ b/code/packages/fsharp/hmac/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hmac/CHANGELOG.md
+++ b/code/packages/fsharp/hmac/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# HMAC package for MD5, SHA-1, SHA-256, and SHA-512.
+- Include generic RFC 2104 construction, lowercase hex helpers, constant-time verification, and xUnit coverage.

--- a/code/packages/fsharp/hmac/CodingAdventures.Hmac.fsproj
+++ b/code/packages/fsharp/hmac/CodingAdventures.Hmac.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Hmac.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Hmac.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hmac/Hmac.fs
+++ b/code/packages/fsharp/hmac/Hmac.fs
@@ -1,0 +1,64 @@
+namespace CodingAdventures.Hmac.FSharp
+
+open System
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Hmac =
+    let private ipad = 0x36uy
+    let private opad = 0x5cuy
+
+    let private ensureNonEmptyKey (key: byte array) =
+        if key.Length = 0 then invalidArg "key" "HMAC key must not be empty."
+
+    let private concat (left: byte array) (right: byte array) =
+        Array.concat [ left; right ]
+
+    let private normalizeKey (hashFunction: byte array -> byte array) blockSize (key: byte array) =
+        let normalized =
+            if key.Length > blockSize then
+                hashFunction key
+            else
+                Array.copy key
+
+        if normalized.Length > blockSize then
+            invalidArg "hashFunction" "Hash output must not exceed the HMAC block size."
+
+        Array.append normalized (Array.zeroCreate (blockSize - normalized.Length))
+
+    let compute (hashFunction: byte array -> byte array) blockSize (key: byte array) (message: byte array) =
+        if isNull (box hashFunction) then nullArg "hashFunction"
+        if isNull key then nullArg "key"
+        if isNull message then nullArg "message"
+        if blockSize <= 0 then invalidArg "blockSize" "Block size must be positive."
+        ensureNonEmptyKey key
+
+        let keyPrime = normalizeKey hashFunction blockSize key
+        let innerKey = keyPrime |> Array.map (fun value -> value ^^^ ipad)
+        let outerKey = keyPrime |> Array.map (fun value -> value ^^^ opad)
+        let inner = hashFunction (concat innerKey message)
+        hashFunction (concat outerKey inner)
+
+    let hmacMd5 key message = compute MD5.HashData 64 key message
+
+    let hmacSha1 key message = compute SHA1.HashData 64 key message
+
+    let hmacSha256 key message = compute SHA256.HashData 64 key message
+
+    let hmacSha512 key message = compute SHA512.HashData 128 key message
+
+    let private toHex (data: byte array) =
+        Convert.ToHexString(data).ToLowerInvariant()
+
+    let hmacMd5Hex key message = hmacMd5 key message |> toHex
+
+    let hmacSha1Hex key message = hmacSha1 key message |> toHex
+
+    let hmacSha256Hex key message = hmacSha256 key message |> toHex
+
+    let hmacSha512Hex key message = hmacSha512 key message |> toHex
+
+    let verify (expected: byte array) (actual: byte array) =
+        if isNull expected then nullArg "expected"
+        if isNull actual then nullArg "actual"
+        CryptographicOperations.FixedTimeEquals(expected, actual)

--- a/code/packages/fsharp/hmac/README.md
+++ b/code/packages/fsharp/hmac/README.md
@@ -1,0 +1,14 @@
+# CodingAdventures.Hmac.FSharp
+
+HMAC helpers for .NET.
+
+The package provides named HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512, plus a generic RFC 2104 `compute` helper and constant-time tag verification.
+
+```fsharp
+open CodingAdventures.Hmac.FSharp
+
+let tag = Hmac.hmacSha256 "key"B "message"B
+let hex = Hmac.hmacSha256Hex "key"B "message"B
+
+let ok = Hmac.verify tag (Hmac.hmacSha256 "key"B "message"B)
+```

--- a/code/packages/fsharp/hmac/required_capabilities.json
+++ b/code/packages/fsharp/hmac/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/hmac",
+  "capabilities": [],
+  "justification": "Pure in-memory message authentication using .NET hash primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj
+++ b/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Hmac.fsproj" />
+    <Compile Include="HmacTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.fs
+++ b/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.fs
@@ -1,0 +1,79 @@
+namespace CodingAdventures.Hmac.Tests
+
+open System
+open System.Security.Cryptography
+open System.Text
+open Xunit
+open CodingAdventures.Hmac.FSharp
+
+module HmacTests =
+    [<Fact>]
+    let ``hmac sha256 matches RFC 4231 vectors`` () =
+        Assert.Equal(
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+            Hmac.hmacSha256Hex (Array.create 20 0x0buy) "Hi There"B)
+        Assert.Equal(
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+            Hmac.hmacSha256Hex "Jefe"B (Encoding.ASCII.GetBytes "what do ya want for nothing?"))
+
+    [<Fact>]
+    let ``hmac sha512 matches RFC 4231 vectors`` () =
+        Assert.Equal(
+            "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854",
+            Hmac.hmacSha512Hex (Array.create 20 0x0buy) "Hi There"B)
+        Assert.Equal(
+            "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737",
+            Hmac.hmacSha512Hex "Jefe"B (Encoding.ASCII.GetBytes "what do ya want for nothing?"))
+
+    [<Fact>]
+    let ``legacy variants match RFC 2202 vectors`` () =
+        Assert.Equal("9294727a3638bb1c13f48ef8158bfc9d", Hmac.hmacMd5Hex (Array.create 16 0x0buy) "Hi There"B)
+        Assert.Equal("b617318655057264e28bc0b6fb378c8ef146be00", Hmac.hmacSha1Hex (Array.create 20 0x0buy) "Hi There"B)
+        Assert.Equal("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79", Hmac.hmacSha1Hex "Jefe"B (Encoding.ASCII.GetBytes "what do ya want for nothing?"))
+
+    [<Fact>]
+    let ``return lengths match hash families`` () =
+        let key = "key"B
+        let message = "message"B
+
+        Assert.Equal(16, (Hmac.hmacMd5 key message).Length)
+        Assert.Equal(20, (Hmac.hmacSha1 key message).Length)
+        Assert.Equal(32, (Hmac.hmacSha256 key message).Length)
+        Assert.Equal(64, (Hmac.hmacSha512 key message).Length)
+        Assert.Equal(64, (Hmac.hmacSha256Hex key message).Length)
+        Assert.Equal(128, (Hmac.hmacSha512Hex key message).Length)
+
+    [<Fact>]
+    let ``generic compute matches named variant`` () =
+        let key = Array.create 100 0x01uy
+        let message = "msg"B
+
+        Assert.Equal<byte array>(Hmac.hmacSha256 key message, Hmac.compute SHA256.HashData 64 key message)
+        Assert.Equal<byte array>(Hmac.hmacSha512 key message, Hmac.compute SHA512.HashData 128 key message)
+
+    [<Fact>]
+    let ``verify uses constant time comparison semantics`` () =
+        let tag = Hmac.hmacSha256 "key"B "message"B
+
+        Assert.True(Hmac.verify tag (Array.copy tag))
+        Assert.False(Hmac.verify tag (Hmac.hmacSha256 "key2"B "message"B))
+        Assert.False(Hmac.verify tag tag.[0 .. tag.Length - 2])
+
+    [<Fact>]
+    let ``empty key is rejected but empty message is allowed`` () =
+        Assert.Throws<ArgumentException>(fun () -> Hmac.hmacSha256 [||] "message"B |> ignore) |> ignore
+        Assert.Equal(32, (Hmac.hmacSha256 "key"B [||]).Length)
+
+    [<Fact>]
+    let ``null inputs are rejected`` () =
+        let nullHash = Unchecked.defaultof<byte array -> byte array>
+        Assert.Throws<ArgumentNullException>(fun () -> Hmac.compute nullHash 64 "key"B "message"B |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hmac.hmacSha256 null "message"B |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hmac.hmacSha256 "key"B null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hmac.verify null [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hmac.verify [||] null |> ignore) |> ignore
+
+    [<Fact>]
+    let ``invalid block size is rejected`` () =
+        Assert.Throws<ArgumentException>(fun () -> Hmac.compute SHA256.HashData 0 "key"B "message"B |> ignore)
+        |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# HMAC packages for MD5, SHA-1, SHA-256, and SHA-512
- expose generic RFC 2104 compute helpers, named byte/hex helpers, empty-key validation, and constant-time tag verification
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\hmac\tests\CodingAdventures.Hmac.Tests\CodingAdventures.Hmac.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\hmac\tests\CodingAdventures.Hmac.Tests\CodingAdventures.Hmac.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line