### PR TITLE
feat(parity): add dotnet barcode-1d packages

### DIFF
--- a/code/packages/csharp/barcode-1d/BUILD
+++ b/code/packages/csharp/barcode-1d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/barcode-1d/BUILD_windows
+++ b/code/packages/csharp/barcode-1d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/barcode-1d/Barcode1D.cs
+++ b/code/packages/csharp/barcode-1d/Barcode1D.cs
@@ -1,0 +1,145 @@
+using CodingAdventures.BarcodeLayout1D;
+using CodingAdventures.PaintInstructions;
+using PixelBuffer = CodingAdventures.PixelContainer.PixelContainer;
+
+namespace CodingAdventures.Barcode1D;
+
+public enum Symbology
+{
+    Codabar,
+    Code128,
+    Code39,
+    Ean13,
+    Itf,
+    UpcA,
+}
+
+public sealed record Barcode1DOptions
+{
+    public Symbology Symbology { get; init; } = Symbology.Code39;
+
+    public PaintBarcode1DOptions Paint { get; init; } = new();
+
+    public string? CodabarStart { get; init; }
+
+    public string? CodabarStop { get; init; }
+}
+
+public class Barcode1DException(string message) : Exception(message);
+
+public sealed class UnsupportedSymbologyException(string message) : Barcode1DException(message);
+
+public sealed class BackendUnavailableException(string message) : Barcode1DException(message);
+
+public static class Barcode1D
+{
+    public const string Version = "0.1.0";
+
+    public static Barcode1DRenderConfig DefaultRenderConfig() => new();
+
+    public static Barcode1DOptions DefaultOptions() => new();
+
+    public static string AsString(this Symbology symbology) =>
+        symbology switch
+        {
+            Symbology.Codabar => "codabar",
+            Symbology.Code128 => "code128",
+            Symbology.Code39 => "code39",
+            Symbology.Ean13 => "ean13",
+            Symbology.Itf => "itf",
+            Symbology.UpcA => "upca",
+            _ => throw new ArgumentOutOfRangeException(nameof(symbology), symbology, null),
+        };
+
+    public static string? CurrentBackend() => null;
+
+    public static Symbology NormalizeSymbology(string symbology)
+    {
+        ArgumentNullException.ThrowIfNull(symbology);
+
+        var normalized = symbology
+            .Trim()
+            .ToLowerInvariant()
+            .Replace("-", string.Empty)
+            .Replace("_", string.Empty);
+
+        normalized = normalized.Length == 0 ? "code39" : normalized;
+
+        return normalized switch
+        {
+            "codabar" => Symbology.Codabar,
+            "code128" => Symbology.Code128,
+            "code39" => Symbology.Code39,
+            "ean13" => Symbology.Ean13,
+            "itf" => Symbology.Itf,
+            "upca" => Symbology.UpcA,
+            _ => throw new UnsupportedSymbologyException($"unsupported symbology: {symbology}"),
+        };
+    }
+
+    public static PaintScene BuildScene(string data, Barcode1DOptions? options = null)
+    {
+        options ??= new Barcode1DOptions();
+
+        return options.Symbology switch
+        {
+            Symbology.Codabar => CodingAdventures.Codabar.Codabar.LayoutCodabar(
+                data,
+                options.Paint,
+                options.CodabarStart ?? "A",
+                options.CodabarStop ?? "A"),
+            Symbology.Code128 => CodingAdventures.Code128.Code128.LayoutCode128(data, options.Paint),
+            Symbology.Code39 => CodingAdventures.Code39.Code39.LayoutCode39(data, options.Paint),
+            Symbology.Ean13 => CodingAdventures.Ean13.Ean13.LayoutEan13(data, options.Paint),
+            Symbology.Itf => CodingAdventures.Itf.Itf.LayoutItf(data, options.Paint),
+            Symbology.UpcA => CodingAdventures.UpcA.UpcA.LayoutUpcA(data, options.Paint),
+            _ => throw new ArgumentOutOfRangeException(nameof(options), options.Symbology, null),
+        };
+    }
+
+    public static PaintScene BuildSceneForSymbology(
+        string symbology,
+        string data,
+        Barcode1DOptions? options = null)
+    {
+        var nextOptions = (options ?? new Barcode1DOptions()) with
+        {
+            Symbology = NormalizeSymbology(symbology),
+        };
+
+        return BuildScene(data, nextOptions);
+    }
+
+    public static PixelBuffer RenderPixels(string data, Barcode1DOptions? options = null)
+    {
+        _ = BuildScene(data, options);
+        throw NewBackendUnavailable();
+    }
+
+    public static PixelBuffer RenderPixelsForSymbology(
+        string symbology,
+        string data,
+        Barcode1DOptions? options = null)
+    {
+        _ = BuildSceneForSymbology(symbology, data, options);
+        throw NewBackendUnavailable();
+    }
+
+    public static byte[] RenderPng(string data, Barcode1DOptions? options = null)
+    {
+        _ = RenderPixels(data, options);
+        throw NewBackendUnavailable();
+    }
+
+    public static byte[] RenderPngForSymbology(
+        string symbology,
+        string data,
+        Barcode1DOptions? options = null)
+    {
+        _ = RenderPixelsForSymbology(symbology, data, options);
+        throw NewBackendUnavailable();
+    }
+
+    private static BackendUnavailableException NewBackendUnavailable() =>
+        new("native barcode rendering is not wired for dotnet yet; BuildScene() is available, but pixel and PNG rendering await a paint backend.");
+}

