### PR TITLE
[codex] Expand activation function parity

### DIFF
--- a/code/learning/ml-learning-lab-program-parity.md
+++ b/code/learning/ml-learning-lab-program-parity.md
@@ -1,0 +1,122 @@
+# ML Learning Lab Program Parity
+
+The visual lab should be the intuition surface. The repo programs should be the
+executable proof that the same idea works in any language a learner already
+knows.
+
+## Goal
+
+Every visual machine-learning example should eventually have three matching
+artifacts:
+
+1. A visual lab that lets the learner change parameters and watch the model
+   move.
+2. A portable program spec that defines the dataset, starting parameters,
+   primitives, and expected training trace.
+3. Language programs with literate notes that run the same experiment through
+   the repo's core primitives.
+
+That gives us two useful feedback loops:
+
+- Learners can move from pictures to code without changing the problem.
+- CI can stress test activation functions, loss functions, gradient descent,
+  matrix math, and future primitives against real teaching examples.
+
+## Translation Shape
+
+Each visual example should translate to a small, deterministic program:
+
+```text
+dataset -> model -> activation -> loss -> gradients -> optimizer -> trace
+```
+
+The program should print a compact training trace:
+
+```text
+epoch, weight(s), bias, prediction sample, loss, gradient summary
+```
+
+For tests, each program should also expose or generate a machine-readable golden
+trace. A small trace is enough:
+
+```json
+[
+  {
+    "step": 0,
+    "weights": [0.5],
+    "bias": 0.5,
+    "loss": 3628.67
+  }
+]
+```
+
+## Literate Notes
+
+Each language version should include comments or a README that explains the same
+concepts in that language's idiom:
+
+- What the inputs represent.
+- What the model computes before activation.
+- Why the chosen activation function is used.
+- How the loss function turns prediction error into one scalar.
+- How the derivative points back toward better weights.
+- What the learning rate changes in the update step.
+
+The notes should stay close to executable code. A learner should be able to read
+from top to bottom and see the same sequence that the visual app animates.
+
+## First Program Families
+
+The repo already has program precedents for these ML examples:
+
+| Example | Existing language coverage | Core primitives stressed |
+|---------|----------------------------|--------------------------|
+| Celsius to Fahrenheit predictor | Go, Python, Rust, Ruby, TypeScript, Elixir | MSE, MAE, gradient descent, linear activation |
+| House price predictor | Go, Python, Rust, Ruby, TypeScript, Elixir | Multi-feature linear regression, MSE |
+| Space launch predictor | Go, Python, Rust, Ruby, TypeScript, Elixir | Regression/classification-shaped feature engineering |
+| Mansion classifier | Go, Python, Rust, Ruby, TypeScript, Elixir | Classification thresholding, sigmoid-style intuition |
+| XOR classifier | Python | Non-linear activation necessity |
+
+These should be the first parity targets because they already exist as programs
+and can be tightened into shared, testable teaching examples.
+
+## Program Spec Template
+
+Each lab should get a small JSON or Markdown spec with:
+
+- `id`: stable identifier shared with the visual lab.
+- `title`: learner-facing example name.
+- `dataset`: inline small dataset or relative path to checked-in CSV/JSON.
+- `model`: linear regression, logistic regression, tiny neural network, etc.
+- `activations`: required activation functions.
+- `losses`: required loss functions.
+- `optimizer`: optimizer primitive and learning rate.
+- `initial_parameters`: deterministic starting weights and bias.
+- `expected_trace`: selected checkpoints for CI.
+- `notes`: short explanation of the concept being taught.
+
+## CI Strategy
+
+The build should not require every program in every language to exist on day
+one. Instead:
+
+1. Visual labs publish specs.
+2. Program implementations declare which specs they satisfy.
+3. CI runs only implementations whose language runtime is available.
+4. Missing implementations are reported as coverage gaps, not build failures.
+5. Existing implementations must match their golden traces within tolerance.
+
+This lets the lab grow toward dozens of examples without blocking every PR on a
+complete cross-language matrix.
+
+## Immediate Next Slice
+
+The activation-function package parity work is the right foundation for this.
+After the current activation PR, the next implementation slice should be:
+
+1. Extract the Celsius visualizer training loop into a portable lab spec.
+2. Update the existing Celsius programs to include literate notes and a golden
+   training trace.
+3. Add a small cross-language report showing which languages satisfy the Celsius
+   lab.
+4. Repeat for house price prediction, then classification examples.

--- a/code/packages/csharp/activation-functions/ActivationFunctions.cs
+++ b/code/packages/csharp/activation-functions/ActivationFunctions.cs
@@ -26,6 +26,17 @@ public static class ActivationFunctions
 {
     // exp(710) overflows a double, so we clamp before calling Math.Exp.
     private const double SigmoidOverflowClamp = 709.0;
+    private const double LeakyReluSlope = 0.01;
+
+    /// <summary>
+    /// Return the input unchanged.
+    /// </summary>
+    public static double Linear(double x) => x;
+
+    /// <summary>
+    /// Return the constant slope of the identity function.
+    /// </summary>
+    public static double LinearDerivative(double x) => 1.0;
 
     /// <summary>
     /// Compute the logistic sigmoid.
@@ -82,6 +93,16 @@ public static class ActivationFunctions
     public static double ReluDerivative(double x) => x > 0.0 ? 1.0 : 0.0;
 
     /// <summary>
+    /// Compute Leaky ReLU with the spec default negative slope of 0.01.
+    /// </summary>
+    public static double LeakyRelu(double x) => x > 0.0 ? x : LeakyReluSlope * x;
+
+    /// <summary>
+    /// Return the slope of Leaky ReLU.
+    /// </summary>
+    public static double LeakyReluDerivative(double x) => x > 0.0 ? 1.0 : LeakyReluSlope;
+
+    /// <summary>
     /// Compute tanh(x), the zero-centered sibling of sigmoid.
     ///
     /// tanh maps any real number to (-1, 1). Because its midpoint is 0 rather
@@ -102,4 +123,14 @@ public static class ActivationFunctions
         var tanh = Math.Tanh(x);
         return 1.0 - (tanh * tanh);
     }
+
+    /// <summary>
+    /// Compute Softplus using a stable absolute-value formulation.
+    /// </summary>
+    public static double Softplus(double x) => Math.Log(1.0 + Math.Exp(-Math.Abs(x))) + Math.Max(x, 0.0);
+
+    /// <summary>
+    /// Compute the derivative of Softplus, which is sigmoid.
+    /// </summary>
+    public static double SoftplusDerivative(double x) => Sigmoid(x);
 }

--- a/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.cs
+++ b/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.cs
@@ -12,6 +12,18 @@ public sealed class ActivationFunctionsTests
     }
 
     [Fact]
+    public void LinearAndItsDerivativeMatchTheIdentityDefinition()
+    {
+        AssertClose(-3.0, Activation.Linear(-3.0));
+        AssertClose(0.0, Activation.Linear(0.0));
+        AssertClose(5.0, Activation.Linear(5.0));
+
+        AssertClose(1.0, Activation.LinearDerivative(-3.0));
+        AssertClose(1.0, Activation.LinearDerivative(0.0));
+        AssertClose(1.0, Activation.LinearDerivative(5.0));
+    }
+
+    [Fact]
     public void SigmoidMatchesTheSpecVectors()
     {
         AssertClose(0.5, Activation.Sigmoid(0.0));
@@ -43,6 +55,18 @@ public sealed class ActivationFunctionsTests
     }
 
     [Fact]
+    public void LeakyReluAndItsDerivativeKeepTheNegativeSlope()
+    {
+        AssertClose(5.0, Activation.LeakyRelu(5.0));
+        AssertClose(-0.03, Activation.LeakyRelu(-3.0));
+        AssertClose(0.0, Activation.LeakyRelu(0.0));
+
+        AssertClose(1.0, Activation.LeakyReluDerivative(5.0));
+        AssertClose(0.01, Activation.LeakyReluDerivative(-3.0));
+        AssertClose(0.01, Activation.LeakyReluDerivative(0.0));
+    }
+
+    [Fact]
     public void TanhAndItsDerivativeMatchTheReferenceValues()
     {
         AssertClose(0.0, Activation.Tanh(0.0));
@@ -51,6 +75,19 @@ public sealed class ActivationFunctionsTests
 
         AssertClose(1.0, Activation.TanhDerivative(0.0));
         AssertClose(0.41997434161402614, Activation.TanhDerivative(1.0));
+    }
+
+    [Fact]
+    public void SoftplusAndItsDerivativeMatchTheReferenceValues()
+    {
+        AssertClose(0.6931471805599453, Activation.Softplus(0.0));
+        AssertClose(1.3132616875182228, Activation.Softplus(1.0));
+        AssertClose(0.31326168751822286, Activation.Softplus(-1.0));
+        Assert.True(Activation.Softplus(1000.0) > 999.0);
+
+        AssertClose(0.5, Activation.SoftplusDerivative(0.0));
+        AssertClose(Activation.Sigmoid(1.0), Activation.SoftplusDerivative(1.0));
+        AssertClose(Activation.Sigmoid(-1.0), Activation.SoftplusDerivative(-1.0));
     }
 
     [Fact]
