### PR TITLE
feat(parity): add dotnet code39 packages

### DIFF
--- a/code/packages/csharp/code39/BUILD
+++ b/code/packages/csharp/code39/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/code39/BUILD_windows
+++ b/code/packages/csharp/code39/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/code39/CHANGELOG.md
+++ b/code/packages/csharp/code39/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# Code 39 normalization, encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/code39/Code39.cs
+++ b/code/packages/csharp/code39/Code39.cs
@@ -1,0 +1,143 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Code39;
+
+public static class Code39
+{
+    public const string Version = "0.1.0";
+
+    private static readonly IReadOnlyDictionary<string, string> Patterns = new Dictionary<string, string>
+    {
+        ["0"] = "bwbWBwBwb", ["1"] = "BwbWbwbwB", ["2"] = "bwBWbwbwB", ["3"] = "BwBWbwbwb",
+        ["4"] = "bwbWBwbwB", ["5"] = "BwbWBwbwb", ["6"] = "bwBWBwbwb", ["7"] = "bwbWbwBwB",
+        ["8"] = "BwbWbwBwb", ["9"] = "bwBWbwBwb", ["A"] = "BwbwbWbwB", ["B"] = "bwBwbWbwB",
+        ["C"] = "BwBwbWbwb", ["D"] = "bwbwBWbwB", ["E"] = "BwbwBWbwb", ["F"] = "bwBwBWbwb",
+        ["G"] = "bwbwbWBwB", ["H"] = "BwbwbWBwb", ["I"] = "bwBwbWBwb", ["J"] = "bwbwBWBwb",
+        ["K"] = "BwbwbwbWB", ["L"] = "bwBwbwbWB", ["M"] = "BwBwbwbWb", ["N"] = "bwbwBwbWB",
+        ["O"] = "BwbwBwbWb", ["P"] = "bwBwBwbWb", ["Q"] = "bwbwbwBWB", ["R"] = "BwbwbwBWb",
+        ["S"] = "bwBwbwBWb", ["T"] = "bwbwBwBWb", ["U"] = "BWbwbwbwB", ["V"] = "bWBwbwbwB",
+        ["W"] = "BWBwbwbwb", ["X"] = "bWbwBwbwB", ["Y"] = "BWbwBwbwb", ["Z"] = "bWBwBwbwb",
+        ["-"] = "bWbwbwBwB", ["."] = "BWbwbwBwb", [" "] = "bWBwbwBwb", ["$"] = "bWbWbWbwb",
+        ["/"] = "bWbWbwbWb", ["+"] = "bWbwbWbWb", ["%"] = "bwbWbWbWb", ["*"] = "bWbwBwBwb",
+    };
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string NormalizeCode39(string data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var normalized = data.ToUpperInvariant();
+        foreach (var ch in normalized)
+        {
+            var value = ch.ToString();
+            if (value == "*")
+            {
+                throw new InvalidCharacterException("input must not contain \"*\" because it is reserved for start/stop");
+            }
+
+            if (!Patterns.ContainsKey(value))
+            {
+                throw new InvalidCharacterException($"invalid character: \"{value}\" is not supported by Code 39");
+            }
+        }
+
+        return normalized;
+    }
+
+    public static EncodedCharacter EncodeCode39Char(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (!Patterns.TryGetValue(value, out var pattern))
+        {
+            throw new InvalidCharacterException($"invalid character: \"{value}\" is not supported by Code 39");
+        }
+
+        return new EncodedCharacter(value, value == "*", WidthPattern(pattern));
+    }
+
+    public static IReadOnlyList<EncodedCharacter> EncodeCode39(string data)
+    {
+        var normalized = NormalizeCode39(data);
+        return $"*{normalized}*"
+            .Select(ch => EncodeCode39Char(ch.ToString()))
+            .ToArray();
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandCode39Runs(string data)
+    {
+        var encoded = EncodeCode39(data);
+        var runs = new List<Barcode1DRun>();
+
+        for (var sourceIndex = 0; sourceIndex < encoded.Count; sourceIndex++)
+        {
+            var encodedChar = encoded[sourceIndex];
+            var role = RunRoleFor(sourceIndex, encoded.Count, encodedChar);
+            foreach (var run in BarcodeLayout1D.BarcodeLayout1D.RunsFromWidthPattern(
+                         encodedChar.Pattern,
+                         new RunsFromWidthPatternOptions(encodedChar.Char, sourceIndex, role)))
+            {
+                runs.Add(run);
+            }
+
+            if (sourceIndex < encoded.Count - 1)
+            {
+                runs.Add(new Barcode1DRun(
+                    Barcode1DRunColor.Space,
+                    1,
+                    encodedChar.Char,
+                    sourceIndex,
+                    Barcode1DRunRole.InterCharacterGap));
+            }
+        }
+
+        return runs;
+    }
+
+    public static PaintScene LayoutCode39(string data, PaintBarcode1DOptions? options = null)
+    {
+        var normalized = NormalizeCode39(data);
+        var runs = ExpandCode39Runs(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "code39",
+            ["encodedText"] = normalized,
+        };
+
+        var layoutOptions = options with
+        {
+            Label = options.Label ?? (normalized.Length == 0 ? "Code 39 barcode" : $"Code 39 barcode for {normalized}"),
+            HumanReadableText = options.HumanReadableText ?? normalized,
+            Metadata = metadata,
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(runs, layoutOptions);
+    }
+
+    public static PaintScene DrawCode39(string data, PaintBarcode1DOptions? options = null) =>
+        LayoutCode39(data, options);
+
+    private static string WidthPattern(string pattern) =>
+        new(pattern.Select(part => char.IsUpper(part) ? 'W' : 'N').ToArray());
+
+    private static Barcode1DRunRole RunRoleFor(int sourceIndex, int encodedLength, EncodedCharacter encodedCharacter)
+    {
+        if (!encodedCharacter.IsStartStop)
+        {
+            return Barcode1DRunRole.Data;
+        }
+
+        if (sourceIndex == 0)
+        {
+            return Barcode1DRunRole.Start;
+        }
+
+        return sourceIndex == encodedLength - 1 ? Barcode1DRunRole.Stop : Barcode1DRunRole.Guard;
+    }
+}
+
+public sealed record EncodedCharacter(string Char, bool IsStartStop, string Pattern);
+
+public sealed class InvalidCharacterException(string message) : ArgumentException(message);

--- a/code/packages/csharp/code39/CodingAdventures.Code39.csproj
+++ b/code/packages/csharp/code39/CodingAdventures.Code39.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Code39.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Code 39 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/code39/README.md
+++ b/code/packages/csharp/code39/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Code39.CSharp
+
+Code 39 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/code39/required_capabilities.json
+++ b/code/packages/csharp/code39/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/code39",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/code39/tests/CodingAdventures.Code39.Tests/Code39Tests.cs
+++ b/code/packages/csharp/code39/tests/CodingAdventures.Code39.Tests/Code39Tests.cs
@@ -1,0 +1,68 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Code39.Tests;
+
+public sealed class Code39Tests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Code39.Version);
+    }
+
+    [Fact]
+    public void NormalizesSupportedInput()
+    {
+        Assert.Equal("ABC-123", Code39.NormalizeCode39("abc-123"));
+    }
+
+    [Fact]
+    public void EncodesCharacterAndFullSequence()
+    {
+        var encoded = Code39.EncodeCode39Char("A");
+
+        Assert.Equal("WNNNNWNNW", encoded.Pattern);
+        Assert.False(encoded.IsStartStop);
+        Assert.Equal(["*", "A", "*"], Code39.EncodeCode39("A").Select(item => item.Char));
+    }
+
+    [Fact]
+    public void ExpandRunsIncludesStartStopAndInterCharacterGaps()
+    {
+        var runs = Code39.ExpandCode39Runs("A");
+
+        Assert.Equal(29, runs.Count);
+        Assert.Equal(Barcode1DRunColor.Bar, runs[0].Color);
+        Assert.Equal(Barcode1DRunRole.Start, runs[0].Role);
+        Assert.Equal(Barcode1DRunRole.InterCharacterGap, runs[9].Role);
+        Assert.Equal(3u, runs[10].Modules);
+        Assert.Equal(Barcode1DRunRole.Stop, runs[^1].Role);
+    }
+
+    [Fact]
+    public void LayoutCode39BuildsPaintSceneMetadata()
+    {
+        var scene = Code39.DrawCode39("A");
+
+        Assert.Equal("code39", scene.Metadata?["symbology"]);
+        Assert.Equal("A", scene.Metadata?["encodedText"]);
+        Assert.Equal("Code 39 barcode for A", scene.Metadata?["label"]);
+        Assert.True(scene.Width > 0);
+        Assert.Equal(Code39.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Fact]
+    public void InvalidInputsAndConfigsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => Code39.NormalizeCode39(null!));
+        Assert.Throws<InvalidCharacterException>(() => Code39.NormalizeCode39("*"));
+        Assert.Throws<InvalidCharacterException>(() => Code39.NormalizeCode39("~"));
+        Assert.Throws<InvalidCharacterException>(() => Code39.EncodeCode39Char("~"));
+
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+        Assert.Throws<ArgumentException>(() => Code39.LayoutCode39("A", badOptions));
+    }
+}

