### PR TITLE
feat(parity): add dotnet aes modes packages

### DIFF
--- a/code/packages/csharp/aes-modes/AesModes.cs
+++ b/code/packages/csharp/aes-modes/AesModes.cs
@@ -1,0 +1,265 @@
+using System.Security.Cryptography;
+using CodingAdventures.Aes;
+
+namespace CodingAdventures.AesModes;
+
+/// <summary>
+/// AES modes of operation helpers for educational use.
+/// </summary>
+public static class AesModes
+{
+    /// <summary>AES block size in bytes.</summary>
+    public const int BlockSizeBytes = 16;
+
+    private const int GcmNonceSizeBytes = 12;
+    private const int GcmTagSizeBytes = 16;
+
+    /// <summary>Pad data to a 16-byte boundary using PKCS#7.</summary>
+    public static byte[] Pkcs7Pad(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var padLength = BlockSizeBytes - (data.Length % BlockSizeBytes);
+        var result = new byte[data.Length + padLength];
+        Buffer.BlockCopy(data, 0, result, 0, data.Length);
+        Array.Fill(result, (byte)padLength, data.Length, padLength);
+        return result;
+    }
+
+    /// <summary>Remove PKCS#7 padding from block-aligned data.</summary>
+    public static byte[] Pkcs7Unpad(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length == 0 || data.Length % BlockSizeBytes != 0)
+        {
+            throw new ArgumentException("Padded data must be a positive multiple of 16 bytes.", nameof(data));
+        }
+
+        var padLength = data[^1];
+        if (padLength is < 1 or > BlockSizeBytes)
+        {
+            throw new ArgumentException("Invalid PKCS#7 padding.", nameof(data));
+        }
+
+        var diff = 0;
+        for (var index = data.Length - padLength; index < data.Length; index++)
+        {
+            diff |= data[index] ^ padLength;
+        }
+
+        if (diff != 0)
+        {
+            throw new ArgumentException("Invalid PKCS#7 padding.", nameof(data));
+        }
+
+        var result = new byte[data.Length - padLength];
+        Buffer.BlockCopy(data, 0, result, 0, result.Length);
+        return result;
+    }
+
+    /// <summary>XOR two byte arrays of equal length.</summary>
+    public static byte[] XorBytes(byte[] left, byte[] right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (left.Length != right.Length)
+        {
+            throw new ArgumentException("Byte arrays must have the same length.", nameof(right));
+        }
+
+        var result = new byte[left.Length];
+        for (var index = 0; index < result.Length; index++)
+        {
+            result[index] = (byte)(left[index] ^ right[index]);
+        }
+
+        return result;
+    }
+
+    /// <summary>Encrypt with AES-ECB. ECB is insecure and included for parity and education.</summary>
+    public static byte[] EcbEncrypt(byte[] plaintext, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+
+        var padded = Pkcs7Pad(plaintext);
+        var result = new byte[padded.Length];
+        for (var offset = 0; offset < padded.Length; offset += BlockSizeBytes)
+        {
+            var encrypted = AesBlock.EncryptBlock(ReadBlock(padded, offset), key);
+            Buffer.BlockCopy(encrypted, 0, result, offset, BlockSizeBytes);
+        }
+
+        return result;
+    }
+
+    /// <summary>Decrypt with AES-ECB and remove PKCS#7 padding.</summary>
+    public static byte[] EcbDecrypt(byte[] ciphertext, byte[] key)
+    {
+        ValidateCiphertext(ciphertext, nameof(ciphertext), "ECB ciphertext");
+        ValidateKey(key);
+
+        var padded = new byte[ciphertext.Length];
+        for (var offset = 0; offset < ciphertext.Length; offset += BlockSizeBytes)
+        {
+            var decrypted = AesBlock.DecryptBlock(ReadBlock(ciphertext, offset), key);
+            Buffer.BlockCopy(decrypted, 0, padded, offset, BlockSizeBytes);
+        }
+
+        return Pkcs7Unpad(padded);
+    }
+
+    /// <summary>Encrypt with AES-CBC using a 16-byte IV and PKCS#7 padding.</summary>
+    public static byte[] CbcEncrypt(byte[] plaintext, byte[] key, byte[] iv)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+        ValidateLength(iv, BlockSizeBytes, nameof(iv), "CBC IV");
+
+        var padded = Pkcs7Pad(plaintext);
+        var result = new byte[padded.Length];
+        var previous = iv.ToArray();
+
+        for (var offset = 0; offset < padded.Length; offset += BlockSizeBytes)
+        {
+            var block = XorBytes(ReadBlock(padded, offset), previous);
+            var encrypted = AesBlock.EncryptBlock(block, key);
+            Buffer.BlockCopy(encrypted, 0, result, offset, BlockSizeBytes);
+            previous = encrypted;
+        }
+
+        return result;
+    }
+
+    /// <summary>Decrypt with AES-CBC using a 16-byte IV and PKCS#7 padding.</summary>
+    public static byte[] CbcDecrypt(byte[] ciphertext, byte[] key, byte[] iv)
+    {
+        ValidateCiphertext(ciphertext, nameof(ciphertext), "CBC ciphertext");
+        ValidateKey(key);
+        ValidateLength(iv, BlockSizeBytes, nameof(iv), "CBC IV");
+
+        var padded = new byte[ciphertext.Length];
+        var previous = iv.ToArray();
+
+        for (var offset = 0; offset < ciphertext.Length; offset += BlockSizeBytes)
+        {
+            var cipherBlock = ReadBlock(ciphertext, offset);
+            var decrypted = AesBlock.DecryptBlock(cipherBlock, key);
+            var plainBlock = XorBytes(decrypted, previous);
+            Buffer.BlockCopy(plainBlock, 0, padded, offset, BlockSizeBytes);
+            previous = cipherBlock;
+        }
+
+        return Pkcs7Unpad(padded);
+    }
+
+    /// <summary>Encrypt with AES-CTR using a 12-byte nonce and a 32-bit big-endian counter.</summary>
+    public static byte[] CtrEncrypt(byte[] plaintext, byte[] key, byte[] nonce)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+        ValidateLength(nonce, GcmNonceSizeBytes, nameof(nonce), "CTR nonce");
+
+        var result = new byte[plaintext.Length];
+        var counter = 1u;
+
+        for (var offset = 0; offset < plaintext.Length; offset += BlockSizeBytes)
+        {
+            var keystream = AesBlock.EncryptBlock(BuildCounterBlock(nonce, counter), key);
+            var count = Math.Min(BlockSizeBytes, plaintext.Length - offset);
+            for (var index = 0; index < count; index++)
+            {
+                result[offset + index] = (byte)(plaintext[offset + index] ^ keystream[index]);
+            }
+
+            counter++;
+        }
+
+        return result;
+    }
+
+    /// <summary>Decrypt with AES-CTR. CTR decryption is the same operation as encryption.</summary>
+    public static byte[] CtrDecrypt(byte[] ciphertext, byte[] key, byte[] nonce) =>
+        CtrEncrypt(ciphertext, key, nonce);
+
+    /// <summary>Encrypt and authenticate with AES-GCM using a 12-byte IV.</summary>
+    public static (byte[] Ciphertext, byte[] Tag) GcmEncrypt(
+        byte[] plaintext,
+        byte[] key,
+        byte[] iv,
+        byte[]? aad = null)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+        ValidateLength(iv, GcmNonceSizeBytes, nameof(iv), "GCM IV");
+
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[GcmTagSizeBytes];
+        using var gcm = new AesGcm(key, GcmTagSizeBytes);
+        gcm.Encrypt(iv, plaintext, ciphertext, tag, aad ?? Array.Empty<byte>());
+        return (ciphertext, tag);
+    }
+
+    /// <summary>Decrypt and authenticate with AES-GCM using a 12-byte IV and 16-byte tag.</summary>
+    public static byte[] GcmDecrypt(
+        byte[] ciphertext,
+        byte[] key,
+        byte[] iv,
+        byte[]? aad,
+        byte[] tag)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+        ValidateKey(key);
+        ValidateLength(iv, GcmNonceSizeBytes, nameof(iv), "GCM IV");
+        ValidateLength(tag, GcmTagSizeBytes, nameof(tag), "GCM tag");
+
+        var plaintext = new byte[ciphertext.Length];
+        using var gcm = new AesGcm(key, GcmTagSizeBytes);
+        gcm.Decrypt(iv, ciphertext, tag, plaintext, aad ?? Array.Empty<byte>());
+        return plaintext;
+    }
+
+    private static byte[] ReadBlock(byte[] data, int offset)
+    {
+        var block = new byte[BlockSizeBytes];
+        Buffer.BlockCopy(data, offset, block, 0, BlockSizeBytes);
+        return block;
+    }
+
+    private static byte[] BuildCounterBlock(byte[] nonce, uint counter)
+    {
+        var block = new byte[BlockSizeBytes];
+        Buffer.BlockCopy(nonce, 0, block, 0, nonce.Length);
+        block[12] = (byte)(counter >> 24);
+        block[13] = (byte)(counter >> 16);
+        block[14] = (byte)(counter >> 8);
+        block[15] = (byte)counter;
+        return block;
+    }
+
+    private static void ValidateCiphertext(byte[] ciphertext, string paramName, string label)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+        if (ciphertext.Length == 0 || ciphertext.Length % BlockSizeBytes != 0)
+        {
+            throw new ArgumentException($"{label} must be a positive multiple of 16 bytes.", paramName);
+        }
+    }
+
+    private static void ValidateLength(byte[] value, int length, string paramName, string label)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (value.Length != length)
+        {
+            throw new ArgumentException($"{label} must be {length} bytes.", paramName);
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length is not (16 or 24 or 32))
+        {
+            throw new ArgumentException("AES key must be 16, 24, or 32 bytes.", nameof(key));
+        }
+    }
+}

