### PR TITLE
feat(parity): add dotnet barcode layout packages

### DIFF
--- a/code/packages/csharp/barcode-layout-1d/BUILD
+++ b/code/packages/csharp/barcode-layout-1d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/barcode-layout-1d/BUILD_windows
+++ b/code/packages/csharp/barcode-layout-1d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/barcode-layout-1d/BarcodeLayout1D.cs
+++ b/code/packages/csharp/barcode-layout-1d/BarcodeLayout1D.cs
@@ -1,0 +1,446 @@
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.BarcodeLayout1D;
+
+public enum Barcode1DRunColor
+{
+    Bar,
+    Space,
+}
+
+public enum Barcode1DRunRole
+{
+    Data,
+    Start,
+    Stop,
+    Guard,
+    Check,
+    InterCharacterGap,
+}
+
+public enum Barcode1DSymbolRole
+{
+    Data,
+    Start,
+    Stop,
+    Guard,
+    Check,
+}
+
+public enum Barcode1DLayoutTarget
+{
+    NativePaintVm,
+    CanvasPaintVm,
+    DomPaintVm,
+}
+
+public sealed record Barcode1DRun(
+    Barcode1DRunColor Color,
+    uint Modules,
+    string SourceLabel,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public sealed record Barcode1DSymbolLayout(
+    string Label,
+    uint StartModule,
+    uint EndModule,
+    int SourceIndex,
+    Barcode1DSymbolRole Role);
+
+public sealed record Barcode1DLayout(
+    uint LeftQuietZoneModules,
+    uint RightQuietZoneModules,
+    uint ContentModules,
+    uint TotalModules,
+    IReadOnlyList<Barcode1DSymbolLayout> SymbolLayouts);
+
+public sealed record Barcode1DSymbolDescriptor(
+    string Label,
+    uint Modules,
+    int SourceIndex,
+    Barcode1DSymbolRole Role);
+
+public sealed record Barcode1DRenderConfig
+{
+    public Barcode1DLayoutTarget LayoutTarget { get; init; } = Barcode1DLayoutTarget.NativePaintVm;
+    public double ModuleWidth { get; init; } = 4.0;
+    public double BarHeight { get; init; } = 120.0;
+    public uint QuietZoneModules { get; init; } = 10;
+    public bool IncludeHumanReadableText { get; init; }
+    public double TextFontSize { get; init; } = 16.0;
+    public double TextMargin { get; init; } = 8.0;
+    public string Foreground { get; init; } = "#000000";
+    public string Background { get; init; } = "#ffffff";
+}
+
+public sealed record PaintBarcode1DOptions
+{
+    public Barcode1DRenderConfig RenderConfig { get; init; } = new();
+    public string? HumanReadableText { get; init; }
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; } = new Dictionary<string, object?>();
+    public string? Label { get; init; }
+    public IReadOnlyList<Barcode1DSymbolDescriptor>? Symbols { get; init; }
+}
+
+public sealed record RunsFromBinaryPatternOptions(
+    string SourceLabel,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public sealed record RunsFromWidthPatternOptions(
+    string SourceLabel,
+    int SourceIndex,
+    Barcode1DRunRole Role)
+{
+    public uint NarrowModules { get; init; } = 1;
+    public uint WideModules { get; init; } = 3;
+    public char NarrowMarker { get; init; } = 'N';
+    public char WideMarker { get; init; } = 'W';
+    public Barcode1DRunColor StartingColor { get; init; } = Barcode1DRunColor.Bar;
+}
+
+public static class BarcodeLayout1D
+{
+    public const string VERSION = "0.1.0";
+
+    public static string AsString(this Barcode1DRunColor color) =>
+        color switch
+        {
+            Barcode1DRunColor.Bar => "bar",
+            Barcode1DRunColor.Space => "space",
+            _ => throw new ArgumentOutOfRangeException(nameof(color), color, null),
+        };
+
+    public static string AsString(this Barcode1DRunRole role) =>
+        role switch
+        {
+            Barcode1DRunRole.Data => "data",
+            Barcode1DRunRole.Start => "start",
+            Barcode1DRunRole.Stop => "stop",
+            Barcode1DRunRole.Guard => "guard",
+            Barcode1DRunRole.Check => "check",
+            Barcode1DRunRole.InterCharacterGap => "inter-character-gap",
+            _ => throw new ArgumentOutOfRangeException(nameof(role), role, null),
+        };
+
+    public static string AsString(this Barcode1DSymbolRole role) =>
+        role switch
+        {
+            Barcode1DSymbolRole.Data => "data",
+            Barcode1DSymbolRole.Start => "start",
+            Barcode1DSymbolRole.Stop => "stop",
+            Barcode1DSymbolRole.Guard => "guard",
+            Barcode1DSymbolRole.Check => "check",
+            _ => throw new ArgumentOutOfRangeException(nameof(role), role, null),
+        };
+
+    public static string AsString(this Barcode1DLayoutTarget target) =>
+        target switch
+        {
+            Barcode1DLayoutTarget.NativePaintVm => "native-paint-vm",
+            Barcode1DLayoutTarget.CanvasPaintVm => "canvas-paint-vm",
+            Barcode1DLayoutTarget.DomPaintVm => "dom-paint-vm",
+            _ => throw new ArgumentOutOfRangeException(nameof(target), target, null),
+        };
+
+    public static uint TotalModules(IEnumerable<Barcode1DRun> runs)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+        return runs.Aggregate(0u, (sum, run) => sum + run.Modules);
+    }
+
+    public static Barcode1DLayout ComputeBarcode1DLayout(
+        IReadOnlyList<Barcode1DRun> runs,
+        uint quietZoneModules,
+        IReadOnlyList<Barcode1DSymbolDescriptor>? symbols = null)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+        ValidateRuns(runs);
+        if (quietZoneModules == 0)
+        {
+            throw new ArgumentException("quiet_zone_modules must be greater than zero.", nameof(quietZoneModules));
+        }
+
+        var contentModules = TotalModules(runs);
+        var symbolLayouts = symbols is null
+            ? InferSymbolLayouts(runs)
+            : LayoutExplicitSymbols(symbols, contentModules);
+
+        return new Barcode1DLayout(
+            quietZoneModules,
+            quietZoneModules,
+            contentModules,
+            quietZoneModules + contentModules + quietZoneModules,
+            symbolLayouts);
+    }
+
+    public static IReadOnlyList<Barcode1DRun> RunsFromBinaryPattern(
+        string pattern,
+        RunsFromBinaryPatternOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(options);
+        if (pattern.Length == 0)
+        {
+            throw new ArgumentException("Binary pattern must not be empty.", nameof(pattern));
+        }
+
+        if (pattern.Any(bit => bit is not ('0' or '1')))
+        {
+            throw new ArgumentException("Binary pattern must contain only 0 or 1.", nameof(pattern));
+        }
+
+        var runs = new List<Barcode1DRun>();
+        var currentBit = pattern[0];
+        var width = 1u;
+
+        for (var index = 1; index < pattern.Length; index++)
+        {
+            if (pattern[index] == currentBit)
+            {
+                width++;
+                continue;
+            }
+
+            runs.Add(MakeRun(currentBit, width, options.SourceLabel, options.SourceIndex, options.Role));
+            currentBit = pattern[index];
+            width = 1;
+        }
+
+        runs.Add(MakeRun(currentBit, width, options.SourceLabel, options.SourceIndex, options.Role));
+        return runs;
+    }
+
+    public static IReadOnlyList<Barcode1DRun> RunsFromWidthPattern(
+        string pattern,
+        RunsFromWidthPatternOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(options);
+        if (pattern.Length == 0)
+        {
+            throw new ArgumentException("Width pattern must not be empty.", nameof(pattern));
+        }
+
+        if (options.NarrowModules == 0 || options.WideModules == 0)
+        {
+            throw new ArgumentException("Narrow and wide module counts must be greater than zero.", nameof(options));
+        }
+
+        var runs = new List<Barcode1DRun>();
+        var color = options.StartingColor;
+        foreach (var marker in pattern)
+        {
+            var modules = marker == options.NarrowMarker
+                ? options.NarrowModules
+                : marker == options.WideMarker
+                    ? options.WideModules
+                    : throw new ArgumentException($"Unknown width marker '{marker}'.", nameof(pattern));
+
+            runs.Add(new Barcode1DRun(color, modules, options.SourceLabel, options.SourceIndex, options.Role));
+            color = color == Barcode1DRunColor.Bar ? Barcode1DRunColor.Space : Barcode1DRunColor.Bar;
+        }
+
+        return runs;
+    }
+
+    public static PaintScene LayoutBarcode1D(
+        IReadOnlyList<Barcode1DRun> runs,
+        PaintBarcode1DOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+        options ??= new PaintBarcode1DOptions();
+        ValidateRenderConfig(options.RenderConfig);
+
+        if (options.RenderConfig.IncludeHumanReadableText)
+        {
+            throw new NotSupportedException("Human-readable text shaping is not wired for dotnet barcode-layout-1d yet.");
+        }
+
+        var layout = ComputeBarcode1DLayout(runs, options.RenderConfig.QuietZoneModules, options.Symbols);
+        var instructions = new List<PaintInstructionBase>();
+        var moduleCursor = layout.LeftQuietZoneModules;
+
+        foreach (var run in runs)
+        {
+            var x = moduleCursor * options.RenderConfig.ModuleWidth;
+            var width = run.Modules * options.RenderConfig.ModuleWidth;
+            if (run.Color == Barcode1DRunColor.Bar)
+            {
+                instructions.Add(CodingAdventures.PaintInstructions.PaintInstructions.PaintRect(
+                    x,
+                    0,
+                    width,
+                    options.RenderConfig.BarHeight,
+                    new PaintRectOptions
+                    {
+                        Fill = options.RenderConfig.Foreground,
+                        Metadata = new Dictionary<string, object?>
+                        {
+                            ["sourceLabel"] = run.SourceLabel,
+                            ["sourceIndex"] = run.SourceIndex,
+                            ["role"] = run.Role.AsString(),
+                            ["moduleStart"] = moduleCursor,
+                            ["moduleEnd"] = moduleCursor + run.Modules,
+                        },
+                    }));
+            }
+
+            moduleCursor += run.Modules;
+        }
+
+        var sceneWidth = layout.TotalModules * options.RenderConfig.ModuleWidth;
+        var sceneHeight = options.RenderConfig.BarHeight;
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["label"] = options.Label ?? "1D barcode",
+            ["leftQuietZoneModules"] = layout.LeftQuietZoneModules,
+            ["rightQuietZoneModules"] = layout.RightQuietZoneModules,
+            ["contentModules"] = layout.ContentModules,
+            ["totalModules"] = layout.TotalModules,
+            ["moduleWidthPx"] = options.RenderConfig.ModuleWidth,
+            ["barHeightPx"] = options.RenderConfig.BarHeight,
+            ["sceneWidthPx"] = sceneWidth,
+            ["sceneHeightPx"] = sceneHeight,
+            ["symbolCount"] = layout.SymbolLayouts.Count,
+            ["layoutTarget"] = options.RenderConfig.LayoutTarget.AsString(),
+        };
+
+        if (options.HumanReadableText is not null)
+        {
+            metadata["humanReadableText"] = options.HumanReadableText;
+        }
+
+        return CodingAdventures.PaintInstructions.PaintInstructions.PaintScene(
+            sceneWidth,
+            sceneHeight,
+            options.RenderConfig.Background,
+            instructions,
+            new SceneOptions { Metadata = metadata });
+    }
+
+    private static Barcode1DRun MakeRun(char bit, uint modules, string sourceLabel, int sourceIndex, Barcode1DRunRole role) =>
+        new(bit == '1' ? Barcode1DRunColor.Bar : Barcode1DRunColor.Space, modules, sourceLabel, sourceIndex, role);
+
+    private static IReadOnlyList<Barcode1DSymbolLayout> LayoutExplicitSymbols(
+        IReadOnlyList<Barcode1DSymbolDescriptor> symbols,
+        uint contentModules)
+    {
+        var layouts = new List<Barcode1DSymbolLayout>();
+        var cursor = 0u;
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Modules == 0)
+            {
+                throw new ArgumentException($"Symbol '{symbol.Label}' modules must be greater than zero.", nameof(symbols));
+            }
+
+            layouts.Add(new Barcode1DSymbolLayout(symbol.Label, cursor, cursor + symbol.Modules, symbol.SourceIndex, symbol.Role));
+            cursor += symbol.Modules;
+        }
+
+        if (cursor != contentModules)
+        {
+            throw new ArgumentException("Symbol descriptors must add up to the same total width as the run stream.", nameof(symbols));
+        }
+
+        return layouts;
+    }
+
+    private static IReadOnlyList<Barcode1DSymbolLayout> InferSymbolLayouts(IReadOnlyList<Barcode1DRun> runs)
+    {
+        var layouts = new List<Barcode1DSymbolLayout>();
+        var cursor = 0u;
+        uint currentStart = 0;
+        string? currentLabel = null;
+        var currentSourceIndex = 0;
+        Barcode1DSymbolRole? currentRole = null;
+
+        foreach (var run in runs)
+        {
+            var symbolRole = ToSymbolRole(run.Role);
+            if (symbolRole is not null)
+            {
+                var sameSymbol = currentLabel == run.SourceLabel
+                    && currentSourceIndex == run.SourceIndex
+                    && currentRole == symbolRole;
+                if (!sameSymbol)
+                {
+                    Flush();
+                    currentStart = cursor;
+                    currentLabel = run.SourceLabel;
+                    currentSourceIndex = run.SourceIndex;
+                    currentRole = symbolRole;
+                }
+            }
+
+            cursor += run.Modules;
+        }
+
+        Flush();
+        return layouts;
+
+        void Flush()
+        {
+            if (currentLabel is not null && currentRole is not null)
+            {
+                layouts.Add(new Barcode1DSymbolLayout(currentLabel, currentStart, cursor, currentSourceIndex, currentRole.Value));
+            }
+        }
+    }
+
+    private static Barcode1DSymbolRole? ToSymbolRole(Barcode1DRunRole role) =>
+        role switch
+        {
+            Barcode1DRunRole.Data => Barcode1DSymbolRole.Data,
+            Barcode1DRunRole.Start => Barcode1DSymbolRole.Start,
+            Barcode1DRunRole.Stop => Barcode1DSymbolRole.Stop,
+            Barcode1DRunRole.Guard => Barcode1DSymbolRole.Guard,
+            Barcode1DRunRole.Check => Barcode1DSymbolRole.Check,
+            Barcode1DRunRole.InterCharacterGap => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(role), role, null),
+        };
+
+    private static void ValidateRuns(IReadOnlyList<Barcode1DRun> runs)
+    {
+        for (var index = 0; index < runs.Count; index++)
+        {
+            if (runs[index].Modules == 0)
+            {
+                throw new ArgumentException($"runs[{index}].modules must be greater than zero.", nameof(runs));
+            }
+
+            if (index > 0 && runs[index - 1].Color == runs[index].Color)
+            {
+                throw new ArgumentException("Runs must alternate between bars and spaces.", nameof(runs));
+            }
+        }
+    }
+
+    private static void ValidateRenderConfig(Barcode1DRenderConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ValidatePositive(config.ModuleWidth, nameof(config.ModuleWidth));
+        ValidatePositive(config.BarHeight, nameof(config.BarHeight));
+        ValidatePositive(config.TextFontSize, nameof(config.TextFontSize));
+
+        if (config.QuietZoneModules == 0)
+        {
+            throw new ArgumentException("Quiet zone modules must be greater than zero.", nameof(config));
+        }
+
+        if (!double.IsFinite(config.TextMargin) || config.TextMargin < 0)
+        {
+            throw new ArgumentException("Text margin must be zero or greater.", nameof(config));
+        }
+    }
+
+    private static void ValidatePositive(double value, string name)
+    {
+        if (!double.IsFinite(value) || value <= 0)
+        {
+            throw new ArgumentException($"{name} must be a positive number.");
+        }
+    }
+}