--- a/code/packages/csharp/code39/tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.csproj
+++ b/code/packages/csharp/code39/tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Code39]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Code39.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/code39/BUILD
+++ b/code/packages/fsharp/code39/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/code39/BUILD_windows
+++ b/code/packages/fsharp/code39/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/code39/CHANGELOG.md
+++ b/code/packages/fsharp/code39/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# Code 39 normalization, encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/code39/Code39.fs
+++ b/code/packages/fsharp/code39/Code39.fs
@@ -1,0 +1,134 @@
+namespace CodingAdventures.Code39.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidCharacterException of string
+
+type EncodedCharacter =
+    { Char: string
+      IsStartStop: bool
+      Pattern: string }
+
+[<RequireQualifiedAccess>]
+module Code39 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let patterns =
+        Map.ofList [
+            "0", "bwbWBwBwb"; "1", "BwbWbwbwB"; "2", "bwBWbwbwB"; "3", "BwBWbwbwb"
+            "4", "bwbWBwbwB"; "5", "BwbWBwbwb"; "6", "bwBWBwbwb"; "7", "bwbWbwBwB"
+            "8", "BwbWbwBwb"; "9", "bwBWbwBwb"; "A", "BwbwbWbwB"; "B", "bwBwbWbwB"
+            "C", "BwBwbWbwb"; "D", "bwbwBWbwB"; "E", "BwbwBWbwb"; "F", "bwBwBWbwb"
+            "G", "bwbwbWBwB"; "H", "BwbwbWBwb"; "I", "bwBwbWBwb"; "J", "bwbwBWBwb"
+            "K", "BwbwbwbWB"; "L", "bwBwbwbWB"; "M", "BwBwbwbWb"; "N", "bwbwBwbWB"
+            "O", "BwbwBwbWb"; "P", "bwBwBwbWb"; "Q", "bwbwbwBWB"; "R", "BwbwbwBWb"
+            "S", "bwBwbwBWb"; "T", "bwbwBwBWb"; "U", "BWbwbwbwB"; "V", "bWBwbwbwB"
+            "W", "BWBwbwbwb"; "X", "bWbwBwbwB"; "Y", "BWbwBwbwb"; "Z", "bWBwBwbwb"
+            "-", "bWbwbwBwB"; ".", "BWbwbwBwb"; " ", "bWBwbwBwb"; "$", "bWbWbWbwb"
+            "/", "bWbWbwbWb"; "+", "bWbwbWbWb"; "%", "bwbWbWbWb"; "*", "bWbwBwBwb"
+        ]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidCharacter message =
+        raise (InvalidCharacterException message)
+
+    let private widthPattern (pattern: string) =
+        pattern
+        |> Seq.map (fun part -> if Char.IsUpper part then 'W' else 'N')
+        |> Array.ofSeq
+        |> String
+
+    let normalizeCode39 (data: string) =
+        if isNull data then
+            nullArg (nameof data)
+
+        let normalized = data.ToUpperInvariant()
+        for ch in normalized do
+            let value = string ch
+            if value = "*" then
+                invalidCharacter "input must not contain \"*\" because it is reserved for start/stop"
+            if not (patterns.ContainsKey value) then
+                invalidCharacter $"invalid character: \"{value}\" is not supported by Code 39"
+
+        normalized
+
+    let encodeCode39Char (value: string) =
+        if isNull value then
+            nullArg (nameof value)
+
+        match patterns.TryFind value with
+        | Some pattern ->
+            { Char = value
+              IsStartStop = value = "*"
+              Pattern = widthPattern pattern }
+        | None -> invalidCharacter $"invalid character: \"{value}\" is not supported by Code 39"
+
+    let encodeCode39 data =
+        let normalized = normalizeCode39 data
+        $"*{normalized}*"
+        |> Seq.map (string >> encodeCode39Char)
+        |> Seq.toList
+
+    let private runRoleFor sourceIndex encodedLength encodedChar =
+        if not encodedChar.IsStartStop then
+            Data
+        elif sourceIndex = 0 then
+            Start
+        elif sourceIndex = encodedLength - 1 then
+            Stop
+        else
+            Guard
+
+    let expandCode39Runs data =
+        let encoded = encodeCode39 data
+        let runs = ResizeArray<Barcode1DRun>()
+
+        encoded
+        |> List.iteri (fun sourceIndex encodedChar ->
+            let role = runRoleFor sourceIndex encoded.Length encodedChar
+            let charRuns =
+                BarcodeLayout1D.runsFromWidthPattern
+                    encodedChar.Pattern
+                    (BarcodeLayout1D.defaultWidthPatternOptions encodedChar.Char sourceIndex role)
+
+            runs.AddRange(charRuns)
+
+            if sourceIndex < encoded.Length - 1 then
+                runs.Add
+                    { Color = Space
+                      Modules = 1u
+                      SourceLabel = encodedChar.Char
+                      SourceIndex = sourceIndex
+                      Role = InterCharacterGap })
+
+        List.ofSeq runs
+
+    let layoutCode39 data options =
+        let normalized = normalizeCode39 data
+        let runs = expandCode39Runs normalized
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata.[pair.Key] <- pair.Value
+
+        metadata.["symbology"] <- box "code39"
+        metadata.["encodedText"] <- box normalized
+
+        let layoutOptions =
+            { options with
+                Label =
+                    options.Label
+                    |> Option.orElse (Some(if normalized.Length = 0 then "Code 39 barcode" else $"Code 39 barcode for {normalized}"))
+                HumanReadableText = options.HumanReadableText |> Option.orElse (Some normalized)
+                Metadata = metadata :> Metadata }
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some layoutOptions)
+
+    let drawCode39 data options =
+        layoutCode39 data options

