### PR TITLE
feat(parity): add dotnet hkdf packages

### DIFF
--- a/code/packages/csharp/hkdf/BUILD
+++ b/code/packages/csharp/hkdf/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hkdf/BUILD_windows
+++ b/code/packages/csharp/hkdf/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hkdf/CHANGELOG.md
+++ b/code/packages/csharp/hkdf/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# HKDF package for SHA-256 and SHA-512.
+- Include extract, expand, derive, validation, RFC 5869 vectors, and xUnit coverage.

--- a/code/packages/csharp/hkdf/CodingAdventures.Hkdf.csproj
+++ b/code/packages/csharp/hkdf/CodingAdventures.Hkdf.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Hkdf.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HKDF extract-and-expand helpers for SHA-256 and SHA-512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hkdf/Hkdf.cs
+++ b/code/packages/csharp/hkdf/Hkdf.cs
@@ -1,0 +1,116 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Hkdf;
+
+/// <summary>Hash families supported by the HKDF helpers.</summary>
+public enum HkdfHash
+{
+    /// <summary>HKDF-HMAC-SHA256.</summary>
+    Sha256,
+
+    /// <summary>HKDF-HMAC-SHA512.</summary>
+    Sha512,
+}
+
+/// <summary>
+/// HKDF extract-and-expand helpers from RFC 5869.
+/// </summary>
+public static class Hkdf
+{
+    /// <summary>HKDF-Extract: concentrate input keying material into a pseudorandom key.</summary>
+    public static byte[] Extract(byte[] salt, byte[] ikm, HkdfHash hash = HkdfHash.Sha256)
+    {
+        ArgumentNullException.ThrowIfNull(salt);
+        ArgumentNullException.ThrowIfNull(ikm);
+
+        var hashLength = HashLength(hash);
+        var actualSalt = salt.Length == 0 ? new byte[hashLength] : salt;
+        using var hmac = CreateHmac(hash, actualSalt);
+        return hmac.ComputeHash(ikm);
+    }
+
+    /// <summary>HKDF-Expand: derive output keying material from a pseudorandom key.</summary>
+    public static byte[] Expand(byte[] prk, byte[] info, int length, HkdfHash hash = HkdfHash.Sha256)
+    {
+        ArgumentNullException.ThrowIfNull(prk);
+        ArgumentNullException.ThrowIfNull(info);
+
+        var hashLength = HashLength(hash);
+        if (length <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "HKDF output length must be positive.");
+        }
+
+        var maxLength = 255 * hashLength;
+        if (length > maxLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), $"HKDF output length must not exceed {maxLength} bytes.");
+        }
+
+        var okm = new byte[length];
+        var previous = Array.Empty<byte>();
+        var offset = 0;
+        var counter = 1;
+
+        while (offset < length)
+        {
+            using var hmac = CreateHmac(hash, prk);
+            var input = new byte[previous.Length + info.Length + 1];
+            Buffer.BlockCopy(previous, 0, input, 0, previous.Length);
+            Buffer.BlockCopy(info, 0, input, previous.Length, info.Length);
+            input[^1] = (byte)counter;
+
+            previous = hmac.ComputeHash(input);
+            var toCopy = Math.Min(previous.Length, length - offset);
+            Buffer.BlockCopy(previous, 0, okm, offset, toCopy);
+            offset += toCopy;
+            counter++;
+        }
+
+        return okm;
+    }
+
+    /// <summary>HKDF extract followed by expand.</summary>
+    public static byte[] Derive(byte[] salt, byte[] ikm, byte[] info, int length, HkdfHash hash = HkdfHash.Sha256) =>
+        Expand(Extract(salt, ikm, hash), info, length, hash);
+
+    /// <summary>SHA-256 HKDF-Extract convenience helper.</summary>
+    public static byte[] ExtractSha256(byte[] salt, byte[] ikm) =>
+        Extract(salt, ikm, HkdfHash.Sha256);
+
+    /// <summary>SHA-256 HKDF-Expand convenience helper.</summary>
+    public static byte[] ExpandSha256(byte[] prk, byte[] info, int length) =>
+        Expand(prk, info, length, HkdfHash.Sha256);
+
+    /// <summary>SHA-256 HKDF convenience helper.</summary>
+    public static byte[] DeriveSha256(byte[] salt, byte[] ikm, byte[] info, int length) =>
+        Derive(salt, ikm, info, length, HkdfHash.Sha256);
+
+    /// <summary>SHA-512 HKDF-Extract convenience helper.</summary>
+    public static byte[] ExtractSha512(byte[] salt, byte[] ikm) =>
+        Extract(salt, ikm, HkdfHash.Sha512);
+
+    /// <summary>SHA-512 HKDF-Expand convenience helper.</summary>
+    public static byte[] ExpandSha512(byte[] prk, byte[] info, int length) =>
+        Expand(prk, info, length, HkdfHash.Sha512);
+
+    /// <summary>SHA-512 HKDF convenience helper.</summary>
+    public static byte[] DeriveSha512(byte[] salt, byte[] ikm, byte[] info, int length) =>
+        Derive(salt, ikm, info, length, HkdfHash.Sha512);
+
+    private static HMAC CreateHmac(HkdfHash hash, byte[] key) =>
+        hash switch
+        {
+            HkdfHash.Sha256 => new HMACSHA256(key),
+            HkdfHash.Sha512 => new HMACSHA512(key),
+            _ => throw new ArgumentOutOfRangeException(nameof(hash), "Unsupported HKDF hash algorithm."),
+        };
+
+    private static int HashLength(HkdfHash hash) =>
+        hash switch
+        {
+            HkdfHash.Sha256 => 32,
+            HkdfHash.Sha512 => 64,
+            _ => throw new ArgumentOutOfRangeException(nameof(hash), "Unsupported HKDF hash algorithm."),
+        };
+}