--- a/code/packages/csharp/barcode-1d/CHANGELOG.md
+++ b/code/packages/csharp/barcode-1d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# high-level 1D barcode orchestration package with Code 39, Code 128, Codabar, EAN-13, ITF, and UPC-A scene routing.

--- a/code/packages/csharp/barcode-1d/CodingAdventures.Barcode1D.csproj
+++ b/code/packages/csharp/barcode-1d/CodingAdventures.Barcode1D.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Barcode1D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>High-level 1D barcode pipeline for C#: symbology selection over shared barcode encoders and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.csproj" />
+    <ProjectReference Include="../codabar/CodingAdventures.Codabar.csproj" />
+    <ProjectReference Include="../code128/CodingAdventures.Code128.csproj" />
+    <ProjectReference Include="../code39/CodingAdventures.Code39.csproj" />
+    <ProjectReference Include="../ean-13/CodingAdventures.Ean13.csproj" />
+    <ProjectReference Include="../itf/CodingAdventures.Itf.csproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.csproj" />
+    <ProjectReference Include="../pixel-container/CodingAdventures.PixelContainer.csproj" />
+    <ProjectReference Include="../upc-a/CodingAdventures.UpcA.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/barcode-1d/README.md
+++ b/code/packages/csharp/barcode-1d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Barcode1D.CSharp
+
+High-level 1D barcode pipeline for C#: selects a symbology, delegates to the shared barcode encoder packages, and returns backend-neutral paint scenes.

--- a/code/packages/csharp/barcode-1d/required_capabilities.json
+++ b/code/packages/csharp/barcode-1d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/barcode-1d",
+  "capabilities": [],
+  "justification": "Pure orchestration over local barcode encoder and layout packages. Pixel/PNG rendering is explicitly unavailable until a native dotnet paint backend is added."
+}

