### PR TITLE
feat(parity): add dotnet json rpc packages

### DIFF
--- a/code/packages/csharp/json-rpc/BUILD
+++ b/code/packages/csharp/json-rpc/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-rpc/BUILD_windows
+++ b/code/packages/csharp/json-rpc/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/json-rpc/CHANGELOG.md
+++ b/code/packages/csharp/json-rpc/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# JSON-RPC 2.0 messages, Content-Length reader/writer, and dispatch server.

--- a/code/packages/csharp/json-rpc/CodingAdventures.JsonRpc.csproj
+++ b/code/packages/csharp/json-rpc/CodingAdventures.JsonRpc.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <PackageId>CodingAdventures.JsonRpc.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON-RPC 2.0 message model, Content-Length framing, and dispatch server</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-rpc/JsonRpc.cs
+++ b/code/packages/csharp/json-rpc/JsonRpc.cs
@@ -1,0 +1,487 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CodingAdventures.JsonRpc;
+
+public static class JsonRpc
+{
+    public const string Version = "0.1.0";
+    public const int ParseError = -32700;
+    public const int InvalidRequest = -32600;
+    public const int MethodNotFound = -32601;
+    public const int InvalidParams = -32602;
+    public const int InternalError = -32603;
+
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public static Message ParseMessage(string raw)
+    {
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(raw);
+        }
+        catch (JsonException ex)
+        {
+            throw new JsonRpcException(ParseError, $"Parse error: {ex.Message}");
+        }
+
+        if (node is not JsonObject obj)
+        {
+            throw new JsonRpcException(InvalidRequest, "Invalid Request: top-level value must be a JSON object");
+        }
+
+        if (obj["jsonrpc"]?.GetValue<string>() != "2.0")
+        {
+            throw new JsonRpcException(InvalidRequest, "Invalid Request: missing or wrong jsonrpc field");
+        }
+
+        if (obj.ContainsKey("result") || obj.ContainsKey("error"))
+        {
+            ResponseError? error = null;
+            var errorNode = obj["error"];
+            if (errorNode is not null)
+            {
+                if (errorNode is not JsonObject errorObject)
+                {
+                    throw new JsonRpcException(InvalidRequest, "Invalid Request: error must be a JSON object");
+                }
+
+                if (!TryGetInt(errorObject["code"], out var code))
+                {
+                    throw new JsonRpcException(InvalidRequest, "Invalid Request: error code must be an integer");
+                }
+
+                var message = TryGetString(errorObject["message"], out var text) ? text : string.Empty;
+                error = new ResponseError(code, message, Clone(errorObject["data"]));
+            }
+
+            return new Response(Clone(obj["id"]), Clone(obj["result"]), error);
+        }
+
+        if (!TryGetString(obj["method"], out var method))
+        {
+            throw new JsonRpcException(InvalidRequest, "Invalid Request: method must be a string");
+        }
+
+        var parameters = Clone(obj["params"]);
+        if (obj.ContainsKey("id"))
+        {
+            var id = obj["id"];
+            if (id is null || !IsValidId(id))
+            {
+                throw new JsonRpcException(InvalidRequest, "Invalid Request: id must be a string or integer");
+            }
+
+            return new Request(Clone(id)!, method, parameters);
+        }
+
+        return new Notification(method, parameters);
+    }
+
+    public static JsonObject MessageToNode(Message message) =>
+        message switch
+        {
+            Request request => RequestToNode(request),
+            Response response => ResponseToNode(response),
+            Notification notification => NotificationToNode(notification),
+            _ => throw new ArgumentOutOfRangeException(nameof(message), "Unknown message type"),
+        };
+
+    public static JsonNode? ToJsonNode(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            JsonNode node => node.DeepClone(),
+            JsonElement element => JsonNode.Parse(element.GetRawText()),
+            string text => JsonValue.Create(text),
+            int number => JsonValue.Create(number),
+            long number => JsonValue.Create(number),
+            bool boolean => JsonValue.Create(boolean),
+            double number => JsonValue.Create(number),
+            ResponseError error => ResponseErrorToNode(error),
+            _ => JsonSerializer.SerializeToNode(value, value.GetType(), JsonOptions),
+        };
+    }
+
+    internal static JsonNode? Clone(JsonNode? node) => node?.DeepClone();
+
+    internal static string ToJsonString(Message message) => MessageToNode(message).ToJsonString(JsonOptions);
+
+    private static JsonObject RequestToNode(Request request)
+    {
+        var obj = BaseObject();
+        obj["id"] = Clone(request.Id);
+        obj["method"] = request.Method;
+        if (request.Params is not null)
+        {
+            obj["params"] = Clone(request.Params);
+        }
+
+        return obj;
+    }
+
+    private static JsonObject ResponseToNode(Response response)
+    {
+        var obj = BaseObject();
+        obj["id"] = Clone(response.Id);
+        if (response.Error is not null)
+        {
+            obj["error"] = ResponseErrorToNode(response.Error);
+        }
+        else
+        {
+            obj["result"] = Clone(response.Result);
+        }
+
+        return obj;
+    }
+
+    private static JsonObject NotificationToNode(Notification notification)
+    {
+        var obj = BaseObject();
+        obj["method"] = notification.Method;
+        if (notification.Params is not null)
+        {
+            obj["params"] = Clone(notification.Params);
+        }
+
+        return obj;
+    }
+
+    private static JsonObject ResponseErrorToNode(ResponseError error)
+    {
+        var obj = new JsonObject
+        {
+            ["code"] = error.Code,
+            ["message"] = error.Message,
+        };
+        if (error.Data is not null)
+        {
+            obj["data"] = Clone(error.Data);
+        }
+
+        return obj;
+    }
+
+    private static JsonObject BaseObject() => new() { ["jsonrpc"] = "2.0" };
+
+    private static bool TryGetString(JsonNode? node, out string value)
+    {
+        value = string.Empty;
+        return node is JsonValue jsonValue && jsonValue.TryGetValue(out value!);
+    }
+
+    private static bool TryGetInt(JsonNode? node, out int value)
+    {
+        value = default;
+        return node is JsonValue jsonValue && jsonValue.TryGetValue(out value);
+    }
+
+    private static bool IsValidId(JsonNode node)
+    {
+        if (node is not JsonValue value)
+        {
+            return false;
+        }
+
+        return value.TryGetValue<string>(out _) || value.TryGetValue<int>(out _) || value.TryGetValue<long>(out _);
+    }
+}
+
+public sealed class JsonRpcException : Exception
+{
+    public JsonRpcException(int code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public int Code { get; }
+}
+
+public abstract record Message;
+
+public sealed record ResponseError(int Code, string Message, JsonNode? Data = null);
+
+public sealed record Request(JsonNode Id, string Method, JsonNode? Params = null) : Message;
+
+public sealed record Response(JsonNode? Id, JsonNode? Result = null, ResponseError? Error = null) : Message;
+
+public sealed record Notification(string Method, JsonNode? Params = null) : Message;
+
+public sealed class MessageReader
+{
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    private readonly Stream _stream;
+
+    public MessageReader(Stream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+    }
+
+    public string? ReadRaw()
+    {
+        int? contentLength = null;
+
+        while (true)
+        {
+            var lineBytes = ReadLine();
+            if (lineBytes is null)
+            {
+                if (contentLength is null)
+                {
+                    return null;
+                }
+
+                throw new JsonRpcException(JsonRpc.ParseError, "Parse error: unexpected EOF in header block");
+            }
+
+            var line = Encoding.ASCII.GetString(lineBytes).TrimEnd('\r', '\n');
+            if (line.Length == 0)
+            {
+                break;
+            }
+
+            var separator = line.IndexOf(':', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                continue;
+            }
+
+            var name = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+            if (!name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!int.TryParse(value, out var parsed))
+            {
+                throw new JsonRpcException(JsonRpc.ParseError, $"Parse error: invalid Content-Length value: {value}");
+            }
+
+            contentLength = parsed;
+        }
+
+        if (contentLength is null)
+        {
+            throw new JsonRpcException(JsonRpc.ParseError, "Parse error: no Content-Length header found");
+        }
+
+        if (contentLength < 0)
+        {
+            throw new JsonRpcException(JsonRpc.ParseError, $"Parse error: Content-Length must be non-negative, got {contentLength}");
+        }
+
+        var payload = ReadExactly(contentLength.Value);
+        try
+        {
+            return StrictUtf8.GetString(payload);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new JsonRpcException(JsonRpc.ParseError, $"Parse error: payload is not valid UTF-8: {ex.Message}");
+        }
+    }
+
+    public Message? ReadMessage()
+    {
+        var raw = ReadRaw();
+        return raw is null ? null : JsonRpc.ParseMessage(raw);
+    }
+
+    private byte[]? ReadLine()
+    {
+        var bytes = new List<byte>();
+        while (true)
+        {
+            var value = _stream.ReadByte();
+            if (value < 0)
+            {
+                return bytes.Count == 0 ? null : bytes.ToArray();
+            }
+
+            bytes.Add((byte)value);
+            if (value == '\n')
+            {
+                return bytes.ToArray();
+            }
+        }
+    }
+
+    private byte[] ReadExactly(int count)
+    {
+        var buffer = new byte[count];
+        var offset = 0;
+        while (offset < count)
+        {
+            var read = _stream.Read(buffer, offset, count - offset);
+            if (read == 0)
+            {
+                throw new JsonRpcException(JsonRpc.ParseError, $"Parse error: expected {count} bytes but stream ended after {offset}");
+            }
+
+            offset += read;
+        }
+
+        return buffer;
+    }
+}
+
+public sealed class MessageWriter
+{
+    private readonly Stream _stream;
+
+    public MessageWriter(Stream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+    }
+
+    public void WriteRaw(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        var payload = Encoding.UTF8.GetBytes(json);
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n");
+        _stream.Write(header);
+        _stream.Write(payload);
+        _stream.Flush();
+    }
+
+    public void WriteMessage(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        WriteRaw(JsonRpc.ToJsonString(message));
+    }
+}
+
+public delegate object? RequestHandler(JsonNode id, JsonNode? parameters);
+
+public delegate void NotificationHandler(JsonNode? parameters);
+
+public sealed class Server
+{
+    private readonly MessageReader _reader;
+    private readonly MessageWriter _writer;
+    private readonly Dictionary<string, RequestHandler> _requestHandlers = [];
+    private readonly Dictionary<string, NotificationHandler> _notificationHandlers = [];
+
+    public Server(Stream input, Stream output)
+    {
+        _reader = new MessageReader(input);
+        _writer = new MessageWriter(output);
+    }
+
+    public Server OnRequest(string method, RequestHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(handler);
+        _requestHandlers[method] = handler;
+        return this;
+    }
+
+    public Server OnNotification(string method, NotificationHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(handler);
+        _notificationHandlers[method] = handler;
+        return this;
+    }
+
+    public void Serve()
+    {
+        while (true)
+        {
+            Message? message;
+            try
+            {
+                message = _reader.ReadMessage();
+            }
+            catch (JsonRpcException ex)
+            {
+                SendError(null, ex.Code, ex.Message);
+                continue;
+            }
+
+            if (message is null)
+            {
+                break;
+            }
+
+            Dispatch(message);
+        }
+    }
+
+    private void Dispatch(Message message)
+    {
+        switch (message)
+        {
+            case Request request:
+                HandleRequest(request);
+                break;
+            case Notification notification:
+                HandleNotification(notification);
+                break;
+        }
+    }
+
+    private void HandleRequest(Request request)
+    {
+        if (!_requestHandlers.TryGetValue(request.Method, out var handler))
+        {
+            SendError(request.Id, JsonRpc.MethodNotFound, "Method not found");
+            return;
+        }
+
+        object? result;
+        try
+        {
+            result = handler(request.Id, request.Params);
+        }
+        catch (Exception ex)
+        {
+            SendError(request.Id, JsonRpc.InternalError, $"Internal error: {ex.Message}");
+            return;
+        }
+
+        var response = result is ResponseError error
+            ? new Response(JsonRpc.Clone(request.Id), Error: error)
+            : new Response(JsonRpc.Clone(request.Id), Result: JsonRpc.ToJsonNode(result));
+
+        _writer.WriteMessage(response);
+    }
+
+    private void HandleNotification(Notification notification)
+    {
+        if (!_notificationHandlers.TryGetValue(notification.Method, out var handler))
+        {
+            return;
+        }
+
+        try
+        {
+            handler(notification.Params);
+        }
+        catch
+        {
+            // JSON-RPC notifications never receive error responses.
+        }
+    }
+
+    private void SendError(JsonNode? id, int code, string message)
+    {
+        _writer.WriteMessage(new Response(JsonRpc.Clone(id), Error: new ResponseError(code, message)));
+    }
+}

--- a/code/packages/csharp/json-rpc/README.md
+++ b/code/packages/csharp/json-rpc/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.JsonRpc.CSharp
+
+JSON-RPC 2.0 message model, Content-Length framing, and a small dispatch server.
+
+```csharp
+using CodingAdventures.JsonRpc;
+using System.Text.Json.Nodes;
+
+var server = new Server(input, output)
+    .OnRequest("initialize", (_, _) => new JsonObject { ["capabilities"] = new JsonObject() })
+    .OnNotification("exit", _ => { });
+
+server.Serve();
+```
+
+The package implements request, response, notification, error envelopes,
+Content-Length readers/writers, and sequential server dispatch.

--- a/code/packages/csharp/json-rpc/required_capabilities.json
+++ b/code/packages/csharp/json-rpc/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/json-rpc",
+  "capabilities": [],
+  "justification": "Pure JSON-RPC framing and in-memory stream dispatch. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.csproj
+++ b/code/packages/csharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JsonRpc.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/JsonRpcTests.cs
+++ b/code/packages/csharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/JsonRpcTests.cs
@@ -1,0 +1,206 @@
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace CodingAdventures.JsonRpc.Tests;
+
+public sealed class JsonRpcTests
+{
+    [Fact]
+    public void ParsesRequestsNotificationsAndResponses()
+    {
+        var request = Assert.IsType<Request>(JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"x":1}}"""));
+        Assert.Equal(1, request.Id!.GetValue<int>());
+        Assert.Equal("initialize", request.Method);
+        Assert.Equal(1, request.Params!["x"]!.GetValue<int>());
+
+        var notification = Assert.IsType<Notification>(JsonRpc.ParseMessage("""{"jsonrpc":"2.0","method":"exit"}"""));
+        Assert.Equal("exit", notification.Method);
+        Assert.Null(notification.Params);
+
+        var response = Assert.IsType<Response>(JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":"abc","result":{"ok":true}}"""));
+        Assert.Equal("abc", response.Id!.GetValue<string>());
+        Assert.True(response.Result!["ok"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void ParsesErrorResponsesAndReportsInvalidMessages()
+    {
+        var response = Assert.IsType<Response>(JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found","data":"hover"}}"""));
+        Assert.NotNull(response.Error);
+        Assert.Equal(JsonRpc.MethodNotFound, response.Error!.Code);
+        Assert.Equal("hover", response.Error.Data!.GetValue<string>());
+
+        AssertRpcError(JsonRpc.ParseError, () => JsonRpc.ParseMessage("{not json}"));
+        AssertRpcError(JsonRpc.InvalidRequest, () => JsonRpc.ParseMessage("""[{"jsonrpc":"2.0"}]"""));
+        AssertRpcError(JsonRpc.InvalidRequest, () => JsonRpc.ParseMessage("""{"jsonrpc":"1.0","method":"x"}"""));
+        AssertRpcError(JsonRpc.InvalidRequest, () => JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":null,"method":"x"}"""));
+        AssertRpcError(JsonRpc.InvalidRequest, () => JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":1,"error":"bad"}"""));
+        AssertRpcError(JsonRpc.InvalidRequest, () => JsonRpc.ParseMessage("""{"jsonrpc":"2.0","id":1,"error":{"code":"oops","message":"bad"}}"""));
+    }
+
+    [Fact]
+    public void ConvertsMessagesToWireObjects()
+    {
+        var request = JsonRpc.MessageToNode(new Request(JsonValue.Create(1)!, "foo", new JsonObject { ["a"] = 1 }));
+        Assert.Equal("2.0", request["jsonrpc"]!.GetValue<string>());
+        Assert.Equal("foo", request["method"]!.GetValue<string>());
+        Assert.Equal(1, request["params"]!["a"]!.GetValue<int>());
+
+        var notification = JsonRpc.MessageToNode(new Notification("exit"));
+        Assert.False(notification.ContainsKey("id"));
+        Assert.False(notification.ContainsKey("params"));
+
+        var error = JsonRpc.MessageToNode(new Response(JsonValue.Create("id")!, Error: new ResponseError(JsonRpc.InvalidParams, "Bad", JsonValue.Create("detail"))));
+        Assert.Equal(JsonRpc.InvalidParams, error["error"]!["code"]!.GetValue<int>());
+        Assert.Equal("detail", error["error"]!["data"]!.GetValue<string>());
+
+        var success = JsonRpc.MessageToNode(new Response(JsonValue.Create(2)!, Result: null));
+        Assert.True(success.ContainsKey("result"));
+    }
+
+    [Fact]
+    public void ReaderHandlesFramingAndEof()
+    {
+        var raw1 = """{"jsonrpc":"2.0","id":1,"method":"foo"}""";
+        var raw2 = """{"jsonrpc":"2.0","method":"bar"}""";
+        using var stream = new MemoryStream(Frame(raw1).Concat(Frame(raw2)).ToArray());
+        var reader = new MessageReader(stream);
+
+        Assert.IsType<Request>(reader.ReadMessage());
+        Assert.IsType<Notification>(reader.ReadMessage());
+        Assert.Null(reader.ReadMessage());
+
+        using var rawStream = new MemoryStream(Frame(raw1, "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"));
+        Assert.Equal(raw1, new MessageReader(rawStream).ReadRaw());
+    }
+
+    [Fact]
+    public void ReaderReportsMalformedFrames()
+    {
+        AssertRpcError(JsonRpc.ParseError, () => new MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Type: text/plain\r\n\r\nhello"))).ReadMessage());
+        AssertRpcError(JsonRpc.ParseError, () => new MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: nope\r\n\r\n{}"))).ReadMessage());
+        AssertRpcError(JsonRpc.ParseError, () => new MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: -1\r\n\r\n"))).ReadMessage());
+        AssertRpcError(JsonRpc.ParseError, () => new MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: 10\r\n\r\nshort"))).ReadMessage());
+        AssertRpcError(JsonRpc.ParseError, () => new MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: 1\r\n\r\n\xFF"))).ReadMessage());
+    }
+
+    [Fact]
+    public void WriterProducesContentLengthFrames()
+    {
+        using var stream = new MemoryStream();
+        var writer = new MessageWriter(stream);
+        writer.WriteMessage(new Request(JsonValue.Create(1)!, "ping", new JsonObject { ["text"] = "日本語" }));
+
+        var data = stream.ToArray();
+        var separator = IndexOf(data, Encoding.ASCII.GetBytes("\r\n\r\n"));
+        Assert.True(separator > 0);
+        var header = Encoding.ASCII.GetString(data[..separator]);
+        var payload = data[(separator + 4)..];
+        var declared = int.Parse(header.Split(':')[1].Trim());
+
+        Assert.Equal(declared, payload.Length);
+        Assert.Contains("日本語", Encoding.UTF8.GetString(payload));
+    }
+
+    [Fact]
+    public void RoundTripsMessagesThroughWriterAndReader()
+    {
+        using var stream = new MemoryStream();
+        var writer = new MessageWriter(stream);
+        writer.WriteMessage(new Notification("initialized", new JsonObject { ["ok"] = true }));
+        stream.Position = 0;
+
+        var recovered = Assert.IsType<Notification>(new MessageReader(stream).ReadMessage());
+        Assert.Equal("initialized", recovered.Method);
+        Assert.True(recovered.Params!["ok"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void ServerDispatchesRequestsAndNotifications()
+    {
+        var input = Frame("""{"jsonrpc":"2.0","id":1,"method":"add","params":{"a":1,"b":2}}""")
+            .Concat(Frame("""{"jsonrpc":"2.0","method":"ping","params":{"seen":true}}"""))
+            .ToArray();
+        using var inStream = new MemoryStream(input);
+        using var outStream = new MemoryStream();
+        var notified = false;
+
+        new Server(inStream, outStream)
+            .OnRequest("add", (_, p) => JsonValue.Create(p!["a"]!.GetValue<int>() + p["b"]!.GetValue<int>()))
+            .OnNotification("ping", p => notified = p!["seen"]!.GetValue<bool>())
+            .Serve();
+
+        Assert.True(notified);
+        outStream.Position = 0;
+        var response = Assert.IsType<Response>(new MessageReader(outStream).ReadMessage());
+        Assert.Equal(3, response.Result!.GetValue<int>());
+    }
+
+    [Fact]
+    public void ServerHandlesErrors()
+    {
+        var input = Frame("""{"jsonrpc":"2.0","id":1,"method":"unknown"}""")
+            .Concat(Frame("""{"jsonrpc":"2.0","id":2,"method":"bad"}"""))
+            .Concat(Frame("""{"jsonrpc":"2.0","id":3,"method":"boom"}"""))
+            .Concat(Frame("""{"jsonrpc":"2.0","method":"missing"}"""))
+            .ToArray();
+        using var inStream = new MemoryStream(input);
+        using var outStream = new MemoryStream();
+
+        new Server(inStream, outStream)
+            .OnRequest("bad", (_, _) => new ResponseError(JsonRpc.InvalidParams, "Bad params"))
+            .OnRequest("boom", (_, _) => throw new InvalidOperationException("boom"))
+            .Serve();
+
+        outStream.Position = 0;
+        var reader = new MessageReader(outStream);
+        Assert.Equal(JsonRpc.MethodNotFound, Assert.IsType<Response>(reader.ReadMessage()).Error!.Code);
+        Assert.Equal(JsonRpc.InvalidParams, Assert.IsType<Response>(reader.ReadMessage()).Error!.Code);
+        Assert.Equal(JsonRpc.InternalError, Assert.IsType<Response>(reader.ReadMessage()).Error!.Code);
+        Assert.Null(reader.ReadMessage());
+    }
+
+    [Fact]
+    public void ServerSendsParseErrorsAndIgnoresResponses()
+    {
+        var input = Frame("NOT JSON")
+            .Concat(Frame("""{"jsonrpc":"2.0","id":1,"result":42}"""))
+            .ToArray();
+        using var inStream = new MemoryStream(input);
+        using var outStream = new MemoryStream();
+
+        new Server(inStream, outStream).Serve();
+
+        outStream.Position = 0;
+        var response = Assert.IsType<Response>(new MessageReader(outStream).ReadMessage());
+        Assert.Equal(JsonRpc.ParseError, response.Error!.Code);
+        Assert.Null(new MessageReader(outStream).ReadMessage());
+    }
+
+    private static void AssertRpcError(int code, Action action)
+    {
+        var ex = Assert.Throws<JsonRpcException>(action);
+        Assert.Equal(code, ex.Code);
+    }
+
+    private static byte[] Frame(string json, string extraHeader = "")
+    {
+        var payload = Encoding.UTF8.GetBytes(json);
+        return Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n{extraHeader}\r\n")
+            .Concat(payload)
+            .ToArray();
+    }
+
+    private static int IndexOf(byte[] haystack, byte[] needle)
+    {
+        for (var i = 0; i <= haystack.Length - needle.Length; i++)
+        {
+            if (haystack.AsSpan(i, needle.Length).SequenceEqual(needle))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/code/packages/fsharp/json-rpc/BUILD
+++ b/code/packages/fsharp/json-rpc/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-rpc/BUILD_windows
+++ b/code/packages/fsharp/json-rpc/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/json-rpc/CHANGELOG.md
+++ b/code/packages/fsharp/json-rpc/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# JSON-RPC 2.0 messages, Content-Length reader/writer, and dispatch server.

--- a/code/packages/fsharp/json-rpc/CodingAdventures.JsonRpc.fsproj
+++ b/code/packages/fsharp/json-rpc/CodingAdventures.JsonRpc.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.JsonRpc.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JSON-RPC 2.0 message model, Content-Length framing, and dispatch server</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JsonRpc.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-rpc/JsonRpc.fs
+++ b/code/packages/fsharp/json-rpc/JsonRpc.fs
@@ -1,0 +1,418 @@
+namespace CodingAdventures.JsonRpc.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Text.Encodings.Web
+open System.Text.Json
+open System.Text.Json.Nodes
+
+[<RequireQualifiedAccess>]
+module ErrorCodes =
+    [<Literal>]
+    let PARSE_ERROR = -32700
+
+    [<Literal>]
+    let INVALID_REQUEST = -32600
+
+    [<Literal>]
+    let METHOD_NOT_FOUND = -32601
+
+    [<Literal>]
+    let INVALID_PARAMS = -32602
+
+    [<Literal>]
+    let INTERNAL_ERROR = -32603
+
+type JsonRpcException(code: int, message: string) =
+    inherit Exception(message)
+    member _.Code = code
+
+type ResponseError =
+    { Code: int
+      Message: string
+      Data: JsonNode option }
+
+type Request =
+    { Id: JsonNode
+      Method: string
+      Params: JsonNode option }
+
+type Response =
+    { Id: JsonNode option
+      Result: JsonNode option
+      Error: ResponseError option }
+
+type Notification =
+    { Method: string
+      Params: JsonNode option }
+
+type Message =
+    | RequestMessage of Request
+    | ResponseMessage of Response
+    | NotificationMessage of Notification
+
+module private Helpers =
+    let jsonOptions = JsonSerializerOptions()
+    do
+        jsonOptions.WriteIndented <- false
+        jsonOptions.Encoder <- JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+
+    let strictUtf8 = UTF8Encoding(false, true)
+
+    let fail code message = raise (JsonRpcException(code, message))
+
+    let clone (node: JsonNode) = node.DeepClone()
+
+    let cloneOpt (node: JsonNode option) = node |> Option.map clone
+
+    let item (object: JsonObject) (name: string) : JsonNode = object.Item(name)
+
+    let tryGetString (node: JsonNode) =
+        if isNull node then
+            None
+        else
+            match node with
+            | :? JsonValue as value ->
+                let mutable text = Unchecked.defaultof<string>
+                if value.TryGetValue<string>(&text) then Some text else None
+            | _ -> None
+
+    let tryGetInt (node: JsonNode) =
+        if isNull node then
+            None
+        else
+            match node with
+            | :? JsonValue as value ->
+                let mutable number = 0
+                if value.TryGetValue<int>(&number) then Some number else None
+            | _ -> None
+
+    let isValidId (node: JsonNode) =
+        if isNull node then
+            false
+        else
+            match node with
+            | :? JsonValue as value ->
+                let mutable text = Unchecked.defaultof<string>
+                let mutable number = 0
+                let mutable longNumber = 0L
+                value.TryGetValue<string>(&text)
+                || value.TryGetValue<int>(&number)
+                || value.TryGetValue<int64>(&longNumber)
+            | _ -> false
+
+    let responseErrorToNode error =
+        let object = JsonObject()
+        object.Item("code") <- JsonValue.Create(error.Code)
+        object.Item("message") <- JsonValue.Create(error.Message)
+        match error.Data with
+        | Some data -> object.Item("data") <- clone data
+        | None -> ()
+        object
+
+    let toJsonNode (value: obj) =
+        if isNull value then
+            None
+        else
+            match value with
+            | :? JsonNode as node -> Some(clone node)
+            | :? string as text -> Some(JsonValue.Create(text) :> JsonNode)
+            | :? int as number -> Some(JsonValue.Create(number) :> JsonNode)
+            | :? int64 as number -> Some(JsonValue.Create(number) :> JsonNode)
+            | :? bool as boolean -> Some(JsonValue.Create(boolean) :> JsonNode)
+            | :? double as number -> Some(JsonValue.Create(number) :> JsonNode)
+            | :? ResponseError as error -> Some(responseErrorToNode error :> JsonNode)
+            | _ -> JsonSerializer.SerializeToNode(value, value.GetType(), jsonOptions) |> Option.ofObj
+
+    let baseObject () =
+        let object = JsonObject()
+        object.Item("jsonrpc") <- JsonValue.Create("2.0")
+        object
+
+    let messageToNode message =
+        match message with
+        | RequestMessage request ->
+            let object = baseObject()
+            object.Item("id") <- clone request.Id
+            object.Item("method") <- JsonValue.Create(request.Method)
+            match request.Params with
+            | Some parameters -> object.Item("params") <- clone parameters
+            | None -> ()
+            object
+        | ResponseMessage response ->
+            let object = baseObject()
+            object.Item("id") <-
+                match response.Id with
+                | Some id -> clone id
+                | None -> null
+            match response.Error with
+            | Some error -> object.Item("error") <- responseErrorToNode error
+            | None ->
+                object.Item("result") <-
+                    match response.Result with
+                    | Some result -> clone result
+                    | None -> null
+            object
+        | NotificationMessage notification ->
+            let object = baseObject()
+            object.Item("method") <- JsonValue.Create(notification.Method)
+            match notification.Params with
+            | Some parameters -> object.Item("params") <- clone parameters
+            | None -> ()
+            object
+
+    let messageToJson message = (messageToNode message).ToJsonString(jsonOptions)
+
+    let parseMessage (raw: string) =
+        let node =
+            try
+                JsonNode.Parse(raw)
+            with :? JsonException as ex ->
+                fail ErrorCodes.PARSE_ERROR $"Parse error: {ex.Message}"
+
+        match node with
+        | :? JsonObject as object ->
+            match tryGetString (item object "jsonrpc") with
+            | Some "2.0" -> ()
+            | _ -> fail ErrorCodes.INVALID_REQUEST "Invalid Request: missing or wrong jsonrpc field"
+
+            if object.ContainsKey("result") || object.ContainsKey("error") then
+                let errorNode = item object "error"
+                let error =
+                    if isNull errorNode then
+                        None
+                    else
+                        match errorNode with
+                        | :? JsonObject as errorObject ->
+                            let code =
+                                match tryGetInt (item errorObject "code") with
+                                | Some code -> code
+                                | None -> fail ErrorCodes.INVALID_REQUEST "Invalid Request: error code must be an integer"
+
+                            let message = defaultArg (tryGetString (item errorObject "message")) ""
+                            Some
+                                { Code = code
+                                  Message = message
+                                  Data = if isNull (item errorObject "data") then None else Some(clone (item errorObject "data")) }
+                        | _ -> fail ErrorCodes.INVALID_REQUEST "Invalid Request: error must be a JSON object"
+
+                ResponseMessage
+                    { Id = if isNull (item object "id") then None else Some(clone (item object "id"))
+                      Result = if isNull (item object "result") then None else Some(clone (item object "result"))
+                      Error = error }
+            else
+                let method =
+                    match tryGetString (item object "method") with
+                    | Some method -> method
+                    | None -> fail ErrorCodes.INVALID_REQUEST "Invalid Request: method must be a string"
+
+                let parameters = if isNull (item object "params") then None else Some(clone (item object "params"))
+
+                if object.ContainsKey("id") then
+                    let id = item object "id"
+                    if not (isValidId id) then
+                        fail ErrorCodes.INVALID_REQUEST "Invalid Request: id must be a string or integer"
+
+                    RequestMessage
+                        { Id = clone id
+                          Method = method
+                          Params = parameters }
+                else
+                    NotificationMessage { Method = method; Params = parameters }
+        | _ -> fail ErrorCodes.INVALID_REQUEST "Invalid Request: top-level value must be a JSON object"
+
+    let readLineBytes (stream: Stream) =
+        let bytes = ResizeArray<byte>()
+        let mutable keepReading = true
+
+        while keepReading do
+            let value = stream.ReadByte()
+            if value < 0 then
+                keepReading <- false
+            else
+                bytes.Add(byte value)
+                if value = int '\n' then
+                    keepReading <- false
+
+        if bytes.Count = 0 then None else Some(bytes.ToArray())
+
+    let readExactly (stream: Stream) count =
+        let buffer = Array.zeroCreate<byte> count
+        let mutable offset = 0
+        while offset < count do
+            let read = stream.Read(buffer, offset, count - offset)
+            if read = 0 then
+                fail ErrorCodes.PARSE_ERROR $"Parse error: expected {count} bytes but stream ended after {offset}"
+            offset <- offset + read
+        buffer
+
+type MessageReader(stream: Stream) =
+    do
+        if isNull stream then nullArg "stream"
+
+    member _.ReadRaw() =
+        let mutable contentLength: int option = None
+        let mutable readingHeaders = true
+        let mutable eofBetweenMessages = false
+
+        while readingHeaders do
+            match Helpers.readLineBytes stream with
+            | None ->
+                if Option.isNone contentLength then
+                    eofBetweenMessages <- true
+                    readingHeaders <- false
+                else
+                    Helpers.fail ErrorCodes.PARSE_ERROR "Parse error: unexpected EOF in header block"
+            | Some lineBytes ->
+                let line = Encoding.ASCII.GetString(lineBytes).TrimEnd([| '\r'; '\n' |])
+                if line.Length = 0 then
+                    readingHeaders <- false
+                else
+                    let separator = line.IndexOf(':')
+                    if separator >= 0 then
+                        let name = line.Substring(0, separator).Trim()
+                        let value = line.Substring(separator + 1).Trim()
+                        if name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) then
+                            let mutable parsed = 0
+                            if Int32.TryParse(value, &parsed) then
+                                contentLength <- Some parsed
+                            else
+                                Helpers.fail ErrorCodes.PARSE_ERROR $"Parse error: invalid Content-Length value: {value}"
+
+        if eofBetweenMessages then
+            None
+        else
+            match contentLength with
+            | None -> Helpers.fail ErrorCodes.PARSE_ERROR "Parse error: no Content-Length header found"
+            | Some length when length < 0 ->
+                Helpers.fail ErrorCodes.PARSE_ERROR $"Parse error: Content-Length must be non-negative, got {length}"
+            | Some length ->
+                let payload = Helpers.readExactly stream length
+                try
+                    Some(Helpers.strictUtf8.GetString(payload))
+                with :? DecoderFallbackException as ex ->
+                    Helpers.fail ErrorCodes.PARSE_ERROR $"Parse error: payload is not valid UTF-8: {ex.Message}"
+
+    member this.ReadMessage() =
+        match this.ReadRaw() with
+        | None -> None
+        | Some raw -> Some(Helpers.parseMessage raw)
+
+type MessageWriter(stream: Stream) =
+    do
+        if isNull stream then nullArg "stream"
+
+    member _.WriteRaw(json: string) =
+        if isNull json then nullArg "json"
+        let payload = Encoding.UTF8.GetBytes(json)
+        let header = Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n")
+        stream.Write(header, 0, header.Length)
+        stream.Write(payload, 0, payload.Length)
+        stream.Flush()
+
+    member this.WriteMessage(message: Message) =
+        this.WriteRaw(Helpers.messageToJson message)
+
+type RequestHandler = JsonNode -> JsonNode option -> obj
+
+type NotificationHandler = JsonNode option -> unit
+
+type Server(input: Stream, output: Stream) =
+    let reader = MessageReader(input)
+    let writer = MessageWriter(output)
+    let requestHandlers = Dictionary<string, RequestHandler>()
+    let notificationHandlers = Dictionary<string, NotificationHandler>()
+
+    member this.OnRequest(methodName: string, handler: RequestHandler) =
+        if isNull methodName then nullArg "methodName"
+        if isNull (box handler) then nullArg "handler"
+        requestHandlers[methodName] <- handler
+        this
+
+    member this.OnNotification(methodName: string, handler: NotificationHandler) =
+        if isNull methodName then nullArg "methodName"
+        if isNull (box handler) then nullArg "handler"
+        notificationHandlers[methodName] <- handler
+        this
+
+    member this.Serve() =
+        let mutable running = true
+        while running do
+            try
+                match reader.ReadMessage() with
+                | None -> running <- false
+                | Some message -> this.Dispatch message
+            with :? JsonRpcException as ex ->
+                this.SendError(None, ex.Code, ex.Message)
+
+    member private this.Dispatch(message: Message) =
+        match message with
+        | RequestMessage request -> this.HandleRequest request
+        | NotificationMessage notification -> this.HandleNotification notification
+        | ResponseMessage _ -> ()
+
+    member private this.HandleRequest(request: Request) =
+        let mutable handler = Unchecked.defaultof<RequestHandler>
+        if not (requestHandlers.TryGetValue(request.Method, &handler)) then
+            this.SendError(Some request.Id, ErrorCodes.METHOD_NOT_FOUND, "Method not found")
+        else
+            try
+                let result = handler request.Id request.Params
+                let response =
+                    match result with
+                    | :? ResponseError as error ->
+                        ResponseMessage
+                            { Id = Some(Helpers.clone request.Id)
+                              Result = None
+                              Error = Some error }
+                    | _ ->
+                        ResponseMessage
+                            { Id = Some(Helpers.clone request.Id)
+                              Result = Helpers.toJsonNode result
+                              Error = None }
+
+                writer.WriteMessage response
+            with ex ->
+                this.SendError(Some request.Id, ErrorCodes.INTERNAL_ERROR, $"Internal error: {ex.Message}")
+
+    member private _.HandleNotification(notification: Notification) =
+        let mutable handler = Unchecked.defaultof<NotificationHandler>
+        if notificationHandlers.TryGetValue(notification.Method, &handler) then
+            try
+                handler notification.Params
+            with _ ->
+                ()
+
+    member private _.SendError(id: JsonNode option, code: int, message: string) =
+        writer.WriteMessage(
+            ResponseMessage
+                { Id = Helpers.cloneOpt id
+                  Result = None
+                  Error = Some { Code = code; Message = message; Data = None } }
+        )
+
+[<RequireQualifiedAccess>]
+module JsonRpc =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    [<Literal>]
+    let PARSE_ERROR = ErrorCodes.PARSE_ERROR
+
+    [<Literal>]
+    let INVALID_REQUEST = ErrorCodes.INVALID_REQUEST
+
+    [<Literal>]
+    let METHOD_NOT_FOUND = ErrorCodes.METHOD_NOT_FOUND
+
+    [<Literal>]
+    let INVALID_PARAMS = ErrorCodes.INVALID_PARAMS
+
+    [<Literal>]
+    let INTERNAL_ERROR = ErrorCodes.INTERNAL_ERROR
+
+    let parseMessage raw = Helpers.parseMessage raw
+
+    let messageToNode message = Helpers.messageToNode message

--- a/code/packages/fsharp/json-rpc/README.md
+++ b/code/packages/fsharp/json-rpc/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.JsonRpc.FSharp
+
+JSON-RPC 2.0 message model, Content-Length framing, and a small dispatch server.
+
+```fsharp
+open System.Text.Json.Nodes
+open CodingAdventures.JsonRpc.FSharp
+
+Server(input, output)
+    .OnRequest("initialize", fun _ _ -> JsonObject() :> obj)
+    .OnNotification("exit", fun _ -> ())
+    .Serve()
+```
+
+The package implements request, response, notification, error envelopes,
+Content-Length readers/writers, and sequential server dispatch.

--- a/code/packages/fsharp/json-rpc/required_capabilities.json
+++ b/code/packages/fsharp/json-rpc/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/json-rpc",
+  "capabilities": [],
+  "justification": "Pure JSON-RPC framing and in-memory stream dispatch. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.fsproj
+++ b/code/packages/fsharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/CodingAdventures.JsonRpc.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JsonRpc.fsproj" />
+    <Compile Include="JsonRpcTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/JsonRpcTests.fs
+++ b/code/packages/fsharp/json-rpc/tests/CodingAdventures.JsonRpc.Tests/JsonRpcTests.fs
@@ -1,0 +1,212 @@
+namespace CodingAdventures.JsonRpc.Tests
+
+open System
+open System.IO
+open System.Linq
+open System.Text
+open System.Text.Json.Nodes
+open Xunit
+open CodingAdventures.JsonRpc.FSharp
+
+module JsonRpcTests =
+    let private frame (json: string) =
+        let payload = Encoding.UTF8.GetBytes json
+        Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n").Concat(payload).ToArray()
+
+    let private frameWithHeader (json: string) (extra: string) =
+        let payload = Encoding.UTF8.GetBytes json
+        Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n{extra}\r\n\r\n").Concat(payload).ToArray()
+
+    let private assertRpcError code action =
+        let ex = Assert.Throws<JsonRpcException>(fun () -> action() |> ignore)
+        Assert.Equal(code, ex.Code)
+
+    [<Fact>]
+    let ``parses requests notifications and responses`` () =
+        match JsonRpc.parseMessage """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"x":1}}""" with
+        | RequestMessage request ->
+            Assert.Equal(1, request.Id.GetValue<int>())
+            Assert.Equal("initialize", request.Method)
+            Assert.Equal(1, request.Params.Value["x"].GetValue<int>())
+        | _ -> failwith "expected request"
+
+        match JsonRpc.parseMessage """{"jsonrpc":"2.0","method":"exit"}""" with
+        | NotificationMessage notification ->
+            Assert.Equal("exit", notification.Method)
+            Assert.Equal(None, notification.Params)
+        | _ -> failwith "expected notification"
+
+        match JsonRpc.parseMessage """{"jsonrpc":"2.0","id":"abc","result":{"ok":true}}""" with
+        | ResponseMessage response ->
+            Assert.Equal("abc", response.Id.Value.GetValue<string>())
+            Assert.True(response.Result.Value["ok"].GetValue<bool>())
+        | _ -> failwith "expected response"
+
+    [<Fact>]
+    let ``parses error responses and reports invalid messages`` () =
+        match JsonRpc.parseMessage """{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found","data":"hover"}}""" with
+        | ResponseMessage response ->
+            Assert.Equal(JsonRpc.METHOD_NOT_FOUND, response.Error.Value.Code)
+            Assert.Equal("hover", response.Error.Value.Data.Value.GetValue<string>())
+        | _ -> failwith "expected error response"
+
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> JsonRpc.parseMessage "{not json}")
+        assertRpcError JsonRpc.INVALID_REQUEST (fun () -> JsonRpc.parseMessage """[{"jsonrpc":"2.0"}]""")
+        assertRpcError JsonRpc.INVALID_REQUEST (fun () -> JsonRpc.parseMessage """{"jsonrpc":"1.0","method":"x"}""")
+        assertRpcError JsonRpc.INVALID_REQUEST (fun () -> JsonRpc.parseMessage """{"jsonrpc":"2.0","id":null,"method":"x"}""")
+        assertRpcError JsonRpc.INVALID_REQUEST (fun () -> JsonRpc.parseMessage """{"jsonrpc":"2.0","id":1,"error":"bad"}""")
+        assertRpcError JsonRpc.INVALID_REQUEST (fun () -> JsonRpc.parseMessage """{"jsonrpc":"2.0","id":1,"error":{"code":"oops","message":"bad"}}""")
+
+    [<Fact>]
+    let ``converts messages to wire objects`` () =
+        let parameters = JsonObject()
+        parameters["a"] <- JsonValue.Create(1)
+        let request = JsonRpc.messageToNode (RequestMessage { Id = JsonValue.Create(1); Method = "foo"; Params = Some parameters })
+        Assert.Equal("2.0", request["jsonrpc"].GetValue<string>())
+        Assert.Equal("foo", request["method"].GetValue<string>())
+        Assert.Equal(1, request.Item("params").Item("a").GetValue<int>())
+
+        let notification = JsonRpc.messageToNode (NotificationMessage { Method = "exit"; Params = None })
+        Assert.False(notification.ContainsKey("id"))
+        Assert.False(notification.ContainsKey("params"))
+
+        let error =
+            JsonRpc.messageToNode (
+                ResponseMessage
+                    { Id = Some(JsonValue.Create("id"))
+                      Result = None
+                      Error = Some { Code = JsonRpc.INVALID_PARAMS; Message = "Bad"; Data = Some(JsonValue.Create("detail")) } }
+            )
+        Assert.Equal(JsonRpc.INVALID_PARAMS, error.Item("error").Item("code").GetValue<int>())
+        Assert.Equal("detail", error.Item("error").Item("data").GetValue<string>())
+
+    [<Fact>]
+    let ``reader handles framing and eof`` () =
+        let raw1 = """{"jsonrpc":"2.0","id":1,"method":"foo"}"""
+        let raw2 = """{"jsonrpc":"2.0","method":"bar"}"""
+        use stream = new MemoryStream(Array.append (frame raw1) (frame raw2))
+        let reader = MessageReader stream
+
+        match reader.ReadMessage() with
+        | Some(RequestMessage _) -> ()
+        | _ -> failwith "expected request"
+
+        match reader.ReadMessage() with
+        | Some(NotificationMessage _) -> ()
+        | _ -> failwith "expected notification"
+
+        Assert.Equal(None, reader.ReadMessage())
+
+        use rawStream = new MemoryStream(frameWithHeader raw1 "Content-Type: application/vscode-jsonrpc; charset=utf-8")
+        Assert.Equal(Some raw1, (MessageReader rawStream).ReadRaw())
+
+    [<Fact>]
+    let ``reader reports malformed frames`` () =
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> (MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Type: text/plain\r\n\r\nhello")))).ReadMessage())
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> (MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: nope\r\n\r\n{}")))).ReadMessage())
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> (MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: -1\r\n\r\n")))).ReadMessage())
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> (MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: 10\r\n\r\nshort")))).ReadMessage())
+        assertRpcError JsonRpc.PARSE_ERROR (fun () -> (MessageReader(new MemoryStream(Encoding.ASCII.GetBytes("Content-Length: 1\r\n\r\n\xFF")))).ReadMessage())
+
+    [<Fact>]
+    let ``writer produces content length frames`` () =
+        use stream = new MemoryStream()
+        let writer = MessageWriter stream
+        let parameters = JsonObject()
+        parameters["text"] <- JsonValue.Create("日本語")
+        writer.WriteMessage(RequestMessage { Id = JsonValue.Create(1); Method = "ping"; Params = Some parameters })
+
+        let data = stream.ToArray()
+        let separator = Encoding.UTF8.GetString(data).IndexOf("\r\n\r\n", StringComparison.Ordinal)
+        Assert.True(separator > 0)
+        let header = Encoding.ASCII.GetString(data[0 .. separator - 1])
+        let payload = data[separator + 4 ..]
+        let parts = header.Split(':')
+        let declared = Int32.Parse(parts[1].Trim())
+
+        Assert.Equal(declared, payload.Length)
+        Assert.Contains("日本語", Encoding.UTF8.GetString(payload))
+
+    [<Fact>]
+    let ``round trips messages through writer and reader`` () =
+        use stream = new MemoryStream()
+        let parameters = JsonObject()
+        parameters["ok"] <- JsonValue.Create(true)
+        MessageWriter(stream).WriteMessage(NotificationMessage { Method = "initialized"; Params = Some parameters })
+        stream.Position <- 0L
+
+        match (MessageReader stream).ReadMessage() with
+        | Some(NotificationMessage recovered) ->
+            Assert.Equal("initialized", recovered.Method)
+            Assert.True(recovered.Params.Value["ok"].GetValue<bool>())
+        | _ -> failwith "expected notification"
+
+    [<Fact>]
+    let ``server dispatches requests and notifications`` () =
+        let input =
+            Array.append
+                (frame """{"jsonrpc":"2.0","id":1,"method":"add","params":{"a":1,"b":2}}""")
+                (frame """{"jsonrpc":"2.0","method":"ping","params":{"seen":true}}""")
+
+        use inStream = new MemoryStream(input)
+        use outStream = new MemoryStream()
+        let mutable notified = false
+
+        Server(inStream, outStream)
+            .OnRequest("add", fun _ parameters -> JsonValue.Create(parameters.Value["a"].GetValue<int>() + parameters.Value["b"].GetValue<int>()))
+            .OnNotification("ping", fun parameters -> notified <- parameters.Value["seen"].GetValue<bool>())
+            .Serve()
+
+        Assert.True(notified)
+        outStream.Position <- 0L
+        match (MessageReader outStream).ReadMessage() with
+        | Some(ResponseMessage response) -> Assert.Equal(3, response.Result.Value.GetValue<int>())
+        | _ -> failwith "expected response"
+
+    [<Fact>]
+    let ``server handles errors`` () =
+        let input =
+            [| frame """{"jsonrpc":"2.0","id":1,"method":"unknown"}"""
+               frame """{"jsonrpc":"2.0","id":2,"method":"bad"}"""
+               frame """{"jsonrpc":"2.0","id":3,"method":"boom"}"""
+               frame """{"jsonrpc":"2.0","method":"missing"}""" |]
+            |> Array.concat
+
+        use inStream = new MemoryStream(input)
+        use outStream = new MemoryStream()
+
+        Server(inStream, outStream)
+            .OnRequest("bad", fun _ _ -> box { Code = JsonRpc.INVALID_PARAMS; Message = "Bad params"; Data = None })
+            .OnRequest("boom", fun _ _ -> raise (InvalidOperationException("boom")))
+            .Serve()
+
+        outStream.Position <- 0L
+        let reader = MessageReader outStream
+        let readCode () =
+            match reader.ReadMessage() with
+            | Some(ResponseMessage response) -> response.Error.Value.Code
+            | _ -> failwith "expected error response"
+
+        Assert.Equal(JsonRpc.METHOD_NOT_FOUND, readCode())
+        Assert.Equal(JsonRpc.INVALID_PARAMS, readCode())
+        Assert.Equal(JsonRpc.INTERNAL_ERROR, readCode())
+        Assert.Equal(None, reader.ReadMessage())
+
+    [<Fact>]
+    let ``server sends parse errors and ignores responses`` () =
+        let input =
+            Array.append
+                (frame "NOT JSON")
+                (frame """{"jsonrpc":"2.0","id":1,"result":42}""")
+
+        use inStream = new MemoryStream(input)
+        use outStream = new MemoryStream()
+
+        Server(inStream, outStream).Serve()
+
+        outStream.Position <- 0L
+        match (MessageReader outStream).ReadMessage() with
+        | Some(ResponseMessage response) -> Assert.Equal(JsonRpc.PARSE_ERROR, response.Error.Value.Code)
+        | _ -> failwith "expected parse error"
+
+        Assert.Equal(None, (MessageReader outStream).ReadMessage())


### PR DESCRIPTION
## Summary
- add native C# and F# JSON-RPC 2.0 packages with request/response/notification models and standard error codes
- implement Content-Length framed readers/writers plus sequential request/notification dispatch servers
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\json-rpc\tests\CodingAdventures.JsonRpc.Tests\CodingAdventures.JsonRpc.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\json-rpc\tests\CodingAdventures.JsonRpc.Tests\CodingAdventures.JsonRpc.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line