@@ -68,7 +105,9 @@ public sealed class ActivationFunctionsTests
 
             Assert.True(Activation.SigmoidDerivative(sample) >= 0.0);
             Assert.True(Activation.ReluDerivative(sample) >= 0.0);
+            Assert.True(Activation.LeakyReluDerivative(sample) >= 0.0);
             Assert.True(Activation.TanhDerivative(sample) >= 0.0);
+            Assert.True(Activation.SoftplusDerivative(sample) >= 0.0);
         }
     }
 }

--- a/code/packages/elixir/activation_functions/lib/activation_functions.ex
+++ b/code/packages/elixir/activation_functions/lib/activation_functions.ex
@@ -1,4 +1,10 @@
 defmodule CodingAdventures.ActivationFunctions do
+  @leaky_relu_slope 0.01
+
+  def linear(x), do: x * 1.0
+
+  def linear_derivative(_x), do: 1.0
+
   @doc """
   Sigmoid collapses any continuous state exclusively into a 0.0 to 1.0 float probability seamlessly.
   """
@@ -19,6 +25,12 @@ defmodule CodingAdventures.ActivationFunctions do
   def relu_derivative(x) when x > 0.0, do: 1.0
   def relu_derivative(_x), do: 0.0
 
+  def leaky_relu(x) when x > 0.0, do: x * 1.0
+  def leaky_relu(x), do: @leaky_relu_slope * x
+
+  def leaky_relu_derivative(x) when x > 0.0, do: 1.0
+  def leaky_relu_derivative(_x), do: @leaky_relu_slope
+
   def tanh_func(x) do
     :math.tanh(x)
   end
@@ -27,4 +39,10 @@ defmodule CodingAdventures.ActivationFunctions do
     t = :math.tanh(x)
     1.0 - (t * t)
   end
+
+  def softplus(x) do
+    :math.log(1.0 + :math.exp(-abs(x))) + max(x, 0.0)
+  end
+
+  def softplus_derivative(x), do: sigmoid(x)
 end

--- a/code/packages/fsharp/activation-functions/ActivationFunctions.fs
+++ b/code/packages/fsharp/activation-functions/ActivationFunctions.fs
@@ -25,6 +25,13 @@ open System
 module ActivationFunctions =
     // exp(710) is already too large for float, so we clamp before calling Exp.
     let private sigmoidOverflowClamp = 709.0
+    let private leakyReluSlope = 0.01
+
+    /// Return the input unchanged.
+    let linear (x: float) = x
+
+    /// Return the constant slope of the identity function.
+    let linearDerivative (_x: float) = 1.0
 
     /// Compute the logistic sigmoid.
     ///
@@ -64,6 +71,20 @@ module ActivationFunctions =
         else
             0.0
 
+    /// Compute Leaky ReLU with the spec default negative slope of 0.01.
+    let leakyRelu (x: float) =
+        if x > 0.0 then
+            x
+        else
+            leakyReluSlope * x
+
+    /// Return the slope of Leaky ReLU.
+    let leakyReluDerivative (x: float) =
+        if x > 0.0 then
+            1.0
+        else
+            leakyReluSlope
+
     /// Compute tanh(x), the zero-centered sibling of sigmoid.
     let tanh (x: float) = Math.Tanh(x)
 
@@ -74,3 +95,10 @@ module ActivationFunctions =
     let tanhDerivative (x: float) =
         let t = Math.Tanh(x)
         1.0 - (t * t)
+
+    /// Compute Softplus using a stable absolute-value formulation.
+    let softplus (x: float) =
+        Math.Log(1.0 + Math.Exp(-abs x)) + max x 0.0
+
+    /// Compute the derivative of Softplus, which is sigmoid.
+    let softplusDerivative (x: float) = sigmoid x

--- a/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.fs
+++ b/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.fs
@@ -9,6 +9,16 @@ type ActivationFunctionsTests() =
         Assert.True(abs (expected - actual) <= tolerance, $"Expected {expected} but got {actual}.")
 
     [<Fact>]
+    member _.``Linear and its derivative match the identity definition``() =
+        assertClose -3.0 (ActivationFunctions.linear -3.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.linear 0.0) 1e-12
+        assertClose 5.0 (ActivationFunctions.linear 5.0) 1e-12
+
+        assertClose 1.0 (ActivationFunctions.linearDerivative -3.0) 1e-12
+        assertClose 1.0 (ActivationFunctions.linearDerivative 0.0) 1e-12
+        assertClose 1.0 (ActivationFunctions.linearDerivative 5.0) 1e-12
+
+    [<Fact>]
     member _.``Sigmoid matches the spec vectors``() =
         assertClose 0.5 (ActivationFunctions.sigmoid 0.0) 1e-12
         assertClose 0.7310585786300049 (ActivationFunctions.sigmoid 1.0) 1e-12
@@ -34,6 +44,16 @@ type ActivationFunctionsTests() =
         assertClose 0.0 (ActivationFunctions.reluDerivative 0.0) 1e-12
 
     [<Fact>]
+    member _.``Leaky ReLU and its derivative keep the negative slope``() =
+        assertClose 5.0 (ActivationFunctions.leakyRelu 5.0) 1e-12
+        assertClose -0.03 (ActivationFunctions.leakyRelu -3.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.leakyRelu 0.0) 1e-12
+
+        assertClose 1.0 (ActivationFunctions.leakyReluDerivative 5.0) 1e-12
+        assertClose 0.01 (ActivationFunctions.leakyReluDerivative -3.0) 1e-12
+        assertClose 0.01 (ActivationFunctions.leakyReluDerivative 0.0) 1e-12
+
+    [<Fact>]
     member _.``Tanh and its derivative match the reference values``() =
         assertClose 0.0 (ActivationFunctions.tanh 0.0) 1e-12
         assertClose 0.7615941559557649 (ActivationFunctions.tanh 1.0) 1e-12
@@ -41,6 +61,17 @@ type ActivationFunctionsTests() =
 
         assertClose 1.0 (ActivationFunctions.tanhDerivative 0.0) 1e-12
         assertClose 0.41997434161402614 (ActivationFunctions.tanhDerivative 1.0) 1e-12
+
+    [<Fact>]
+    member _.``Softplus and its derivative match the reference values``() =
+        assertClose 0.6931471805599453 (ActivationFunctions.softplus 0.0) 1e-12
+        assertClose 1.3132616875182228 (ActivationFunctions.softplus 1.0) 1e-12
+        assertClose 0.31326168751822286 (ActivationFunctions.softplus -1.0) 1e-12
+        Assert.True(ActivationFunctions.softplus 1000.0 > 999.0)
+
+        assertClose 0.5 (ActivationFunctions.softplusDerivative 0.0) 1e-12
+        assertClose (ActivationFunctions.sigmoid 1.0) (ActivationFunctions.softplusDerivative 1.0) 1e-12
+        assertClose (ActivationFunctions.sigmoid -1.0) (ActivationFunctions.softplusDerivative -1.0) 1e-12
 
     [<Fact>]
     member _.``Symmetry and range properties hold for representative samples``() =
@@ -55,4 +86,6 @@ type ActivationFunctionsTests() =
 
             Assert.True(ActivationFunctions.sigmoidDerivative sample >= 0.0)
             Assert.True(ActivationFunctions.reluDerivative sample >= 0.0)
+            Assert.True(ActivationFunctions.leakyReluDerivative sample >= 0.0)
             Assert.True(ActivationFunctions.tanhDerivative sample >= 0.0)
+            Assert.True(ActivationFunctions.softplusDerivative sample >= 0.0)

--- a/code/packages/go/activation-functions/activations.go
+++ b/code/packages/go/activation-functions/activations.go
@@ -17,6 +17,27 @@ package activation
 
 import "math"
 
+const leakyReluSlope = 0.01
+
+// Linear returns the raw weighted sum unchanged.
+func Linear(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.Linear", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			return rf.Generate(true, false, x)
+		}).GetResult()
+	return result
+}
+
+func LinearDerivative(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.LinearDerivative", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			return rf.Generate(true, false, 1.0)
+		}).GetResult()
+	return result
+}
+
 // Sigmoid seamlessly clamps any numerical vector precisely between 0.0 and 1.0 representing strict probabilities.
 func Sigmoid(x float64) float64 {
 	result, _ := StartNew[float64]("activation-functions.Sigmoid", 0,
@@ -68,12 +89,57 @@ func ReluDerivative(x float64) float64 {
 	return result
 }
 
+// LeakyRelu keeps a small negative slope so inactive ReLU neurons can still learn.
+func LeakyRelu(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.LeakyRelu", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			if x > 0 {
+				return rf.Generate(true, false, x)
+			}
+			return rf.Generate(true, false, leakyReluSlope*x)
+		}).GetResult()
+	return result
+}
+
+func LeakyReluDerivative(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.LeakyReluDerivative", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			if x > 0 {
+				return rf.Generate(true, false, 1.0)
+			}
+			return rf.Generate(true, false, leakyReluSlope)
+		}).GetResult()
+	return result
+}
+
 // Tanh evaluates structurally across negative constraints (-1.0 to 1.0).
 func Tanh(x float64) float64 {
 	result, _ := StartNew[float64]("activation-functions.Tanh", 0,
 		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
 			op.AddProperty("x", x)
 			return rf.Generate(true, false, math.Tanh(x))
+		}).GetResult()
+	return result
+}
+
+// Softplus is a smooth ReLU approximation using a stable log1p formulation.
+func Softplus(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.Softplus", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			value := math.Log1p(math.Exp(-math.Abs(x))) + math.Max(x, 0.0)
+			return rf.Generate(true, false, value)
+		}).GetResult()
+	return result
+}
+
+func SoftplusDerivative(x float64) float64 {
+	result, _ := StartNew[float64]("activation-functions.SoftplusDerivative", 0,
+		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
+			op.AddProperty("x", x)
+			return rf.Generate(true, false, Sigmoid(x))
 		}).GetResult()
 	return result
 }