--- a/code/packages/csharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/Barcode1DTests.cs
+++ b/code/packages/csharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/Barcode1DTests.cs
@@ -1,0 +1,113 @@
+using CodingAdventures.BarcodeLayout1D;
+
+namespace CodingAdventures.Barcode1D.Tests;
+
+public sealed class Barcode1DTests
+{
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Barcode1D.Version);
+    }
+
+    [Fact]
+    public void NormalizeSymbologyAcceptsCommonSpellings()
+    {
+        Assert.Equal(Symbology.Code39, Barcode1D.NormalizeSymbology("code39"));
+        Assert.Equal(Symbology.Code128, Barcode1D.NormalizeSymbology("code-128"));
+        Assert.Equal(Symbology.Ean13, Barcode1D.NormalizeSymbology("ean_13"));
+        Assert.Equal(Symbology.UpcA, Barcode1D.NormalizeSymbology("UPC-A"));
+        Assert.Equal(Symbology.Code39, Barcode1D.NormalizeSymbology(" "));
+        Assert.Equal("itf", Symbology.Itf.AsString());
+    }
+
+    [Fact]
+    public void NormalizeSymbologyRejectsUnsupportedNames()
+    {
+        Assert.Throws<ArgumentNullException>(() => Barcode1D.NormalizeSymbology(null!));
+        Assert.Throws<UnsupportedSymbologyException>(() => Barcode1D.NormalizeSymbology("qr"));
+    }
+
+    [Fact]
+    public void BuildSceneRoutesToCode39ByDefault()
+    {
+        var scene = Barcode1D.BuildScene("HELLO-123");
+
+        Assert.Equal("code39", scene.Metadata?["symbology"]);
+        Assert.Equal("HELLO-123", scene.Metadata?["humanReadableText"]);
+        Assert.True(scene.Width > 0);
+        Assert.Equal(Barcode1D.DefaultRenderConfig().BarHeight, scene.Height);
+    }
+
+    [Theory]
+    [InlineData("codabar", "40156", "codabar")]
+    [InlineData("code128", "Code 128", "code128")]
+    [InlineData("ean-13", "400638133393", "ean-13")]
+    [InlineData("itf", "123456", "itf")]
+    [InlineData("upc_a", "03600029145", "upc-a")]
+    public void BuildSceneForSymbologyRoutesAdditionalEncoders(string symbology, string data, string expected)
+    {
+        var scene = Barcode1D.BuildSceneForSymbology(symbology, data);
+
+        Assert.Equal(expected, scene.Metadata?["symbology"]);
+        Assert.True(scene.Width > 0);
+        Assert.True((uint)scene.Metadata!["contentModules"]! > 0);
+    }
+
+    [Fact]
+    public void BuildSceneUsesTypedOptionsAndPaintOptions()
+    {
+        var options = new Barcode1DOptions
+        {
+            Symbology = Symbology.Ean13,
+            Paint = new PaintBarcode1DOptions
+            {
+                RenderConfig = new Barcode1DRenderConfig { ModuleWidth = 2.0 },
+                Metadata = new Dictionary<string, object?> { ["batch"] = "aggregate" },
+            },
+        };
+
+        var scene = Barcode1D.BuildScene("400638133393", options);
+
+        Assert.Equal("ean-13", scene.Metadata?["symbology"]);
+        Assert.Equal("aggregate", scene.Metadata?["batch"]);
+        Assert.Equal(2.0, scene.Metadata?["moduleWidthPx"]);
+    }
+
+    [Fact]
+    public void CodabarStartStopCanBeSelected()
+    {
+        var scene = Barcode1D.BuildScene(
+            "40156",
+            new Barcode1DOptions
+            {
+                Symbology = Symbology.Codabar,
+                CodabarStart = "B",
+                CodabarStop = "C",
+            });
+
+        Assert.Equal("codabar", scene.Metadata?["symbology"]);
+        Assert.Equal("B", scene.Metadata?["start"]);
+        Assert.Equal("C", scene.Metadata?["stop"]);
+    }
+
+    [Fact]
+    public void CurrentBackendIsHonestAboutMissingNativeRenderer()
+    {
+        Assert.Null(Barcode1D.CurrentBackend());
+    }
+
+    [Fact]
+    public void RenderPixelsFailsUntilNativeBackendExists()
+    {
+        Assert.Throws<BackendUnavailableException>(() => Barcode1D.RenderPixels("HELLO-123"));
+        Assert.Throws<BackendUnavailableException>(() => Barcode1D.RenderPixelsForSymbology("code-128", "Code 128"));
+    }
+
+    [Fact]
+    public void RenderPngFailsUntilNativeBackendExists()
+    {
+        Assert.Throws<BackendUnavailableException>(() => Barcode1D.RenderPng("HELLO-123"));
+        Assert.Throws<BackendUnavailableException>(() => Barcode1D.RenderPngForSymbology("ean13", "400638133393"));
+    }
+}

