### PR TITLE
feat(parity): add dotnet intel 4004 packager packages

### DIFF
--- a/code/packages/csharp/intel-4004-packager/BUILD
+++ b/code/packages/csharp/intel-4004-packager/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/intel-4004-packager/BUILD_windows
+++ b/code/packages/csharp/intel-4004-packager/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/intel-4004-packager/CHANGELOG.md
+++ b/code/packages/csharp/intel-4004-packager/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# Intel HEX encoder and decoder for 4004 ROM images.

--- a/code/packages/csharp/intel-4004-packager/CodingAdventures.Intel4004Packager.csproj
+++ b/code/packages/csharp/intel-4004-packager/CodingAdventures.Intel4004Packager.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <PackageId>CodingAdventures.Intel4004Packager.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Intel HEX ROM image encoder and decoder for Intel 4004 tooling</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/intel-4004-packager/Intel4004Packager.cs
+++ b/code/packages/csharp/intel-4004-packager/Intel4004Packager.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using System.Text;
+
+namespace CodingAdventures.Intel4004Packager;
+
+public static class Intel4004Packager
+{
+    public const string Version = "0.1.0";
+    private const int BytesPerRecord = 16;
+    private const byte RecordTypeData = 0x00;
+    private const byte RecordTypeEof = 0x01;
+    private const int MaxImageSize = 0x1000;
+
+    public static string EncodeHex(ReadOnlySpan<byte> binary, int origin = 0)
+    {
+        if (binary.IsEmpty)
+        {
+            throw new ArgumentException("binary must be non-empty", nameof(binary));
+        }
+
+        if (origin < 0 || origin > 0xFFFF)
+        {
+            throw new ArgumentOutOfRangeException(nameof(origin), "origin must be 0-65535");
+        }
+
+        if (origin + binary.Length > 0x10000)
+        {
+            throw new ArgumentException("image overflows 16-bit address space", nameof(binary));
+        }
+
+        var builder = new StringBuilder();
+        for (var offset = 0; offset < binary.Length; offset += BytesPerRecord)
+        {
+            var count = Math.Min(BytesPerRecord, binary.Length - offset);
+            builder.Append(DataRecord(origin + offset, binary.Slice(offset, count)));
+        }
+
+        builder.Append(":00000001FF\n");
+        return builder.ToString();
+    }
+
+    public static DecodedHex DecodeHex(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var segments = new SortedDictionary<int, byte[]>();
+        var normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n');
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index].Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var lineNumber = index + 1;
+            if (!line.StartsWith(':'))
+            {
+                throw new FormatException($"line {lineNumber}: expected ':'");
+            }
+
+            var record = DecodeHexBytes(line[1..], lineNumber);
+            if (record.Length < 5)
+            {
+                throw new FormatException($"line {lineNumber}: record too short");
+            }
+
+            var byteCount = record[0];
+            var address = (record[1] << 8) | record[2];
+            var recordType = record[3];
+            var expectedLength = 4 + byteCount + 1;
+            if (record.Length < expectedLength)
+            {
+                throw new FormatException($"line {lineNumber}: truncated record");
+            }
+
+            var computedChecksum = Checksum(record.AsSpan(0, 4 + byteCount));
+            var storedChecksum = record[4 + byteCount];
+            if (computedChecksum != storedChecksum)
+            {
+                throw new FormatException($"line {lineNumber}: checksum mismatch");
+            }
+
+            if (recordType == RecordTypeEof)
+            {
+                break;
+            }
+
+            if (recordType != RecordTypeData)
+            {
+                throw new FormatException($"line {lineNumber}: unsupported record type");
+            }
+
+            segments[address] = record.AsSpan(4, byteCount).ToArray();
+        }
+
+        if (segments.Count == 0)
+        {
+            return new DecodedHex(0, []);
+        }
+
+        var origin = segments.Keys.First();
+        var end = segments.Max(pair => pair.Key + pair.Value.Length);
+        if (end - origin > MaxImageSize)
+        {
+            throw new FormatException("decoded image too large");
+        }
+
+        var binary = new byte[end - origin];
+        foreach (var (address, data) in segments)
+        {
+            data.CopyTo(binary.AsSpan(address - origin));
+        }
+
+        return new DecodedHex(origin, binary);
+    }
+
+    private static string DataRecord(int address, ReadOnlySpan<byte> chunk)
+    {
+        var fields = new byte[4 + chunk.Length];
+        fields[0] = (byte)chunk.Length;
+        fields[1] = (byte)((address >> 8) & 0xFF);
+        fields[2] = (byte)(address & 0xFF);
+        fields[3] = RecordTypeData;
+        chunk.CopyTo(fields.AsSpan(4));
+
+        return $":{chunk.Length:X2}{address:X4}00{Convert.ToHexString(chunk)}{Checksum(fields):X2}\n";
+    }
+
+    private static byte Checksum(ReadOnlySpan<byte> fields)
+    {
+        var total = 0;
+        foreach (var field in fields)
+        {
+            total += field;
+        }
+
+        return (byte)((0x100 - (total % 0x100)) % 0x100);
+    }
+
+    private static byte[] DecodeHexBytes(string hex, int lineNumber)
+    {
+        try
+        {
+            return Convert.FromHexString(hex);
+        }
+        catch (FormatException ex)
+        {
+            throw new FormatException($"line {lineNumber}: invalid hex", ex);
+        }
+    }
+}
+
+public sealed record DecodedHex(int Origin, byte[] Binary);

