### PR TITLE
feat(parity): add dotnet aes packages

### DIFF
--- a/code/packages/csharp/aes/AesBlock.cs
+++ b/code/packages/csharp/aes/AesBlock.cs
@@ -1,0 +1,58 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Aes;
+
+/// <summary>
+/// AES single-block encryption and decryption helpers.
+/// </summary>
+public static class AesBlock
+{
+    private const int BlockSizeBytes = 16;
+
+    /// <summary>Encrypt one 16-byte block with a 16-, 24-, or 32-byte AES key.</summary>
+    public static byte[] EncryptBlock(byte[] block, byte[] key)
+    {
+        ValidateBlock(block);
+        ValidateKey(key);
+        using var aes = CreateAes(key);
+        using var encryptor = aes.CreateEncryptor();
+        return encryptor.TransformFinalBlock(block, 0, block.Length);
+    }
+
+    /// <summary>Decrypt one 16-byte block with a 16-, 24-, or 32-byte AES key.</summary>
+    public static byte[] DecryptBlock(byte[] block, byte[] key)
+    {
+        ValidateBlock(block);
+        ValidateKey(key);
+        using var aes = CreateAes(key);
+        using var decryptor = aes.CreateDecryptor();
+        return decryptor.TransformFinalBlock(block, 0, block.Length);
+    }
+
+    private static System.Security.Cryptography.Aes CreateAes(byte[] key)
+    {
+        var aes = System.Security.Cryptography.Aes.Create();
+        aes.Mode = CipherMode.ECB;
+        aes.Padding = PaddingMode.None;
+        aes.Key = key.ToArray();
+        return aes;
+    }
+
+    private static void ValidateBlock(byte[] block)
+    {
+        ArgumentNullException.ThrowIfNull(block);
+        if (block.Length != BlockSizeBytes)
+        {
+            throw new ArgumentException("AES block must be exactly 16 bytes.", nameof(block));
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length is not (16 or 24 or 32))
+        {
+            throw new ArgumentException("AES key must be 16, 24, or 32 bytes.", nameof(key));
+        }
+    }
+}

--- a/code/packages/csharp/aes/BUILD
+++ b/code/packages/csharp/aes/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/aes/BUILD_windows
+++ b/code/packages/csharp/aes/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/aes/CHANGELOG.md
+++ b/code/packages/csharp/aes/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# AES block package backed by `System.Security.Cryptography.Aes`.
+- Include AES-128, AES-192, AES-256 vectors, validation, and xUnit coverage.

--- a/code/packages/csharp/aes/CodingAdventures.Aes.csproj
+++ b/code/packages/csharp/aes/CodingAdventures.Aes.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Aes.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>AES single-block encryption and decryption helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/aes/README.md
+++ b/code/packages/csharp/aes/README.md
@@ -1,0 +1,12 @@
+# CodingAdventures.Aes.CSharp
+
+AES single-block helpers for .NET.
+
+This package mirrors the repository's low-level AES block API. It encrypts or decrypts exactly one 16-byte block with a 16-, 24-, or 32-byte key.
+
+```csharp
+using CodingAdventures.Aes;
+
+byte[] ciphertext = AesBlock.EncryptBlock(plaintextBlock, key);
+byte[] plaintext = AesBlock.DecryptBlock(ciphertext, key);
+```