--- a/code/packages/csharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.csproj
+++ b/code/packages/csharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Barcode1D]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Barcode1D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/barcode-1d/BUILD
+++ b/code/packages/fsharp/barcode-1d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/barcode-1d/BUILD_windows
+++ b/code/packages/fsharp/barcode-1d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/barcode-1d/Barcode1D.fs
+++ b/code/packages/fsharp/barcode-1d/Barcode1D.fs
@@ -1,0 +1,129 @@
+namespace CodingAdventures.Barcode1D.FSharp
+
+open System
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+open CodingAdventures.PixelContainer
+
+[<RequireQualifiedAccess>]
+type Symbology =
+    | Codabar
+    | Code128
+    | Code39
+    | Ean13
+    | Itf
+    | UpcA
+
+type Barcode1DOptions =
+    {
+        Symbology: Symbology
+        Paint: PaintBarcode1DOptions
+        CodabarStart: string option
+        CodabarStop: string option
+    }
+
+type Barcode1DError(message: string) =
+    inherit Exception(message)
+
+type UnsupportedSymbologyException(message: string) =
+    inherit Barcode1DError(message)
+
+type BackendUnavailableException(message: string) =
+    inherit Barcode1DError(message)
+
+[<RequireQualifiedAccess>]
+module Barcode1D =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let defaultRenderConfig =
+        BarcodeLayout1D.defaultRenderConfig
+
+    let defaultOptions =
+        {
+            Symbology = Symbology.Code39
+            Paint = BarcodeLayout1D.defaultPaintOptions
+            CodabarStart = None
+            CodabarStop = None
+        }
+
+    let symbologyAsString symbology =
+        match symbology with
+        | Symbology.Codabar -> "codabar"
+        | Symbology.Code128 -> "code128"
+        | Symbology.Code39 -> "code39"
+        | Symbology.Ean13 -> "ean13"
+        | Symbology.Itf -> "itf"
+        | Symbology.UpcA -> "upca"
+
+    let currentBackend () : string option =
+        None
+
+    let normalizeSymbology (symbology: string) =
+        if isNull symbology then
+            nullArg (nameof symbology)
+
+        let normalized =
+            symbology.Trim().ToLowerInvariant().Replace("-", String.Empty).Replace("_", String.Empty)
+
+        let normalized =
+            if normalized.Length = 0 then "code39" else normalized
+
+        match normalized with
+        | "codabar" -> Symbology.Codabar
+        | "code128" -> Symbology.Code128
+        | "code39" -> Symbology.Code39
+        | "ean13" -> Symbology.Ean13
+        | "itf" -> Symbology.Itf
+        | "upca" -> Symbology.UpcA
+        | _ -> raise (UnsupportedSymbologyException $"unsupported symbology: {symbology}")
+
+    let buildScene data options =
+        let options = defaultArg options defaultOptions
+
+        match options.Symbology with
+        | Symbology.Codabar ->
+            CodingAdventures.Codabar.FSharp.Codabar.layoutCodabar
+                data
+                (Some options.Paint)
+                options.CodabarStart
+                options.CodabarStop
+        | Symbology.Code128 ->
+            CodingAdventures.Code128.FSharp.Code128.layoutCode128 data (Some options.Paint)
+        | Symbology.Code39 ->
+            CodingAdventures.Code39.FSharp.Code39.layoutCode39 data (Some options.Paint)
+        | Symbology.Ean13 ->
+            CodingAdventures.Ean13.FSharp.Ean13.layoutEan13 data (Some options.Paint)
+        | Symbology.Itf ->
+            CodingAdventures.Itf.FSharp.Itf.layoutItf data (Some options.Paint)
+        | Symbology.UpcA ->
+            CodingAdventures.UpcA.FSharp.UpcA.layoutUpcA data (Some options.Paint)
+
+    let buildSceneForSymbology symbology data options =
+        let options =
+            { defaultArg options defaultOptions with
+                Symbology = normalizeSymbology symbology }
+
+        buildScene data (Some options)
+
+    let private backendUnavailable () =
+        raise (
+            BackendUnavailableException
+                "native barcode rendering is not wired for dotnet yet; buildScene is available, but pixel and PNG rendering await a paint backend."
+        )
+
+    let renderPixels data options : PixelContainer =
+        buildScene data options |> ignore
+        backendUnavailable ()
+
+    let renderPixelsForSymbology symbology data options : PixelContainer =
+        buildSceneForSymbology symbology data options |> ignore
+        backendUnavailable ()
+
+    let renderPng data options : byte array =
+        renderPixels data options |> ignore
+        backendUnavailable ()
+
+    let renderPngForSymbology symbology data options : byte array =
+        renderPixelsForSymbology symbology data options |> ignore
+        backendUnavailable ()

