### PR TITLE
feat(parity): add dotnet url parser packages

### DIFF
--- a/code/packages/csharp/url-parser/BUILD
+++ b/code/packages/csharp/url-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/url-parser/BUILD_windows
+++ b/code/packages/csharp/url-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/url-parser/CHANGELOG.md
+++ b/code/packages/csharp/url-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# URL parser with component parsing, relative resolution, default ports, and percent encoding.

--- a/code/packages/csharp/url-parser/CodingAdventures.UrlParser.csproj
+++ b/code/packages/csharp/url-parser/CodingAdventures.UrlParser.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.UrlParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>RFC-style URL parser with relative resolution and percent encoding</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/url-parser/README.md
+++ b/code/packages/csharp/url-parser/README.md
@@ -1,0 +1,28 @@
+# CodingAdventures.UrlParser.CSharp
+
+RFC-style URL parser with relative resolution and percent encoding for C#.
+
+```csharp
+using CodingAdventures.UrlParser;
+
+var url = Url.Parse("https://example.com:8080/path?q=hello#top");
+
+Console.WriteLine(url.Scheme);          // https
+Console.WriteLine(url.Host);            // example.com
+Console.WriteLine(url.EffectivePort()); // 8080
+
+var baseUrl = Url.Parse("http://example.com/a/b/c");
+var resolved = baseUrl.Resolve("../d");
+Console.WriteLine(resolved.ToUrlString()); // http://example.com/a/d
+
+Console.WriteLine(UrlParser.PercentEncode("hello world")); // hello%20world
+```
+
+## API
+
+- `Url.Parse(input)` parses an absolute URL.
+- `Url.Resolve(relative)` resolves a relative URL against a base URL.
+- `Url.EffectivePort()` returns an explicit port or an HTTP/HTTPS/FTP default.
+- `Url.Authority()` reconstructs `[userinfo@]host[:port]`.
+- `Url.ToUrlString()` serializes the URL.
+- `UrlParser.PercentEncode(input)` and `UrlParser.PercentDecode(input)` handle UTF-8 percent encoding.

