### PR TITLE
feat(parity): add dotnet codabar packages

### DIFF
--- a/code/packages/csharp/codabar/BUILD
+++ b/code/packages/csharp/codabar/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/codabar/BUILD_windows
+++ b/code/packages/csharp/codabar/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/codabar/CHANGELOG.md
+++ b/code/packages/csharp/codabar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# Codabar normalization, encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/codabar/Codabar.cs
+++ b/code/packages/csharp/codabar/Codabar.cs
@@ -1,0 +1,171 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Codabar;
+
+public static class Codabar
+{
+    public const string Version = "0.1.0";
+
+    private static readonly HashSet<string> Guards = ["A", "B", "C", "D"];
+
+    private static readonly IReadOnlyDictionary<string, string> Patterns = new Dictionary<string, string>
+    {
+        ["0"] = "101010011",
+        ["1"] = "101011001",
+        ["2"] = "101001011",
+        ["3"] = "110010101",
+        ["4"] = "101101001",
+        ["5"] = "110101001",
+        ["6"] = "100101011",
+        ["7"] = "100101101",
+        ["8"] = "100110101",
+        ["9"] = "110100101",
+        ["-"] = "101001101",
+        ["$"] = "101100101",
+        [":"] = "1101011011",
+        ["/"] = "1101101011",
+        ["."] = "1101101101",
+        ["+"] = "1011011011",
+        ["A"] = "1011001001",
+        ["B"] = "1001001011",
+        ["C"] = "1010010011",
+        ["D"] = "1010011001",
+    };
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string NormalizeCodabar(string data, string start = "A", string stop = "A")
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(start);
+        ArgumentNullException.ThrowIfNull(stop);
+        var normalized = data.ToUpperInvariant();
+
+        if (normalized.Length >= 2)
+        {
+            var first = normalized[0].ToString();
+            var last = normalized[^1].ToString();
+            if (IsGuard(first) && IsGuard(last))
+            {
+                AssertBodyChars(normalized[1..^1]);
+                return normalized;
+            }
+        }
+
+        ValidateGuard(start, nameof(start));
+        ValidateGuard(stop, nameof(stop));
+        AssertBodyChars(normalized);
+        return $"{start.ToUpperInvariant()}{normalized}{stop.ToUpperInvariant()}";
+    }
+
+    public static IReadOnlyList<EncodedCodabarSymbol> EncodeCodabar(string data, string start = "A", string stop = "A")
+    {
+        var normalized = NormalizeCodabar(data, start, stop);
+        return normalized
+            .Select((ch, index) =>
+            {
+                var value = ch.ToString();
+                return new EncodedCodabarSymbol(
+                    value,
+                    Patterns[value],
+                    index,
+                    index == 0 ? Barcode1DRunRole.Start : index == normalized.Length - 1 ? Barcode1DRunRole.Stop : Barcode1DRunRole.Data);
+            })
+            .ToArray();
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandCodabarRuns(string data, string start = "A", string stop = "A")
+    {
+        var encoded = EncodeCodabar(data, start, stop);
+        var runs = new List<Barcode1DRun>();
+
+        for (var index = 0; index < encoded.Count; index++)
+        {
+            var symbol = encoded[index];
+            foreach (var run in BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+                         symbol.Pattern,
+                         new RunsFromBinaryPatternOptions(symbol.Char, symbol.SourceIndex, symbol.Role)))
+            {
+                runs.Add(run);
+            }
+
+            if (index < encoded.Count - 1)
+            {
+                runs.Add(new Barcode1DRun(
+                    Barcode1DRunColor.Space,
+                    1,
+                    symbol.Char,
+                    symbol.SourceIndex,
+                    Barcode1DRunRole.InterCharacterGap));
+            }
+        }
+
+        return runs;
+    }
+
+    public static PaintScene LayoutCodabar(
+        string data,
+        PaintBarcode1DOptions? options = null,
+        string start = "A",
+        string stop = "A")
+    {
+        var normalized = NormalizeCodabar(data, start, stop);
+        var runs = ExpandCodabarRuns(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "codabar",
+            ["start"] = normalized[0].ToString(),
+            ["stop"] = normalized[^1].ToString(),
+        };
+
+        var layoutOptions = options with
+        {
+            Label = options.Label ?? $"Codabar barcode for {normalized}",
+            HumanReadableText = options.HumanReadableText ?? normalized,
+            Metadata = metadata,
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(runs, layoutOptions);
+    }
+
+    public static PaintScene DrawCodabar(
+        string data,
+        PaintBarcode1DOptions? options = null,
+        string start = "A",
+        string stop = "A") =>
+        LayoutCodabar(data, options, start, stop);
+
+    private static bool IsGuard(string value) => Guards.Contains(value);
+
+    private static void ValidateGuard(string value, string paramName)
+    {
+        var normalized = value.ToUpperInvariant();
+        if (!IsGuard(normalized))
+        {
+            throw new InvalidCodabarInputException($"Codabar {paramName} guard must be one of A, B, C, or D");
+        }
+    }
+
+    private static void AssertBodyChars(string body)
+    {
+        foreach (var ch in body)
+        {
+            var value = ch.ToString();
+            if (!Patterns.ContainsKey(value) || IsGuard(value))
+            {
+                throw new InvalidCodabarInputException($"invalid Codabar body character \"{value}\"");
+            }
+        }
+    }
+}
+
+public sealed record EncodedCodabarSymbol(
+    string Char,
+    string Pattern,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public sealed class InvalidCodabarInputException(string message) : ArgumentException(message);

--- a/code/packages/csharp/codabar/CodingAdventures.Codabar.csproj
+++ b/code/packages/csharp/codabar/CodingAdventures.Codabar.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Codabar.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Codabar encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/codabar/README.md
+++ b/code/packages/csharp/codabar/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Codabar.CSharp
+
+Codabar encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/codabar/required_capabilities.json
+++ b/code/packages/csharp/codabar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/codabar",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/codabar/tests/CodingAdventures.Codabar.Tests/CodabarTests.cs
+++ b/code/packages/csharp/codabar/tests/CodingAdventures.Codabar.Tests/CodabarTests.cs
@@ -1,0 +1,74 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Codabar.Tests;
+
+public sealed class CodabarTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Codabar.Version);
+    }
+
+    [Fact]
+    public void NormalizeCodabarAddsDefaultOrRequestedGuards()
+    {
+        Assert.Equal("A40156A", Codabar.NormalizeCodabar("40156"));
+        Assert.Equal("B40156D", Codabar.NormalizeCodabar("40156", "B", "D"));
+        Assert.Equal("C40156D", Codabar.NormalizeCodabar("c40156d"));
+    }
+
+    [Fact]
+    public void EncodeCodabarMarksOuterSymbols()
+    {
+        var encoded = Codabar.EncodeCodabar("40156", "B", "D");
+
+        Assert.Equal("B", encoded[0].Char);
+        Assert.Equal("1001001011", encoded[0].Pattern);
+        Assert.Equal(Barcode1DRunRole.Start, encoded[0].Role);
+        Assert.Equal(Barcode1DRunRole.Data, encoded[1].Role);
+        Assert.Equal("D", encoded[^1].Char);
+        Assert.Equal(Barcode1DRunRole.Stop, encoded[^1].Role);
+    }
+
+    [Fact]
+    public void ExpandRunsIncludesInterCharacterGaps()
+    {
+        var runs = Codabar.ExpandCodabarRuns("1");
+
+        Assert.True(runs.Count > 0);
+        Assert.Equal(Barcode1DRunColor.Bar, runs[0].Color);
+        Assert.Equal(Barcode1DRunRole.Start, runs[0].Role);
+        Assert.Contains(runs, run => run.Role == Barcode1DRunRole.InterCharacterGap);
+        Assert.Equal(Barcode1DRunRole.Stop, runs[^1].Role);
+    }
+
+    [Fact]
+    public void LayoutCodabarBuildsPaintSceneMetadata()
+    {
+        var scene = Codabar.DrawCodabar("40156", start: "B", stop: "D");
+
+        Assert.Equal("codabar", scene.Metadata?["symbology"]);
+        Assert.Equal("B", scene.Metadata?["start"]);
+        Assert.Equal("D", scene.Metadata?["stop"]);
+        Assert.Equal("Codabar barcode for B40156D", scene.Metadata?["label"]);
+        Assert.Equal("B40156D", scene.Metadata?["humanReadableText"]);
+        Assert.True(scene.Width > 0);
+        Assert.Equal(Codabar.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Fact]
+    public void InvalidInputsAndConfigsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => Codabar.NormalizeCodabar(null!));
+        Assert.Throws<InvalidCodabarInputException>(() => Codabar.NormalizeCodabar("40*56"));
+        Assert.Throws<InvalidCodabarInputException>(() => Codabar.NormalizeCodabar("A"));
+        Assert.Throws<InvalidCodabarInputException>(() => Codabar.NormalizeCodabar("40156", "Z", "A"));
+
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+        Assert.Throws<ArgumentException>(() => Codabar.LayoutCodabar("40156", badOptions));
+    }
+}