--- a/code/packages/csharp/hkdf/README.md
+++ b/code/packages/csharp/hkdf/README.md
@@ -1,0 +1,13 @@
+# CodingAdventures.Hkdf.CSharp
+
+HKDF extract-and-expand helpers for .NET.
+
+```csharp
+using CodingAdventures.Hkdf;
+
+byte[] okm = Hkdf.DeriveSha256(
+    salt: "salt"u8.ToArray(),
+    ikm: "input keying material"u8.ToArray(),
+    info: "context"u8.ToArray(),
+    length: 32);
+```

--- a/code/packages/csharp/hkdf/required_capabilities.json
+++ b/code/packages/csharp/hkdf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/hkdf",
+  "capabilities": [],
+  "justification": "Pure in-memory key derivation using .NET HMAC primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj
+++ b/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Hkdf.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/HkdfTests.cs
+++ b/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/HkdfTests.cs
@@ -1,0 +1,83 @@
+using HkdfAlgorithm = CodingAdventures.Hkdf.Hkdf;
+using HkdfHashAlgorithm = CodingAdventures.Hkdf.HkdfHash;
+
+namespace CodingAdventures.Hkdf.Tests;
+
+public sealed class HkdfTests
+{
+    [Fact]
+    public void Sha256MatchesRfc5869TestCase1()
+    {
+        var ikm = Enumerable.Repeat((byte)0x0b, 22).ToArray();
+        var salt = Convert.FromHexString("000102030405060708090a0b0c");
+        var info = Convert.FromHexString("f0f1f2f3f4f5f6f7f8f9");
+
+        Assert.Equal(
+            "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5",
+            Convert.ToHexString(HkdfAlgorithm.ExtractSha256(salt, ikm)).ToLowerInvariant());
+        Assert.Equal(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            Convert.ToHexString(HkdfAlgorithm.DeriveSha256(salt, ikm, info, 42)).ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Sha256EmptySaltMatchesRfc5869TestCase3()
+    {
+        var ikm = Enumerable.Repeat((byte)0x0b, 22).ToArray();
+
+        Assert.Equal(
+            "19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04",
+            Convert.ToHexString(HkdfAlgorithm.Extract([], ikm)).ToLowerInvariant());
+        Assert.Equal(
+            "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+            Convert.ToHexString(HkdfAlgorithm.Derive([], ikm, [], 42)).ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ExpandSupportsBoundsAndInfoDomainSeparation()
+    {
+        var prk = Enumerable.Repeat((byte)0x01, 32).ToArray();
+
+        Assert.Single(HkdfAlgorithm.ExpandSha256(prk, [], 1));
+        Assert.Equal(255 * 32, HkdfAlgorithm.ExpandSha256(prk, [], 255 * 32).Length);
+        Assert.NotEqual(
+            HkdfAlgorithm.ExpandSha256(prk, "purpose-a"u8.ToArray(), 32),
+            HkdfAlgorithm.ExpandSha256(prk, "purpose-b"u8.ToArray(), 32));
+    }
+
+    [Fact]
+    public void Sha512VariantUsesLargerDigestAndBounds()
+    {
+        var ikm = Enumerable.Repeat((byte)0x0b, 22).ToArray();
+        var prk = HkdfAlgorithm.ExtractSha512([], ikm);
+
+        Assert.Equal(64, prk.Length);
+        Assert.Equal(64, HkdfAlgorithm.ExpandSha512(prk, "info"u8.ToArray(), 64).Length);
+        Assert.Equal(255 * 64, HkdfAlgorithm.ExpandSha512(Enumerable.Repeat((byte)0x01, 64).ToArray(), [], 255 * 64).Length);
+    }
+
+    [Fact]
+    public void DeriveEqualsManualExtractThenExpandAndDefaultIsSha256()
+    {
+        var salt = "salt"u8.ToArray();
+        var ikm = "input keying material"u8.ToArray();
+        var info = "context"u8.ToArray();
+
+        var combined = HkdfAlgorithm.Derive(salt, ikm, info, 42);
+        var manual = HkdfAlgorithm.Expand(HkdfAlgorithm.Extract(salt, ikm), info, 42);
+        Assert.Equal(manual, combined);
+        Assert.Equal(HkdfAlgorithm.ExtractSha256(salt, ikm), HkdfAlgorithm.Extract(salt, ikm));
+    }
+
+    [Fact]
+    public void ValidationRejectsInvalidInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => HkdfAlgorithm.Extract(null!, "ikm"u8.ToArray()));
+        Assert.Throws<ArgumentNullException>(() => HkdfAlgorithm.Extract([], null!));
+        Assert.Throws<ArgumentNullException>(() => HkdfAlgorithm.Expand(null!, [], 1));
+        Assert.Throws<ArgumentNullException>(() => HkdfAlgorithm.Expand([], null!, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HkdfAlgorithm.Expand([], [], 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HkdfAlgorithm.Expand(Enumerable.Repeat((byte)0x01, 32).ToArray(), [], 255 * 32 + 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HkdfAlgorithm.Extract([], [], (HkdfHashAlgorithm)99));
+    }
+}

--- a/code/packages/fsharp/hkdf/BUILD
+++ b/code/packages/fsharp/hkdf/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hkdf/BUILD_windows
+++ b/code/packages/fsharp/hkdf/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hkdf/CHANGELOG.md
+++ b/code/packages/fsharp/hkdf/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# HKDF package for SHA-256 and SHA-512.
+- Include extract, expand, derive, validation, RFC 5869 vectors, and xUnit coverage.

--- a/code/packages/fsharp/hkdf/CodingAdventures.Hkdf.fsproj
+++ b/code/packages/fsharp/hkdf/CodingAdventures.Hkdf.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Hkdf.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HKDF extract-and-expand helpers for SHA-256 and SHA-512</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Hkdf.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hkdf/Hkdf.fs
+++ b/code/packages/fsharp/hkdf/Hkdf.fs
@@ -1,0 +1,72 @@
+namespace CodingAdventures.Hkdf.FSharp
+
+open System
+open System.Security.Cryptography
+
+type HkdfHash =
+    | Sha256
+    | Sha512
+
+[<RequireQualifiedAccess>]
+module Hkdf =
+    let private hashLength hash =
+        match hash with
+        | Sha256 -> 32
+        | Sha512 -> 64
+
+    let private createHmac hash key =
+        match hash with
+        | Sha256 -> new HMACSHA256(key) :> HMAC
+        | Sha512 -> new HMACSHA512(key) :> HMAC
+
+    let extract (salt: byte array) (ikm: byte array) hash =
+        if isNull salt then nullArg "salt"
+        if isNull ikm then nullArg "ikm"
+
+        let actualSalt =
+            if salt.Length = 0 then
+                Array.zeroCreate (hashLength hash)
+            else
+                salt
+
+        use hmac = createHmac hash actualSalt
+        hmac.ComputeHash(ikm)
+
+    let expand (prk: byte array) (info: byte array) length hash =
+        if isNull prk then nullArg "prk"
+        if isNull info then nullArg "info"
+        let digestLength = hashLength hash
+        if length <= 0 then invalidArg "length" "HKDF output length must be positive."
+        let maxLength = 255 * digestLength
+        if length > maxLength then invalidArg "length" $"HKDF output length must not exceed {maxLength} bytes."
+
+        let okm = Array.zeroCreate<byte> length
+        let mutable previous = [||]
+        let mutable offset = 0
+        let mutable counter = 1
+
+        while offset < length do
+            use hmac = createHmac hash prk
+            let input = Array.concat [ previous; info; [| byte counter |] ]
+            previous <- hmac.ComputeHash(input)
+            let toCopy = min previous.Length (length - offset)
+            Buffer.BlockCopy(previous, 0, okm, offset, toCopy)
+            offset <- offset + toCopy
+            counter <- counter + 1
+
+        okm
+
+    let derive salt ikm info length hash =
+        expand (extract salt ikm hash) info length hash
+
+    let extractSha256 salt ikm = extract salt ikm Sha256
+
+    let expandSha256 prk info length = expand prk info length Sha256
+
+    let deriveSha256 salt ikm info length = derive salt ikm info length Sha256
+
+    let extractSha512 salt ikm = extract salt ikm Sha512
+
+    let expandSha512 prk info length = expand prk info length Sha512
+
+    let deriveSha512 salt ikm info length = derive salt ikm info length Sha512

--- a/code/packages/fsharp/hkdf/README.md
+++ b/code/packages/fsharp/hkdf/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Hkdf.FSharp
+
+HKDF extract-and-expand helpers for .NET.
+
+```fsharp
+open CodingAdventures.Hkdf.FSharp
+
+let okm =
+    Hkdf.deriveSha256 "salt"B "input keying material"B "context"B 32
+```

--- a/code/packages/fsharp/hkdf/required_capabilities.json
+++ b/code/packages/fsharp/hkdf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/hkdf",
+  "capabilities": [],
+  "justification": "Pure in-memory key derivation using .NET HMAC primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj
+++ b/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Hkdf.fsproj" />
+    <Compile Include="HkdfTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/HkdfTests.fs
+++ b/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/HkdfTests.fs
@@ -1,0 +1,69 @@
+namespace CodingAdventures.Hkdf.Tests
+
+open System
+open Xunit
+open CodingAdventures.Hkdf.FSharp
+
+module HkdfTests =
+    [<Fact>]
+    let ``sha256 matches RFC 5869 test case 1`` () =
+        let ikm = Array.create 22 0x0buy
+        let salt = Convert.FromHexString "000102030405060708090a0b0c"
+        let info = Convert.FromHexString "f0f1f2f3f4f5f6f7f8f9"
+
+        Assert.Equal(
+            "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5",
+            Convert.ToHexString(Hkdf.extractSha256 salt ikm).ToLowerInvariant())
+        Assert.Equal(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            Convert.ToHexString(Hkdf.deriveSha256 salt ikm info 42).ToLowerInvariant())
+
+    [<Fact>]
+    let ``sha256 empty salt matches RFC 5869 test case 3`` () =
+        let ikm = Array.create 22 0x0buy
+
+        Assert.Equal(
+            "19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04",
+            Convert.ToHexString(Hkdf.extract [||] ikm Sha256).ToLowerInvariant())
+        Assert.Equal(
+            "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+            Convert.ToHexString(Hkdf.derive [||] ikm [||] 42 Sha256).ToLowerInvariant())
+
+    [<Fact>]
+    let ``expand supports bounds and info domain separation`` () =
+        let prk = Array.create 32 0x01uy
+
+        Assert.Equal(1, (Hkdf.expandSha256 prk [||] 1).Length)
+        Assert.Equal(255 * 32, (Hkdf.expandSha256 prk [||] (255 * 32)).Length)
+        Assert.NotEqual<byte array>(
+            Hkdf.expandSha256 prk "purpose-a"B 32,
+            Hkdf.expandSha256 prk "purpose-b"B 32)
+
+    [<Fact>]
+    let ``sha512 variant uses larger digest and bounds`` () =
+        let ikm = Array.create 22 0x0buy
+        let prk = Hkdf.extractSha512 [||] ikm
+
+        Assert.Equal(64, prk.Length)
+        Assert.Equal(64, (Hkdf.expandSha512 prk "info"B 64).Length)
+        Assert.Equal(255 * 64, (Hkdf.expandSha512 (Array.create 64 0x01uy) [||] (255 * 64)).Length)
+
+    [<Fact>]
+    let ``derive equals manual extract then expand and default sha256 helpers`` () =
+        let salt = "salt"B
+        let ikm = "input keying material"B
+        let info = "context"B
+
+        let combined = Hkdf.derive salt ikm info 42 Sha256
+        let manual = Hkdf.expand (Hkdf.extract salt ikm Sha256) info 42 Sha256
+        Assert.Equal<byte array>(manual, combined)
+        Assert.Equal<byte array>(Hkdf.extractSha256 salt ikm, Hkdf.extract salt ikm Sha256)
+
+    [<Fact>]
+    let ``validation rejects invalid inputs`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Hkdf.extract null "ikm"B Sha256 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hkdf.extract [||] null Sha256 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hkdf.expand null [||] 1 Sha256 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Hkdf.expand [||] null 1 Sha256 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Hkdf.expand [||] [||] 0 Sha256 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Hkdf.expand (Array.create 32 0x01uy) [||] (255 * 32 + 1) Sha256 |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# HKDF packages implementing RFC 5869 extract/expand/derive for SHA-256 and SHA-512
- support empty-salt zero-key behavior, output length bounds, convenience helpers, and validation
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\hkdf\tests\CodingAdventures.Hkdf.Tests\CodingAdventures.Hkdf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\hkdf\tests\CodingAdventures.Hkdf.Tests\CodingAdventures.Hkdf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line