### PR TITLE
feat(parity): add dotnet resistor packages

### DIFF
--- a/code/packages/csharp/resistor/BUILD
+++ b/code/packages/csharp/resistor/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/resistor/BUILD_windows
+++ b/code/packages/csharp/resistor/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/resistor/CHANGELOG.md
+++ b/code/packages/csharp/resistor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# resistor modeling with Ohm's law, power, energy, tolerance, temperature, and network helpers.

--- a/code/packages/csharp/resistor/CodingAdventures.Resistor.csproj
+++ b/code/packages/csharp/resistor/CodingAdventures.Resistor.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Resistor.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ideal resistor modeling and resistor network helpers from first principles</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/resistor/README.md
+++ b/code/packages/csharp/resistor/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Resistor.CSharp
+
+Ideal resistor modeling and resistor network helpers from first principles.

--- a/code/packages/csharp/resistor/Resistor.cs
+++ b/code/packages/csharp/resistor/Resistor.cs
@@ -1,0 +1,159 @@
+namespace CodingAdventures.Resistor;
+
+public static class ResistorPackage
+{
+    public const string Version = "0.1.0";
+}
+
+public sealed record Resistor
+{
+    public Resistor(
+        double resistanceOhms,
+        double tolerance = 0.0,
+        double tempcoPpmPerC = 0.0,
+        double? powerRatingWatts = null)
+    {
+        if (resistanceOhms <= 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(resistanceOhms), "Resistance must be > 0 ohms.");
+        }
+
+        if (tolerance < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tolerance), "Tolerance must be >= 0.");
+        }
+
+        if (powerRatingWatts is <= 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(powerRatingWatts), "Power rating must be > 0 watts when provided.");
+        }
+
+        ResistanceOhms = resistanceOhms;
+        Tolerance = tolerance;
+        TempcoPpmPerC = tempcoPpmPerC;
+        PowerRatingWatts = powerRatingWatts;
+    }
+
+    public double ResistanceOhms { get; }
+    public double Tolerance { get; }
+    public double TempcoPpmPerC { get; }
+    public double? PowerRatingWatts { get; }
+
+    public double Conductance()
+    {
+        return 1.0 / ResistanceOhms;
+    }
+
+    public double CurrentForVoltage(double voltage)
+    {
+        return voltage / ResistanceOhms;
+    }
+
+    public double VoltageForCurrent(double current)
+    {
+        return current * ResistanceOhms;
+    }
+
+    public double PowerForVoltage(double voltage)
+    {
+        return voltage * voltage / ResistanceOhms;
+    }
+
+    public double PowerForCurrent(double current)
+    {
+        return current * current * ResistanceOhms;
+    }
+
+    public double EnergyForVoltage(double voltage, double durationSeconds)
+    {
+        ValidateDuration(durationSeconds);
+        return PowerForVoltage(voltage) * durationSeconds;
+    }
+
+    public double EnergyForCurrent(double current, double durationSeconds)
+    {
+        ValidateDuration(durationSeconds);
+        return PowerForCurrent(current) * durationSeconds;
+    }
+
+    public double MinResistance()
+    {
+        return ResistanceOhms * (1.0 - Tolerance);
+    }
+
+    public double MaxResistance()
+    {
+        return ResistanceOhms * (1.0 + Tolerance);
+    }
+
+    public double ResistanceAtTemperature(double celsius, double referenceCelsius = 25.0)
+    {
+        var alpha = TempcoPpmPerC * 1e-6;
+        var deltaT = celsius - referenceCelsius;
+        return ResistanceOhms * (1.0 + alpha * deltaT);
+    }
+
+    public bool IsWithinPowerRatingForVoltage(double voltage)
+    {
+        return PowerRatingWatts is null || PowerForVoltage(voltage) <= PowerRatingWatts;
+    }
+
+    public bool IsWithinPowerRatingForCurrent(double current)
+    {
+        return PowerRatingWatts is null || PowerForCurrent(current) <= PowerRatingWatts;
+    }
+
+    private static void ValidateDuration(double durationSeconds)
+    {
+        if (durationSeconds < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(durationSeconds), "Duration must be >= 0 seconds.");
+        }
+    }
+}
+
+public static class ResistorNetwork
+{
+    public static double SeriesEquivalent(IEnumerable<Resistor> resistors)
+    {
+        var (items, count) = Materialize(resistors);
+        if (count == 0)
+        {
+            throw new ArgumentException("At least one resistor is required.", nameof(resistors));
+        }
+
+        return items.Sum(resistor => resistor.ResistanceOhms);
+    }
+
+    public static double ParallelEquivalent(IEnumerable<Resistor> resistors)
+    {
+        var (items, count) = Materialize(resistors);
+        if (count == 0)
+        {
+            throw new ArgumentException("At least one resistor is required.", nameof(resistors));
+        }
+
+        return 1.0 / items.Sum(resistor => 1.0 / resistor.ResistanceOhms);
+    }
+
+    public static double VoltageDivider(double vin, Resistor rTop, Resistor rBottom)
+    {
+        ArgumentNullException.ThrowIfNull(rTop);
+        ArgumentNullException.ThrowIfNull(rBottom);
+
+        var total = rTop.ResistanceOhms + rBottom.ResistanceOhms;
+        return vin * (rBottom.ResistanceOhms / total);
+    }
+
+    private static (IReadOnlyList<Resistor> Items, int Count) Materialize(IEnumerable<Resistor> resistors)
+    {
+        ArgumentNullException.ThrowIfNull(resistors);
+        var items = resistors.ToList();
+        foreach (var resistor in items)
+        {
+            ArgumentNullException.ThrowIfNull(resistor);
+        }
+
+        return (items, items.Count);
+    }
+}

