### PR TITLE
feat(parity): add dotnet code128 packages

### DIFF
--- a/code/packages/csharp/code128/BUILD
+++ b/code/packages/csharp/code128/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/code128/BUILD_windows
+++ b/code/packages/csharp/code128/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/code128/CHANGELOG.md
+++ b/code/packages/csharp/code128/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# Code 128 Code Set B normalization, checksum, encoding, run expansion, and paint scene layout.

--- a/code/packages/csharp/code128/Code128.cs
+++ b/code/packages/csharp/code128/Code128.cs
@@ -1,0 +1,161 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Code128;
+
+public static class Code128
+{
+    public const string Version = "0.1.0";
+
+    private const int StartB = 104;
+    private const int Stop = 106;
+
+    private static readonly string[] Patterns =
+    [
+        "11011001100", "11001101100", "11001100110", "10010011000", "10010001100",
+        "10001001100", "10011001000", "10011000100", "10001100100", "11001001000",
+        "11001000100", "11000100100", "10110011100", "10011011100", "10011001110",
+        "10111001100", "10011101100", "10011100110", "11001110010", "11001011100",
+        "11001001110", "11011100100", "11001110100", "11101101110", "11101001100",
+        "11100101100", "11100100110", "11101100100", "11100110100", "11100110010",
+        "11011011000", "11011000110", "11000110110", "10100011000", "10001011000",
+        "10001000110", "10110001000", "10001101000", "10001100010", "11010001000",
+        "11000101000", "11000100010", "10110111000", "10110001110", "10001101110",
+        "10111011000", "10111000110", "10001110110", "11101110110", "11010001110",
+        "11000101110", "11011101000", "11011100010", "11011101110", "11101011000",
+        "11101000110", "11100010110", "11101101000", "11101100010", "11100011010",
+        "11101111010", "11001000010", "11110001010", "10100110000", "10100001100",
+        "10010110000", "10010000110", "10000101100", "10000100110", "10110010000",
+        "10110000100", "10011010000", "10011000010", "10000110100", "10000110010",
+        "11000010010", "11001010000", "11110111010", "11000010100", "10001111010",
+        "10100111100", "10010111100", "10010011110", "10111100100", "10011110100",
+        "10011110010", "11110100100", "11110010100", "11110010010", "11011011110",
+        "11011110110", "11110110110", "10101111000", "10100011110", "10001011110",
+        "10111101000", "10111100010", "11110101000", "11110100010", "10111011110",
+        "10111101110", "11101011110", "11110101110", "11010000100", "11010010000",
+        "11010011100", "1100011101011",
+    ];
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static string NormalizeCode128B(string data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        foreach (var ch in data)
+        {
+            if (ch is < ' ' or > '~')
+            {
+                throw new InvalidCode128InputException("Code 128 Code Set B supports printable ASCII characters only");
+            }
+        }
+
+        return data;
+    }
+
+    public static int ComputeCode128Checksum(IReadOnlyList<int> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var total = StartB;
+        for (var index = 0; index < values.Count; index++)
+        {
+            total += values[index] * (index + 1);
+        }
+
+        return total % 103;
+    }
+
+    public static IReadOnlyList<EncodedCode128Symbol> EncodeCode128B(string data)
+    {
+        var normalized = NormalizeCode128B(data);
+        var dataSymbols = normalized
+            .Select((ch, index) =>
+            {
+                var value = ValueForCode128BChar(ch);
+                return new EncodedCode128Symbol(ch.ToString(), value, Patterns[value], index, Barcode1DRunRole.Data);
+            })
+            .ToArray();
+        var checksum = ComputeCode128Checksum(dataSymbols.Select(symbol => symbol.Value).ToArray());
+
+        return new[]
+        {
+            new EncodedCode128Symbol("Start B", StartB, Patterns[StartB], -1, Barcode1DRunRole.Start),
+        }
+        .Concat(dataSymbols)
+        .Concat(
+        [
+            new EncodedCode128Symbol($"Checksum {checksum}", checksum, Patterns[checksum], normalized.Length, Barcode1DRunRole.Check),
+            new EncodedCode128Symbol("Stop", Stop, Patterns[Stop], normalized.Length + 1, Barcode1DRunRole.Stop),
+        ])
+        .ToArray();
+    }
+
+    public static IReadOnlyList<Barcode1DRun> ExpandCode128Runs(string data)
+    {
+        var encoded = EncodeCode128B(data);
+        var runs = new List<Barcode1DRun>();
+
+        foreach (var symbol in encoded)
+        {
+            runs.AddRange(BarcodeLayout1D.BarcodeLayout1D.RunsFromBinaryPattern(
+                symbol.Pattern,
+                new RunsFromBinaryPatternOptions(symbol.Label, symbol.SourceIndex, symbol.Role)));
+        }
+
+        return runs;
+    }
+
+    public static PaintScene LayoutCode128(string data, PaintBarcode1DOptions? options = null)
+    {
+        var normalized = NormalizeCode128B(data);
+        var encoded = EncodeCode128B(normalized);
+        var checksum = encoded[^2].Value;
+        var runs = ExpandCode128Runs(normalized);
+        options ??= new PaintBarcode1DOptions();
+
+        var metadata = new Dictionary<string, object?>(options.Metadata)
+        {
+            ["symbology"] = "code128",
+            ["codeSet"] = "B",
+            ["checksum"] = checksum,
+        };
+
+        var layoutOptions = options with
+        {
+            Label = options.Label ?? $"Code 128 barcode for {normalized}",
+            HumanReadableText = options.HumanReadableText ?? normalized,
+            Metadata = metadata,
+            Symbols = BuildSymbols(encoded),
+        };
+
+        return BarcodeLayout1D.BarcodeLayout1D.LayoutBarcode1D(runs, layoutOptions);
+    }
+
+    public static PaintScene DrawCode128(string data, PaintBarcode1DOptions? options = null) =>
+        LayoutCode128(data, options);
+
+    private static int ValueForCode128BChar(char ch) => ch - 32;
+
+    private static IReadOnlyList<Barcode1DSymbolDescriptor> BuildSymbols(IReadOnlyList<EncodedCode128Symbol> encoded) =>
+        encoded
+            .Select(symbol => new Barcode1DSymbolDescriptor(
+                symbol.Label,
+                symbol.Role == Barcode1DRunRole.Stop ? 13u : 11u,
+                symbol.SourceIndex,
+                symbol.Role switch
+                {
+                    Barcode1DRunRole.Start => Barcode1DSymbolRole.Start,
+                    Barcode1DRunRole.Check => Barcode1DSymbolRole.Check,
+                    Barcode1DRunRole.Stop => Barcode1DSymbolRole.Stop,
+                    _ => Barcode1DSymbolRole.Data,
+                }))
+            .ToArray();
+}
+
+public sealed record EncodedCode128Symbol(
+    string Label,
+    int Value,
+    string Pattern,
+    int SourceIndex,
+    Barcode1DRunRole Role);
+
+public sealed class InvalidCode128InputException(string message) : ArgumentException(message);

