### PR TITLE
feat(parity): add dotnet upca packages

### DIFF
--- a/code/packages/csharp/upc-a/BUILD
+++ b/code/packages/csharp/upc-a/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/upc-a/BUILD_windows
+++ b/code/packages/csharp/upc-a/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/upc-a/CHANGELOG.md
+++ b/code/packages/csharp/upc-a/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# UPC-A normalization, check-digit validation, encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/upc-a/CodingAdventures.UpcA.csproj
+++ b/code/packages/csharp/upc-a/CodingAdventures.UpcA.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.UpcA.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>UPC-A encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/upc-a/README.md
+++ b/code/packages/csharp/upc-a/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.UpcA.CSharp
+
+UPC-A encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/upc-a/UpcA.cs
+++ b/code/packages/csharp/upc-a/UpcA.cs
@@ -1,0 +1,189 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.UpcA;
+
+public static class UpcA
+{
+    public const string Version = "0.1.0";
+
+    private const string SideGuard = "101";
+    private const string CenterGuard = "01010";
+
+    private static readonly string[] LeftPatterns =
+    [
+        "0001101", "0011001", "0010011", "0111101", "0100011",
+        "0110001", "0101111", "0111011", "0110111", "0001011",
+    ];
+
+    private static readonly string[] RightPatterns =
+    [
+        "1110010", "1100110", "1101100", "1000010", "1011100",
+        "1001110", "1010000", "1000100", "1001000", "1110100",
+    ];
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string ComputeUpcACheckDigit(string payload11)
+    {
+        AssertDigits(payload11, 11);
+        var oddSum = 0;
+        var evenSum = 0;
+
+        for (var index = 0; index < payload11.Length; index++)
+        {
+            var value = DigitValue(payload11[index]);
+            if (index % 2 == 0)
+            {
+                oddSum += value;
+            }
+            else
+            {
+                evenSum += value;
+            }
+        }
+
+        return ((10 - ((oddSum * 3 + evenSum) % 10)) % 10).ToString();
+    }
+
+    public static string NormalizeUpcA(string data)
+    {
+        AssertDigits(data, 11, 12);
+
+        if (data.Length == 11)
+        {
+            return $"{data}{ComputeUpcACheckDigit(data)}";
+        }
+
+        var expected = ComputeUpcACheckDigit(data[..11]);
+        var actual = data[11].ToString();
+        if (expected != actual)
+        {
+            throw new InvalidUpcACheckDigitException($"invalid UPC-A check digit: expected {expected} but received {actual}");
+        }
+
+        return data;
+    }
+
+    public static IReadOnlyList<EncodedDigit> EncodeUpcA(string data)
+    {
+        var normalized = NormalizeUpcA(data);
+        return normalized
+            .Select((digit, index) => new EncodedDigit(
+                digit.ToString(),
+                index < 6 ? "L" : "R",
+                index < 6 ? LeftPatterns[DigitValue(digit)] : RightPatterns[DigitValue(digit)],
+                index,
+                index == 11 ? Barcode1DRunRole.Check : Barcode1DRunRole.Data))
+            .ToArray();
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandUpcARuns(string data)
+    {
+        var encoded = EncodeUpcA(data);
+        var runs = new List<Barcode1DRun>();
+
+        AddPatternRuns(runs, SideGuard, "start", -1, Barcode1DRunRole.Guard);
+        foreach (var digit in encoded.Take(6))
+        {
+            AddPatternRuns(runs, digit.Pattern, digit.Digit, digit.SourceIndex, digit.Role);
+        }
+
+        AddPatternRuns(runs, CenterGuard, "center", -2, Barcode1DRunRole.Guard);
+        foreach (var digit in encoded.Skip(6))
+        {
+            AddPatternRuns(runs, digit.Pattern, digit.Digit, digit.SourceIndex, digit.Role);
+        }
+
+        AddPatternRuns(runs, SideGuard, "end", -3, Barcode1DRunRole.Guard);
+        return runs;
+    }
+
+    public static PaintScene LayoutUpcA(string data, PaintBarcode1DOptions? options = null)
+    {
+        var normalized = NormalizeUpcA(data);
+        var encoded = EncodeUpcA(normalized);
+        var runs = ExpandUpcARuns(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "upc-a",
+        };
+
+        var layoutOptions = options with
+        {
+            Label = options.Label ?? $"UPC-A barcode for {normalized}",
+            HumanReadableText = options.HumanReadableText ?? normalized,
+            Metadata = metadata,
+            Symbols = BuildSymbols(encoded),
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(runs, layoutOptions);
+    }
+
+    public static PaintScene DrawUpcA(string data, PaintBarcode1DOptions? options = null) =>
+        LayoutUpcA(data, options);
+
+    private static IReadOnlyList<Barcode1DSymbolDescriptor> BuildSymbols(IReadOnlyList<EncodedDigit> encoded)
+    {
+        var symbols = new List<Barcode1DSymbolDescriptor>
+        {
+            new("start", 3, -1, Barcode1DSymbolRole.Guard),
+        };
+
+        symbols.AddRange(encoded.Take(6).Select(SymbolFor));
+        symbols.Add(new Barcode1DSymbolDescriptor("center", 5, -2, Barcode1DSymbolRole.Guard));
+        symbols.AddRange(encoded.Skip(6).Select(SymbolFor));
+        symbols.Add(new Barcode1DSymbolDescriptor("end", 3, -3, Barcode1DSymbolRole.Guard));
+        return symbols;
+    }
+
+    private static Barcode1DSymbolDescriptor SymbolFor(EncodedDigit digit) =>
+        new(
+            digit.Digit,
+            7,
+            digit.SourceIndex,
+            digit.Role == Barcode1DRunRole.Check ? Barcode1DSymbolRole.Check : Barcode1DSymbolRole.Data);
+
+    private static void AddPatternRuns(
+        List<Barcode1DRun> runs,
+        string pattern,
+        string sourceLabel,
+        int sourceIndex,
+        Barcode1DRunRole role)
+    {
+        runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+            pattern,
+            new RunsFromBinaryPatternOptions(sourceLabel, sourceIndex, role)));
+    }
+
+    private static void AssertDigits(string data, params int[] expectedLengths)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Any(ch => ch is < '0' or > '9'))
+        {
+            throw new InvalidUpcAInputException("UPC-A input must contain digits only");
+        }
+
+        if (!expectedLengths.Contains(data.Length))
+        {
+            throw new InvalidUpcAInputException("UPC-A input must contain 11 digits or 12 digits");
+        }
+    }
+
+    private static int DigitValue(char digit) => digit - '0';
+}
+
+public sealed record EncodedDigit(
+    string Digit,
+    string Encoding,
+    string Pattern,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public class UpcAException(string message) : ArgumentException(message);
+
+public sealed class InvalidUpcAInputException(string message) : UpcAException(message);
+
+public sealed class InvalidUpcACheckDigitException(string message) : UpcAException(message);

--- a/code/packages/csharp/upc-a/required_capabilities.json
+++ b/code/packages/csharp/upc-a/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/upc-a",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/upc-a/tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.csproj
+++ b/code/packages/csharp/upc-a/tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.UpcA]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.UpcA.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/upc-a/tests/CodingAdventures.UpcA.Tests/UpcATests.cs
+++ b/code/packages/csharp/upc-a/tests/CodingAdventures.UpcA.Tests/UpcATests.cs
@@ -1,0 +1,81 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.UpcA.Tests;
+
+public sealed class UpcATests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", UpcA.Version);
+    }
+
+    [Fact]
+    public void ComputesAndValidatesCheckDigit()
+    {
+        Assert.Equal("2", UpcA.ComputeUpcACheckDigit("03600029145"));
+        Assert.Equal("036000291452", UpcA.NormalizeUpcA("03600029145"));
+        Assert.Equal("036000291452", UpcA.NormalizeUpcA("036000291452"));
+    }
+
+    [Fact]
+    public void RejectsMalformedInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => UpcA.NormalizeUpcA(null!));
+        Assert.Throws<InvalidUpcAInputException>(() => UpcA.NormalizeUpcA("0360002914A"));
+        Assert.Throws<InvalidUpcAInputException>(() => UpcA.NormalizeUpcA("123"));
+        Assert.Throws<InvalidUpcACheckDigitException>(() => UpcA.NormalizeUpcA("036000291453"));
+    }
+
+    [Fact]
+    public void EncodeTracksLeftRightAndCheckDigit()
+    {
+        var encoded = UpcA.EncodeUpcA("03600029145");
+
+        Assert.Equal(12, encoded.Count);
+        Assert.Equal("0", encoded[0].Digit);
+        Assert.Equal("L", encoded[0].Encoding);
+        Assert.Equal("0", encoded[5].Digit);
+        Assert.Equal("L", encoded[5].Encoding);
+        Assert.Equal("2", encoded[6].Digit);
+        Assert.Equal("R", encoded[6].Encoding);
+        Assert.Equal(Barcode1DRunRole.Check, encoded[^1].Role);
+        Assert.Equal("2", encoded[^1].Digit);
+    }
+
+    [Fact]
+    public void ExpandRunsTotalNinetyFiveModules()
+    {
+        var runs = UpcA.ExpandUpcARuns("03600029145");
+
+        Assert.Equal(95u, runs.Aggregate(0u, (sum, run) => sum + run.Modules));
+        Assert.Equal(Barcode1DRunRole.Guard, runs[0].Role);
+        Assert.Equal("start", runs[0].SourceLabel);
+        Assert.Contains(runs, run => run.SourceLabel == "center" && run.Role == Barcode1DRunRole.Guard);
+        Assert.Equal("end", runs[^1].SourceLabel);
+    }
+
+    [Fact]
+    public void LayoutBuildsSceneMetadataAndSymbols()
+    {
+        var scene = UpcA.DrawUpcA("03600029145");
+
+        Assert.Equal("upc-a", scene.Metadata?["symbology"]);
+        Assert.Equal("UPC-A barcode for 036000291452", scene.Metadata?["label"]);
+        Assert.Equal("036000291452", scene.Metadata?["humanReadableText"]);
+        Assert.Equal(95u, scene.Metadata?["contentModules"]);
+        Assert.Equal(15, scene.Metadata?["symbolCount"]);
+        Assert.Equal(UpcA.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Fact]
+    public void InvalidRenderConfigIsRejected()
+    {
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+
+        Assert.Throws<ArgumentException>(() => UpcA.LayoutUpcA("03600029145", badOptions));
+    }
+}

