### PR TITLE
feat(parity): add dotnet write ahead log packages

### DIFF
--- a/code/packages/csharp/write-ahead-log/BUILD
+++ b/code/packages/csharp/write-ahead-log/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/write-ahead-log/BUILD_windows
+++ b/code/packages/csharp/write-ahead-log/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/write-ahead-log/CHANGELOG.md
+++ b/code/packages/csharp/write-ahead-log/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a C# write-ahead log reader and writer for length-prefixed byte records.

--- a/code/packages/csharp/write-ahead-log/CodingAdventures.WriteAheadLog.csproj
+++ b/code/packages/csharp/write-ahead-log/CodingAdventures.WriteAheadLog.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.WriteAheadLog.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>A generic append-only durable write-ahead log</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/write-ahead-log/README.md
+++ b/code/packages/csharp/write-ahead-log/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.WriteAheadLog.CSharp
+
+A generic append-only C# write-ahead log that stores byte records with 4-byte little-endian length prefixes.

--- a/code/packages/csharp/write-ahead-log/WriteAheadLog.cs
+++ b/code/packages/csharp/write-ahead-log/WriteAheadLog.cs
@@ -1,0 +1,100 @@
+namespace CodingAdventures.WriteAheadLog;
+
+using System.Buffers.Binary;
+
+public static class WriteAheadLogPackage
+{
+    public const string Version = "0.1.0";
+}
+
+public sealed class WalWriter : IDisposable
+{
+    private readonly FileStream _file;
+
+    public WalWriter(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        _file = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, FileOptions.WriteThrough);
+    }
+
+    public void AppendRecord(ReadOnlySpan<byte> data)
+    {
+        Span<byte> lengthBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(lengthBytes, checked((uint)data.Length));
+        _file.Write(lengthBytes);
+        _file.Write(data);
+        _file.Flush(flushToDisk: true);
+    }
+
+    public void Dispose()
+    {
+        _file.Dispose();
+    }
+}
+
+public sealed class WalReader : IDisposable
+{
+    private readonly FileStream _file;
+
+    public WalReader(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        _file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+    }
+
+    public byte[]? ReadNext()
+    {
+        Span<byte> lengthBytes = stackalloc byte[4];
+        if (!TryReadLength(lengthBytes))
+        {
+            return null;
+        }
+
+        var length = BinaryPrimitives.ReadUInt32LittleEndian(lengthBytes);
+        if (length > int.MaxValue)
+        {
+            throw new InvalidDataException("WAL record is too large for this runtime.");
+        }
+
+        var record = new byte[length];
+        ReadExactly(record);
+        return record;
+    }
+
+    public void Dispose()
+    {
+        _file.Dispose();
+    }
+
+    private bool TryReadLength(Span<byte> buffer)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = _file.Read(buffer[total..]);
+            if (read == 0)
+            {
+                return false;
+            }
+
+            total += read;
+        }
+
+        return true;
+    }
+
+    private void ReadExactly(Span<byte> buffer)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = _file.Read(buffer[total..]);
+            if (read == 0)
+            {
+                throw new EndOfStreamException("WAL record ended before its length-prefixed payload was complete.");
+            }
+
+            total += read;
+        }
+    }
+}

--- a/code/packages/csharp/write-ahead-log/required_capabilities.json
+++ b/code/packages/csharp/write-ahead-log/required_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/write-ahead-log",
+  "capabilities": [
+    "filesystem"
+  ],
+  "justification": "The package writes and reads local WAL files during normal operation and tests."
+}

