### PR TITLE
feat(parity): add dotnet pbkdf2 packages

### DIFF
--- a/code/packages/csharp/pbkdf2/BUILD
+++ b/code/packages/csharp/pbkdf2/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/pbkdf2/BUILD_windows
+++ b/code/packages/csharp/pbkdf2/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/pbkdf2/CHANGELOG.md
+++ b/code/packages/csharp/pbkdf2/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# PBKDF2 package backed by `Rfc2898DeriveBytes.Pbkdf2`.
+- Include SHA-1, SHA-256, SHA-512, hex helpers, validation, and xUnit coverage.

--- a/code/packages/csharp/pbkdf2/CodingAdventures.Pbkdf2.csproj
+++ b/code/packages/csharp/pbkdf2/CodingAdventures.Pbkdf2.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Pbkdf2.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>PBKDF2 key derivation helpers for HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/pbkdf2/Pbkdf2.cs
+++ b/code/packages/csharp/pbkdf2/Pbkdf2.cs
@@ -1,0 +1,78 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Pbkdf2;
+
+/// <summary>
+/// PBKDF2 key derivation helpers for HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512.
+/// </summary>
+public static class Pbkdf2
+{
+    private const int MaxKeyLength = 1 << 20;
+
+    /// <summary>Derive key material using PBKDF2 and a specific HMAC hash algorithm.</summary>
+    public static byte[] Derive(
+        byte[] password,
+        byte[] salt,
+        int iterations,
+        int keyLength,
+        HashAlgorithmName hashAlgorithm,
+        bool allowEmptyPassword = false)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+        ArgumentNullException.ThrowIfNull(salt);
+
+        if (!allowEmptyPassword && password.Length == 0)
+        {
+            throw new ArgumentException("PBKDF2 password must not be empty.", nameof(password));
+        }
+
+        if (iterations <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(iterations), "Iterations must be positive.");
+        }
+
+        if (keyLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keyLength), "Key length must be positive.");
+        }
+
+        if (keyLength > MaxKeyLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keyLength), "Key length must not exceed 2^20 bytes.");
+        }
+
+        return Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keyLength);
+    }
+
+    /// <summary>Derive key material using PBKDF2-HMAC-SHA1.</summary>
+    public static byte[] Pbkdf2HmacSha1(byte[] password, byte[] salt, int iterations, int keyLength) =>
+        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA1);
+
+    /// <summary>Derive key material using PBKDF2-HMAC-SHA256.</summary>
+    public static byte[] Pbkdf2HmacSha256(
+        byte[] password,
+        byte[] salt,
+        int iterations,
+        int keyLength,
+        bool allowEmptyPassword = false) =>
+        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA256, allowEmptyPassword);
+
+    /// <summary>Derive key material using PBKDF2-HMAC-SHA512.</summary>
+    public static byte[] Pbkdf2HmacSha512(byte[] password, byte[] salt, int iterations, int keyLength) =>
+        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA512);
+
+    /// <summary>Derive PBKDF2-HMAC-SHA1 and return lowercase hex.</summary>
+    public static string Pbkdf2HmacSha1Hex(byte[] password, byte[] salt, int iterations, int keyLength) =>
+        ToHex(Pbkdf2HmacSha1(password, salt, iterations, keyLength));
+
+    /// <summary>Derive PBKDF2-HMAC-SHA256 and return lowercase hex.</summary>
+    public static string Pbkdf2HmacSha256Hex(byte[] password, byte[] salt, int iterations, int keyLength) =>
+        ToHex(Pbkdf2HmacSha256(password, salt, iterations, keyLength));
+
+    /// <summary>Derive PBKDF2-HMAC-SHA512 and return lowercase hex.</summary>
+    public static string Pbkdf2HmacSha512Hex(byte[] password, byte[] salt, int iterations, int keyLength) =>
+        ToHex(Pbkdf2HmacSha512(password, salt, iterations, keyLength));
+
+    private static string ToHex(byte[] data) =>
+        Convert.ToHexString(data).ToLowerInvariant();
+}