--- a/code/packages/fsharp/barcode-1d/CHANGELOG.md
+++ b/code/packages/fsharp/barcode-1d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# high-level 1D barcode orchestration package with Code 39, Code 128, Codabar, EAN-13, ITF, and UPC-A scene routing.

--- a/code/packages/fsharp/barcode-1d/CodingAdventures.Barcode1D.fsproj
+++ b/code/packages/fsharp/barcode-1d/CodingAdventures.Barcode1D.fsproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Barcode1D.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Barcode1D.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>High-level 1D barcode pipeline for F#: symbology selection over shared barcode encoders and paint scenes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-layout-1d/CodingAdventures.BarcodeLayout1D.fsproj" />
+    <ProjectReference Include="../codabar/CodingAdventures.Codabar.fsproj" />
+    <ProjectReference Include="../code128/CodingAdventures.Code128.fsproj" />
+    <ProjectReference Include="../code39/CodingAdventures.Code39.fsproj" />
+    <ProjectReference Include="../ean-13/CodingAdventures.Ean13.fsproj" />
+    <ProjectReference Include="../itf/CodingAdventures.Itf.fsproj" />
+    <ProjectReference Include="../paint-instructions/CodingAdventures.PaintInstructions.fsproj" />
+    <ProjectReference Include="../pixel-container/CodingAdventures.PixelContainer.fsproj" />
+    <ProjectReference Include="../upc-a/CodingAdventures.UpcA.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Barcode1D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/barcode-1d/README.md
+++ b/code/packages/fsharp/barcode-1d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Barcode1D.FSharp
+
+High-level 1D barcode pipeline for F#: selects a symbology, delegates to the shared barcode encoder packages, and returns backend-neutral paint scenes.

--- a/code/packages/fsharp/barcode-1d/required_capabilities.json
+++ b/code/packages/fsharp/barcode-1d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/barcode-1d",
+  "capabilities": [],
+  "justification": "Pure orchestration over local barcode encoder and layout packages. Pixel/PNG rendering is explicitly unavailable until a native dotnet paint backend is added."
+}

