### PR TITLE
feat(parity): add dotnet event loop packages

### DIFF
--- a/code/packages/csharp/event-loop/BUILD
+++ b/code/packages/csharp/event-loop/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/event-loop/BUILD_windows
+++ b/code/packages/csharp/event-loop/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/event-loop/CHANGELOG.md
+++ b/code/packages/csharp/event-loop/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a C# generic event loop with event sources, handlers, control-flow signaling, and stop handles.

--- a/code/packages/csharp/event-loop/CodingAdventures.EventLoop.csproj
+++ b/code/packages/csharp/event-loop/CodingAdventures.EventLoop.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.EventLoop.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>A pluggable, generic event loop for pull-based event sources</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/event-loop/EventLoop.cs
+++ b/code/packages/csharp/event-loop/EventLoop.cs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.EventLoop;
+
+using System.Threading;
+
+public static class EventLoopPackage
+{
+    public const string Version = "0.1.0";
+}
+
+public enum ControlFlow
+{
+    Continue,
+    Exit,
+}
+
+public interface IEventSource<TEvent>
+{
+    IReadOnlyList<TEvent> Poll();
+}
+
+public sealed class StopHandle
+{
+    private readonly StopState _state;
+
+    internal StopHandle(StopState state)
+    {
+        _state = state;
+    }
+
+    public void Stop()
+    {
+        _state.Stop();
+    }
+}
+
+public sealed class EventLoop<TEvent>
+{
+    private readonly List<IEventSource<TEvent>> _sources = [];
+    private readonly List<Func<TEvent, ControlFlow>> _handlers = [];
+    private readonly StopState _state = new();
+
+    public void AddSource(IEventSource<TEvent> source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        _sources.Add(source);
+    }
+
+    public void OnEvent(Func<TEvent, ControlFlow> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _handlers.Add(handler);
+    }
+
+    public StopHandle GetStopHandle()
+    {
+        return new StopHandle(_state);
+    }
+
+    public void Stop()
+    {
+        _state.Stop();
+    }
+
+    public void Run()
+    {
+        _state.Reset();
+
+        while (!_state.IsStopped)
+        {
+            var queue = new List<TEvent>();
+            foreach (var source in _sources)
+            {
+                queue.AddRange(source.Poll());
+            }
+
+            var shouldExit = false;
+            foreach (var eventItem in queue)
+            {
+                foreach (var handler in _handlers)
+                {
+                    if (handler(eventItem) == ControlFlow.Exit)
+                    {
+                        shouldExit = true;
+                        break;
+                    }
+                }
+
+                if (shouldExit)
+                {
+                    break;
+                }
+            }
+
+            if (shouldExit)
+            {
+                return;
+            }
+
+            if (queue.Count == 0)
+            {
+                Thread.Yield();
+            }
+        }
+    }
+}
+
+internal sealed class StopState
+{
+    private int _stopped;
+
+    public bool IsStopped => Volatile.Read(ref _stopped) != 0;
+
+    public void Stop()
+    {
+        Volatile.Write(ref _stopped, 1);
+    }
+
+    public void Reset()
+    {
+        Volatile.Write(ref _stopped, 0);
+    }
+}

--- a/code/packages/csharp/event-loop/README.md
+++ b/code/packages/csharp/event-loop/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.EventLoop.CSharp
+
+A pluggable, generic C# event loop for polling event sources and dispatching events to registered handlers.

--- a/code/packages/csharp/event-loop/required_capabilities.json
+++ b/code/packages/csharp/event-loop/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/event-loop",
+  "capabilities": [],
+  "justification": "Pure in-process event loop package and tests."
+}

