### PR TITLE
feat(parity): add dotnet itf packages

### DIFF
--- a/code/packages/csharp/itf/BUILD
+++ b/code/packages/csharp/itf/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/itf/BUILD_windows
+++ b/code/packages/csharp/itf/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/itf/CHANGELOG.md
+++ b/code/packages/csharp/itf/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# ITF validation, digit-pair encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/itf/CodingAdventures.Itf.csproj
+++ b/code/packages/csharp/itf/CodingAdventures.Itf.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Itf.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Interleaved 2 of 5 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/itf/Itf.cs
+++ b/code/packages/csharp/itf/Itf.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Itf;
+
+public static class Itf
+{
+    public const string Version = "0.1.0";
+
+    private const string StartPattern = "1010";
+    private const string StopPattern = "11101";
+
+    private static readonly string[] DigitPatterns =
+    [
+        "00110",
+        "10001",
+        "01001",
+        "11000",
+        "00101",
+        "10100",
+        "01100",
+        "00011",
+        "10010",
+        "01010",
+    ];
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string NormalizeItf(string data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length == 0 || data.Length % 2 != 0)
+        {
+            throw new InvalidItfInputException("ITF input must contain an even number of digits");
+        }
+
+        if (data.Any(ch => !char.IsDigit(ch)))
+        {
+            throw new InvalidItfInputException("ITF input must contain digits only");
+        }
+
+        return data;
+    }
+
+    public static IReadOnlyList<EncodedPair> EncodeItf(string data)
+    {
+        var normalized = NormalizeItf(data);
+        var encoded = new List<EncodedPair>();
+        for (var index = 0; index < normalized.Length; index += 2)
+        {
+            encoded.Add(EncodePair(normalized[index..(index + 2)], index / 2));
+        }
+
+        return encoded;
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandItfRuns(string data)
+    {
+        var encodedPairs = EncodeItf(data);
+        var runs = new List<Barcode1DRun>();
+
+        runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+            StartPattern,
+            new RunsFromBinaryPatternOptions("start", -1, Barcode1DRunRole.Start)));
+
+        foreach (var pair in encodedPairs)
+        {
+            runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+                pair.BinaryPattern,
+                new RunsFromBinaryPatternOptions(pair.Pair, pair.SourceIndex, Barcode1DRunRole.Data)));
+        }
+
+        runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+            StopPattern,
+            new RunsFromBinaryPatternOptions("stop", -2, Barcode1DRunRole.Stop)));
+
+        return runs;
+    }
+
+    public static PaintScene LayoutItf(string data, PaintBarcode1DOptions? options = null)
+    {
+        var normalized = NormalizeItf(data);
+        var runs = ExpandItfRuns(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "itf",
+            ["pairCount"] = normalized.Length / 2,
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(
+            runs,
+            options with { Metadata = metadata });
+    }
+
+    public static PaintScene DrawItf(string data, PaintBarcode1DOptions? options = null) =>
+        LayoutItf(data, options);
+
+    private static EncodedPair EncodePair(string pair, int sourceIndex)
+    {
+        var barPattern = DigitPatterns[pair[0] - '0'];
+        var spacePattern = DigitPatterns[pair[1] - '0'];
+        var binaryPattern = new StringBuilder();
+
+        for (var index = 0; index < barPattern.Length; index++)
+        {
+            binaryPattern.Append(barPattern[index] == '1' ? "111" : "1");
+            binaryPattern.Append(spacePattern[index] == '1' ? "000" : "0");
+        }
+
+        return new EncodedPair(pair, barPattern, spacePattern, binaryPattern.ToString(), sourceIndex);
+    }
+}
+
+public sealed record EncodedPair(
+    string Pair,
+    string BarPattern,
+    string SpacePattern,
+    string BinaryPattern,
+    int SourceIndex);
+
+public sealed class InvalidItfInputException(string message) : ArgumentException(message);

