### PR TITLE
feat(parity): add dotnet zeroize packages

### DIFF
--- a/code/packages/csharp/zeroize/BUILD
+++ b/code/packages/csharp/zeroize/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/zeroize/BUILD_windows
+++ b/code/packages/csharp/zeroize/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/zeroize/CHANGELOG.md
+++ b/code/packages/csharp/zeroize/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# zeroize package.
+- Include byte, char, generic array clearing, a disposable buffer wrapper, validation, and xUnit coverage.

--- a/code/packages/csharp/zeroize/CodingAdventures.Zeroize.csproj
+++ b/code/packages/csharp/zeroize/CodingAdventures.Zeroize.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Zeroize.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Helpers for clearing sensitive managed buffers in place</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/zeroize/README.md
+++ b/code/packages/csharp/zeroize/README.md
@@ -1,0 +1,12 @@
+# CodingAdventures.Zeroize.CSharp
+
+Helpers for clearing sensitive managed buffers in place.
+
+```csharp
+using CodingAdventures.Zeroize;
+
+byte[] secret = [1, 2, 3, 4];
+Zeroize.ZeroizeBytes(secret);
+
+using var owned = new ZeroizingBuffer([1, 2, 3, 4]);
+```

--- a/code/packages/csharp/zeroize/Zeroize.cs
+++ b/code/packages/csharp/zeroize/Zeroize.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.Zeroize;
+
+/// <summary>
+/// Helpers for clearing sensitive managed buffers in place.
+/// </summary>
+public static class Zeroize
+{
+    /// <summary>Overwrite a byte buffer with zeroes.</summary>
+    public static void ZeroizeBytes(byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        CryptographicOperations.ZeroMemory(buffer.AsSpan());
+    }
+
+    /// <summary>Clear a character buffer.</summary>
+    public static void ZeroizeChars(char[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        Array.Clear(buffer);
+    }
+
+    /// <summary>Clear any managed array using the element type's default value.</summary>
+    public static void ZeroizeArray<T>(T[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        Array.Clear(buffer);
+    }
+}
+
+/// <summary>
+/// Disposable wrapper that zeroizes its byte buffer when disposed.
+/// </summary>
+public sealed class ZeroizingBuffer : IDisposable
+{
+    private bool _disposed;
+
+    /// <summary>Create a wrapper around an existing byte buffer.</summary>
+    public ZeroizingBuffer(byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        Buffer = buffer;
+    }
+
+    /// <summary>The wrapped mutable byte buffer.</summary>
+    public byte[] Buffer { get; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Zeroize.ZeroizeBytes(Buffer);
+        _disposed = true;
+    }
+}

--- a/code/packages/csharp/zeroize/required_capabilities.json
+++ b/code/packages/csharp/zeroize/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/zeroize",
+  "capabilities": [],
+  "justification": "Pure in-memory buffer clearing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/zeroize/tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.csproj
+++ b/code/packages/csharp/zeroize/tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Zeroize.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/zeroize/tests/CodingAdventures.Zeroize.Tests/ZeroizeTests.cs
+++ b/code/packages/csharp/zeroize/tests/CodingAdventures.Zeroize.Tests/ZeroizeTests.cs
@@ -1,0 +1,51 @@
+using ZeroizeAlgorithm = CodingAdventures.Zeroize.Zeroize;
+
+namespace CodingAdventures.Zeroize.Tests;
+
+public sealed class ZeroizeTests
+{
+    [Fact]
+    public void ZeroizeBytesClearsBuffer()
+    {
+        var secret = new byte[] { 1, 2, 3, 4 };
+
+        ZeroizeAlgorithm.ZeroizeBytes(secret);
+
+        Assert.All(secret, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void ZeroizeCharsAndArraysClearBuffers()
+    {
+        var chars = "secret".ToCharArray();
+        var numbers = new[] { 1, 2, 3 };
+
+        ZeroizeAlgorithm.ZeroizeChars(chars);
+        ZeroizeAlgorithm.ZeroizeArray(numbers);
+
+        Assert.All(chars, value => Assert.Equal('\0', value));
+        Assert.All(numbers, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void DisposableBufferZeroizesOnDisposeAndIsIdempotent()
+    {
+        var secret = new byte[] { 9, 8, 7 };
+        var wrapper = new ZeroizingBuffer(secret);
+
+        wrapper.Dispose();
+        wrapper.Dispose();
+
+        Assert.Same(secret, wrapper.Buffer);
+        Assert.All(secret, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void ValidationRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => ZeroizeAlgorithm.ZeroizeBytes(null!));
+        Assert.Throws<ArgumentNullException>(() => ZeroizeAlgorithm.ZeroizeChars(null!));
+        Assert.Throws<ArgumentNullException>(() => ZeroizeAlgorithm.ZeroizeArray<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => new ZeroizingBuffer(null!));
+    }
+}

--- a/code/packages/fsharp/zeroize/BUILD
+++ b/code/packages/fsharp/zeroize/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/zeroize/BUILD_windows
+++ b/code/packages/fsharp/zeroize/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/zeroize/CHANGELOG.md
+++ b/code/packages/fsharp/zeroize/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# zeroize package.
+- Include byte, char, generic array clearing, a disposable buffer wrapper, validation, and xUnit coverage.

--- a/code/packages/fsharp/zeroize/CodingAdventures.Zeroize.fsproj
+++ b/code/packages/fsharp/zeroize/CodingAdventures.Zeroize.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Zeroize.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Helpers for clearing sensitive managed buffers in place</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Zeroize.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/zeroize/README.md
+++ b/code/packages/fsharp/zeroize/README.md
@@ -1,0 +1,10 @@
+# CodingAdventures.Zeroize.FSharp
+
+Helpers for clearing sensitive managed buffers in place.
+
+```fsharp
+open CodingAdventures.Zeroize.FSharp
+
+let secret = [| 1uy; 2uy; 3uy |]
+Zeroize.zeroizeBytes secret
+```

--- a/code/packages/fsharp/zeroize/Zeroize.fs
+++ b/code/packages/fsharp/zeroize/Zeroize.fs
@@ -1,0 +1,32 @@
+namespace CodingAdventures.Zeroize.FSharp
+
+open System
+open System.Security.Cryptography
+
+[<RequireQualifiedAccess>]
+module Zeroize =
+    let zeroizeBytes (buffer: byte array) =
+        if isNull buffer then nullArg "buffer"
+        CryptographicOperations.ZeroMemory(buffer.AsSpan())
+
+    let zeroizeChars (buffer: char array) =
+        if isNull buffer then nullArg "buffer"
+        Array.Clear(buffer)
+
+    let zeroizeArray (buffer: 'T array) =
+        if isNull buffer then nullArg "buffer"
+        Array.Clear(buffer)
+
+type ZeroizingBuffer(buffer: byte array) =
+    let mutable disposed = false
+
+    do
+        if isNull buffer then nullArg "buffer"
+
+    member _.Buffer = buffer
+
+    interface IDisposable with
+        member _.Dispose() =
+            if not disposed then
+                Zeroize.zeroizeBytes buffer
+                disposed <- true

--- a/code/packages/fsharp/zeroize/required_capabilities.json
+++ b/code/packages/fsharp/zeroize/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/zeroize",
+  "capabilities": [],
+  "justification": "Pure in-memory buffer clearing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/zeroize/tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.fsproj
+++ b/code/packages/fsharp/zeroize/tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Zeroize.fsproj" />
+    <Compile Include="ZeroizeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/zeroize/tests/CodingAdventures.Zeroize.Tests/ZeroizeTests.fs
+++ b/code/packages/fsharp/zeroize/tests/CodingAdventures.Zeroize.Tests/ZeroizeTests.fs
@@ -1,0 +1,45 @@
+namespace CodingAdventures.Zeroize.Tests
+
+open System
+open Xunit
+open CodingAdventures.Zeroize.FSharp
+
+module ZeroizeTests =
+    [<Fact>]
+    let ``zeroize bytes clears buffer`` () =
+        let secret = [| 1uy; 2uy; 3uy; 4uy |]
+
+        Zeroize.zeroizeBytes secret
+
+        Assert.All<byte>(secret, fun value -> Assert.Equal(0uy, value))
+
+    [<Fact>]
+    let ``zeroize chars and arrays clear buffers`` () =
+        let chars = "secret".ToCharArray()
+        let numbers = [| 1; 2; 3 |]
+
+        Zeroize.zeroizeChars chars
+        Zeroize.zeroizeArray numbers
+
+        Assert.All<char>(chars, fun value -> Assert.Equal('\000', value))
+        Assert.All<int>(numbers, fun value -> Assert.Equal(0, value))
+
+    [<Fact>]
+    let ``disposable buffer zeroizes on dispose and is idempotent`` () =
+        let secret = [| 9uy; 8uy; 7uy |]
+        let wrapper = new ZeroizingBuffer(secret)
+        let disposable = wrapper :> IDisposable
+
+        disposable.Dispose()
+        disposable.Dispose()
+
+        Assert.Same(secret, wrapper.Buffer)
+        Assert.All<byte>(secret, fun value -> Assert.Equal(0uy, value))
+
+    [<Fact>]
+    let ``validation rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Zeroize.zeroizeBytes null) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Zeroize.zeroizeChars null) |> ignore
+        let nullInts: int array = null
+        Assert.Throws<ArgumentNullException>(fun () -> Zeroize.zeroizeArray nullInts) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> new ZeroizingBuffer(null) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# zeroize packages for clearing sensitive managed buffers
- expose byte, char, and generic array clearing plus disposable byte-buffer wrappers
- include package metadata, capability manifests, BUILD commands, project files, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\zeroize\tests\CodingAdventures.Zeroize.Tests\CodingAdventures.Zeroize.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\zeroize\tests\CodingAdventures.Zeroize.Tests\CodingAdventures.Zeroize.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line