--- a/code/packages/csharp/codabar/tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.csproj
+++ b/code/packages/csharp/codabar/tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Codabar]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Codabar.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/codabar/BUILD
+++ b/code/packages/fsharp/codabar/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/codabar/BUILD_windows
+++ b/code/packages/fsharp/codabar/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/codabar/CHANGELOG.md
+++ b/code/packages/fsharp/codabar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# Codabar normalization, encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/codabar/Codabar.fs
+++ b/code/packages/fsharp/codabar/Codabar.fs
@@ -1,0 +1,155 @@
+namespace CodingAdventures.Codabar.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidCodabarInputException of string
+
+type EncodedCodabarSymbol =
+    { Char: string
+      Pattern: string
+      SourceIndex: int
+      Role: Barcode1DRunRole }
+
+[<RequireQualifiedAccess>]
+module Codabar =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private guards = Set.ofList [ "A"; "B"; "C"; "D" ]
+
+    let patterns =
+        Map.ofList [
+            "0", "101010011"
+            "1", "101011001"
+            "2", "101001011"
+            "3", "110010101"
+            "4", "101101001"
+            "5", "110101001"
+            "6", "100101011"
+            "7", "100101101"
+            "8", "100110101"
+            "9", "110100101"
+            "-", "101001101"
+            "$", "101100101"
+            ":", "1101011011"
+            "/", "1101101011"
+            ".", "1101101101"
+            "+", "1011011011"
+            "A", "1011001001"
+            "B", "1001001011"
+            "C", "1010010011"
+            "D", "1010011001"
+        ]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidInput message =
+        raise (InvalidCodabarInputException message)
+
+    let private isGuard value =
+        guards.Contains value
+
+    let private validateGuard paramName (value: string) =
+        if isNull value then
+            nullArg paramName
+
+        let normalized = value.ToUpperInvariant()
+        if not (isGuard normalized) then
+            invalidInput $"Codabar {paramName} guard must be one of A, B, C, or D"
+
+    let private assertBodyChars (body: string) =
+        for ch in body do
+            let value = string ch
+            if not (patterns.ContainsKey value) || isGuard value then
+                invalidInput $"invalid Codabar body character \"{value}\""
+
+    let normalizeCodabar (data: string) (start: string option) (stop: string option) =
+        if isNull data then
+            nullArg (nameof data)
+
+        let start = defaultArg start "A"
+        let stop = defaultArg stop "A"
+        let normalized = data.ToUpperInvariant()
+
+        if normalized.Length >= 2 then
+            let first = string normalized[0]
+            let last = string normalized[normalized.Length - 1]
+            if isGuard first && isGuard last then
+                assertBodyChars normalized[1 .. normalized.Length - 2]
+                normalized
+            else
+                validateGuard "start" start
+                validateGuard "stop" stop
+                assertBodyChars normalized
+                $"{start.ToUpperInvariant()}{normalized}{stop.ToUpperInvariant()}"
+        else
+            validateGuard "start" start
+            validateGuard "stop" stop
+            assertBodyChars normalized
+            $"{start.ToUpperInvariant()}{normalized}{stop.ToUpperInvariant()}"
+
+    let encodeCodabar data start stop =
+        let normalized = normalizeCodabar data start stop
+        normalized
+        |> Seq.mapi (fun index ch ->
+            let value = string ch
+            { Char = value
+              Pattern = patterns[value]
+              SourceIndex = index
+              Role =
+                if index = 0 then Start
+                elif index = normalized.Length - 1 then Stop
+                else Data })
+        |> Seq.toList
+
+    let expandCodabarRuns data start stop =
+        let encoded = encodeCodabar data start stop
+        let runs = ResizeArray<Barcode1DRun>()
+
+        encoded
+        |> List.iteri (fun index symbol ->
+            let symbolRuns =
+                BarcodeLayout1D.runsFromBinaryPattern
+                    symbol.Pattern
+                    { SourceLabel = symbol.Char
+                      SourceIndex = symbol.SourceIndex
+                      Role = symbol.Role }
+
+            runs.AddRange(symbolRuns)
+
+            if index < encoded.Length - 1 then
+                runs.Add
+                    { Color = Space
+                      Modules = 1u
+                      SourceLabel = symbol.Char
+                      SourceIndex = symbol.SourceIndex
+                      Role = InterCharacterGap })
+
+        List.ofSeq runs
+
+    let layoutCodabar data options start stop =
+        let normalized = normalizeCodabar data start stop
+        let runs = expandCodabarRuns normalized None None
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata.[pair.Key] <- pair.Value
+
+        metadata.["symbology"] <- box "codabar"
+        metadata.["start"] <- box (string normalized[0])
+        metadata.["stop"] <- box (string normalized[normalized.Length - 1])
+
+        let layoutOptions =
+            { options with
+                Label = options.Label |> Option.orElse (Some $"Codabar barcode for {normalized}")
+                HumanReadableText = options.HumanReadableText |> Option.orElse (Some normalized)
+                Metadata = metadata :> Metadata }
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some layoutOptions)
+
+    let drawCodabar data options start stop =
+        layoutCodabar data options start stop

