### PR TITLE
fix(zstd): RFC-compliant seq_count encoding across ports

### DIFF
--- a/code/packages/dart/zstd/CHANGELOG.md
+++ b/code/packages/dart/zstd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.1
+
+- Tests: added `Seq count: 200 KB repetitive text — endianness regression`
+  to lock in the wire-format invariant for the 2-byte sequence-count form.
+  This is the same shape as the regression added to TS+Go in PR #1448 — it
+  reliably produces ≥ 128 sequences in a single block, exercising the
+  2-byte path of `_encodeSeqCount` / `_decodeSeqCount`.
+- Audited `_encodeSeqCount` / `_decodeSeqCount`: already RFC 8878
+  §3.1.1.3.1-compliant (the existing comment near the encoder explicitly
+  cites the `or 0x8000 as LE16` form being avoided); no fix needed.
+
 ## 0.1.0
 
 - Added the initial Dart implementation of the CMP07 ZStd compression package.

--- a/code/packages/dart/zstd/pubspec.yaml
+++ b/code/packages/dart/zstd/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coding_adventures_zstd
 description: >
   ZStd (RFC 8878) lossless compression algorithm from scratch — CMP07.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/adhithyan15/coding-adventures
 publish_to: none
 

--- a/code/packages/dart/zstd/test/zstd_test.dart
+++ b/code/packages/dart/zstd/test/zstd_test.dart
@@ -274,4 +274,27 @@ void main() {
     final data = bytes(List.generate(1024, (i) => (i * 17 + 3) % 256));
     expect(rt(data), equals(data));
   });
+
+  // ── Regression: seq_count endianness bug ──────────────────────────────────
+  //
+  // The 2-byte seq_count form must place the format-flag byte (with bit 7 set)
+  // FIRST, not last. An earlier broken pattern in TS+Go wrote
+  // `[count & 0xFF, (count >> 8) | 0x80]` — low byte first. For any count ≥ 128
+  // whose low byte happened to be < 128 (e.g. 515 = 0x0203 → byte0 = 0x03), the
+  // decoder mis-took the 1-byte path and silently returned a tiny garbage
+  // count, mis-aligning every byte downstream (modes byte, FSE bitstream, …).
+  //
+  // 200 KB of long-period repetitive text reliably yields ≥ 128 sequences in
+  // a single block (LZSS finds ~one match per pattern repetition). This
+  // round-trip is the canonical regression: same pattern as the TS/Go
+  // regression tests added in PR #1448.
+  test('Seq count: 200 KB repetitive text — endianness regression', () {
+    final pattern = 'hello world and more text for compression testing!\n';
+    final buf = StringBuffer();
+    for (var i = 0; i < 4000; i++) {
+      buf.write(pattern);
+    }
+    final data = bytes(buf.toString().codeUnits);
+    expect(rt(data), equals(data));
+  });
 }