--- a/code/packages/fsharp/upc-a/BUILD
+++ b/code/packages/fsharp/upc-a/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/upc-a/BUILD_windows
+++ b/code/packages/fsharp/upc-a/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/upc-a/CHANGELOG.md
+++ b/code/packages/fsharp/upc-a/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# UPC-A normalization, check-digit validation, encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/upc-a/CodingAdventures.UpcA.fsproj
+++ b/code/packages/fsharp/upc-a/CodingAdventures.UpcA.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.UpcA.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.UpcA.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>UPC-A encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="UpcA.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/upc-a/README.md
+++ b/code/packages/fsharp/upc-a/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.UpcA.FSharp
+
+UPC-A encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/upc-a/UpcA.fs
+++ b/code/packages/fsharp/upc-a/UpcA.fs
@@ -1,0 +1,149 @@
+namespace CodingAdventures.UpcA.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidUpcAInputException of string
+exception InvalidUpcACheckDigitException of string
+
+type EncodedDigit =
+    { Digit: string
+      Encoding: string
+      Pattern: string
+      SourceIndex: int
+      Role: Barcode1DRunRole }
+
+[<RequireQualifiedAccess>]
+module UpcA =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private sideGuard = "101"
+    let private centerGuard = "01010"
+
+    let private leftPatterns =
+        [| "0001101"; "0011001"; "0010011"; "0111101"; "0100011"
+           "0110001"; "0101111"; "0111011"; "0110111"; "0001011" |]
+
+    let private rightPatterns =
+        [| "1110010"; "1100110"; "1101100"; "1000010"; "1011100"
+           "1001110"; "1010000"; "1000100"; "1001000"; "1110100" |]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidInput message =
+        raise (InvalidUpcAInputException message)
+
+    let private invalidCheckDigit message =
+        raise (InvalidUpcACheckDigitException message)
+
+    let private digitValue (digit: char) =
+        int digit - int '0'
+
+    let private assertDigits (data: string) expectedLengths =
+        if isNull data then
+            nullArg (nameof data)
+
+        if data |> Seq.exists (fun ch -> ch < '0' || ch > '9') then
+            invalidInput "UPC-A input must contain digits only"
+
+        if not (expectedLengths |> List.contains data.Length) then
+            invalidInput "UPC-A input must contain 11 digits or 12 digits"
+
+    let computeUpcACheckDigit (payload11: string) =
+        assertDigits payload11 [ 11 ]
+
+        let mutable oddSum = 0
+        let mutable evenSum = 0
+        for index in 0 .. payload11.Length - 1 do
+            let value = digitValue payload11[index]
+            if index % 2 = 0 then
+                oddSum <- oddSum + value
+            else
+                evenSum <- evenSum + value
+
+        string ((10 - ((oddSum * 3 + evenSum) % 10)) % 10)
+
+    let normalizeUpcA (data: string) =
+        assertDigits data [ 11; 12 ]
+
+        if data.Length = 11 then
+            $"{data}{computeUpcACheckDigit data}"
+        else
+            let expected = computeUpcACheckDigit data[0..10]
+            let actual = string data[11]
+            if expected <> actual then
+                invalidCheckDigit $"invalid UPC-A check digit: expected {expected} but received {actual}"
+
+            data
+
+    let encodeUpcA data =
+        let normalized = normalizeUpcA data
+        [ for index in 0 .. normalized.Length - 1 do
+            let digit = normalized[index]
+            { Digit = string digit
+              Encoding = if index < 6 then "L" else "R"
+              Pattern = if index < 6 then leftPatterns[digitValue digit] else rightPatterns[digitValue digit]
+              SourceIndex = index
+              Role = if index = 11 then Check else Data } ]
+
+    let private symbolFor digit =
+        { Label = digit.Digit
+          Modules = 7u
+          SourceIndex = digit.SourceIndex
+          Role = if digit.Role = Check then SymbolCheck else SymbolData }
+
+    let private buildSymbols encoded =
+        [ yield { Label = "start"; Modules = 3u; SourceIndex = -1; Role = SymbolGuard }
+          yield! encoded |> List.take 6 |> List.map symbolFor
+          yield { Label = "center"; Modules = 5u; SourceIndex = -2; Role = SymbolGuard }
+          yield! encoded |> List.skip 6 |> List.map symbolFor
+          yield { Label = "end"; Modules = 3u; SourceIndex = -3; Role = SymbolGuard } ]
+
+    let private addPatternRuns (runs: ResizeArray<Barcode1DRun>) pattern sourceLabel sourceIndex role =
+        let patternRuns =
+            BarcodeLayout1D.runsFromBinaryPattern
+                pattern
+                { SourceLabel = sourceLabel
+                  SourceIndex = sourceIndex
+                  Role = role }
+
+        runs.AddRange(patternRuns)
+
+    let expandUpcARuns data =
+        let encoded = encodeUpcA data
+        let runs = ResizeArray<Barcode1DRun>()
+
+        addPatternRuns runs sideGuard "start" -1 Guard
+        encoded |> List.take 6 |> List.iter (fun digit -> addPatternRuns runs digit.Pattern digit.Digit digit.SourceIndex digit.Role)
+        addPatternRuns runs centerGuard "center" -2 Guard
+        encoded |> List.skip 6 |> List.iter (fun digit -> addPatternRuns runs digit.Pattern digit.Digit digit.SourceIndex digit.Role)
+        addPatternRuns runs sideGuard "end" -3 Guard
+
+        List.ofSeq runs
+
+    let layoutUpcA data options =
+        let normalized = normalizeUpcA data
+        let encoded = encodeUpcA normalized
+        let runs = expandUpcARuns normalized
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata.[pair.Key] <- pair.Value
+
+        metadata.["symbology"] <- box "upc-a"
+
+        let layoutOptions =
+            { options with
+                Label = options.Label |> Option.orElse (Some $"UPC-A barcode for {normalized}")
+                HumanReadableText = options.HumanReadableText |> Option.orElse (Some normalized)
+                Metadata = metadata :> Metadata
+                Symbols = Some(buildSymbols encoded) }
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some layoutOptions)
+
+    let drawUpcA data options =
+        layoutUpcA data options

