### PR TITLE
feat(parity): add dotnet jit compiler packages

### DIFF
--- a/code/packages/csharp/jit-compiler/BUILD
+++ b/code/packages/csharp/jit-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/jit-compiler/BUILD_windows
+++ b/code/packages/csharp/jit-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/jit-compiler/CHANGELOG.md
+++ b/code/packages/csharp/jit-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# JIT compiler shell with hot-path profiling, shell block registration, lookup, and deoptimization.

--- a/code/packages/csharp/jit-compiler/CodingAdventures.JitCompiler.csproj
+++ b/code/packages/csharp/jit-compiler/CodingAdventures.JitCompiler.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.JitCompiler.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JIT compiler shell with hot-path profiling and native block registry</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/jit-compiler/JitCompiler.cs
+++ b/code/packages/csharp/jit-compiler/JitCompiler.cs
@@ -1,0 +1,112 @@
+namespace CodingAdventures.JitCompiler;
+
+public enum TargetIsa
+{
+    RiscV,
+    Arm,
+    X86,
+}
+
+public sealed record JitCompilerConfig
+{
+    public JitCompilerConfig(TargetIsa target, ulong hotThreshold)
+    {
+        if (hotThreshold == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hotThreshold), "hotThreshold must be greater than zero.");
+        }
+
+        Target = target;
+        HotThreshold = hotThreshold;
+    }
+
+    public TargetIsa Target { get; }
+
+    public ulong HotThreshold { get; }
+}
+
+public sealed record HotPathProfile(int BytecodeOffset, ulong ExecutionCount, bool IsHot);
+
+public sealed record NativeBlock(
+    int BytecodeOffset,
+    TargetIsa Target,
+    IReadOnlyList<byte> MachineCode,
+    IReadOnlyList<string> Assumptions);
+
+public sealed class JitCompiler
+{
+    public const string Version = "0.1.0";
+
+    private readonly SortedDictionary<int, ulong> _executionCounts = [];
+    private readonly SortedDictionary<int, NativeBlock> _nativeBlocks = [];
+
+    public JitCompiler(JitCompilerConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        Config = config;
+    }
+
+    public JitCompilerConfig Config { get; }
+
+    public bool ObserveExecution(int bytecodeOffset)
+    {
+        ValidateOffset(bytecodeOffset);
+        _executionCounts.TryGetValue(bytecodeOffset, out var count);
+        count++;
+        _executionCounts[bytecodeOffset] = count;
+        return count == Config.HotThreshold;
+    }
+
+    public HotPathProfile? Profile(int bytecodeOffset)
+    {
+        ValidateOffset(bytecodeOffset);
+        return _executionCounts.TryGetValue(bytecodeOffset, out var executionCount)
+            ? new HotPathProfile(bytecodeOffset, executionCount, executionCount >= Config.HotThreshold)
+            : null;
+    }
+
+    public NativeBlock InstallShellBlock(int bytecodeOffset, IEnumerable<string> assumptions)
+    {
+        ValidateOffset(bytecodeOffset);
+        ArgumentNullException.ThrowIfNull(assumptions);
+        var block = new NativeBlock(
+            bytecodeOffset,
+            Config.Target,
+            Array.Empty<byte>(),
+            assumptions.ToArray());
+
+        _nativeBlocks[bytecodeOffset] = block;
+        return block;
+    }
+
+    public bool HasNativeBlock(int bytecodeOffset)
+    {
+        ValidateOffset(bytecodeOffset);
+        return _nativeBlocks.ContainsKey(bytecodeOffset);
+    }
+
+    public NativeBlock? GetNativeBlock(int bytecodeOffset)
+    {
+        ValidateOffset(bytecodeOffset);
+        return _nativeBlocks.TryGetValue(bytecodeOffset, out var block) ? block : null;
+    }
+
+    public NativeBlock? Deoptimize(int bytecodeOffset)
+    {
+        ValidateOffset(bytecodeOffset);
+        if (!_nativeBlocks.Remove(bytecodeOffset, out var block))
+        {
+            return null;
+        }
+
+        return block;
+    }
+
+    private static void ValidateOffset(int bytecodeOffset)
+    {
+        if (bytecodeOffset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytecodeOffset), "bytecodeOffset must be zero or greater.");
+        }
+    }
+}