--- a/code/packages/csharp/resistor/required_capabilities.json
+++ b/code/packages/csharp/resistor/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/resistor",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/csharp/resistor/tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.csproj
+++ b/code/packages/csharp/resistor/tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Resistor.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/resistor/tests/CodingAdventures.Resistor.Tests/ResistorTests.cs
+++ b/code/packages/csharp/resistor/tests/CodingAdventures.Resistor.Tests/ResistorTests.cs
@@ -1,0 +1,116 @@
+using CodingAdventures.Resistor;
+
+namespace CodingAdventures.Resistor.Tests;
+
+public sealed class ResistorTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", ResistorPackage.Version);
+    }
+
+    [Fact]
+    public void StoresNominalProperties()
+    {
+        var resistor = new Resistor(1_000.0, tolerance: 0.01, tempcoPpmPerC: 100.0, powerRatingWatts: 0.25);
+
+        Assert.Equal(1_000.0, resistor.ResistanceOhms);
+        Assert.Equal(0.01, resistor.Tolerance);
+        Assert.Equal(100.0, resistor.TempcoPpmPerC);
+        Assert.Equal(0.25, resistor.PowerRatingWatts);
+    }
+
+    [Fact]
+    public void RejectsInvalidConstruction()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Resistor(0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Resistor(100.0, tolerance: -0.01));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Resistor(100.0, powerRatingWatts: 0.0));
+    }
+
+    [Fact]
+    public void OhmsLawHelpersUseResistance()
+    {
+        var resistor = new Resistor(1_000.0);
+
+        Assert.Equal(0.001, resistor.Conductance(), 12);
+        Assert.Equal(0.005, resistor.CurrentForVoltage(5.0), 12);
+        Assert.Equal(5.0, resistor.VoltageForCurrent(0.005), 12);
+        Assert.Equal(-0.002, resistor.CurrentForVoltage(-2.0), 12);
+    }
+
+    [Fact]
+    public void PowerAndEnergyHelpersAgree()
+    {
+        var resistor = new Resistor(1_000.0);
+
+        Assert.Equal(0.025, resistor.PowerForVoltage(5.0), 12);
+        Assert.Equal(0.025, resistor.PowerForCurrent(0.005), 12);
+        Assert.Equal(0.05, resistor.EnergyForVoltage(5.0, 2.0), 12);
+        Assert.Equal(0.05, resistor.EnergyForCurrent(0.005, 2.0), 12);
+    }
+
+    [Fact]
+    public void EnergyRejectsNegativeDurations()
+    {
+        var resistor = new Resistor(100.0);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => resistor.EnergyForVoltage(10.0, -1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => resistor.EnergyForCurrent(0.1, -1.0));
+    }
+
+    [Fact]
+    public void ToleranceAndTemperatureHelpersWork()
+    {
+        var resistor = new Resistor(1_000.0, tolerance: 0.01, tempcoPpmPerC: 100.0);
+
+        Assert.Equal(990.0, resistor.MinResistance(), 12);
+        Assert.Equal(1_010.0, resistor.MaxResistance(), 12);
+        Assert.Equal(1_005.0, resistor.ResistanceAtTemperature(75.0), 12);
+        Assert.Equal(995.0, resistor.ResistanceAtTemperature(-25.0), 12);
+    }
+
+    [Fact]
+    public void PowerRatingChecksRespectOptionalRating()
+    {
+        var unrated = new Resistor(100.0);
+        var rated = new Resistor(100.0, powerRatingWatts: 0.25);
+
+        Assert.True(unrated.IsWithinPowerRatingForVoltage(1_000.0));
+        Assert.True(unrated.IsWithinPowerRatingForCurrent(100.0));
+        Assert.True(rated.IsWithinPowerRatingForVoltage(5.0));
+        Assert.False(rated.IsWithinPowerRatingForVoltage(10.0));
+        Assert.True(rated.IsWithinPowerRatingForCurrent(0.04));
+        Assert.False(rated.IsWithinPowerRatingForCurrent(0.1));
+    }
+
+    [Fact]
+    public void NetworkHelpersComputeEquivalentResistance()
+    {
+        var resistors = new[] { new Resistor(100.0), new Resistor(200.0), new Resistor(300.0) };
+
+        Assert.Equal(600.0, ResistorNetwork.SeriesEquivalent(resistors), 12);
+        Assert.Equal(500.0, ResistorNetwork.ParallelEquivalent([new Resistor(1_000.0), new Resistor(1_000.0)]), 12);
+    }
+
+    [Fact]
+    public void NetworkHelpersValidateResistorLists()
+    {
+        Assert.Throws<ArgumentNullException>(() => ResistorNetwork.SeriesEquivalent(null!));
+        Assert.Throws<ArgumentException>(() => ResistorNetwork.SeriesEquivalent([]));
+        Assert.Throws<ArgumentNullException>(() => ResistorNetwork.SeriesEquivalent([null!]));
+        Assert.Throws<ArgumentException>(() => ResistorNetwork.ParallelEquivalent([]));
+    }
+
+    [Fact]
+    public void VoltageDividerUsesBottomResistanceRatio()
+    {
+        var top = new Resistor(1_000.0);
+        var bottom = new Resistor(1_000.0);
+
+        Assert.Equal(2.5, ResistorNetwork.VoltageDivider(5.0, top, bottom), 12);
+        Assert.Throws<ArgumentNullException>(() => ResistorNetwork.VoltageDivider(5.0, null!, bottom));
+        Assert.Throws<ArgumentNullException>(() => ResistorNetwork.VoltageDivider(5.0, top, null!));
+    }
+}