--- a/code/packages/elixir/zstd/CHANGELOG.md
+++ b/code/packages/elixir/zstd/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.1] — 2026-04-26
+
+### Tests
+
+- Added `seq_count: 200 KB repetitive text — endianness regression`. The
+  test round-trips 200 KB of repetitive ASCII, which reliably yields ≥ 128
+  sequences in a single block — exercising the 2-byte path of
+  `encode_seq_count` / `decode_seq_count`. Same shape as the regression
+  added to TS+Go in PR #1448.
+- Audited `encode_seq_count` / `decode_seq_count`: already RFC 8878
+  §3.1.1.3.1-compliant (`(cnt >>> 8) ||| 0x80, cnt &&& 0xFF`); no fix needed.
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/elixir/zstd/mix.exs
+++ b/code/packages/elixir/zstd/mix.exs
@@ -4,7 +4,7 @@ defmodule CodingAdventures.Zstd.MixProject do
   def project do
     [
       app: :coding_adventures_zstd,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/code/packages/elixir/zstd/test/zstd_test.exs
+++ b/code/packages/elixir/zstd/test/zstd_test.exs
@@ -233,4 +233,21 @@ defmodule CodingAdventures.ZstdTest do
     result = Zstd.decompress(truncated)
     assert match?({:error, _}, result)
   end
+
+  # ── Regression: seq_count endianness bug ────────────────────────────────────
+  #
+  # The 2-byte seq_count form must place the format-flag byte (bit 7 set) FIRST.
+  # An earlier broken pattern in TS+Go wrote `[count & 0xFF, (count >> 8) | 0x80]`
+  # — low byte first. For any count ≥ 128 whose low byte happened to be < 128
+  # (e.g. 515 → byte0 = 0x03), the decoder mis-took the 1-byte path and silently
+  # returned a tiny garbage count, mis-aligning every byte downstream.
+  #
+  # 200 KB of long-period repetitive text reliably yields ≥ 128 sequences in a
+  # single block (LZSS finds ~one match per pattern repetition). This is the
+  # canonical regression — the same shape as the TS/Go regression in PR #1448.
+  test "seq_count: 200 KB repetitive text — endianness regression" do
+    pattern = "hello world and more text for compression testing!\n"
+    input = pattern |> List.duplicate(4000) |> IO.iodata_to_binary()
+    assert rt(input) == input
+  end
 end

--- a/code/packages/go/zstd/CHANGELOG.md
+++ b/code/packages/go/zstd/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this package follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.0.2] — 2026-04-26
+
+### Fixed
+
+- **`encodeSeqCount` / `decodeSeqCount` now use RFC 8878 §3.1.1.3.1 layout.**
+  The 2-byte form previously emitted bytes via
+  `binary.LittleEndian.AppendUint16(nil, count|0x8000)`, placing the LOW
+  byte first. The decoder branches on byte0 to determine the form: for any
+  count ≥ 128 whose low byte was < 128 (e.g. count=515 → byte0=0x03), the
+  decoder mis-took the 1-byte path and returned a tiny garbage count,
+  mis-aligning every byte downstream. Roughly half of all counts in the
+  2-byte range silently corrupted; the other half worked, so most existing
+  tests passed.
+- New `TestSeqCountEndiannessRegression` round-trips 200 KB of repetitive
+  text (> 128 sequences in a single block).
+- New `TestEncodeSeqCountRoundTrip` exhaustively round-trips every count in
+  the 1-byte range (0..127), the entire 2-byte range (128..0x7EFF), and a
+  spot of 3-byte values.
+
 ## [0.0.1] — 2026-04-24
 
 ### Added