--- a/code/packages/csharp/aes/required_capabilities.json
+++ b/code/packages/csharp/aes/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/aes",
+  "capabilities": [],
+  "justification": "Pure in-memory block encryption using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/aes/tests/CodingAdventures.Aes.Tests/AesBlockTests.cs
+++ b/code/packages/csharp/aes/tests/CodingAdventures.Aes.Tests/AesBlockTests.cs
@@ -1,0 +1,61 @@
+namespace CodingAdventures.Aes.Tests;
+
+public sealed class AesBlockTests
+{
+    [Theory]
+    [InlineData(
+        "2b7e151628aed2a6abf7158809cf4f3c",
+        "3243f6a8885a308d313198a2e0370734",
+        "3925841d02dc09fbdc118597196a0b32")]
+    [InlineData(
+        "000102030405060708090a0b0c0d0e0f",
+        "00112233445566778899aabbccddeeff",
+        "69c4e0d86a7b0430d8cdb78070b4c55a")]
+    [InlineData(
+        "000102030405060708090a0b0c0d0e0f1011121314151617",
+        "00112233445566778899aabbccddeeff",
+        "dda97ca4864cdfe06eaf70a0ec0d7191")]
+    [InlineData(
+        "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+        "6bc1bee22e409f96e93d7e117393172a",
+        "f3eed1bdb5d2a03c064b5a7e3db181f8")]
+    [InlineData(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "00112233445566778899aabbccddeeff",
+        "8ea2b7ca516745bfeafc49904b496089")]
+    public void EncryptAndDecryptMatchKnownVectors(string keyHex, string plainHex, string cipherHex)
+    {
+        var key = Convert.FromHexString(keyHex);
+        var plaintext = Convert.FromHexString(plainHex);
+        var ciphertext = Convert.FromHexString(cipherHex);
+
+        Assert.Equal(ciphertext, AesBlock.EncryptBlock(plaintext, key));
+        Assert.Equal(plaintext, AesBlock.DecryptBlock(ciphertext, key));
+    }
+
+    [Fact]
+    public void RoundTripsAcrossKeySizesAndInputs()
+    {
+        foreach (var keyLength in new[] { 16, 24, 32 })
+        {
+            var key = Enumerable.Range(0, keyLength).Select(value => (byte)value).ToArray();
+            var plaintext = Enumerable.Range(0, 16).Select(value => (byte)(255 - value)).ToArray();
+
+            Assert.Equal(plaintext, AesBlock.DecryptBlock(AesBlock.EncryptBlock(plaintext, key), key));
+        }
+    }
+
+    [Fact]
+    public void ValidationRejectsInvalidInputs()
+    {
+        var key = new byte[16];
+        var block = new byte[16];
+
+        Assert.Throws<ArgumentNullException>(() => AesBlock.EncryptBlock(null!, key));
+        Assert.Throws<ArgumentNullException>(() => AesBlock.DecryptBlock(block, null!));
+        Assert.Throws<ArgumentException>(() => AesBlock.EncryptBlock(new byte[15], key));
+        Assert.Throws<ArgumentException>(() => AesBlock.DecryptBlock(new byte[17], key));
+        Assert.Throws<ArgumentException>(() => AesBlock.EncryptBlock(block, new byte[10]));
+        Assert.Throws<ArgumentException>(() => AesBlock.DecryptBlock(block, new byte[20]));
+    }
+}

--- a/code/packages/csharp/aes/tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.csproj
+++ b/code/packages/csharp/aes/tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Aes.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/aes/AesBlock.fs
+++ b/code/packages/fsharp/aes/AesBlock.fs
@@ -1,0 +1,39 @@
+namespace CodingAdventures.Aes.FSharp
+
+open System
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module AesBlock =
+    let private blockSizeBytes = 16
+
+    let private validateBlock (block: byte array) =
+        if isNull block then nullArg "block"
+        if block.Length <> blockSizeBytes then
+            invalidArg "block" "AES block must be exactly 16 bytes."
+
+    let private validateKey (key: byte array) =
+        if isNull key then nullArg "key"
+        if key.Length <> 16 && key.Length <> 24 && key.Length <> 32 then
+            invalidArg "key" "AES key must be 16, 24, or 32 bytes."
+
+    let private createAes (key: byte array) =
+        let aes = Aes.Create()
+        aes.Mode <- CipherMode.ECB
+        aes.Padding <- PaddingMode.None
+        aes.Key <- Array.copy key
+        aes
+
+    let encryptBlock (block: byte array) (key: byte array) =
+        validateBlock block
+        validateKey key
+        use aes = createAes key
+        use encryptor = aes.CreateEncryptor()
+        encryptor.TransformFinalBlock(block, 0, block.Length)
+
+    let decryptBlock (block: byte array) (key: byte array) =
+        validateBlock block
+        validateKey key
+        use aes = createAes key
+        use decryptor = aes.CreateDecryptor()
+        decryptor.TransformFinalBlock(block, 0, block.Length)

--- a/code/packages/fsharp/aes/BUILD
+++ b/code/packages/fsharp/aes/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/aes/BUILD_windows
+++ b/code/packages/fsharp/aes/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/aes/CHANGELOG.md
+++ b/code/packages/fsharp/aes/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# AES block package backed by `System.Security.Cryptography.Aes`.
+- Include AES-128, AES-192, AES-256 vectors, validation, and xUnit coverage.