--- a/code/packages/csharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.csproj
+++ b/code/packages/csharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.WriteAheadLog.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/WriteAheadLogTests.cs
+++ b/code/packages/csharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/WriteAheadLogTests.cs
@@ -1,0 +1,165 @@
+using CodingAdventures.WriteAheadLog;
+
+namespace CodingAdventures.WriteAheadLog.Tests;
+
+public sealed class WriteAheadLogTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", WriteAheadLogPackage.Version);
+    }
+
+    [Fact]
+    public void AppendRecordWritesLengthPrefixedPayloads()
+    {
+        var path = TempPath();
+        try
+        {
+            using (var writer = new WalWriter(path))
+            {
+                writer.AppendRecord([1, 2, 3]);
+                writer.AppendRecord([4, 5]);
+            }
+
+            Assert.Equal([3, 0, 0, 0, 1, 2, 3, 2, 0, 0, 0, 4, 5], File.ReadAllBytes(path));
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void ReaderReturnsRecordsInOrderThenNullAtEnd()
+    {
+        var path = TempPath();
+        try
+        {
+            using (var writer = new WalWriter(path))
+            {
+                writer.AppendRecord([10, 20]);
+                writer.AppendRecord([30]);
+            }
+
+            using var reader = new WalReader(path);
+
+            Assert.Equal([10, 20], reader.ReadNext());
+            Assert.Equal([30], reader.ReadNext());
+            Assert.Null(reader.ReadNext());
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void EmptyRecordsRoundTrip()
+    {
+        var path = TempPath();
+        try
+        {
+            using (var writer = new WalWriter(path))
+            {
+                writer.AppendRecord([]);
+            }
+
+            using var reader = new WalReader(path);
+
+            var record = reader.ReadNext();
+            Assert.NotNull(record);
+            Assert.Empty(record);
+            Assert.Null(reader.ReadNext());
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void WriterAppendsToExistingLog()
+    {
+        var path = TempPath();
+        try
+        {
+            using (var writer = new WalWriter(path))
+            {
+                writer.AppendRecord([1]);
+            }
+
+            using (var writer = new WalWriter(path))
+            {
+                writer.AppendRecord([2, 3]);
+            }
+
+            using var reader = new WalReader(path);
+
+            Assert.Equal([1], reader.ReadNext());
+            Assert.Equal([2, 3], reader.ReadNext());
+            Assert.Null(reader.ReadNext());
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void PartialLengthPrefixIsTreatedAsEndOfFile()
+    {
+        var path = TempPath();
+        try
+        {
+            File.WriteAllBytes(path, [2, 0]);
+
+            using var reader = new WalReader(path);
+
+            Assert.Null(reader.ReadNext());
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void TruncatedPayloadThrows()
+    {
+        var path = TempPath();
+        try
+        {
+            File.WriteAllBytes(path, [4, 0, 0, 0, 1, 2]);
+
+            using var reader = new WalReader(path);
+
+            Assert.Throws<EndOfStreamException>(() => reader.ReadNext());
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void InvalidArgumentsAreRejected()
+    {
+        Assert.Throws<ArgumentException>(() => new WalWriter(""));
+        Assert.Throws<ArgumentException>(() => new WalReader(""));
+        Assert.Throws<FileNotFoundException>(() => new WalReader(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))));
+    }
+
+    private static string TempPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.wal");
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/code/packages/fsharp/write-ahead-log/BUILD
+++ b/code/packages/fsharp/write-ahead-log/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/write-ahead-log/BUILD_windows
+++ b/code/packages/fsharp/write-ahead-log/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/write-ahead-log/CHANGELOG.md
+++ b/code/packages/fsharp/write-ahead-log/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add an F# write-ahead log reader and writer for length-prefixed byte records.

--- a/code/packages/fsharp/write-ahead-log/CodingAdventures.WriteAheadLog.fsproj
+++ b/code/packages/fsharp/write-ahead-log/CodingAdventures.WriteAheadLog.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.WriteAheadLog.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.WriteAheadLog.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>A generic append-only durable write-ahead log</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="WriteAheadLog.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/write-ahead-log/README.md
+++ b/code/packages/fsharp/write-ahead-log/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.WriteAheadLog.FSharp
+
+A generic append-only F# write-ahead log that stores byte records with 4-byte little-endian length prefixes.

--- a/code/packages/fsharp/write-ahead-log/WriteAheadLog.fs
+++ b/code/packages/fsharp/write-ahead-log/WriteAheadLog.fs
@@ -1,0 +1,73 @@
+namespace CodingAdventures.WriteAheadLog
+
+open System
+open System.Buffers.Binary
+open System.IO
+
+module WriteAheadLogPackage =
+    [<Literal>]
+    let Version = "0.1.0"
+
+type WalWriter(path: string) =
+    do
+        if String.IsNullOrWhiteSpace(path) then
+            invalidArg (nameof path) "A WAL path is required."
+
+    let file =
+        new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, FileOptions.WriteThrough)
+
+    member _.AppendRecord(data: byte array) =
+        if isNull data then
+            nullArg (nameof data)
+
+        let lengthBytes = Array.zeroCreate<byte> 4
+        BinaryPrimitives.WriteUInt32LittleEndian(Span<byte>(lengthBytes), uint32 data.Length)
+        file.Write(lengthBytes, 0, lengthBytes.Length)
+        file.Write(data, 0, data.Length)
+        file.Flush(true)
+
+    interface IDisposable with
+        member _.Dispose() =
+            file.Dispose()
+
+type WalReader(path: string) =
+    do
+        if String.IsNullOrWhiteSpace(path) then
+            invalidArg (nameof path) "A WAL path is required."
+
+    let file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
+
+    let rec readInto (buffer: byte array) offset count =
+        if count = 0 then
+            offset
+        else
+            let read = file.Read(buffer, offset, count)
+
+            if read = 0 then
+                offset
+            else
+                readInto buffer (offset + read) (count - read)
+
+    member _.ReadNext() =
+        let lengthBytes = Array.zeroCreate<byte> 4
+        let lengthRead = readInto lengthBytes 0 lengthBytes.Length
+
+        if lengthRead < lengthBytes.Length then
+            None
+        else
+            let length = BinaryPrimitives.ReadUInt32LittleEndian(ReadOnlySpan<byte>(lengthBytes))
+
+            if length > uint32 Int32.MaxValue then
+                raise (InvalidDataException("WAL record is too large for this runtime."))
+
+            let record = Array.zeroCreate<byte> (int length)
+            let payloadRead = readInto record 0 record.Length
+
+            if payloadRead < record.Length then
+                raise (EndOfStreamException("WAL record ended before its length-prefixed payload was complete."))
+
+            Some record
+
+    interface IDisposable with
+        member _.Dispose() =
+            file.Dispose()

--- a/code/packages/fsharp/write-ahead-log/required_capabilities.json
+++ b/code/packages/fsharp/write-ahead-log/required_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/write-ahead-log",
+  "capabilities": [
+    "filesystem"
+  ],
+  "justification": "The package writes and reads local WAL files during normal operation and tests."
+}

--- a/code/packages/fsharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.fsproj
+++ b/code/packages/fsharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.WriteAheadLog.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.WriteAheadLog.fsproj" />
+    <Compile Include="WriteAheadLogTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/WriteAheadLogTests.fs
+++ b/code/packages/fsharp/write-ahead-log/tests/CodingAdventures.WriteAheadLog.Tests/WriteAheadLogTests.fs
@@ -1,0 +1,133 @@
+namespace CodingAdventures.WriteAheadLog.Tests
+
+open System
+open System.IO
+open CodingAdventures.WriteAheadLog
+open Xunit
+
+type WriteAheadLogTests() =
+    let tempPath () =
+        Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.wal")
+
+    let deleteIfExists path =
+        if File.Exists(path) then
+            File.Delete(path)
+
+    [<Fact>]
+    member _.VersionExists() =
+        Assert.Equal("0.1.0", WriteAheadLogPackage.Version)
+
+    [<Fact>]
+    member _.AppendRecordWritesLengthPrefixedPayloads() =
+        let path = tempPath ()
+
+        try
+            use writer = new WalWriter(path)
+            writer.AppendRecord([| 1uy; 2uy; 3uy |])
+            writer.AppendRecord([| 4uy; 5uy |])
+            (writer :> IDisposable).Dispose()
+
+            Assert.Equal<byte array>(
+                [| 3uy; 0uy; 0uy; 0uy; 1uy; 2uy; 3uy; 2uy; 0uy; 0uy; 0uy; 4uy; 5uy |],
+                File.ReadAllBytes(path)
+            )
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.ReaderReturnsRecordsInOrderThenNoneAtEnd() =
+        let path = tempPath ()
+
+        try
+            use writer = new WalWriter(path)
+            writer.AppendRecord([| 10uy; 20uy |])
+            writer.AppendRecord([| 30uy |])
+            (writer :> IDisposable).Dispose()
+
+            use reader = new WalReader(path)
+
+            Assert.Equal<byte array>([| 10uy; 20uy |], reader.ReadNext().Value)
+            Assert.Equal<byte array>([| 30uy |], reader.ReadNext().Value)
+            Assert.True(reader.ReadNext().IsNone)
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.EmptyRecordsRoundTrip() =
+        let path = tempPath ()
+
+        try
+            use writer = new WalWriter(path)
+            writer.AppendRecord([||])
+            (writer :> IDisposable).Dispose()
+
+            use reader = new WalReader(path)
+
+            Assert.Equal<byte array>([||], reader.ReadNext().Value)
+            Assert.True(reader.ReadNext().IsNone)
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.WriterAppendsToExistingLog() =
+        let path = tempPath ()
+
+        try
+            use writer = new WalWriter(path)
+            writer.AppendRecord([| 1uy |])
+            (writer :> IDisposable).Dispose()
+
+            use writer2 = new WalWriter(path)
+            writer2.AppendRecord([| 2uy; 3uy |])
+            (writer2 :> IDisposable).Dispose()
+
+            use reader = new WalReader(path)
+
+            Assert.Equal<byte array>([| 1uy |], reader.ReadNext().Value)
+            Assert.Equal<byte array>([| 2uy; 3uy |], reader.ReadNext().Value)
+            Assert.True(reader.ReadNext().IsNone)
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.PartialLengthPrefixIsTreatedAsEndOfFile() =
+        let path = tempPath ()
+
+        try
+            File.WriteAllBytes(path, [| 2uy; 0uy |])
+
+            use reader = new WalReader(path)
+
+            Assert.True(reader.ReadNext().IsNone)
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.TruncatedPayloadThrows() =
+        let path = tempPath ()
+
+        try
+            File.WriteAllBytes(path, [| 4uy; 0uy; 0uy; 0uy; 1uy; 2uy |])
+
+            use reader = new WalReader(path)
+
+            Assert.Throws<EndOfStreamException>(fun () -> reader.ReadNext() |> ignore) |> ignore
+        finally
+            deleteIfExists path
+
+    [<Fact>]
+    member _.InvalidArgumentsAreRejected() =
+        Assert.Throws<ArgumentException>(fun () -> new WalWriter("") |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> new WalReader("") |> ignore) |> ignore
+        Assert.Throws<FileNotFoundException>(fun () -> new WalReader(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.WriterRejectsNullPayload() =
+        let path = tempPath ()
+
+        try
+            use writer = new WalWriter(path)
+
+            Assert.Throws<ArgumentNullException>(fun () -> writer.AppendRecord(Unchecked.defaultof<byte array>)) |> ignore
+        finally
+            deleteIfExists path


### PR DESCRIPTION
## Summary
- add C# and F# write-ahead-log packages matching the Rust length-prefixed byte-record format
- support append-only durable writers and sequential readers with EOF and truncated-payload handling
- add xUnit coverage for raw file format, ordered reads, empty records, appending, invalid paths, and partial records

## Verification
- dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.WriteAheadLog.Tests/CodingAdventures.WriteAheadLog.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line