--- a/code/packages/go/zstd/zstd.go
+++ b/code/packages/go/zstd/zstd.go
@@ -827,17 +827,37 @@ func decodeLiteralsSection(data []byte) ([]byte, int, error) {
 //     read OF extra bits
 //  5. Apply sequence to output buffer.
 
-// encodeSeqCount encodes the sequence count in 1-3 bytes per RFC 8878.
+// encodeSeqCount encodes the sequence count in 1-3 bytes per RFC 8878 §3.1.1.3.1.
+//
+// Layout — byte0 is the FORMAT MARKER:
+//
+//	byte0 < 128            → 1-byte form, count = byte0
+//	byte0 ∈ [128, 254]     → 2-byte form, count = ((byte0 - 128) << 8) | byte1
+//	byte0 == 0xFF          → 3-byte form, count = byte1 + (byte2 << 8) + 0x7F00
+//
+// The decoder branches on byte0 alone, so the encoder MUST place the byte
+// that determines the form first. The previous implementation used
+// `binary.LittleEndian.AppendUint16(nil, count|0x8000)`, which writes the
+// LOW byte first. For any count ≥ 128 whose low byte happened to be < 128
+// (e.g. count = 515 → byte0 = 0x03), the decoder mis-took the 1-byte
+// path and returned a tiny garbage count, mis-aligning every byte downstream
+// (including the symbol-modes byte). Because the bug was silent for any
+// count whose low byte was ≥ 128 — roughly half the range — most tests
+// still passed.
 func encodeSeqCount(count int) []byte {
 	if count == 0 {
 		return []byte{0}
-	} else if count < 128 {
-		return []byte{byte(count)}
-	} else if count < 0x7FFF {
-		v := uint16(count) | 0x8000
-		return binary.LittleEndian.AppendUint16(nil, v)
 	}
-	// 3-byte encoding: first byte = 0xFF, next 2 bytes = count - 0x7F00
+	if count < 128 {
+		return []byte{byte(count)}
+	}
+	if count < 0x7F00 {
+		// 2-byte form: byte0 = (count >> 8) | 0x80, byte1 = count & 0xFF.
+		// count < 0x7F00 keeps byte0 in [0x80, 0xFE]; counts at or above 0x7F00
+		// fall through to the 3-byte form (byte0 = 0xFF).
+		return []byte{byte((count >> 8) | 0x80), byte(count & 0xFF)}
+	}
+	// 3-byte encoding: first byte = 0xFF, next 2 bytes = (count - 0x7F00) LE
 	r := count - 0x7F00
 	return []byte{0xFF, byte(r & 0xFF), byte((r >> 8) & 0xFF)}
 }
@@ -851,14 +871,15 @@ func decodeSeqCount(data []byte) (int, int, error) {
 	if b0 < 128 {
 		// 1-byte encoding: value is in [0, 127]
 		return int(b0), 1, nil
-	} else if b0 < 0xFF {
-		// 2-byte encoding: the pair is a LE u16 with the high bit set.
-		// The count = (u16 value) & 0x7FFF.
+	}
+	if b0 < 0xFF {
+		// 2-byte encoding: count = ((b0 - 128) << 8) | b1
+		// Equivalent to ((b0 & 0x7F) << 8) | b1 since b0's bit 7 is set.
 		if len(data) < 2 {
 			return 0, 0, fmt.Errorf("truncated sequence count")
 		}
-		v := binary.LittleEndian.Uint16(data[:2])
-		return int(v & 0x7FFF), 2, nil
+		count := (int(b0&0x7F) << 8) | int(data[1])
+		return count, 2, nil
 	}
 	// 3-byte encoding: byte0=0xFF, then (count - 0x7F00) as LE u16
 	if len(data) < 3 {

--- a/code/packages/go/zstd/zstd_test.go
+++ b/code/packages/go/zstd/zstd_test.go
@@ -185,6 +185,69 @@ func TestTC8RepeatOffset(t *testing.T) {
 	}
 }
 
+// ─── Regression: seq_count endianness bug ────────────────────────────────────
+//
+// The original encodeSeqCount for counts in [128, 0x7FFE] wrote bytes in the
+// wrong order via `binary.LittleEndian.AppendUint16(nil, count|0x8000)`,
+// which puts the LOW byte first. When the low byte happened to be < 128,
+// the decoder mis-took the 1-byte path and returned a tiny garbage count,
+// mis-aligning every byte downstream. Roughly half of all counts in the
+// 2-byte range trigger it (e.g. 515 = 0x0203, low byte 0x03).
+//
+// 200 KB of long-period repetitive text reliably yields enough sequences
+// per single block to push past 128 (LZSS finds ~one match per pattern
+// repetition), so this round-trip exercises the 2-byte seq_count path.
+func TestSeqCountEndiannessRegression(t *testing.T) {
+	pattern := "hello world and more text for compression testing!\n"
+	var sb []byte
+	for i := 0; i < 4000; i++ {
+		sb = append(sb, pattern...)
+	}
+	compressed := Compress(sb)
+	got, err := Decompress(compressed)
+	if err != nil {
+		t.Fatalf("decompress failed: %v", err)
+	}
+	assertBytes(t, got, sb, "seq_count regression round-trip")
+}
+
+// TestEncodeSeqCountRoundTrip exhaustively checks the encode↔decode pair on
+// the 1-byte boundary, the entire 2-byte range, and a few 3-byte values.
+// This is the lowest-level confirmation that the format is self-consistent
+// and matches RFC 8878 §3.1.1.3.1's decoder formula.
+func TestEncodeSeqCountRoundTrip(t *testing.T) {
+	check := func(count int) {
+		t.Helper()
+		bs := encodeSeqCount(count)
+		got, consumed, err := decodeSeqCount(bs)
+		if err != nil {
+			t.Fatalf("count=%d: decode error: %v", count, err)
+		}
+		if got != count {
+			t.Errorf("count=%d: round-trip got %d (bytes=%v consumed=%d)",
+				count, got, bs, consumed)
+		}
+		if consumed != len(bs) {
+			t.Errorf("count=%d: consumed=%d but encoded %d bytes",
+				count, consumed, len(bs))
+		}
+	}
+
+	// 1-byte form: 0..127
+	for c := 0; c < 128; c++ {
+		check(c)
+	}
+	// 2-byte form: every value in [128, 0x7F00). This is the range that
+	// previously had silent corruption for low-byte-< 128.
+	for c := 128; c < 0x7F00; c++ {
+		check(c)
+	}
+	// 3-byte form: spot checks
+	for _, c := range []int{0x7F00, 0x7F01, 0x8000, 0x10000, 0x17EFE} {
+		check(c)
+	}
+}
+
 // ─── TC-9: deterministic output ───────────────────────────────────────────────
 
 // TestTC9Deterministic verifies that compressing the same data twice produces

--- a/code/packages/ruby/zstd/CHANGELOG.md
+++ b/code/packages/ruby/zstd/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are recorded here.
 Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.1.1] — 2026-04-26
+
+### Tests
+
+- Added `TestSeqCount#test_low_byte_lt_128_regression` covering counts whose
+  low byte is < 128 (128, 256, 300, 515, 768, 1024, 32258). These would have
+  silently round-tripped wrong if the encoder ever regressed to the
+  byte-swapped form (`[count & 0xFF, (count >> 8) | 0x80]`) that broke the
+  TS and Go ports — see PR #1448. Also asserts that `byte0 ≥ 128` for the
+  2-byte form, locking in the wire-format invariant.
+- Audited `encode_seq_count` / `decode_seq_count`: already RFC 8878
+  §3.1.1.3.1-compliant (`[(count >> 8) | 0x80, count & 0xFF]`); no fix
+  needed in Ruby.
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/ruby/zstd/lib/coding_adventures/zstd/version.rb
+++ b/code/packages/ruby/zstd/lib/coding_adventures/zstd/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module Zstd
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/code/packages/ruby/zstd/test/test_zstd.rb
+++ b/code/packages/ruby/zstd/test/test_zstd.rb
@@ -390,11 +390,42 @@ end
 # ── Unit: Sequence count encode/decode ───────────────────────────────────────
 
 class TestSeqCount < Minitest::Test
+  # ── Endianness regression: low-byte-< 128 values ───────────────────────────
+  #
+  # The 2-byte form must place the format-flag byte (with bit 7 set) FIRST.
+  # An earlier broken pattern in TS+Go wrote `[count & 0xFF, (count >> 8) | 0x80]`
+  # — low byte first. For any count ≥ 128 whose low byte happens to be < 128
+  # (e.g. 515 = 0x0203 → byte0 = 0x03), the decoder mis-takes the 1-byte path
+  # and silently returns a tiny garbage count. The values below all have
+  # low byte < 128, so they'd round-trip wrong if Ruby ever regressed.
+  REGRESSION_VALUES = [
+    128,       # 0x0080 — boundary, low byte = 0x80 (high bit borderline)
+    256,       # 0x0100 — low byte 0x00, would decode as 1-byte 0
+    300,       # 0x012C — low byte 0x2C, would decode as 1-byte 44
+    515,       # 0x0203 — Lua's TC-8 case, low byte 0x03 = decode as 3
+    768,       # 0x0300 — low byte 0x00
+    1024,      # 0x0400 — low byte 0x00
+    32258      # 0x7E02 — near upper end of 2-byte range, low 0x02
+  ].freeze
+
   def test_roundtrip_values
     [0, 1, 50, 127, 128, 1000, 0x7FFE].each do |n|
       encoded = CodingAdventures::Zstd.encode_seq_count(n).b
       decoded, = CodingAdventures::Zstd.decode_seq_count(encoded)
       assert_equal n, decoded, "seq count #{n}"
+    end
+  end
+
+  def test_low_byte_lt_128_regression
+    REGRESSION_VALUES.each do |n|
+      encoded = CodingAdventures::Zstd.encode_seq_count(n).b
+      decoded, consumed = CodingAdventures::Zstd.decode_seq_count(encoded)
+      assert_equal n, decoded, "seq count #{n} (low byte = 0x#{(n & 0xFF).to_s(16)})"
+      assert_equal 2, consumed, "seq count #{n} should consume 2 bytes"
+      # Wire format check: byte0 must have bit 7 set so the decoder picks
+      # the 2-byte branch unambiguously.
+      assert_operator encoded.getbyte(0), :>=, 128,
+        "byte0 for count=#{n} must have bit 7 set; got 0x#{encoded.getbyte(0).to_s(16)}"
     end
   end
 

--- a/code/packages/swift/zstd/CHANGELOG.md
+++ b/code/packages/swift/zstd/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `swift/zstd` package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.1] — 2026-04-26
+
+### Tests
+
+- Added `testSeqCountEndiannessRegression`. The test round-trips 200 KB of
+  repetitive ASCII, reliably yielding ≥ 128 sequences in a single block —
+  exercising the 2-byte path of `encodeSeqCount` / `decodeSeqCount`. Same
+  shape as the regression added to TS+Go in PR #1448.
+- Audited `encodeSeqCount` / `decodeSeqCount`: already RFC 8878
+  §3.1.1.3.1-compliant (`0x80 | (count >> 8), count & 0xFF`); no fix needed.
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/swift/zstd/Tests/ZstdTests/ZstdTests.swift
+++ b/code/packages/swift/zstd/Tests/ZstdTests/ZstdTests.swift
@@ -335,4 +335,30 @@ final class ZstdTests: XCTestCase {
                 "using Finite State Entropy coding and LZ77 back-references."
         try rt(Array(s.utf8))
     }
