### PR TITLE
feat(parity): add dotnet irc framing packages

### DIFF
--- a/code/packages/csharp/irc-framing/BUILD
+++ b/code/packages/csharp/irc-framing/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/irc-framing/BUILD_windows
+++ b/code/packages/csharp/irc-framing/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/irc-framing/CHANGELOG.md
+++ b/code/packages/csharp/irc-framing/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# IRC framer with partial buffering, CRLF/LF extraction, reset, and RFC 1459 length enforcement.

--- a/code/packages/csharp/irc-framing/CodingAdventures.IrcFraming.csproj
+++ b/code/packages/csharp/irc-framing/CodingAdventures.IrcFraming.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.IrcFraming.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Stateful byte-stream to IRC line frame converter</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/irc-framing/IrcFraming.cs
+++ b/code/packages/csharp/irc-framing/IrcFraming.cs
@@ -1,0 +1,68 @@
+namespace CodingAdventures.IrcFraming;
+
+/// <summary>Stable IRC framing package version.</summary>
+public static class IrcFraming
+{
+    /// <summary>Package semantic version.</summary>
+    public const string Version = "0.1.0";
+}
+
+/// <summary>Stateful byte-stream-to-line-frame converter for IRC CRLF framing.</summary>
+public sealed class Framer
+{
+    /// <summary>RFC 1459 maximum message content length, excluding CRLF.</summary>
+    public const int MaxContentBytes = 510;
+
+    private readonly List<byte> _buffer = [];
+
+    /// <summary>Number of bytes currently held as partial input.</summary>
+    public int BufferSize => _buffer.Count;
+
+    /// <summary>Append raw bytes to the internal buffer.</summary>
+    public void Feed(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        Feed(data.AsSpan());
+    }
+
+    /// <summary>Append raw bytes to the internal buffer.</summary>
+    public void Feed(ReadOnlySpan<byte> data)
+    {
+        foreach (var b in data)
+        {
+            _buffer.Add(b);
+        }
+    }
+
+    /// <summary>Drain all complete frames from the buffer, stripping LF and an optional preceding CR.</summary>
+    public IReadOnlyList<byte[]> Frames()
+    {
+        var result = new List<byte[]>();
+
+        while (true)
+        {
+            var lfPos = _buffer.IndexOf((byte)'\n');
+            if (lfPos < 0)
+            {
+                break;
+            }
+
+            var contentEnd = lfPos > 0 && _buffer[lfPos - 1] == (byte)'\r'
+                ? lfPos - 1
+                : lfPos;
+
+            var line = _buffer.GetRange(0, contentEnd).ToArray();
+            _buffer.RemoveRange(0, lfPos + 1);
+
+            if (line.Length <= MaxContentBytes)
+            {
+                result.Add(line);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Discard all buffered partial input.</summary>
+    public void Reset() => _buffer.Clear();
+}

--- a/code/packages/csharp/irc-framing/README.md
+++ b/code/packages/csharp/irc-framing/README.md
@@ -1,0 +1,19 @@
+# CodingAdventures.IrcFraming.CSharp
+
+Stateful byte-stream to IRC line frame converter for C#.
+
+```csharp
+using CodingAdventures.IrcFraming;
+using System.Text;
+
+var framer = new Framer();
+framer.Feed(Encoding.ASCII.GetBytes("NICK alice\r\nUSER alice 0 * :Alice\r\n"));
+
+foreach (var frame in framer.Frames())
+{
+    Console.WriteLine(Encoding.ASCII.GetString(frame));
+}
+```
+
+IRC messages end in CRLF and are capped at 512 bytes including CRLF, leaving
+510 bytes of content. Overlong frames are discarded.

--- a/code/packages/csharp/irc-framing/required_capabilities.json
+++ b/code/packages/csharp/irc-framing/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/irc-framing",
+  "capabilities": [],
+  "justification": "Pure in-memory IRC byte framing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.csproj
+++ b/code/packages/csharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.IrcFraming.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/IrcFramingTests.cs
+++ b/code/packages/csharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/IrcFramingTests.cs
@@ -1,0 +1,149 @@
+using System.Text;
+
+namespace CodingAdventures.IrcFraming.Tests;
+
+public sealed class IrcFramingTests
+{
+    [Fact]
+    public void VersionIsExposed()
+    {
+        Assert.Equal("0.1.0", IrcFraming.Version);
+        Assert.Equal(510, Framer.MaxContentBytes);
+    }
+
+    [Fact]
+    public void ExtractsSingleCrlfFrame()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("NICK alice\r\n"));
+
+        var frames = framer.Frames();
+
+        Assert.Single(frames);
+        Assert.Equal<byte>(Bytes("NICK alice"), frames[0]);
+        Assert.Equal(0, framer.BufferSize);
+    }
+
+    [Fact]
+    public void AcceptsLfOnlyFrames()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("NICK alice\nUSER bob\n"));
+
+        var frames = framer.Frames();
+
+        Assert.Equal(2, frames.Count);
+        Assert.Equal<byte>(Bytes("NICK alice"), frames[0]);
+        Assert.Equal<byte>(Bytes("USER bob"), frames[1]);
+    }
+
+    [Fact]
+    public void ExtractsMultipleFramesAndLeavesPartialTail()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("A\r\nB\r\nC"));
+
+        var frames = framer.Frames();
+
+        Assert.Equal(2, frames.Count);
+        Assert.Equal<byte>(Bytes("A"), frames[0]);
+        Assert.Equal<byte>(Bytes("B"), frames[1]);
+        Assert.Equal(1, framer.BufferSize);
+
+        framer.Feed(Bytes("\r\n"));
+        Assert.Equal<byte>(Bytes("C"), framer.Frames()[0]);
+    }
+
+    [Fact]
+    public void BuffersMessagesSplitAcrossFeeds()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("NICK al"));
+
+        Assert.Empty(framer.Frames());
+        Assert.Equal(7, framer.BufferSize);
+
+        framer.Feed(Bytes("ice\r\n"));
+
+        Assert.Equal<byte>(Bytes("NICK alice"), framer.Frames()[0]);
+        Assert.Equal(0, framer.BufferSize);
+    }
+
+    [Fact]
+    public void HandlesCrlfSplitAcrossFeeds()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("NICK alice\r"));
+        Assert.Empty(framer.Frames());
+
+        framer.Feed(Bytes("\n"));
+
+        Assert.Equal<byte>(Bytes("NICK alice"), framer.Frames()[0]);
+    }
+
+    [Fact]
+    public void EmptyFeedIsNoopAndEmptyLineYieldsEmptyFrame()
+    {
+        var framer = new Framer();
+        framer.Feed([]);
+        Assert.Equal(0, framer.BufferSize);
+        Assert.Empty(framer.Frames());
+
+        framer.Feed(Bytes("\r\n"));
+        var frame = Assert.Single(framer.Frames());
+        Assert.Empty(frame);
+    }
+
+    [Fact]
+    public void RejectsNullFeed()
+    {
+        var framer = new Framer();
+        Assert.Throws<ArgumentNullException>(() => framer.Feed((byte[]?)null!));
+    }
+
+    [Fact]
+    public void AcceptsExactMaximumAndDiscardsOverlongLines()
+    {
+        var exact = Enumerable.Repeat((byte)'A', 510).ToArray();
+        var overlong = Enumerable.Repeat((byte)'X', 511).ToArray();
+        var framer = new Framer();
+
+        framer.Feed(exact);
+        framer.Feed(Bytes("\r\n"));
+        Assert.Equal(510, framer.Frames()[0].Length);
+
+        framer.Feed(overlong);
+        framer.Feed(Bytes("\r\n"));
+        Assert.Empty(framer.Frames());
+    }
+
+    [Fact]
+    public void OverlongLineDoesNotBlockFollowingValidFrames()
+    {
+        var framer = new Framer();
+        framer.Feed(Enumerable.Repeat((byte)'X', 511).ToArray());
+        framer.Feed(Bytes("\r\nNICK alice\r\nUSER bob\r\n"));
+
+        var frames = framer.Frames();
+
+        Assert.Equal(2, frames.Count);
+        Assert.Equal<byte>(Bytes("NICK alice"), frames[0]);
+        Assert.Equal<byte>(Bytes("USER bob"), frames[1]);
+    }
+
+    [Fact]
+    public void ResetClearsBufferedData()
+    {
+        var framer = new Framer();
+        framer.Feed(Bytes("partial"));
+        Assert.Equal(7, framer.BufferSize);
+
+        framer.Reset();
+
+        Assert.Equal(0, framer.BufferSize);
+        framer.Feed(Bytes("PING :x\r\n"));
+        Assert.Equal<byte>(Bytes("PING :x"), framer.Frames()[0]);
+    }
+
+    private static byte[] Bytes(string text) => Encoding.ASCII.GetBytes(text);
+}