--- a/code/packages/csharp/barcode-layout-1d/CHANGELOG.md
+++ b/code/packages/csharp/barcode-layout-1d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# package for shared one-dimensional barcode layout helpers.

--- a/code/packages/csharp/barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj
+++ b/code/packages/csharp/barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BarcodeLayout1D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared layout utilities for one-dimensional barcodes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\paint-instructions\CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/barcode-layout-1d/README.md
+++ b/code/packages/csharp/barcode-layout-1d/README.md
@@ -1,0 +1,15 @@
+# CodingAdventures.BarcodeLayout1D.CSharp
+
+Shared layout utilities for one-dimensional barcode symbologies.
+
+This package converts logical bar/space runs into `PaintScene` rectangle instructions, with quiet zones, symbol layout metadata, and render configuration.
+
+```csharp
+using CodingAdventures.BarcodeLayout1D;
+
+var runs = BarcodeLayout1D.RunsFromBinaryPattern(
+    "101",
+    new RunsFromBinaryPatternOptions("guard", 0, Barcode1DRunRole.Guard));
+
+var scene = BarcodeLayout1D.LayoutBarcode1D(runs);
+```

--- a/code/packages/csharp/barcode-layout-1d/required_capabilities.json
+++ b/code/packages/csharp/barcode-layout-1d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/barcode-layout-1d",
+  "capabilities": [],
+  "justification": "Pure in-memory barcode layout into paint instructions. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/BarcodeLayout1DTests.cs
+++ b/code/packages/csharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/BarcodeLayout1DTests.cs
@@ -1,0 +1,110 @@
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.BarcodeLayout1D.Tests;
+
+public sealed class BarcodeLayout1DTests
+{
+    [Fact]
+    public void BinaryPatternExpandsToRuns()
+    {
+        var runs = BarcodeLayout1D.RunsFromBinaryPattern(
+            "11001",
+            new RunsFromBinaryPatternOptions("start", -1, Barcode1DRunRole.Guard));
+
+        Assert.Equal(3, runs.Count);
+        Assert.Equal(Barcode1DRunColor.Bar, runs[0].Color);
+        Assert.Equal(2u, runs[0].Modules);
+        Assert.Equal(Barcode1DRunColor.Space, runs[1].Color);
+        Assert.Equal(1u, runs[2].Modules);
+        Assert.Throws<ArgumentException>(() => BarcodeLayout1D.RunsFromBinaryPattern("10x", new("bad", 0, Barcode1DRunRole.Data)));
+    }
+
+    [Fact]
+    public void WidthPatternExpandsToRuns()
+    {
+        var runs = BarcodeLayout1D.RunsFromWidthPattern(
+            "NWN",
+            new RunsFromWidthPatternOptions("A", 0, Barcode1DRunRole.Data));
+
+        Assert.Equal(3, runs.Count);
+        Assert.Equal(1u, runs[0].Modules);
+        Assert.Equal(3u, runs[1].Modules);
+        Assert.Equal(Barcode1DRunColor.Bar, runs[2].Color);
+        Assert.Throws<ArgumentException>(() => BarcodeLayout1D.RunsFromWidthPattern("NX", new("A", 0, Barcode1DRunRole.Data)));
+    }
+
+    [Fact]
+    public void ComputesQuietZoneAwareLayout()
+    {
+        var runs = new[]
+        {
+            new Barcode1DRun(Barcode1DRunColor.Bar, 1, "*", 0, Barcode1DRunRole.Start),
+            new Barcode1DRun(Barcode1DRunColor.Space, 1, "*", 0, Barcode1DRunRole.InterCharacterGap),
+            new Barcode1DRun(Barcode1DRunColor.Bar, 2, "A", 1, Barcode1DRunRole.Data),
+        };
+
+        var layout = BarcodeLayout1D.ComputeBarcode1DLayout(runs, 10);
+
+        Assert.Equal(4u, layout.ContentModules);
+        Assert.Equal(24u, layout.TotalModules);
+        Assert.Equal(2, layout.SymbolLayouts.Count);
+        Assert.Equal("*", layout.SymbolLayouts[0].Label);
+        Assert.Equal(2u, layout.SymbolLayouts[0].EndModule);
+    }
+
+    [Fact]
+    public void ExplicitSymbolsMustMatchRunWidth()
+    {
+        var runs = BarcodeLayout1D.RunsFromBinaryPattern("101", new("demo", 0, Barcode1DRunRole.Guard));
+
+        var symbols = new[]
+        {
+            new Barcode1DSymbolDescriptor("demo", 3, 0, Barcode1DSymbolRole.Guard),
+        };
+
+        var layout = BarcodeLayout1D.ComputeBarcode1DLayout(runs, 10, symbols);
+        Assert.Single(layout.SymbolLayouts);
+        Assert.Throws<ArgumentException>(() => BarcodeLayout1D.ComputeBarcode1DLayout(runs, 10, [new("bad", 2, 0, Barcode1DSymbolRole.Data)]));
+    }
+
+    [Fact]
+    public void LaysOutRunsIntoPaintScene()
+    {
+        var runs = BarcodeLayout1D.RunsFromBinaryPattern("101", new("demo", 0, Barcode1DRunRole.Guard));
+        var scene = BarcodeLayout1D.LayoutBarcode1D(
+            runs,
+            new PaintBarcode1DOptions { Label = "Demo barcode" });
+
+        Assert.Equal("#ffffff", scene.Background);
+        Assert.Equal(2, scene.Instructions.Count);
+        Assert.All(scene.Instructions, instruction => Assert.IsType<PaintRect>(instruction));
+        Assert.Equal("Demo barcode", scene.Metadata?["label"]);
+        Assert.Equal(23u, scene.Metadata?["totalModules"]);
+    }
+
+    [Fact]
+    public void ValidatesLayoutAndRenderConfiguration()
+    {
+        Assert.Throws<ArgumentException>(() => BarcodeLayout1D.ComputeBarcode1DLayout(
+            [
+                new Barcode1DRun(Barcode1DRunColor.Bar, 1, "a", 0, Barcode1DRunRole.Data),
+                new Barcode1DRun(Barcode1DRunColor.Bar, 1, "b", 1, Barcode1DRunRole.Data),
+            ],
+            10));
+
+        var runs = BarcodeLayout1D.RunsFromBinaryPattern("101", new("demo", 0, Barcode1DRunRole.Guard));
+        Assert.Throws<NotSupportedException>(() => BarcodeLayout1D.LayoutBarcode1D(
+            runs,
+            new PaintBarcode1DOptions
+            {
+                RenderConfig = new Barcode1DRenderConfig { IncludeHumanReadableText = true },
+                HumanReadableText = "demo",
+            }));
+        Assert.Throws<ArgumentException>(() => BarcodeLayout1D.LayoutBarcode1D(
+            runs,
+            new PaintBarcode1DOptions
+            {
+                RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+            }));
+    }
+}

