### PR TITLE
feat(parity): add dotnet ean13 packages

### DIFF
--- a/code/packages/csharp/ean-13/BUILD
+++ b/code/packages/csharp/ean-13/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ean-13/BUILD_windows
+++ b/code/packages/csharp/ean-13/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/ean-13/CHANGELOG.md
+++ b/code/packages/csharp/ean-13/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# EAN-13 normalization, check-digit validation, encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/ean-13/CodingAdventures.Ean13.csproj
+++ b/code/packages/csharp/ean-13/CodingAdventures.Ean13.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Ean13.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>EAN-13 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ean-13/Ean13.cs
+++ b/code/packages/csharp/ean-13/Ean13.cs
@@ -1,0 +1,213 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Ean13;
+
+public static class Ean13
+{
+    public const string Version = "0.1.0";
+
+    private const string SideGuard = "101";
+    private const string CenterGuard = "01010";
+
+    private static readonly string[] LeftPatterns =
+    [
+        "0001101", "0011001", "0010011", "0111101", "0100011",
+        "0110001", "0101111", "0111011", "0110111", "0001011",
+    ];
+
+    private static readonly string[] GPatterns =
+    [
+        "0100111", "0110011", "0011011", "0100001", "0011101",
+        "0111001", "0000101", "0010001", "0001001", "0010111",
+    ];
+
+    private static readonly string[] RightPatterns =
+    [
+        "1110010", "1100110", "1101100", "1000010", "1011100",
+        "1001110", "1010000", "1000100", "1001000", "1110100",
+    ];
+
+    private static readonly string[] LeftParityPatterns =
+    [
+        "LLLLLL", "LLGLGG", "LLGGLG", "LLGGGL", "LGLLGG",
+        "LGGLLG", "LGGGLL", "LGLGLG", "LGLGGL", "LGGLGL",
+    ];
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string ComputeEan13CheckDigit(string payload12)
+    {
+        AssertDigits(payload12, 12);
+        var total = payload12
+            .Reverse()
+            .Select((digit, index) => DigitValue(digit) * (index % 2 == 0 ? 3 : 1))
+            .Sum();
+
+        return ((10 - (total % 10)) % 10).ToString();
+    }
+
+    public static string NormalizeEan13(string data)
+    {
+        AssertDigits(data, 12, 13);
+
+        if (data.Length == 12)
+        {
+            return $"{data}{ComputeEan13CheckDigit(data)}";
+        }
+
+        var expected = ComputeEan13CheckDigit(data[..12]);
+        var actual = data[12].ToString();
+        if (expected != actual)
+        {
+            throw new InvalidEan13CheckDigitException($"invalid EAN-13 check digit: expected {expected} but received {actual}");
+        }
+
+        return data;
+    }
+
+    public static string LeftParityPattern(string data)
+    {
+        var normalized = NormalizeEan13(data);
+        return LeftParityPatterns[DigitValue(normalized[0])];
+    }
+
+    public static IReadOnlyList<EncodedDigit> EncodeEan13(string data)
+    {
+        var normalized = NormalizeEan13(data);
+        var parity = LeftParityPatterns[DigitValue(normalized[0])];
+        var encoded = new List<EncodedDigit>();
+
+        for (var offset = 0; offset < 6; offset++)
+        {
+            var digit = normalized[offset + 1];
+            var encoding = parity[offset].ToString();
+            var pattern = encoding == "L" ? LeftPatterns[DigitValue(digit)] : GPatterns[DigitValue(digit)];
+            encoded.Add(new EncodedDigit(digit.ToString(), encoding, pattern, offset + 1, Barcode1DRunRole.Data));
+        }
+
+        for (var offset = 0; offset < 6; offset++)
+        {
+            var digit = normalized[offset + 7];
+            encoded.Add(new EncodedDigit(
+                digit.ToString(),
+                "R",
+                RightPatterns[DigitValue(digit)],
+                offset + 7,
+                offset == 5 ? Barcode1DRunRole.Check : Barcode1DRunRole.Data));
+        }
+
+        return encoded;
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandEan13Runs(string data)
+    {
+        var encoded = EncodeEan13(data);
+        var runs = new List<Barcode1DRun>();
+
+        AddPatternRuns(runs, SideGuard, "start", -1, Barcode1DRunRole.Guard);
+        foreach (var digit in encoded.Take(6))
+        {
+            AddPatternRuns(runs, digit.Pattern, digit.Digit, digit.SourceIndex, digit.Role);
+        }
+
+        AddPatternRuns(runs, CenterGuard, "center", -2, Barcode1DRunRole.Guard);
+        foreach (var digit in encoded.Skip(6))
+        {
+            AddPatternRuns(runs, digit.Pattern, digit.Digit, digit.SourceIndex, digit.Role);
+        }
+
+        AddPatternRuns(runs, SideGuard, "end", -3, Barcode1DRunRole.Guard);
+        return runs;
+    }
+
+    public static PaintScene LayoutEan13(string data, PaintBarcode1DOptions? options = null)
+    {
+        var normalized = NormalizeEan13(data);
+        var encoded = EncodeEan13(normalized);
+        var runs = ExpandEan13Runs(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "ean-13",
+            ["leadingDigit"] = normalized[0].ToString(),
+            ["leftParity"] = LeftParityPatterns[DigitValue(normalized[0])],
+        };
+
+        var layoutOptions = options with
+        {
+            Label = options.Label ?? $"EAN-13 barcode for {normalized}",
+            HumanReadableText = options.HumanReadableText ?? normalized,
+            Metadata = metadata,
+            Symbols = BuildSymbols(encoded),
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(runs, layoutOptions);
+    }
+
+    public static PaintScene DrawEan13(string data, PaintBarcode1DOptions? options = null) =>
+        LayoutEan13(data, options);
+
+    private static IReadOnlyList<Barcode1DSymbolDescriptor> BuildSymbols(IReadOnlyList<EncodedDigit> encoded)
+    {
+        var symbols = new List<Barcode1DSymbolDescriptor>
+        {
+            new("start", 3, -1, Barcode1DSymbolRole.Guard),
+        };
+
+        symbols.AddRange(encoded.Take(6).Select(SymbolFor));
+        symbols.Add(new Barcode1DSymbolDescriptor("center", 5, -2, Barcode1DSymbolRole.Guard));
+        symbols.AddRange(encoded.Skip(6).Select(SymbolFor));
+        symbols.Add(new Barcode1DSymbolDescriptor("end", 3, -3, Barcode1DSymbolRole.Guard));
+        return symbols;
+    }
+
+    private static Barcode1DSymbolDescriptor SymbolFor(EncodedDigit digit) =>
+        new(
+            digit.Digit,
+            7,
+            digit.SourceIndex,
+            digit.Role == Barcode1DRunRole.Check ? Barcode1DSymbolRole.Check : Barcode1DSymbolRole.Data);
+
+    private static void AddPatternRuns(
+        List<Barcode1DRun> runs,
+        string pattern,
+        string sourceLabel,
+        int sourceIndex,
+        Barcode1DRunRole role)
+    {
+        runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+            pattern,
+            new RunsFromBinaryPatternOptions(sourceLabel, sourceIndex, role)));
+    }
+
+    private static void AssertDigits(string data, params int[] expectedLengths)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Any(ch => ch is < '0' or > '9'))
+        {
+            throw new InvalidEan13InputException("EAN-13 input must contain digits only");
+        }
+
+        if (!expectedLengths.Contains(data.Length))
+        {
+            throw new InvalidEan13InputException("EAN-13 input must contain 12 digits or 13 digits");
+        }
+    }
+
+    private static int DigitValue(char digit) => digit - '0';
+}
+
+public sealed record EncodedDigit(
+    string Digit,
+    string Encoding,
+    string Pattern,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public class Ean13Exception(string message) : ArgumentException(message);
+
+public sealed class InvalidEan13InputException(string message) : Ean13Exception(message);
+
+public sealed class InvalidEan13CheckDigitException(string message) : Ean13Exception(message);

--- a/code/packages/csharp/ean-13/README.md
+++ b/code/packages/csharp/ean-13/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Ean13.CSharp
+
+EAN-13 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/ean-13/required_capabilities.json
+++ b/code/packages/csharp/ean-13/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/ean-13",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/ean-13/tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.csproj
+++ b/code/packages/csharp/ean-13/tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Ean13]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Ean13.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ean-13/tests/CodingAdventures.Ean13.Tests/Ean13Tests.cs
+++ b/code/packages/csharp/ean-13/tests/CodingAdventures.Ean13.Tests/Ean13Tests.cs
@@ -1,0 +1,87 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Ean13.Tests;
+
+public sealed class Ean13Tests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Ean13.Version);
+    }
+
+    [Fact]
+    public void ComputesAndValidatesCheckDigit()
+    {
+        Assert.Equal("1", Ean13.ComputeEan13CheckDigit("400638133393"));
+        Assert.Equal("4006381333931", Ean13.NormalizeEan13("400638133393"));
+        Assert.Equal("4006381333931", Ean13.NormalizeEan13("4006381333931"));
+    }
+
+    [Fact]
+    public void RejectsMalformedInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => Ean13.NormalizeEan13(null!));
+        Assert.Throws<InvalidEan13InputException>(() => Ean13.NormalizeEan13("40063813339A"));
+        Assert.Throws<InvalidEan13InputException>(() => Ean13.NormalizeEan13("123"));
+        Assert.Throws<InvalidEan13CheckDigitException>(() => Ean13.NormalizeEan13("4006381333932"));
+    }
+
+    [Fact]
+    public void LeftParityPatternMatchesReference()
+    {
+        Assert.Equal("LGLLGG", Ean13.LeftParityPattern("400638133393"));
+    }
+
+    [Fact]
+    public void EncodeEan13TracksParityAndCheckDigit()
+    {
+        var encoded = Ean13.EncodeEan13("400638133393");
+
+        Assert.Equal(12, encoded.Count);
+        Assert.Equal("0", encoded[0].Digit);
+        Assert.Equal("L", encoded[0].Encoding);
+        Assert.Equal("0", encoded[1].Digit);
+        Assert.Equal("G", encoded[1].Encoding);
+        Assert.Equal(Barcode1DRunRole.Check, encoded[^1].Role);
+        Assert.Equal("1", encoded[^1].Digit);
+    }
+
+    [Fact]
+    public void ExpandRunsTotalNinetyFiveModules()
+    {
+        var runs = Ean13.ExpandEan13Runs("400638133393");
+
+        Assert.Equal(95u, runs.Aggregate(0u, (sum, run) => sum + run.Modules));
+        Assert.Equal(Barcode1DRunRole.Guard, runs[0].Role);
+        Assert.Equal("start", runs[0].SourceLabel);
+        Assert.Contains(runs, run => run.SourceLabel == "center" && run.Role == Barcode1DRunRole.Guard);
+        Assert.Equal("end", runs[^1].SourceLabel);
+    }
+
+    [Fact]
+    public void LayoutBuildsSceneMetadataAndSymbols()
+    {
+        var scene = Ean13.DrawEan13("400638133393");
+
+        Assert.Equal("ean-13", scene.Metadata?["symbology"]);
+        Assert.Equal("4", scene.Metadata?["leadingDigit"]);
+        Assert.Equal("LGLLGG", scene.Metadata?["leftParity"]);
+        Assert.Equal("EAN-13 barcode for 4006381333931", scene.Metadata?["label"]);
+        Assert.Equal("4006381333931", scene.Metadata?["humanReadableText"]);
+        Assert.Equal(95u, scene.Metadata?["contentModules"]);
+        Assert.Equal(15, scene.Metadata?["symbolCount"]);
+        Assert.Equal(Ean13.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Fact]
+    public void InvalidRenderConfigIsRejected()
+    {
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+
+        Assert.Throws<ArgumentException>(() => Ean13.LayoutEan13("400638133393", badOptions));
+    }
+}

