### PR TITLE
feat(parity): add dotnet http core packages

### DIFF
--- a/code/packages/csharp/http-core/BUILD
+++ b/code/packages/csharp/http-core/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/http-core/BUILD_windows
+++ b/code/packages/csharp/http-core/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/http-core/CHANGELOG.md
+++ b/code/packages/csharp/http-core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# shared HTTP types, header helpers, body kind modes, and route pattern matching.

--- a/code/packages/csharp/http-core/CodingAdventures.HttpCore.csproj
+++ b/code/packages/csharp/http-core/CodingAdventures.HttpCore.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <PackageId>CodingAdventures.HttpCore.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared HTTP message types and helpers for request and response heads</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/http-core/HttpCore.cs
+++ b/code/packages/csharp/http-core/HttpCore.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+
+namespace CodingAdventures.HttpCore;
+
+public static class HttpCore
+{
+    public const string Version = "0.1.0";
+
+    public static string? FindHeader(IEnumerable<Header> headers, string name) =>
+        headers.FirstOrDefault(header => header.Name.Equals(name, StringComparison.OrdinalIgnoreCase))?.Value;
+
+    public static int? ParseContentLength(IEnumerable<Header> headers)
+    {
+        var value = FindHeader(headers, "Content-Length");
+        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var length) && length >= 0
+            ? length
+            : null;
+    }
+
+    public static (string MediaType, string? Charset)? ParseContentType(IEnumerable<Header> headers)
+    {
+        var value = FindHeader(headers, "Content-Type");
+        if (value is null)
+        {
+            return null;
+        }
+
+        var pieces = value.Split(';', StringSplitOptions.TrimEntries);
+        var mediaType = pieces.FirstOrDefault() ?? string.Empty;
+        if (mediaType.Length == 0)
+        {
+            return null;
+        }
+
+        string? charset = null;
+        foreach (var piece in pieces.Skip(1))
+        {
+            var pair = piece.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (pair.Length == 2 && pair[0].Equals("charset", StringComparison.OrdinalIgnoreCase))
+            {
+                charset = pair[1].Trim('"');
+                break;
+            }
+        }
+
+        return (mediaType, charset);
+    }
+
+    public static IReadOnlyList<string> SplitPathSegments(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return path == "/"
+            ? []
+            : path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+    }
+}
+
+public sealed record Header(string Name, string Value);
+
+public readonly record struct HttpVersion(ushort Major, ushort Minor)
+{
+    public static HttpVersion Parse(string text)
+    {
+        if (!text.StartsWith("HTTP/", StringComparison.Ordinal))
+        {
+            throw new FormatException($"invalid HTTP version: {text}");
+        }
+
+        var rest = text[5..];
+        var dot = rest.IndexOf('.');
+        if (dot < 0
+            || !ushort.TryParse(rest[..dot], NumberStyles.None, CultureInfo.InvariantCulture, out var major)
+            || !ushort.TryParse(rest[(dot + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out var minor))
+        {
+            throw new FormatException($"invalid HTTP version: {text}");
+        }
+
+        return new HttpVersion(major, minor);
+    }
+
+    public override string ToString() => $"HTTP/{Major}.{Minor}";
+}
+
+public sealed record BodyKind(string Mode, int? Length = null)
+{
+    public static BodyKind None() => new("none");
+
+    public static BodyKind ContentLength(int length) => new("content-length", length);
+
+    public static BodyKind UntilEof() => new("until-eof");
+
+    public static BodyKind Chunked() => new("chunked");
+}
+
+public sealed record RequestHead(string Method, string Target, HttpVersion Version, IReadOnlyList<Header> Headers)
+{
+    public string? Header(string name) => HttpCore.FindHeader(Headers, name);
+
+    public int? ContentLength() => HttpCore.ParseContentLength(Headers);
+
+    public (string MediaType, string? Charset)? ContentType() => HttpCore.ParseContentType(Headers);
+}
+
+public sealed record ResponseHead(HttpVersion Version, ushort Status, string Reason, IReadOnlyList<Header> Headers)
+{
+    public string? Header(string name) => HttpCore.FindHeader(Headers, name);
+
+    public int? ContentLength() => HttpCore.ParseContentLength(Headers);
+
+    public (string MediaType, string? Charset)? ContentType() => HttpCore.ParseContentType(Headers);
+}
+
+public abstract record RouteSegment
+{
+    public sealed record Literal(string Value) : RouteSegment;
+
+    public sealed record Param(string Name) : RouteSegment;
+}
+
+public sealed record RoutePattern(IReadOnlyList<RouteSegment> Segments)
+{
+    public static RoutePattern Parse(string pattern)
+    {
+        var segments = HttpCore.SplitPathSegments(pattern)
+            .Select(segment => segment.StartsWith(':')
+                ? (RouteSegment)new RouteSegment.Param(segment[1..])
+                : new RouteSegment.Literal(segment))
+            .ToArray();
+        return new RoutePattern(segments);
+    }
+
+    public IReadOnlyList<(string Name, string Value)>? MatchPath(string path)
+    {
+        var pathSegments = HttpCore.SplitPathSegments(path);
+        if (pathSegments.Count != Segments.Count)
+        {
+            return null;
+        }
+
+        var parameters = new List<(string Name, string Value)>();
+        for (var i = 0; i < Segments.Count; i++)
+        {
+            switch (Segments[i])
+            {
+                case RouteSegment.Literal literal when literal.Value == pathSegments[i]:
+                    break;
+                case RouteSegment.Param param:
+                    parameters.Add((param.Name, pathSegments[i]));
+                    break;
+                default:
+                    return null;
+            }
+        }
+
+        return parameters;
+    }
+}

--- a/code/packages/csharp/http-core/README.md
+++ b/code/packages/csharp/http-core/README.md
@@ -1,0 +1,13 @@
+# CodingAdventures.HttpCore.CSharp
+
+Shared HTTP semantic types and helpers for C#.
+
+```csharp
+using CodingAdventures.HttpCore;
+
+var version = HttpVersion.Parse("HTTP/1.1");
+var head = new RequestHead("GET", "/", version, [new Header("Accept", "*/*")]);
+```
+
+Includes request/response heads, headers, body framing modes, content helper
+parsers, and simple route pattern matching.

--- a/code/packages/csharp/http-core/required_capabilities.json
+++ b/code/packages/csharp/http-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/http-core",
+  "capabilities": [],
+  "justification": "Pure HTTP metadata parsing and route matching. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/http-core/tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.csproj
+++ b/code/packages/csharp/http-core/tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.HttpCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/http-core/tests/CodingAdventures.HttpCore.Tests/HttpCoreTests.cs
+++ b/code/packages/csharp/http-core/tests/CodingAdventures.HttpCore.Tests/HttpCoreTests.cs
@@ -1,0 +1,78 @@
+namespace CodingAdventures.HttpCore.Tests;
+
+public sealed class HttpCoreTests
+{
+    [Fact]
+    public void ParsesHttpVersions()
+    {
+        var version = HttpVersion.Parse("HTTP/1.1");
+        Assert.Equal((ushort)1, version.Major);
+        Assert.Equal((ushort)1, version.Minor);
+        Assert.Equal("HTTP/1.1", version.ToString());
+
+        Assert.Throws<FormatException>(() => HttpVersion.Parse("HTP/1.1"));
+        Assert.Throws<FormatException>(() => HttpVersion.Parse("HTTP/one.1"));
+    }
+
+    [Fact]
+    public void FindsHeadersAndParsesContentHelpers()
+    {
+        var headers = new[]
+        {
+            new Header("Content-Length", "42"),
+            new Header("Content-Type", "text/html; charset=\"utf-8\""),
+        };
+
+        Assert.Equal("42", HttpCore.FindHeader(headers, "content-length"));
+        Assert.Equal(42, HttpCore.ParseContentLength(headers));
+        Assert.Equal(("text/html", "utf-8"), HttpCore.ParseContentType(headers));
+        Assert.Null(HttpCore.FindHeader(headers, "missing"));
+        Assert.Null(HttpCore.ParseContentLength([new Header("Content-Length", "forty-two")]));
+        Assert.Null(HttpCore.ParseContentType([new Header("Content-Type", "")]));
+    }
+
+    [Fact]
+    public void HeadsDelegateToHelpers()
+    {
+        var request = new RequestHead("POST", "/submit", new HttpVersion(1, 1), [new Header("Content-Length", "5")]);
+        var response = new ResponseHead(new HttpVersion(1, 0), 200, "OK", [new Header("Content-Type", "application/json")]);
+
+        Assert.Equal("5", request.Header("content-length"));
+        Assert.Equal(5, request.ContentLength());
+        Assert.Equal(("application/json", null), response.ContentType());
+        Assert.Null(response.ContentLength());
+    }
+
+    [Fact]
+    public void BodyKindConstructorsMatchSemanticModes()
+    {
+        Assert.Equal(new BodyKind("none"), BodyKind.None());
+        Assert.Equal(new BodyKind("content-length", 7), BodyKind.ContentLength(7));
+        Assert.Equal(new BodyKind("until-eof"), BodyKind.UntilEof());
+        Assert.Equal(new BodyKind("chunked"), BodyKind.Chunked());
+    }
+
+    [Fact]
+    public void SplitsPathsAndMatchesRoutePatterns()
+    {
+        Assert.Empty(HttpCore.SplitPathSegments("/"));
+        Assert.Equal(["hello", "world"], HttpCore.SplitPathSegments("/hello/world/"));
+
+        var pattern = RoutePattern.Parse("/hello/:name");
+        var parameters = pattern.MatchPath("/hello/Adhithya");
+
+        Assert.NotNull(parameters);
+        Assert.Equal(("name", "Adhithya"), parameters![0]);
+        Assert.Null(pattern.MatchPath("/hello"));
+        Assert.Null(pattern.MatchPath("/goodbye/Adhithya"));
+    }
+
+    [Fact]
+    public void RoutePatternHandlesRoot()
+    {
+        var pattern = RoutePattern.Parse("/");
+        Assert.Empty(pattern.Segments);
+        Assert.Empty(pattern.MatchPath("/")!);
+        Assert.Null(pattern.MatchPath("/extra"));
+    }
+}

--- a/code/packages/fsharp/http-core/BUILD
+++ b/code/packages/fsharp/http-core/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/http-core/BUILD_windows
+++ b/code/packages/fsharp/http-core/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/http-core/CHANGELOG.md
+++ b/code/packages/fsharp/http-core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# shared HTTP types, header helpers, body kind modes, and route pattern matching.

--- a/code/packages/fsharp/http-core/CodingAdventures.HttpCore.fsproj
+++ b/code/packages/fsharp/http-core/CodingAdventures.HttpCore.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.HttpCore.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared HTTP message types and helpers for request and response heads</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="HttpCore.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/http-core/HttpCore.fs
+++ b/code/packages/fsharp/http-core/HttpCore.fs
@@ -1,0 +1,144 @@
+namespace CodingAdventures.HttpCore.FSharp
+
+open System
+open System.Globalization
+
+type Header = { Name: string; Value: string }
+
+[<Struct>]
+type HttpVersion =
+    { Major: uint16
+      Minor: uint16 }
+
+    static member Parse(text: string) =
+        if not (text.StartsWith("HTTP/", StringComparison.Ordinal)) then
+            raise (FormatException($"invalid HTTP version: {text}"))
+
+        let rest = text.Substring(5)
+        let dot = rest.IndexOf('.')
+        let mutable major = 0us
+        let mutable minor = 0us
+
+        if dot < 0
+           || not (UInt16.TryParse(rest.Substring(0, dot), NumberStyles.None, CultureInfo.InvariantCulture, &major))
+           || not (UInt16.TryParse(rest.Substring(dot + 1), NumberStyles.None, CultureInfo.InvariantCulture, &minor)) then
+            raise (FormatException($"invalid HTTP version: {text}"))
+
+        { Major = major; Minor = minor }
+
+    override this.ToString() = $"HTTP/{this.Major}.{this.Minor}"
+
+type BodyKind =
+    { Mode: string
+      Length: int option }
+
+    static member None() = { Mode = "none"; Length = None }
+
+    static member ContentLength(length: int) = { Mode = "content-length"; Length = Some length }
+
+    static member UntilEof() = { Mode = "until-eof"; Length = None }
+
+    static member Chunked() = { Mode = "chunked"; Length = None }
+
+type RouteSegment =
+    | Literal of string
+    | Param of string
+
+type RoutePattern =
+    { Segments: RouteSegment list }
+
+    static member Parse(pattern: string) =
+        { Segments =
+            HttpCore.splitPathSegments pattern
+            |> List.map (fun (segment: string) ->
+                if segment.StartsWith(":", StringComparison.Ordinal) then
+                    Param(segment.Substring(1))
+                else
+                    Literal segment) }
+
+    member this.MatchPath(path: string) =
+        let pathSegments = HttpCore.splitPathSegments path
+        if pathSegments.Length <> this.Segments.Length then
+            None
+        else
+            let mutable failed = false
+            let parameters = ResizeArray<string * string>()
+
+            for segment, actual in List.zip this.Segments pathSegments do
+                match segment with
+                | Literal expected when expected = actual -> ()
+                | Literal _ -> failed <- true
+                | Param name -> parameters.Add(name, actual)
+
+            if failed then None else Some(List.ofSeq parameters)
+
+and RequestHead =
+    { Method: string
+      Target: string
+      Version: HttpVersion
+      Headers: Header list }
+
+    member this.Header(name: string) = HttpCore.findHeader this.Headers name
+
+    member this.ContentLength() = HttpCore.parseContentLength this.Headers
+
+    member this.ContentType() = HttpCore.parseContentType this.Headers
+
+and ResponseHead =
+    { Version: HttpVersion
+      Status: uint16
+      Reason: string
+      Headers: Header list }
+
+    member this.Header(name: string) = HttpCore.findHeader this.Headers name
+
+    member this.ContentLength() = HttpCore.parseContentLength this.Headers
+
+    member this.ContentType() = HttpCore.parseContentType this.Headers
+
+and [<RequireQualifiedAccess>] HttpCore =
+    static member VERSION = "0.1.0"
+
+    static member findHeader (headers: Header list) (name: string) =
+        headers
+        |> List.tryFind (fun header -> header.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+        |> Option.map _.Value
+
+    static member parseContentLength headers =
+        match HttpCore.findHeader headers "Content-Length" with
+        | None -> None
+        | Some value ->
+            let mutable length = 0
+            if Int32.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, &length) && length >= 0 then
+                Some length
+            else
+                None
+
+    static member parseContentType headers =
+        match HttpCore.findHeader headers "Content-Type" with
+        | None -> None
+        | Some value ->
+            let pieces = value.Split(';', StringSplitOptions.TrimEntries)
+            let mediaType = if pieces.Length = 0 then "" else pieces[0]
+
+            if mediaType.Length = 0 then
+                None
+            else
+                let charset =
+                    pieces
+                    |> Array.skip 1
+                    |> Array.tryPick (fun piece ->
+                        let pair = piece.Split('=', 2, StringSplitOptions.TrimEntries)
+                        if pair.Length = 2 && pair[0].Equals("charset", StringComparison.OrdinalIgnoreCase) then
+                            Some(pair[1].Trim('"'))
+                        else
+                            None)
+
+                Some(mediaType, charset)
+
+    static member splitPathSegments(path: string) =
+        if isNull path then nullArg "path"
+        if path = "/" then
+            []
+        else
+            path.Split('/', StringSplitOptions.RemoveEmptyEntries) |> Array.toList

--- a/code/packages/fsharp/http-core/README.md
+++ b/code/packages/fsharp/http-core/README.md
@@ -1,0 +1,13 @@
+# CodingAdventures.HttpCore.FSharp
+
+Shared HTTP semantic types and helpers for F#.
+
+```fsharp
+open CodingAdventures.HttpCore.FSharp
+
+let version = HttpVersion.Parse "HTTP/1.1"
+let head = { Method = "GET"; Target = "/"; Version = version; Headers = [ { Name = "Accept"; Value = "*/*" } ] }
+```
+
+Includes request/response heads, headers, body framing modes, content helper
+parsers, and simple route pattern matching.

--- a/code/packages/fsharp/http-core/required_capabilities.json
+++ b/code/packages/fsharp/http-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/http-core",
+  "capabilities": [],
+  "justification": "Pure HTTP metadata parsing and route matching. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/http-core/tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.fsproj
+++ b/code/packages/fsharp/http-core/tests/CodingAdventures.HttpCore.Tests/CodingAdventures.HttpCore.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.HttpCore.fsproj" />
+    <Compile Include="HttpCoreTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/http-core/tests/CodingAdventures.HttpCore.Tests/HttpCoreTests.fs
+++ b/code/packages/fsharp/http-core/tests/CodingAdventures.HttpCore.Tests/HttpCoreTests.fs
@@ -1,0 +1,74 @@
+namespace CodingAdventures.HttpCore.Tests
+
+open System
+open Xunit
+open CodingAdventures.HttpCore.FSharp
+
+module HttpCoreTests =
+    [<Fact>]
+    let ``parses http versions`` () =
+        let version = HttpVersion.Parse "HTTP/1.1"
+        Assert.Equal(1us, version.Major)
+        Assert.Equal(1us, version.Minor)
+        Assert.Equal("HTTP/1.1", version.ToString())
+
+        Assert.Throws<FormatException>(fun () -> HttpVersion.Parse "HTP/1.1" |> ignore) |> ignore
+        Assert.Throws<FormatException>(fun () -> HttpVersion.Parse "HTTP/one.1" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``finds headers and parses content helpers`` () =
+        let headers =
+            [ { Name = "Content-Length"; Value = "42" }
+              { Name = "Content-Type"; Value = "text/html; charset=\"utf-8\"" } ]
+
+        Assert.Equal(Some "42", HttpCore.findHeader headers "content-length")
+        Assert.Equal(Some 42, HttpCore.parseContentLength headers)
+        Assert.Equal(Some("text/html", Some "utf-8"), HttpCore.parseContentType headers)
+        Assert.Equal(None, HttpCore.findHeader headers "missing")
+        Assert.Equal(None, HttpCore.parseContentLength [ { Name = "Content-Length"; Value = "forty-two" } ])
+        Assert.Equal(None, HttpCore.parseContentType [ { Name = "Content-Type"; Value = "" } ])
+
+    [<Fact>]
+    let ``heads delegate to helpers`` () =
+        let request =
+            { Method = "POST"
+              Target = "/submit"
+              Version = { Major = 1us; Minor = 1us }
+              Headers = [ { Name = "Content-Length"; Value = "5" } ] }
+
+        let response =
+            { Version = { Major = 1us; Minor = 0us }
+              Status = 200us
+              Reason = "OK"
+              Headers = [ { Name = "Content-Type"; Value = "application/json" } ] }
+
+        Assert.Equal(Some "5", request.Header "content-length")
+        Assert.Equal(Some 5, request.ContentLength())
+        Assert.Equal(Some("application/json", None), response.ContentType())
+        Assert.Equal(None, response.ContentLength())
+
+    [<Fact>]
+    let ``body kind constructors match semantic modes`` () =
+        Assert.Equal({ Mode = "none"; Length = None }, BodyKind.None())
+        Assert.Equal({ Mode = "content-length"; Length = Some 7 }, BodyKind.ContentLength 7)
+        Assert.Equal({ Mode = "until-eof"; Length = None }, BodyKind.UntilEof())
+        Assert.Equal({ Mode = "chunked"; Length = None }, BodyKind.Chunked())
+
+    [<Fact>]
+    let ``splits paths and matches route patterns`` () =
+        Assert.Empty(HttpCore.splitPathSegments "/")
+        Assert.Equal<string>([ "hello"; "world" ], HttpCore.splitPathSegments "/hello/world/")
+
+        let pattern = RoutePattern.Parse "/hello/:name"
+        let parameters = pattern.MatchPath "/hello/Adhithya"
+
+        Assert.Equal(Some [ ("name", "Adhithya") ], parameters)
+        Assert.Equal(None, pattern.MatchPath "/hello")
+        Assert.Equal(None, pattern.MatchPath "/goodbye/Adhithya")
+
+    [<Fact>]
+    let ``route pattern handles root`` () =
+        let pattern = RoutePattern.Parse "/"
+        Assert.Empty(pattern.Segments)
+        Assert.Equal(Some [], pattern.MatchPath "/")
+        Assert.Equal(None, pattern.MatchPath "/extra")


### PR DESCRIPTION
## Summary
- add native C# and F# HTTP core packages with headers, versions, body kind modes, request/response heads, and route patterns
- include helpers for case-insensitive header lookup, Content-Length, Content-Type, and path segment splitting
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\http-core\tests\CodingAdventures.HttpCore.Tests\CodingAdventures.HttpCore.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\http-core\tests\CodingAdventures.HttpCore.Tests\CodingAdventures.HttpCore.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line