--- a/code/packages/csharp/intel-4004-packager/README.md
+++ b/code/packages/csharp/intel-4004-packager/README.md
@@ -1,0 +1,13 @@
+# CodingAdventures.Intel4004Packager.CSharp
+
+Intel HEX ROM image encoder and decoder for Intel 4004 tooling.
+
+```csharp
+using CodingAdventures.Intel4004Packager;
+
+var hex = Intel4004Packager.EncodeHex([0xD5, 0x01]);
+var decoded = Intel4004Packager.DecodeHex(hex);
+```
+
+The encoder emits 16-byte data records plus the required EOF record. The
+decoder verifies record checksums and reconstructs the binary image.

--- a/code/packages/csharp/intel-4004-packager/required_capabilities.json
+++ b/code/packages/csharp/intel-4004-packager/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/intel-4004-packager",
+  "capabilities": [],
+  "justification": "Pure Intel HEX encoding and decoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.csproj
+++ b/code/packages/csharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Intel4004Packager.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/Intel4004PackagerTests.cs
+++ b/code/packages/csharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/Intel4004PackagerTests.cs
@@ -1,0 +1,82 @@
+namespace CodingAdventures.Intel4004Packager.Tests;
+
+public sealed class Intel4004PackagerTests
+{
+    [Fact]
+    public void VersionIsExposed()
+    {
+        Assert.Equal("0.1.0", Intel4004Packager.Version);
+    }
+
+    [Fact]
+    public void EncodesRecordsWithValidChecksumsAndEof()
+    {
+        var hex = Intel4004Packager.EncodeHex(Enumerable.Range(0, 17).Select(i => (byte)i).ToArray());
+        var lines = hex.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(3, lines.Length);
+        Assert.Equal("10", lines[0][1..3]);
+        Assert.Equal("01", lines[1][1..3]);
+        Assert.Equal(":00000001FF", lines[^1]);
+        Assert.All(lines, VerifyChecksum);
+    }
+
+    [Fact]
+    public void AppliesOriginAndRoundTrips()
+    {
+        var binary = new byte[] { 0xD5, 0x01, 0xC0 };
+        var hex = Intel4004Packager.EncodeHex(binary, 0x0300);
+        Assert.Equal("0300", hex.Split('\n')[0][3..7]);
+
+        var decoded = Intel4004Packager.DecodeHex(hex);
+
+        Assert.Equal(0x0300, decoded.Origin);
+        Assert.Equal<byte>(binary, decoded.Binary);
+    }
+
+    [Fact]
+    public void DecodesSparseSegmentsWithZeroFill()
+    {
+        var first = Intel4004Packager.EncodeHex([0xAA], 0x0010).Split('\n')[0];
+        var second = Intel4004Packager.EncodeHex([0xBB], 0x0012).Split('\n')[0];
+
+        var decoded = Intel4004Packager.DecodeHex(first + "\n" + second + "\n:00000001FF\n");
+
+        Assert.Equal(0x0010, decoded.Origin);
+        Assert.Equal<byte>([0xAA, 0x00, 0xBB], decoded.Binary);
+    }
+
+    [Fact]
+    public void RejectsInvalidEncodeInputs()
+    {
+        Assert.Throws<ArgumentException>(() => Intel4004Packager.EncodeHex([]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Intel4004Packager.EncodeHex([0x00], -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Intel4004Packager.EncodeHex([0x00], 0x10000));
+        Assert.Throws<ArgumentException>(() => Intel4004Packager.EncodeHex(new byte[100], 0xFFFF));
+    }
+
+    [Fact]
+    public void RejectsMalformedHex()
+    {
+        Assert.Throws<FormatException>(() => Intel4004Packager.DecodeHex("020000000000D5012A\n"));
+        Assert.Throws<FormatException>(() => Intel4004Packager.DecodeHex(":0Z000000D5\n"));
+        Assert.Throws<FormatException>(() => Intel4004Packager.DecodeHex(":01000000D500\n:00000001FF\n"));
+        Assert.Throws<FormatException>(() => Intel4004Packager.DecodeHex(":10000002D5AA\n"));
+        Assert.Throws<FormatException>(() => Intel4004Packager.DecodeHex(":10000000D5\n"));
+    }
+
+    [Fact]
+    public void EmptyDecodeReturnsEmptyBinary()
+    {
+        var decoded = Intel4004Packager.DecodeHex("");
+
+        Assert.Equal(0, decoded.Origin);
+        Assert.Empty(decoded.Binary);
+    }
+
+    private static void VerifyChecksum(string line)
+    {
+        var bytes = Convert.FromHexString(line[1..]);
+        Assert.Equal(0, bytes.Sum(b => b) % 256);
+    }
+}

--- a/code/packages/fsharp/intel-4004-packager/BUILD
+++ b/code/packages/fsharp/intel-4004-packager/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/intel-4004-packager/BUILD_windows
+++ b/code/packages/fsharp/intel-4004-packager/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/intel-4004-packager/CHANGELOG.md
+++ b/code/packages/fsharp/intel-4004-packager/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# Intel HEX encoder and decoder for 4004 ROM images.

--- a/code/packages/fsharp/intel-4004-packager/CodingAdventures.Intel4004Packager.fsproj
+++ b/code/packages/fsharp/intel-4004-packager/CodingAdventures.Intel4004Packager.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Intel4004Packager.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Intel HEX ROM image encoder and decoder for Intel 4004 tooling</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Intel4004Packager.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/intel-4004-packager/Intel4004Packager.fs
+++ b/code/packages/fsharp/intel-4004-packager/Intel4004Packager.fs
@@ -1,0 +1,112 @@
+namespace CodingAdventures.Intel4004Packager.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text
+
+type DecodedHex =
+    { Origin: int
+      Binary: byte array }
+
+[<RequireQualifiedAccess>]
+module Intel4004Packager =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private bytesPerRecord = 16
+    let private recordTypeData = 0uy
+    let private recordTypeEof = 1uy
+    let private maxImageSize = 0x1000
+
+    let private checksum (fields: byte seq) =
+        let total = fields |> Seq.sumBy int
+        byte ((0x100 - (total % 0x100)) % 0x100)
+
+    let private dataRecord address (chunk: byte array) =
+        let fields = Array.zeroCreate<byte> (4 + chunk.Length)
+        fields[0] <- byte chunk.Length
+        fields[1] <- byte ((address >>> 8) &&& 0xFF)
+        fields[2] <- byte (address &&& 0xFF)
+        fields[3] <- recordTypeData
+        Array.Copy(chunk, 0, fields, 4, chunk.Length)
+        $":{chunk.Length:X2}{address:X4}00{Convert.ToHexString(chunk)}{checksum fields:X2}\n"
+
+    let encodeHex (binary: byte array) (origin: int) =
+        if isNull binary then nullArg "binary"
+        if binary.Length = 0 then invalidArg "binary" "binary must be non-empty"
+        if origin < 0 || origin > 0xFFFF then invalidArg "origin" "origin must be 0-65535"
+        if origin + binary.Length > 0x10000 then invalidArg "binary" "image overflows 16-bit address space"
+
+        let builder = StringBuilder()
+        let mutable offset = 0
+        while offset < binary.Length do
+            let count = min bytesPerRecord (binary.Length - offset)
+            let chunk = binary[offset .. offset + count - 1]
+            builder.Append(dataRecord (origin + offset) chunk) |> ignore
+            offset <- offset + count
+
+        builder.Append(":00000001FF\n").ToString()
+
+    let encodeHexAtZero binary = encodeHex binary 0
+
+    let private decodeHexBytes lineNumber (text: string) =
+        try
+            Convert.FromHexString(text)
+        with :? FormatException as ex ->
+            raise (FormatException($"line {lineNumber}: invalid hex", ex))
+
+    let decodeHex (text: string) =
+        if isNull text then nullArg "text"
+
+        let segments = SortedDictionary<int, byte array>()
+        let lines = text.Replace("\r\n", "\n").Split('\n')
+
+        let mutable index = 0
+        let mutable doneReading = false
+        while index < lines.Length && not doneReading do
+            let line = lines[index].Trim()
+            let lineNumber = index + 1
+
+            if line.Length > 0 then
+                if not (line.StartsWith(":", StringComparison.Ordinal)) then
+                    raise (FormatException($"line {lineNumber}: expected ':'"))
+
+                let record = decodeHexBytes lineNumber line[1..]
+                if record.Length < 5 then
+                    raise (FormatException($"line {lineNumber}: record too short"))
+
+                let byteCount = int record[0]
+                let address = (int record[1] <<< 8) ||| int record[2]
+                let recordType = record[3]
+                let expectedLength = 4 + byteCount + 1
+
+                if record.Length < expectedLength then
+                    raise (FormatException($"line {lineNumber}: truncated record"))
+
+                let computed = checksum record[0 .. 3 + byteCount]
+                let stored = record[4 + byteCount]
+                if computed <> stored then
+                    raise (FormatException($"line {lineNumber}: checksum mismatch"))
+
+                if recordType = recordTypeEof then
+                    doneReading <- true
+                elif recordType <> recordTypeData then
+                    raise (FormatException($"line {lineNumber}: unsupported record type"))
+                else
+                    segments[address] <- record[4 .. 3 + byteCount]
+
+            index <- index + 1
+
+        if segments.Count = 0 then
+            { Origin = 0; Binary = Array.empty }
+        else
+            let origin = segments.Keys |> Seq.min
+            let endAddress = segments |> Seq.map (fun pair -> pair.Key + pair.Value.Length) |> Seq.max
+            if endAddress - origin > maxImageSize then
+                raise (FormatException("decoded image too large"))
+
+            let binary = Array.zeroCreate<byte> (endAddress - origin)
+            for pair in segments do
+                Array.Copy(pair.Value, 0, binary, pair.Key - origin, pair.Value.Length)
+
+            { Origin = origin; Binary = binary }

--- a/code/packages/fsharp/intel-4004-packager/README.md
+++ b/code/packages/fsharp/intel-4004-packager/README.md
@@ -1,0 +1,13 @@
+# CodingAdventures.Intel4004Packager.FSharp
+
+Intel HEX ROM image encoder and decoder for Intel 4004 tooling.
+
+```fsharp
+open CodingAdventures.Intel4004Packager.FSharp
+
+let hex = Intel4004Packager.encodeHexAtZero [| 0xD5uy; 0x01uy |]
+let decoded = Intel4004Packager.decodeHex hex
+```
+
+The encoder emits 16-byte data records plus the required EOF record. The
+decoder verifies record checksums and reconstructs the binary image.

--- a/code/packages/fsharp/intel-4004-packager/required_capabilities.json
+++ b/code/packages/fsharp/intel-4004-packager/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/intel-4004-packager",
+  "capabilities": [],
+  "justification": "Pure Intel HEX encoding and decoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.fsproj
+++ b/code/packages/fsharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/CodingAdventures.Intel4004Packager.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Intel4004Packager.fsproj" />
+    <Compile Include="Intel4004PackagerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/Intel4004PackagerTests.fs
+++ b/code/packages/fsharp/intel-4004-packager/tests/CodingAdventures.Intel4004Packager.Tests/Intel4004PackagerTests.fs
@@ -1,0 +1,69 @@
+namespace CodingAdventures.Intel4004Packager.Tests
+
+open System
+open Xunit
+open CodingAdventures.Intel4004Packager.FSharp
+
+module Intel4004PackagerTests =
+    let private verifyChecksum (line: string) =
+        let bytes = Convert.FromHexString(line.Substring(1))
+        Assert.Equal(0, (bytes |> Seq.sumBy int) % 256)
+
+    [<Fact>]
+    let ``version is exposed`` () =
+        Assert.Equal("0.1.0", Intel4004Packager.VERSION)
+
+    [<Fact>]
+    let ``encodes records with valid checksums and eof`` () =
+        let hex = Intel4004Packager.encodeHexAtZero ([| 0uy .. 16uy |])
+        let lines = hex.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+
+        Assert.Equal(3, lines.Length)
+        Assert.Equal("10", lines[0].Substring(1, 2))
+        Assert.Equal("01", lines[1].Substring(1, 2))
+        Assert.Equal(":00000001FF", lines[lines.Length - 1])
+        lines |> Array.iter verifyChecksum
+
+    [<Fact>]
+    let ``applies origin and round trips`` () =
+        let binary = [| 0xD5uy; 0x01uy; 0xC0uy |]
+        let hex = Intel4004Packager.encodeHex binary 0x0300
+        let firstLine = hex.Split('\n')[0]
+        Assert.Equal("0300", firstLine.Substring(3, 4))
+
+        let decoded = Intel4004Packager.decodeHex hex
+
+        Assert.Equal(0x0300, decoded.Origin)
+        Assert.Equal<byte>(binary, decoded.Binary)
+
+    [<Fact>]
+    let ``decodes sparse segments with zero fill`` () =
+        let first = (Intel4004Packager.encodeHex [| 0xAAuy |] 0x0010).Split('\n')[0]
+        let second = (Intel4004Packager.encodeHex [| 0xBBuy |] 0x0012).Split('\n')[0]
+
+        let decoded = Intel4004Packager.decodeHex (first + "\n" + second + "\n:00000001FF\n")
+
+        Assert.Equal(0x0010, decoded.Origin)
+        Assert.Equal<byte>([| 0xAAuy; 0x00uy; 0xBBuy |], decoded.Binary)
+
+    [<Fact>]
+    let ``rejects invalid encode inputs`` () =
+        Assert.Throws<ArgumentException>(fun () -> Intel4004Packager.encodeHexAtZero Array.empty |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Intel4004Packager.encodeHex [| 0uy |] -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Intel4004Packager.encodeHex [| 0uy |] 0x10000 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Intel4004Packager.encodeHex (Array.zeroCreate<byte> 100) 0xFFFF |> ignore) |> ignore
+
+    [<Fact>]
+    let ``rejects malformed hex`` () =
+        Assert.Throws<FormatException>(fun () -> Intel4004Packager.decodeHex "020000000000D5012A\n" |> ignore) |> ignore
+        Assert.Throws<FormatException>(fun () -> Intel4004Packager.decodeHex ":0Z000000D5\n" |> ignore) |> ignore
+        Assert.Throws<FormatException>(fun () -> Intel4004Packager.decodeHex ":01000000D500\n:00000001FF\n" |> ignore) |> ignore
+        Assert.Throws<FormatException>(fun () -> Intel4004Packager.decodeHex ":10000002D5AA\n" |> ignore) |> ignore
+        Assert.Throws<FormatException>(fun () -> Intel4004Packager.decodeHex ":10000000D5\n" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``empty decode returns empty binary`` () =
+        let decoded = Intel4004Packager.decodeHex ""
+
+        Assert.Equal(0, decoded.Origin)
+        Assert.Empty(decoded.Binary)


### PR DESCRIPTION
## Summary
- add native C# and F# Intel 4004 packager packages for Intel HEX encoding and decoding
- validate checksums, EOF records, origins, 16-bit address overflow, malformed records, and sparse segment decoding
- include package metadata, capability manifests, BUILD commands, READMEs, changelogs, and xUnit coverage for both languages

## Verification
- dotnet test code\packages\csharp\intel-4004-packager\tests\CodingAdventures.Intel4004Packager.Tests\CodingAdventures.Intel4004Packager.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test code\packages\fsharp\intel-4004-packager\tests\CodingAdventures.Intel4004Packager.Tests\CodingAdventures.Intel4004Packager.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line