--- a/code/packages/csharp/itf/README.md
+++ b/code/packages/csharp/itf/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Itf.CSharp
+
+Interleaved 2 of 5 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/itf/required_capabilities.json
+++ b/code/packages/csharp/itf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/itf",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/itf/tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.csproj
+++ b/code/packages/csharp/itf/tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Itf]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Itf.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/itf/tests/CodingAdventures.Itf.Tests/ItfTests.cs
+++ b/code/packages/csharp/itf/tests/CodingAdventures.Itf.Tests/ItfTests.cs
@@ -1,0 +1,74 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Itf.Tests;
+
+public sealed class ItfTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Itf.Version);
+    }
+
+    [Fact]
+    public void NormalizeItfAcceptsEvenLengthDigitStrings()
+    {
+        Assert.Equal("123456", Itf.NormalizeItf("123456"));
+    }
+
+    [Fact]
+    public void NormalizeItfRejectsInvalidInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => Itf.NormalizeItf(null!));
+        Assert.Throws<InvalidItfInputException>(() => Itf.NormalizeItf(""));
+        Assert.Throws<InvalidItfInputException>(() => Itf.NormalizeItf("12345"));
+        Assert.Throws<InvalidItfInputException>(() => Itf.NormalizeItf("12A4"));
+    }
+
+    [Fact]
+    public void EncodeItfEncodesDigitPairs()
+    {
+        var encoded = Itf.EncodeItf("123456");
+
+        Assert.Equal(3, encoded.Count);
+        Assert.Equal("12", encoded[0].Pair);
+        Assert.Equal("10001", encoded[0].BarPattern);
+        Assert.Equal("01001", encoded[0].SpacePattern);
+        Assert.Equal(0, encoded[0].SourceIndex);
+        Assert.NotEmpty(encoded[0].BinaryPattern);
+    }
+
+    [Fact]
+    public void ExpandItfRunsIncludeStartAndStopPatterns()
+    {
+        var runs = Itf.ExpandItfRuns("123456");
+
+        Assert.Equal("start", runs[0].SourceLabel);
+        Assert.Equal(Barcode1DRunRole.Start, runs[0].Role);
+        Assert.Equal("stop", runs[^1].SourceLabel);
+        Assert.Equal(Barcode1DRunRole.Stop, runs[^1].Role);
+        Assert.Contains(runs, run => run.Role == Barcode1DRunRole.Data && run.SourceLabel == "12");
+    }
+
+    [Fact]
+    public void DrawItfReturnsBarcodeScene()
+    {
+        var scene = Itf.DrawItf("123456");
+
+        Assert.Equal("itf", scene.Metadata?["symbology"]);
+        Assert.Equal(3, scene.Metadata?["pairCount"]);
+        Assert.True(scene.Width > 0);
+        Assert.Equal(Itf.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Fact]
+    public void InvalidLayoutConfigIsRejected()
+    {
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+
+        Assert.Throws<ArgumentException>(() => Itf.LayoutItf("123456", badOptions));
+    }
+}

--- a/code/packages/fsharp/itf/BUILD
+++ b/code/packages/fsharp/itf/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/itf/BUILD_windows
+++ b/code/packages/fsharp/itf/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/itf/CHANGELOG.md
+++ b/code/packages/fsharp/itf/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# ITF validation, digit-pair encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/itf/CodingAdventures.Itf.fsproj
+++ b/code/packages/fsharp/itf/CodingAdventures.Itf.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Itf.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Itf.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Interleaved 2 of 5 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Itf.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/itf/Itf.fs
+++ b/code/packages/fsharp/itf/Itf.fs
@@ -1,0 +1,118 @@
+namespace CodingAdventures.Itf.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidItfInputException of string
+
+type EncodedPair =
+    { Pair: string
+      BarPattern: string
+      SpacePattern: string
+      BinaryPattern: string
+      SourceIndex: int }
+
+[<RequireQualifiedAccess>]
+module Itf =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private startPattern = "1010"
+    let private stopPattern = "11101"
+
+    let private digitPatterns =
+        [|
+            "00110"
+            "10001"
+            "01001"
+            "11000"
+            "00101"
+            "10100"
+            "01100"
+            "00011"
+            "10010"
+            "01010"
+        |]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidInput message =
+        raise (InvalidItfInputException message)
+
+    let normalizeItf (data: string) =
+        if isNull data then
+            nullArg (nameof data)
+
+        if data.Length = 0 || data.Length % 2 <> 0 then
+            invalidInput "ITF input must contain an even number of digits"
+
+        if data |> Seq.exists (fun ch -> not (Char.IsDigit ch)) then
+            invalidInput "ITF input must contain digits only"
+
+        data
+
+    let private encodePair (pair: string) sourceIndex =
+        let barPattern = digitPatterns[int pair[0] - int '0']
+        let spacePattern = digitPatterns[int pair[1] - int '0']
+        let builder = StringBuilder()
+
+        for index in 0 .. barPattern.Length - 1 do
+            builder.Append(if barPattern[index] = '1' then "111" else "1") |> ignore
+            builder.Append(if spacePattern[index] = '1' then "000" else "0") |> ignore
+
+        { Pair = pair
+          BarPattern = barPattern
+          SpacePattern = spacePattern
+          BinaryPattern = builder.ToString()
+          SourceIndex = sourceIndex }
+
+    let encodeItf data =
+        let normalized = normalizeItf data
+
+        [ for index in 0 .. 2 .. normalized.Length - 1 ->
+              encodePair (normalized.Substring(index, 2)) (index / 2) ]
+
+    let expandItfRuns data =
+        let encodedPairs = encodeItf data
+        let runs = ResizeArray<Barcode1DRun>()
+
+        runs.AddRange(
+            BarcodeLayout1D.runsFromBinaryPattern
+                startPattern
+                { SourceLabel = "start"; SourceIndex = -1; Role = Start }
+        )
+
+        for pair in encodedPairs do
+            runs.AddRange(
+                BarcodeLayout1D.runsFromBinaryPattern
+                    pair.BinaryPattern
+                    { SourceLabel = pair.Pair; SourceIndex = pair.SourceIndex; Role = Data }
+            )
+
+        runs.AddRange(
+            BarcodeLayout1D.runsFromBinaryPattern
+                stopPattern
+                { SourceLabel = "stop"; SourceIndex = -2; Role = Stop }
+        )
+
+        List.ofSeq runs
+
+    let layoutItf data options =
+        let normalized = normalizeItf data
+        let runs = expandItfRuns normalized
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata[pair.Key] <- pair.Value
+
+        metadata["symbology"] <- box "itf"
+        metadata["pairCount"] <- box (normalized.Length / 2)
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some { options with Metadata = metadata :> Metadata })
+
+    let drawItf data options =
+        layoutItf data options