--- a/code/packages/fsharp/aes/CodingAdventures.Aes.fsproj
+++ b/code/packages/fsharp/aes/CodingAdventures.Aes.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Aes.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>AES single-block encryption and decryption helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="AesBlock.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/aes/README.md
+++ b/code/packages/fsharp/aes/README.md
@@ -1,0 +1,12 @@
+# CodingAdventures.Aes.FSharp
+
+AES single-block helpers for .NET.
+
+This package mirrors the repository's low-level AES block API. It encrypts or decrypts exactly one 16-byte block with a 16-, 24-, or 32-byte key.
+
+```fsharp
+open CodingAdventures.Aes.FSharp
+
+let ciphertext = AesBlock.encryptBlock plaintextBlock key
+let plaintext = AesBlock.decryptBlock ciphertext key
+```

--- a/code/packages/fsharp/aes/required_capabilities.json
+++ b/code/packages/fsharp/aes/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/aes",
+  "capabilities": [],
+  "justification": "Pure in-memory block encryption using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/aes/tests/CodingAdventures.Aes.Tests/AesBlockTests.fs
+++ b/code/packages/fsharp/aes/tests/CodingAdventures.Aes.Tests/AesBlockTests.fs
@@ -1,0 +1,40 @@
+namespace CodingAdventures.Aes.Tests
+
+open System
+open Xunit
+open CodingAdventures.Aes.FSharp
+
+module AesBlockTests =
+    [<Theory>]
+    [<InlineData("2b7e151628aed2a6abf7158809cf4f3c", "3243f6a8885a308d313198a2e0370734", "3925841d02dc09fbdc118597196a0b32")>]
+    [<InlineData("000102030405060708090a0b0c0d0e0f", "00112233445566778899aabbccddeeff", "69c4e0d86a7b0430d8cdb78070b4c55a")>]
+    [<InlineData("000102030405060708090a0b0c0d0e0f1011121314151617", "00112233445566778899aabbccddeeff", "dda97ca4864cdfe06eaf70a0ec0d7191")>]
+    [<InlineData("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "6bc1bee22e409f96e93d7e117393172a", "f3eed1bdb5d2a03c064b5a7e3db181f8")>]
+    [<InlineData("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "00112233445566778899aabbccddeeff", "8ea2b7ca516745bfeafc49904b496089")>]
+    let ``encrypt and decrypt match known vectors`` (keyHex: string) (plainHex: string) (cipherHex: string) =
+        let key = Convert.FromHexString keyHex
+        let plaintext = Convert.FromHexString plainHex
+        let ciphertext = Convert.FromHexString cipherHex
+
+        Assert.Equal<byte array>(ciphertext, AesBlock.encryptBlock plaintext key)
+        Assert.Equal<byte array>(plaintext, AesBlock.decryptBlock ciphertext key)
+
+    [<Fact>]
+    let ``round trips across key sizes and inputs`` () =
+        for keyLength in [ 16; 24; 32 ] do
+            let key = [| 0 .. keyLength - 1 |] |> Array.map byte
+            let plaintext = [| 0 .. 15 |] |> Array.map (fun value -> byte (255 - value))
+
+            Assert.Equal<byte array>(plaintext, AesBlock.decryptBlock (AesBlock.encryptBlock plaintext key) key)
+
+    [<Fact>]
+    let ``validation rejects invalid inputs`` () =
+        let key = Array.zeroCreate<byte> 16
+        let block = Array.zeroCreate<byte> 16
+
+        Assert.Throws<ArgumentNullException>(fun () -> AesBlock.encryptBlock null key |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> AesBlock.decryptBlock block null |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesBlock.encryptBlock (Array.zeroCreate 15) key |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesBlock.decryptBlock (Array.zeroCreate 17) key |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesBlock.encryptBlock block (Array.zeroCreate 10) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesBlock.decryptBlock block (Array.zeroCreate 20) |> ignore) |> ignore

--- a/code/packages/fsharp/aes/tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.fsproj
+++ b/code/packages/fsharp/aes/tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Aes.fsproj" />
+    <Compile Include="AesBlockTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add native C# and F# AES single-block packages backed by `System.Security.Cryptography.Aes`
- support 16-byte block encryption/decryption with AES-128, AES-192, and AES-256 keys plus validation
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\aes\tests\CodingAdventures.Aes.Tests\CodingAdventures.Aes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\aes\tests\CodingAdventures.Aes.Tests\CodingAdventures.Aes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line