--- a/code/packages/fsharp/irc-framing/BUILD
+++ b/code/packages/fsharp/irc-framing/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/irc-framing/BUILD_windows
+++ b/code/packages/fsharp/irc-framing/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/irc-framing/CHANGELOG.md
+++ b/code/packages/fsharp/irc-framing/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# IRC framer with partial buffering, CRLF/LF extraction, reset, and RFC 1459 length enforcement.

--- a/code/packages/fsharp/irc-framing/CodingAdventures.IrcFraming.fsproj
+++ b/code/packages/fsharp/irc-framing/CodingAdventures.IrcFraming.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.IrcFraming.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Stateful byte-stream to IRC line frame converter</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="IrcFraming.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/irc-framing/IrcFraming.fs
+++ b/code/packages/fsharp/irc-framing/IrcFraming.fs
@@ -1,0 +1,53 @@
+namespace CodingAdventures.IrcFraming.FSharp
+
+open System
+
+[<RequireQualifiedAccess>]
+module IrcFraming =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    [<Literal>]
+    let MAX_CONTENT_BYTES = 510
+
+type Framer() =
+    let buffer = ResizeArray<byte>()
+
+    member _.BufferSize = buffer.Count
+
+    member _.Feed(data: byte array) =
+        if isNull data then nullArg "data"
+        buffer.AddRange(data)
+
+    member _.Frames() =
+        let frames = ResizeArray<byte array>()
+        let mutable keepGoing = true
+
+        while keepGoing do
+            let mutable lfPos = -1
+            let mutable index = 0
+
+            while lfPos = -1 && index < buffer.Count do
+                if buffer[index] = byte '\n' then
+                    lfPos <- index
+                else
+                    index <- index + 1
+
+            if lfPos < 0 then
+                keepGoing <- false
+            else
+                let contentEnd =
+                    if lfPos > 0 && buffer[lfPos - 1] = byte '\r' then
+                        lfPos - 1
+                    else
+                        lfPos
+
+                let line = buffer.GetRange(0, contentEnd).ToArray()
+                buffer.RemoveRange(0, lfPos + 1)
+
+                if line.Length <= IrcFraming.MAX_CONTENT_BYTES then
+                    frames.Add(line)
+
+        frames |> Seq.toList
+
+    member _.Reset() = buffer.Clear()

