### PR TITLE
feat(parity): add dotnet csprng packages

### DIFF
--- a/code/packages/csharp/csprng/BUILD
+++ b/code/packages/csharp/csprng/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csprng/BUILD_windows
+++ b/code/packages/csharp/csprng/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csprng/CHANGELOG.md
+++ b/code/packages/csharp/csprng/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# CSPRNG package backed by `RandomNumberGenerator`.
+- Include random byte buffers, fill helpers, random `uint`/`ulong`, validation, and xUnit coverage.

--- a/code/packages/csharp/csprng/CodingAdventures.Csprng.csproj
+++ b/code/packages/csharp/csprng/CodingAdventures.Csprng.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Csprng.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Cryptographically secure random byte and integer helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csprng/Csprng.cs
+++ b/code/packages/csharp/csprng/Csprng.cs
@@ -1,0 +1,51 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Csprng;
+
+/// <summary>
+/// Cryptographically secure random byte and integer helpers.
+/// </summary>
+public static class Csprng
+{
+    /// <summary>Fill an existing buffer with cryptographically secure random bytes.</summary>
+    public static void FillRandom(byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if (buffer.Length == 0)
+        {
+            throw new ArgumentException("Random byte request must not be empty.", nameof(buffer));
+        }
+
+        RandomNumberGenerator.Fill(buffer);
+    }
+
+    /// <summary>Return a new buffer of cryptographically secure random bytes.</summary>
+    public static byte[] RandomBytes(int length)
+    {
+        if (length <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Random byte request length must be positive.");
+        }
+
+        var buffer = new byte[length];
+        RandomNumberGenerator.Fill(buffer);
+        return buffer;
+    }
+
+    /// <summary>Return a random unsigned 32-bit integer.</summary>
+    public static uint RandomUInt32()
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        RandomNumberGenerator.Fill(bytes);
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    /// <summary>Return a random unsigned 64-bit integer.</summary>
+    public static ulong RandomUInt64()
+    {
+        Span<byte> bytes = stackalloc byte[8];
+        RandomNumberGenerator.Fill(bytes);
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+}

--- a/code/packages/csharp/csprng/README.md
+++ b/code/packages/csharp/csprng/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Csprng.CSharp
+
+Cryptographically secure random byte and integer helpers for .NET.
+
+```csharp
+using CodingAdventures.Csprng;
+
+byte[] nonce = Csprng.RandomBytes(24);
+uint id = Csprng.RandomUInt32();
+```

--- a/code/packages/csharp/csprng/required_capabilities.json
+++ b/code/packages/csharp/csprng/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/csprng",
+  "capabilities": [],
+  "justification": "Uses .NET OS-backed random number generation in memory. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/csprng/tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.csproj
+++ b/code/packages/csharp/csprng/tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Csprng.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csprng/tests/CodingAdventures.Csprng.Tests/CsprngTests.cs
+++ b/code/packages/csharp/csprng/tests/CodingAdventures.Csprng.Tests/CsprngTests.cs
@@ -1,0 +1,41 @@
+using CsprngAlgorithm = CodingAdventures.Csprng.Csprng;
+
+namespace CodingAdventures.Csprng.Tests;
+
+public sealed class CsprngTests
+{
+    [Fact]
+    public void RandomBytesReturnsRequestedLengthAndEntropy()
+    {
+        var bytes = CsprngAlgorithm.RandomBytes(32);
+
+        Assert.Equal(32, bytes.Length);
+        Assert.Contains(bytes, value => value != 0);
+    }
+
+    [Fact]
+    public void FillRandomMutatesBuffer()
+    {
+        var buffer = new byte[32];
+
+        CsprngAlgorithm.FillRandom(buffer);
+
+        Assert.Contains(buffer, value => value != 0);
+    }
+
+    [Fact]
+    public void RandomIntegersReturnValues()
+    {
+        _ = CsprngAlgorithm.RandomUInt32();
+        _ = CsprngAlgorithm.RandomUInt64();
+    }
+
+    [Fact]
+    public void ValidationRejectsInvalidRequests()
+    {
+        Assert.Throws<ArgumentNullException>(() => CsprngAlgorithm.FillRandom(null!));
+        Assert.Throws<ArgumentException>(() => CsprngAlgorithm.FillRandom([]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CsprngAlgorithm.RandomBytes(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CsprngAlgorithm.RandomBytes(-1));
+    }
+}

--- a/code/packages/fsharp/csprng/BUILD
+++ b/code/packages/fsharp/csprng/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csprng/BUILD_windows
+++ b/code/packages/fsharp/csprng/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csprng/CHANGELOG.md
+++ b/code/packages/fsharp/csprng/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# CSPRNG package backed by `RandomNumberGenerator`.
+- Include random byte buffers, fill helpers, random `uint32`/`uint64`, validation, and xUnit coverage.

--- a/code/packages/fsharp/csprng/CodingAdventures.Csprng.fsproj
+++ b/code/packages/fsharp/csprng/CodingAdventures.Csprng.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Csprng.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Cryptographically secure random byte and integer helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Csprng.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csprng/Csprng.fs
+++ b/code/packages/fsharp/csprng/Csprng.fs
@@ -1,0 +1,25 @@
+namespace CodingAdventures.Csprng.FSharp
+
+open System
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Csprng =
+    let fillRandom (buffer: byte array) =
+        if isNull buffer then nullArg "buffer"
+        if buffer.Length = 0 then invalidArg "buffer" "Random byte request must not be empty."
+        RandomNumberGenerator.Fill(buffer)
+
+    let randomBytes length =
+        if length <= 0 then invalidArg "length" "Random byte request length must be positive."
+        let buffer = Array.zeroCreate<byte> length
+        RandomNumberGenerator.Fill(buffer)
+        buffer
+
+    let randomUInt32 () =
+        let bytes = randomBytes 4
+        BitConverter.ToUInt32(bytes, 0)
+
+    let randomUInt64 () =
+        let bytes = randomBytes 8
+        BitConverter.ToUInt64(bytes, 0)

--- a/code/packages/fsharp/csprng/README.md
+++ b/code/packages/fsharp/csprng/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Csprng.FSharp
+
+Cryptographically secure random byte and integer helpers for .NET.
+
+```fsharp
+open CodingAdventures.Csprng.FSharp
+
+let nonce = Csprng.randomBytes 24
+let id = Csprng.randomUInt32 ()
+```

--- a/code/packages/fsharp/csprng/required_capabilities.json
+++ b/code/packages/fsharp/csprng/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/csprng",
+  "capabilities": [],
+  "justification": "Uses .NET OS-backed random number generation in memory. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/csprng/tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.fsproj
+++ b/code/packages/fsharp/csprng/tests/CodingAdventures.Csprng.Tests/CodingAdventures.Csprng.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Csprng.fsproj" />
+    <Compile Include="CsprngTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csprng/tests/CodingAdventures.Csprng.Tests/CsprngTests.fs
+++ b/code/packages/fsharp/csprng/tests/CodingAdventures.Csprng.Tests/CsprngTests.fs
@@ -1,0 +1,33 @@
+namespace CodingAdventures.Csprng.Tests
+
+open System
+open Xunit
+open CodingAdventures.Csprng.FSharp
+
+module CsprngTests =
+    [<Fact>]
+    let ``random bytes returns requested length and entropy`` () =
+        let bytes = Csprng.randomBytes 32
+
+        Assert.Equal(32, bytes.Length)
+        Assert.Contains<byte>(bytes, fun value -> value <> 0uy)
+
+    [<Fact>]
+    let ``fill random mutates buffer`` () =
+        let buffer = Array.zeroCreate<byte> 32
+
+        Csprng.fillRandom buffer
+
+        Assert.Contains<byte>(buffer, fun value -> value <> 0uy)
+
+    [<Fact>]
+    let ``random integers return values`` () =
+        Csprng.randomUInt32 () |> ignore
+        Csprng.randomUInt64 () |> ignore
+
+    [<Fact>]
+    let ``validation rejects invalid requests`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Csprng.fillRandom null) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Csprng.fillRandom [||]) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Csprng.randomBytes 0 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Csprng.randomBytes -1 |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# CSPRNG packages backed by `RandomNumberGenerator`
- expose random byte buffers, in-place fill helpers, random 32-bit and 64-bit unsigned integers, and validation
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\csprng\tests\CodingAdventures.Csprng.Tests\CodingAdventures.Csprng.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\csprng\tests\CodingAdventures.Csprng.Tests\CodingAdventures.Csprng.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line