--- a/code/packages/csharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.csproj
+++ b/code/packages/csharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.PaintInstructions]*,[CodingAdventures.PixelContainer]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BarcodeLayout1D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/barcode-layout-1d/BUILD
+++ b/code/packages/fsharp/barcode-layout-1d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/barcode-layout-1d/BUILD_windows
+++ b/code/packages/fsharp/barcode-layout-1d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/barcode-layout-1d/BarcodeLayout1D.fs
+++ b/code/packages/fsharp/barcode-layout-1d/BarcodeLayout1D.fs
@@ -1,0 +1,419 @@
+namespace CodingAdventures.BarcodeLayout1D.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.PaintInstructions
+
+type Barcode1DRunColor =
+    | Bar
+    | Space
+    member this.AsString =
+        match this with
+        | Bar -> "bar"
+        | Space -> "space"
+
+type Barcode1DRunRole =
+    | Data
+    | Start
+    | Stop
+    | Guard
+    | Check
+    | InterCharacterGap
+    member this.AsString =
+        match this with
+        | Data -> "data"
+        | Start -> "start"
+        | Stop -> "stop"
+        | Guard -> "guard"
+        | Check -> "check"
+        | InterCharacterGap -> "inter-character-gap"
+
+type Barcode1DSymbolRole =
+    | SymbolData
+    | SymbolStart
+    | SymbolStop
+    | SymbolGuard
+    | SymbolCheck
+    member this.AsString =
+        match this with
+        | SymbolData -> "data"
+        | SymbolStart -> "start"
+        | SymbolStop -> "stop"
+        | SymbolGuard -> "guard"
+        | SymbolCheck -> "check"
+
+type Barcode1DLayoutTarget =
+    | NativePaintVm
+    | CanvasPaintVm
+    | DomPaintVm
+    member this.AsString =
+        match this with
+        | NativePaintVm -> "native-paint-vm"
+        | CanvasPaintVm -> "canvas-paint-vm"
+        | DomPaintVm -> "dom-paint-vm"
+
+type Barcode1DRun =
+    {
+        Color: Barcode1DRunColor
+        Modules: uint32
+        SourceLabel: string
+        SourceIndex: int
+        Role: Barcode1DRunRole
+    }
+
+type Barcode1DSymbolLayout =
+    {
+        Label: string
+        StartModule: uint32
+        EndModule: uint32
+        SourceIndex: int
+        Role: Barcode1DSymbolRole
+    }
+
+type Barcode1DLayout =
+    {
+        LeftQuietZoneModules: uint32
+        RightQuietZoneModules: uint32
+        ContentModules: uint32
+        TotalModules: uint32
+        SymbolLayouts: Barcode1DSymbolLayout list
+    }
+
+type Barcode1DSymbolDescriptor =
+    {
+        Label: string
+        Modules: uint32
+        SourceIndex: int
+        Role: Barcode1DSymbolRole
+    }
+
+type Barcode1DRenderConfig =
+    {
+        LayoutTarget: Barcode1DLayoutTarget
+        ModuleWidth: float
+        BarHeight: float
+        QuietZoneModules: uint32
+        IncludeHumanReadableText: bool
+        TextFontSize: float
+        TextMargin: float
+        Foreground: string
+        Background: string
+    }
+
+type PaintBarcode1DOptions =
+    {
+        RenderConfig: Barcode1DRenderConfig
+        HumanReadableText: string option
+        Metadata: Metadata
+        Label: string option
+        Symbols: Barcode1DSymbolDescriptor list option
+    }
+
+type RunsFromBinaryPatternOptions =
+    {
+        SourceLabel: string
+        SourceIndex: int
+        Role: Barcode1DRunRole
+    }
+
+type RunsFromWidthPatternOptions =
+    {
+        SourceLabel: string
+        SourceIndex: int
+        Role: Barcode1DRunRole
+        NarrowModules: uint32
+        WideModules: uint32
+        NarrowMarker: char
+        WideMarker: char
+        StartingColor: Barcode1DRunColor
+    }
+
+[<RequireQualifiedAccess>]
+module BarcodeLayout1D =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let emptyMetadata : Metadata = Dictionary<string, obj>() :> Metadata
+
+    let defaultRenderConfig =
+        {
+            LayoutTarget = NativePaintVm
+            ModuleWidth = 4.0
+            BarHeight = 120.0
+            QuietZoneModules = 10u
+            IncludeHumanReadableText = false
+            TextFontSize = 16.0
+            TextMargin = 8.0
+            Foreground = "#000000"
+            Background = "#ffffff"
+        }
+
+    let defaultPaintOptions =
+        {
+            RenderConfig = defaultRenderConfig
+            HumanReadableText = None
+            Metadata = emptyMetadata
+            Label = None
+            Symbols = None
+        }
+
+    let defaultWidthPatternOptions sourceLabel sourceIndex role =
+        {
+            SourceLabel = sourceLabel
+            SourceIndex = sourceIndex
+            Role = role
+            NarrowModules = 1u
+            WideModules = 3u
+            NarrowMarker = 'N'
+            WideMarker = 'W'
+            StartingColor = Bar
+        }
+
+    let totalModules (runs: seq<Barcode1DRun>) =
+        if isNull (box runs) then nullArg "runs"
+        runs |> Seq.sumBy _.Modules
+
+    let private validateRuns (runs: Barcode1DRun list) =
+        runs
+        |> List.iteri (fun index run ->
+            if run.Modules = 0u then
+                invalidArg "runs" $"runs[{index}].modules must be greater than zero."
+            if index > 0 && runs.[index - 1].Color = run.Color then
+                invalidArg "runs" "Runs must alternate between bars and spaces.")
+
+    let private toSymbolRole role =
+        match role with
+        | Data -> Some SymbolData
+        | Start -> Some SymbolStart
+        | Stop -> Some SymbolStop
+        | Guard -> Some SymbolGuard
+        | Check -> Some SymbolCheck
+        | InterCharacterGap -> None
+
+    let private inferSymbolLayouts (runs: Barcode1DRun list) =
+        let layouts = ResizeArray<Barcode1DSymbolLayout>()
+        let mutable cursor = 0u
+        let mutable currentStart = 0u
+        let mutable currentLabel: string option = None
+        let mutable currentSourceIndex = 0
+        let mutable currentRole: Barcode1DSymbolRole option = None
+
+        let flush () =
+            match currentLabel, currentRole with
+            | Some label, Some role ->
+                layouts.Add
+                    {
+                        Label = label
+                        StartModule = currentStart
+                        EndModule = cursor
+                        SourceIndex = currentSourceIndex
+                        Role = role
+                    }
+            | _ -> ()
+
+        for run in runs do
+            match toSymbolRole run.Role with
+            | Some symbolRole ->
+                let sameSymbol =
+                    currentLabel = Some run.SourceLabel
+                    && currentSourceIndex = run.SourceIndex
+                    && currentRole = Some symbolRole
+
+                if not sameSymbol then
+                    flush ()
+                    currentStart <- cursor
+                    currentLabel <- Some run.SourceLabel
+                    currentSourceIndex <- run.SourceIndex
+                    currentRole <- Some symbolRole
+            | None -> ()
+
+            cursor <- cursor + run.Modules
+
+        flush ()
+        List.ofSeq layouts
+
+    let private layoutExplicitSymbols (symbols: Barcode1DSymbolDescriptor list) contentModules =
+        let layouts = ResizeArray<Barcode1DSymbolLayout>()
+        let mutable cursor = 0u
+
+        for symbol in symbols do
+            if symbol.Modules = 0u then
+                invalidArg "symbols" $"Symbol '{symbol.Label}' modules must be greater than zero."
+
+            layouts.Add
+                {
+                    Label = symbol.Label
+                    StartModule = cursor
+                    EndModule = cursor + symbol.Modules
+                    SourceIndex = symbol.SourceIndex
+                    Role = symbol.Role
+                }
+            cursor <- cursor + symbol.Modules
+
+        if cursor <> contentModules then
+            invalidArg "symbols" "Symbol descriptors must add up to the same total width as the run stream."
+
+        List.ofSeq layouts
+
+    let computeBarcode1DLayout (runs: Barcode1DRun list) quietZoneModules (symbols: Barcode1DSymbolDescriptor list option) =
+        if isNull (box runs) then nullArg "runs"
+        validateRuns runs
+        if quietZoneModules = 0u then
+            invalidArg "quietZoneModules" "quiet_zone_modules must be greater than zero."
+
+        let contentModules = totalModules runs
+        let symbolLayouts =
+            match symbols with
+            | Some values -> layoutExplicitSymbols values contentModules
+            | None -> inferSymbolLayouts runs
+
+        {
+            LeftQuietZoneModules = quietZoneModules
+            RightQuietZoneModules = quietZoneModules
+            ContentModules = contentModules
+            TotalModules = quietZoneModules + contentModules + quietZoneModules
+            SymbolLayouts = symbolLayouts
+        }
+
+    let runsFromBinaryPattern (pattern: string) (options: RunsFromBinaryPatternOptions) =
+        if isNull pattern then nullArg "pattern"
+        if pattern.Length = 0 then
+            invalidArg "pattern" "Binary pattern must not be empty."
+        if pattern |> Seq.exists (fun bit -> bit <> '0' && bit <> '1') then
+            invalidArg "pattern" "Binary pattern must contain only 0 or 1."
+
+        let runs = ResizeArray<Barcode1DRun>()
+        let mutable currentBit = pattern.[0]
+        let mutable width = 1u
+
+        let addRun bit modules =
+            runs.Add
+                {
+                    Color = if bit = '1' then Bar else Space
+                    Modules = modules
+                    SourceLabel = options.SourceLabel
+                    SourceIndex = options.SourceIndex
+                    Role = options.Role
+                }
+
+        for index in 1 .. pattern.Length - 1 do
+            if pattern.[index] = currentBit then
+                width <- width + 1u
+            else
+                addRun currentBit width
+                currentBit <- pattern.[index]
+                width <- 1u
+
+        addRun currentBit width
+        List.ofSeq runs
+
+    let runsFromWidthPattern (pattern: string) (options: RunsFromWidthPatternOptions) =
+        if isNull pattern then nullArg "pattern"
+        if pattern.Length = 0 then
+            invalidArg "pattern" "Width pattern must not be empty."
+        if options.NarrowModules = 0u || options.WideModules = 0u then
+            invalidArg "options" "Narrow and wide module counts must be greater than zero."
+
+        let runs = ResizeArray<Barcode1DRun>()
+        let mutable color = options.StartingColor
+
+        for marker in pattern do
+            let modules =
+                if marker = options.NarrowMarker then options.NarrowModules
+                elif marker = options.WideMarker then options.WideModules
+                else invalidArg "pattern" $"Unknown width marker '{marker}'."
+
+            runs.Add
+                {
+                    Color = color
+                    Modules = modules
+                    SourceLabel = options.SourceLabel
+                    SourceIndex = options.SourceIndex
+                    Role = options.Role
+                }
+            color <- if color = Bar then Space else Bar
+
+        List.ofSeq runs
+
+    let private validatePositive name value =
+        if not (Double.IsFinite value) || value <= 0.0 then
+            invalidArg name $"{name} must be a positive number."
+
+    let private validateRenderConfig config =
+        validatePositive "ModuleWidth" config.ModuleWidth
+        validatePositive "BarHeight" config.BarHeight
+        validatePositive "TextFontSize" config.TextFontSize
+        if config.QuietZoneModules = 0u then
+            invalidArg "RenderConfig" "Quiet zone modules must be greater than zero."
+        if not (Double.IsFinite config.TextMargin) || config.TextMargin < 0.0 then
+            invalidArg "RenderConfig" "Text margin must be zero or greater."
+
+    let private copyMetadata (metadata: Metadata) =
+        let result = Dictionary<string, obj>()
+        for pair in metadata do
+            result.[pair.Key] <- pair.Value
+        result
+
+    let layoutBarcode1D (runs: Barcode1DRun list) (options: PaintBarcode1DOptions option) =
+        if isNull (box runs) then nullArg "runs"
+        let options = defaultArg options defaultPaintOptions
+        validateRenderConfig options.RenderConfig
+
+        if options.RenderConfig.IncludeHumanReadableText then
+            raise (NotSupportedException "Human-readable text shaping is not wired for dotnet barcode-layout-1d yet.")
+
+        let layout = computeBarcode1DLayout runs options.RenderConfig.QuietZoneModules options.Symbols
+        let instructions = ResizeArray<PaintInstruction>()
+        let mutable moduleCursor = layout.LeftQuietZoneModules
+
+        for run in runs do
+            let x = float moduleCursor * options.RenderConfig.ModuleWidth
+            let width = float run.Modules * options.RenderConfig.ModuleWidth
+            if run.Color = Bar then
+                let metadata =
+                    let values = Dictionary<string, obj>()
+                    values.["sourceLabel"] <- box run.SourceLabel
+                    values.["sourceIndex"] <- box run.SourceIndex
+                    values.["role"] <- box run.Role.AsString
+                    values.["moduleStart"] <- box moduleCursor
+                    values.["moduleEnd"] <- box (moduleCursor + run.Modules)
+                    values :> Metadata
+
+                instructions.Add(
+                    PaintInstructions.paintRectWith
+                        { PaintInstructions.defaultPaintRectOptions with
+                            Fill = Some options.RenderConfig.Foreground
+                            Metadata = Some metadata }
+                        x
+                        0.0
+                        width
+                        options.RenderConfig.BarHeight
+                )
+
+            moduleCursor <- moduleCursor + run.Modules
+
+        let sceneWidth = float layout.TotalModules * options.RenderConfig.ModuleWidth
+        let sceneHeight = options.RenderConfig.BarHeight
+        let metadata = copyMetadata options.Metadata
+        metadata.["label"] <- box (defaultArg options.Label "1D barcode")
+        metadata.["leftQuietZoneModules"] <- box layout.LeftQuietZoneModules
+        metadata.["rightQuietZoneModules"] <- box layout.RightQuietZoneModules
+        metadata.["contentModules"] <- box layout.ContentModules
+        metadata.["totalModules"] <- box layout.TotalModules
+        metadata.["moduleWidthPx"] <- box options.RenderConfig.ModuleWidth
+        metadata.["barHeightPx"] <- box options.RenderConfig.BarHeight
+        metadata.["sceneWidthPx"] <- box sceneWidth
+        metadata.["sceneHeightPx"] <- box sceneHeight
+        metadata.["symbolCount"] <- box layout.SymbolLayouts.Length
+        metadata.["layoutTarget"] <- box options.RenderConfig.LayoutTarget.AsString
+
+        match options.HumanReadableText with
+        | Some text -> metadata.["humanReadableText"] <- box text
+        | None -> ()
+
+        PaintInstructions.paintSceneWith
+            { PaintInstructions.defaultSceneOptions with Metadata = Some (metadata :> Metadata) }
+            sceneWidth
+            sceneHeight
+            options.RenderConfig.Background
+            (List.ofSeq instructions)