--- a/code/packages/csharp/pbkdf2/README.md
+++ b/code/packages/csharp/pbkdf2/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Pbkdf2.CSharp
+
+PBKDF2 key derivation helpers for .NET, backed by `Rfc2898DeriveBytes.Pbkdf2`.
+
+```csharp
+using CodingAdventures.Pbkdf2;
+
+byte[] key = Pbkdf2.Pbkdf2HmacSha256("password"u8.ToArray(), "salt"u8.ToArray(), 100_000, 32);
+string hex = Pbkdf2.Pbkdf2HmacSha256Hex("password"u8.ToArray(), "salt"u8.ToArray(), 100_000, 32);
+```

--- a/code/packages/csharp/pbkdf2/required_capabilities.json
+++ b/code/packages/csharp/pbkdf2/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/pbkdf2",
+  "capabilities": [],
+  "justification": "Pure in-memory key derivation using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj
+++ b/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Pbkdf2.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/Pbkdf2Tests.cs
+++ b/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/Pbkdf2Tests.cs
@@ -1,0 +1,86 @@
+using Pbkdf2Algorithm = CodingAdventures.Pbkdf2.Pbkdf2;
+
+namespace CodingAdventures.Pbkdf2.Tests;
+
+public sealed class Pbkdf2Tests
+{
+    [Fact]
+    public void Sha1MatchesRfc6070Vectors()
+    {
+        Assert.Equal(
+            "0c60c80f961f0e71f3a9b524af6012062fe037a6",
+            Pbkdf2Algorithm.Pbkdf2HmacSha1Hex("password"u8.ToArray(), "salt"u8.ToArray(), 1, 20));
+        Assert.Equal(
+            "4b007901b765489abead49d926f721d065a429c1",
+            Pbkdf2Algorithm.Pbkdf2HmacSha1Hex("password"u8.ToArray(), "salt"u8.ToArray(), 4096, 20));
+        Assert.Equal(
+            "56fa6aa75548099dcc37d7f03425e0c3",
+            Pbkdf2Algorithm.Pbkdf2HmacSha1Hex("pass\0word"u8.ToArray(), "sa\0lt"u8.ToArray(), 4096, 16));
+    }
+
+    [Fact]
+    public void Sha256MatchesKnownVectorAndCanExtendPastOneBlock()
+    {
+        var key = Pbkdf2Algorithm.Pbkdf2HmacSha256("passwd"u8.ToArray(), "salt"u8.ToArray(), 1, 64);
+        Assert.Equal(
+            "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783",
+            Convert.ToHexString(key).ToLowerInvariant());
+
+        Assert.Equal(
+            Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), "salt"u8.ToArray(), 1, 32),
+            Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), "salt"u8.ToArray(), 1, 64)[..32]);
+    }
+
+    [Fact]
+    public void Sha512SupportsCustomKeyLengths()
+    {
+        var full = Pbkdf2Algorithm.Pbkdf2HmacSha512("secret"u8.ToArray(), "nacl"u8.ToArray(), 1, 64);
+        var shortKey = Pbkdf2Algorithm.Pbkdf2HmacSha512("secret"u8.ToArray(), "nacl"u8.ToArray(), 1, 32);
+
+        Assert.Equal(64, full.Length);
+        Assert.Equal(shortKey, full[..32]);
+        Assert.Equal(128, Pbkdf2Algorithm.Pbkdf2HmacSha512("key"u8.ToArray(), "salt"u8.ToArray(), 1, 128).Length);
+    }
+
+    [Fact]
+    public void HexHelpersMatchByteOutput()
+    {
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2Algorithm.Pbkdf2HmacSha1("password"u8.ToArray(), "salt"u8.ToArray(), 1, 20)).ToLowerInvariant(),
+            Pbkdf2Algorithm.Pbkdf2HmacSha1Hex("password"u8.ToArray(), "salt"u8.ToArray(), 1, 20));
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2Algorithm.Pbkdf2HmacSha256("passwd"u8.ToArray(), "salt"u8.ToArray(), 1, 32)).ToLowerInvariant(),
+            Pbkdf2Algorithm.Pbkdf2HmacSha256Hex("passwd"u8.ToArray(), "salt"u8.ToArray(), 1, 32));
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2Algorithm.Pbkdf2HmacSha512("secret"u8.ToArray(), "nacl"u8.ToArray(), 1, 64)).ToLowerInvariant(),
+            Pbkdf2Algorithm.Pbkdf2HmacSha512Hex("secret"u8.ToArray(), "nacl"u8.ToArray(), 1, 64));
+    }
+
+    [Fact]
+    public void ValidationRejectsInvalidInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256(null!, "salt"u8.ToArray(), 1, 32));
+        Assert.Throws<ArgumentNullException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), null!, 1, 32));
+        Assert.Throws<ArgumentException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256([], "salt"u8.ToArray(), 1, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256("pw"u8.ToArray(), "salt"u8.ToArray(), 0, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256("pw"u8.ToArray(), "salt"u8.ToArray(), 1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Pbkdf2Algorithm.Pbkdf2HmacSha256("pw"u8.ToArray(), "salt"u8.ToArray(), 1, (1 << 20) + 1));
+    }
+
+    [Fact]
+    public void EmptySaltIsAllowedAndEmptyPasswordCanBeExplicitlyAllowed()
+    {
+        Assert.Equal(32, Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), [], 1, 32).Length);
+        Assert.Equal(32, Pbkdf2Algorithm.Pbkdf2HmacSha256([], "salt"u8.ToArray(), 1, 32, allowEmptyPassword: true).Length);
+    }
+
+    [Fact]
+    public void SaltPasswordAndIterationsAffectOutput()
+    {
+        var baseKey = Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), "salt"u8.ToArray(), 1, 32);
+
+        Assert.NotEqual(baseKey, Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), "salt2"u8.ToArray(), 1, 32));
+        Assert.NotEqual(baseKey, Pbkdf2Algorithm.Pbkdf2HmacSha256("password2"u8.ToArray(), "salt"u8.ToArray(), 1, 32));
+        Assert.NotEqual(baseKey, Pbkdf2Algorithm.Pbkdf2HmacSha256("password"u8.ToArray(), "salt"u8.ToArray(), 2, 32));
+    }
+}