--- a/code/packages/fsharp/resistor/BUILD
+++ b/code/packages/fsharp/resistor/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/resistor/BUILD_windows
+++ b/code/packages/fsharp/resistor/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/resistor/CHANGELOG.md
+++ b/code/packages/fsharp/resistor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# resistor modeling with Ohm's law, power, energy, tolerance, temperature, and network helpers.

--- a/code/packages/fsharp/resistor/CodingAdventures.Resistor.fsproj
+++ b/code/packages/fsharp/resistor/CodingAdventures.Resistor.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Resistor.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Resistor.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Ideal resistor modeling and resistor network helpers from first principles</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Resistor.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/resistor/README.md
+++ b/code/packages/fsharp/resistor/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Resistor.FSharp
+
+Ideal resistor modeling and resistor network helpers from first principles.

--- a/code/packages/fsharp/resistor/Resistor.fs
+++ b/code/packages/fsharp/resistor/Resistor.fs
@@ -1,0 +1,118 @@
+namespace CodingAdventures.Resistor
+
+open System
+
+module ResistorPackage =
+    [<Literal>]
+    let Version = "0.1.0"
+
+type Resistor(
+    resistanceOhms: float,
+    ?tolerance: float,
+    ?tempcoPpmPerC: float,
+    ?powerRatingWatts: float) =
+
+    let tolerance = defaultArg tolerance 0.0
+    let tempcoPpmPerC = defaultArg tempcoPpmPerC 0.0
+
+    do
+        if resistanceOhms <= 0.0 then
+            invalidArg (nameof resistanceOhms) "Resistance must be > 0 ohms."
+
+        if tolerance < 0.0 then
+            invalidArg (nameof tolerance) "Tolerance must be >= 0."
+
+        match powerRatingWatts with
+        | Some rating when rating <= 0.0 -> invalidArg (nameof powerRatingWatts) "Power rating must be > 0 watts when provided."
+        | _ -> ()
+
+    member _.ResistanceOhms = resistanceOhms
+    member _.Tolerance = tolerance
+    member _.TempcoPpmPerC = tempcoPpmPerC
+    member _.PowerRatingWatts = powerRatingWatts
+
+    member _.Conductance() =
+        1.0 / resistanceOhms
+
+    member _.CurrentForVoltage(voltage: float) =
+        voltage / resistanceOhms
+
+    member _.VoltageForCurrent(current: float) =
+        current * resistanceOhms
+
+    member _.PowerForVoltage(voltage: float) =
+        voltage * voltage / resistanceOhms
+
+    member _.PowerForCurrent(current: float) =
+        current * current * resistanceOhms
+
+    member this.EnergyForVoltage(voltage: float, durationSeconds: float) =
+        Resistor.validateDuration durationSeconds
+        this.PowerForVoltage(voltage) * durationSeconds
+
+    member this.EnergyForCurrent(current: float, durationSeconds: float) =
+        Resistor.validateDuration durationSeconds
+        this.PowerForCurrent(current) * durationSeconds
+
+    member _.MinResistance() =
+        resistanceOhms * (1.0 - tolerance)
+
+    member _.MaxResistance() =
+        resistanceOhms * (1.0 + tolerance)
+
+    member _.ResistanceAtTemperature(celsius: float, ?referenceCelsius: float) =
+        let referenceCelsius = defaultArg referenceCelsius 25.0
+        let alpha = tempcoPpmPerC * 1e-6
+        let deltaT = celsius - referenceCelsius
+        resistanceOhms * (1.0 + alpha * deltaT)
+
+    member this.IsWithinPowerRatingForVoltage(voltage: float) =
+        match powerRatingWatts with
+        | None -> true
+        | Some rating -> this.PowerForVoltage(voltage) <= rating
+
+    member this.IsWithinPowerRatingForCurrent(current: float) =
+        match powerRatingWatts with
+        | None -> true
+        | Some rating -> this.PowerForCurrent(current) <= rating
+
+    static member private validateDuration(durationSeconds: float) =
+        if durationSeconds < 0.0 then
+            invalidArg (nameof durationSeconds) "Duration must be >= 0 seconds."
+
+module ResistorNetwork =
+    let private materialize (resistors: seq<Resistor>) : Resistor list =
+        if isNull (box resistors) then
+            nullArg (nameof resistors)
+
+        let items = resistors |> Seq.toList
+
+        for resistor in items do
+            if isNull (box resistor) then
+                nullArg (nameof resistors)
+
+        if List.isEmpty items then
+            invalidArg (nameof resistors) "At least one resistor is required."
+
+        items
+
+    let seriesEquivalent (resistors: seq<Resistor>) =
+        materialize resistors
+        |> List.sumBy (fun resistor -> resistor.ResistanceOhms)
+
+    let parallelEquivalent (resistors: seq<Resistor>) =
+        let reciprocalSum =
+            materialize resistors
+            |> List.sumBy (fun resistor -> 1.0 / resistor.ResistanceOhms)
+
+        1.0 / reciprocalSum
+
+    let voltageDivider vin (rTop: Resistor) (rBottom: Resistor) =
+        if isNull (box rTop) then
+            nullArg (nameof rTop)
+
+        if isNull (box rBottom) then
+            nullArg (nameof rBottom)
+
+        let total = rTop.ResistanceOhms + rBottom.ResistanceOhms
+        vin * (rBottom.ResistanceOhms / total)