--- a/code/packages/csharp/aes-modes/BUILD
+++ b/code/packages/csharp/aes-modes/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/aes-modes/BUILD_windows
+++ b/code/packages/csharp/aes-modes/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/aes-modes/CHANGELOG.md
+++ b/code/packages/csharp/aes-modes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for AES ECB, CBC, CTR, and GCM helpers.

--- a/code/packages/csharp/aes-modes/CodingAdventures.AesModes.csproj
+++ b/code/packages/csharp/aes-modes/CodingAdventures.AesModes.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AesModes.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>AES modes of operation helpers for ECB, CBC, CTR, and GCM</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\aes\CodingAdventures.Aes.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/aes-modes/README.md
+++ b/code/packages/csharp/aes-modes/README.md
@@ -1,0 +1,19 @@
+# CodingAdventures.AesModes.CSharp
+
+AES modes of operation helpers for .NET.
+
+This package mirrors the repository's AES modes API with PKCS#7 padding, XOR helpers, ECB, CBC, CTR, and GCM. ECB is included for educational parity only; prefer GCM for authenticated encryption.
+
+```csharp
+using CodingAdventures.AesModes;
+
+byte[] key = Convert.FromHexString("2b7e151628aed2a6abf7158809cf4f3c");
+byte[] iv = new byte[16];
+byte[] nonce = new byte[12];
+
+byte[] cbcCiphertext = AesModes.CbcEncrypt(plaintext, key, iv);
+byte[] cbcPlaintext = AesModes.CbcDecrypt(cbcCiphertext, key, iv);
+
+var (ciphertext, tag) = AesModes.GcmEncrypt(plaintext, key, nonce, aad);
+byte[] verifiedPlaintext = AesModes.GcmDecrypt(ciphertext, key, nonce, aad, tag);
+```