--- a/code/packages/csharp/code128/CodingAdventures.Code128.csproj
+++ b/code/packages/csharp/code128/CodingAdventures.Code128.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Code128.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Code 128 Code Set B encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/code128/README.md
+++ b/code/packages/csharp/code128/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Code128.CSharp
+
+Code 128 Code Set B encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/csharp/code128/required_capabilities.json
+++ b/code/packages/csharp/code128/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/code128",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/csharp/code128/tests/CodingAdventures.Code128.Tests/Code128Tests.cs
+++ b/code/packages/csharp/code128/tests/CodingAdventures.Code128.Tests/Code128Tests.cs
@@ -1,0 +1,85 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Code128.Tests;
+
+public sealed class Code128Tests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Code128.Version);
+    }
+
+    [Fact]
+    public void NormalizeCode128BAcceptsPrintableAscii()
+    {
+        Assert.Equal("Code 128", Code128.NormalizeCode128B("Code 128"));
+        Assert.Equal("~", Code128.NormalizeCode128B("~"));
+    }
+
+    [Fact]
+    public void NormalizeCode128BRejectsUnsupportedInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => Code128.NormalizeCode128B(null!));
+        Assert.Throws<InvalidCode128InputException>(() => Code128.NormalizeCode128B("bad\ninput"));
+        Assert.Throws<InvalidCode128InputException>(() => Code128.NormalizeCode128B("cafe\u00e9"));
+    }
+
+    [Fact]
+    public void ComputesReferenceChecksum()
+    {
+        Assert.Equal(64, Code128.ComputeCode128Checksum([35, 79, 68, 69, 0, 17, 18, 24]));
+        Assert.Throws<ArgumentNullException>(() => Code128.ComputeCode128Checksum(null!));
+    }
+
+    [Fact]
+    public void EncodeCode128BAddsStartChecksumAndStop()
+    {
+        var encoded = Code128.EncodeCode128B("Code 128");
+
+        Assert.Equal("Start B", encoded[0].Label);
+        Assert.Equal(104, encoded[0].Value);
+        Assert.Equal(Barcode1DRunRole.Start, encoded[0].Role);
+        Assert.Equal("Checksum 64", encoded[^2].Label);
+        Assert.Equal(Barcode1DRunRole.Check, encoded[^2].Role);
+        Assert.Equal("Stop", encoded[^1].Label);
+        Assert.Equal(Barcode1DRunRole.Stop, encoded[^1].Role);
+    }
+
+    [Fact]
+    public void ExpandCode128RunsEndsWithStopPattern()
+    {
+        var runs = Code128.ExpandCode128Runs("Hi");
+
+        Assert.Equal(57u, runs.Aggregate(0u, (sum, run) => sum + run.Modules));
+        Assert.Equal("Start B", runs[0].SourceLabel);
+        Assert.Equal(Barcode1DRunRole.Start, runs[0].Role);
+        Assert.Equal("Stop", runs[^1].SourceLabel);
+        Assert.Equal(Barcode1DRunRole.Stop, runs[^1].Role);
+    }
+
+    [Fact]
+    public void LayoutBuildsSceneMetadataAndSymbols()
+    {
+        var scene = Code128.DrawCode128("Code 128");
+
+        Assert.Equal("code128", scene.Metadata?["symbology"]);
+        Assert.Equal("B", scene.Metadata?["codeSet"]);
+        Assert.Equal(64, scene.Metadata?["checksum"]);
+        Assert.Equal("Code 128 barcode for Code 128", scene.Metadata?["label"]);
+        Assert.Equal("Code 128", scene.Metadata?["humanReadableText"]);
+        Assert.Equal(123u, scene.Metadata?["contentModules"]);
+        Assert.Equal(11, scene.Metadata?["symbolCount"]);
+    }
+
+    [Fact]
+    public void InvalidRenderConfigIsRejected()
+    {
+        var badOptions = new PaintBarcode1DOptions
+        {
+            RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 0 },
+        };
+
+        Assert.Throws<ArgumentException>(() => Code128.LayoutCode128("Code 128", badOptions));
+    }
+}