--- a/code/packages/csharp/jit-compiler/README.md
+++ b/code/packages/csharp/jit-compiler/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.JitCompiler.CSharp
+
+JIT compiler shell with hot-path profiling and a placeholder native block registry for future code generation.

--- a/code/packages/csharp/jit-compiler/required_capabilities.json
+++ b/code/packages/csharp/jit-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/jit-compiler",
+  "capabilities": [],
+  "justification": "Pure profiling and registry package; it does not emit or execute native code."
+}

--- a/code/packages/csharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.csproj
+++ b/code/packages/csharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JitCompiler]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.JitCompiler.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/JitCompilerTests.cs
+++ b/code/packages/csharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/JitCompilerTests.cs
@@ -1,0 +1,93 @@
+namespace CodingAdventures.JitCompiler.Tests;
+
+public sealed class JitCompilerTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", JitCompiler.Version);
+    }
+
+    [Fact]
+    public void ConfigValidatesHotThreshold()
+    {
+        var config = new JitCompilerConfig(TargetIsa.RiscV, 3);
+
+        Assert.Equal(TargetIsa.RiscV, config.Target);
+        Assert.Equal(3UL, config.HotThreshold);
+        Assert.Throws<ArgumentOutOfRangeException>(() => new JitCompilerConfig(TargetIsa.Arm, 0));
+    }
+
+    [Fact]
+    public void PathBecomesHotExactlyAtThreshold()
+    {
+        var jit = new JitCompiler(new JitCompilerConfig(TargetIsa.RiscV, 3));
+
+        Assert.False(jit.ObserveExecution(24));
+        Assert.False(jit.ObserveExecution(24));
+        Assert.True(jit.ObserveExecution(24));
+        Assert.False(jit.ObserveExecution(24));
+    }
+
+    [Fact]
+    public void ProfileReportsExecutionCountAndHotness()
+    {
+        var jit = new JitCompiler(new JitCompilerConfig(TargetIsa.Arm, 2));
+
+        Assert.Null(jit.Profile(8));
+        jit.ObserveExecution(8);
+        var profile = jit.Profile(8);
+        Assert.NotNull(profile);
+        Assert.Equal(1UL, profile.ExecutionCount);
+        Assert.False(profile.IsHot);
+
+        jit.ObserveExecution(8);
+        var hotProfile = jit.Profile(8);
+        Assert.NotNull(hotProfile);
+        Assert.Equal(2UL, hotProfile.ExecutionCount);
+        Assert.True(hotProfile.IsHot);
+    }
+
+    [Fact]
+    public void ShellBlockInstallationUsesConfiguredTarget()
+    {
+        var jit = new JitCompiler(new JitCompilerConfig(TargetIsa.X86, 5));
+
+        var block = jit.InstallShellBlock(32, ["locals stay integers"]);
+
+        Assert.Equal(32, block.BytecodeOffset);
+        Assert.Equal(TargetIsa.X86, block.Target);
+        Assert.Empty(block.MachineCode);
+        Assert.Equal(["locals stay integers"], block.Assumptions);
+        Assert.True(jit.HasNativeBlock(32));
+        Assert.Same(block, jit.GetNativeBlock(32));
+    }
+
+    [Fact]
+    public void DeoptimizeRemovesNativeBlock()
+    {
+        var jit = new JitCompiler(new JitCompilerConfig(TargetIsa.RiscV, 10));
+        jit.InstallShellBlock(99, ["shape stays stable"]);
+
+        var block = jit.Deoptimize(99);
+
+        Assert.NotNull(block);
+        Assert.Equal(99, block.BytecodeOffset);
+        Assert.False(jit.HasNativeBlock(99));
+        Assert.Null(jit.GetNativeBlock(99));
+        Assert.Null(jit.Deoptimize(99));
+    }
+
+    [Fact]
+    public void InvalidArgumentsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => new JitCompiler(null!));
+        var jit = new JitCompiler(new JitCompilerConfig(TargetIsa.Arm, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => jit.ObserveExecution(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => jit.Profile(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => jit.HasNativeBlock(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => jit.GetNativeBlock(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => jit.Deoptimize(-1));
+        Assert.Throws<ArgumentNullException>(() => jit.InstallShellBlock(1, null!));
+    }
+}

--- a/code/packages/fsharp/jit-compiler/BUILD
+++ b/code/packages/fsharp/jit-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/jit-compiler/BUILD_windows
+++ b/code/packages/fsharp/jit-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/jit-compiler/CHANGELOG.md
+++ b/code/packages/fsharp/jit-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# JIT compiler shell with hot-path profiling, shell block registration, lookup, and deoptimization.

--- a/code/packages/fsharp/jit-compiler/CodingAdventures.JitCompiler.fsproj
+++ b/code/packages/fsharp/jit-compiler/CodingAdventures.JitCompiler.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.JitCompiler.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.JitCompiler.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>JIT compiler shell with hot-path profiling and native block registry</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="JitCompiler.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/jit-compiler/JitCompiler.fs
+++ b/code/packages/fsharp/jit-compiler/JitCompiler.fs
@@ -1,0 +1,100 @@
+namespace CodingAdventures.JitCompiler.FSharp
+
+open System
+open System.Collections.Generic
+
+type TargetIsa =
+    | RiscV
+    | Arm
+    | X86
+
+type JitCompilerConfig =
+    { Target: TargetIsa
+      HotThreshold: uint64 }
+
+[<RequireQualifiedAccess>]
+module JitCompilerConfig =
+    let create target hotThreshold =
+        if hotThreshold = 0UL then
+            invalidArg (nameof hotThreshold) "hotThreshold must be greater than zero."
+
+        { Target = target
+          HotThreshold = hotThreshold }
+
+type HotPathProfile =
+    { BytecodeOffset: int
+      ExecutionCount: uint64
+      IsHot: bool }
+
+type NativeBlock =
+    { BytecodeOffset: int
+      Target: TargetIsa
+      MachineCode: byte list
+      Assumptions: string list }
+
+type JitCompiler(config: JitCompilerConfig) =
+    do
+        if isNull (box config) then
+            nullArg (nameof config)
+
+    let executionCounts = SortedDictionary<int, uint64>()
+    let nativeBlocks = SortedDictionary<int, NativeBlock>()
+
+    let validateOffset bytecodeOffset =
+        if bytecodeOffset < 0 then
+            invalidArg (nameof bytecodeOffset) "bytecodeOffset must be zero or greater."
+
+    static member VERSION = "0.1.0"
+
+    member _.Config = config
+
+    member _.ObserveExecution(bytecodeOffset: int) =
+        validateOffset bytecodeOffset
+        let mutable count = 0UL
+        executionCounts.TryGetValue(bytecodeOffset, &count) |> ignore
+        count <- count + 1UL
+        executionCounts[bytecodeOffset] <- count
+        count = config.HotThreshold
+
+    member _.Profile(bytecodeOffset: int) =
+        validateOffset bytecodeOffset
+        let mutable executionCount = 0UL
+        if executionCounts.TryGetValue(bytecodeOffset, &executionCount) then
+            Some
+                { BytecodeOffset = bytecodeOffset
+                  ExecutionCount = executionCount
+                  IsHot = executionCount >= config.HotThreshold }
+        else
+            None
+
+    member _.InstallShellBlock(bytecodeOffset: int, assumptions: string list) =
+        validateOffset bytecodeOffset
+        if isNull (box assumptions) then
+            nullArg (nameof assumptions)
+
+        let block =
+            { BytecodeOffset = bytecodeOffset
+              Target = config.Target
+              MachineCode = []
+              Assumptions = assumptions }
+
+        nativeBlocks[bytecodeOffset] <- block
+        block
+
+    member _.HasNativeBlock(bytecodeOffset: int) =
+        validateOffset bytecodeOffset
+        nativeBlocks.ContainsKey bytecodeOffset
+
+    member _.GetNativeBlock(bytecodeOffset: int) =
+        validateOffset bytecodeOffset
+        let mutable block = Unchecked.defaultof<NativeBlock>
+        if nativeBlocks.TryGetValue(bytecodeOffset, &block) then Some block else None
+
+    member _.Deoptimize(bytecodeOffset: int) =
+        validateOffset bytecodeOffset
+        let mutable block = Unchecked.defaultof<NativeBlock>
+        if nativeBlocks.TryGetValue(bytecodeOffset, &block) then
+            nativeBlocks.Remove bytecodeOffset |> ignore
+            Some block
+        else
+            None

--- a/code/packages/fsharp/jit-compiler/README.md
+++ b/code/packages/fsharp/jit-compiler/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.JitCompiler.FSharp
+
+JIT compiler shell with hot-path profiling and a placeholder native block registry for future code generation.

--- a/code/packages/fsharp/jit-compiler/required_capabilities.json
+++ b/code/packages/fsharp/jit-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/jit-compiler",
+  "capabilities": [],
+  "justification": "Pure profiling and registry package; it does not emit or execute native code."
+}

--- a/code/packages/fsharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.fsproj
+++ b/code/packages/fsharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.JitCompiler.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.JitCompiler.fsproj" />
+    <Compile Include="JitCompilerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/JitCompilerTests.fs
+++ b/code/packages/fsharp/jit-compiler/tests/CodingAdventures.JitCompiler.Tests/JitCompilerTests.fs
@@ -1,0 +1,78 @@
+namespace CodingAdventures.JitCompiler.Tests
+
+open System
+open CodingAdventures.JitCompiler.FSharp
+open Xunit
+
+module JitCompilerTests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", JitCompiler.VERSION)
+
+    [<Fact>]
+    let ``config validates hot threshold`` () =
+        let config = JitCompilerConfig.create RiscV 3UL
+
+        Assert.Equal(RiscV, config.Target)
+        Assert.Equal(3UL, config.HotThreshold)
+        Assert.Throws<ArgumentException>(fun () -> JitCompilerConfig.create Arm 0UL |> ignore) |> ignore
+
+    [<Fact>]
+    let ``path becomes hot exactly at threshold`` () =
+        let jit = JitCompiler(JitCompilerConfig.create RiscV 3UL)
+
+        Assert.False(jit.ObserveExecution 24)
+        Assert.False(jit.ObserveExecution 24)
+        Assert.True(jit.ObserveExecution 24)
+        Assert.False(jit.ObserveExecution 24)
+
+    [<Fact>]
+    let ``profile reports execution count and hotness`` () =
+        let jit = JitCompiler(JitCompilerConfig.create Arm 2UL)
+
+        Assert.True((jit.Profile 8).IsNone)
+        jit.ObserveExecution 8 |> ignore
+        let profile = (jit.Profile 8).Value
+        Assert.Equal(1UL, profile.ExecutionCount)
+        Assert.False(profile.IsHot)
+
+        jit.ObserveExecution 8 |> ignore
+        let hotProfile = (jit.Profile 8).Value
+        Assert.Equal(2UL, hotProfile.ExecutionCount)
+        Assert.True(hotProfile.IsHot)
+
+    [<Fact>]
+    let ``shell block installation uses configured target`` () =
+        let jit = JitCompiler(JitCompilerConfig.create X86 5UL)
+
+        let block = jit.InstallShellBlock(32, [ "locals stay integers" ])
+
+        Assert.Equal(32, block.BytecodeOffset)
+        Assert.Equal(X86, block.Target)
+        Assert.Empty(block.MachineCode)
+        Assert.Equal<string list>([ "locals stay integers" ], block.Assumptions)
+        Assert.True(jit.HasNativeBlock 32)
+        Assert.Equal(Some block, jit.GetNativeBlock 32)
+
+    [<Fact>]
+    let ``deoptimize removes native block`` () =
+        let jit = JitCompiler(JitCompilerConfig.create RiscV 10UL)
+        jit.InstallShellBlock(99, [ "shape stays stable" ]) |> ignore
+
+        let block = (jit.Deoptimize 99).Value
+
+        Assert.Equal(99, block.BytecodeOffset)
+        Assert.False(jit.HasNativeBlock 99)
+        Assert.True((jit.GetNativeBlock 99).IsNone)
+        Assert.True((jit.Deoptimize 99).IsNone)
+
+    [<Fact>]
+    let ``invalid arguments are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> JitCompiler(Unchecked.defaultof<JitCompilerConfig>) |> ignore) |> ignore
+        let jit = JitCompiler(JitCompilerConfig.create Arm 1UL)
+        Assert.Throws<ArgumentException>(fun () -> jit.ObserveExecution -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> jit.Profile -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> jit.HasNativeBlock -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> jit.GetNativeBlock -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> jit.Deoptimize -1 |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> jit.InstallShellBlock(1, Unchecked.defaultof<string list>) |> ignore) |> ignore


### PR DESCRIPTION
## Summary
- add C# and F# JIT compiler shell packages matching the Rust management layer
- support target configuration, hot-path execution profiling, shell native-block registration, lookup, and deoptimization without emitting native code
- add xUnit coverage for threshold transitions, profile hotness, native block lifecycle, and invalid argument handling

## Verification
- dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.JitCompiler.Tests/CodingAdventures.JitCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line