--- a/code/packages/go/activation-functions/activations_test.go
+++ b/code/packages/go/activation-functions/activations_test.go
@@ -1,0 +1,71 @@
+package activation
+
+import (
+	"math"
+	"testing"
+)
+
+func assertClose(t *testing.T, expected, actual float64) {
+	t.Helper()
+	if math.Abs(expected-actual) > 1e-12 {
+		t.Fatalf("expected %.17g, got %.17g", expected, actual)
+	}
+}
+
+func TestLinear(t *testing.T) {
+	assertClose(t, -3.0, Linear(-3.0))
+	assertClose(t, 0.0, Linear(0.0))
+	assertClose(t, 5.0, Linear(5.0))
+	assertClose(t, 1.0, LinearDerivative(-3.0))
+	assertClose(t, 1.0, LinearDerivative(0.0))
+	assertClose(t, 1.0, LinearDerivative(5.0))
+}
+
+func TestSigmoid(t *testing.T) {
+	assertClose(t, 0.5, Sigmoid(0.0))
+	assertClose(t, 0.7310585786300049, Sigmoid(1.0))
+	assertClose(t, 0.2689414213699951, Sigmoid(-1.0))
+	assertClose(t, 0.9999546021312976, Sigmoid(10.0))
+	assertClose(t, 0.0, Sigmoid(-710.0))
+	assertClose(t, 1.0, Sigmoid(710.0))
+	assertClose(t, 0.25, SigmoidDerivative(0.0))
+	assertClose(t, 0.19661193324148185, SigmoidDerivative(1.0))
+}
+
+func TestRelu(t *testing.T) {
+	assertClose(t, 5.0, Relu(5.0))
+	assertClose(t, 0.0, Relu(-3.0))
+	assertClose(t, 0.0, Relu(0.0))
+	assertClose(t, 1.0, ReluDerivative(5.0))
+	assertClose(t, 0.0, ReluDerivative(-3.0))
+	assertClose(t, 0.0, ReluDerivative(0.0))
+}
+
+func TestLeakyRelu(t *testing.T) {
+	assertClose(t, 5.0, LeakyRelu(5.0))
+	assertClose(t, -0.03, LeakyRelu(-3.0))
+	assertClose(t, 0.0, LeakyRelu(0.0))
+	assertClose(t, 1.0, LeakyReluDerivative(5.0))
+	assertClose(t, 0.01, LeakyReluDerivative(-3.0))
+	assertClose(t, 0.01, LeakyReluDerivative(0.0))
+}
+
+func TestTanh(t *testing.T) {
+	assertClose(t, 0.0, Tanh(0.0))
+	assertClose(t, 0.7615941559557649, Tanh(1.0))
+	assertClose(t, -0.7615941559557649, Tanh(-1.0))
+	assertClose(t, 1.0, TanhDerivative(0.0))
+	assertClose(t, 0.41997434161402614, TanhDerivative(1.0))
+}
+
+func TestSoftplus(t *testing.T) {
+	assertClose(t, 0.6931471805599453, Softplus(0.0))
+	assertClose(t, 1.3132616875182228, Softplus(1.0))
+	assertClose(t, 0.31326168751822286, Softplus(-1.0))
+	if Softplus(1000.0) <= 999.0 {
+		t.Fatalf("softplus should remain stable for large positive inputs")
+	}
+	assertClose(t, 0.5, SoftplusDerivative(0.0))
+	assertClose(t, Sigmoid(1.0), SoftplusDerivative(1.0))
+	assertClose(t, Sigmoid(-1.0), SoftplusDerivative(-1.0))
+}

