### PR TITLE
feat(parity): add dotnet hash functions packages

### DIFF
--- a/code/packages/csharp/hash-functions/BUILD
+++ b/code/packages/csharp/hash-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hash-functions/BUILD_windows
+++ b/code/packages/csharp/hash-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/hash-functions/CHANGELOG.md
+++ b/code/packages/csharp/hash-functions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for FNV-1a, DJB2, polynomial rolling, MurmurHash3, SipHash-2-4, and hash analysis helpers.

--- a/code/packages/csharp/hash-functions/CodingAdventures.HashFunctions.csproj
+++ b/code/packages/csharp/hash-functions/CodingAdventures.HashFunctions.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.HashFunctions.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Non-cryptographic hash functions and analysis helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hash-functions/HashFunctions.cs
+++ b/code/packages/csharp/hash-functions/HashFunctions.cs
@@ -1,0 +1,379 @@
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CodingAdventures.HashFunctions;
+
+/// <summary>Common interface for fixed-output non-cryptographic hash functions.</summary>
+public interface IHashFunction
+{
+    /// <summary>Hash the supplied bytes.</summary>
+    ulong Hash(byte[] data);
+
+    /// <summary>Number of output bits produced by the hash.</summary>
+    int OutputBits { get; }
+}
+
+public readonly struct Fnv1a32 : IHashFunction
+{
+    public ulong Hash(byte[] data) => HashFunctions.Fnv1a32(data);
+    public int OutputBits => 32;
+}
+
+public readonly struct Fnv1a64 : IHashFunction
+{
+    public ulong Hash(byte[] data) => HashFunctions.Fnv1a64(data);
+    public int OutputBits => 64;
+}
+
+public readonly struct Djb2Hash : IHashFunction
+{
+    public ulong Hash(byte[] data) => HashFunctions.Djb2(data);
+    public int OutputBits => 64;
+}
+
+public readonly struct PolynomialRollingHash(ulong @base, ulong modulus) : IHashFunction
+{
+    public PolynomialRollingHash()
+        : this(HashFunctions.PolynomialRollingDefaultBase, HashFunctions.PolynomialRollingDefaultModulus)
+    {
+    }
+
+    public ulong Base { get; } = @base;
+    public ulong Modulus { get; } = modulus;
+    public ulong Hash(byte[] data) => HashFunctions.PolynomialRolling(data, Base, Modulus);
+    public int OutputBits => 64;
+}
+
+public readonly struct Murmur3_32(uint seed) : IHashFunction
+{
+    public Murmur3_32()
+        : this(0)
+    {
+    }
+
+    public uint Seed { get; } = seed;
+    public ulong Hash(byte[] data) => HashFunctions.Murmur3_32(data, Seed);
+    public int OutputBits => 32;
+}
+
+public readonly struct SipHash24(byte[] key) : IHashFunction
+{
+    public byte[] Key { get; } = key.ToArray();
+    public ulong Hash(byte[] data) => HashFunctions.SipHash24(data, Key);
+    public int OutputBits => 64;
+}
+
+/// <summary>Non-cryptographic hash functions and quality analysis helpers.</summary>
+public static class HashFunctions
+{
+    public const uint Fnv32OffsetBasis = 0x811C9DC5;
+    public const uint Fnv32Prime = 0x01000193;
+    public const ulong Fnv64OffsetBasis = 0xCBF29CE484222325;
+    public const ulong Fnv64Prime = 0x00000100000001B3;
+    public const ulong Djb2OffsetBasis = 5381;
+    public const ulong PolynomialRollingDefaultBase = 31;
+    public const ulong PolynomialRollingDefaultModulus = (1UL << 61) - 1;
+
+    private const uint MurmurC1 = 0xCC9E2D51;
+    private const uint MurmurC2 = 0x1B873593;
+
+    private const ulong SipHashV0 = 0x736F6D6570736575;
+    private const ulong SipHashV1 = 0x646F72616E646F6D;
+    private const ulong SipHashV2 = 0x6C7967656E657261;
+    private const ulong SipHashV3 = 0x7465646279746573;
+
+    public static uint Fnv1a32(string data) => Fnv1a32(ToBytes(data));
+
+    public static uint Fnv1a32(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var hash = Fnv32OffsetBasis;
+        foreach (var value in data)
+        {
+            hash ^= value;
+            hash = unchecked(hash * Fnv32Prime);
+        }
+
+        return hash;
+    }
+
+    public static ulong Fnv1a64(string data) => Fnv1a64(ToBytes(data));
+
+    public static ulong Fnv1a64(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var hash = Fnv64OffsetBasis;
+        foreach (var value in data)
+        {
+            hash ^= value;
+            hash = unchecked(hash * Fnv64Prime);
+        }
+
+        return hash;
+    }
+
+    public static ulong Djb2(string data) => Djb2(ToBytes(data));
+
+    public static ulong Djb2(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var hash = Djb2OffsetBasis;
+        foreach (var value in data)
+        {
+            hash = unchecked((hash << 5) + hash + value);
+        }
+
+        return hash;
+    }
+
+    public static ulong PolynomialRolling(
+        string data,
+        ulong @base = PolynomialRollingDefaultBase,
+        ulong modulus = PolynomialRollingDefaultModulus) =>
+        PolynomialRolling(ToBytes(data), @base, modulus);
+
+    public static ulong PolynomialRolling(
+        byte[] data,
+        ulong @base = PolynomialRollingDefaultBase,
+        ulong modulus = PolynomialRollingDefaultModulus)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (modulus == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(modulus), "Modulus must be positive.");
+        }
+
+        UInt128 hash = 0;
+        var baseValue = (UInt128)@base;
+        var modulusValue = (UInt128)modulus;
+        foreach (var value in data)
+        {
+            hash = ((hash * baseValue) + value) % modulusValue;
+        }
+
+        return (ulong)hash;
+    }
+
+    public static uint Murmur3_32(string data, uint seed = 0) => Murmur3_32(ToBytes(data), seed);
+
+    public static uint Murmur3_32(byte[] data, uint seed = 0)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var hash = seed;
+        var offset = 0;
+
+        while (offset + 4 <= data.Length)
+        {
+            var k = (uint)(data[offset]
+                | (data[offset + 1] << 8)
+                | (data[offset + 2] << 16)
+                | (data[offset + 3] << 24));
+            k = unchecked(k * MurmurC1);
+            k = BitOperations.RotateLeft(k, 15);
+            k = unchecked(k * MurmurC2);
+
+            hash ^= k;
+            hash = BitOperations.RotateLeft(hash, 13);
+            hash = unchecked((hash * 5) + 0xE6546B64);
+            offset += 4;
+        }
+
+        var tail = 0u;
+        var remaining = data.Length - offset;
+        if (remaining >= 3)
+        {
+            tail ^= (uint)data[offset + 2] << 16;
+        }
+
+        if (remaining >= 2)
+        {
+            tail ^= (uint)data[offset + 1] << 8;
+        }
+
+        if (remaining >= 1)
+        {
+            tail ^= data[offset];
+            tail = unchecked(tail * MurmurC1);
+            tail = BitOperations.RotateLeft(tail, 15);
+            tail = unchecked(tail * MurmurC2);
+            hash ^= tail;
+        }
+
+        hash ^= (uint)data.Length;
+        return Fmix32(hash);
+    }
+
+    public static uint HashStringFnv1a32(string data) => Fnv1a32(data);
+
+    public static ulong HashStringSipHash(string data, byte[] key) => SipHash24(ToBytes(data), key);
+
+    public static ulong SipHash24(byte[] data, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ValidateKey(key, 16, nameof(key), "SipHash key");
+
+        var k0 = ReadUInt64LittleEndian(key, 0);
+        var k1 = ReadUInt64LittleEndian(key, 8);
+        var v0 = SipHashV0 ^ k0;
+        var v1 = SipHashV1 ^ k1;
+        var v2 = SipHashV2 ^ k0;
+        var v3 = SipHashV3 ^ k1;
+
+        var offset = 0;
+        while (offset + 8 <= data.Length)
+        {
+            var m = ReadUInt64LittleEndian(data, offset);
+            v3 ^= m;
+            SipRound(ref v0, ref v1, ref v2, ref v3);
+            SipRound(ref v0, ref v1, ref v2, ref v3);
+            v0 ^= m;
+            offset += 8;
+        }
+
+        var last = ((ulong)data.Length & 0xff) << 56;
+        for (var index = 0; index < data.Length - offset; index++)
+        {
+            last |= (ulong)data[offset + index] << (index * 8);
+        }
+
+        v3 ^= last;
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+        v0 ^= last;
+
+        v2 ^= 0xff;
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+        SipRound(ref v0, ref v1, ref v2, ref v3);
+
+        return v0 ^ v1 ^ v2 ^ v3;
+    }
+
+    public static double AvalancheScore(Func<byte[], ulong> hashFunction, int outputBits, int sampleSize = 1000)
+    {
+        ArgumentNullException.ThrowIfNull(hashFunction);
+        if (outputBits is < 1 or > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(outputBits), "Output bits must be in 1..=64.");
+        }
+
+        if (sampleSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleSize), "Sample size must be positive.");
+        }
+
+        var input = new byte[8];
+        ulong totalBitFlips = 0;
+        ulong totalTrials = 0;
+
+        for (var sample = 0; sample < sampleSize; sample++)
+        {
+            RandomNumberGenerator.Fill(input);
+            var h1 = hashFunction(input);
+
+            for (var bitPosition = 0; bitPosition < input.Length * 8; bitPosition++)
+            {
+                var flipped = input.ToArray();
+                flipped[bitPosition / 8] ^= (byte)(1 << (bitPosition % 8));
+                var h2 = hashFunction(flipped);
+                totalBitFlips += (ulong)BitOperations.PopCount(h1 ^ h2);
+                totalTrials += (ulong)outputBits;
+            }
+        }
+
+        return (double)totalBitFlips / totalTrials;
+    }
+
+    public static double DistributionTest(Func<byte[], ulong> hashFunction, IEnumerable<byte[]> inputs, int numBuckets)
+    {
+        ArgumentNullException.ThrowIfNull(hashFunction);
+        ArgumentNullException.ThrowIfNull(inputs);
+        if (numBuckets <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numBuckets), "Number of buckets must be positive.");
+        }
+
+        var counts = new ulong[numBuckets];
+        ulong total = 0;
+        foreach (var input in inputs)
+        {
+            var bucket = (int)(hashFunction(input) % (ulong)numBuckets);
+            counts[bucket]++;
+            total++;
+        }
+
+        if (total == 0)
+        {
+            throw new ArgumentException("Inputs must not be empty.", nameof(inputs));
+        }
+
+        var expected = (double)total / numBuckets;
+        var chiSquared = 0.0;
+        foreach (var count in counts)
+        {
+            var delta = count - expected;
+            chiSquared += delta * delta / expected;
+        }
+
+        return chiSquared;
+    }
+
+    private static uint Fmix32(uint hash)
+    {
+        hash ^= hash >> 16;
+        hash = unchecked(hash * 0x85EBCA6B);
+        hash ^= hash >> 13;
+        hash = unchecked(hash * 0xC2B2AE35);
+        hash ^= hash >> 16;
+        return hash;
+    }
+
+    private static void SipRound(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3)
+    {
+        v0 = unchecked(v0 + v1);
+        v1 = BitOperations.RotateLeft(v1, 13);
+        v1 ^= v0;
+        v0 = BitOperations.RotateLeft(v0, 32);
+
+        v2 = unchecked(v2 + v3);
+        v3 = BitOperations.RotateLeft(v3, 16);
+        v3 ^= v2;
+
+        v0 = unchecked(v0 + v3);
+        v3 = BitOperations.RotateLeft(v3, 21);
+        v3 ^= v0;
+
+        v2 = unchecked(v2 + v1);
+        v1 = BitOperations.RotateLeft(v1, 17);
+        v1 ^= v2;
+        v2 = BitOperations.RotateLeft(v2, 32);
+    }
+
+    private static ulong ReadUInt64LittleEndian(byte[] data, int offset)
+    {
+        var value = 0UL;
+        for (var index = 0; index < 8; index++)
+        {
+            value |= (ulong)data[offset + index] << (index * 8);
+        }
+
+        return value;
+    }
+
+    private static byte[] ToBytes(string data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        return Encoding.UTF8.GetBytes(data);
+    }
+
+    private static void ValidateKey(byte[] key, int length, string paramName, string label)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != length)
+        {
+            throw new ArgumentException($"{label} must be {length} bytes.", paramName);
+        }
+    }
+}