--- a/code/packages/csharp/code128/tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.csproj
+++ b/code/packages/csharp/code128/tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Code128]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Code128.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/code128/BUILD
+++ b/code/packages/fsharp/code128/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/code128/BUILD_windows
+++ b/code/packages/fsharp/code128/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/code128/CHANGELOG.md
+++ b/code/packages/fsharp/code128/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# Code 128 Code Set B normalization, checksum, encoding, run expansion, and paint scene layout.

--- a/code/packages/fsharp/code128/Code128.fs
+++ b/code/packages/fsharp/code128/Code128.fs
@@ -1,0 +1,148 @@
+namespace CodingAdventures.Code128.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+
+exception InvalidCode128InputException of string
+
+type EncodedCode128Symbol =
+    { Label: string
+      Value: int
+      Pattern: string
+      SourceIndex: int
+      Role: Barcode1DRunRole }
+
+[<RequireQualifiedAccess>]
+module Code128 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private startB = 104
+    let private stop = 106
+
+    let private patterns =
+        [| "11011001100"; "11001101100"; "11001100110"; "10010011000"; "10010001100"
+           "10001001100"; "10011001000"; "10011000100"; "10001100100"; "11001001000"
+           "11001000100"; "11000100100"; "10110011100"; "10011011100"; "10011001110"
+           "10111001100"; "10011101100"; "10011100110"; "11001110010"; "11001011100"
+           "11001001110"; "11011100100"; "11001110100"; "11101101110"; "11101001100"
+           "11100101100"; "11100100110"; "11101100100"; "11100110100"; "11100110010"
+           "11011011000"; "11011000110"; "11000110110"; "10100011000"; "10001011000"
+           "10001000110"; "10110001000"; "10001101000"; "10001100010"; "11010001000"
+           "11000101000"; "11000100010"; "10110111000"; "10110001110"; "10001101110"
+           "10111011000"; "10111000110"; "10001110110"; "11101110110"; "11010001110"
+           "11000101110"; "11011101000"; "11011100010"; "11011101110"; "11101011000"
+           "11101000110"; "11100010110"; "11101101000"; "11101100010"; "11100011010"
+           "11101111010"; "11001000010"; "11110001010"; "10100110000"; "10100001100"
+           "10010110000"; "10010000110"; "10000101100"; "10000100110"; "10110010000"
+           "10110000100"; "10011010000"; "10011000010"; "10000110100"; "10000110010"
+           "11000010010"; "11001010000"; "11110111010"; "11000010100"; "10001111010"
+           "10100111100"; "10010111100"; "10010011110"; "10111100100"; "10011110100"
+           "10011110010"; "11110100100"; "11110010100"; "11110010010"; "11011011110"
+           "11011110110"; "11110110110"; "10101111000"; "10100011110"; "10001011110"
+           "10111101000"; "10111100010"; "11110101000"; "11110100010"; "10111011110"
+           "10111101110"; "11101011110"; "11110101110"; "11010000100"; "11010010000"
+           "11010011100"; "1100011101011" |]
+
+    let defaultRenderConfig = BarcodeLayout1D.defaultRenderConfig
+
+    let private invalidInput message =
+        raise (InvalidCode128InputException message)
+
+    let normalizeCode128B (data: string) =
+        if isNull data then
+            nullArg (nameof data)
+
+        for ch in data do
+            if ch < ' ' || ch > '~' then
+                invalidInput "Code 128 Code Set B supports printable ASCII characters only"
+
+        data
+
+    let private valueForCode128BChar ch =
+        int ch - 32
+
+    let computeCode128Checksum (values: int list) =
+        if isNull (box values) then
+            nullArg (nameof values)
+
+        values
+        |> List.mapi (fun index value -> value * (index + 1))
+        |> List.sum
+        |> (+) startB
+        |> fun total -> total % 103
+
+    let encodeCode128B data =
+        let normalized = normalizeCode128B data
+        let dataSymbols =
+            normalized
+            |> Seq.mapi (fun index ch ->
+                let value = valueForCode128BChar ch
+                { Label = string ch
+                  Value = value
+                  Pattern = patterns[value]
+                  SourceIndex = index
+                  Role = Data })
+            |> Seq.toList
+        let checksum = dataSymbols |> List.map _.Value |> computeCode128Checksum
+
+        [ yield { Label = "Start B"; Value = startB; Pattern = patterns[startB]; SourceIndex = -1; Role = Start }
+          yield! dataSymbols
+          yield { Label = $"Checksum {checksum}"; Value = checksum; Pattern = patterns[checksum]; SourceIndex = normalized.Length; Role = Check }
+          yield { Label = "Stop"; Value = stop; Pattern = patterns[stop]; SourceIndex = normalized.Length + 1; Role = Stop } ]
+
+    let private symbolFor symbol =
+        { Label = symbol.Label
+          Modules = if symbol.Role = Stop then 13u else 11u
+          SourceIndex = symbol.SourceIndex
+          Role =
+            match symbol.Role with
+            | Start -> SymbolStart
+            | Check -> SymbolCheck
+            | Stop -> SymbolStop
+            | _ -> SymbolData }
+
+    let expandCode128Runs data =
+        let encoded = encodeCode128B data
+        let runs = ResizeArray<Barcode1DRun>()
+
+        for symbol in encoded do
+            let symbolRuns =
+                BarcodeLayout1D.runsFromBinaryPattern
+                    symbol.Pattern
+                    { SourceLabel = symbol.Label
+                      SourceIndex = symbol.SourceIndex
+                      Role = symbol.Role }
+
+            runs.AddRange(symbolRuns)
+
+        List.ofSeq runs
+
+    let layoutCode128 data options =
+        let normalized = normalizeCode128B data
+        let encoded = encodeCode128B normalized
+        let checksum = encoded[encoded.Length - 2].Value
+        let runs = expandCode128Runs normalized
+        let options = defaultArg options BarcodeLayout1D.defaultPaintOptions
+        let metadata = Dictionary<string, obj>()
+
+        for pair in options.Metadata do
+            metadata.[pair.Key] <- pair.Value
+
+        metadata.["symbology"] <- box "code128"
+        metadata.["codeSet"] <- box "B"
+        metadata.["checksum"] <- box checksum
+
+        let layoutOptions =
+            { options with
+                Label = options.Label |> Option.orElse (Some $"Code 128 barcode for {normalized}")
+                HumanReadableText = options.HumanReadableText |> Option.orElse (Some normalized)
+                Metadata = metadata :> Metadata
+                Symbols = Some(encoded |> List.map symbolFor) }
+
+        BarcodeLayout1D.layoutBarcode1D runs (Some layoutOptions)
+
+    let drawCode128 data options =
+        layoutCode128 data options