--- a/code/packages/fsharp/pbkdf2/BUILD
+++ b/code/packages/fsharp/pbkdf2/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/pbkdf2/BUILD_windows
+++ b/code/packages/fsharp/pbkdf2/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/pbkdf2/CHANGELOG.md
+++ b/code/packages/fsharp/pbkdf2/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# PBKDF2 package backed by `Rfc2898DeriveBytes.Pbkdf2`.
+- Include SHA-1, SHA-256, SHA-512, hex helpers, validation, and xUnit coverage.

--- a/code/packages/fsharp/pbkdf2/CodingAdventures.Pbkdf2.fsproj
+++ b/code/packages/fsharp/pbkdf2/CodingAdventures.Pbkdf2.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Pbkdf2.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>PBKDF2 key derivation helpers for HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Pbkdf2.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/pbkdf2/Pbkdf2.fs
+++ b/code/packages/fsharp/pbkdf2/Pbkdf2.fs
@@ -1,0 +1,43 @@
+namespace CodingAdventures.Pbkdf2.FSharp
+
+open System
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Pbkdf2 =
+    let private maxKeyLength = 1 <<< 20
+
+    let derive (password: byte array) (salt: byte array) iterations keyLength hashAlgorithm allowEmptyPassword =
+        if isNull password then nullArg "password"
+        if isNull salt then nullArg "salt"
+        if not allowEmptyPassword && password.Length = 0 then
+            invalidArg "password" "PBKDF2 password must not be empty."
+        if iterations <= 0 then invalidArg "iterations" "Iterations must be positive."
+        if keyLength <= 0 then invalidArg "keyLength" "Key length must be positive."
+        if keyLength > maxKeyLength then invalidArg "keyLength" "Key length must not exceed 2^20 bytes."
+
+        Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keyLength)
+
+    let pbkdf2HmacSha1 password salt iterations keyLength =
+        derive password salt iterations keyLength HashAlgorithmName.SHA1 false
+
+    let pbkdf2HmacSha256 password salt iterations keyLength =
+        derive password salt iterations keyLength HashAlgorithmName.SHA256 false
+
+    let pbkdf2HmacSha256AllowEmptyPassword password salt iterations keyLength =
+        derive password salt iterations keyLength HashAlgorithmName.SHA256 true
+
+    let pbkdf2HmacSha512 password salt iterations keyLength =
+        derive password salt iterations keyLength HashAlgorithmName.SHA512 false
+
+    let private toHex (data: byte array) =
+        Convert.ToHexString(data).ToLowerInvariant()
+
+    let pbkdf2HmacSha1Hex password salt iterations keyLength =
+        pbkdf2HmacSha1 password salt iterations keyLength |> toHex
+
+    let pbkdf2HmacSha256Hex password salt iterations keyLength =
+        pbkdf2HmacSha256 password salt iterations keyLength |> toHex
+
+    let pbkdf2HmacSha512Hex password salt iterations keyLength =
+        pbkdf2HmacSha512 password salt iterations keyLength |> toHex