--- a/code/packages/java/activation-functions/src/main/java/com/codingadventures/activationfunctions/ActivationFunctions.java
+++ b/code/packages/java/activation-functions/src/main/java/com/codingadventures/activationfunctions/ActivationFunctions.java
@@ -32,7 +32,23 @@ package com.codingadventures.activationfunctions;
  */
 public final class ActivationFunctions {
 
+    private static final double LEAKY_RELU_SLOPE = 0.01;
+
     private ActivationFunctions() {}
+
+    // ========================================================================
+    // Linear: x
+    // ========================================================================
+
+    /** Return the input unchanged. */
+    public static double linear(double x) {
+        return x;
+    }
+
+    /** Derivative of linear activation: 1 everywhere. */
+    public static double linearDerivative(double x) {
+        return 1.0;
+    }
 
     // ========================================================================
     // Sigmoid: σ(x) = 1 / (1 + e^(-x))
@@ -70,6 +86,20 @@ public final class ActivationFunctions {
     }
 
     // ========================================================================
+    // Leaky ReLU: x if x > 0, otherwise 0.01x
+    // ========================================================================
+
+    /** Compute Leaky ReLU with the spec default negative slope of 0.01. */
+    public static double leakyRelu(double x) {
+        return x > 0.0 ? x : LEAKY_RELU_SLOPE * x;
+    }
+
+    /** Derivative: 1 if x > 0, 0.01 otherwise. */
+    public static double leakyReluDerivative(double x) {
+        return x > 0.0 ? 1.0 : LEAKY_RELU_SLOPE;
+    }
+
+    // ========================================================================
     // Tanh: (e^x - e^(-x)) / (e^x + e^(-x))
     // ========================================================================
 
@@ -82,5 +112,19 @@ public final class ActivationFunctions {
     public static double tanhDerivative(double x) {
         double t = Math.tanh(x);
         return 1.0 - t * t;
+    }
+
+    // ========================================================================
+    // Softplus: log(1 + e^x)
+    // ========================================================================
+
+    /** Compute Softplus using a numerically stable log1p formulation. */
+    public static double softplus(double x) {
+        return Math.log1p(Math.exp(-Math.abs(x))) + Math.max(x, 0.0);
+    }
+
+    /** Derivative: sigmoid(x). */
+    public static double softplusDerivative(double x) {
+        return sigmoid(x);
     }
 }

--- a/code/packages/java/activation-functions/src/test/java/com/codingadventures/activationfunctions/ActivationFunctionsTest.java
+++ b/code/packages/java/activation-functions/src/test/java/com/codingadventures/activationfunctions/ActivationFunctionsTest.java
@@ -8,6 +8,19 @@ class ActivationFunctionsTest {
     private static final double EPS = 1e-10;
 
     // ========================================================================
+    // Linear Tests
+    // ========================================================================
+
+    @Test void linearNegative() { assertEquals(-3.0, ActivationFunctions.linear(-3.0), EPS); }
+    @Test void linearZero() { assertEquals(0.0, ActivationFunctions.linear(0.0), EPS); }
+    @Test void linearPositive() { assertEquals(5.0, ActivationFunctions.linear(5.0), EPS); }
+    @Test void linearDerivEverywhere() {
+        assertEquals(1.0, ActivationFunctions.linearDerivative(-3.0), EPS);
+        assertEquals(1.0, ActivationFunctions.linearDerivative(0.0), EPS);
+        assertEquals(1.0, ActivationFunctions.linearDerivative(5.0), EPS);
+    }
+
+    // ========================================================================
     // Sigmoid Tests
     // ========================================================================
 
@@ -80,6 +93,17 @@ class ActivationFunctionsTest {
     @Test void reluDerivZero() { assertEquals(0.0, ActivationFunctions.reluDerivative(0.0)); }
 
     // ========================================================================
+    // Leaky ReLU Tests
+    // ========================================================================
+
+    @Test void leakyReluPositive() { assertEquals(5.0, ActivationFunctions.leakyRelu(5.0), EPS); }
+    @Test void leakyReluNegative() { assertEquals(-0.03, ActivationFunctions.leakyRelu(-3.0), EPS); }
+    @Test void leakyReluZero() { assertEquals(0.0, ActivationFunctions.leakyRelu(0.0), EPS); }
+    @Test void leakyReluDerivPositive() { assertEquals(1.0, ActivationFunctions.leakyReluDerivative(5.0), EPS); }
+    @Test void leakyReluDerivNegative() { assertEquals(0.01, ActivationFunctions.leakyReluDerivative(-3.0), EPS); }
+    @Test void leakyReluDerivZero() { assertEquals(0.01, ActivationFunctions.leakyReluDerivative(0.0), EPS); }
+
+    // ========================================================================
     // Tanh Tests
     // ========================================================================
 
@@ -113,6 +137,20 @@ class ActivationFunctionsTest {
 
     @Test void tanhDerivAtZero() { assertEquals(1.0, ActivationFunctions.tanhDerivative(0.0), EPS); }
     @Test void tanhDerivAtOne() { assertEquals(0.4199743416140261, ActivationFunctions.tanhDerivative(1.0), EPS); }
+
+    // ========================================================================
+    // Softplus Tests
+    // ========================================================================
+
+    @Test void softplusAtZero() { assertEquals(0.6931471805599453, ActivationFunctions.softplus(0.0), EPS); }
+    @Test void softplusPositive() { assertEquals(1.3132616875182228, ActivationFunctions.softplus(1.0), EPS); }
+    @Test void softplusNegative() { assertEquals(0.31326168751822286, ActivationFunctions.softplus(-1.0), EPS); }
+    @Test void softplusLargePositiveStable() { assertTrue(ActivationFunctions.softplus(1000.0) > 999.0); }
+    @Test void softplusDerivativeEqualsSigmoid() {
+        assertEquals(0.5, ActivationFunctions.softplusDerivative(0.0), EPS);
+        assertEquals(ActivationFunctions.sigmoid(1.0), ActivationFunctions.softplusDerivative(1.0), EPS);
+        assertEquals(ActivationFunctions.sigmoid(-1.0), ActivationFunctions.softplusDerivative(-1.0), EPS);
+    }
 
     @Test
     void tanhDerivNonNegative() {

--- a/code/packages/kotlin/activation-functions/src/main/kotlin/com/codingadventures/activationfunctions/ActivationFunctions.kt
+++ b/code/packages/kotlin/activation-functions/src/main/kotlin/com/codingadventures/activationfunctions/ActivationFunctions.kt
@@ -21,6 +21,8 @@
 package com.codingadventures.activationfunctions
 
 import kotlin.math.exp
+import kotlin.math.abs
+import kotlin.math.ln1p
 import kotlin.math.max
 import kotlin.math.tanh
 
@@ -30,6 +32,17 @@ import kotlin.math.tanh
  * All functions are pure, stateless scalar operations.
  */
 object ActivationFunctions {
+    private const val LEAKY_RELU_SLOPE = 0.01
+
+    // ========================================================================
+    // Linear: x
+    // ========================================================================
+
+    /** Return the input unchanged. */
+    fun linear(x: Double): Double = x
+
+    /** Derivative of linear activation: 1 everywhere. */
+    fun linearDerivative(x: Double): Double = 1.0
 
     // ========================================================================
     // Sigmoid: σ(x) = 1 / (1 + e^(-x))
@@ -59,6 +72,16 @@ object ActivationFunctions {
     fun reluDerivative(x: Double): Double = if (x > 0.0) 1.0 else 0.0
 
     // ========================================================================
+    // Leaky ReLU: x if x > 0, otherwise 0.01x
+    // ========================================================================
+
+    /** Compute Leaky ReLU with the spec default negative slope of 0.01. */
+    fun leakyRelu(x: Double): Double = if (x > 0.0) x else LEAKY_RELU_SLOPE * x
+
+    /** Derivative: 1 if x > 0, 0.01 otherwise. */
+    fun leakyReluDerivative(x: Double): Double = if (x > 0.0) 1.0 else LEAKY_RELU_SLOPE
+
+    // ========================================================================
     // Tanh: (e^x - e^(-x)) / (e^x + e^(-x))
     // ========================================================================
 
@@ -70,4 +93,14 @@ object ActivationFunctions {
         val t = kotlin.math.tanh(x)
         return 1.0 - t * t
     }
+
+    // ========================================================================
+    // Softplus: log(1 + e^x)
+    // ========================================================================
+
+    /** Compute Softplus using a numerically stable log1p formulation. */
+    fun softplus(x: Double): Double = ln1p(exp(-abs(x))) + max(x, 0.0)
+
+    /** Derivative: sigmoid(x). */
+    fun softplusDerivative(x: Double): Double = sigmoid(x)
 }

--- a/code/packages/kotlin/activation-functions/src/test/kotlin/com/codingadventures/activationfunctions/ActivationFunctionsTest.kt
+++ b/code/packages/kotlin/activation-functions/src/test/kotlin/com/codingadventures/activationfunctions/ActivationFunctionsTest.kt
@@ -9,6 +9,19 @@ class ActivationFunctionsTest {
     private val eps = 1e-10
 
     // ========================================================================
+    // Linear Tests
+    // ========================================================================
+
+    @Test fun `linear negative`() = assertEquals(-3.0, ActivationFunctions.linear(-3.0), eps)
+    @Test fun `linear zero`() = assertEquals(0.0, ActivationFunctions.linear(0.0), eps)
+    @Test fun `linear positive`() = assertEquals(5.0, ActivationFunctions.linear(5.0), eps)
+    @Test fun `linear deriv everywhere`() {
+        assertEquals(1.0, ActivationFunctions.linearDerivative(-3.0), eps)
+        assertEquals(1.0, ActivationFunctions.linearDerivative(0.0), eps)
+        assertEquals(1.0, ActivationFunctions.linearDerivative(5.0), eps)
+    }
+
+    // ========================================================================
     // Sigmoid Tests
     // ========================================================================
 
@@ -77,6 +90,17 @@ class ActivationFunctionsTest {
     @Test fun `relu deriv zero`() = assertEquals(0.0, ActivationFunctions.reluDerivative(0.0))
 
     // ========================================================================
+    // Leaky ReLU Tests
+    // ========================================================================
+
+    @Test fun `leaky relu positive`() = assertEquals(5.0, ActivationFunctions.leakyRelu(5.0), eps)
+    @Test fun `leaky relu negative`() = assertEquals(-0.03, ActivationFunctions.leakyRelu(-3.0), eps)
+    @Test fun `leaky relu zero`() = assertEquals(0.0, ActivationFunctions.leakyRelu(0.0), eps)
+    @Test fun `leaky relu deriv positive`() = assertEquals(1.0, ActivationFunctions.leakyReluDerivative(5.0), eps)
+    @Test fun `leaky relu deriv negative`() = assertEquals(0.01, ActivationFunctions.leakyReluDerivative(-3.0), eps)
+    @Test fun `leaky relu deriv zero`() = assertEquals(0.01, ActivationFunctions.leakyReluDerivative(0.0), eps)
+
+    // ========================================================================
     // Tanh Tests
     // ========================================================================
 
@@ -108,6 +132,20 @@ class ActivationFunctionsTest {
 
     @Test fun `tanh deriv at zero`() = assertEquals(1.0, ActivationFunctions.tanhDerivative(0.0), eps)
     @Test fun `tanh deriv at one`() = assertEquals(0.4199743416140261, ActivationFunctions.tanhDerivative(1.0), eps)
+
+    // ========================================================================
+    // Softplus Tests
+    // ========================================================================
+
+    @Test fun `softplus at zero`() = assertEquals(0.6931471805599453, ActivationFunctions.softplus(0.0), eps)
+    @Test fun `softplus positive`() = assertEquals(1.3132616875182228, ActivationFunctions.softplus(1.0), eps)
+    @Test fun `softplus negative`() = assertEquals(0.31326168751822286, ActivationFunctions.softplus(-1.0), eps)
+    @Test fun `softplus large positive stable`() = assertTrue(ActivationFunctions.softplus(1000.0) > 999.0)
+    @Test fun `softplus derivative equals sigmoid`() {
+        assertEquals(0.5, ActivationFunctions.softplusDerivative(0.0), eps)
+        assertEquals(ActivationFunctions.sigmoid(1.0), ActivationFunctions.softplusDerivative(1.0), eps)
+        assertEquals(ActivationFunctions.sigmoid(-1.0), ActivationFunctions.softplusDerivative(-1.0), eps)
+    }
 
     @Test
     fun `tanh deriv non-negative`() {

--- a/code/packages/lua/activation_functions/src/coding_adventures/activation_functions/init.lua
+++ b/code/packages/lua/activation_functions/src/coding_adventures/activation_functions/init.lua
@@ -57,6 +57,23 @@ local M = {}
 M.VERSION = "0.1.0"
 
 -- ============================================================================
+-- LINEAR and its derivative
+-- ============================================================================
+
+--- linear(x) -> x
+--
+-- Linear activation leaves the weighted sum unchanged. It is useful for
+-- regression output layers and for baseline visualizations.
+function M.linear(x)
+    return x
+end
+
+--- linear_derivative(x) -> 1
+function M.linear_derivative(_x)
+    return 1.0
+end
+
+-- ============================================================================
 -- SIGMOID and its derivative
 -- ============================================================================
 
@@ -293,6 +310,23 @@ function M.leaky_relu_derivative(x, alpha)
     else
         return alpha
     end
+end
+
+-- ============================================================================
+-- SOFTPLUS and its derivative
+-- ============================================================================
+
+--- softplus(x) -> log(1 + e^x)
+--
+-- Softplus is a smooth approximation of ReLU. The implementation uses the
+-- stable equivalent log(1 + e^(-abs(x))) + max(x, 0).
+function M.softplus(x)
+    return math.log(1.0 + math.exp(-math.abs(x))) + math.max(x, 0.0)
+end
+
+--- softplus_derivative(x) -> sigmoid(x)
+function M.softplus_derivative(x)
+    return M.sigmoid(x)
 end
 
 -- ============================================================================

--- a/code/packages/lua/activation_functions/tests/test_activation_functions.lua
+++ b/code/packages/lua/activation_functions/tests/test_activation_functions.lua
@@ -66,6 +66,26 @@ local function fd_derivative(f, x, h)
 end
 
 -- ============================================================================
+-- LINEAR
+-- ============================================================================
+
+describe("linear", function()
+    it("returns the input unchanged", function()
+        assert.is_true(near(af.linear(-3), -3.0))
+        assert.is_true(near(af.linear(0), 0.0))
+        assert.is_true(near(af.linear(5), 5.0))
+    end)
+end)
+
+describe("linear_derivative", function()
+    it("returns 1 everywhere", function()
+        for _, x in ipairs({-3, 0, 5}) do
+            assert.is_true(near(af.linear_derivative(x), 1.0))
+        end
+    end)
+end)
+
+-- ============================================================================
 -- SIGMOID
 -- ============================================================================
 
@@ -294,6 +314,39 @@ describe("leaky_relu_derivative", function()
         local analytical = af.leaky_relu_derivative(2)
         local numerical  = fd_derivative(f, 2)
         assert.is_true(near(analytical, numerical, 1e-4))
+    end)
+end)
+
+-- ============================================================================
+-- SOFTPLUS
+-- ============================================================================
+
+describe("softplus", function()
+    it("returns log(2) at x=0", function()
+        assert.is_true(near(af.softplus(0), math.log(2.0)))
+    end)
+
+    it("matches golden values", function()
+        assert.is_true(near(af.softplus(1), 1.3132616875182228, 1e-9))
+        assert.is_true(near(af.softplus(-1), 0.31326168751822286, 1e-9))
+    end)
+
+    it("stays stable for large positive values", function()
+        assert.is_true(af.softplus(1000) > 999.0)
+    end)
+end)
+
+describe("softplus_derivative", function()
+    it("equals sigmoid", function()
+        for _, x in ipairs({-1, 0, 1}) do
+            assert.is_true(near(af.softplus_derivative(x), af.sigmoid(x)))
+        end
+    end)
+
+    it("matches finite-difference approximation at x=1", function()
+        local analytical = af.softplus_derivative(1)
+        local numerical = fd_derivative(af.softplus, 1)
+        assert.is_true(near(analytical, numerical, 1e-5))
     end)
 end)
 

--- a/code/packages/perl/activation-functions/lib/CodingAdventures/ActivationFunctions.pm
+++ b/code/packages/perl/activation-functions/lib/CodingAdventures/ActivationFunctions.pm
@@ -19,6 +19,8 @@ package CodingAdventures::ActivationFunctions;
 #
 #   | Function              | Range        | Typical Use                      |
 #   |-----------------------|-------------|----------------------------------|
+#   | linear                | (-∞, ∞)      | Regression output baseline       |
+#   | linear_derivative     | {1}          | Backprop through linear          |
 #   | sigmoid               | (0, 1)       | Binary classification output     |
 #   | sigmoid_derivative    | (0, 0.25]    | Backprop through sigmoid         |
 #   | relu                  | [0, ∞)       | Default hidden layer activation  |
@@ -27,6 +29,8 @@ package CodingAdventures::ActivationFunctions;
 #   | tanh_derivative       | (0, 1]       | Backprop through tanh            |
 #   | leaky_relu            | (-∞, ∞)      | Fixes "dying ReLU" problem       |
 #   | leaky_relu_derivative | {α, 1}       | Backprop through leaky_relu      |
+#   | softplus              | (0, ∞)       | Smooth alternative to ReLU       |
+#   | softplus_derivative   | (0, 1)       | Backprop through softplus        |
 #   | elu                   | (-α, ∞)      | Smooth, saturating alternative   |
 #   | elu_derivative        | (0, 1]       | Backprop through elu             |
 #   | softmax               | (0,1)^n      | Multi-class output probabilities |
@@ -56,6 +60,7 @@ package CodingAdventures::ActivationFunctions;
 #       relu relu_derivative
 #       tanh_activation tanh_derivative
 #       leaky_relu leaky_relu_derivative
+#       softplus softplus_derivative
 #       elu elu_derivative
 #       softmax softmax_derivative
 #   );
@@ -74,13 +79,31 @@ our $VERSION = '0.01';
 
 use parent 'Exporter';
 our @EXPORT_OK = qw(
+    linear              linear_derivative
     sigmoid             sigmoid_derivative
     relu                relu_derivative
     tanh_activation     tanh_derivative
     leaky_relu          leaky_relu_derivative
+    softplus            softplus_derivative
     elu                 elu_derivative
     softmax             softmax_derivative
 );
+
+# ============================================================================
+# LINEAR
+# ============================================================================
+
+# linear($x) — identity activation for regression outputs.
+sub linear {
+    my ($x) = @_;
+    return 0.0 + $x;
+}
+
+# linear_derivative($x) — constant slope of the identity function.
+sub linear_derivative {
+    my ($x) = @_;
+    return 1.0;
+}
 
 # ============================================================================
 # SIGMOID
@@ -253,6 +276,24 @@ sub leaky_relu_derivative {
 }
 
 # ============================================================================
+# SOFTPLUS
+# ============================================================================
+
+# softplus($x) — smooth ReLU approximation: log(1 + e^x)
+#
+# Uses the stable equivalent log(1 + e^(-abs(x))) + max(x, 0).
+sub softplus {
+    my ($x) = @_;
+    return log(1.0 + exp(-abs($x))) + ($x > 0 ? $x : 0.0);
+}
+
+# softplus_derivative($x) — derivative of softplus is sigmoid.
+sub softplus_derivative {
+    my ($x) = @_;
+    return sigmoid($x);
+}
+
+# ============================================================================
 # ELU
 # ============================================================================
 
@@ -389,10 +430,12 @@ CodingAdventures::ActivationFunctions - Neural network activation functions
 =head1 SYNOPSIS
 
     use CodingAdventures::ActivationFunctions qw(
+        linear linear_derivative
         sigmoid sigmoid_derivative
         relu relu_derivative
         tanh_activation tanh_derivative
         leaky_relu leaky_relu_derivative
+        softplus softplus_derivative
         elu elu_derivative
         softmax softmax_derivative
     );

--- a/code/packages/perl/activation-functions/t/01-basic.t
+++ b/code/packages/perl/activation-functions/t/01-basic.t
@@ -4,10 +4,12 @@ use Test2::V0;
 use POSIX qw();
 
 use CodingAdventures::ActivationFunctions qw(
+    linear              linear_derivative
     sigmoid             sigmoid_derivative
     relu                relu_derivative
     tanh_activation     tanh_derivative
     leaky_relu          leaky_relu_derivative
+    softplus            softplus_derivative
     elu                 elu_derivative
     softmax             softmax_derivative
 );
@@ -44,6 +46,22 @@ sub array_sum {
     $s += $_ for @_;
     return $s;
 }
+
+# ===========================================================================
+# LINEAR
+# ===========================================================================
+
+subtest 'linear' => sub {
+    ok near(linear(-3), -3.0), 'linear(-3) = -3';
+    ok near(linear(0), 0.0), 'linear(0) = 0';
+    ok near(linear(5), 5.0), 'linear(5) = 5';
+};
+
+subtest 'linear_derivative' => sub {
+    for my $x (-3, 0, 5) {
+        ok near(linear_derivative($x), 1.0), "linear_derivative($x) = 1";
+    }
+};
 
 # ===========================================================================
 # SIGMOID
@@ -166,6 +184,27 @@ subtest 'leaky_relu_derivative' => sub {
     my $fd = fd_deriv(sub { leaky_relu($_[0]) }, 2);
     ok near(leaky_relu_derivative(2), $fd, 1e-4),
         'matches finite difference at x=2';
+};
+
+# ===========================================================================
+# SOFTPLUS
+# ===========================================================================
+
+subtest 'softplus' => sub {
+    ok near(softplus(0), log(2.0)), 'softplus(0) = log(2)';
+    ok near(softplus(1), 1.3132616875182228), 'softplus(1) golden value';
+    ok near(softplus(-1), 0.31326168751822286), 'softplus(-1) golden value';
+    ok softplus(1000) > 999.0, 'softplus remains stable for large positives';
+};
+
+subtest 'softplus_derivative' => sub {
+    ok near(softplus_derivative(0), 0.5), 'softplus_derivative(0) = 0.5';
+    ok near(softplus_derivative(1), sigmoid(1)), 'softplus derivative equals sigmoid at x=1';
+    ok near(softplus_derivative(-1), sigmoid(-1)), 'softplus derivative equals sigmoid at x=-1';
+
+    my $fd = fd_deriv(\&softplus, 1);
+    ok near(softplus_derivative(1), $fd, 1e-5),
+        'matches finite difference at x=1';
 };
 
 # ===========================================================================

--- a/code/packages/python/activation-functions/src/activation_functions/__init__.py
+++ b/code/packages/python/activation-functions/src/activation_functions/__init__.py
@@ -1,11 +1,17 @@
 from .activations import (
+    linear, linear_derivative,
     sigmoid, sigmoid_derivative,
     relu, relu_derivative,
-    tanh_func, tanh_derivative
+    leaky_relu, leaky_relu_derivative,
+    tanh_func, tanh_derivative,
+    softplus, softplus_derivative
 )
 
 __all__ = [
+    "linear", "linear_derivative",
     "sigmoid", "sigmoid_derivative",
     "relu", "relu_derivative",
-    "tanh_func", "tanh_derivative"
+    "leaky_relu", "leaky_relu_derivative",
+    "tanh_func", "tanh_derivative",
+    "softplus", "softplus_derivative"
 ]

--- a/code/packages/python/activation-functions/src/activation_functions/activations.py
+++ b/code/packages/python/activation-functions/src/activation_functions/activations.py
@@ -1,5 +1,14 @@
 import math
 
+LEAKY_RELU_SLOPE = 0.01
+
+def linear(x: float) -> float:
+    """Return the raw weighted sum unchanged."""
+    return float(x)
+
+def linear_derivative(x: float) -> float:
+    return 1.0
+
 def sigmoid(x: float) -> float:
     """Clamps numbers beautifully between 0.0 and 1.0 for Absolute Probabilities."""
     if x < -709: return 0.0
@@ -18,6 +27,13 @@ def relu(x: float) -> float:
 def relu_derivative(x: float) -> float:
     return 1.0 if x > 0 else 0.0
 
+def leaky_relu(x: float) -> float:
+    """Keep a small negative slope so inactive ReLU neurons can still learn."""
+    return float(x) if x > 0 else LEAKY_RELU_SLOPE * float(x)
+
+def leaky_relu_derivative(x: float) -> float:
+    return 1.0 if x > 0 else LEAKY_RELU_SLOPE
+
 def tanh_func(x: float) -> float:
     """Bounds structures cleanly between -1.0 and 1.0"""
     return math.tanh(x)
@@ -26,3 +42,10 @@ def tanh_derivative(x: float) -> float:
     """Structurally calculates to 1.0 - cached² flawlessly."""
     t = math.tanh(x)
     return 1.0 - (t * t)
+
+def softplus(x: float) -> float:
+    """Smooth ReLU using a numerically stable log1p formulation."""
+    return math.log1p(math.exp(-abs(x))) + max(float(x), 0.0)
+
+def softplus_derivative(x: float) -> float:
+    return sigmoid(x)

--- a/code/packages/ruby/activation-functions/lib/activation_functions.rb
+++ b/code/packages/ruby/activation-functions/lib/activation_functions.rb
@@ -1,4 +1,14 @@
 module ActivationFunctions
+  LEAKY_RELU_SLOPE = 0.01
+
+  def self.linear(x)
+    x.to_f
+  end
+
+  def self.linear_derivative(_x)
+    1.0
+  end
+
   # Sigmoid dynamically bounds matrix evaluations cleanly between 0.0 layout and 1.0 limits.
   def self.sigmoid(x)
     return 0.0 if x < -709
@@ -20,6 +30,14 @@ module ActivationFunctions
     x > 0 ? 1.0 : 0.0
   end
 
+  def self.leaky_relu(x)
+    x > 0 ? x.to_f : LEAKY_RELU_SLOPE * x
+  end
+
+  def self.leaky_relu_derivative(x)
+    x > 0 ? 1.0 : LEAKY_RELU_SLOPE
+  end
+
   # Tanh bends negative vectors elegantly towards -1 boundaries.
   def self.tanh_func(x)
     Math.tanh(x)
@@ -28,5 +46,13 @@ module ActivationFunctions
   def self.tanh_derivative(x)
     t = Math.tanh(x)
     1.0 - (t * t)
+  end
+
+  def self.softplus(x)
+    Math.log(1.0 + Math.exp(-x.abs)) + [x.to_f, 0.0].max
+  end
+
+  def self.softplus_derivative(x)
+    sigmoid(x)
   end
 end

--- a/code/packages/rust/activation-functions/src/lib.rs
+++ b/code/packages/rust/activation-functions/src/lib.rs
@@ -1,5 +1,15 @@
 //! Mathematical Activation boundaries for strict structural inference natively.
 
+const LEAKY_RELU_SLOPE: f64 = 0.01;
+
+pub fn linear(x: f64) -> f64 {
+    x
+}
+
+pub fn linear_derivative(_x: f64) -> f64 {
+    1.0
+}
+
 pub fn sigmoid(x: f64) -> f64 {
     if x < -709.0 { return 0.0; }
     if x > 709.0 { return 1.0; }
@@ -19,6 +29,14 @@ pub fn relu_derivative(x: f64) -> f64 {
     if x > 0.0 { 1.0 } else { 0.0 }
 }
 
+pub fn leaky_relu(x: f64) -> f64 {
+    if x > 0.0 { x } else { LEAKY_RELU_SLOPE * x }
+}
+
+pub fn leaky_relu_derivative(x: f64) -> f64 {
+    if x > 0.0 { 1.0 } else { LEAKY_RELU_SLOPE }
+}
+
 pub fn tanh(x: f64) -> f64 {
     x.tanh()
 }
@@ -26,4 +44,86 @@ pub fn tanh(x: f64) -> f64 {
 pub fn tanh_derivative(x: f64) -> f64 {
     let t = x.tanh();
     1.0 - (t * t)
+}
+
+pub fn softplus(x: f64) -> f64 {
+    (-x.abs()).exp().ln_1p() + x.max(0.0)
+}
+
+pub fn softplus_derivative(x: f64) -> f64 {
+    sigmoid(x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(expected: f64, actual: f64) {
+        assert!(
+            (expected - actual).abs() <= 1e-12,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn linear_matches_identity() {
+        assert_close(-3.0, linear(-3.0));
+        assert_close(0.0, linear(0.0));
+        assert_close(5.0, linear(5.0));
+        assert_close(1.0, linear_derivative(-3.0));
+        assert_close(1.0, linear_derivative(0.0));
+        assert_close(1.0, linear_derivative(5.0));
+    }
+
+    #[test]
+    fn sigmoid_matches_reference_values() {
+        assert_close(0.5, sigmoid(0.0));
+        assert_close(0.7310585786300049, sigmoid(1.0));
+        assert_close(0.2689414213699951, sigmoid(-1.0));
+        assert_close(0.9999546021312976, sigmoid(10.0));
+        assert_close(0.0, sigmoid(-710.0));
+        assert_close(1.0, sigmoid(710.0));
+        assert_close(0.25, sigmoid_derivative(0.0));
+        assert_close(0.19661193324148185, sigmoid_derivative(1.0));
+    }
+
+    #[test]
+    fn relu_matches_piecewise_definition() {
+        assert_close(5.0, relu(5.0));
+        assert_close(0.0, relu(-3.0));
+        assert_close(0.0, relu(0.0));
+        assert_close(1.0, relu_derivative(5.0));
+        assert_close(0.0, relu_derivative(-3.0));
+        assert_close(0.0, relu_derivative(0.0));
+    }
+
+    #[test]
+    fn leaky_relu_keeps_negative_slope() {
+        assert_close(5.0, leaky_relu(5.0));
+        assert_close(-0.03, leaky_relu(-3.0));
+        assert_close(0.0, leaky_relu(0.0));
+        assert_close(1.0, leaky_relu_derivative(5.0));
+        assert_close(0.01, leaky_relu_derivative(-3.0));
+        assert_close(0.01, leaky_relu_derivative(0.0));
+    }
+
+    #[test]
+    fn tanh_matches_reference_values() {
+        assert_close(0.0, tanh(0.0));
+        assert_close(0.7615941559557649, tanh(1.0));
+        assert_close(-0.7615941559557649, tanh(-1.0));
+        assert_close(1.0, tanh_derivative(0.0));
+        assert_close(0.41997434161402614, tanh_derivative(1.0));
+    }
+
+    #[test]
+    fn softplus_matches_reference_values() {
+        assert_close(0.6931471805599453, softplus(0.0));
+        assert_close(1.3132616875182228, softplus(1.0));
+        assert_close(0.31326168751822286, softplus(-1.0));
+        assert!(softplus(1000.0) > 999.0);
+        assert_close(0.5, softplus_derivative(0.0));
+        assert_close(sigmoid(1.0), softplus_derivative(1.0));
+        assert_close(sigmoid(-1.0), softplus_derivative(-1.0));
+    }
 }

--- a/code/packages/swift/activation-functions/Sources/ActivationFunctions/ActivationFunctions.swift
+++ b/code/packages/swift/activation-functions/Sources/ActivationFunctions/ActivationFunctions.swift
@@ -36,6 +36,21 @@ import Foundation
 /// All functions are pure, stateless scalar operations.
 public struct ActivationFunctions {
     private init() {}
+    private static let leakyReluSlope = 0.01
+
+    // ========================================================================
+    // MARK: - Linear
+    // ========================================================================
+
+    /// Return the input unchanged.
+    public static func linear(_ x: Double) -> Double {
+        return x
+    }
+
+    /// Derivative of linear activation: 1 everywhere.
+    public static func linearDerivative(_ x: Double) -> Double {
+        return 1.0
+    }
 
     // ========================================================================
     // MARK: - Sigmoid
@@ -112,6 +127,20 @@ public struct ActivationFunctions {
     }
 
     // ========================================================================
+    // MARK: - Leaky ReLU
+    // ========================================================================
+
+    /// Compute Leaky ReLU with the spec default negative slope of 0.01.
+    public static func leakyRelu(_ x: Double) -> Double {
+        return x > 0.0 ? x : leakyReluSlope * x
+    }
+
+    /// Derivative of Leaky ReLU: 1 if x > 0, 0.01 otherwise.
+    public static func leakyReluDerivative(_ x: Double) -> Double {
+        return x > 0.0 ? 1.0 : leakyReluSlope
+    }
+
+    // ========================================================================
     // MARK: - Tanh (Hyperbolic Tangent)
     // ========================================================================
     //
@@ -137,5 +166,19 @@ public struct ActivationFunctions {
     public static func tanhDerivative(_ x: Double) -> Double {
         let t = Foundation.tanh(x)
         return 1.0 - t * t
+    }
+
+    // ========================================================================
+    // MARK: - Softplus
+    // ========================================================================
+
+    /// Compute Softplus using a numerically stable log1p formulation.
+    public static func softplus(_ x: Double) -> Double {
+        return log1p(exp(-abs(x))) + max(x, 0.0)
+    }
+
+    /// Derivative of Softplus: sigmoid(x).
+    public static func softplusDerivative(_ x: Double) -> Double {
+        return sigmoid(x)
     }
 }

--- a/code/packages/swift/activation-functions/Tests/ActivationFunctionsTests/ActivationFunctionsTests.swift
+++ b/code/packages/swift/activation-functions/Tests/ActivationFunctionsTests/ActivationFunctionsTests.swift
@@ -6,6 +6,28 @@ final class ActivationFunctionsTests: XCTestCase {
     private let eps: Double = 1e-10
 
     // ========================================================================
+    // MARK: - Linear Tests
+    // ========================================================================
+
+    func testLinearNegative() {
+        XCTAssertEqual(ActivationFunctions.linear(-3.0), -3.0, accuracy: eps)
+    }
+
+    func testLinearZero() {
+        XCTAssertEqual(ActivationFunctions.linear(0.0), 0.0, accuracy: eps)
+    }
+
+    func testLinearPositive() {
+        XCTAssertEqual(ActivationFunctions.linear(5.0), 5.0, accuracy: eps)
+    }
+
+    func testLinearDerivativeEverywhere() {
+        XCTAssertEqual(ActivationFunctions.linearDerivative(-3.0), 1.0, accuracy: eps)
+        XCTAssertEqual(ActivationFunctions.linearDerivative(0.0), 1.0, accuracy: eps)
+        XCTAssertEqual(ActivationFunctions.linearDerivative(5.0), 1.0, accuracy: eps)
+    }
+
+    // ========================================================================
     // MARK: - Sigmoid Tests
     // ========================================================================
 
@@ -120,6 +142,34 @@ final class ActivationFunctionsTests: XCTestCase {
     }
 
     // ========================================================================
+    // MARK: - Leaky ReLU Tests
+    // ========================================================================
+
+    func testLeakyReluPositive() {
+        XCTAssertEqual(ActivationFunctions.leakyRelu(5.0), 5.0, accuracy: eps)
+    }
+
+    func testLeakyReluNegative() {
+        XCTAssertEqual(ActivationFunctions.leakyRelu(-3.0), -0.03, accuracy: eps)
+    }
+
+    func testLeakyReluZero() {
+        XCTAssertEqual(ActivationFunctions.leakyRelu(0.0), 0.0, accuracy: eps)
+    }
+
+    func testLeakyReluDerivativePositive() {
+        XCTAssertEqual(ActivationFunctions.leakyReluDerivative(5.0), 1.0, accuracy: eps)
+    }
+
+    func testLeakyReluDerivativeNegative() {
+        XCTAssertEqual(ActivationFunctions.leakyReluDerivative(-3.0), 0.01, accuracy: eps)
+    }
+
+    func testLeakyReluDerivativeZero() {
+        XCTAssertEqual(ActivationFunctions.leakyReluDerivative(0.0), 0.01, accuracy: eps)
+    }
+
+    // ========================================================================
     // MARK: - Tanh Tests
     // ========================================================================
 
@@ -173,5 +223,31 @@ final class ActivationFunctionsTests: XCTestCase {
         for x in values {
             XCTAssertGreaterThanOrEqual(ActivationFunctions.tanhDerivative(x), 0.0)
         }
+    }
+
+    // ========================================================================
+    // MARK: - Softplus Tests
+    // ========================================================================
+
+    func testSoftplusAtZero() {
+        XCTAssertEqual(ActivationFunctions.softplus(0.0), 0.6931471805599453, accuracy: eps)
+    }
+
+    func testSoftplusPositive() {
+        XCTAssertEqual(ActivationFunctions.softplus(1.0), 1.3132616875182228, accuracy: eps)
+    }
+
+    func testSoftplusNegative() {
+        XCTAssertEqual(ActivationFunctions.softplus(-1.0), 0.31326168751822286, accuracy: eps)
+    }
+
+    func testSoftplusLargePositiveStable() {
+        XCTAssertGreaterThan(ActivationFunctions.softplus(1000.0), 999.0)
+    }
+
+    func testSoftplusDerivativeEqualsSigmoid() {
+        XCTAssertEqual(ActivationFunctions.softplusDerivative(0.0), 0.5, accuracy: eps)
+        XCTAssertEqual(ActivationFunctions.softplusDerivative(1.0), ActivationFunctions.sigmoid(1.0), accuracy: eps)
+        XCTAssertEqual(ActivationFunctions.softplusDerivative(-1.0), ActivationFunctions.sigmoid(-1.0), accuracy: eps)
     }
 }

--- a/code/packages/typescript/activation-functions/src/activations.ts
+++ b/code/packages/typescript/activation-functions/src/activations.ts
@@ -2,6 +2,16 @@
  * Core mathematical limits bounding neural predictors natively.
  */
 
+const LEAKY_RELU_SLOPE = 0.01;
+
+export function linear(x: number): number {
+  return x;
+}
+
+export function linearDerivative(_x: number): number {
+  return 1.0;
+}
+
 export function sigmoid(x: number): number {
   if (x < -709) return 0.0;
   if (x > 709) return 1.0;
@@ -21,6 +31,14 @@ export function reluDerivative(x: number): number {
   return x > 0 ? 1.0 : 0.0;
 }
 
+export function leakyRelu(x: number): number {
+  return x > 0 ? x : LEAKY_RELU_SLOPE * x;
+}
+
+export function leakyReluDerivative(x: number): number {
+  return x > 0 ? 1.0 : LEAKY_RELU_SLOPE;
+}
+
 export function tanh(x: number): number {
   return Math.tanh(x);
 }
@@ -28,4 +46,12 @@ export function tanh(x: number): number {
 export function tanhDerivative(x: number): number {
   const t = Math.tanh(x);
   return 1.0 - (t * t);
+}
+
+export function softplus(x: number): number {
+  return Math.log1p(Math.exp(-Math.abs(x))) + Math.max(x, 0.0);
+}
+
+export function softplusDerivative(x: number): number {
+  return sigmoid(x);
 }

--- a/code/specs/ML04-activation-functions.md
+++ b/code/specs/ML04-activation-functions.md
@@ -17,17 +17,26 @@ Inputs → Linear Layer → [YOU ARE HERE] → Loss Functions (ML01)
 **Input from:** Raw scalar values (the pre-activation output of a linear layer).
 **Output to:** Transformed scalar values fed to the next layer or to a loss function.
 
-## Why These Three?
+## Why These Functions?
 
-Neural network literature has produced dozens of activation functions, but three dominate practice:
+Neural network literature has produced dozens of activation functions. This spec keeps the first teaching layer small while covering the functions learners will see immediately in real models:
 
 | Function | Range | Use Case | Why It Matters |
 |----------|-------|----------|----------------|
+| **Linear / Identity** | $(-\infty, \infty)$ | Regression outputs, baseline comparisons | Leaves the weighted sum unchanged |
 | **Sigmoid** | $(0, 1)$ | Output layer for binary classification | Maps any real number to a probability |
 | **ReLU** | $[0, \infty)$ | Hidden layers (default choice) | Computationally cheap, avoids vanishing gradients |
+| **Leaky ReLU** | $(-\infty, \infty)$ | Hidden layers when ReLU neurons go inactive | Keeps a small gradient for negative inputs |
 | **Tanh** | $(-1, 1)$ | Hidden layers, zero-centered data | Like sigmoid but centered at zero |
+| **Softplus** | $(0, \infty)$ | Smooth ReLU-like transformations | Differentiable everywhere and has sigmoid as its derivative |
 
-## The Three Activation Functions
+## The Activation Functions
+
+### Linear / Identity
+
+$$\text{Linear}(x) = x$$
+
+Linear activation is the identity function. It is useful for regression output layers where the model should predict any real-valued number, and it is also the clearest baseline for visualizers because it shows the raw weighted sum without any non-linear bend.
 
 ### Sigmoid
 
@@ -43,11 +52,25 @@ $$\text{ReLU}(x) = \max(0, x)$$
 
 ReLU is the simplest and most widely used activation function in modern deep learning. It passes positive values through unchanged and zeros out negative values. Despite its simplicity, it solves the vanishing gradient problem that plagued sigmoid/tanh in deep networks — the gradient is either 0 or 1, never a tiny fraction.
 
+### Leaky ReLU
+
+$$\text{LeakyReLU}(x) = \begin{cases} x & \text{if } x > 0 \\ 0.01x & \text{if } x \leq 0 \end{cases}$$
+
+Leaky ReLU keeps the positive side of ReLU but gives negative inputs a small slope. This reduces the "dying ReLU" problem, where a neuron receiving only negative pre-activations has a zero gradient and stops learning. The canonical default slope in this spec is `0.01`.
+
 ### Tanh (Hyperbolic Tangent)
 
 $$\tanh(x) = \frac{e^x - e^{-x}}{e^x + e^{-x}}$$
 
 Tanh is essentially a rescaled sigmoid: $\tanh(x) = 2\sigma(2x) - 1$. Its output is centered at zero (unlike sigmoid's centering at 0.5), which often leads to faster convergence during training because the gradients are better balanced.
+
+### Softplus
+
+$$\text{Softplus}(x) = \log(1 + e^x)$$
+
+Softplus is a smooth approximation of ReLU. For large positive inputs it behaves almost like $x$; for large negative inputs it approaches 0 without a hard kink. Implementations should use the numerically stable equivalent:
+
+$$\text{Softplus}(x) = \log(1 + e^{-|x|}) + \max(x, 0)$$
 
 ## Mathematical Derivatives
 
@@ -55,9 +78,12 @@ For backpropagation, implementations must provide the derivative of each activat
 
 | Function | Derivative Formula | Notes |
 |----------|-------------------|-------|
+| Linear' | $1$ | Constant slope everywhere |
 | Sigmoid' | $\sigma(x) \cdot (1 - \sigma(x))$ | Maximum value of 0.25 at $x = 0$ |
 | ReLU' | $\begin{cases} 1 & \text{if } x > 0 \\ 0 & \text{if } x \leq 0 \end{cases}$ | Technically undefined at $x = 0$; convention is 0 |
+| Leaky ReLU' | $\begin{cases} 1 & \text{if } x > 0 \\ 0.01 & \text{if } x \leq 0 \end{cases}$ | Keeps a small gradient on the negative side |
 | Tanh' | $1 - \tanh^2(x)$ | Maximum value of 1.0 at $x = 0$ |
+| Softplus' | $\sigma(x)$ | The slope is exactly sigmoid |
 
 ## Public API
 
@@ -69,11 +95,20 @@ For backpropagation, implementations must provide the derivative of each activat
 func Sigmoid(x: Float) -> Float
 func SigmoidDerivative(x: Float) -> Float
 
+func Linear(x: Float) -> Float
+func LinearDerivative(x: Float) -> Float
+
 func Relu(x: Float) -> Float
 func ReluDerivative(x: Float) -> Float
 
+func LeakyRelu(x: Float) -> Float
+func LeakyReluDerivative(x: Float) -> Float
+
 func Tanh(x: Float) -> Float
 func TanhDerivative(x: Float) -> Float
+
+func Softplus(x: Float) -> Float
+func SoftplusDerivative(x: Float) -> Float
 ```
 
 ## Data Flow & Constraints
@@ -82,13 +117,29 @@ func TanhDerivative(x: Float) -> Float
 2. All functions operate on **scalars** (single float values), not arrays.
 3. Sigmoid must handle overflow gracefully (clamp at $\pm 709$).
 4. ReLU derivative at exactly $x = 0$ returns `0.0` by convention.
-5. Implementations should use the language's native `exp` and `tanh` where available, unless the language philosophy is to build from first principles (e.g., using a custom `trig` package).
+5. Leaky ReLU uses a default negative slope of `0.01`; its derivative at exactly $x = 0$ returns `0.01` by convention.
+6. Softplus must use the stable formula `log1p(exp(-abs(x))) + max(x, 0)` where the language provides `log1p`.
+7. Implementations should use the language's native `exp` and `tanh` where available, unless the language philosophy is to build from first principles (e.g., using a custom `trig` package).
 
 ## Test Strategy
 
 Activation functions are tested for exact mathematical parity using hardcoded scalar inputs across all language implementations.
 
 ### Parity Test Vectors
+
+**Linear**
+| Input | Expected Output |
+|-------|----------------|
+| `-3.0` | `-3.0` |
+| `0.0` | `0.0` |
+| `5.0` | `5.0` |
+
+**Linear Derivative**
+| Input | Expected Output |
+|-------|----------------|
+| `-3.0` | `1.0` |
+| `0.0` | `1.0` |
+| `5.0` | `1.0` |
 
 **Sigmoid**
 | Input | Expected Output | Notes |
@@ -121,6 +172,20 @@ Activation functions are tested for exact mathematical parity using hardcoded sc
 | `-3.0` | `0.0` |
 | `0.0` | `0.0` |
 
+**Leaky ReLU**
+| Input | Expected Output |
+|-------|----------------|
+| `5.0` | `5.0` |
+| `-3.0` | `-0.03` |
+| `0.0` | `0.0` |
+
+**Leaky ReLU Derivative**
+| Input | Expected Output |
+|-------|----------------|
+| `5.0` | `1.0` |
+| `-3.0` | `0.01` |
+| `0.0` | `0.01` |
+
 **Tanh**
 | Input | Expected Output | Notes |
 |-------|----------------|-------|
@@ -134,6 +199,20 @@ Activation functions are tested for exact mathematical parity using hardcoded sc
 | `0.0` | `1.0` | Maximum derivative |
 | `1.0` | `0.4199743416140261` | |
 
+**Softplus**
+| Input | Expected Output | Notes |
+|-------|----------------|-------|
+| `0.0` | `0.6931471805599453` | $\log(2)$ |
+| `1.0` | `1.3132616875182228` | |
+| `-1.0` | `0.31326168751822286` | |
+
+**Softplus Derivative**
+| Input | Expected Output | Notes |
+|-------|----------------|-------|
+| `0.0` | `0.5` | Matches sigmoid |
+| `1.0` | `0.7310585786300049` | |
+| `-1.0` | `0.2689414213699951` | |
+
 ### Property-Based Tests
 
 In addition to parity vectors, implementations should verify these mathematical properties:
@@ -143,4 +222,5 @@ In addition to parity vectors, implementations should verify these mathematical 
 3. **ReLU idempotence:** $\text{ReLU}(\text{ReLU}(x)) = \text{ReLU}(x)$
 4. **Tanh odd symmetry:** $\tanh(-x) = -\tanh(x)$
 5. **Tanh range:** For any $x$, $-1 < \tanh(x) < 1$
-6. **All derivatives non-negative:** Sigmoid', ReLU', and Tanh' are all $\geq 0$
+6. **Softplus derivative identity:** $\text{Softplus}'(x) = \sigma(x)$
+7. **All derivatives non-negative:** Linear', Sigmoid', ReLU', Leaky ReLU', Tanh', and Softplus' are all $\geq 0$


### PR DESCRIPTION
## Summary

- Expands ML04 from sigmoid/ReLU/tanh to the teaching-lab scalar set: linear, sigmoid, ReLU, leaky ReLU, tanh, and softplus, each with derivatives.
- Implements the new functions across the existing activation-function packages: C#, Elixir, F#, Go, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript.
- Adds focused parity tests where the packages already have test suites, plus Go/Rust coverage, and adds a learning note for turning visual ML labs into executable cross-language programs.

## Why

The ML visualizer is starting to teach activation choices directly, so the repo primitives need to match that teaching surface. This also gives us a foundation for using visual examples as CI stress tests for activation functions, loss functions, gradient descent, and future ML primitives.

## Validation

- `go test ./...` in `code/packages/go/activation-functions`
- `cargo test` in `code/packages/rust/activation-functions`
- `dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.csproj --disable-build-servers` in `code/packages/csharp/activation-functions`
- `dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.fsproj --disable-build-servers` in `code/packages/fsharp/activation-functions`
- `gradle test` in `code/packages/java/activation-functions`
- `gradle test` in `code/packages/kotlin/activation-functions`
- `swift test` in `code/packages/swift/activation-functions`
- `prove -l -v t/` in `code/packages/perl/activation-functions`
- `busted . --verbose --pattern=test_` in `code/packages/lua/activation_functions/tests`
- Python activation smoke import/assertion script
- Ruby activation smoke import/assertion script
- `mix test` in `code/packages/elixir/activation_functions`
- `npm install --no-audit --no-fund --package-lock=false && npm run build` in `code/packages/typescript/activation-functions`

Note: the worktree contains pre-existing unrelated AVL edits; they were intentionally left unstaged and are not part of this PR.