--- a/code/packages/csharp/event-loop/tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.csproj
+++ b/code/packages/csharp/event-loop/tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.EventLoop.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/event-loop/tests/CodingAdventures.EventLoop.Tests/EventLoopTests.cs
+++ b/code/packages/csharp/event-loop/tests/CodingAdventures.EventLoop.Tests/EventLoopTests.cs
@@ -1,0 +1,262 @@
+using CodingAdventures.EventLoop;
+
+namespace CodingAdventures.EventLoop.Tests;
+
+public sealed class EventLoopTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", EventLoopPackage.Version);
+    }
+
+    [Fact]
+    public void DeliversAllEvents()
+    {
+        var loop = new EventLoop<int>();
+        loop.AddSource(new FixedSource<int>([1, 2, 3], [-1]));
+        var received = new List<int>();
+
+        loop.OnEvent(eventItem =>
+        {
+            if (eventItem == -1)
+            {
+                return ControlFlow.Exit;
+            }
+
+            received.Add(eventItem);
+            return ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal([1, 2, 3], received);
+    }
+
+    [Fact]
+    public void ExitStopsLoopImmediately()
+    {
+        var loop = new EventLoop<string>();
+        loop.AddSource(new FixedSource<string>(["a", "b", "stop", "c", "d"]));
+        var seen = new List<string>();
+
+        loop.OnEvent(eventItem =>
+        {
+            seen.Add(eventItem);
+            return eventItem == "stop" ? ControlFlow.Exit : ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal(["a", "b", "stop"], seen);
+    }
+
+    [Fact]
+    public void StopFromHandlerTerminatesLoop()
+    {
+        var loop = new EventLoop<int>();
+        loop.AddSource(new InfiniteSource());
+        var count = 0;
+
+        loop.OnEvent(_ =>
+        {
+            count++;
+            if (count >= 5)
+            {
+                loop.Stop();
+            }
+
+            return ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal(5, count);
+    }
+
+    [Fact]
+    public void MultipleHandlersAllSeeEvent()
+    {
+        var loop = new EventLoop<int>();
+        loop.AddSource(new FixedSource<int>([99], [-1]));
+        int? first = null;
+        int? second = null;
+
+        loop.OnEvent(eventItem =>
+        {
+            if (eventItem == 99)
+            {
+                first = eventItem;
+            }
+
+            return eventItem == -1 ? ControlFlow.Exit : ControlFlow.Continue;
+        });
+        loop.OnEvent(eventItem =>
+        {
+            if (eventItem == 99)
+            {
+                second = eventItem;
+            }
+
+            return ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal(99, first);
+        Assert.Equal(99, second);
+    }
+
+    [Fact]
+    public void MultipleSourcesAreMerged()
+    {
+        var loop = new EventLoop<string>();
+        loop.AddSource(new FixedSource<string>(["from-a"]));
+        loop.AddSource(new FixedSource<string>(["from-b"]));
+        loop.AddSource(new FixedSource<string>([], ["stop"]));
+        var seen = new List<string>();
+
+        loop.OnEvent(eventItem =>
+        {
+            if (eventItem == "stop")
+            {
+                return ControlFlow.Exit;
+            }
+
+            seen.Add(eventItem);
+            return ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal(2, seen.Count);
+        Assert.Contains("from-a", seen);
+        Assert.Contains("from-b", seen);
+    }
+
+    [Fact]
+    public async Task StopWhileIdleTerminatesLoop()
+    {
+        var loop = new EventLoop<int>();
+        var called = false;
+        loop.OnEvent(_ =>
+        {
+            called = true;
+            return ControlFlow.Continue;
+        });
+
+        var stopTask = Task.Run(() =>
+        {
+            Thread.Sleep(10);
+            loop.Stop();
+        });
+
+        loop.Run();
+        await stopTask;
+
+        Assert.False(called);
+    }
+
+    [Fact]
+    public async Task StopHandleTerminatesIdleLoop()
+    {
+        var loop = new EventLoop<int>();
+        var handle = loop.GetStopHandle();
+        var stopTask = Task.Run(() =>
+        {
+            Thread.Sleep(10);
+            handle.Stop();
+        });
+
+        loop.Run();
+        await stopTask;
+    }
+
+    [Fact]
+    public void ControlFlowValuesAreDistinct()
+    {
+        Assert.NotEqual(ControlFlow.Continue, ControlFlow.Exit);
+    }
+
+    [Fact]
+    public void AddSourceAndOnEventRejectNull()
+    {
+        var loop = new EventLoop<int>();
+
+        Assert.Throws<ArgumentNullException>(() => loop.AddSource(null!));
+        Assert.Throws<ArgumentNullException>(() => loop.OnEvent(null!));
+    }
+
+    [Fact]
+    public async Task NoEventsMeansHandlersAreNotCalled()
+    {
+        var loop = new EventLoop<int>();
+        loop.AddSource(new FixedSource<int>());
+        var count = 0;
+        loop.OnEvent(_ =>
+        {
+            count++;
+            return ControlFlow.Continue;
+        });
+
+        var stopTask = Task.Run(() =>
+        {
+            Thread.Sleep(10);
+            loop.Stop();
+        });
+
+        loop.Run();
+        await stopTask;
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void HandlerSeesEventsInOrder()
+    {
+        var loop = new EventLoop<int>();
+        loop.AddSource(new FixedSource<int>([3, 1, 4, 1, 5], [-1]));
+        var received = new List<int>();
+
+        loop.OnEvent(eventItem =>
+        {
+            if (eventItem == -1)
+            {
+                return ControlFlow.Exit;
+            }
+
+            received.Add(eventItem);
+            return ControlFlow.Continue;
+        });
+
+        loop.Run();
+
+        Assert.Equal([3, 1, 4, 1, 5], received);
+    }
+
+    private sealed class FixedSource<TEvent>(params IReadOnlyList<TEvent>[] batches) : IEventSource<TEvent>
+    {
+        private int _index;
+
+        public IReadOnlyList<TEvent> Poll()
+        {
+            if (_index >= batches.Length)
+            {
+                return [];
+            }
+
+            return batches[_index++];
+        }
+    }
+
+    private sealed class InfiniteSource : IEventSource<int>
+    {
+        private int _next;
+
+        public IReadOnlyList<int> Poll()
+        {
+            _next++;
+            return [_next];
+        }
+    }
+}

--- a/code/packages/fsharp/event-loop/BUILD
+++ b/code/packages/fsharp/event-loop/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/event-loop/BUILD_windows
+++ b/code/packages/fsharp/event-loop/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/event-loop/CHANGELOG.md
+++ b/code/packages/fsharp/event-loop/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add an F# generic event loop with event sources, handlers, control-flow signaling, and stop handles.

--- a/code/packages/fsharp/event-loop/CodingAdventures.EventLoop.fsproj
+++ b/code/packages/fsharp/event-loop/CodingAdventures.EventLoop.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.EventLoop.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.EventLoop.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>A pluggable, generic event loop for pull-based event sources</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="EventLoop.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/event-loop/EventLoop.fs
+++ b/code/packages/fsharp/event-loop/EventLoop.fs
@@ -1,0 +1,86 @@
+namespace CodingAdventures.EventLoop
+
+open System
+open System.Collections.Generic
+open System.Threading
+
+module EventLoopPackage =
+    [<Literal>]
+    let Version = "0.1.0"
+
+[<RequireQualifiedAccess>]
+type ControlFlow =
+    | Continue
+    | Exit
+
+type IEventSource<'T> =
+    abstract Poll: unit -> 'T list
+
+type internal StopState() =
+    let mutable stopped = 0
+
+    member _.IsStopped =
+        Volatile.Read(&stopped) <> 0
+
+    member _.Stop() =
+        Volatile.Write(&stopped, 1)
+
+    member _.Reset() =
+        Volatile.Write(&stopped, 0)
+
+type StopHandle internal (state: StopState) =
+    member _.Stop() = state.Stop()
+
+type EventLoop<'T>() =
+    let sources = ResizeArray<IEventSource<'T>>()
+    let handlers = ResizeArray<'T -> ControlFlow>()
+    let state = StopState()
+
+    member _.AddSource(source: IEventSource<'T>) =
+        if isNull (box source) then
+            nullArg (nameof source)
+
+        sources.Add(source)
+
+    member _.OnEvent(handler: 'T -> ControlFlow) =
+        if isNull (box handler) then
+            nullArg (nameof handler)
+
+        handlers.Add(handler)
+
+    member _.GetStopHandle() =
+        StopHandle(state)
+
+    member _.Stop() =
+        state.Stop()
+
+    member _.Run() =
+        state.Reset()
+
+        while not state.IsStopped do
+            let queue = ResizeArray<'T>()
+
+            for source in sources do
+                queue.AddRange(source.Poll())
+
+            let mutable shouldExit = false
+            let mutable eventIndex = 0
+
+            while eventIndex < queue.Count && not shouldExit do
+                let eventItem = queue[eventIndex]
+                let mutable handlerIndex = 0
+
+                while handlerIndex < handlers.Count && not shouldExit do
+                    let handler = handlers[handlerIndex]
+
+                    if handler eventItem = ControlFlow.Exit then
+                        shouldExit <- true
+
+                    handlerIndex <- handlerIndex + 1
+
+                eventIndex <- eventIndex + 1
+
+            if shouldExit then
+                state.Stop()
+            elif queue.Count = 0 then
+                Thread.Yield() |> ignore

--- a/code/packages/fsharp/event-loop/README.md
+++ b/code/packages/fsharp/event-loop/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.EventLoop.FSharp
+
+A pluggable, generic F# event loop for polling event sources and dispatching events to registered handlers.

--- a/code/packages/fsharp/event-loop/required_capabilities.json
+++ b/code/packages/fsharp/event-loop/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/event-loop",
+  "capabilities": [],
+  "justification": "Pure in-process event loop package and tests."
+}

--- a/code/packages/fsharp/event-loop/tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.fsproj
+++ b/code/packages/fsharp/event-loop/tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.EventLoop.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.EventLoop.fsproj" />
+    <Compile Include="EventLoopTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/event-loop/tests/CodingAdventures.EventLoop.Tests/EventLoopTests.fs
+++ b/code/packages/fsharp/event-loop/tests/CodingAdventures.EventLoop.Tests/EventLoopTests.fs
@@ -1,0 +1,213 @@
+namespace CodingAdventures.EventLoop.Tests
+
+open System
+open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
+open CodingAdventures.EventLoop
+open Xunit
+
+type FixedSource<'T>(batches: 'T list list) =
+    let mutable remaining = batches
+
+    interface IEventSource<'T> with
+        member _.Poll() =
+            match remaining with
+            | [] -> []
+            | batch :: tail ->
+                remaining <- tail
+                batch
+
+type InfiniteSource() =
+    let mutable next = 0
+
+    interface IEventSource<int> with
+        member _.Poll() =
+            next <- next + 1
+            [ next ]
+
+type EventLoopTests() =
+    [<Fact>]
+    member _.VersionExists() =
+        Assert.Equal("0.1.0", EventLoopPackage.Version)
+
+    [<Fact>]
+    member _.DeliversAllEvents() =
+        let loop = EventLoop<int>()
+        loop.AddSource(FixedSource([ [ 1; 2; 3 ]; [ -1 ] ]))
+        let received = ResizeArray<int>()
+
+        loop.OnEvent(fun eventItem ->
+            if eventItem = -1 then
+                ControlFlow.Exit
+            else
+                received.Add(eventItem)
+                ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal<int list>([ 1; 2; 3 ], received |> Seq.toList)
+
+    [<Fact>]
+    member _.ExitStopsLoopImmediately() =
+        let loop = EventLoop<string>()
+        loop.AddSource(FixedSource([ [ "a"; "b"; "stop"; "c"; "d" ] ]))
+        let seen = ResizeArray<string>()
+
+        loop.OnEvent(fun eventItem ->
+            seen.Add(eventItem)
+
+            if eventItem = "stop" then
+                ControlFlow.Exit
+            else
+                ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal<string list>([ "a"; "b"; "stop" ], seen |> Seq.toList)
+
+    [<Fact>]
+    member _.StopFromHandlerTerminatesLoop() =
+        let loop = EventLoop<int>()
+        loop.AddSource(InfiniteSource())
+        let mutable count = 0
+
+        loop.OnEvent(fun _ ->
+            count <- count + 1
+
+            if count >= 5 then
+                loop.Stop()
+
+            ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal(5, count)
+
+    [<Fact>]
+    member _.MultipleHandlersAllSeeEvent() =
+        let loop = EventLoop<int>()
+        loop.AddSource(FixedSource([ [ 99 ]; [ -1 ] ]))
+        let mutable first = Nullable<int>()
+        let mutable second = Nullable<int>()
+
+        loop.OnEvent(fun eventItem ->
+            if eventItem = 99 then
+                first <- Nullable(eventItem)
+
+            if eventItem = -1 then
+                ControlFlow.Exit
+            else
+                ControlFlow.Continue)
+
+        loop.OnEvent(fun eventItem ->
+            if eventItem = 99 then
+                second <- Nullable(eventItem)
+
+            ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal(99, first.Value)
+        Assert.Equal(99, second.Value)
+
+    [<Fact>]
+    member _.MultipleSourcesAreMerged() =
+        let loop = EventLoop<string>()
+        loop.AddSource(FixedSource([ [ "from-a" ] ]))
+        loop.AddSource(FixedSource([ [ "from-b" ] ]))
+        loop.AddSource(FixedSource([ []; [ "stop" ] ]))
+        let seen = ResizeArray<string>()
+
+        loop.OnEvent(fun eventItem ->
+            if eventItem = "stop" then
+                ControlFlow.Exit
+            else
+                seen.Add(eventItem)
+                ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal(2, seen.Count)
+        Assert.Contains("from-a", seen)
+        Assert.Contains("from-b", seen)
+
+    [<Fact>]
+    member _.StopWhileIdleTerminatesLoop() =
+        let loop = EventLoop<int>()
+        let mutable called = false
+
+        loop.OnEvent(fun _ ->
+            called <- true
+            ControlFlow.Continue)
+
+        let stopTask =
+            Task.Run(Action(fun () ->
+                Thread.Sleep(10)
+                loop.Stop()))
+
+        loop.Run()
+        stopTask.Wait()
+
+        Assert.False(called)
+
+    [<Fact>]
+    member _.StopHandleTerminatesIdleLoop() =
+        let loop = EventLoop<int>()
+        let handle = loop.GetStopHandle()
+
+        let stopTask =
+            Task.Run(Action(fun () ->
+                Thread.Sleep(10)
+                handle.Stop()))
+
+        loop.Run()
+        stopTask.Wait()
+
+    [<Fact>]
+    member _.ControlFlowValuesAreDistinct() =
+        Assert.NotEqual(ControlFlow.Continue, ControlFlow.Exit)
+
+    [<Fact>]
+    member _.AddSourceAndOnEventRejectNull() =
+        let loop = EventLoop<int>()
+
+        Assert.Throws<ArgumentNullException>(fun () -> loop.AddSource(Unchecked.defaultof<IEventSource<int>>)) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> loop.OnEvent(Unchecked.defaultof<int -> ControlFlow>)) |> ignore
+
+    [<Fact>]
+    member _.NoEventsMeansHandlersAreNotCalled() =
+        let loop = EventLoop<int>()
+        loop.AddSource(FixedSource([ [] ]))
+        let mutable count = 0
+
+        loop.OnEvent(fun _ ->
+            count <- count + 1
+            ControlFlow.Continue)
+
+        let stopTask =
+            Task.Run(Action(fun () ->
+                Thread.Sleep(10)
+                loop.Stop()))
+
+        loop.Run()
+        stopTask.Wait()
+
+        Assert.Equal(0, count)
+
+    [<Fact>]
+    member _.HandlerSeesEventsInOrder() =
+        let loop = EventLoop<int>()
+        loop.AddSource(FixedSource([ [ 3; 1; 4; 1; 5 ]; [ -1 ] ]))
+        let received = ResizeArray<int>()
+
+        loop.OnEvent(fun eventItem ->
+            if eventItem = -1 then
+                ControlFlow.Exit
+            else
+                received.Add(eventItem)
+                ControlFlow.Continue)
+
+        loop.Run()
+
+        Assert.Equal<int list>([ 3; 1; 4; 1; 5 ], received |> Seq.toList)


### PR DESCRIPTION
## Summary
- add C# and F# event-loop packages matching the Rust/Python generic event source and handler model
- expose ControlFlow, event source interfaces, EventLoop runners, direct stop calls, and external stop handles
- add xUnit suites for event delivery, immediate exit, external stops, multiple handlers/sources, idle behavior, and ordering

## Verification
- dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.EventLoop.Tests/CodingAdventures.EventLoop.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line