--- a/code/packages/fsharp/barcode-layout-1d/CHANGELOG.md
+++ b/code/packages/fsharp/barcode-layout-1d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# package for shared one-dimensional barcode layout helpers.

--- a/code/packages/fsharp/barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj
+++ b/code/packages/fsharp/barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BarcodeLayout1D.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared layout utilities for one-dimensional barcodes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\paint-instructions\CodingAdventures.PaintInstructions.fsproj" />
+    <Compile Include="BarcodeLayout1D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/barcode-layout-1d/README.md
+++ b/code/packages/fsharp/barcode-layout-1d/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.BarcodeLayout1D.FSharp
+
+Shared layout utilities for one-dimensional barcode symbologies.
+
+This package converts logical bar/space runs into `PaintScene` rectangle instructions, with quiet zones, symbol layout metadata, and render configuration.
+
+```fsharp
+open CodingAdventures.BarcodeLayout1D.FSharp
+
+let runs =
+    BarcodeLayout1D.runsFromBinaryPattern
+        "101"
+        { SourceLabel = "guard"; SourceIndex = 0; Role = Guard }
+
+let scene = BarcodeLayout1D.layoutBarcode1D runs None
+```

--- a/code/packages/fsharp/barcode-layout-1d/required_capabilities.json
+++ b/code/packages/fsharp/barcode-layout-1d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/barcode-layout-1d",
+  "capabilities": [],
+  "justification": "Pure in-memory barcode layout into paint instructions. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/BarcodeLayout1DTests.fs
+++ b/code/packages/fsharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/BarcodeLayout1DTests.fs
@@ -1,0 +1,119 @@
+namespace CodingAdventures.BarcodeLayout1D.Tests
+
+open System
+open Xunit
+open CodingAdventures.PaintInstructions
+open CodingAdventures.BarcodeLayout1D.FSharp
+
+module BarcodeLayout1DTests =
+    [<Fact>]
+    let ``binary pattern expands to runs`` () =
+        let runs =
+            BarcodeLayout1D.runsFromBinaryPattern
+                "11001"
+                { SourceLabel = "start"; SourceIndex = -1; Role = Guard }
+
+        Assert.Equal(3, runs.Length)
+        Assert.Equal(Bar, runs.[0].Color)
+        Assert.Equal(2u, runs.[0].Modules)
+        Assert.Equal(Space, runs.[1].Color)
+        Assert.Equal(1u, runs.[2].Modules)
+        Assert.Throws<ArgumentException>(fun () ->
+            BarcodeLayout1D.runsFromBinaryPattern "10x" { SourceLabel = "bad"; SourceIndex = 0; Role = Data } |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``width pattern expands to runs`` () =
+        let runs =
+            BarcodeLayout1D.runsFromWidthPattern
+                "NWN"
+                (BarcodeLayout1D.defaultWidthPatternOptions "A" 0 Data)
+
+        Assert.Equal(3, runs.Length)
+        Assert.Equal(1u, runs.[0].Modules)
+        Assert.Equal(3u, runs.[1].Modules)
+        Assert.Equal(Bar, runs.[2].Color)
+        Assert.Throws<ArgumentException>(fun () ->
+            BarcodeLayout1D.runsFromWidthPattern "NX" (BarcodeLayout1D.defaultWidthPatternOptions "A" 0 Data) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``computes quiet zone aware layout`` () =
+        let runs =
+            [
+                { Color = Bar; Modules = 1u; SourceLabel = "*"; SourceIndex = 0; Role = Start }
+                { Color = Space; Modules = 1u; SourceLabel = "*"; SourceIndex = 0; Role = InterCharacterGap }
+                { Color = Bar; Modules = 2u; SourceLabel = "A"; SourceIndex = 1; Role = Data }
+            ]
+
+        let layout = BarcodeLayout1D.computeBarcode1DLayout runs 10u None
+
+        Assert.Equal(4u, layout.ContentModules)
+        Assert.Equal(24u, layout.TotalModules)
+        Assert.Equal(2, layout.SymbolLayouts.Length)
+        Assert.Equal("*", layout.SymbolLayouts.[0].Label)
+        Assert.Equal(2u, layout.SymbolLayouts.[0].EndModule)
+
+    [<Fact>]
+    let ``explicit symbols must match run width`` () =
+        let runs = BarcodeLayout1D.runsFromBinaryPattern "101" { SourceLabel = "demo"; SourceIndex = 0; Role = Guard }
+        let symbols = [ { Label = "demo"; Modules = 3u; SourceIndex = 0; Role = SymbolGuard } ]
+
+        let layout = BarcodeLayout1D.computeBarcode1DLayout runs 10u (Some symbols)
+        Assert.Single(layout.SymbolLayouts) |> ignore
+        Assert.Throws<ArgumentException>(fun () ->
+            BarcodeLayout1D.computeBarcode1DLayout runs 10u (Some [ { Label = "bad"; Modules = 2u; SourceIndex = 0; Role = SymbolData } ])
+            |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``lays out runs into paint scene`` () =
+        let runs = BarcodeLayout1D.runsFromBinaryPattern "101" { SourceLabel = "demo"; SourceIndex = 0; Role = Guard }
+        let scene =
+            BarcodeLayout1D.layoutBarcode1D
+                runs
+                (Some { BarcodeLayout1D.defaultPaintOptions with Label = Some "Demo barcode" })
+
+        Assert.Equal("#ffffff", scene.Background)
+        Assert.Equal(2, scene.Instructions.Length)
+        Assert.All<PaintInstruction>(scene.Instructions, fun instruction ->
+            match instruction with
+            | Rect _ -> ()
+            | _ -> failwith "expected rect")
+
+        Assert.Equal(box "Demo barcode", scene.Metadata.Value.["label"])
+        Assert.Equal(box 23u, scene.Metadata.Value.["totalModules"])
+
+    [<Fact>]
+    let ``validates layout and render configuration`` () =
+        Assert.Throws<ArgumentException>(fun () ->
+            BarcodeLayout1D.computeBarcode1DLayout
+                [
+                    { Color = Bar; Modules = 1u; SourceLabel = "a"; SourceIndex = 0; Role = Data }
+                    { Color = Bar; Modules = 1u; SourceLabel = "b"; SourceIndex = 1; Role = Data }
+                ]
+                10u
+                None
+            |> ignore)
+        |> ignore
+
+        let runs = BarcodeLayout1D.runsFromBinaryPattern "101" { SourceLabel = "demo"; SourceIndex = 0; Role = Guard }
+
+        Assert.Throws<NotSupportedException>(fun () ->
+            BarcodeLayout1D.layoutBarcode1D
+                runs
+                (Some
+                    { BarcodeLayout1D.defaultPaintOptions with
+                        RenderConfig = { BarcodeLayout1D.defaultRenderConfig with IncludeHumanReadableText = true }
+                        HumanReadableText = Some "demo" })
+            |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () ->
+            BarcodeLayout1D.layoutBarcode1D
+                runs
+                (Some
+                    { BarcodeLayout1D.defaultPaintOptions with
+                        RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } })
+            |> ignore)
+        |> ignore

--- a/code/packages/fsharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.fsproj
+++ b/code/packages/fsharp/barcode-layout-1d/tests/CodingAdventures.BarcodeLayout1D.Tests/CodingAdventures.BarcodeLayout1D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.PaintInstructions]*,[CodingAdventures.PixelContainer]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BarcodeLayout1D.fsproj" />
+    <Compile Include="BarcodeLayout1DTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add native C# and F# barcode-layout-1d packages for logical bar/space runs, symbol layout metadata, quiet zones, and paint-scene rectangle output
- include binary and width-pattern run builders plus render options for downstream 1D symbologies
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\barcode-layout-1d\tests\CodingAdventures.BarcodeLayout1D.Tests\CodingAdventures.BarcodeLayout1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\barcode-layout-1d\tests\CodingAdventures.BarcodeLayout1D.Tests\CodingAdventures.BarcodeLayout1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

## Notes
- Human-readable text shaping is represented as an explicit unsupported path in this dotnet batch because the current dotnet paint packages expose glyph-run IR but do not yet include the native text stack used by the Rust implementation.