--- a/code/packages/fsharp/code128/CodingAdventures.Code128.fsproj
+++ b/code/packages/fsharp/code128/CodingAdventures.Code128.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Code128.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Code128.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Code 128 Code Set B encoder that emits shared 1D barcode runs and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Code128.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/code128/README.md
+++ b/code/packages/fsharp/code128/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Code128.FSharp
+
+Code 128 Code Set B encoder that emits shared 1D barcode runs and backend-neutral paint scenes.

--- a/code/packages/fsharp/code128/required_capabilities.json
+++ b/code/packages/fsharp/code128/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/code128",
+  "capabilities": [],
+  "justification": "Pure barcode encoding and layout package."
+}

--- a/code/packages/fsharp/code128/tests/CodingAdventures.Code128.Tests/Code128Tests.fs
+++ b/code/packages/fsharp/code128/tests/CodingAdventures.Code128.Tests/Code128Tests.fs
@@ -1,0 +1,69 @@
+namespace CodingAdventures.Code128.Tests
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.Code128.FSharp
+open Xunit
+
+module Code128Tests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Code128.VERSION)
+
+    [<Fact>]
+    let ``normalize accepts printable ascii`` () =
+        Assert.Equal("Code 128", Code128.normalizeCode128B "Code 128")
+        Assert.Equal("~", Code128.normalizeCode128B "~")
+
+    [<Fact>]
+    let ``normalize rejects unsupported input`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Code128.normalizeCode128B Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<InvalidCode128InputException>(fun () -> Code128.normalizeCode128B "bad\ninput" |> ignore) |> ignore
+        Assert.Throws<InvalidCode128InputException>(fun () -> Code128.normalizeCode128B "cafe\u00e9" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``computes reference checksum`` () =
+        Assert.Equal(64, Code128.computeCode128Checksum [ 35; 79; 68; 69; 0; 17; 18; 24 ])
+        Assert.Throws<ArgumentNullException>(fun () -> Code128.computeCode128Checksum Unchecked.defaultof<int list> |> ignore) |> ignore
+
+    [<Fact>]
+    let ``encode adds start checksum and stop`` () =
+        let encoded = Code128.encodeCode128B "Code 128"
+
+        Assert.Equal("Start B", encoded[0].Label)
+        Assert.Equal(104, encoded[0].Value)
+        Assert.Equal(Start, encoded[0].Role)
+        Assert.Equal("Checksum 64", encoded[encoded.Length - 2].Label)
+        Assert.Equal(Check, encoded[encoded.Length - 2].Role)
+        Assert.Equal("Stop", encoded[encoded.Length - 1].Label)
+        Assert.Equal(Stop, encoded[encoded.Length - 1].Role)
+
+    [<Fact>]
+    let ``expand runs ends with stop pattern`` () =
+        let runs = Code128.expandCode128Runs "Hi"
+
+        Assert.Equal(57u, runs |> List.sumBy _.Modules)
+        Assert.Equal("Start B", runs[0].SourceLabel)
+        Assert.Equal(Start, runs[0].Role)
+        Assert.Equal("Stop", runs[runs.Length - 1].SourceLabel)
+        Assert.Equal(Stop, runs[runs.Length - 1].Role)
+
+    [<Fact>]
+    let ``layout builds scene metadata and symbols`` () =
+        let scene = Code128.drawCode128 "Code 128" None
+
+        Assert.Equal(box "code128", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "B", scene.Metadata.Value["codeSet"])
+        Assert.Equal(box 64, scene.Metadata.Value["checksum"])
+        Assert.Equal(box "Code 128 barcode for Code 128", scene.Metadata.Value["label"])
+        Assert.Equal(box "Code 128", scene.Metadata.Value["humanReadableText"])
+        Assert.Equal(box 123u, scene.Metadata.Value["contentModules"])
+        Assert.Equal(box 11, scene.Metadata.Value["symbolCount"])
+
+    [<Fact>]
+    let ``invalid render config is rejected`` () =
+        let badOptions =
+            { BarcodeLayout1D.defaultPaintOptions with
+                RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 0.0 } }
+
+        Assert.Throws<ArgumentException>(fun () -> Code128.layoutCode128 "Code 128" (Some badOptions) |> ignore) |> ignore

--- a/code/packages/fsharp/code128/tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.fsproj
+++ b/code/packages/fsharp/code128/tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Code128.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Code128.fsproj" />
+    <Compile Include="Code128Tests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# Code 128 Code Set B packages on top of the shared 1D barcode layout layer
- support printable ASCII validation, weighted checksum calculation, start/check/stop symbols, run expansion, and explicit symbol layout metadata
- add xUnit coverage for unsupported input, reference checksum, stop pattern modules, scene metadata, and invalid render config propagation

## Verification
- dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Code128.Tests/CodingAdventures.Code128.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line