--- a/code/packages/fsharp/resistor/required_capabilities.json
+++ b/code/packages/fsharp/resistor/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/resistor",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/fsharp/resistor/tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.fsproj
+++ b/code/packages/fsharp/resistor/tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Resistor.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Resistor.fsproj" />
+    <Compile Include="ResistorTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/resistor/tests/CodingAdventures.Resistor.Tests/ResistorTests.fs
+++ b/code/packages/fsharp/resistor/tests/CodingAdventures.Resistor.Tests/ResistorTests.fs
@@ -1,0 +1,93 @@
+namespace CodingAdventures.Resistor.Tests
+
+open System
+open CodingAdventures.Resistor
+open Xunit
+
+type ResistorTests() =
+    [<Fact>]
+    member _.VersionExists() =
+        Assert.Equal("0.1.0", ResistorPackage.Version)
+
+    [<Fact>]
+    member _.StoresNominalProperties() =
+        let resistor =
+            Resistor(1_000.0, tolerance = 0.01, tempcoPpmPerC = 100.0, powerRatingWatts = 0.25)
+
+        Assert.Equal(1_000.0, resistor.ResistanceOhms)
+        Assert.Equal(0.01, resistor.Tolerance)
+        Assert.Equal(100.0, resistor.TempcoPpmPerC)
+        Assert.Equal(Some 0.25, resistor.PowerRatingWatts)
+
+    [<Fact>]
+    member _.RejectsInvalidConstruction() =
+        Assert.Throws<ArgumentException>(fun () -> Resistor(0.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Resistor(100.0, tolerance = -0.01) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Resistor(100.0, powerRatingWatts = 0.0) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.OhmsLawHelpersUseResistance() =
+        let resistor = Resistor(1_000.0)
+
+        Assert.Equal(0.001, resistor.Conductance(), 12)
+        Assert.Equal(0.005, resistor.CurrentForVoltage(5.0), 12)
+        Assert.Equal(5.0, resistor.VoltageForCurrent(0.005), 12)
+        Assert.Equal(-0.002, resistor.CurrentForVoltage(-2.0), 12)
+
+    [<Fact>]
+    member _.PowerAndEnergyHelpersAgree() =
+        let resistor = Resistor(1_000.0)
+
+        Assert.Equal(0.025, resistor.PowerForVoltage(5.0), 12)
+        Assert.Equal(0.025, resistor.PowerForCurrent(0.005), 12)
+        Assert.Equal(0.05, resistor.EnergyForVoltage(5.0, 2.0), 12)
+        Assert.Equal(0.05, resistor.EnergyForCurrent(0.005, 2.0), 12)
+
+    [<Fact>]
+    member _.EnergyRejectsNegativeDurations() =
+        let resistor = Resistor(100.0)
+
+        Assert.Throws<ArgumentException>(fun () -> resistor.EnergyForVoltage(10.0, -1.0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> resistor.EnergyForCurrent(0.1, -1.0) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.ToleranceAndTemperatureHelpersWork() =
+        let resistor = Resistor(1_000.0, tolerance = 0.01, tempcoPpmPerC = 100.0)
+
+        Assert.Equal(990.0, resistor.MinResistance(), 12)
+        Assert.Equal(1_010.0, resistor.MaxResistance(), 12)
+        Assert.Equal(1_005.0, resistor.ResistanceAtTemperature(75.0), 12)
+        Assert.Equal(995.0, resistor.ResistanceAtTemperature(-25.0), 12)
+
+    [<Fact>]
+    member _.PowerRatingChecksRespectOptionalRating() =
+        let unrated = Resistor(100.0)
+        let rated = Resistor(100.0, powerRatingWatts = 0.25)
+
+        Assert.True(unrated.IsWithinPowerRatingForVoltage(1_000.0))
+        Assert.True(unrated.IsWithinPowerRatingForCurrent(100.0))
+        Assert.True(rated.IsWithinPowerRatingForVoltage(5.0))
+        Assert.False(rated.IsWithinPowerRatingForVoltage(10.0))
+        Assert.True(rated.IsWithinPowerRatingForCurrent(0.04))
+        Assert.False(rated.IsWithinPowerRatingForCurrent(0.1))
+
+    [<Fact>]
+    member _.NetworkHelpersComputeEquivalentResistance() =
+        Assert.Equal(600.0, ResistorNetwork.seriesEquivalent [ Resistor(100.0); Resistor(200.0); Resistor(300.0) ], 12)
+        Assert.Equal(500.0, ResistorNetwork.parallelEquivalent [ Resistor(1_000.0); Resistor(1_000.0) ], 12)
+
+    [<Fact>]
+    member _.NetworkHelpersValidateResistorLists() =
+        Assert.Throws<ArgumentNullException>(fun () -> ResistorNetwork.seriesEquivalent Unchecked.defaultof<Resistor list> |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ResistorNetwork.seriesEquivalent [] |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> ResistorNetwork.seriesEquivalent [ Unchecked.defaultof<Resistor> ] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ResistorNetwork.parallelEquivalent [] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.VoltageDividerUsesBottomResistanceRatio() =
+        let top = Resistor(1_000.0)
+        let bottom = Resistor(1_000.0)
+
+        Assert.Equal(2.5, ResistorNetwork.voltageDivider 5.0 top bottom, 12)
+        Assert.Throws<ArgumentNullException>(fun () -> ResistorNetwork.voltageDivider 5.0 Unchecked.defaultof<Resistor> bottom |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> ResistorNetwork.voltageDivider 5.0 top Unchecked.defaultof<Resistor> |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# resistor packages matching the Python circuit primitive API
- model conductance, Ohm's law, power, energy, tolerance bounds, temperature coefficient adjustment, and optional power ratings
- add series, parallel, and unloaded voltage divider helpers with validation coverage

## Verification
- dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Resistor.Tests/CodingAdventures.Resistor.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line