### PR TITLE
feat(parity): add dotnet http1 packages

### DIFF
--- a/code/packages/csharp/http1/BUILD
+++ b/code/packages/csharp/http1/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/http1/BUILD_windows
+++ b/code/packages/csharp/http1/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/http1/CHANGELOG.md
+++ b/code/packages/csharp/http1/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# HTTP/1 request and response head parsing backed by shared HTTP core types.

--- a/code/packages/csharp/http1/CodingAdventures.Http1.csproj
+++ b/code/packages/csharp/http1/CodingAdventures.Http1.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Http1.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HTTP/1 request and response head parsing</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../http-core/CodingAdventures.HttpCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/http1/Http1.cs
+++ b/code/packages/csharp/http1/Http1.cs
@@ -1,0 +1,257 @@
+using System.Globalization;
+using System.Text;
+using CodingAdventures.HttpCore;
+
+namespace CodingAdventures.Http1;
+
+public static class Http1
+{
+    public const string Version = "0.1.0";
+
+    public static ParsedRequestHead ParseRequestHead(ReadOnlySpan<byte> input)
+    {
+        var (lines, bodyOffset) = SplitHeadLines(input);
+        if (lines.Count == 0)
+        {
+            throw Http1ParseException.InvalidStartLine(string.Empty);
+        }
+
+        var startLine = lines[0];
+        var parts = SplitWhitespace(startLine);
+        if (parts.Length != 3)
+        {
+            throw Http1ParseException.InvalidStartLine(startLine);
+        }
+
+        HttpVersion version;
+        try
+        {
+            version = HttpVersion.Parse(parts[2]);
+        }
+        catch (FormatException)
+        {
+            throw Http1ParseException.InvalidVersion(parts[2]);
+        }
+
+        var headers = ParseHeaders(lines.Skip(1));
+        var bodyKind = RequestBodyKind(headers);
+
+        return new ParsedRequestHead(
+            new RequestHead(parts[0], parts[1], version, headers),
+            bodyOffset,
+            bodyKind);
+    }
+
+    public static ParsedResponseHead ParseResponseHead(ReadOnlySpan<byte> input)
+    {
+        var (lines, bodyOffset) = SplitHeadLines(input);
+        if (lines.Count == 0)
+        {
+            throw Http1ParseException.InvalidStartLine(string.Empty);
+        }
+
+        var statusLine = lines[0];
+        var parts = SplitWhitespace(statusLine);
+        if (parts.Length < 2)
+        {
+            throw Http1ParseException.InvalidStartLine(statusLine);
+        }
+
+        HttpVersion version;
+        try
+        {
+            version = HttpVersion.Parse(parts[0]);
+        }
+        catch (FormatException)
+        {
+            throw Http1ParseException.InvalidVersion(parts[0]);
+        }
+
+        if (!ushort.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var status))
+        {
+            throw Http1ParseException.InvalidStatus(parts[1]);
+        }
+
+        var reason = parts.Length > 2 ? string.Join(" ", parts.Skip(2)) : string.Empty;
+        var headers = ParseHeaders(lines.Skip(1));
+        var bodyKind = ResponseBodyKind(status, headers);
+
+        return new ParsedResponseHead(
+            new ResponseHead(version, status, reason, headers),
+            bodyOffset,
+            bodyKind);
+    }
+
+    private static (List<string> Lines, int BodyOffset) SplitHeadLines(ReadOnlySpan<byte> input)
+    {
+        var index = 0;
+        while (index < input.Length)
+        {
+            if (input[index..].StartsWith("\r\n"u8))
+            {
+                index += 2;
+            }
+            else if (input[index] == (byte)'\n')
+            {
+                index += 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        var lines = new List<string>();
+        while (true)
+        {
+            if (index >= input.Length)
+            {
+                throw Http1ParseException.IncompleteHead();
+            }
+
+            var lineStart = index;
+            while (index < input.Length && input[index] != (byte)'\n')
+            {
+                index++;
+            }
+
+            if (index >= input.Length)
+            {
+                throw Http1ParseException.IncompleteHead();
+            }
+
+            var lineEnd = index > lineStart && input[index - 1] == (byte)'\r'
+                ? index - 1
+                : index;
+            var line = Encoding.Latin1.GetString(input[lineStart..lineEnd]);
+            index++;
+
+            if (line.Length == 0)
+            {
+                return (lines, index);
+            }
+
+            lines.Add(line);
+        }
+    }
+
+    private static IReadOnlyList<Header> ParseHeaders(IEnumerable<string> lines)
+    {
+        var headers = new List<Header>();
+        foreach (var line in lines)
+        {
+            var colon = line.IndexOf(':');
+            if (colon < 0)
+            {
+                throw Http1ParseException.InvalidHeader(line);
+            }
+
+            var name = line[..colon].Trim();
+            if (name.Length == 0)
+            {
+                throw Http1ParseException.InvalidHeader(line);
+            }
+
+            headers.Add(new Header(name, line[(colon + 1)..].Trim(' ', '\t')));
+        }
+
+        return headers;
+    }
+
+    private static BodyKind RequestBodyKind(IReadOnlyList<Header> headers)
+    {
+        if (HasChunkedTransferEncoding(headers))
+        {
+            return BodyKind.Chunked();
+        }
+
+        return DeclaredContentLength(headers) switch
+        {
+            null or 0 => BodyKind.None(),
+            var length => BodyKind.ContentLength(length.Value),
+        };
+    }
+
+    private static BodyKind ResponseBodyKind(ushort status, IReadOnlyList<Header> headers)
+    {
+        if ((status >= 100 && status < 200) || status is 204 or 304)
+        {
+            return BodyKind.None();
+        }
+
+        if (HasChunkedTransferEncoding(headers))
+        {
+            return BodyKind.Chunked();
+        }
+
+        return DeclaredContentLength(headers) switch
+        {
+            null => BodyKind.UntilEof(),
+            0 => BodyKind.None(),
+            var length => BodyKind.ContentLength(length.Value),
+        };
+    }
+
+    private static int? DeclaredContentLength(IEnumerable<Header> headers)
+    {
+        var value = headers
+            .FirstOrDefault(header => header.Name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var length) || length < 0)
+        {
+            throw Http1ParseException.InvalidContentLength(value);
+        }
+
+        return length;
+    }
+
+    private static bool HasChunkedTransferEncoding(IEnumerable<Header> headers)
+    {
+        return headers
+            .Where(header => header.Name.Equals("Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(header => header.Value.Split(','))
+            .Any(piece => piece.Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] SplitWhitespace(string value)
+    {
+        return value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+    }
+}
+
+public sealed record ParsedRequestHead(RequestHead Head, int BodyOffset, BodyKind BodyKind);
+
+public sealed record ParsedResponseHead(ResponseHead Head, int BodyOffset, BodyKind BodyKind);
+
+public sealed class Http1ParseException : Exception
+{
+    private Http1ParseException(string kind, string message) : base(message)
+    {
+        Kind = kind;
+    }
+
+    public string Kind { get; }
+
+    internal static Http1ParseException IncompleteHead() =>
+        new("IncompleteHead", "incomplete HTTP/1 head");
+
+    internal static Http1ParseException InvalidStartLine(string line) =>
+        new("InvalidStartLine", $"invalid HTTP/1 start line: {line}");
+
+    internal static Http1ParseException InvalidHeader(string line) =>
+        new("InvalidHeader", $"invalid HTTP/1 header: {line}");
+
+    internal static Http1ParseException InvalidVersion(string value) =>
+        new("InvalidVersion", $"invalid HTTP version: {value}");
+
+    internal static Http1ParseException InvalidStatus(string value) =>
+        new("InvalidStatus", $"invalid HTTP status: {value}");
+
+    internal static Http1ParseException InvalidContentLength(string value) =>
+        new("InvalidContentLength", $"invalid Content-Length: {value}");
+}

--- a/code/packages/csharp/http1/README.md
+++ b/code/packages/csharp/http1/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Http1.CSharp
+
+HTTP/1 request and response head parsing for callers that consume the body bytes separately.

--- a/code/packages/csharp/http1/required_capabilities.json
+++ b/code/packages/csharp/http1/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/http1",
+  "capabilities": [],
+  "justification": "Pure parsing package and tests."
+}

--- a/code/packages/csharp/http1/tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.csproj
+++ b/code/packages/csharp/http1/tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Http1]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Http1.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/http1/tests/CodingAdventures.Http1.Tests/Http1Tests.cs
+++ b/code/packages/csharp/http1/tests/CodingAdventures.Http1.Tests/Http1Tests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using CodingAdventures.HttpCore;
+
+namespace CodingAdventures.Http1.Tests;
+
+public sealed class Http1Tests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Http1.Version);
+    }
+
+    [Fact]
+    public void ParseSimpleRequest()
+    {
+        var parsed = Http1.ParseRequestHead("GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"u8);
+
+        Assert.Equal("GET", parsed.Head.Method);
+        Assert.Equal("/", parsed.Head.Target);
+        Assert.Equal(new HttpVersion(1, 0), parsed.Head.Version);
+        Assert.Equal("example.com", parsed.Head.Headers[0].Value);
+        Assert.Equal(BodyKind.None(), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void ParsePostRequestWithContentLength()
+    {
+        var parsed = Http1.ParseRequestHead("POST /submit HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello"u8);
+
+        Assert.Equal(44, parsed.BodyOffset);
+        Assert.Equal(BodyKind.ContentLength(5), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void ChunkedTransferEncodingWinsForRequests()
+    {
+        var parsed = Http1.ParseRequestHead("POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\nContent-Length: 99\r\n\r\n"u8);
+
+        Assert.Equal(BodyKind.Chunked(), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void ParseResponseHead()
+    {
+        var parsed = Http1.ParseResponseHead("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody"u8);
+
+        Assert.Equal(200, parsed.Head.Status);
+        Assert.Equal("OK", parsed.Head.Reason);
+        Assert.Equal(BodyKind.ContentLength(4), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void ResponseWithoutLengthUsesUntilEof()
+    {
+        var parsed = Http1.ParseResponseHead("HTTP/1.0 200 OK\r\nServer: Venture\r\n\r\n"u8);
+
+        Assert.Equal(BodyKind.UntilEof(), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void BodylessStatusCodesIgnoreBodyHeaders()
+    {
+        var parsed = Http1.ParseResponseHead("HTTP/1.1 204 No Content\r\nContent-Length: 12\r\n\r\n"u8);
+
+        Assert.Equal(BodyKind.None(), parsed.BodyKind);
+    }
+
+    [Fact]
+    public void AcceptsLfOnlyAndPreservesDuplicateHeaders()
+    {
+        var parsed = Http1.ParseResponseHead("\nHTTP/1.1 200 OK\nSet-Cookie: a=1\nSet-Cookie: b=2\n\npayload"u8);
+
+        Assert.Equal(["a=1", "b=2"], parsed.Head.Headers.Select(header => header.Value));
+    }
+
+    [Fact]
+    public void DecodesHeaderValuesAsLatin1()
+    {
+        var bytes = Encoding.Latin1.GetBytes("GET / HTTP/1.1\r\nX-Name: café\r\n\r\n");
+        var parsed = Http1.ParseRequestHead(bytes);
+
+        Assert.Equal("café", parsed.Head.Headers[0].Value);
+    }
+
+    [Fact]
+    public void InvalidInputsRaiseParseExceptions()
+    {
+        AssertError("IncompleteHead", () => Http1.ParseRequestHead("GET / HTTP/1.1\r\nHost: example.com"u8));
+        AssertError("InvalidStartLine", () => Http1.ParseRequestHead("GET / too many HTTP/1.1\r\n\r\n"u8));
+        AssertError("InvalidHeader", () => Http1.ParseRequestHead("GET / HTTP/1.1\r\nHost example.com\r\n\r\n"u8));
+        AssertError("InvalidHeader", () => Http1.ParseRequestHead("GET / HTTP/1.1\r\n: nope\r\n\r\n"u8));
+        AssertError("InvalidVersion", () => Http1.ParseRequestHead("GET / NOPE\r\n\r\n"u8));
+        AssertError("InvalidVersion", () => Http1.ParseResponseHead("NOPE 200 OK\r\n\r\n"u8));
+        AssertError("InvalidStatus", () => Http1.ParseResponseHead("HTTP/1.1 NOPE OK\r\n\r\n"u8));
+        AssertError("InvalidContentLength", () => Http1.ParseResponseHead("HTTP/1.1 200 OK\r\nContent-Length: nope\r\n\r\n"u8));
+    }
+
+    private static void AssertError(string kind, Action action)
+    {
+        var error = Assert.Throws<Http1ParseException>(action);
+        Assert.Equal(kind, error.Kind);
+    }
+}

--- a/code/packages/fsharp/http1/BUILD
+++ b/code/packages/fsharp/http1/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/http1/BUILD_windows
+++ b/code/packages/fsharp/http1/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/http1/CHANGELOG.md
+++ b/code/packages/fsharp/http1/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# HTTP/1 request and response head parsing backed by shared HTTP core types.

--- a/code/packages/fsharp/http1/CodingAdventures.Http1.fsproj
+++ b/code/packages/fsharp/http1/CodingAdventures.Http1.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Http1.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Http1.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>HTTP/1 request and response head parsing</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../http-core/CodingAdventures.HttpCore.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Http1.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/http1/Http1.fs
+++ b/code/packages/fsharp/http1/Http1.fs
@@ -1,0 +1,211 @@
+namespace CodingAdventures.Http1.FSharp
+
+open System
+open System.Globalization
+open System.Text
+open CodingAdventures.HttpCore.FSharp
+
+exception Http1ParseException of string
+
+type ParsedRequestHead =
+    { Head: RequestHead
+      BodyOffset: int
+      BodyKind: BodyKind }
+
+type ParsedResponseHead =
+    { Head: ResponseHead
+      BodyOffset: int
+      BodyKind: BodyKind }
+
+module Http1 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private raiseParse message =
+        raise (Http1ParseException message)
+
+    let private startsWithAt (input: byte array) index (pattern: byte array) =
+        if index + pattern.Length > input.Length then
+            false
+        else
+            let mutable same = true
+            let mutable offset = 0
+            while offset < pattern.Length && same do
+                if input[index + offset] <> pattern[offset] then
+                    same <- false
+                offset <- offset + 1
+            same
+
+    let private splitHeadLines (input: byte array) =
+        let crlf = [| 13uy; 10uy |]
+        let mutable index = 0
+
+        while index < input.Length && (startsWithAt input index crlf || input[index] = 10uy) do
+            if startsWithAt input index crlf then
+                index <- index + 2
+            else
+                index <- index + 1
+
+        let lines = ResizeArray<string>()
+        let mutable finished = false
+        let mutable bodyOffset = 0
+
+        while not finished do
+            if index >= input.Length then
+                raiseParse "incomplete HTTP/1 head"
+
+            let lineStart = index
+
+            while index < input.Length && input[index] <> 10uy do
+                index <- index + 1
+
+            if index >= input.Length then
+                raiseParse "incomplete HTTP/1 head"
+
+            let lineEnd =
+                if index > lineStart && input[index - 1] = 13uy then
+                    index - 1
+                else
+                    index
+
+            let line = Encoding.Latin1.GetString(input, lineStart, lineEnd - lineStart)
+            index <- index + 1
+
+            if line.Length = 0 then
+                finished <- true
+                bodyOffset <- index
+            else
+                lines.Add(line)
+
+        List.ofSeq lines, bodyOffset
+
+    let private splitWhitespace (line: string) =
+        line.Split([| ' '; '\t' |], StringSplitOptions.RemoveEmptyEntries)
+
+    let private parseHeaders lines =
+        lines
+        |> List.map (fun (line: string) ->
+            let colon = line.IndexOf(':')
+
+            if colon < 0 then
+                raiseParse $"invalid HTTP/1 header: {line}"
+
+            let name = line.Substring(0, colon).Trim()
+
+            if name.Length = 0 then
+                raiseParse $"invalid HTTP/1 header: {line}"
+
+            { Name = name
+              Value = line.Substring(colon + 1).Trim([| ' '; '\t' |]) })
+
+    let private declaredContentLength headers =
+        headers
+        |> List.tryFind (fun header -> header.Name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+        |> Option.map (fun header ->
+            let mutable length = 0
+
+            if not (Int32.TryParse(header.Value, NumberStyles.None, CultureInfo.InvariantCulture, &length)) || length < 0 then
+                raiseParse $"invalid Content-Length: {header.Value}"
+
+            length)
+
+    let private hasChunkedTransferEncoding headers =
+        headers
+        |> List.filter (fun header -> header.Name.Equals("Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+        |> List.exists (fun header ->
+            header.Value.Split(',')
+            |> Array.exists (fun piece -> piece.Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase)))
+
+    let private requestBodyKind headers =
+        if hasChunkedTransferEncoding headers then
+            BodyKind.Chunked()
+        else
+            match declaredContentLength headers with
+            | None
+            | Some 0 -> BodyKind.None()
+            | Some length -> BodyKind.ContentLength length
+
+    let private responseBodyKind status headers =
+        if (status >= 100us && status < 200us) || status = 204us || status = 304us then
+            BodyKind.None()
+        elif hasChunkedTransferEncoding headers then
+            BodyKind.Chunked()
+        else
+            match declaredContentLength headers with
+            | None -> BodyKind.UntilEof()
+            | Some 0 -> BodyKind.None()
+            | Some length -> BodyKind.ContentLength length
+
+    let parseRequestHead (input: byte array) =
+        let lines, bodyOffset = splitHeadLines input
+
+        match lines with
+        | [] -> raiseParse "invalid HTTP/1 start line"
+        | startLine :: headerLines ->
+            let parts = splitWhitespace startLine
+
+            if parts.Length <> 3 then
+                raiseParse $"invalid HTTP/1 start line: {startLine}"
+
+            let version =
+                try
+                    HttpVersion.Parse(parts[2])
+                with :? FormatException ->
+                    raiseParse $"invalid HTTP version: {parts[2]}"
+
+            let headers = parseHeaders headerLines
+
+            let head: RequestHead =
+                { Method = parts[0]
+                  Target = parts[1]
+                  Version = version
+                  Headers = headers }
+
+            let result: ParsedRequestHead =
+                { Head = head
+                  BodyOffset = bodyOffset
+                  BodyKind = requestBodyKind headers }
+
+            result
+
+    let parseResponseHead (input: byte array) =
+        let lines, bodyOffset = splitHeadLines input
+
+        match lines with
+        | [] -> raiseParse "invalid HTTP/1 status line"
+        | statusLine :: headerLines ->
+            let parts = splitWhitespace statusLine
+
+            if parts.Length < 2 then
+                raiseParse $"invalid HTTP/1 status line: {statusLine}"
+
+            let version =
+                try
+                    HttpVersion.Parse(parts[0])
+                with :? FormatException ->
+                    raiseParse $"invalid HTTP version: {parts[0]}"
+
+            let mutable status = 0us
+            if not (UInt16.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, &status)) then
+                raiseParse $"invalid HTTP status: {parts[1]}"
+
+            let reason =
+                if parts.Length > 2 then
+                    String.Join(" ", parts[2..])
+                else
+                    String.Empty
+
+            let headers = parseHeaders headerLines
+
+            let head: ResponseHead =
+                { Version = version
+                  Status = status
+                  Reason = reason
+                  Headers = headers }
+
+            let result: ParsedResponseHead =
+                { Head = head
+                  BodyOffset = bodyOffset
+                  BodyKind = responseBodyKind status headers }
+
+            result

--- a/code/packages/fsharp/http1/README.md
+++ b/code/packages/fsharp/http1/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Http1.FSharp
+
+HTTP/1 request and response head parsing for callers that consume the body bytes separately.

--- a/code/packages/fsharp/http1/required_capabilities.json
+++ b/code/packages/fsharp/http1/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/http1",
+  "capabilities": [],
+  "justification": "Pure parsing package and tests."
+}

--- a/code/packages/fsharp/http1/tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.fsproj
+++ b/code/packages/fsharp/http1/tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Http1.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Http1.fsproj" />
+    <Compile Include="Http1Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/http1/tests/CodingAdventures.Http1.Tests/Http1Tests.fs
+++ b/code/packages/fsharp/http1/tests/CodingAdventures.Http1.Tests/Http1Tests.fs
@@ -1,0 +1,84 @@
+namespace CodingAdventures.Http1.Tests
+
+open System
+open System.Text
+open CodingAdventures.Http1.FSharp
+open CodingAdventures.HttpCore.FSharp
+open Xunit
+
+type Http1Tests() =
+    let bytes (text: string) = Encoding.Latin1.GetBytes(text)
+
+    [<Fact>]
+    member _.VersionExists() =
+        Assert.Equal("0.1.0", Http1.VERSION)
+
+    [<Fact>]
+    member _.ParseSimpleRequest() =
+        let parsed = Http1.parseRequestHead (bytes "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n")
+
+        Assert.Equal("GET", parsed.Head.Method)
+        Assert.Equal("/", parsed.Head.Target)
+        Assert.Equal({ Major = 1us; Minor = 0us }, parsed.Head.Version)
+        Assert.Equal("example.com", parsed.Head.Headers[0].Value)
+        Assert.Equal(BodyKind.None(), parsed.BodyKind)
+
+    [<Fact>]
+    member _.ParsePostRequestWithContentLength() =
+        let parsed = Http1.parseRequestHead (bytes "POST /submit HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+
+        Assert.Equal(44, parsed.BodyOffset)
+        Assert.Equal(BodyKind.ContentLength 5, parsed.BodyKind)
+
+    [<Fact>]
+    member _.ChunkedTransferEncodingWinsForRequests() =
+        let parsed =
+            Http1.parseRequestHead (bytes "POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\nContent-Length: 99\r\n\r\n")
+
+        Assert.Equal(BodyKind.Chunked(), parsed.BodyKind)
+
+    [<Fact>]
+    member _.ParseResponseHead() =
+        let parsed = Http1.parseResponseHead (bytes "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody")
+
+        Assert.Equal(200us, parsed.Head.Status)
+        Assert.Equal("OK", parsed.Head.Reason)
+        Assert.Equal(BodyKind.ContentLength 4, parsed.BodyKind)
+
+    [<Fact>]
+    member _.ResponseWithoutLengthUsesUntilEof() =
+        let parsed = Http1.parseResponseHead (bytes "HTTP/1.0 200 OK\r\nServer: Venture\r\n\r\n")
+
+        Assert.Equal(BodyKind.UntilEof(), parsed.BodyKind)
+
+    [<Fact>]
+    member _.BodylessStatusCodesIgnoreBodyHeaders() =
+        let parsed = Http1.parseResponseHead (bytes "HTTP/1.1 204 No Content\r\nContent-Length: 12\r\n\r\n")
+
+        Assert.Equal(BodyKind.None(), parsed.BodyKind)
+
+    [<Fact>]
+    member _.AcceptsLfOnlyAndPreservesDuplicateHeaders() =
+        let parsed = Http1.parseResponseHead (bytes "\nHTTP/1.1 200 OK\nSet-Cookie: a=1\nSet-Cookie: b=2\n\npayload")
+
+        Assert.Equal<string list>([ "a=1"; "b=2" ], parsed.Head.Headers |> List.map _.Value)
+
+    [<Fact>]
+    member _.DecodesHeaderValuesAsLatin1() =
+        let parsed = Http1.parseRequestHead (bytes "GET / HTTP/1.1\r\nX-Name: café\r\n\r\n")
+
+        Assert.Equal("café", parsed.Head.Headers[0].Value)
+
+    [<Fact>]
+    member _.InvalidInputsRaiseParseExceptions() =
+        let assertError thunk =
+            Assert.Throws<Http1ParseException>(fun () -> thunk () |> ignore) |> ignore
+
+        assertError (fun () -> Http1.parseRequestHead (bytes "GET / HTTP/1.1\r\nHost: example.com"))
+        assertError (fun () -> Http1.parseRequestHead (bytes "GET / too many HTTP/1.1\r\n\r\n"))
+        assertError (fun () -> Http1.parseRequestHead (bytes "GET / HTTP/1.1\r\nHost example.com\r\n\r\n"))
+        assertError (fun () -> Http1.parseRequestHead (bytes "GET / HTTP/1.1\r\n: nope\r\n\r\n"))
+        assertError (fun () -> Http1.parseRequestHead (bytes "GET / NOPE\r\n\r\n"))
+        assertError (fun () -> Http1.parseResponseHead (bytes "NOPE 200 OK\r\n\r\n"))
+        assertError (fun () -> Http1.parseResponseHead (bytes "HTTP/1.1 NOPE OK\r\n\r\n"))
+        assertError (fun () -> Http1.parseResponseHead (bytes "HTTP/1.1 200 OK\r\nContent-Length: nope\r\n\r\n"))


### PR DESCRIPTION
## Summary
- add C# and F# HTTP/1 packages on top of the shared HTTP core types
- parse request and response heads, preserve duplicate headers, compute body offsets, and classify bodies as none/content-length/chunked/until-eof
- add parser error coverage for incomplete heads, bad start lines, invalid headers, invalid versions/statuses, and invalid Content-Length values

## Verification
- dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Http1.Tests/CodingAdventures.Http1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line