+
+    // =========================================================================
+    // Regression: seq_count endianness bug
+    // =========================================================================
+    //
+    // The 2-byte seq_count form must place the format-flag byte (bit 7 set)
+    // FIRST. An earlier broken pattern in TS+Go wrote
+    // `[count & 0xFF, (count >> 8) | 0x80]` — low byte first. For any count ≥
+    // 128 whose low byte happened to be < 128 (e.g. 515 = 0x0203 → byte0 =
+    // 0x03), the decoder mis-took the 1-byte path and silently returned a
+    // tiny garbage count, mis-aligning every byte downstream.
+    //
+    // 200 KB of long-period repetitive text reliably yields ≥ 128 sequences
+    // in a single block (LZSS finds ~one match per pattern repetition). This
+    // round-trip mirrors the TS/Go regression added in PR #1448.
+
+    func testSeqCountEndiannessRegression() throws {
+        let pattern = "hello world and more text for compression testing!\n"
+        var data = [UInt8]()
+        data.reserveCapacity(pattern.utf8.count * 4000)
+        let bytes = Array(pattern.utf8)
+        for _ in 0..<4000 {
+            data.append(contentsOf: bytes)
+        }
+        try rt(data)
+    }
 }

--- a/code/packages/typescript/zstd/CHANGELOG.md
+++ b/code/packages/typescript/zstd/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1] — 2026-04-26
+
+### Fixed
+
+- **`encodeSeqCount` / `decodeSeqCount` now use RFC 8878 §3.1.1.3.1 layout.**
+  The 2-byte form previously wrote bytes in the wrong order
+  (`[count & 0xFF, (count >> 8) | 0x80]`), placing the LOW byte first. The
+  decoder reads byte0 to determine the form: for any count ≥ 128 whose low
+  byte was < 128 (e.g. count=515 → byte0=0x03), the decoder mis-took the
+  1-byte path and returned a tiny garbage count, mis-aligning every byte
+  downstream — including the symbol-modes byte, which then often parsed
+  with `LL_Mode != 0` and threw "unsupported FSE modes". Roughly half of all
+  counts in the 2-byte range silently corrupted; the other half worked, so
+  most existing tests passed.
+- New regression test in TC-8 round-trips 200 KB of repetitive text, which
+  reliably produces > 128 sequences in a single block.
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/typescript/zstd/package.json
+++ b/code/packages/typescript/zstd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/zstd",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZStd (RFC 8878) lossless compression from scratch — CMP07",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/zstd/src/zstd.ts
+++ b/code/packages/typescript/zstd/src/zstd.ts
@@ -847,11 +847,26 @@ function decodeLiteralsSection(data: Uint8Array, offset: number): [Uint8Array, n
 
 /** Encode sequence count as 1, 2, or 3 bytes. */
 function encodeSeqCount(count: number): number[] {
+  // RFC 8878 §3.1.1.3.1 layout — byte0 is the FORMAT MARKER:
+  //   byte0 < 128            → 1-byte form, count = byte0
+  //   byte0 ∈ [128, 254]     → 2-byte form, count = ((byte0 - 128) << 8) | byte1
+  //   byte0 == 0xFF          → 3-byte form, count = byte1 + (byte2 << 8) + 0x7F00
+  //
+  // The decoder branches on byte0 alone, so the encoder MUST write the byte
+  // that determines the form first. The previous implementation wrote
+  // `[count & 0xFF, (count >> 8) | 0x80]` (low byte first). For any
+  // count ≥ 128 whose low byte happened to be < 128 (e.g. count=515 →
+  // byte0=0x03), the decoder mis-took the 1-byte path and returned a tiny
+  // garbage count, mis-aligning every byte that followed (including the
+  // symbol-modes byte). The bug was silent for counts whose low byte was
+  // ≥ 128, which is roughly half — so most existing tests still passed.
   if (count === 0) return [0];
   if (count < 128) return [count];
-  if (count < 0x7FFF) {
-    const v = count | 0x8000;
-    return [v & 0xFF, (v >>> 8) & 0xFF];
+  if (count < 0x7F00) {
+    // 2-byte form: byte0 = (count >> 8) | 0x80, byte1 = count & 0xFF.
+    // count < 0x7F00 keeps byte0 in [0x80, 0xFE]; counts at or above 0x7F00
+    // fall through to the 3-byte form (byte0 = 0xFF).
+    return [(count >>> 8) | 0x80, count & 0xFF];
   }
   // 3-byte: first byte = 0xFF, then (count - 0x7F00) as LE u16
   const r = count - 0x7F00;
@@ -865,8 +880,9 @@ function decodeSeqCount(data: Uint8Array, offset: number): [number, number] {
   if (b0 < 128) return [b0, 1];
   if (b0 < 0xFF) {
     if (offset + 2 > data.length) throw new Error("truncated sequence count");
-    const v = b0 | (data[offset + 1]! << 8);
-    return [(v & 0x7FFF), 2];
+    // Equivalent to `((b0 - 128) << 8) | b1` per RFC 8878 §3.1.1.3.1.
+    const count = ((b0 & 0x7F) << 8) | data[offset + 1]!;
+    return [count, 2];
   }
   // b0 === 0xFF
   if (offset + 3 > data.length) throw new Error("truncated sequence count (3-byte)");

--- a/code/packages/typescript/zstd/tests/zstd.test.ts
+++ b/code/packages/typescript/zstd/tests/zstd.test.ts
@@ -181,6 +181,25 @@ describe("TC-8: large repetitive text", () => {
     const threshold = Math.floor(input.length * 70 / 100);
     expect(compressed.length).toBeLessThan(threshold);
   });
+
+  // ── Regression for the seq_count endianness bug ──────────────────────────
+  //
+  // The original encoder for counts in [128, 0x7FFE] wrote bytes in the
+  // wrong order: `[count & 0xFF, (count >> 8) | 0x80]`. When the LOW byte
+  // of `count` happened to be < 128, the decoder mis-took the 1-byte path
+  // and returned a tiny garbage count. Roughly half of all counts in the
+  // 2-byte range trigger this — for example, 515 (= 0x0203, low byte 0x03).
+  //
+  // 200 KB of long-period repetitive text reliably yields enough sequences
+  // per single block to push past 128 (LZSS finds ~one match per pattern
+  // repetition). This round-trip is the canonical regression: it must pass
+  // for the same reason the analogous Lua TC-8 must pass.
+  it("round-trips 200 KB of repetitive text (>= 128 sequences per block)", () => {
+    const pattern = "hello world and more text for compression testing!\n";
+    const text = pattern.repeat(4000); // ~204 KB → first block has ~500 sequences
+    const input = new TextEncoder().encode(text);
+    expect(rt(input)).toEqual(input);
+  });
 });
 
 // ─── TC-9: Bad magic throws ───────────────────────────────────────────────────

--- a/code/packages/typescript/zstd/tests/zstd.test.ts
+++ b/code/packages/typescript/zstd/tests/zstd.test.ts
@@ -194,12 +194,15 @@ describe("TC-8: large repetitive text", () => {
   // per single block to push past 128 (LZSS finds ~one match per pattern
   // repetition). This round-trip is the canonical regression: it must pass
   // for the same reason the analogous Lua TC-8 must pass.
+  //
+  // Timeout bumped to 30 s: the LZSS pass over 200 KB takes ~10 s on slower
+  // CI runners. Default 5 s timeout was too tight.
   it("round-trips 200 KB of repetitive text (>= 128 sequences per block)", () => {
     const pattern = "hello world and more text for compression testing!\n";
     const text = pattern.repeat(4000); // ~204 KB → first block has ~500 sequences
     const input = new TextEncoder().encode(text);
     expect(rt(input)).toEqual(input);
-  });
+  }, 30_000);
 });
 
 // ─── TC-9: Bad magic throws ───────────────────────────────────────────────────