--- a/code/packages/fsharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/Barcode1DTests.fs
+++ b/code/packages/fsharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/Barcode1DTests.fs
@@ -1,0 +1,97 @@
+namespace CodingAdventures.Barcode1D.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.Barcode1D.FSharp
+open CodingAdventures.BarcodeLayout1D.FSharp
+open CodingAdventures.PaintInstructions
+open Xunit
+
+module Barcode1DTests =
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Barcode1D.VERSION)
+
+    [<Fact>]
+    let ``normalize accepts common spellings`` () =
+        Assert.Equal(Symbology.Code39, Barcode1D.normalizeSymbology "code39")
+        Assert.Equal(Symbology.Code128, Barcode1D.normalizeSymbology "code-128")
+        Assert.Equal(Symbology.Ean13, Barcode1D.normalizeSymbology "ean_13")
+        Assert.Equal(Symbology.UpcA, Barcode1D.normalizeSymbology "UPC-A")
+        Assert.Equal(Symbology.Code39, Barcode1D.normalizeSymbology " ")
+        Assert.Equal("itf", Barcode1D.symbologyAsString Symbology.Itf)
+
+    [<Fact>]
+    let ``normalize rejects unsupported names`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Barcode1D.normalizeSymbology Unchecked.defaultof<string> |> ignore) |> ignore
+        Assert.Throws<UnsupportedSymbologyException>(fun () -> Barcode1D.normalizeSymbology "qr" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``build scene routes to code39 by default`` () =
+        let scene = Barcode1D.buildScene "HELLO-123" None
+
+        Assert.Equal(box "code39", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "HELLO-123", scene.Metadata.Value["humanReadableText"])
+        Assert.True(scene.Width > 0.0)
+        Assert.Equal(Barcode1D.defaultRenderConfig.BarHeight, scene.Height)
+
+    [<Theory>]
+    [<InlineData("codabar", "40156", "codabar")>]
+    [<InlineData("code128", "Code 128", "code128")>]
+    [<InlineData("ean-13", "400638133393", "ean-13")>]
+    [<InlineData("itf", "123456", "itf")>]
+    [<InlineData("upc_a", "03600029145", "upc-a")>]
+    let ``build scene for symbology routes additional encoders`` symbology data expected =
+        let scene = Barcode1D.buildSceneForSymbology symbology data None
+
+        Assert.Equal(box expected, scene.Metadata.Value["symbology"])
+        Assert.True(scene.Width > 0.0)
+        Assert.True(unbox<uint32> scene.Metadata.Value["contentModules"] > 0u)
+
+    [<Fact>]
+    let ``build scene uses typed options and paint options`` () =
+        let metadata = Dictionary<string, obj>()
+        metadata.["batch"] <- box "aggregate"
+
+        let options =
+            { Barcode1D.defaultOptions with
+                Symbology = Symbology.Ean13
+                Paint =
+                    { BarcodeLayout1D.defaultPaintOptions with
+                        RenderConfig = { BarcodeLayout1D.defaultRenderConfig with ModuleWidth = 2.0 }
+                        Metadata = metadata :> Metadata } }
+
+        let scene = Barcode1D.buildScene "400638133393" (Some options)
+
+        Assert.Equal(box "ean-13", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "aggregate", scene.Metadata.Value["batch"])
+        Assert.Equal(box 2.0, scene.Metadata.Value["moduleWidthPx"])
+
+    [<Fact>]
+    let ``codabar start stop can be selected`` () =
+        let scene =
+            Barcode1D.buildScene
+                "40156"
+                (Some
+                    { Barcode1D.defaultOptions with
+                        Symbology = Symbology.Codabar
+                        CodabarStart = Some "B"
+                        CodabarStop = Some "C" })
+
+        Assert.Equal(box "codabar", scene.Metadata.Value["symbology"])
+        Assert.Equal(box "B", scene.Metadata.Value["start"])
+        Assert.Equal(box "C", scene.Metadata.Value["stop"])
+
+    [<Fact>]
+    let ``current backend is honest about missing native renderer`` () =
+        Assert.True(Barcode1D.currentBackend().IsNone)
+
+    [<Fact>]
+    let ``render pixels fails until native backend exists`` () =
+        Assert.Throws<BackendUnavailableException>(fun () -> Barcode1D.renderPixels "HELLO-123" None |> ignore) |> ignore
+        Assert.Throws<BackendUnavailableException>(fun () -> Barcode1D.renderPixelsForSymbology "code-128" "Code 128" None |> ignore) |> ignore
+
+    [<Fact>]
+    let ``render png fails until native backend exists`` () =
+        Assert.Throws<BackendUnavailableException>(fun () -> Barcode1D.renderPng "HELLO-123" None |> ignore) |> ignore
+        Assert.Throws<BackendUnavailableException>(fun () -> Barcode1D.renderPngForSymbology "ean13" "400638133393" None |> ignore) |> ignore

--- a/code/packages/fsharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.fsproj
+++ b/code/packages/fsharp/barcode-1d/tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Barcode1D.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Barcode1D.fsproj" />
+    <Compile Include="Barcode1DTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# barcode-1d aggregate packages over Code 39, Code 128, Codabar, EAN-13, ITF, and UPC-A
- add symbology normalization, typed options, Codabar guard selection, and build-scene routing into the shared paint-scene pipeline
- expose explicit backend-unavailable pixel/PNG render calls until dotnet native paint renderers/codecs exist

## Verification
- dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Barcode1D.Tests/CodingAdventures.Barcode1D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line