--- a/code/packages/fsharp/codabar/CodingAdventures.Codabar.fsproj
+++ b/code/packages/fsharp/codabar/CodingAdventures.Codabar.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Codabar.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Codabar.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Codabar encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Codabar.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/codabar/README.md
+++ b/code/packages/fsharp/codabar/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Codabar.FSharp
+
+Codabar encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/codabar/required_capabilities.json
+++ b/code/packages/fsharp/codabar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/codabar",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/codabar/tests/CodingAdventures.Codabar.Tests/CodabarTests.fs
+++ b/code/packages/fsharp/codabar/tests/CodingAdventures.Codabar.Tests/CodabarTests.fs
@@ -1,0 +1,63 @@
+namespace CodingAdventures.Codabar.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.Codabar.FSharp
+open Xunit
+
+module CodabarTests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Codabar.VERSION)
+
+    [<Fact>]
+    let ``normalize adds default or requested guards`` () =
+        Assert.Equal("A40156A", Codabar.normalizeCodabar "40156" None None)
+        Assert.Equal("B40156D", Codabar.normalizeCodabar "40156" (Some "B") (Some "D"))
+        Assert.Equal("C40156D", Codabar.normalizeCodabar "c40156d" None None)
+
+    [<Fact>]
+    let ``encode marks outer symbols`` () =
+        let encoded = Codabar.encodeCodabar "40156" (Some "B") (Some "D")
+
+        Assert.Equal("B", encoded[0].Char)
+        Assert.Equal("1001001011", encoded[0].Pattern)
+        Assert.Equal(Start, encoded[0].Role)
+        Assert.Equal(Data, encoded[1].Role)
+        Assert.Equal("D", encoded[encoded.Length - 1].Char)
+        Assert.Equal(Stop, encoded[encoded.Length - 1].Role)
+
+    [<Fact>]
+    let ``expand runs includes inter character gaps`` () =
+        let runs = Codabar.expandCodabarRuns "1" None None
+
+        Assert.True(runs.Length > 0)
+        Assert.Equal(Bar, runs[0].Color)
+        Assert.Equal(Start, runs[0].Role)
+        Assert.Contains(runs, fun run -> run.Role = InterCharacterGap)
+        Assert.Equal(Stop, runs[runs.Length - 1].Role)
+
+    [<Fact>]
+    let ``layout builds paint scene metadata`` () =
+        let scene = Codabar.drawCodabar "40156" None (Some "B") (Some "D")
+
+        Assert.Equal(box "codabar", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "B", scene.Metadata.Value["start"])
+        Assert.Equal(box "D", scene.Metadata.Value["stop"])
+        Assert.Equal(box "Codabar barcode for B40156D", scene.Metadata.Value["label"])
+        Assert.Equal(box "B40156D", scene.Metadata.Value["humanReadableText"])
+        Assert.True(scene.Width > 0.0)
+        Assert.Equal(Codabar.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Fact>]
+    let ``invalid inputs and configs are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Codabar.normalizeCodabar Unchecked.defaultof<string> None None |> ignore) |> ignore
+        Assert.Throws<InvalidCodabarInputException>(fun () -> Codabar.normalizeCodabar "40*56" None None |> ignore) |> ignore
+        Assert.Throws<InvalidCodabarInputException>(fun () -> Codabar.normalizeCodabar "A" None None |> ignore) |> ignore
+        Assert.Throws<InvalidCodabarInputException>(fun () -> Codabar.normalizeCodabar "40156" (Some "Z") (Some "A") |> ignore) |> ignore
+
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> Codabar.layoutCodabar "40156" (Some badOptions) None None |> ignore) |> ignore

--- a/code/packages/fsharp/codabar/tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.fsproj
+++ b/code/packages/fsharp/codabar/tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Codabar.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Codabar.fsproj" />
+    <Compile Include="CodabarTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# Codabar packages on top of the shared 1D barcode layout layer
- support A/B/C/D guards, payload validation, symbol encoding, binary run expansion, and paint scene metadata
- add xUnit coverage for guard normalization, encoding roles, inter-character gaps, scene metadata, and invalid inputs/configs

## Verification
- dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Codabar.Tests/CodingAdventures.Codabar.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line