--- a/lessons.md
+++ b/lessons.md
@@ -3433,3 +3433,31 @@ This keeps the `LuaConduitApp` reachable from the Lua registry (which is always 
 **Fix:** Remove all `mise exec --` prefixes.  Just call `cargo`, `npm`, `npx`, `node`, etc. directly.  The Python conduit BUILD already documented this pattern explicitly in a comment.
 
 **Rule:** BUILD files should call language tools (cargo, npm, npx, node, python, go, etc.) directly without any wrapper.  `mise` provides shims locally so direct invocation works in both environments.  CI installs tools into PATH itself.
+
+---
+
+## Lesson: In variable-length encodings, the FORMAT MARKER must come first — never write the length-distinguishing flag on the LOW byte of an LE16
+
+**Date:** 2026-04-26
+
+**What happened:** Several zstd ports (TS, Go, Lua) encoded the 2-byte sequence count as a little-endian u16 with `0x8000` ORed in, then wrote it LE — which puts the LOW byte of `count` first and the flag byte (with bit 7 set) second:
+
+```ts
+// BROKEN: low byte first
+const v = count | 0x8000;
+return [v & 0xFF, (v >>> 8) & 0xFF];
+```
+
+The decoder branches on `byte0` to choose form (`< 128` → 1 byte, `< 0xFF` → 2 bytes, `== 0xFF` → 3 bytes). For any count ≥ 128 whose LOW byte happened to be < 128 (e.g. count=515 → `[0x03, 0x82]`), the decoder mis-took the 1-byte path and silently returned a tiny garbage count, mis-aligning the modes byte and the FSE bitstream that followed. About half of all 2-byte counts triggered this; the other half worked. Round-trip tests with counts like 1000 (low byte 0xE8) or 0x7FFE (both high) silently passed despite the bug. Discovered when Lua's TC-8 (300 KB → 515 sequences) finally hit a count whose low byte was < 128 and threw `unsupported FSE modes` from a misaligned modes byte.
+
+**Rule:** Any variable-length integer encoding whose decoder branches on `byte0` MUST place the byte that carries the format marker **first** in the wire stream — independent of the host's natural endianness. For zstd's seq_count specifically, the RFC 8878 §3.1.1.3.1 layout is:
+
+```
+count < 128:           [count]
+128 ≤ count < 0x7FFF:  [(count >> 8) | 0x80, count & 0xFF]   # high byte first
+count ≥ 0x7FFF:        [0xFF, low, high]                       # 3-byte form
+```
+
+Decode: `((b0 & 0x7F) << 8) | b1`, equivalent to RFC's `((byte0 - 128) << 8) | byte1`.
+
+When testing variable-length codecs, the round-trip test parameter set MUST include at least one value in each form whose low byte is < 128 (e.g. 256, 300, 515, 768) — otherwise a low-byte-first regression silently passes. Pure round-trip tests on a self-consistent broken codec are blind to byte-order bugs by construction. The integration test that catches it reliably is "≥ 200 KB of repetitive text → ≥ 128 sequences in a single block" — that input distribution naturally produces counts spanning both halves of the 2-byte range.


### PR DESCRIPTION
## Summary

Audit and fix follow-up to PR #1431. The 2-byte sequence-count encoding in the TypeScript reference and Go port wrote bytes in the wrong order, causing silent corruption when `count`'s low byte happened to be < 128. Discovered while babysitting CI for #1431 (Lua's TC-8 hit it; the lua fix landed in commit `404af0d91`).

This PR audits all 9 ports, fixes TS and Go, and adds defensive regression tests to the four ports that were RFC-compliant but lacked coverage that would catch a future low-byte-first regression.

## Audit results across all 9 zstd ports

| Port       | Status                                      | Regression test added? |
|------------|---------------------------------------------|------------------------|
| python     | ✅ already correct (uses `count - 0x80` form) | already covers 515 |
| ruby       | ✅ already correct                           | ✅ added (515 + 5 others) |
| swift      | ✅ already correct                           | ✅ added (200 KB round-trip) |
| dart       | ✅ already correct (the comment explicitly cites the bug being avoided) | ✅ added (200 KB round-trip) |
| elixir     | ✅ already correct                           | ✅ added (200 KB round-trip) |
| perl       | ✅ already correct                           | already covers 515 |
| **typescript** | **❌ broken — fixed in this PR**         | ✅ added (200 KB TC-8) |
| **go**         | **❌ broken — fixed in this PR**         | ✅ added (200 KB + exhaustive 0..0x7EFF) |
| lua        | fixed in PR #1431 commit `404af0d91`        | covered by lua TC-8 |

## The bug

The decoder branches on `byte0` to choose the form:
- `byte0 < 128` → 1-byte form
- `byte0 ∈ [128, 254]` → 2-byte form
- `byte0 == 0xFF` → 3-byte form

The buggy encoder wrote `[count & 0xFF, (count >> 8) | 0x80]` — low byte first. For any count ≥ 128 whose low byte happened to be < 128 (e.g. count=515 → byte0=0x03), the decoder mis-took the 1-byte path and returned a tiny garbage count, mis-aligning every byte downstream — including the symbol-modes byte, which then often parsed with `LL_Mode != 0` and threw `unsupported FSE modes`.

Roughly **half** of all counts in the 2-byte range silently corrupted; the other half worked, so most existing tests passed.

## Fix (TS + Go)

Both ports now write `[(count >> 8) | 0x80, count & 0xFF]` (high byte with format flag first) and decode `((b0 & 0x7F) << 8) | b1` — equivalent to RFC 8878 §3.1.1.3.1's `((byte0 - 128) << 8) | byte1`.

## Defensive tests (Ruby/Dart/Elixir/Swift)

These four ports were already RFC-compliant on the wire, but their existing test coverage didn't catch a low-byte-first regression:

- **ruby:** previously tested `[127, 128, 1000, 0x7FFE]` — none have a low byte < 128 in the 2-byte range. Added `test_low_byte_lt_128_regression` covering `[128, 256, 300, 515, 768, 1024, 32258]` plus a wire-format invariant assert (`byte0 ≥ 128`).
- **dart:** previously only `count = 0` and a 1024-byte fuzz. Added the canonical 200 KB repetitive round-trip.
- **elixir:** previously no seq_count-specific test. Added the canonical 200 KB repetitive round-trip.
- **swift:** TC-8 (300 KB) implicitly covered the path. Added an explicit `testSeqCountEndiannessRegression` mirroring the TS+Go form.

The 200 KB pattern (`"hello world and more text for compression testing!\n"` × 4000) is the canonical regression input — it reliably yields ≥ 128 sequences in a single block.

## Lessons.md

Added a new lesson: **"In variable-length encodings, the FORMAT MARKER must come first — never write the length-distinguishing flag on the LOW byte of an LE16."** Includes the general rule, the specific zstd seq_count layout, and the testing pitfall (round-trip-only tests on a self-consistent broken codec are blind to byte-order bugs).

## Test plan

- [x] TS: 36/36 vitest pass (200 KB regression in TC-8)
- [x] TS: confirmed regression test fails on the broken code, passes on the fix
- [x] Go: all pass — `TestSeqCountEndiannessRegression` + `TestEncodeSeqCountRoundTrip` (exhaustive 0..0x7EFF)
- [x] Ruby: 55/55 minitest pass with `test_low_byte_lt_128_regression`
- [x] Dart: 24/24 dart-test pass with the new regression case
- [x] Elixir: 25/25 ExUnit pass with the new regression case
- [x] Swift: 22/22 XCTest pass with `testSeqCountEndiannessRegression`
- [x] Security review passed (line-by-line bounds-check verification of TS+Go decoder; no new vulnerabilities)
- [ ] CI runs full matrix — being monitored via `/babysit-pr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)