--- a/code/packages/fsharp/ean-13/BUILD
+++ b/code/packages/fsharp/ean-13/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ean-13/BUILD_windows
+++ b/code/packages/fsharp/ean-13/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/ean-13/CHANGELOG.md
+++ b/code/packages/fsharp/ean-13/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# EAN-13 normalization, check-digit validation, encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/ean-13/CodingAdventures.Ean13.fsproj
+++ b/code/packages/fsharp/ean-13/CodingAdventures.Ean13.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Ean13.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Ean13.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>EAN-13 encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Ean13.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ean-13/Ean13.fs
+++ b/code/packages/fsharp/ean-13/Ean13.fs
@@ -1,0 +1,176 @@
+namespace CodingAdventures.Ean13.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidEan13InputException of string
+exception InvalidEan13CheckDigitException of string
+
+type EncodedDigit =
+    { Digit: string
+      Encoding: string
+      Pattern: string
+      SourceIndex: int
+      Role: Barcode1DRunRole }
+
+[<RequireQualifiedAccess>]
+module Ean13 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private sideGuard = "101"
+    let private centerGuard = "01010"
+
+    let private leftPatterns =
+        [| "0001101"; "0011001"; "0010011"; "0111101"; "0100011"
+           "0110001"; "0101111"; "0111011"; "0110111"; "0001011" |]
+
+    let private gPatterns =
+        [| "0100111"; "0110011"; "0011011"; "0100001"; "0011101"
+           "0111001"; "0000101"; "0010001"; "0001001"; "0010111" |]
+
+    let private rightPatterns =
+        [| "1110010"; "1100110"; "1101100"; "1000010"; "1011100"
+           "1001110"; "1010000"; "1000100"; "1001000"; "1110100" |]
+
+    let private leftParityPatterns =
+        [| "LLLLLL"; "LLGLGG"; "LLGGLG"; "LLGGGL"; "LGLLGG"
+           "LGGLLG"; "LGGGLL"; "LGLGLG"; "LGLGGL"; "LGGLGL" |]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidInput message =
+        raise (InvalidEan13InputException message)
+
+    let private invalidCheckDigit message =
+        raise (InvalidEan13CheckDigitException message)
+
+    let private digitValue (digit: char) =
+        int digit - int '0'
+
+    let private assertDigits (data: string) expectedLengths =
+        if isNull data then
+            nullArg (nameof data)
+
+        if data |> Seq.exists (fun ch -> ch < '0' || ch > '9') then
+            invalidInput "EAN-13 input must contain digits only"
+
+        if not (expectedLengths |> List.contains data.Length) then
+            invalidInput "EAN-13 input must contain 12 digits or 13 digits"
+
+    let computeEan13CheckDigit (payload12: string) =
+        assertDigits payload12 [ 12 ]
+
+        let total =
+            payload12
+            |> Seq.rev
+            |> Seq.mapi (fun index digit -> digitValue digit * if index % 2 = 0 then 3 else 1)
+            |> Seq.sum
+
+        string ((10 - (total % 10)) % 10)
+
+    let normalizeEan13 (data: string) =
+        assertDigits data [ 12; 13 ]
+
+        if data.Length = 12 then
+            $"{data}{computeEan13CheckDigit data}"
+        else
+            let expected = computeEan13CheckDigit data[0..11]
+            let actual = string data[12]
+            if expected <> actual then
+                invalidCheckDigit $"invalid EAN-13 check digit: expected {expected} but received {actual}"
+
+            data
+
+    let leftParityPattern data =
+        let normalized = normalizeEan13 data
+        leftParityPatterns[digitValue normalized[0]]
+
+    let encodeEan13 data =
+        let normalized = normalizeEan13 data
+        let parity = leftParityPatterns[digitValue normalized[0]]
+
+        let left =
+            [ for offset in 0 .. 5 do
+                let digit = normalized[offset + 1]
+                let encoding = string parity[offset]
+                let pattern = if encoding = "L" then leftPatterns[digitValue digit] else gPatterns[digitValue digit]
+                { Digit = string digit
+                  Encoding = encoding
+                  Pattern = pattern
+                  SourceIndex = offset + 1
+                  Role = Data } ]
+
+        let right =
+            [ for offset in 0 .. 5 do
+                let digit = normalized[offset + 7]
+                { Digit = string digit
+                  Encoding = "R"
+                  Pattern = rightPatterns[digitValue digit]
+                  SourceIndex = offset + 7
+                  Role = if offset = 5 then Check else Data } ]
+
+        left @ right
+
+    let private symbolFor digit =
+        { Label = digit.Digit
+          Modules = 7u
+          SourceIndex = digit.SourceIndex
+          Role = if digit.Role = Check then SymbolCheck else SymbolData }
+
+    let private buildSymbols encoded =
+        [ yield { Label = "start"; Modules = 3u; SourceIndex = -1; Role = SymbolGuard }
+          yield! encoded |> List.take 6 |> List.map symbolFor
+          yield { Label = "center"; Modules = 5u; SourceIndex = -2; Role = SymbolGuard }
+          yield! encoded |> List.skip 6 |> List.map symbolFor
+          yield { Label = "end"; Modules = 3u; SourceIndex = -3; Role = SymbolGuard } ]
+
+    let private addPatternRuns (runs: ResizeArray<Barcode1DRun>) pattern sourceLabel sourceIndex role =
+        let patternRuns =
+            BarcodeLayout1D.runsFromBinaryPattern
+                pattern
+                { SourceLabel = sourceLabel
+                  SourceIndex = sourceIndex
+                  Role = role }
+
+        runs.AddRange(patternRuns)
+
+    let expandEan13Runs data =
+        let encoded = encodeEan13 data
+        let runs = ResizeArray<Barcode1DRun>()
+
+        addPatternRuns runs sideGuard "start" -1 Guard
+        encoded |> List.take 6 |> List.iter (fun digit -> addPatternRuns runs digit.Pattern digit.Digit digit.SourceIndex digit.Role)
+        addPatternRuns runs centerGuard "center" -2 Guard
+        encoded |> List.skip 6 |> List.iter (fun digit -> addPatternRuns runs digit.Pattern digit.Digit digit.SourceIndex digit.Role)
+        addPatternRuns runs sideGuard "end" -3 Guard
+
+        List.ofSeq runs
+
+    let layoutEan13 data options =
+        let normalized = normalizeEan13 data
+        let encoded = encodeEan13 normalized
+        let runs = expandEan13Runs normalized
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata.[pair.Key] <- pair.Value
+
+        metadata.["symbology"] <- box "ean-13"
+        metadata.["leadingDigit"] <- box (string normalized[0])
+        metadata.["leftParity"] <- box leftParityPatterns[digitValue normalized[0]]
+
+        let layoutOptions =
+            { options with
+                Label = options.Label |> Option.orElse (Some $"EAN-13 barcode for {normalized}")
+                HumanReadableText = options.HumanReadableText |> Option.orElse (Some normalized)
+                Metadata = metadata :> Metadata
+                Symbols = Some(buildSymbols encoded) }
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some layoutOptions)
+
+    let drawEan13 data options =
+        layoutEan13 data options