--- a/code/packages/fsharp/pbkdf2/README.md
+++ b/code/packages/fsharp/pbkdf2/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Pbkdf2.FSharp
+
+PBKDF2 key derivation helpers for .NET, backed by `Rfc2898DeriveBytes.Pbkdf2`.
+
+```fsharp
+open CodingAdventures.Pbkdf2.FSharp
+
+let key = Pbkdf2.pbkdf2HmacSha256 "password"B "salt"B 100_000 32
+let hex = Pbkdf2.pbkdf2HmacSha256Hex "password"B "salt"B 100_000 32
+```

--- a/code/packages/fsharp/pbkdf2/required_capabilities.json
+++ b/code/packages/fsharp/pbkdf2/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/pbkdf2",
+  "capabilities": [],
+  "justification": "Pure in-memory key derivation using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj
+++ b/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Pbkdf2.fsproj" />
+    <Compile Include="Pbkdf2Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/Pbkdf2Tests.fs
+++ b/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/Pbkdf2Tests.fs
@@ -1,0 +1,73 @@
+namespace CodingAdventures.Pbkdf2.Tests
+
+open System
+open Xunit
+open CodingAdventures.Pbkdf2.FSharp
+
+module Pbkdf2Tests =
+    [<Fact>]
+    let ``sha1 matches RFC 6070 vectors`` () =
+        Assert.Equal(
+            "0c60c80f961f0e71f3a9b524af6012062fe037a6",
+            Pbkdf2.pbkdf2HmacSha1Hex "password"B "salt"B 1 20)
+        Assert.Equal(
+            "4b007901b765489abead49d926f721d065a429c1",
+            Pbkdf2.pbkdf2HmacSha1Hex "password"B "salt"B 4096 20)
+        Assert.Equal(
+            "56fa6aa75548099dcc37d7f03425e0c3",
+            Pbkdf2.pbkdf2HmacSha1Hex "pass\000word"B "sa\000lt"B 4096 16)
+
+    [<Fact>]
+    let ``sha256 matches known vector and can extend past one block`` () =
+        let key = Pbkdf2.pbkdf2HmacSha256 "passwd"B "salt"B 1 64
+
+        Assert.Equal(
+            "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783",
+            Convert.ToHexString(key).ToLowerInvariant())
+
+        Assert.Equal<byte array>(
+            Pbkdf2.pbkdf2HmacSha256 "password"B "salt"B 1 32,
+            (Pbkdf2.pbkdf2HmacSha256 "password"B "salt"B 1 64).[0..31])
+
+    [<Fact>]
+    let ``sha512 supports custom key lengths`` () =
+        let full = Pbkdf2.pbkdf2HmacSha512 "secret"B "nacl"B 1 64
+        let shortKey = Pbkdf2.pbkdf2HmacSha512 "secret"B "nacl"B 1 32
+
+        Assert.Equal(64, full.Length)
+        Assert.Equal<byte array>(shortKey, full.[0..31])
+        Assert.Equal(128, (Pbkdf2.pbkdf2HmacSha512 "key"B "salt"B 1 128).Length)
+
+    [<Fact>]
+    let ``hex helpers match byte output`` () =
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2.pbkdf2HmacSha1 "password"B "salt"B 1 20).ToLowerInvariant(),
+            Pbkdf2.pbkdf2HmacSha1Hex "password"B "salt"B 1 20)
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2.pbkdf2HmacSha256 "passwd"B "salt"B 1 32).ToLowerInvariant(),
+            Pbkdf2.pbkdf2HmacSha256Hex "passwd"B "salt"B 1 32)
+        Assert.Equal(
+            Convert.ToHexString(Pbkdf2.pbkdf2HmacSha512 "secret"B "nacl"B 1 64).ToLowerInvariant(),
+            Pbkdf2.pbkdf2HmacSha512Hex "secret"B "nacl"B 1 64)
+
+    [<Fact>]
+    let ``validation rejects invalid inputs`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Pbkdf2.pbkdf2HmacSha256 null "salt"B 1 32 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Pbkdf2.pbkdf2HmacSha256 "password"B null 1 32 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Pbkdf2.pbkdf2HmacSha256 [||] "salt"B 1 32 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Pbkdf2.pbkdf2HmacSha256 "pw"B "salt"B 0 32 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Pbkdf2.pbkdf2HmacSha256 "pw"B "salt"B 1 0 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Pbkdf2.pbkdf2HmacSha256 "pw"B "salt"B 1 ((1 <<< 20) + 1) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``empty salt is allowed and empty password can be explicitly allowed`` () =
+        Assert.Equal(32, (Pbkdf2.pbkdf2HmacSha256 "password"B [||] 1 32).Length)
+        Assert.Equal(32, (Pbkdf2.pbkdf2HmacSha256AllowEmptyPassword [||] "salt"B 1 32).Length)
+
+    [<Fact>]
+    let ``salt password and iterations affect output`` () =
+        let baseKey = Pbkdf2.pbkdf2HmacSha256 "password"B "salt"B 1 32
+
+        Assert.NotEqual<byte array>(baseKey, Pbkdf2.pbkdf2HmacSha256 "password"B "salt2"B 1 32)
+        Assert.NotEqual<byte array>(baseKey, Pbkdf2.pbkdf2HmacSha256 "password2"B "salt"B 1 32)
+        Assert.NotEqual<byte array>(baseKey, Pbkdf2.pbkdf2HmacSha256 "password"B "salt"B 2 32)


### PR DESCRIPTION
## Summary
- add native C# and F# PBKDF2 packages backed by `Rfc2898DeriveBytes.Pbkdf2`
- expose SHA-1, SHA-256, and SHA-512 byte/hex helpers with password, iteration, and key-length validation
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\pbkdf2\tests\CodingAdventures.Pbkdf2.Tests\CodingAdventures.Pbkdf2.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\pbkdf2\tests\CodingAdventures.Pbkdf2.Tests\CodingAdventures.Pbkdf2.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line