--- a/code/packages/csharp/aes-modes/required_capabilities.json
+++ b/code/packages/csharp/aes-modes/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/aes-modes",
+  "capabilities": [],
+  "justification": "Pure in-memory AES mode operations using local helpers and the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.cs
+++ b/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+
+namespace CodingAdventures.AesModes.Tests;
+
+public sealed class AesModesTests
+{
+    private static readonly byte[] NistKey = Convert.FromHexString("2b7e151628aed2a6abf7158809cf4f3c");
+    private static readonly byte[] NistPlaintext = Convert.FromHexString(
+        "6bc1bee22e409f96e93d7e117393172a" +
+        "ae2d8a571e03ac9c9eb76fac45af8e51" +
+        "30c81c46a35ce411e5fbc1191a0a52ef" +
+        "f69f2445df4f9b17ad2b417be66c3710");
+
+    [Fact]
+    public void Pkcs7PadAndUnpadRoundTrips()
+    {
+        var padded = AesModes.Pkcs7Pad("hello"u8.ToArray());
+
+        Assert.Equal(16, padded.Length);
+        Assert.Equal(11, padded[^1]);
+        Assert.Equal("hello"u8.ToArray(), AesModes.Pkcs7Unpad(padded));
+        Assert.Equal(32, AesModes.Pkcs7Pad(new byte[16]).Length);
+    }
+
+    [Fact]
+    public void Pkcs7UnpadRejectsInvalidPadding()
+    {
+        Assert.Throws<ArgumentException>(() => AesModes.Pkcs7Unpad(Array.Empty<byte>()));
+        Assert.Throws<ArgumentException>(() => AesModes.Pkcs7Unpad("short"u8.ToArray()));
+        Assert.Throws<ArgumentException>(() => AesModes.Pkcs7Unpad(Convert.FromHexString("30313233343536373839616263646500")));
+        Assert.Throws<ArgumentException>(() => AesModes.Pkcs7Unpad(Convert.FromHexString("30313233343536373839616263030203")));
+    }
+
+    [Fact]
+    public void XorBytesRequiresEqualLengths()
+    {
+        Assert.Equal(new byte[] { 0x0f, 0xf0 }, AesModes.XorBytes(new byte[] { 0xff, 0x00 }, new byte[] { 0xf0, 0xf0 }));
+        Assert.Throws<ArgumentException>(() => AesModes.XorBytes(new byte[] { 1 }, Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void EcbMatchesNistBlocksAndRoundTrips()
+    {
+        var ciphertext = AesModes.EcbEncrypt(NistPlaintext, NistKey);
+
+        Assert.Equal("3ad77bb40d7a3660a89ecaf32466ef97", Convert.ToHexString(ciphertext[..16]).ToLowerInvariant());
+        Assert.Equal("f5d3d58503b9699de785895a96fdbaaf", Convert.ToHexString(ciphertext[16..32]).ToLowerInvariant());
+        Assert.Equal(NistPlaintext, AesModes.EcbDecrypt(ciphertext, NistKey));
+    }
+
+    [Fact]
+    public void EcbShowsIdenticalBlockLeak()
+    {
+        var plaintext = Enumerable.Repeat((byte)'A', 48).ToArray();
+        var ciphertext = AesModes.EcbEncrypt(plaintext, NistKey);
+
+        Assert.Equal(ciphertext[..16], ciphertext[16..32]);
+        Assert.Equal(ciphertext[16..32], ciphertext[32..48]);
+        Assert.Throws<ArgumentException>(() => AesModes.EcbDecrypt("short"u8.ToArray(), NistKey));
+    }
+
+    [Fact]
+    public void CbcMatchesNistBlocksAndRoundTrips()
+    {
+        var iv = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var ciphertext = AesModes.CbcEncrypt(NistPlaintext, NistKey, iv);
+
+        Assert.Equal("7649abac8119b246cee98e9b12e9197d", Convert.ToHexString(ciphertext[..16]).ToLowerInvariant());
+        Assert.Equal("5086cb9b507219ee95db113a917678b2", Convert.ToHexString(ciphertext[16..32]).ToLowerInvariant());
+        Assert.Equal(NistPlaintext, AesModes.CbcDecrypt(ciphertext, NistKey, iv));
+    }
+
+    [Fact]
+    public void CbcRejectsInvalidInputs()
+    {
+        Assert.Throws<ArgumentException>(() => AesModes.CbcEncrypt("test"u8.ToArray(), NistKey, "short"u8.ToArray()));
+        Assert.Throws<ArgumentException>(() => AesModes.CbcDecrypt("short"u8.ToArray(), NistKey, new byte[16]));
+    }
+
+    [Fact]
+    public void CtrRoundTripsWithoutPadding()
+    {
+        var nonce = new byte[12];
+        var plaintext = "CTR keeps the same length."u8.ToArray();
+        var ciphertext = AesModes.CtrEncrypt(plaintext, NistKey, nonce);
+
+        Assert.Equal(plaintext.Length, ciphertext.Length);
+        Assert.Equal(plaintext, AesModes.CtrDecrypt(ciphertext, NistKey, nonce));
+        Assert.Empty(AesModes.CtrEncrypt(Array.Empty<byte>(), NistKey, nonce));
+        Assert.Throws<ArgumentException>(() => AesModes.CtrEncrypt(plaintext, NistKey, new byte[16]));
+    }
+
+    [Fact]
+    public void GcmMatchesNistTestCaseAndRoundTripsWithAad()
+    {
+        var key = Convert.FromHexString("feffe9928665731c6d6a8f9467308308");
+        var iv = Convert.FromHexString("cafebabefacedbaddecaf888");
+        var plaintext = Convert.FromHexString(
+            "d9313225f88406e5a55909c5aff5269a" +
+            "86a7a9531534f7da2e4c303d8a318a72" +
+            "1c3c0c95956809532fcf0e2449a6b525" +
+            "b16aedf5aa0de657ba637b391aafd255");
+        var expectedCiphertext = Convert.FromHexString(
+            "42831ec2217774244b7221b784d0d49c" +
+            "e3aa212f2c02a4e035c17e2329aca12e" +
+            "21d514b25466931c7d8f6a5aac84aa05" +
+            "1ba30b396a0aac973d58e091473f5985");
+        var expectedTag = Convert.FromHexString("4d5c2af327cd64a62cf35abd2ba6fab4");
+
+        var (ciphertext, tag) = AesModes.GcmEncrypt(plaintext, key, iv);
+
+        Assert.Equal(expectedCiphertext, ciphertext);
+        Assert.Equal(expectedTag, tag);
+        Assert.Equal(plaintext, AesModes.GcmDecrypt(ciphertext, key, iv, null, tag));
+
+        var aad = "metadata"u8.ToArray();
+        var roundTrip = AesModes.GcmEncrypt("secret"u8.ToArray(), key, iv, aad);
+        Assert.Equal("secret"u8.ToArray(), AesModes.GcmDecrypt(roundTrip.Ciphertext, key, iv, aad, roundTrip.Tag));
+    }
+
+    [Fact]
+    public void GcmRejectsTamperingAndInvalidLengths()
+    {
+        var key = Convert.FromHexString("feffe9928665731c6d6a8f9467308308");
+        var iv = Convert.FromHexString("cafebabefacedbaddecaf888");
+        var (ciphertext, tag) = AesModes.GcmEncrypt("secret"u8.ToArray(), key, iv);
+
+        ciphertext[0] ^= 1;
+        Assert.Throws<AuthenticationTagMismatchException>(() => AesModes.GcmDecrypt(ciphertext, key, iv, null, tag));
+        Assert.Throws<ArgumentException>(() => AesModes.GcmEncrypt("test"u8.ToArray(), key, new byte[16]));
+        Assert.Throws<ArgumentException>(() => AesModes.GcmDecrypt(Array.Empty<byte>(), key, iv, null, new byte[8]));
+    }
+}

--- a/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.csproj
+++ b/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AesModes.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/aes-modes/AesModes.fs
+++ b/code/packages/fsharp/aes-modes/AesModes.fs
@@ -1,0 +1,181 @@
+namespace CodingAdventures.AesModes.FSharp
+
+open System
+open System.Security.Cryptography
+open CodingAdventures.Aes.FSharp
+
+[<RequireQualifiedAccess>]
+module AesModes =
+    let blockSizeBytes = 16
+
+    let private gcmNonceSizeBytes = 12
+    let private gcmTagSizeBytes = 16
+
+    let private requireBytes name (value: byte array) =
+        if isNull value then
+            nullArg name
+
+    let private validateKey (key: byte array) =
+        requireBytes "key" key
+        if key.Length <> 16 && key.Length <> 24 && key.Length <> 32 then
+            invalidArg "key" "AES key must be 16, 24, or 32 bytes."
+
+    let private validateLength name label length (value: byte array) =
+        requireBytes name value
+        if value.Length <> length then
+            invalidArg name $"{label} must be {length} bytes."
+
+    let private validateCiphertext name label (ciphertext: byte array) =
+        requireBytes name ciphertext
+        if ciphertext.Length = 0 || ciphertext.Length % blockSizeBytes <> 0 then
+            invalidArg name $"{label} must be a positive multiple of 16 bytes."
+
+    let private readBlock (data: byte array) offset =
+        let block = Array.zeroCreate<byte> blockSizeBytes
+        Buffer.BlockCopy(data, offset, block, 0, blockSizeBytes)
+        block
+
+    let private buildCounterBlock (nonce: byte array) (counter: uint32) =
+        let block = Array.zeroCreate<byte> blockSizeBytes
+        Buffer.BlockCopy(nonce, 0, block, 0, nonce.Length)
+        block.[12] <- byte (counter >>> 24)
+        block.[13] <- byte (counter >>> 16)
+        block.[14] <- byte (counter >>> 8)
+        block.[15] <- byte counter
+        block
+
+    let pkcs7Pad (data: byte array) =
+        requireBytes "data" data
+        let padLength = blockSizeBytes - (data.Length % blockSizeBytes)
+        let result = Array.zeroCreate<byte> (data.Length + padLength)
+        Buffer.BlockCopy(data, 0, result, 0, data.Length)
+        for index in data.Length .. result.Length - 1 do
+            result.[index] <- byte padLength
+        result
+
+    let pkcs7Unpad (data: byte array) =
+        requireBytes "data" data
+        if data.Length = 0 || data.Length % blockSizeBytes <> 0 then
+            invalidArg "data" "Padded data must be a positive multiple of 16 bytes."
+
+        let padLength = int data.[data.Length - 1]
+        if padLength < 1 || padLength > blockSizeBytes then
+            invalidArg "data" "Invalid PKCS#7 padding."
+
+        let mutable diff = 0
+        for index in data.Length - padLength .. data.Length - 1 do
+            diff <- diff ||| (int data.[index] ^^^ padLength)
+
+        if diff <> 0 then
+            invalidArg "data" "Invalid PKCS#7 padding."
+
+        let result = Array.zeroCreate<byte> (data.Length - padLength)
+        Buffer.BlockCopy(data, 0, result, 0, result.Length)
+        result
+
+    let xorBytes (left: byte array) (right: byte array) =
+        requireBytes "left" left
+        requireBytes "right" right
+        if left.Length <> right.Length then
+            invalidArg "right" "Byte arrays must have the same length."
+
+        Array.init left.Length (fun index -> byte (int left.[index] ^^^ int right.[index]))
+
+    let ecbEncrypt (plaintext: byte array) (key: byte array) =
+        requireBytes "plaintext" plaintext
+        validateKey key
+        let padded = pkcs7Pad plaintext
+        let result = Array.zeroCreate<byte> padded.Length
+
+        for offset in 0 .. blockSizeBytes .. padded.Length - 1 do
+            let encrypted = AesBlock.encryptBlock (readBlock padded offset) key
+            Buffer.BlockCopy(encrypted, 0, result, offset, blockSizeBytes)
+
+        result
+
+    let ecbDecrypt (ciphertext: byte array) (key: byte array) =
+        validateCiphertext "ciphertext" "ECB ciphertext" ciphertext
+        validateKey key
+        let padded = Array.zeroCreate<byte> ciphertext.Length
+
+        for offset in 0 .. blockSizeBytes .. ciphertext.Length - 1 do
+            let decrypted = AesBlock.decryptBlock (readBlock ciphertext offset) key
+            Buffer.BlockCopy(decrypted, 0, padded, offset, blockSizeBytes)
+
+        pkcs7Unpad padded
+
+    let cbcEncrypt (plaintext: byte array) (key: byte array) (iv: byte array) =
+        requireBytes "plaintext" plaintext
+        validateKey key
+        validateLength "iv" "CBC IV" blockSizeBytes iv
+        let padded = pkcs7Pad plaintext
+        let result = Array.zeroCreate<byte> padded.Length
+        let mutable previous = Array.copy iv
+
+        for offset in 0 .. blockSizeBytes .. padded.Length - 1 do
+            let block = xorBytes (readBlock padded offset) previous
+            let encrypted = AesBlock.encryptBlock block key
+            Buffer.BlockCopy(encrypted, 0, result, offset, blockSizeBytes)
+            previous <- encrypted
+
+        result
+
+    let cbcDecrypt (ciphertext: byte array) (key: byte array) (iv: byte array) =
+        validateCiphertext "ciphertext" "CBC ciphertext" ciphertext
+        validateKey key
+        validateLength "iv" "CBC IV" blockSizeBytes iv
+        let padded = Array.zeroCreate<byte> ciphertext.Length
+        let mutable previous = Array.copy iv
+
+        for offset in 0 .. blockSizeBytes .. ciphertext.Length - 1 do
+            let cipherBlock = readBlock ciphertext offset
+            let decrypted = AesBlock.decryptBlock cipherBlock key
+            let plainBlock = xorBytes decrypted previous
+            Buffer.BlockCopy(plainBlock, 0, padded, offset, blockSizeBytes)
+            previous <- cipherBlock
+
+        pkcs7Unpad padded
+
+    let ctrEncrypt (plaintext: byte array) (key: byte array) (nonce: byte array) =
+        requireBytes "plaintext" plaintext
+        validateKey key
+        validateLength "nonce" "CTR nonce" gcmNonceSizeBytes nonce
+        let result = Array.zeroCreate<byte> plaintext.Length
+        let mutable counter = 1u
+        let mutable offset = 0
+
+        while offset < plaintext.Length do
+            let keystream = AesBlock.encryptBlock (buildCounterBlock nonce counter) key
+            let count = min blockSizeBytes (plaintext.Length - offset)
+            for index in 0 .. count - 1 do
+                result.[offset + index] <- byte (int plaintext.[offset + index] ^^^ int keystream.[index])
+
+            counter <- counter + 1u
+            offset <- offset + blockSizeBytes
+
+        result
+
+    let ctrDecrypt (ciphertext: byte array) (key: byte array) (nonce: byte array) =
+        ctrEncrypt ciphertext key nonce
+
+    let gcmEncrypt (plaintext: byte array) (key: byte array) (iv: byte array) (aad: byte array) =
+        requireBytes "plaintext" plaintext
+        validateKey key
+        validateLength "iv" "GCM IV" gcmNonceSizeBytes iv
+        let aadValue = if isNull aad then Array.empty<byte> else aad
+        let ciphertext = Array.zeroCreate<byte> plaintext.Length
+        let tag = Array.zeroCreate<byte> gcmTagSizeBytes
+        use gcm = new AesGcm(key, gcmTagSizeBytes)
+        gcm.Encrypt(iv, plaintext, ciphertext, tag, aadValue)
+        ciphertext, tag
+
+    let gcmDecrypt (ciphertext: byte array) (key: byte array) (iv: byte array) (aad: byte array) (tag: byte array) =
+        requireBytes "ciphertext" ciphertext
+        validateKey key
+        validateLength "iv" "GCM IV" gcmNonceSizeBytes iv
+        validateLength "tag" "GCM tag" gcmTagSizeBytes tag
+        let aadValue = if isNull aad then Array.empty<byte> else aad
+        let plaintext = Array.zeroCreate<byte> ciphertext.Length
+        use gcm = new AesGcm(key, gcmTagSizeBytes)
+        gcm.Decrypt(iv, ciphertext, tag, plaintext, aadValue)
+        plaintext

--- a/code/packages/fsharp/aes-modes/BUILD
+++ b/code/packages/fsharp/aes-modes/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/aes-modes/BUILD_windows
+++ b/code/packages/fsharp/aes-modes/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/aes-modes/CHANGELOG.md
+++ b/code/packages/fsharp/aes-modes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for AES ECB, CBC, CTR, and GCM helpers.

--- a/code/packages/fsharp/aes-modes/CodingAdventures.AesModes.fsproj
+++ b/code/packages/fsharp/aes-modes/CodingAdventures.AesModes.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AesModes.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>AES modes of operation helpers for ECB, CBC, CTR, and GCM</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\aes\CodingAdventures.Aes.fsproj" />
+    <Compile Include="AesModes.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/aes-modes/README.md
+++ b/code/packages/fsharp/aes-modes/README.md
@@ -1,0 +1,19 @@
+# CodingAdventures.AesModes.FSharp
+
+AES modes of operation helpers for .NET.
+
+This package mirrors the repository's AES modes API with PKCS#7 padding, XOR helpers, ECB, CBC, CTR, and GCM. ECB is included for educational parity only; prefer GCM for authenticated encryption.
+
+```fsharp
+open CodingAdventures.AesModes.FSharp
+
+let key = Convert.FromHexString "2b7e151628aed2a6abf7158809cf4f3c"
+let iv = Array.zeroCreate<byte> 16
+let nonce = Array.zeroCreate<byte> 12
+
+let cbcCiphertext = AesModes.cbcEncrypt plaintext key iv
+let cbcPlaintext = AesModes.cbcDecrypt cbcCiphertext key iv
+
+let ciphertext, tag = AesModes.gcmEncrypt plaintext key nonce aad
+let verifiedPlaintext = AesModes.gcmDecrypt ciphertext key nonce aad tag
+```

--- a/code/packages/fsharp/aes-modes/required_capabilities.json
+++ b/code/packages/fsharp/aes-modes/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/aes-modes",
+  "capabilities": [],
+  "justification": "Pure in-memory AES mode operations using local helpers and the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.fs
+++ b/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.fs
@@ -1,0 +1,126 @@
+namespace CodingAdventures.AesModes.Tests
+
+open System
+open System.Security.Cryptography
+open Xunit
+open CodingAdventures.AesModes.FSharp
+
+module AesModesTests =
+    let nistKey = Convert.FromHexString "2b7e151628aed2a6abf7158809cf4f3c"
+
+    let nistPlaintext =
+        Convert.FromHexString(
+            "6bc1bee22e409f96e93d7e117393172a"
+            + "ae2d8a571e03ac9c9eb76fac45af8e51"
+            + "30c81c46a35ce411e5fbc1191a0a52ef"
+            + "f69f2445df4f9b17ad2b417be66c3710"
+        )
+
+    let utf8 (text: string) = System.Text.Encoding.UTF8.GetBytes text
+
+    [<Fact>]
+    let ``pkcs7 pad and unpad round trips`` () =
+        let padded = AesModes.pkcs7Pad (utf8 "hello")
+
+        Assert.Equal(16, padded.Length)
+        Assert.Equal(11uy, padded.[padded.Length - 1])
+        Assert.Equal<byte array>(utf8 "hello", AesModes.pkcs7Unpad padded)
+        Assert.Equal(32, (AesModes.pkcs7Pad (Array.zeroCreate<byte> 16)).Length)
+
+    [<Fact>]
+    let ``pkcs7 unpad rejects invalid padding`` () =
+        Assert.Throws<ArgumentException>(fun () -> AesModes.pkcs7Unpad Array.empty<byte> |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.pkcs7Unpad (utf8 "short") |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.pkcs7Unpad (Convert.FromHexString "30313233343536373839616263646500") |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.pkcs7Unpad (Convert.FromHexString "30313233343536373839616263030203") |> ignore) |> ignore
+
+    [<Fact>]
+    let ``xor bytes requires equal lengths`` () =
+        let result = AesModes.xorBytes [| 0xffuy; 0x00uy |] [| 0xf0uy; 0xf0uy |]
+        Assert.Equal<byte array>([| 0x0fuy; 0xf0uy |], result)
+        Assert.Throws<ArgumentException>(fun () -> AesModes.xorBytes [| 1uy |] Array.empty<byte> |> ignore) |> ignore
+
+    [<Fact>]
+    let ``ecb matches nist blocks and round trips`` () =
+        let ciphertext = AesModes.ecbEncrypt nistPlaintext nistKey
+
+        Assert.Equal("3ad77bb40d7a3660a89ecaf32466ef97", Convert.ToHexString(ciphertext.[0..15]).ToLowerInvariant())
+        Assert.Equal("f5d3d58503b9699de785895a96fdbaaf", Convert.ToHexString(ciphertext.[16..31]).ToLowerInvariant())
+        Assert.Equal<byte array>(nistPlaintext, AesModes.ecbDecrypt ciphertext nistKey)
+
+    [<Fact>]
+    let ``ecb shows identical block leak`` () =
+        let plaintext = Array.create 48 (byte 'A')
+        let ciphertext = AesModes.ecbEncrypt plaintext nistKey
+
+        Assert.Equal<byte array>(ciphertext.[0..15], ciphertext.[16..31])
+        Assert.Equal<byte array>(ciphertext.[16..31], ciphertext.[32..47])
+        Assert.Throws<ArgumentException>(fun () -> AesModes.ecbDecrypt (utf8 "short") nistKey |> ignore) |> ignore
+
+    [<Fact>]
+    let ``cbc matches nist blocks and round trips`` () =
+        let iv = Convert.FromHexString "000102030405060708090a0b0c0d0e0f"
+        let ciphertext = AesModes.cbcEncrypt nistPlaintext nistKey iv
+
+        Assert.Equal("7649abac8119b246cee98e9b12e9197d", Convert.ToHexString(ciphertext.[0..15]).ToLowerInvariant())
+        Assert.Equal("5086cb9b507219ee95db113a917678b2", Convert.ToHexString(ciphertext.[16..31]).ToLowerInvariant())
+        Assert.Equal<byte array>(nistPlaintext, AesModes.cbcDecrypt ciphertext nistKey iv)
+
+    [<Fact>]
+    let ``cbc rejects invalid inputs`` () =
+        Assert.Throws<ArgumentException>(fun () -> AesModes.cbcEncrypt (utf8 "test") nistKey (utf8 "short") |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.cbcDecrypt (utf8 "short") nistKey (Array.zeroCreate<byte> 16) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``ctr round trips without padding`` () =
+        let nonce = Array.zeroCreate<byte> 12
+        let plaintext = utf8 "CTR keeps the same length."
+        let ciphertext = AesModes.ctrEncrypt plaintext nistKey nonce
+
+        Assert.Equal(plaintext.Length, ciphertext.Length)
+        Assert.Equal<byte array>(plaintext, AesModes.ctrDecrypt ciphertext nistKey nonce)
+        Assert.Empty(AesModes.ctrEncrypt Array.empty<byte> nistKey nonce)
+        Assert.Throws<ArgumentException>(fun () -> AesModes.ctrEncrypt plaintext nistKey (Array.zeroCreate<byte> 16) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``gcm matches nist test case and round trips with aad`` () =
+        let key = Convert.FromHexString "feffe9928665731c6d6a8f9467308308"
+        let iv = Convert.FromHexString "cafebabefacedbaddecaf888"
+
+        let plaintext =
+            Convert.FromHexString(
+                "d9313225f88406e5a55909c5aff5269a"
+                + "86a7a9531534f7da2e4c303d8a318a72"
+                + "1c3c0c95956809532fcf0e2449a6b525"
+                + "b16aedf5aa0de657ba637b391aafd255"
+            )
+
+        let expectedCiphertext =
+            Convert.FromHexString(
+                "42831ec2217774244b7221b784d0d49c"
+                + "e3aa212f2c02a4e035c17e2329aca12e"
+                + "21d514b25466931c7d8f6a5aac84aa05"
+                + "1ba30b396a0aac973d58e091473f5985"
+            )
+
+        let expectedTag = Convert.FromHexString "4d5c2af327cd64a62cf35abd2ba6fab4"
+        let ciphertext, tag = AesModes.gcmEncrypt plaintext key iv null
+
+        Assert.Equal<byte array>(expectedCiphertext, ciphertext)
+        Assert.Equal<byte array>(expectedTag, tag)
+        Assert.Equal<byte array>(plaintext, AesModes.gcmDecrypt ciphertext key iv null tag)
+
+        let aad = utf8 "metadata"
+        let roundTripCiphertext, roundTripTag = AesModes.gcmEncrypt (utf8 "secret") key iv aad
+        Assert.Equal<byte array>(utf8 "secret", AesModes.gcmDecrypt roundTripCiphertext key iv aad roundTripTag)
+
+    [<Fact>]
+    let ``gcm rejects tampering and invalid lengths`` () =
+        let key = Convert.FromHexString "feffe9928665731c6d6a8f9467308308"
+        let iv = Convert.FromHexString "cafebabefacedbaddecaf888"
+        let ciphertext, tag = AesModes.gcmEncrypt (utf8 "secret") key iv null
+
+        ciphertext.[0] <- ciphertext.[0] ^^^ 1uy
+        Assert.Throws<AuthenticationTagMismatchException>(fun () -> AesModes.gcmDecrypt ciphertext key iv null tag |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.gcmEncrypt (utf8 "test") key (Array.zeroCreate<byte> 16) null |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> AesModes.gcmDecrypt Array.empty<byte> key iv null (Array.zeroCreate<byte> 8) |> ignore) |> ignore

--- a/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.fsproj
+++ b/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AesModes.fsproj" />
+    <Compile Include="AesModesTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add native C# and F# AES modes packages covering PKCS#7, XOR, ECB, CBC, CTR, and GCM
- build ECB/CBC/CTR on the existing AES block helpers and use .NET AesGcm for authenticated mode correctness
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\aes-modes\tests\CodingAdventures.AesModes.Tests\CodingAdventures.AesModes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\aes-modes\tests\CodingAdventures.AesModes.Tests\CodingAdventures.AesModes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line