--- a/code/packages/fsharp/upc-a/required_capabilities.json
+++ b/code/packages/fsharp/upc-a/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/upc-a",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/upc-a/tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.fsproj
+++ b/code/packages/fsharp/upc-a/tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.UpcA.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.UpcA.fsproj" />
+    <Compile Include="UpcATests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/upc-a/tests/CodingAdventures.UpcA.Tests/UpcATests.fs
+++ b/code/packages/fsharp/upc-a/tests/CodingAdventures.UpcA.Tests/UpcATests.fs
@@ -1,0 +1,67 @@
+namespace CodingAdventures.UpcA.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.UpcA.FSharp
+open Xunit
+
+module UpcATests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", UpcA.VERSION)
+
+    [<Fact>]
+    let ``computes and validates check digit`` () =
+        Assert.Equal("2", UpcA.computeUpcACheckDigit "03600029145")
+        Assert.Equal("036000291452", UpcA.normalizeUpcA "03600029145")
+        Assert.Equal("036000291452", UpcA.normalizeUpcA "036000291452")
+
+    [<Fact>]
+    let ``rejects malformed input`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> UpcA.normalizeUpcA Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<InvalidUpcAInputException>(fun () -> UpcA.normalizeUpcA "0360002914A" |> ignore) |> ignore
+        Assert.Throws<InvalidUpcAInputException>(fun () -> UpcA.normalizeUpcA "123" |> ignore) |> ignore
+        Assert.Throws<InvalidUpcACheckDigitException>(fun () -> UpcA.normalizeUpcA "036000291453" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``encode tracks left right and check digit`` () =
+        let encoded = UpcA.encodeUpcA "03600029145"
+
+        Assert.Equal(12, encoded.Length)
+        Assert.Equal("0", encoded[0].Digit)
+        Assert.Equal("L", encoded[0].Encoding)
+        Assert.Equal("0", encoded[5].Digit)
+        Assert.Equal("L", encoded[5].Encoding)
+        Assert.Equal("2", encoded[6].Digit)
+        Assert.Equal("R", encoded[6].Encoding)
+        Assert.Equal(Check, encoded[encoded.Length - 1].Role)
+        Assert.Equal("2", encoded[encoded.Length - 1].Digit)
+
+    [<Fact>]
+    let ``expand runs total ninety five modules`` () =
+        let runs = UpcA.expandUpcARuns "03600029145"
+
+        Assert.Equal(95u, runs |> List.sumBy _.Modules)
+        Assert.Equal(Guard, runs[0].Role)
+        Assert.Equal("start", runs[0].SourceLabel)
+        Assert.Contains(runs, fun run -> run.SourceLabel = "center" && run.Role = Guard)
+        Assert.Equal("end", runs[runs.Length - 1].SourceLabel)
+
+    [<Fact>]
+    let ``layout builds scene metadata and symbols`` () =
+        let scene = UpcA.drawUpcA "03600029145" None
+
+        Assert.Equal(box "upc-a", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "UPC-A barcode for 036000291452", scene.Metadata.Value["label"])
+        Assert.Equal(box "036000291452", scene.Metadata.Value["humanReadableText"])
+        Assert.Equal(box 95u, scene.Metadata.Value["contentModules"])
+        Assert.Equal(box 15, scene.Metadata.Value["symbolCount"])
+        Assert.Equal(UpcA.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Fact>]
+    let ``invalid render config is rejected`` () =
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> UpcA.layoutUpcA "03600029145" (Some badOptions) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# UPC-A packages on top of the shared 1D barcode layout layer
- support UPC-A check-digit calculation/validation, left/right digit encoding, guard run expansion, and explicit symbol layout metadata
- add xUnit coverage for malformed input, checksum errors, 95-module run streams, scene metadata, and invalid render config propagation

## Verification
- dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.UpcA.Tests/CodingAdventures.UpcA.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line