--- a/code/packages/fsharp/itf/README.md
+++ b/code/packages/fsharp/itf/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Itf.FSharp
+
+Interleaved 2 of 5 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/itf/required_capabilities.json
+++ b/code/packages/fsharp/itf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/itf",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/itf/tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.fsproj
+++ b/code/packages/fsharp/itf/tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Itf.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Itf.fsproj" />
+    <Compile Include="ItfTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/itf/tests/CodingAdventures.Itf.Tests/ItfTests.fs
+++ b/code/packages/fsharp/itf/tests/CodingAdventures.Itf.Tests/ItfTests.fs
@@ -1,0 +1,60 @@
+namespace CodingAdventures.Itf.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.Itf.FSharp
+open Xunit
+
+module ItfTests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Itf.VERSION)
+
+    [<Fact>]
+    let ``normalize accepts even length digit strings`` () =
+        Assert.Equal("123456", Itf.normalizeItf "123456")
+
+    [<Fact>]
+    let ``normalize rejects invalid input`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Itf.normalizeItf Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<InvalidItfInputException>(fun () -> Itf.normalizeItf "" |> ignore) |> ignore
+        Assert.Throws<InvalidItfInputException>(fun () -> Itf.normalizeItf "12345" |> ignore) |> ignore
+        Assert.Throws<InvalidItfInputException>(fun () -> Itf.normalizeItf "12A4" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``encode encodes digit pairs`` () =
+        let encoded = Itf.encodeItf "123456"
+
+        Assert.Equal(3, encoded.Length)
+        Assert.Equal("12", encoded[0].Pair)
+        Assert.Equal("10001", encoded[0].BarPattern)
+        Assert.Equal("01001", encoded[0].SpacePattern)
+        Assert.Equal(0, encoded[0].SourceIndex)
+        Assert.NotEmpty(encoded[0].BinaryPattern)
+
+    [<Fact>]
+    let ``expand runs includes start and stop patterns`` () =
+        let runs = Itf.expandItfRuns "123456"
+
+        Assert.Equal("start", runs[0].SourceLabel)
+        Assert.Equal(Start, runs[0].Role)
+        Assert.Equal("stop", runs[runs.Length - 1].SourceLabel)
+        Assert.Equal(Stop, runs[runs.Length - 1].Role)
+        Assert.Contains(runs, fun run -> run.Role = Data && run.SourceLabel = "12")
+
+    [<Fact>]
+    let ``draw returns barcode scene`` () =
+        let scene = Itf.drawItf "123456" None
+
+        Assert.Equal(box "itf", scene.Metadata.Value["symbology"])
+        Assert.Equal(box 3, scene.Metadata.Value["pairCount"])
+        Assert.True(scene.Width > 0.0)
+        Assert.Equal(Itf.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Fact>]
+    let ``invalid layout config is rejected`` () =
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> Itf.layoutItf "123456" (Some badOptions) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# ITF packages on top of the shared 1D barcode layout layer
- validate even-length digit payloads, encode digit pairs, expand start/data/stop runs, and emit paint scenes
- add xUnit coverage for validation, encoded pairs, start/stop/data roles, scene metadata, and invalid render config propagation

## Verification
- dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Itf.Tests/CodingAdventures.Itf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line