--- a/code/packages/fsharp/irc-framing/README.md
+++ b/code/packages/fsharp/irc-framing/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.IrcFraming.FSharp
+
+Stateful byte-stream to IRC line frame converter for F#.
+
+```fsharp
+open System.Text
+open CodingAdventures.IrcFraming.FSharp
+
+let framer = Framer()
+framer.Feed(Encoding.ASCII.GetBytes "NICK alice\r\nUSER alice 0 * :Alice\r\n")
+
+for frame in framer.Frames() do
+    printfn "%s" (Encoding.ASCII.GetString frame)
+```
+
+IRC messages end in CRLF and are capped at 512 bytes including CRLF, leaving
+510 bytes of content. Overlong frames are discarded.

--- a/code/packages/fsharp/irc-framing/required_capabilities.json
+++ b/code/packages/fsharp/irc-framing/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/irc-framing",
+  "capabilities": [],
+  "justification": "Pure in-memory IRC byte framing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.fsproj
+++ b/code/packages/fsharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/CodingAdventures.IrcFraming.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.IrcFraming.fsproj" />
+    <Compile Include="IrcFramingTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/IrcFramingTests.fs
+++ b/code/packages/fsharp/irc-framing/tests/CodingAdventures.IrcFraming.Tests/IrcFramingTests.fs
@@ -1,0 +1,134 @@
+namespace CodingAdventures.IrcFraming.Tests
+
+open System
+open System.Linq
+open System.Text
+open Xunit
+open CodingAdventures.IrcFraming.FSharp
+
+module IrcFramingTests =
+    let private bytes (text: string) = Encoding.ASCII.GetBytes text
+
+    [<Fact>]
+    let ``version is exposed`` () =
+        Assert.Equal("0.1.0", IrcFraming.VERSION)
+        Assert.Equal(510, IrcFraming.MAX_CONTENT_BYTES)
+
+    [<Fact>]
+    let ``extracts single crlf frame`` () =
+        let framer = Framer()
+        framer.Feed(bytes "NICK alice\r\n")
+
+        let frames = framer.Frames()
+
+        Assert.Single(frames) |> ignore
+        Assert.Equal<byte>(bytes "NICK alice", frames[0])
+        Assert.Equal(0, framer.BufferSize)
+
+    [<Fact>]
+    let ``accepts lf only frames`` () =
+        let framer = Framer()
+        framer.Feed(bytes "NICK alice\nUSER bob\n")
+
+        let frames = framer.Frames()
+
+        Assert.Equal(2, frames.Length)
+        Assert.Equal<byte>(bytes "NICK alice", frames[0])
+        Assert.Equal<byte>(bytes "USER bob", frames[1])
+
+    [<Fact>]
+    let ``extracts multiple frames and leaves partial tail`` () =
+        let framer = Framer()
+        framer.Feed(bytes "A\r\nB\r\nC")
+
+        let frames = framer.Frames()
+
+        Assert.Equal(2, frames.Length)
+        Assert.Equal<byte>(bytes "A", frames[0])
+        Assert.Equal<byte>(bytes "B", frames[1])
+        Assert.Equal(1, framer.BufferSize)
+
+        framer.Feed(bytes "\r\n")
+        let completedTail = framer.Frames()
+        Assert.Equal<byte>(bytes "C", completedTail[0])
+
+    [<Fact>]
+    let ``buffers messages split across feeds`` () =
+        let framer = Framer()
+        framer.Feed(bytes "NICK al")
+
+        Assert.Empty(framer.Frames())
+        Assert.Equal(7, framer.BufferSize)
+
+        framer.Feed(bytes "ice\r\n")
+
+        let frames = framer.Frames()
+        Assert.Equal<byte>(bytes "NICK alice", frames[0])
+        Assert.Equal(0, framer.BufferSize)
+
+    [<Fact>]
+    let ``handles crlf split across feeds`` () =
+        let framer = Framer()
+        framer.Feed(bytes "NICK alice\r")
+        Assert.Empty(framer.Frames())
+
+        framer.Feed(bytes "\n")
+
+        let frames = framer.Frames()
+        Assert.Equal<byte>(bytes "NICK alice", frames[0])
+
+    [<Fact>]
+    let ``empty feed is noop and empty line yields empty frame`` () =
+        let framer = Framer()
+        framer.Feed(Array.empty)
+        Assert.Equal(0, framer.BufferSize)
+        Assert.Empty(framer.Frames())
+
+        framer.Feed(bytes "\r\n")
+        let frame = Assert.Single(framer.Frames())
+        Assert.Empty(frame)
+
+    [<Fact>]
+    let ``rejects null feed`` () =
+        let framer = Framer()
+        Assert.Throws<ArgumentNullException>(fun () -> framer.Feed(Unchecked.defaultof<byte array>)) |> ignore
+
+    [<Fact>]
+    let ``accepts exact maximum and discards overlong lines`` () =
+        let exact = Enumerable.Repeat(byte 'A', 510).ToArray()
+        let overlong = Enumerable.Repeat(byte 'X', 511).ToArray()
+        let framer = Framer()
+
+        framer.Feed exact
+        framer.Feed(bytes "\r\n")
+        let exactFrames = framer.Frames()
+        Assert.Equal(510, exactFrames[0].Length)
+
+        framer.Feed overlong
+        framer.Feed(bytes "\r\n")
+        Assert.Empty(framer.Frames())
+
+    [<Fact>]
+    let ``overlong line does not block following valid frames`` () =
+        let framer = Framer()
+        framer.Feed(Enumerable.Repeat(byte 'X', 511).ToArray())
+        framer.Feed(bytes "\r\nNICK alice\r\nUSER bob\r\n")
+
+        let frames = framer.Frames()
+
+        Assert.Equal(2, frames.Length)
+        Assert.Equal<byte>(bytes "NICK alice", frames[0])
+        Assert.Equal<byte>(bytes "USER bob", frames[1])
+
+    [<Fact>]
+    let ``reset clears buffered data`` () =
+        let framer = Framer()
+        framer.Feed(bytes "partial")
+        Assert.Equal(7, framer.BufferSize)
+
+        framer.Reset()
+
+        Assert.Equal(0, framer.BufferSize)
+        framer.Feed(bytes "PING :x\r\n")
+        let frames = framer.Frames()
+        Assert.Equal<byte>(bytes "PING :x", frames[0])


### PR DESCRIPTION
## Summary
- add native C# and F# IRC framer packages with stateful byte buffering, CRLF/LF frame extraction, reset, and buffer size reporting
- enforce the RFC 1459 510-byte content limit by discarding overlong frames without blocking later valid frames
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\irc-framing\tests\CodingAdventures.IrcFraming.Tests\CodingAdventures.IrcFraming.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\irc-framing\tests\CodingAdventures.IrcFraming.Tests\CodingAdventures.IrcFraming.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line