--- a/code/packages/fsharp/code39/CodingAdventures.Code39.fsproj
+++ b/code/packages/fsharp/code39/CodingAdventures.Code39.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Code39.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Code39.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Code 39 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Code39.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/code39/README.md
+++ b/code/packages/fsharp/code39/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Code39.FSharp
+
+Code 39 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/code39/required_capabilities.json
+++ b/code/packages/fsharp/code39/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/code39",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/code39/tests/CodingAdventures.Code39.Tests/Code39Tests.fs
+++ b/code/packages/fsharp/code39/tests/CodingAdventures.Code39.Tests/Code39Tests.fs
@@ -1,0 +1,57 @@
+namespace CodingAdventures.Code39.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.Code39.FSharp
+open Xunit
+
+module Code39Tests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Code39.VERSION)
+
+    [<Fact>]
+    let ``normalizes supported input`` () =
+        Assert.Equal("ABC-123", Code39.normalizeCode39 "abc-123")
+
+    [<Fact>]
+    let ``encodes character and full sequence`` () =
+        let encoded = Code39.encodeCode39Char "A"
+
+        Assert.Equal("WNNNNWNNW", encoded.Pattern)
+        Assert.False(encoded.IsStartStop)
+        Assert.Equal<string list>([ "*"; "A"; "*" ], Code39.encodeCode39 "A" |> List.map _.Char)
+
+    [<Fact>]
+    let ``expand runs includes start stop and gaps`` () =
+        let runs = Code39.expandCode39Runs "A"
+
+        Assert.Equal(29, runs.Length)
+        Assert.Equal(Bar, runs[0].Color)
+        Assert.Equal(Start, runs[0].Role)
+        Assert.Equal(InterCharacterGap, runs[9].Role)
+        Assert.Equal(3u, runs[10].Modules)
+        Assert.Equal(Stop, runs[runs.Length - 1].Role)
+
+    [<Fact>]
+    let ``layout builds paint scene metadata`` () =
+        let scene = Code39.drawCode39 "A" None
+
+        Assert.Equal(box "code39", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "A", scene.Metadata.Value["encodedText"])
+        Assert.Equal(box "Code 39 barcode for A", scene.Metadata.Value["label"])
+        Assert.True(scene.Width > 0.0)
+        Assert.Equal(Code39.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Fact>]
+    let ``invalid inputs and configs are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Code39.normalizeCode39 Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<InvalidCharacterException>(fun () -> Code39.normalizeCode39 "*" |> ignore) |> ignore
+        Assert.Throws<InvalidCharacterException>(fun () -> Code39.normalizeCode39 "~" |> ignore) |> ignore
+        Assert.Throws<InvalidCharacterException>(fun () -> Code39.encodeCode39Char "~" |> ignore) |> ignore
+
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> Code39.layoutCode39 "A" (Some badOptions) |> ignore) |> ignore

--- a/code/packages/fsharp/code39/tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.fsproj
+++ b/code/packages/fsharp/code39/tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Code39.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Code39.fsproj" />
+    <Compile Include="Code39Tests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# Code 39 packages on top of the shared 1D barcode layout layer
- support normalization, character encoding, run expansion with start/stop and inter-character gaps, and paint scene generation
- add xUnit coverage for encoding tables, run roles/modules, scene metadata, invalid characters, and invalid render config propagation

## Verification
- dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Code39.Tests/CodingAdventures.Code39.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line