--- a/code/packages/fsharp/ean-13/README.md
+++ b/code/packages/fsharp/ean-13/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Ean13.FSharp
+
+EAN-13 encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/ean-13/required_capabilities.json
+++ b/code/packages/fsharp/ean-13/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/ean-13",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/ean-13/tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.fsproj
+++ b/code/packages/fsharp/ean-13/tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Ean13.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Ean13.fsproj" />
+    <Compile Include="Ean13Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ean-13/tests/CodingAdventures.Ean13.Tests/Ean13Tests.fs
+++ b/code/packages/fsharp/ean-13/tests/CodingAdventures.Ean13.Tests/Ean13Tests.fs
@@ -1,0 +1,71 @@
+namespace CodingAdventures.Ean13.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.Ean13.FSharp
+open Xunit
+
+module Ean13Tests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Ean13.VERSION)
+
+    [<Fact>]
+    let ``computes and validates check digit`` () =
+        Assert.Equal("1", Ean13.computeEan13CheckDigit "400638133393")
+        Assert.Equal("4006381333931", Ean13.normalizeEan13 "400638133393")
+        Assert.Equal("4006381333931", Ean13.normalizeEan13 "4006381333931")
+
+    [<Fact>]
+    let ``rejects malformed input`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Ean13.normalizeEan13 Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<InvalidEan13InputException>(fun () -> Ean13.normalizeEan13 "40063813339A" |> ignore) |> ignore
+        Assert.Throws<InvalidEan13InputException>(fun () -> Ean13.normalizeEan13 "123" |> ignore) |> ignore
+        Assert.Throws<InvalidEan13CheckDigitException>(fun () -> Ean13.normalizeEan13 "4006381333932" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``left parity pattern matches reference`` () =
+        Assert.Equal("LGLLGG", Ean13.leftParityPattern "400638133393")
+
+    [<Fact>]
+    let ``encode tracks parity and check digit`` () =
+        let encoded = Ean13.encodeEan13 "400638133393"
+
+        Assert.Equal(12, encoded.Length)
+        Assert.Equal("0", encoded[0].Digit)
+        Assert.Equal("L", encoded[0].Encoding)
+        Assert.Equal("0", encoded[1].Digit)
+        Assert.Equal("G", encoded[1].Encoding)
+        Assert.Equal(Check, encoded[encoded.Length - 1].Role)
+        Assert.Equal("1", encoded[encoded.Length - 1].Digit)
+
+    [<Fact>]
+    let ``expand runs total ninety five modules`` () =
+        let runs = Ean13.expandEan13Runs "400638133393"
+
+        Assert.Equal(95u, runs |> List.sumBy _.Modules)
+        Assert.Equal(Guard, runs[0].Role)
+        Assert.Equal("start", runs[0].SourceLabel)
+        Assert.Contains(runs, fun run -> run.SourceLabel = "center" && run.Role = Guard)
+        Assert.Equal("end", runs[runs.Length - 1].SourceLabel)
+
+    [<Fact>]
+    let ``layout builds scene metadata and symbols`` () =
+        let scene = Ean13.drawEan13 "400638133393" None
+
+        Assert.Equal(box "ean-13", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "4", scene.Metadata.Value["leadingDigit"])
+        Assert.Equal(box "LGLLGG", scene.Metadata.Value["leftParity"])
+        Assert.Equal(box "EAN-13 barcode for 4006381333931", scene.Metadata.Value["label"])
+        Assert.Equal(box "4006381333931", scene.Metadata.Value["humanReadableText"])
+        Assert.Equal(box 95u, scene.Metadata.Value["contentModules"])
+        Assert.Equal(box 15, scene.Metadata.Value["symbolCount"])
+        Assert.Equal(Ean13.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Fact>]
+    let ``invalid render config is rejected`` () =
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> Ean13.layoutEan13 "400638133393" (Some badOptions) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# EAN-13 packages on top of the shared 1D barcode layout layer
- support check-digit calculation/validation, left parity selection, digit encoding, guard run expansion, and explicit symbol layout metadata
- add xUnit coverage for malformed input, checksum errors, parity, 95-module run streams, scene metadata, and invalid render config propagation

## Verification
- dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Ean13.Tests/CodingAdventures.Ean13.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line