--- a/code/packages/csharp/hash-functions/README.md
+++ b/code/packages/csharp/hash-functions/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.HashFunctions.CSharp
+
+Non-cryptographic hash functions for .NET.
+
+This package mirrors the repository hash-functions surface with FNV-1a, DJB2, polynomial rolling, MurmurHash3, SipHash-2-4, and small analysis helpers.
+
+```csharp
+using CodingAdventures.HashFunctions;
+
+uint fnv = HashFunctions.Fnv1a32("hello");
+ulong djb = HashFunctions.Djb2("abc");
+uint murmur = HashFunctions.Murmur3_32("abc");
+
+double chi2 = HashFunctions.DistributionTest(
+    bytes => HashFunctions.Fnv1a64(bytes),
+    inputs,
+    numBuckets: 16);
+```

--- a/code/packages/csharp/hash-functions/required_capabilities.json
+++ b/code/packages/csharp/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/hash-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory hash algorithms and analysis helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.csproj
+++ b/code/packages/csharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.HashFunctions.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/HashFunctionsTests.cs
+++ b/code/packages/csharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/HashFunctionsTests.cs
@@ -1,0 +1,104 @@
+namespace CodingAdventures.HashFunctions.Tests;
+
+public sealed class HashFunctionsTests
+{
+    [Fact]
+    public void Fnv1aKnownVectors()
+    {
+        Assert.Equal(0x811C9DC5u, HashFunctions.Fnv1a32(Array.Empty<byte>()));
+        Assert.Equal(0xE40C292Cu, HashFunctions.Fnv1a32("a"));
+        Assert.Equal(0x1A47E90Bu, HashFunctions.Fnv1a32("abc"));
+        Assert.Equal(1_335_831_723u, HashFunctions.Fnv1a32("hello"));
+        Assert.Equal(3_214_735_720u, HashFunctions.Fnv1a32("foobar"));
+
+        Assert.Equal(0xCBF29CE484222325UL, HashFunctions.Fnv1a64(Array.Empty<byte>()));
+        Assert.Equal(0xAF63DC4C8601EC8CUL, HashFunctions.Fnv1a64("a"));
+        Assert.Equal(0xE71FA2190541574BUL, HashFunctions.Fnv1a64("abc"));
+        Assert.Equal(0xA430D84680AABD0BUL, HashFunctions.Fnv1a64("hello"));
+    }
+
+    [Fact]
+    public void Djb2AndPolynomialKnownVectors()
+    {
+        Assert.Equal(5_381UL, HashFunctions.Djb2(Array.Empty<byte>()));
+        Assert.Equal(177_670UL, HashFunctions.Djb2("a"));
+        Assert.Equal(193_485_963UL, HashFunctions.Djb2("abc"));
+
+        Assert.Equal(0UL, HashFunctions.PolynomialRolling(Array.Empty<byte>()));
+        Assert.Equal(97UL, HashFunctions.PolynomialRolling("a"));
+        Assert.Equal(3_105UL, HashFunctions.PolynomialRolling("ab"));
+        Assert.Equal(96_354UL, HashFunctions.PolynomialRolling("abc"));
+        Assert.Equal(((97UL * 37 + 98) * 37 + 99), HashFunctions.PolynomialRolling("abc", 37, 1_000_000_007));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HashFunctions.PolynomialRolling("abc", modulus: 0));
+    }
+
+    [Fact]
+    public void Murmur3KnownVectors()
+    {
+        Assert.Equal(0u, HashFunctions.Murmur3_32(Array.Empty<byte>()));
+        Assert.Equal(0x514E28B7u, HashFunctions.Murmur3_32(Array.Empty<byte>(), 1));
+        Assert.Equal(0x3C2569B2u, HashFunctions.Murmur3_32("a"));
+        Assert.Equal(0xB3DD93FAu, HashFunctions.Murmur3_32("abc"));
+        Assert.Equal(0x43ED676Au, HashFunctions.Murmur3_32("abcd"));
+    }
+
+    [Fact]
+    public void SipHashKnownVectorsAndStringHelpers()
+    {
+        var key = Enumerable.Range(0, 16).Select(value => (byte)value).ToArray();
+
+        Assert.Equal(0x726FDB47DD0E0E31UL, HashFunctions.SipHash24(Array.Empty<byte>(), key));
+        Assert.Equal(0x74F839C593DC67FDUL, HashFunctions.SipHash24(new byte[] { 0 }, key));
+        Assert.Equal(HashFunctions.Fnv1a32("hello"), HashFunctions.HashStringFnv1a32("hello"));
+        Assert.Equal(HashFunctions.SipHash24("hello"u8.ToArray(), key), HashFunctions.HashStringSipHash("hello", key));
+        Assert.Throws<ArgumentException>(() => HashFunctions.SipHash24(Array.Empty<byte>(), new byte[8]));
+    }
+
+    [Fact]
+    public void StrategyTypesForwardToFreeFunctions()
+    {
+        IHashFunction[] strategies =
+        [
+            new Fnv1a32(),
+            new Fnv1a64(),
+            new Djb2Hash(),
+            new PolynomialRollingHash(),
+            new Murmur3_32(),
+            new SipHash24(new byte[16]),
+        ];
+
+        var input = "abc"u8.ToArray();
+
+        Assert.Equal(HashFunctions.Fnv1a32(input), (uint)strategies[0].Hash(input));
+        Assert.Equal(HashFunctions.Fnv1a64(input), strategies[1].Hash(input));
+        Assert.Equal(HashFunctions.Djb2(input), strategies[2].Hash(input));
+        Assert.Equal(HashFunctions.PolynomialRolling(input), strategies[3].Hash(input));
+        Assert.Equal(HashFunctions.Murmur3_32(input), (uint)strategies[4].Hash(input));
+        Assert.Equal(HashFunctions.SipHash24(input, new byte[16]), strategies[5].Hash(input));
+        Assert.Equal([32, 64, 64, 64, 32, 64], strategies.Select(strategy => strategy.OutputBits).ToArray());
+    }
+
+    [Fact]
+    public void DistributionTestMatchesExactConstantHashMath()
+    {
+        var inputs = new[]
+        {
+            "a"u8.ToArray(),
+            "b"u8.ToArray(),
+            "c"u8.ToArray(),
+            "d"u8.ToArray(),
+        };
+
+        Assert.Equal(12.0, HashFunctions.DistributionTest(_ => 0UL, inputs, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HashFunctions.DistributionTest(_ => 0UL, inputs, 0));
+        Assert.Throws<ArgumentException>(() => HashFunctions.DistributionTest(_ => 0UL, Array.Empty<byte[]>(), 4));
+    }
+
+    [Fact]
+    public void AvalancheScoreHandlesSmallSamples()
+    {
+        Assert.Equal(0.0, HashFunctions.AvalancheScore(_ => 0UL, 32, sampleSize: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HashFunctions.AvalancheScore(_ => 0UL, 65, sampleSize: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => HashFunctions.AvalancheScore(_ => 0UL, 32, sampleSize: 0));
+    }
+}

--- a/code/packages/fsharp/hash-functions/BUILD
+++ b/code/packages/fsharp/hash-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hash-functions/BUILD_windows
+++ b/code/packages/fsharp/hash-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/hash-functions/CHANGELOG.md
+++ b/code/packages/fsharp/hash-functions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for FNV-1a, DJB2, polynomial rolling, MurmurHash3, SipHash-2-4, and hash analysis helpers.

--- a/code/packages/fsharp/hash-functions/CodingAdventures.HashFunctions.fsproj
+++ b/code/packages/fsharp/hash-functions/CodingAdventures.HashFunctions.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.HashFunctions.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Non-cryptographic hash functions and analysis helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="HashFunctions.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hash-functions/HashFunctions.fs
+++ b/code/packages/fsharp/hash-functions/HashFunctions.fs
@@ -1,0 +1,319 @@
+namespace CodingAdventures.HashFunctions.FSharp
+
+open System
+open System.Numerics
+open System.Security.Cryptography
+open System.Text
+
+type HashFunction =
+    abstract Hash: byte array -> uint64
+    abstract OutputBits: int
+
+[<RequireQualifiedAccess>]
+module HashFunctions =
+    [<Literal>]
+    let fnv32OffsetBasis = 0x811C9DC5u
+
+    [<Literal>]
+    let fnv32Prime = 0x01000193u
+
+    [<Literal>]
+    let fnv64OffsetBasis = 0xCBF29CE484222325UL
+
+    [<Literal>]
+    let fnv64Prime = 0x00000100000001B3UL
+
+    [<Literal>]
+    let djb2OffsetBasis = 5381UL
+
+    [<Literal>]
+    let polynomialRollingDefaultBase = 31UL
+
+    [<Literal>]
+    let polynomialRollingDefaultModulus = (1UL <<< 61) - 1UL
+
+    let private murmurC1 = 0xCC9E2D51u
+    let private murmurC2 = 0x1B873593u
+
+    let private sipHashV0 = 0x736F6D6570736575UL
+    let private sipHashV1 = 0x646F72616E646F6DUL
+    let private sipHashV2 = 0x6C7967656E657261UL
+    let private sipHashV3 = 0x7465646279746573UL
+
+    let private requireBytes name (data: byte array) =
+        if isNull data then
+            nullArg name
+
+    let private toBytes (text: string) =
+        if isNull text then
+            nullArg "text"
+        Encoding.UTF8.GetBytes text
+
+    let fnv1a32Bytes (data: byte array) =
+        requireBytes "data" data
+        let mutable hash = fnv32OffsetBasis
+        for value in data do
+            hash <- hash ^^^ uint32 value
+            hash <- hash * fnv32Prime
+        hash
+
+    let fnv1a32 (text: string) =
+        fnv1a32Bytes (toBytes text)
+
+    let fnv1a64Bytes (data: byte array) =
+        requireBytes "data" data
+        let mutable hash = fnv64OffsetBasis
+        for value in data do
+            hash <- hash ^^^ uint64 value
+            hash <- hash * fnv64Prime
+        hash
+
+    let fnv1a64 (text: string) =
+        fnv1a64Bytes (toBytes text)
+
+    let djb2Bytes (data: byte array) =
+        requireBytes "data" data
+        let mutable hash = djb2OffsetBasis
+        for value in data do
+            hash <- (hash <<< 5) + hash + uint64 value
+        hash
+
+    let djb2 (text: string) =
+        djb2Bytes (toBytes text)
+
+    let polynomialRollingBytes (data: byte array) (baseValue: uint64) (modulus: uint64) =
+        requireBytes "data" data
+        if modulus = 0UL then
+            invalidArg "modulus" "Modulus must be positive."
+
+        let mutable hash = BigInteger.Zero
+        let b = BigInteger baseValue
+        let m = BigInteger modulus
+        for value in data do
+            hash <- (hash * b + BigInteger(int value)) % m
+        uint64 hash
+
+    let polynomialRolling (text: string) =
+        polynomialRollingBytes (toBytes text) polynomialRollingDefaultBase polynomialRollingDefaultModulus
+
+    let polynomialRollingWithParams (text: string) (baseValue: uint64) (modulus: uint64) =
+        polynomialRollingBytes (toBytes text) baseValue modulus
+
+    let private rotateLeft32 (value: uint32) shift =
+        (value <<< shift) ||| (value >>> (32 - shift))
+
+    let private rotateLeft64 (value: uint64) shift =
+        (value <<< shift) ||| (value >>> (64 - shift))
+
+    let private fmix32 (input: uint32) =
+        let mutable hash = input
+        hash <- hash ^^^ (hash >>> 16)
+        hash <- hash * 0x85EBCA6Bu
+        hash <- hash ^^^ (hash >>> 13)
+        hash <- hash * 0xC2B2AE35u
+        hash <- hash ^^^ (hash >>> 16)
+        hash
+
+    let murmur3_32BytesWithSeed (data: byte array) (seed: uint32) =
+        requireBytes "data" data
+        let mutable hash = seed
+        let mutable offset = 0
+
+        while offset + 4 <= data.Length do
+            let mutable k =
+                uint32 data.[offset]
+                ||| (uint32 data.[offset + 1] <<< 8)
+                ||| (uint32 data.[offset + 2] <<< 16)
+                ||| (uint32 data.[offset + 3] <<< 24)
+
+            k <- k * murmurC1
+            k <- rotateLeft32 k 15
+            k <- k * murmurC2
+
+            hash <- hash ^^^ k
+            hash <- rotateLeft32 hash 13
+            hash <- hash * 5u + 0xE6546B64u
+            offset <- offset + 4
+
+        let remaining = data.Length - offset
+        let mutable tail = 0u
+        if remaining >= 3 then
+            tail <- tail ^^^ (uint32 data.[offset + 2] <<< 16)
+        if remaining >= 2 then
+            tail <- tail ^^^ (uint32 data.[offset + 1] <<< 8)
+        if remaining >= 1 then
+            tail <- tail ^^^ uint32 data.[offset]
+            tail <- tail * murmurC1
+            tail <- rotateLeft32 tail 15
+            tail <- tail * murmurC2
+            hash <- hash ^^^ tail
+
+        hash <- hash ^^^ uint32 data.Length
+        fmix32 hash
+
+    let murmur3_32Bytes (data: byte array) =
+        murmur3_32BytesWithSeed data 0u
+
+    let murmur3_32 (text: string) =
+        murmur3_32Bytes (toBytes text)
+
+    let murmur3_32WithSeed (text: string) (seed: uint32) =
+        murmur3_32BytesWithSeed (toBytes text) seed
+
+    let private readUInt64LittleEndian (data: byte array) offset =
+        let mutable value = 0UL
+        for index in 0 .. 7 do
+            value <- value ||| (uint64 data.[offset + index] <<< (index * 8))
+        value
+
+    let private validateKey (key: byte array) =
+        requireBytes "key" key
+        if key.Length <> 16 then
+            invalidArg "key" "SipHash key must be 16 bytes."
+
+    let private sipRound (v0: byref<uint64>) (v1: byref<uint64>) (v2: byref<uint64>) (v3: byref<uint64>) =
+        v0 <- v0 + v1
+        v1 <- rotateLeft64 v1 13
+        v1 <- v1 ^^^ v0
+        v0 <- rotateLeft64 v0 32
+
+        v2 <- v2 + v3
+        v3 <- rotateLeft64 v3 16
+        v3 <- v3 ^^^ v2
+
+        v0 <- v0 + v3
+        v3 <- rotateLeft64 v3 21
+        v3 <- v3 ^^^ v0
+
+        v2 <- v2 + v1
+        v1 <- rotateLeft64 v1 17
+        v1 <- v1 ^^^ v2
+        v2 <- rotateLeft64 v2 32
+
+    let sipHash24 (data: byte array) (key: byte array) =
+        requireBytes "data" data
+        validateKey key
+
+        let k0 = readUInt64LittleEndian key 0
+        let k1 = readUInt64LittleEndian key 8
+        let mutable v0 = sipHashV0 ^^^ k0
+        let mutable v1 = sipHashV1 ^^^ k1
+        let mutable v2 = sipHashV2 ^^^ k0
+        let mutable v3 = sipHashV3 ^^^ k1
+
+        let mutable offset = 0
+        while offset + 8 <= data.Length do
+            let m = readUInt64LittleEndian data offset
+            v3 <- v3 ^^^ m
+            sipRound &v0 &v1 &v2 &v3
+            sipRound &v0 &v1 &v2 &v3
+            v0 <- v0 ^^^ m
+            offset <- offset + 8
+
+        let mutable last = (uint64 data.Length &&& 0xffUL) <<< 56
+        for index in 0 .. data.Length - offset - 1 do
+            last <- last ||| (uint64 data.[offset + index] <<< (index * 8))
+
+        v3 <- v3 ^^^ last
+        sipRound &v0 &v1 &v2 &v3
+        sipRound &v0 &v1 &v2 &v3
+        v0 <- v0 ^^^ last
+
+        v2 <- v2 ^^^ 0xffUL
+        sipRound &v0 &v1 &v2 &v3
+        sipRound &v0 &v1 &v2 &v3
+        sipRound &v0 &v1 &v2 &v3
+        sipRound &v0 &v1 &v2 &v3
+
+        v0 ^^^ v1 ^^^ v2 ^^^ v3
+
+    let hashStringFnv1a32 (text: string) =
+        fnv1a32 text
+
+    let hashStringSipHash (text: string) (key: byte array) =
+        sipHash24 (toBytes text) key
+
+    let avalancheScore (hashFunction: byte array -> uint64) outputBits sampleSize =
+        if isNull (box hashFunction) then
+            nullArg "hashFunction"
+        if outputBits < 1 || outputBits > 64 then
+            invalidArg "outputBits" "Output bits must be in 1..=64."
+        if sampleSize <= 0 then
+            invalidArg "sampleSize" "Sample size must be positive."
+
+        let input = Array.zeroCreate<byte> 8
+        let mutable totalBitFlips = 0UL
+        let mutable totalTrials = 0UL
+        for _ in 1 .. sampleSize do
+            RandomNumberGenerator.Fill input
+            let h1 = hashFunction input
+
+            for bitPosition in 0 .. input.Length * 8 - 1 do
+                let flipped = Array.copy input
+                flipped.[bitPosition / 8] <- flipped.[bitPosition / 8] ^^^ byte (1 <<< (bitPosition % 8))
+                let h2 = hashFunction flipped
+                totalBitFlips <- totalBitFlips + uint64 (BitOperations.PopCount(h1 ^^^ h2))
+                totalTrials <- totalTrials + uint64 outputBits
+
+        float totalBitFlips / float totalTrials
+
+    let distributionTest (hashFunction: byte array -> uint64) (inputs: seq<byte array>) numBuckets =
+        if isNull (box hashFunction) then
+            nullArg "hashFunction"
+        if isNull (box inputs) then
+            nullArg "inputs"
+        if numBuckets <= 0 then
+            invalidArg "numBuckets" "Number of buckets must be positive."
+
+        let counts = Array.zeroCreate<uint64> numBuckets
+        let mutable total = 0UL
+        for input in inputs do
+            let bucket = int (hashFunction input % uint64 numBuckets)
+            counts.[bucket] <- counts.[bucket] + 1UL
+            total <- total + 1UL
+
+        if total = 0UL then
+            invalidArg "inputs" "Inputs must not be empty."
+
+        let expected = float total / float numBuckets
+        counts
+        |> Array.sumBy (fun count ->
+            let delta = float count - expected
+            delta * delta / expected)
+
+type Fnv1a32() =
+    interface HashFunction with
+        member _.Hash(data) = uint64 (HashFunctions.fnv1a32Bytes data)
+        member _.OutputBits = 32
+
+type Fnv1a64() =
+    interface HashFunction with
+        member _.Hash(data) = HashFunctions.fnv1a64Bytes data
+        member _.OutputBits = 64
+
+type Djb2Hash() =
+    interface HashFunction with
+        member _.Hash(data) = HashFunctions.djb2Bytes data
+        member _.OutputBits = 64
+
+type PolynomialRollingHash(?baseValue: uint64, ?modulus: uint64) =
+    let baseValue = defaultArg baseValue HashFunctions.polynomialRollingDefaultBase
+    let modulus = defaultArg modulus HashFunctions.polynomialRollingDefaultModulus
+
+    interface HashFunction with
+        member _.Hash(data) = HashFunctions.polynomialRollingBytes data baseValue modulus
+        member _.OutputBits = 64
+
+type Murmur3_32(?seed: uint32) =
+    let seed = defaultArg seed 0u
+
+    interface HashFunction with
+        member _.Hash(data) = uint64 (HashFunctions.murmur3_32BytesWithSeed data seed)
+        member _.OutputBits = 32
+
+type SipHash24(key: byte array) =
+    let key = Array.copy key
+
+    interface HashFunction with
+        member _.Hash(data) = HashFunctions.sipHash24 data key
+        member _.OutputBits = 64

--- a/code/packages/fsharp/hash-functions/README.md
+++ b/code/packages/fsharp/hash-functions/README.md
@@ -1,0 +1,19 @@
+# CodingAdventures.HashFunctions.FSharp
+
+Non-cryptographic hash functions for .NET.
+
+This package mirrors the repository hash-functions surface with FNV-1a, DJB2, polynomial rolling, MurmurHash3, SipHash-2-4, and small analysis helpers.
+
+```fsharp
+open CodingAdventures.HashFunctions.FSharp
+
+let fnv = HashFunctions.fnv1a32 "hello"
+let djb = HashFunctions.djb2 "abc"
+let murmur = HashFunctions.murmur3_32 "abc"
+
+let chi2 =
+    HashFunctions.distributionTest
+        (fun bytes -> HashFunctions.fnv1a64Bytes bytes)
+        inputs
+        16
+```

--- a/code/packages/fsharp/hash-functions/required_capabilities.json
+++ b/code/packages/fsharp/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/hash-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory hash algorithms and analysis helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.fsproj
+++ b/code/packages/fsharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.HashFunctions.fsproj" />
+    <Compile Include="HashFunctionsTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/HashFunctionsTests.fs
+++ b/code/packages/fsharp/hash-functions/tests/CodingAdventures.HashFunctions.Tests/HashFunctionsTests.fs
@@ -1,0 +1,89 @@
+namespace CodingAdventures.HashFunctions.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.HashFunctions.FSharp
+
+module HashFunctionsTests =
+    let bytes (text: string) = Encoding.UTF8.GetBytes text
+
+    [<Fact>]
+    let ``fnv1a known vectors`` () =
+        Assert.Equal(0x811C9DC5u, HashFunctions.fnv1a32Bytes Array.empty<byte>)
+        Assert.Equal(0xE40C292Cu, HashFunctions.fnv1a32 "a")
+        Assert.Equal(0x1A47E90Bu, HashFunctions.fnv1a32 "abc")
+        Assert.Equal(1_335_831_723u, HashFunctions.fnv1a32 "hello")
+        Assert.Equal(3_214_735_720u, HashFunctions.fnv1a32 "foobar")
+
+        Assert.Equal(0xCBF29CE484222325UL, HashFunctions.fnv1a64Bytes Array.empty<byte>)
+        Assert.Equal(0xAF63DC4C8601EC8CUL, HashFunctions.fnv1a64 "a")
+        Assert.Equal(0xE71FA2190541574BUL, HashFunctions.fnv1a64 "abc")
+        Assert.Equal(0xA430D84680AABD0BUL, HashFunctions.fnv1a64 "hello")
+
+    [<Fact>]
+    let ``djb2 and polynomial known vectors`` () =
+        Assert.Equal(5_381UL, HashFunctions.djb2Bytes Array.empty<byte>)
+        Assert.Equal(177_670UL, HashFunctions.djb2 "a")
+        Assert.Equal(193_485_963UL, HashFunctions.djb2 "abc")
+
+        Assert.Equal(0UL, HashFunctions.polynomialRollingBytes Array.empty<byte> HashFunctions.polynomialRollingDefaultBase HashFunctions.polynomialRollingDefaultModulus)
+        Assert.Equal(97UL, HashFunctions.polynomialRolling "a")
+        Assert.Equal(3_105UL, HashFunctions.polynomialRolling "ab")
+        Assert.Equal(96_354UL, HashFunctions.polynomialRolling "abc")
+        Assert.Equal(((97UL * 37UL + 98UL) * 37UL + 99UL), HashFunctions.polynomialRollingWithParams "abc" 37UL 1_000_000_007UL)
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.polynomialRollingWithParams "abc" 31UL 0UL |> ignore) |> ignore
+
+    [<Fact>]
+    let ``murmur3 known vectors`` () =
+        Assert.Equal(0u, HashFunctions.murmur3_32Bytes Array.empty<byte>)
+        Assert.Equal(0x514E28B7u, HashFunctions.murmur3_32BytesWithSeed Array.empty<byte> 1u)
+        Assert.Equal(0x3C2569B2u, HashFunctions.murmur3_32 "a")
+        Assert.Equal(0xB3DD93FAu, HashFunctions.murmur3_32 "abc")
+        Assert.Equal(0x43ED676Au, HashFunctions.murmur3_32 "abcd")
+
+    [<Fact>]
+    let ``siphash vectors and string helpers`` () =
+        let key = [| for value in 0 .. 15 -> byte value |]
+
+        Assert.Equal(0x726FDB47DD0E0E31UL, HashFunctions.sipHash24 Array.empty<byte> key)
+        Assert.Equal(0x74F839C593DC67FDUL, HashFunctions.sipHash24 [| 0uy |] key)
+        Assert.Equal(HashFunctions.fnv1a32 "hello", HashFunctions.hashStringFnv1a32 "hello")
+        Assert.Equal(HashFunctions.sipHash24 (bytes "hello") key, HashFunctions.hashStringSipHash "hello" key)
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.sipHash24 Array.empty<byte> (Array.zeroCreate<byte> 8) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``strategy types forward to free functions`` () =
+        let strategies: HashFunction array =
+            [|
+                Fnv1a32() :> HashFunction
+                Fnv1a64() :> HashFunction
+                Djb2Hash() :> HashFunction
+                PolynomialRollingHash() :> HashFunction
+                Murmur3_32() :> HashFunction
+                SipHash24(Array.zeroCreate<byte> 16) :> HashFunction
+            |]
+
+        let input = bytes "abc"
+
+        Assert.Equal(uint64 (HashFunctions.fnv1a32Bytes input), strategies.[0].Hash input)
+        Assert.Equal(HashFunctions.fnv1a64Bytes input, strategies.[1].Hash input)
+        Assert.Equal(HashFunctions.djb2Bytes input, strategies.[2].Hash input)
+        Assert.Equal(HashFunctions.polynomialRollingBytes input HashFunctions.polynomialRollingDefaultBase HashFunctions.polynomialRollingDefaultModulus, strategies.[3].Hash input)
+        Assert.Equal(uint64 (HashFunctions.murmur3_32Bytes input), strategies.[4].Hash input)
+        Assert.Equal(HashFunctions.sipHash24 input (Array.zeroCreate<byte> 16), strategies.[5].Hash input)
+        Assert.Equal<int array>([| 32; 64; 64; 64; 32; 64 |], strategies |> Array.map (fun strategy -> strategy.OutputBits))
+
+    [<Fact>]
+    let ``distribution test matches exact constant hash math`` () =
+        let inputs = [| bytes "a"; bytes "b"; bytes "c"; bytes "d" |]
+
+        Assert.Equal(12.0, HashFunctions.distributionTest (fun _ -> 0UL) inputs 4)
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.distributionTest (fun _ -> 0UL) inputs 0 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.distributionTest (fun _ -> 0UL) Array.empty<byte array> 4 |> ignore) |> ignore
+
+    [<Fact>]
+    let ``avalanche score handles small samples`` () =
+        Assert.Equal(0.0, HashFunctions.avalancheScore (fun _ -> 0UL) 32 1)
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.avalancheScore (fun _ -> 0UL) 65 1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> HashFunctions.avalancheScore (fun _ -> 0UL) 32 0 |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add native C# and F# hash-functions packages with FNV-1a, DJB2, polynomial rolling, MurmurHash3, and SipHash-2-4
- include strategy/interface wrappers plus avalanche and distribution analysis helpers
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\hash-functions\tests\CodingAdventures.HashFunctions.Tests\CodingAdventures.HashFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\hash-functions\tests\CodingAdventures.HashFunctions.Tests\CodingAdventures.HashFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line