--- a/code/packages/csharp/url-parser/UrlParser.cs
+++ b/code/packages/csharp/url-parser/UrlParser.cs
@@ -1,0 +1,462 @@
+using System.Globalization;
+using System.Text;
+
+namespace CodingAdventures.UrlParser;
+
+/// <summary>Stable URL parser package version.</summary>
+public static class UrlParser
+{
+    /// <summary>Package semantic version.</summary>
+    public const string Version = "0.1.0";
+
+    /// <summary>Parse an absolute URL string.</summary>
+    public static Url Parse(string input) => Url.Parse(input);
+
+    /// <summary>Percent-encode a string using UTF-8 bytes.</summary>
+    public static string PercentEncode(string input) => UrlInternals.PercentEncode(input);
+
+    /// <summary>Percent-decode a string containing percent encoded UTF-8 bytes.</summary>
+    public static string PercentDecode(string input) => UrlInternals.PercentDecode(input);
+}
+
+/// <summary>Specific URL parser failure modes.</summary>
+public enum UrlErrorKind
+{
+    /// <summary>No scheme was present in the input.</summary>
+    MissingScheme,
+
+    /// <summary>The scheme did not match [a-z][a-z0-9+.-]*.</summary>
+    InvalidScheme,
+
+    /// <summary>The port could not be parsed as an unsigned 16-bit integer.</summary>
+    InvalidPort,
+
+    /// <summary>A percent escape was truncated, non-hex, or invalid UTF-8.</summary>
+    InvalidPercentEncoding,
+
+    /// <summary>The authority form supplied host-like metadata without a host.</summary>
+    EmptyHost,
+
+    /// <summary>A relative URL was supplied without a base URL.</summary>
+    RelativeWithoutBase,
+}
+
+/// <summary>Exception raised for URL parser failures.</summary>
+public sealed class UrlParseException : Exception
+{
+    /// <summary>Create a parser exception for a specific URL error kind.</summary>
+    public UrlParseException(UrlErrorKind kind, string message)
+        : base(message)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>The structured parser error kind.</summary>
+    public UrlErrorKind Kind { get; }
+}
+
+/// <summary>A parsed URL with separated scheme, authority, path, query, and fragment components.</summary>
+public sealed record Url(
+    string Scheme,
+    string? Userinfo,
+    string? Host,
+    ushort? Port,
+    string Path,
+    string? Query,
+    string? Fragment,
+    string Raw)
+{
+    /// <summary>Parse an absolute URL string.</summary>
+    public static Url Parse(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var raw = input;
+        var trimmed = input.Trim();
+        string scheme;
+        string afterScheme;
+        bool hasAuthority;
+
+        var schemeSeparator = trimmed.IndexOf("://", StringComparison.Ordinal);
+        if (schemeSeparator >= 0)
+        {
+            scheme = trimmed[..schemeSeparator].ToLowerInvariant();
+            afterScheme = trimmed[(schemeSeparator + 3)..];
+            hasAuthority = true;
+        }
+        else
+        {
+            var colon = trimmed.IndexOf(':', StringComparison.Ordinal);
+            if (colon <= 0 || trimmed[..colon].Contains('/'))
+            {
+                throw UrlInternals.Error(UrlErrorKind.MissingScheme, "missing scheme");
+            }
+
+            scheme = trimmed[..colon].ToLowerInvariant();
+            afterScheme = trimmed[(colon + 1)..];
+            hasAuthority = false;
+        }
+
+        UrlInternals.ValidateScheme(scheme);
+
+        var (withoutFragment, fragment) = UrlInternals.SplitFragment(afterScheme);
+        var (withoutQuery, query) = UrlInternals.SplitQuery(withoutFragment);
+
+        if (!hasAuthority)
+        {
+            return new Url(
+                scheme,
+                Userinfo: null,
+                Host: null,
+                Port: null,
+                Path: withoutQuery,
+                Query: query,
+                Fragment: fragment,
+                Raw: raw);
+        }
+
+        var firstSlash = withoutQuery.IndexOf('/', StringComparison.Ordinal);
+        var authority = firstSlash >= 0 ? withoutQuery[..firstSlash] : withoutQuery;
+        var path = firstSlash >= 0 ? withoutQuery[firstSlash..] : "/";
+
+        string? userinfo = null;
+        var at = authority.LastIndexOf('@');
+        if (at >= 0)
+        {
+            userinfo = authority[..at];
+            authority = authority[(at + 1)..];
+        }
+
+        var (hostText, port) = UrlInternals.SplitHostAndPort(authority);
+        var host = string.IsNullOrEmpty(hostText) ? null : hostText.ToLowerInvariant();
+
+        return new Url(
+            scheme,
+            userinfo,
+            host,
+            port,
+            path,
+            query,
+            fragment,
+            raw);
+    }
+
+    /// <summary>Resolve a relative URL reference against this URL as the base.</summary>
+    public Url Resolve(string relative)
+    {
+        ArgumentNullException.ThrowIfNull(relative);
+
+        relative = relative.Trim();
+        if (relative.Length == 0)
+        {
+            var result = this with { Fragment = null };
+            return result with { Raw = result.ToUrlString() };
+        }
+
+        if (relative.StartsWith('#'))
+        {
+            var result = this with { Fragment = relative[1..] };
+            return result with { Raw = result.ToUrlString() };
+        }
+
+        if (UrlInternals.StartsWithScheme(relative))
+        {
+            return Parse(relative);
+        }
+
+        if (relative.StartsWith("//", StringComparison.Ordinal))
+        {
+            return Parse($"{Scheme}:{relative}");
+        }
+
+        var (relativeWithoutFragment, fragment) = UrlInternals.SplitFragment(relative);
+        var (relativePath, query) = UrlInternals.SplitQuery(relativeWithoutFragment);
+
+        if (relativePath.StartsWith('/'))
+        {
+            var result = this with
+            {
+                Path = UrlInternals.RemoveDotSegments(relativePath),
+                Query = query,
+                Fragment = fragment,
+            };
+            return result with { Raw = result.ToUrlString() };
+        }
+
+        var merged = UrlInternals.MergePaths(Path, relativePath);
+        var resolved = this with
+        {
+            Path = UrlInternals.RemoveDotSegments(merged),
+            Query = query,
+            Fragment = fragment,
+        };
+        return resolved with { Raw = resolved.ToUrlString() };
+    }
+
+    /// <summary>Return the explicit port or the scheme default.</summary>
+    public ushort? EffectivePort() => Port ?? UrlInternals.DefaultPort(Scheme);
+
+    /// <summary>Reconstruct the authority as [userinfo@]host[:port].</summary>
+    public string Authority()
+    {
+        var builder = new StringBuilder();
+        if (Userinfo is not null)
+        {
+            builder.Append(Userinfo);
+            builder.Append('@');
+        }
+
+        if (Host is not null)
+        {
+            builder.Append(Host);
+        }
+
+        if (Port is not null)
+        {
+            builder.Append(':');
+            builder.Append(Port.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Serialize this URL back to a string.</summary>
+    public string ToUrlString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(Scheme);
+
+        if (Host is not null)
+        {
+            builder.Append("://");
+            builder.Append(Authority());
+        }
+        else
+        {
+            builder.Append(':');
+        }
+
+        builder.Append(Path);
+
+        if (Query is not null)
+        {
+            builder.Append('?');
+            builder.Append(Query);
+        }
+
+        if (Fragment is not null)
+        {
+            builder.Append('#');
+            builder.Append(Fragment);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => ToUrlString();
+}
+
+internal static class UrlInternals
+{
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    public static UrlParseException Error(UrlErrorKind kind, string message) => new(kind, message);
+
+    public static void ValidateScheme(string scheme)
+    {
+        if (scheme.Length == 0 || !IsAsciiLower(scheme[0]))
+        {
+            throw Error(UrlErrorKind.InvalidScheme, "scheme must start with a letter");
+        }
+
+        foreach (var c in scheme)
+        {
+            if (!IsAsciiLower(c) && !char.IsAsciiDigit(c) && c != '+' && c != '-' && c != '.')
+            {
+                throw Error(UrlErrorKind.InvalidScheme, "scheme contains invalid characters");
+            }
+        }
+    }
+
+    public static ushort? DefaultPort(string scheme) =>
+        scheme switch
+        {
+            "http" => 80,
+            "https" => 443,
+            "ftp" => 21,
+            _ => null,
+        };
+
+    public static (string Before, string? After) SplitFragment(string input) => SplitFirst(input, '#');
+
+    public static (string Before, string? After) SplitQuery(string input) => SplitFirst(input, '?');
+
+    public static (string Host, ushort? Port) SplitHostAndPort(string hostPort)
+    {
+        if (hostPort.StartsWith('['))
+        {
+            var bracket = hostPort.IndexOf(']', StringComparison.Ordinal);
+            if (bracket >= 0)
+            {
+                var host = hostPort[..(bracket + 1)];
+                var afterBracket = hostPort[(bracket + 1)..];
+                var port = afterBracket.StartsWith(':') ? ParsePort(afterBracket[1..]) : (ushort?)null;
+                return (host, port);
+            }
+
+            return (hostPort, null);
+        }
+
+        var colon = hostPort.LastIndexOf(':');
+        if (colon >= 0)
+        {
+            var maybePort = hostPort[(colon + 1)..];
+            if (maybePort.Length > 0 && maybePort.All(char.IsAsciiDigit))
+            {
+                return (hostPort[..colon], ParsePort(maybePort));
+            }
+        }
+
+        return (hostPort, null);
+    }
+
+    public static ushort ParsePort(string text)
+    {
+        if (!ushort.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+        {
+            throw Error(UrlErrorKind.InvalidPort, "port must be between 0 and 65535");
+        }
+
+        return port;
+    }
+
+    public static bool StartsWithScheme(string input)
+    {
+        var colon = input.IndexOf(':', StringComparison.Ordinal);
+        if (colon <= 0 || input.StartsWith('/'))
+        {
+            return false;
+        }
+
+        var candidate = input[..colon];
+        return IsAsciiLetter(candidate[0])
+            && candidate.All(c => IsAsciiLetter(c) || char.IsAsciiDigit(c) || c is '+' or '-' or '.');
+    }
+
+    public static string MergePaths(string basePath, string relativePath)
+    {
+        var slash = basePath.LastIndexOf('/');
+        return slash >= 0 ? basePath[..(slash + 1)] + relativePath : "/" + relativePath;
+    }
+
+    public static string RemoveDotSegments(string path)
+    {
+        var output = new List<string>();
+        foreach (var segment in path.Split('/'))
+        {
+            switch (segment)
+            {
+                case ".":
+                    break;
+                case "..":
+                    if (output.Count > 0)
+                    {
+                        output.RemoveAt(output.Count - 1);
+                    }
+
+                    break;
+                default:
+                    output.Add(segment);
+                    break;
+            }
+        }
+
+        var result = string.Join("/", output);
+        return path.StartsWith('/') && !result.StartsWith('/') ? "/" + result : result;
+    }
+
+    public static string PercentEncode(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var builder = new StringBuilder(input.Length);
+        foreach (var b in Encoding.UTF8.GetBytes(input))
+        {
+            if (IsUnreserved(b))
+            {
+                builder.Append((char)b);
+            }
+            else
+            {
+                builder.Append('%');
+                builder.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    public static string PercentDecode(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var bytes = new List<byte>(input.Length);
+        for (var i = 0; i < input.Length;)
+        {
+            if (input[i] == '%')
+            {
+                if (i + 2 >= input.Length)
+                {
+                    throw Error(UrlErrorKind.InvalidPercentEncoding, "truncated percent escape");
+                }
+
+                var hi = HexDigit(input[i + 1]);
+                var lo = HexDigit(input[i + 2]);
+                bytes.Add((byte)((hi << 4) | lo));
+                i += 3;
+            }
+            else if (char.IsHighSurrogate(input[i]) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+            {
+                bytes.AddRange(Encoding.UTF8.GetBytes(input.Substring(i, 2)));
+                i += 2;
+            }
+            else
+            {
+                bytes.AddRange(Encoding.UTF8.GetBytes(input[i].ToString()));
+                i++;
+            }
+        }
+
+        try
+        {
+            return StrictUtf8.GetString(bytes.ToArray());
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw Error(UrlErrorKind.InvalidPercentEncoding, ex.Message);
+        }
+    }
+
+    private static (string Before, string? After) SplitFirst(string input, char delimiter)
+    {
+        var index = input.IndexOf(delimiter);
+        return index >= 0 ? (input[..index], input[(index + 1)..]) : (input, null);
+    }
+
+    private static byte HexDigit(char c) =>
+        c switch
+        {
+            >= '0' and <= '9' => (byte)(c - '0'),
+            >= 'a' and <= 'f' => (byte)(c - 'a' + 10),
+            >= 'A' and <= 'F' => (byte)(c - 'A' + 10),
+            _ => throw Error(UrlErrorKind.InvalidPercentEncoding, "invalid hex digit"),
+        };
+
+    private static bool IsUnreserved(byte b) =>
+        char.IsAsciiLetterOrDigit((char)b) || b is (byte)'-' or (byte)'_' or (byte)'.' or (byte)'~' or (byte)'/';
+
+    private static bool IsAsciiLower(char c) => c is >= 'a' and <= 'z';
+
+    private static bool IsAsciiLetter(char c) => c is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
+}

--- a/code/packages/csharp/url-parser/required_capabilities.json
+++ b/code/packages/csharp/url-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/url-parser",
+  "capabilities": [],
+  "justification": "Pure URL parsing, resolution, and percent encoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/url-parser/tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.csproj
+++ b/code/packages/csharp/url-parser/tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.UrlParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/url-parser/tests/CodingAdventures.UrlParser.Tests/UrlParserTests.cs
+++ b/code/packages/csharp/url-parser/tests/CodingAdventures.UrlParser.Tests/UrlParserTests.cs
@@ -1,0 +1,136 @@
+using CodingAdventures.UrlParser;
+
+namespace CodingAdventures.UrlParser.Tests;
+
+public sealed class UrlParserTests
+{
+    [Fact]
+    public void VersionIsExposed()
+    {
+        Assert.Equal("0.1.0", UrlParser.Version);
+    }
+
+    [Fact]
+    public void ParsesAllHierarchicalComponents()
+    {
+        var url = Url.Parse("http://user:pass@Example.COM:8080/path/to/page?q=1#frag");
+
+        Assert.Equal("http", url.Scheme);
+        Assert.Equal("user:pass", url.Userinfo);
+        Assert.Equal("example.com", url.Host);
+        Assert.Equal((ushort)8080, url.Port);
+        Assert.Equal("/path/to/page", url.Path);
+        Assert.Equal("q=1", url.Query);
+        Assert.Equal("frag", url.Fragment);
+        Assert.Equal("user:pass@example.com:8080", url.Authority());
+        Assert.Equal((ushort)8080, url.EffectivePort());
+    }
+
+    [Fact]
+    public void ParsesOpaqueUrlsAndDefaultPorts()
+    {
+        var mailto = Url.Parse("mailto:alice@example.com?subject=Hi#top");
+        Assert.Equal("mailto", mailto.Scheme);
+        Assert.Null(mailto.Host);
+        Assert.Equal("alice@example.com", mailto.Path);
+        Assert.Equal("subject=Hi", mailto.Query);
+        Assert.Equal("top", mailto.Fragment);
+        Assert.Null(mailto.EffectivePort());
+
+        Assert.Equal((ushort)80, Url.Parse("HTTP://EXAMPLE.COM/Path").EffectivePort());
+        Assert.Equal((ushort)443, Url.Parse("https://example.com").EffectivePort());
+        Assert.Equal((ushort)21, Url.Parse("ftp://example.com").EffectivePort());
+    }
+
+    [Fact]
+    public void ParsesIpv6AndEdgeCaseAuthorityForms()
+    {
+        var ipv6 = Url.Parse("http://[::1]:8080/path");
+        Assert.Equal("[::1]", ipv6.Host);
+        Assert.Equal((ushort)8080, ipv6.Port);
+        Assert.Equal("/path", ipv6.Path);
+
+        var queryOnly = Url.Parse("http://example.com?query=1");
+        Assert.Equal("/", queryOnly.Path);
+        Assert.Equal("query=1", queryOnly.Query);
+
+        var fragmentOnly = Url.Parse("http://example.com#section");
+        Assert.Equal("/", fragmentOnly.Path);
+        Assert.Equal("section", fragmentOnly.Fragment);
+    }
+
+    [Fact]
+    public void ReportsExpectedErrorKinds()
+    {
+        AssertError(UrlErrorKind.MissingScheme, () => Url.Parse("example.com/path"));
+        AssertError(UrlErrorKind.InvalidScheme, () => Url.Parse("1http://example.com"));
+        AssertError(UrlErrorKind.InvalidPort, () => Url.Parse("http://example.com:99999"));
+        AssertError(UrlErrorKind.InvalidPercentEncoding, () => UrlParser.PercentDecode("%GG"));
+        AssertError(UrlErrorKind.InvalidPercentEncoding, () => UrlParser.PercentDecode("%2"));
+        AssertError(UrlErrorKind.InvalidPercentEncoding, () => UrlParser.PercentDecode("%FF"));
+    }
+
+    [Fact]
+    public void PercentEncodingUsesUtf8Bytes()
+    {
+        Assert.Equal("hello%20world/a~b", UrlParser.PercentEncode("hello world/a~b"));
+        Assert.Equal("%E6%97%A5", UrlParser.PercentEncode("日"));
+        Assert.Equal("hello world/日", UrlParser.PercentDecode("hello%20world/%E6%97%A5"));
+        Assert.Equal("cafe", UrlParser.PercentDecode("cafe"));
+    }
+
+    [Theory]
+    [InlineData("d", "/a/b/d", null, null)]
+    [InlineData("../d", "/a/d", null, null)]
+    [InlineData("../../d", "/d", null, null)]
+    [InlineData("./d", "/a/b/d", null, null)]
+    [InlineData("d?key=val", "/a/b/d", "key=val", null)]
+    [InlineData("#frag", "/a/b/c", "x=1", "frag")]
+    [InlineData("", "/a/b/c", "x=1", null)]
+    public void ResolvesRelativeReferences(string relative, string expectedPath, string? expectedQuery, string? expectedFragment)
+    {
+        var baseUrl = Url.Parse("http://example.com/a/b/c?x=1#old");
+        var resolved = baseUrl.Resolve(relative);
+
+        Assert.Equal("http", resolved.Scheme);
+        Assert.Equal("example.com", resolved.Host);
+        Assert.Equal(expectedPath, resolved.Path);
+        Assert.Equal(expectedQuery, resolved.Query);
+        Assert.Equal(expectedFragment, resolved.Fragment);
+    }
+
+    [Fact]
+    public void ResolvesAbsoluteAndSchemeRelativeReferences()
+    {
+        var baseUrl = Url.Parse("http://example.com/a/b/c");
+
+        Assert.Equal("/root/d", baseUrl.Resolve("/root/./x/../d").Path);
+
+        var schemeRelative = baseUrl.Resolve("//other.example/d");
+        Assert.Equal("http", schemeRelative.Scheme);
+        Assert.Equal("other.example", schemeRelative.Host);
+        Assert.Equal("/d", schemeRelative.Path);
+
+        var absolute = baseUrl.Resolve("https://new.example/page");
+        Assert.Equal("https", absolute.Scheme);
+        Assert.Equal("new.example", absolute.Host);
+        Assert.Equal("/page", absolute.Path);
+    }
+
+    [Fact]
+    public void SerializesUrls()
+    {
+        var full = Url.Parse("http://user:pass@example.com:8080/path?query=1#frag");
+        Assert.Equal("http://user:pass@example.com:8080/path?query=1#frag", full.ToUrlString());
+        Assert.Equal(full.ToUrlString(), full.ToString());
+
+        var opaque = Url.Parse("mailto:alice@example.com");
+        Assert.Equal("mailto:alice@example.com", opaque.ToUrlString());
+    }
+
+    private static void AssertError(UrlErrorKind kind, Action action)
+    {
+        var ex = Assert.Throws<UrlParseException>(action);
+        Assert.Equal(kind, ex.Kind);
+    }
+}

--- a/code/packages/fsharp/url-parser/BUILD
+++ b/code/packages/fsharp/url-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/url-parser/BUILD_windows
+++ b/code/packages/fsharp/url-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/url-parser/CHANGELOG.md
+++ b/code/packages/fsharp/url-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# URL parser with component parsing, relative resolution, default ports, and percent encoding.

--- a/code/packages/fsharp/url-parser/CodingAdventures.UrlParser.fsproj
+++ b/code/packages/fsharp/url-parser/CodingAdventures.UrlParser.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.UrlParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>RFC-style URL parser with relative resolution and percent encoding</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="UrlParser.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/url-parser/README.md
+++ b/code/packages/fsharp/url-parser/README.md
@@ -1,0 +1,28 @@
+# CodingAdventures.UrlParser.FSharp
+
+RFC-style URL parser with relative resolution and percent encoding for F#.
+
+```fsharp
+open CodingAdventures.UrlParser.FSharp
+
+let url = Url.Parse "https://example.com:8080/path?q=hello#top"
+
+printfn "%s" url.Scheme
+printfn "%A" url.Host
+printfn "%A" (url.EffectivePort())
+
+let baseUrl = Url.Parse "http://example.com/a/b/c"
+let resolved = baseUrl.Resolve "../d"
+printfn "%s" (resolved.ToUrlString())
+
+printfn "%s" (UrlParser.percentEncode "hello world")
+```
+
+## API
+
+- `Url.Parse input` parses an absolute URL.
+- `url.Resolve relative` resolves a relative URL against a base URL.
+- `url.EffectivePort()` returns an explicit port or an HTTP/HTTPS/FTP default.
+- `url.Authority()` reconstructs `[userinfo@]host[:port]`.
+- `url.ToUrlString()` serializes the URL.
+- `UrlParser.percentEncode input` and `UrlParser.percentDecode input` handle UTF-8 percent encoding.

--- a/code/packages/fsharp/url-parser/UrlParser.fs
+++ b/code/packages/fsharp/url-parser/UrlParser.fs
@@ -1,0 +1,352 @@
+namespace CodingAdventures.UrlParser.FSharp
+
+open System
+open System.Globalization
+open System.Text
+
+[<RequireQualifiedAccess>]
+type UrlErrorKind =
+    | MissingScheme
+    | InvalidScheme
+    | InvalidPort
+    | InvalidPercentEncoding
+    | EmptyHost
+    | RelativeWithoutBase
+
+exception UrlParseException of UrlErrorKind * string
+
+module private Helpers =
+    let strictUtf8 = UTF8Encoding(false, true)
+
+    let fail kind message = raise (UrlParseException(kind, message))
+
+    let isAsciiLower c = c >= 'a' && c <= 'z'
+
+    let isAsciiLetter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+
+    let isSchemeChar c = isAsciiLetter c || Char.IsAsciiDigit c || c = '+' || c = '-' || c = '.'
+
+    let validateScheme (scheme: string) =
+        if scheme.Length = 0 || not (isAsciiLower scheme[0]) then
+            fail UrlErrorKind.InvalidScheme "scheme must start with a letter"
+
+        for c in scheme do
+            if not (isAsciiLower c || Char.IsAsciiDigit c || c = '+' || c = '-' || c = '.') then
+                fail UrlErrorKind.InvalidScheme "scheme contains invalid characters"
+
+    let splitFirst (delimiter: char) (input: string) =
+        let index = input.IndexOf(delimiter)
+        if index >= 0 then
+            input.Substring(0, index), Some(input.Substring(index + 1))
+        else
+            input, None
+
+    let splitFragment input = splitFirst '#' input
+
+    let splitQuery input = splitFirst '?' input
+
+    let parsePort (text: string) =
+        let mutable value = 0us
+        if UInt16.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, &value) then
+            value
+        else
+            fail UrlErrorKind.InvalidPort "port must be between 0 and 65535"
+
+    let defaultPort scheme =
+        match scheme with
+        | "http" -> Some 80us
+        | "https" -> Some 443us
+        | "ftp" -> Some 21us
+        | _ -> None
+
+    let splitHostAndPort (hostPort: string) =
+        if hostPort.StartsWith("[", StringComparison.Ordinal) then
+            let bracket = hostPort.IndexOf(']')
+            if bracket >= 0 then
+                let host = hostPort.Substring(0, bracket + 1)
+                let afterBracket = hostPort.Substring(bracket + 1)
+                let port =
+                    if afterBracket.StartsWith(":", StringComparison.Ordinal) then
+                        Some(parsePort (afterBracket.Substring(1)))
+                    else
+                        None
+                host, port
+            else
+                hostPort, None
+        else
+            let colon = hostPort.LastIndexOf(':')
+            if colon >= 0 then
+                let maybePort = hostPort.Substring(colon + 1)
+                if maybePort.Length > 0 && maybePort |> Seq.forall Char.IsAsciiDigit then
+                    hostPort.Substring(0, colon), Some(parsePort maybePort)
+                else
+                    hostPort, None
+            else
+                hostPort, None
+
+    let startsWithScheme (input: string) =
+        let colon = input.IndexOf(':')
+        if colon <= 0 || input.StartsWith("/", StringComparison.Ordinal) then
+            false
+        else
+            let candidate = input.Substring(0, colon)
+            isAsciiLetter candidate[0] && (candidate |> Seq.forall isSchemeChar)
+
+    let mergePaths (basePath: string) (relativePath: string) =
+        let slash = basePath.LastIndexOf('/')
+        if slash >= 0 then
+            basePath.Substring(0, slash + 1) + relativePath
+        else
+            "/" + relativePath
+
+    let removeDotSegments (path: string) =
+        let output = ResizeArray<string>()
+        for segment in path.Split('/') do
+            match segment with
+            | "." -> ()
+            | ".." ->
+                if output.Count > 0 then
+                    output.RemoveAt(output.Count - 1)
+            | _ -> output.Add segment
+
+        let result = String.Join("/", output)
+        if path.StartsWith("/", StringComparison.Ordinal) && not (result.StartsWith("/", StringComparison.Ordinal)) then
+            "/" + result
+        else
+            result
+
+    let isUnreserved (b: byte) =
+        Char.IsAsciiLetterOrDigit(char b)
+        || b = byte '-'
+        || b = byte '_'
+        || b = byte '.'
+        || b = byte '~'
+        || b = byte '/'
+
+    let percentEncode (input: string) =
+        if isNull input then nullArg "input"
+
+        let builder = StringBuilder(input.Length)
+        for b in Encoding.UTF8.GetBytes(input) do
+            if isUnreserved b then
+                builder.Append(char b) |> ignore
+            else
+                builder.Append('%') |> ignore
+                builder.Append(b.ToString("X2", CultureInfo.InvariantCulture)) |> ignore
+
+        builder.ToString()
+
+    let hexDigit c =
+        match c with
+        | c when c >= '0' && c <= '9' -> byte (int c - int '0')
+        | c when c >= 'a' && c <= 'f' -> byte (int c - int 'a' + 10)
+        | c when c >= 'A' && c <= 'F' -> byte (int c - int 'A' + 10)
+        | _ -> fail UrlErrorKind.InvalidPercentEncoding "invalid hex digit"
+
+    let percentDecode (input: string) =
+        if isNull input then nullArg "input"
+
+        let bytes = ResizeArray<byte>(input.Length)
+        let mutable i = 0
+        while i < input.Length do
+            if input[i] = '%' then
+                if i + 2 >= input.Length then
+                    fail UrlErrorKind.InvalidPercentEncoding "truncated percent escape"
+
+                let hi = hexDigit input[i + 1]
+                let lo = hexDigit input[i + 2]
+                bytes.Add(byte ((int hi <<< 4) ||| int lo))
+                i <- i + 3
+            elif Char.IsHighSurrogate(input[i]) && i + 1 < input.Length && Char.IsLowSurrogate(input[i + 1]) then
+                bytes.AddRange(Encoding.UTF8.GetBytes(input.Substring(i, 2)))
+                i <- i + 2
+            else
+                bytes.AddRange(Encoding.UTF8.GetBytes(input[i].ToString()))
+                i <- i + 1
+
+        try
+            strictUtf8.GetString(bytes.ToArray())
+        with :? DecoderFallbackException as ex ->
+            fail UrlErrorKind.InvalidPercentEncoding ex.Message
+
+type Url =
+    { Scheme: string
+      Userinfo: string option
+      Host: string option
+      Port: uint16 option
+      Path: string
+      Query: string option
+      Fragment: string option
+      Raw: string }
+
+    static member Parse(input: string) =
+        if isNull input then nullArg "input"
+
+        let raw = input
+        let input = input.Trim()
+        let separator = input.IndexOf("://", StringComparison.Ordinal)
+
+        let scheme, afterScheme, hasAuthority =
+            if separator >= 0 then
+                input.Substring(0, separator).ToLowerInvariant(), input.Substring(separator + 3), true
+            else
+                let colon = input.IndexOf(':')
+                if colon <= 0 || input.Substring(0, colon).Contains('/') then
+                    Helpers.fail UrlErrorKind.MissingScheme "missing scheme"
+
+                input.Substring(0, colon).ToLowerInvariant(), input.Substring(colon + 1), false
+
+        Helpers.validateScheme scheme
+
+        let withoutFragment, fragment = Helpers.splitFragment afterScheme
+        let withoutQuery, query = Helpers.splitQuery withoutFragment
+
+        if not hasAuthority then
+            { Scheme = scheme
+              Userinfo = None
+              Host = None
+              Port = None
+              Path = withoutQuery
+              Query = query
+              Fragment = fragment
+              Raw = raw }
+        else
+            let slash = withoutQuery.IndexOf('/')
+            let authority, path =
+                if slash >= 0 then
+                    withoutQuery.Substring(0, slash), withoutQuery.Substring(slash)
+                else
+                    withoutQuery, "/"
+
+            let at = authority.LastIndexOf('@')
+            let userinfo, hostPort =
+                if at >= 0 then
+                    Some(authority.Substring(0, at)), authority.Substring(at + 1)
+                else
+                    None, authority
+
+            let hostText, port = Helpers.splitHostAndPort hostPort
+            let host =
+                if String.IsNullOrEmpty hostText then
+                    None
+                else
+                    Some(hostText.ToLowerInvariant())
+
+            { Scheme = scheme
+              Userinfo = userinfo
+              Host = host
+              Port = port
+              Path = path
+              Query = query
+              Fragment = fragment
+              Raw = raw }
+
+    member this.Resolve(relative: string) =
+        if isNull relative then nullArg "relative"
+
+        let relative = relative.Trim()
+
+        if relative.Length = 0 then
+            let result = { this with Fragment = None }
+            { result with Raw = result.ToUrlString() }
+        elif relative.StartsWith("#", StringComparison.Ordinal) then
+            let result = { this with Fragment = Some(relative.Substring(1)) }
+            { result with Raw = result.ToUrlString() }
+        elif Helpers.startsWithScheme relative then
+            Url.Parse relative
+        elif relative.StartsWith("//", StringComparison.Ordinal) then
+            Url.Parse(this.Scheme + ":" + relative)
+        else
+            let relativeWithoutFragment, fragment = Helpers.splitFragment relative
+            let relativePath, query = Helpers.splitQuery relativeWithoutFragment
+
+            if relativePath.StartsWith("/", StringComparison.Ordinal) then
+                let result =
+                    { this with
+                        Path = Helpers.removeDotSegments relativePath
+                        Query = query
+                        Fragment = fragment }
+
+                { result with Raw = result.ToUrlString() }
+            else
+                let merged = Helpers.mergePaths this.Path relativePath
+                let result =
+                    { this with
+                        Path = Helpers.removeDotSegments merged
+                        Query = query
+                        Fragment = fragment }
+
+                { result with Raw = result.ToUrlString() }
+
+    member this.EffectivePort() =
+        match this.Port with
+        | Some port -> Some port
+        | None -> Helpers.defaultPort this.Scheme
+
+    member this.Authority() =
+        let builder = StringBuilder()
+
+        match this.Userinfo with
+        | Some userinfo ->
+            builder.Append(userinfo) |> ignore
+            builder.Append('@') |> ignore
+        | None -> ()
+
+        match this.Host with
+        | Some host -> builder.Append(host) |> ignore
+        | None -> ()
+
+        match this.Port with
+        | Some port ->
+            builder.Append(':') |> ignore
+            builder.Append(port.ToString(CultureInfo.InvariantCulture)) |> ignore
+        | None -> ()
+
+        builder.ToString()
+
+    member this.ToUrlString() =
+        let builder = StringBuilder()
+        builder.Append(this.Scheme) |> ignore
+
+        match this.Host with
+        | Some _ ->
+            builder.Append("://") |> ignore
+            builder.Append(this.Authority()) |> ignore
+        | None -> builder.Append(':') |> ignore
+
+        builder.Append(this.Path) |> ignore
+
+        match this.Query with
+        | Some query ->
+            builder.Append('?') |> ignore
+            builder.Append(query) |> ignore
+        | None -> ()
+
+        match this.Fragment with
+        | Some fragment ->
+            builder.Append('#') |> ignore
+            builder.Append(fragment) |> ignore
+        | None -> ()
+
+        builder.ToString()
+
+    override this.ToString() = this.ToUrlString()
+
+[<RequireQualifiedAccess>]
+module UrlParser =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let parse input = Url.Parse input
+
+    let resolve relative (baseUrl: Url) = baseUrl.Resolve relative
+
+    let effectivePort (url: Url) = url.EffectivePort()
+
+    let authority (url: Url) = url.Authority()
+
+    let toUrlString (url: Url) = url.ToUrlString()
+
+    let percentEncode input = Helpers.percentEncode input
+
+    let percentDecode input = Helpers.percentDecode input

--- a/code/packages/fsharp/url-parser/required_capabilities.json
+++ b/code/packages/fsharp/url-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/url-parser",
+  "capabilities": [],
+  "justification": "Pure URL parsing, resolution, and percent encoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/url-parser/tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.fsproj
+++ b/code/packages/fsharp/url-parser/tests/CodingAdventures.UrlParser.Tests/CodingAdventures.UrlParser.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.UrlParser.fsproj" />
+    <Compile Include="UrlParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/url-parser/tests/CodingAdventures.UrlParser.Tests/UrlParserTests.fs
+++ b/code/packages/fsharp/url-parser/tests/CodingAdventures.UrlParser.Tests/UrlParserTests.fs
@@ -1,0 +1,123 @@
+namespace CodingAdventures.UrlParser.Tests
+
+open Xunit
+open CodingAdventures.UrlParser.FSharp
+
+module UrlParserTests =
+    let private assertUrlError expected action =
+        let mutable matched = false
+        try
+            action() |> ignore
+        with
+        | UrlParseException(kind, _) ->
+            matched <- true
+            Assert.Equal(expected, kind)
+
+        Assert.True(matched, "expected UrlParseException")
+
+    [<Fact>]
+    let ``version is exposed`` () =
+        Assert.Equal("0.1.0", UrlParser.VERSION)
+
+    [<Fact>]
+    let ``parses all hierarchical components`` () =
+        let url = Url.Parse "http://user:pass@Example.COM:8080/path/to/page?q=1#frag"
+
+        Assert.Equal("http", url.Scheme)
+        Assert.Equal(Some "user:pass", url.Userinfo)
+        Assert.Equal(Some "example.com", url.Host)
+        Assert.Equal(Some 8080us, url.Port)
+        Assert.Equal("/path/to/page", url.Path)
+        Assert.Equal(Some "q=1", url.Query)
+        Assert.Equal(Some "frag", url.Fragment)
+        Assert.Equal("user:pass@example.com:8080", url.Authority())
+        Assert.Equal(Some 8080us, url.EffectivePort())
+
+    [<Fact>]
+    let ``parses opaque urls and default ports`` () =
+        let mailto = UrlParser.parse "mailto:alice@example.com?subject=Hi#top"
+
+        Assert.Equal("mailto", mailto.Scheme)
+        Assert.Equal(None, mailto.Host)
+        Assert.Equal("alice@example.com", mailto.Path)
+        Assert.Equal(Some "subject=Hi", mailto.Query)
+        Assert.Equal(Some "top", mailto.Fragment)
+        Assert.Equal(None, UrlParser.effectivePort mailto)
+
+        Assert.Equal(Some 80us, (Url.Parse "HTTP://EXAMPLE.COM/Path").EffectivePort())
+        Assert.Equal(Some 443us, (Url.Parse "https://example.com").EffectivePort())
+        Assert.Equal(Some 21us, (Url.Parse "ftp://example.com").EffectivePort())
+
+    [<Fact>]
+    let ``parses ipv6 and edge case authority forms`` () =
+        let ipv6 = Url.Parse "http://[::1]:8080/path"
+        Assert.Equal(Some "[::1]", ipv6.Host)
+        Assert.Equal(Some 8080us, ipv6.Port)
+        Assert.Equal("/path", ipv6.Path)
+
+        let queryOnly = Url.Parse "http://example.com?query=1"
+        Assert.Equal("/", queryOnly.Path)
+        Assert.Equal(Some "query=1", queryOnly.Query)
+
+        let fragmentOnly = Url.Parse "http://example.com#section"
+        Assert.Equal("/", fragmentOnly.Path)
+        Assert.Equal(Some "section", fragmentOnly.Fragment)
+
+    [<Fact>]
+    let ``reports expected error kinds`` () =
+        assertUrlError UrlErrorKind.MissingScheme (fun () -> Url.Parse "example.com/path")
+        assertUrlError UrlErrorKind.InvalidScheme (fun () -> Url.Parse "1http://example.com")
+        assertUrlError UrlErrorKind.InvalidPort (fun () -> Url.Parse "http://example.com:99999")
+        assertUrlError UrlErrorKind.InvalidPercentEncoding (fun () -> UrlParser.percentDecode "%GG")
+        assertUrlError UrlErrorKind.InvalidPercentEncoding (fun () -> UrlParser.percentDecode "%2")
+        assertUrlError UrlErrorKind.InvalidPercentEncoding (fun () -> UrlParser.percentDecode "%FF")
+
+    [<Fact>]
+    let ``percent encoding uses utf8 bytes`` () =
+        Assert.Equal("hello%20world/a~b", UrlParser.percentEncode "hello world/a~b")
+        Assert.Equal("%E6%97%A5", UrlParser.percentEncode "日")
+        Assert.Equal("hello world/日", UrlParser.percentDecode "hello%20world/%E6%97%A5")
+        Assert.Equal("cafe", UrlParser.percentDecode "cafe")
+
+    [<Theory>]
+    [<InlineData("d", "/a/b/d", null, null)>]
+    [<InlineData("../d", "/a/d", null, null)>]
+    [<InlineData("../../d", "/d", null, null)>]
+    [<InlineData("./d", "/a/b/d", null, null)>]
+    [<InlineData("d?key=val", "/a/b/d", "key=val", null)>]
+    [<InlineData("#frag", "/a/b/c", "x=1", "frag")>]
+    [<InlineData("", "/a/b/c", "x=1", null)>]
+    let ``resolves relative references`` relative expectedPath expectedQuery expectedFragment =
+        let baseUrl = Url.Parse "http://example.com/a/b/c?x=1#old"
+        let resolved = baseUrl.Resolve relative
+
+        Assert.Equal("http", resolved.Scheme)
+        Assert.Equal(Some "example.com", resolved.Host)
+        Assert.Equal(expectedPath, resolved.Path)
+        Assert.Equal(Option.ofObj expectedQuery, resolved.Query)
+        Assert.Equal(Option.ofObj expectedFragment, resolved.Fragment)
+
+    [<Fact>]
+    let ``resolves absolute and scheme relative references`` () =
+        let baseUrl = Url.Parse "http://example.com/a/b/c"
+
+        Assert.Equal("/root/d", (baseUrl.Resolve "/root/./x/../d").Path)
+
+        let schemeRelative = baseUrl.Resolve "//other.example/d"
+        Assert.Equal("http", schemeRelative.Scheme)
+        Assert.Equal(Some "other.example", schemeRelative.Host)
+        Assert.Equal("/d", schemeRelative.Path)
+
+        let absolute = UrlParser.resolve "https://new.example/page" baseUrl
+        Assert.Equal("https", absolute.Scheme)
+        Assert.Equal(Some "new.example", absolute.Host)
+        Assert.Equal("/page", absolute.Path)
+
+    [<Fact>]
+    let ``serializes urls`` () =
+        let full = Url.Parse "http://user:pass@example.com:8080/path?query=1#frag"
+        Assert.Equal("http://user:pass@example.com:8080/path?query=1#frag", UrlParser.toUrlString full)
+        Assert.Equal(full.ToUrlString(), full.ToString())
+
+        let opaque = Url.Parse "mailto:alice@example.com"
+        Assert.Equal("mailto:alice@example.com", opaque.ToUrlString())


### PR DESCRIPTION
## Summary
- add native C# and F# URL parser packages with component parsing, serialization, relative resolution, default ports, and percent encoding/decoding
- include typed parser errors plus tests for HTTP/HTTPS/FTP/mailto, IPv6, malformed URLs, percent encoding, and relative resolution
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\url-parser\tests\CodingAdventures.UrlParser.Tests\CodingAdventures.UrlParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\url-parser\tests\CodingAdventures.UrlParser.Tests\CodingAdventures.UrlParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line