### PR TITLE
feat(parity): add dotnet geometry 2d packages

### DIFF
--- a/code/packages/csharp/affine2d/Affine2D.cs
+++ b/code/packages/csharp/affine2d/Affine2D.cs
@@ -1,0 +1,97 @@
+using CodingAdventures.Point2D;
+
+namespace CodingAdventures.Affine2D;
+
+public readonly record struct Affine2D(double A, double B, double C, double D, double E, double F)
+{
+    public static Affine2D Identity() => new(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+
+    public static Affine2D Translate(double tx, double ty) => new(1.0, 0.0, 0.0, 1.0, tx, ty);
+
+    public static Affine2D Rotate(double angle)
+    {
+        var cosine = CodingAdventures.Trig.Trig.Cos(angle);
+        var sine = CodingAdventures.Trig.Trig.Sin(angle);
+        return new Affine2D(cosine, sine, -sine, cosine, 0.0, 0.0);
+    }
+
+    public static Affine2D RotateAround(Point center, double angle) =>
+        Translate(-center.X, -center.Y)
+            .Then(Rotate(angle))
+            .Then(Translate(center.X, center.Y));
+
+    public static Affine2D Scale(double sx, double sy) => new(sx, 0.0, 0.0, sy, 0.0, 0.0);
+
+    public static Affine2D ScaleUniform(double scale) => Scale(scale, scale);
+
+    public static Affine2D SkewX(double angle) => new(1.0, 0.0, CodingAdventures.Trig.Trig.Tan(angle), 1.0, 0.0, 0.0);
+
+    public static Affine2D SkewY(double angle) => new(1.0, CodingAdventures.Trig.Trig.Tan(angle), 0.0, 1.0, 0.0, 0.0);
+
+    public Affine2D Then(Affine2D next) => next.Multiply(this);
+
+    public Affine2D Multiply(Affine2D other) =>
+        new(
+            A * other.A + C * other.B,
+            B * other.A + D * other.B,
+            A * other.C + C * other.D,
+            B * other.C + D * other.D,
+            A * other.E + C * other.F + E,
+            B * other.E + D * other.F + F);
+
+    public Point ApplyToPoint(Point point) =>
+        new(
+            A * point.X + C * point.Y + E,
+            B * point.X + D * point.Y + F);
+
+    public Point ApplyToVector(Point vector) =>
+        new(
+            A * vector.X + C * vector.Y,
+            B * vector.X + D * vector.Y);
+
+    public double Determinant() => A * D - B * C;
+
+    public Affine2D? Invert()
+    {
+        var determinant = Determinant();
+        if (Math.Abs(determinant) < 1e-12)
+        {
+            return null;
+        }
+
+        return new Affine2D(
+            D / determinant,
+            -B / determinant,
+            -C / determinant,
+            A / determinant,
+            (C * F - D * E) / determinant,
+            (B * E - A * F) / determinant);
+    }
+
+    public bool IsIdentity()
+    {
+        const double epsilon = 1e-10;
+        return Math.Abs(A - 1.0) < epsilon
+            && Math.Abs(B) < epsilon
+            && Math.Abs(C) < epsilon
+            && Math.Abs(D - 1.0) < epsilon
+            && Math.Abs(E) < epsilon
+            && Math.Abs(F) < epsilon;
+    }
+
+    public bool IsTranslationOnly()
+    {
+        const double epsilon = 1e-10;
+        return Math.Abs(A - 1.0) < epsilon
+            && Math.Abs(B) < epsilon
+            && Math.Abs(C) < epsilon
+            && Math.Abs(D - 1.0) < epsilon;
+    }
+
+    public double[] ToArray() => [A, B, C, D, E, F];
+}
+
+public static class Affine2DPackage
+{
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/affine2d/BUILD
+++ b/code/packages/csharp/affine2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/affine2d/BUILD_windows
+++ b/code/packages/csharp/affine2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/affine2d/CHANGELOG.md
+++ b/code/packages/csharp/affine2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# affine transform factories, composition, point/vector application, inversion, predicates, and array export.

--- a/code/packages/csharp/affine2d/CodingAdventures.Affine2D.csproj
+++ b/code/packages/csharp/affine2d/CodingAdventures.Affine2D.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Affine2D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>2D affine transformation matrix for translate, rotate, scale, and skew operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.csproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/affine2d/README.md
+++ b/code/packages/csharp/affine2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Affine2D.CSharp
+
+2D affine transformation matrix using the SVG/Canvas six-component convention.

--- a/code/packages/csharp/affine2d/required_capabilities.json
+++ b/code/packages/csharp/affine2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/affine2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point and trig packages."
+}

--- a/code/packages/csharp/affine2d/tests/CodingAdventures.Affine2D.Tests/Affine2DTests.cs
+++ b/code/packages/csharp/affine2d/tests/CodingAdventures.Affine2D.Tests/Affine2DTests.cs
@@ -1,0 +1,76 @@
+using CodingAdventures.Point2D;
+using TrigPackage = CodingAdventures.Trig.Trig;
+
+namespace CodingAdventures.Affine2D.Tests;
+
+public sealed class Affine2DTests
+{
+    private const double Epsilon = 1e-9;
+
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Affine2DPackage.Version);
+    }
+
+    [Fact]
+    public void FactoriesApplyExpectedTransforms()
+    {
+        var identity = Affine2D.Identity();
+        Assert.Equal(new[] { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 }, identity.ToArray());
+        Assert.True(PointClose(identity.ApplyToPoint(new Point(3, 4)), new Point(3, 4)));
+
+        Assert.True(PointClose(Affine2D.Translate(5, -3).ApplyToPoint(new Point(1, 2)), new Point(6, -1)));
+        Assert.True(PointClose(Affine2D.Translate(5, -3).ApplyToVector(new Point(1, 2)), new Point(1, 2)));
+        Assert.True(PointClose(Affine2D.Scale(2, 3).ApplyToPoint(new Point(1, 1)), new Point(2, 3)));
+        Assert.True(PointClose(Affine2D.ScaleUniform(5).ApplyToPoint(new Point(2, 3)), new Point(10, 15)));
+    }
+
+    [Fact]
+    public void RotationAndSkewFactoriesWork()
+    {
+        Assert.True(PointClose(Affine2D.Rotate(TrigPackage.PI / 2.0).ApplyToPoint(new Point(1, 0)), new Point(0, 1)));
+        Assert.True(Affine2D.Rotate(2.0 * TrigPackage.PI).IsIdentity());
+
+        var center = new Point(1, 0);
+        Assert.True(PointClose(Affine2D.RotateAround(center, TrigPackage.PI / 2.0).ApplyToPoint(center), center));
+        Assert.True(PointClose(Affine2D.SkewX(TrigPackage.PI / 4.0).ApplyToPoint(new Point(0, 1)), new Point(1, 1)));
+        Assert.True(PointClose(Affine2D.SkewY(TrigPackage.PI / 4.0).ApplyToPoint(new Point(1, 0)), new Point(1, 1)));
+    }
+
+    [Fact]
+    public void CompositionDeterminantAndInvertWork()
+    {
+        var scale = Affine2D.ScaleUniform(2);
+        var translate = Affine2D.Translate(10, 0);
+        var composed = translate.Multiply(scale);
+        Assert.True(PointClose(composed.ApplyToPoint(new Point(1, 1)), new Point(12, 2)));
+
+        Assert.True(AffineClose(Affine2D.Identity().Multiply(translate), translate));
+        Assert.True(AffineClose(scale.Then(translate), composed));
+        Assert.True(Close(Affine2D.Scale(2, 3).Determinant(), 6));
+        Assert.True(Close(Affine2D.Rotate(TrigPackage.PI / 3.0).Determinant(), 1));
+
+        var inverse = translate.Invert();
+        Assert.NotNull(inverse);
+        Assert.True(translate.Multiply(inverse.Value).IsIdentity());
+        Assert.Null(new Affine2D(0, 0, 0, 0, 0, 0).Invert());
+    }
+
+    [Fact]
+    public void PredicatesDistinguishTransformKinds()
+    {
+        Assert.True(Affine2D.Identity().IsIdentity());
+        Assert.False(Affine2D.Translate(1, 0).IsIdentity());
+        Assert.True(Affine2D.Translate(5, 3).IsTranslationOnly());
+        Assert.False(Affine2D.Rotate(0.1).IsTranslationOnly());
+        Assert.False(Affine2D.Scale(2, 1).IsTranslationOnly());
+    }
+
+    private static bool Close(double left, double right) => Math.Abs(left - right) < Epsilon;
+
+    private static bool PointClose(Point left, Point right) => Close(left.X, right.X) && Close(left.Y, right.Y);
+
+    private static bool AffineClose(Affine2D left, Affine2D right) =>
+        left.ToArray().Zip(right.ToArray()).All(pair => Close(pair.First, pair.Second));
+}

--- a/code/packages/csharp/affine2d/tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.csproj
+++ b/code/packages/csharp/affine2d/tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Affine2D]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Affine2D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/arc2d/Arc2D.cs
+++ b/code/packages/csharp/arc2d/Arc2D.cs
@@ -1,0 +1,191 @@
+using CodingAdventures.Bezier2D;
+using CodingAdventures.Point2D;
+
+namespace CodingAdventures.Arc2D;
+
+public readonly record struct CenterArc(
+    Point Center,
+    double Rx,
+    double Ry,
+    double StartAngle,
+    double SweepAngle,
+    double XRotation)
+{
+    public Point Evaluate(double t)
+    {
+        var angle = StartAngle + t * SweepAngle;
+        var xp = Rx * CodingAdventures.Trig.Trig.Cos(angle);
+        var yp = Ry * CodingAdventures.Trig.Trig.Sin(angle);
+        var cosineRotation = CodingAdventures.Trig.Trig.Cos(XRotation);
+        var sineRotation = CodingAdventures.Trig.Trig.Sin(XRotation);
+
+        return new Point(
+            cosineRotation * xp - sineRotation * yp + Center.X,
+            sineRotation * xp + cosineRotation * yp + Center.Y);
+    }
+
+    public Point Tangent(double t)
+    {
+        var angle = StartAngle + t * SweepAngle;
+        var dxp = -Rx * CodingAdventures.Trig.Trig.Sin(angle) * SweepAngle;
+        var dyp = Ry * CodingAdventures.Trig.Trig.Cos(angle) * SweepAngle;
+        var cosineRotation = CodingAdventures.Trig.Trig.Cos(XRotation);
+        var sineRotation = CodingAdventures.Trig.Trig.Sin(XRotation);
+
+        return new Point(
+            cosineRotation * dxp - sineRotation * dyp,
+            sineRotation * dxp + cosineRotation * dyp);
+    }
+
+    public Rect BoundingBox()
+    {
+        const int samples = 100;
+        var minX = double.PositiveInfinity;
+        var minY = double.PositiveInfinity;
+        var maxX = double.NegativeInfinity;
+        var maxY = double.NegativeInfinity;
+
+        for (var index = 0; index <= samples; index++)
+        {
+            var point = Evaluate(index / (double)samples);
+            minX = Math.Min(minX, point.X);
+            maxX = Math.Max(maxX, point.X);
+            minY = Math.Min(minY, point.Y);
+            maxY = Math.Max(maxY, point.Y);
+        }
+
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    public IReadOnlyList<CubicBezier> ToCubicBeziers()
+    {
+        var maxSegment = CodingAdventures.Trig.Trig.PI / 2.0;
+        var segmentCount = Math.Max(1, (int)Math.Ceiling(Math.Abs(SweepAngle) / maxSegment));
+        var segmentSweep = SweepAngle / segmentCount;
+        var cosineRotation = CodingAdventures.Trig.Trig.Cos(XRotation);
+        var sineRotation = CodingAdventures.Trig.Trig.Sin(XRotation);
+        var centerX = Center.X;
+        var centerY = Center.Y;
+        var k = (4.0 / 3.0) * CodingAdventures.Trig.Trig.Tan(segmentSweep / 4.0);
+        var beziers = new List<CubicBezier>(segmentCount);
+
+        for (var index = 0; index < segmentCount; index++)
+        {
+            var alpha = StartAngle + index * segmentSweep;
+            var beta = alpha + segmentSweep;
+            var cosAlpha = CodingAdventures.Trig.Trig.Cos(alpha);
+            var sinAlpha = CodingAdventures.Trig.Trig.Sin(alpha);
+            var cosBeta = CodingAdventures.Trig.Trig.Cos(beta);
+            var sinBeta = CodingAdventures.Trig.Trig.Sin(beta);
+
+            var p0Local = (X: Rx * cosAlpha, Y: Ry * sinAlpha);
+            var p3Local = (X: Rx * cosBeta, Y: Ry * sinBeta);
+            var p1Local = (X: p0Local.X + k * (-Rx * sinAlpha), Y: p0Local.Y + k * (Ry * cosAlpha));
+            var p2Local = (X: p3Local.X - k * (-Rx * sinBeta), Y: p3Local.Y - k * (Ry * cosBeta));
+
+            beziers.Add(new CubicBezier(
+                RotateTranslate(p0Local.X, p0Local.Y),
+                RotateTranslate(p1Local.X, p1Local.Y),
+                RotateTranslate(p2Local.X, p2Local.Y),
+                RotateTranslate(p3Local.X, p3Local.Y)));
+        }
+
+        return beziers;
+
+        Point RotateTranslate(double localX, double localY) =>
+            new(
+                cosineRotation * localX - sineRotation * localY + centerX,
+                sineRotation * localX + cosineRotation * localY + centerY);
+    }
+}
+
+public readonly record struct SvgArc(
+    Point From,
+    Point To,
+    double Rx,
+    double Ry,
+    double XRotation,
+    bool LargeArc,
+    bool Sweep)
+{
+    public CenterArc? ToCenterArc()
+    {
+        if (Math.Abs(From.X - To.X) < 1e-12 && Math.Abs(From.Y - To.Y) < 1e-12)
+        {
+            return null;
+        }
+
+        if (Math.Abs(Rx) < 1e-12 || Math.Abs(Ry) < 1e-12)
+        {
+            return null;
+        }
+
+        var cosineRotation = CodingAdventures.Trig.Trig.Cos(XRotation);
+        var sineRotation = CodingAdventures.Trig.Trig.Sin(XRotation);
+        var dx = (From.X - To.X) / 2.0;
+        var dy = (From.Y - To.Y) / 2.0;
+        var x1Prime = cosineRotation * dx + sineRotation * dy;
+        var y1Prime = -sineRotation * dx + cosineRotation * dy;
+        var rx = Math.Abs(Rx);
+        var ry = Math.Abs(Ry);
+
+        var lambda = (x1Prime / rx) * (x1Prime / rx) + (y1Prime / ry) * (y1Prime / ry);
+        if (lambda > 1.0)
+        {
+            var squareRootLambda = CodingAdventures.Trig.Trig.Sqrt(lambda);
+            rx *= squareRootLambda;
+            ry *= squareRootLambda;
+        }
+
+        var rxSquared = rx * rx;
+        var rySquared = ry * ry;
+        var x1PrimeSquared = x1Prime * x1Prime;
+        var y1PrimeSquared = y1Prime * y1Prime;
+        var numerator = rxSquared * rySquared - rxSquared * y1PrimeSquared - rySquared * x1PrimeSquared;
+        var denominator = rxSquared * y1PrimeSquared + rySquared * x1PrimeSquared;
+        var squareRoot = Math.Abs(denominator) < 1e-12
+            ? 0.0
+            : CodingAdventures.Trig.Trig.Sqrt(Math.Max(0.0, numerator / denominator));
+        var sign = LargeArc == Sweep ? -1.0 : 1.0;
+        var cxPrime = sign * squareRoot * (rx * y1Prime / ry);
+        var cyPrime = sign * squareRoot * -(ry * x1Prime / rx);
+
+        var midX = (From.X + To.X) / 2.0;
+        var midY = (From.Y + To.Y) / 2.0;
+        var cx = cosineRotation * cxPrime - sineRotation * cyPrime + midX;
+        var cy = sineRotation * cxPrime + cosineRotation * cyPrime + midY;
+
+        var ux = (x1Prime - cxPrime) / rx;
+        var uy = (y1Prime - cyPrime) / ry;
+        var vx = (-x1Prime - cxPrime) / rx;
+        var vy = (-y1Prime - cyPrime) / ry;
+        var startAngle = AngleBetween(1.0, 0.0, ux, uy);
+        var sweepAngle = AngleBetween(ux, uy, vx, vy);
+
+        if (!Sweep && sweepAngle > 0.0)
+        {
+            sweepAngle -= 2.0 * CodingAdventures.Trig.Trig.PI;
+        }
+
+        if (Sweep && sweepAngle < 0.0)
+        {
+            sweepAngle += 2.0 * CodingAdventures.Trig.Trig.PI;
+        }
+
+        return new CenterArc(new Point(cx, cy), rx, ry, startAngle, sweepAngle, XRotation);
+    }
+
+    public IReadOnlyList<CubicBezier> ToCubicBeziers() => ToCenterArc()?.ToCubicBeziers() ?? [];
+
+    public Point? Evaluate(double t) => ToCenterArc()?.Evaluate(t);
+
+    public Rect? BoundingBox() => ToCenterArc()?.BoundingBox();
+
+    private static double AngleBetween(double ux, double uy, double vx, double vy) =>
+        CodingAdventures.Trig.Trig.Atan2(ux * vy - uy * vx, ux * vx + uy * vy);
+}
+
+public static class Arc2D
+{
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/arc2d/BUILD
+++ b/code/packages/csharp/arc2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/arc2d/BUILD_windows
+++ b/code/packages/csharp/arc2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/arc2d/CHANGELOG.md
+++ b/code/packages/csharp/arc2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# center-form and SVG endpoint-form elliptical arcs with cubic Bezier conversion.

--- a/code/packages/csharp/arc2d/CodingAdventures.Arc2D.csproj
+++ b/code/packages/csharp/arc2d/CodingAdventures.Arc2D.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Arc2D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Elliptical arcs with SVG endpoint conversion and cubic Bezier approximation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../bezier2d/CodingAdventures.Bezier2D.csproj" />
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.csproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/arc2d/README.md
+++ b/code/packages/csharp/arc2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Arc2D.CSharp
+
+Elliptical arcs with SVG endpoint conversion, center-form evaluation, bounds, tangents, and cubic Bezier approximation.

--- a/code/packages/csharp/arc2d/required_capabilities.json
+++ b/code/packages/csharp/arc2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/arc2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point, trig, and Bezier packages."
+}

--- a/code/packages/csharp/arc2d/tests/CodingAdventures.Arc2D.Tests/Arc2DTests.cs
+++ b/code/packages/csharp/arc2d/tests/CodingAdventures.Arc2D.Tests/Arc2DTests.cs
@@ -1,0 +1,94 @@
+using CodingAdventures.Point2D;
+using TrigPackage = CodingAdventures.Trig.Trig;
+
+namespace CodingAdventures.Arc2D.Tests;
+
+public sealed class Arc2DTests
+{
+    private const double Epsilon = 1e-5;
+
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Arc2D.Version);
+    }
+
+    [Fact]
+    public void CenterArcEvaluatesTangentsAndBounds()
+    {
+        var arc = new CenterArc(Point.Origin(), 1, 1, 0, TrigPackage.PI / 2.0, 0);
+
+        Assert.True(PointClose(arc.Evaluate(0), new Point(1, 0)));
+        Assert.True(PointClose(arc.Evaluate(1), new Point(0, 1)));
+        Assert.True(Close(arc.Tangent(0).X, 0));
+        Assert.True(arc.Tangent(0).Y > 0);
+
+        var fullCircle = new CenterArc(Point.Origin(), 1, 1, 0, 2.0 * TrigPackage.PI, 0);
+        var bounds = fullCircle.BoundingBox();
+        Assert.True(Math.Abs(bounds.X + 1.0) < 0.05);
+        Assert.True(Math.Abs(bounds.Width - 2.0) < 0.05);
+    }
+
+    [Fact]
+    public void CenterArcBuildsCubicBeziers()
+    {
+        var quarter = new CenterArc(Point.Origin(), 1, 1, 0, TrigPackage.PI / 2.0, 0);
+        var quarterBeziers = quarter.ToCubicBeziers();
+        Assert.Single(quarterBeziers);
+        Assert.True(quarter.Evaluate(0.5).Distance(quarterBeziers[0].Evaluate(0.5)) < 0.001);
+
+        var fullCircle = new CenterArc(Point.Origin(), 1, 1, 0, 2.0 * TrigPackage.PI, 0);
+        var beziers = fullCircle.ToCubicBeziers();
+        Assert.Equal(4, beziers.Count);
+        for (var index = 0; index < beziers.Count - 1; index++)
+        {
+            Assert.True(beziers[index].P3.Distance(beziers[index + 1].P0) < 1e-6);
+        }
+    }
+
+    [Fact]
+    public void SvgArcHandlesDegenerateInputs()
+    {
+        Assert.Null(new SvgArc(Point.Origin(), Point.Origin(), 1, 1, 0, false, true).ToCenterArc());
+        Assert.Null(new SvgArc(new Point(0, 0), new Point(1, 0), 0, 1, 0, false, true).ToCenterArc());
+        Assert.Empty(new SvgArc(Point.Origin(), Point.Origin(), 1, 1, 0, false, true).ToCubicBeziers());
+        Assert.Null(new SvgArc(Point.Origin(), Point.Origin(), 1, 1, 0, false, true).Evaluate(0));
+        Assert.Null(new SvgArc(Point.Origin(), Point.Origin(), 1, 1, 0, false, true).BoundingBox());
+    }
+
+    [Fact]
+    public void SvgArcConvertsEndpointForm()
+    {
+        var arc = new SvgArc(new Point(1, 0), new Point(0, 1), 1, 1, 0, false, true);
+        var centerArc = arc.ToCenterArc();
+        Assert.NotNull(centerArc);
+        Assert.True(Close(centerArc.Value.Center.X, 0));
+        Assert.True(Close(centerArc.Value.Center.Y, 0));
+        Assert.True(centerArc.Value.SweepAngle > 0);
+
+        var start = arc.Evaluate(0);
+        Assert.NotNull(start);
+        Assert.True(PointClose(start.Value, new Point(1, 0)));
+        Assert.NotEmpty(arc.ToCubicBeziers());
+        Assert.NotNull(arc.BoundingBox());
+    }
+
+    [Fact]
+    public void SvgArcFlagsSelectDifferentSweeps()
+    {
+        var ccw = new SvgArc(new Point(1, 0), new Point(0, 1), 1, 1, 0, false, true).ToCenterArc();
+        var cw = new SvgArc(new Point(1, 0), new Point(0, 1), 1, 1, 0, false, false).ToCenterArc();
+        Assert.NotNull(ccw);
+        Assert.NotNull(cw);
+        Assert.True(ccw.Value.SweepAngle > 0);
+        Assert.True(cw.Value.SweepAngle < 0);
+
+        var large = new SvgArc(new Point(1, 0), new Point(-1, 0), 1, 1, 0, true, true).ToCenterArc();
+        Assert.NotNull(large);
+        Assert.True(Math.Abs(large.Value.SweepAngle) > TrigPackage.PI - 1e-6);
+    }
+
+    private static bool Close(double left, double right) => Math.Abs(left - right) < Epsilon;
+
+    private static bool PointClose(Point left, Point right) => Close(left.X, right.X) && Close(left.Y, right.Y);
+}

--- a/code/packages/csharp/arc2d/tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.csproj
+++ b/code/packages/csharp/arc2d/tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Arc2D]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Arc2D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/bezier2d/BUILD
+++ b/code/packages/csharp/bezier2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bezier2d/BUILD_windows
+++ b/code/packages/csharp/bezier2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bezier2d/Bezier2D.cs
+++ b/code/packages/csharp/bezier2d/Bezier2D.cs
@@ -1,0 +1,228 @@
+using CodingAdventures.Point2D;
+
+namespace CodingAdventures.Bezier2D;
+
+public readonly record struct QuadraticBezier(Point P0, Point P1, Point P2)
+{
+    public Point Evaluate(double t)
+    {
+        var q0 = P0.Lerp(P1, t);
+        var q1 = P1.Lerp(P2, t);
+        return q0.Lerp(q1, t);
+    }
+
+    public Point Derivative(double t)
+    {
+        var d0 = P1.Subtract(P0);
+        var d1 = P2.Subtract(P1);
+        return d0.Lerp(d1, t).Scale(2.0);
+    }
+
+    public (QuadraticBezier Left, QuadraticBezier Right) Split(double t)
+    {
+        var q0 = P0.Lerp(P1, t);
+        var q1 = P1.Lerp(P2, t);
+        var midpoint = q0.Lerp(q1, t);
+        return (new QuadraticBezier(P0, q0, midpoint), new QuadraticBezier(midpoint, q1, P2));
+    }
+
+    public IReadOnlyList<Point> ToPolyline(double tolerance)
+    {
+        EnsureTolerance(tolerance);
+        var chordMid = P0.Lerp(P2, 0.5);
+        var curveMid = Evaluate(0.5);
+        if (chordMid.Distance(curveMid) <= tolerance)
+        {
+            return [P0, P2];
+        }
+
+        var (left, right) = Split(0.5);
+        var points = left.ToPolyline(tolerance).ToList();
+        points.AddRange(right.ToPolyline(tolerance).Skip(1));
+        return points;
+    }
+
+    public Rect BoundingBox()
+    {
+        var minX = Math.Min(P0.X, P2.X);
+        var maxX = Math.Max(P0.X, P2.X);
+        var minY = Math.Min(P0.Y, P2.Y);
+        var maxY = Math.Max(P0.Y, P2.Y);
+
+        var denomX = P0.X - 2.0 * P1.X + P2.X;
+        if (Math.Abs(denomX) > 1e-12)
+        {
+            var tx = (P0.X - P1.X) / denomX;
+            if (tx is > 0.0 and < 1.0)
+            {
+                var px = Evaluate(tx);
+                minX = Math.Min(minX, px.X);
+                maxX = Math.Max(maxX, px.X);
+            }
+        }
+
+        var denomY = P0.Y - 2.0 * P1.Y + P2.Y;
+        if (Math.Abs(denomY) > 1e-12)
+        {
+            var ty = (P0.Y - P1.Y) / denomY;
+            if (ty is > 0.0 and < 1.0)
+            {
+                var py = Evaluate(ty);
+                minY = Math.Min(minY, py.Y);
+                maxY = Math.Max(maxY, py.Y);
+            }
+        }
+
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    public CubicBezier Elevate()
+    {
+        var q1 = P0.Scale(1.0 / 3.0).Add(P1.Scale(2.0 / 3.0));
+        var q2 = P1.Scale(2.0 / 3.0).Add(P2.Scale(1.0 / 3.0));
+        return new CubicBezier(P0, q1, q2, P2);
+    }
+
+    private static void EnsureTolerance(double tolerance)
+    {
+        if (!double.IsFinite(tolerance) || tolerance < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "tolerance must be finite and non-negative");
+        }
+    }
+}
+
+public readonly record struct CubicBezier(Point P0, Point P1, Point P2, Point P3)
+{
+    public Point Evaluate(double t)
+    {
+        var p01 = P0.Lerp(P1, t);
+        var p12 = P1.Lerp(P2, t);
+        var p23 = P2.Lerp(P3, t);
+        var p012 = p01.Lerp(p12, t);
+        var p123 = p12.Lerp(p23, t);
+        return p012.Lerp(p123, t);
+    }
+
+    public Point Derivative(double t)
+    {
+        var d0 = P1.Subtract(P0);
+        var d1 = P2.Subtract(P1);
+        var d2 = P3.Subtract(P2);
+        var oneMinusT = 1.0 - t;
+        return d0
+            .Scale(oneMinusT * oneMinusT)
+            .Add(d1.Scale(2.0 * oneMinusT * t))
+            .Add(d2.Scale(t * t))
+            .Scale(3.0);
+    }
+
+    public (CubicBezier Left, CubicBezier Right) Split(double t)
+    {
+        var p01 = P0.Lerp(P1, t);
+        var p12 = P1.Lerp(P2, t);
+        var p23 = P2.Lerp(P3, t);
+        var p012 = p01.Lerp(p12, t);
+        var p123 = p12.Lerp(p23, t);
+        var p0123 = p012.Lerp(p123, t);
+
+        return (
+            new CubicBezier(P0, p01, p012, p0123),
+            new CubicBezier(p0123, p123, p23, P3));
+    }
+
+    public IReadOnlyList<Point> ToPolyline(double tolerance)
+    {
+        EnsureTolerance(tolerance);
+        var chordMid = P0.Lerp(P3, 0.5);
+        var curveMid = Evaluate(0.5);
+        if (chordMid.Distance(curveMid) <= tolerance)
+        {
+            return [P0, P3];
+        }
+
+        var (left, right) = Split(0.5);
+        var points = left.ToPolyline(tolerance).ToList();
+        points.AddRange(right.ToPolyline(tolerance).Skip(1));
+        return points;
+    }
+
+    public Rect BoundingBox()
+    {
+        var minX = Math.Min(P0.X, P3.X);
+        var maxX = Math.Max(P0.X, P3.X);
+        var minY = Math.Min(P0.Y, P3.Y);
+        var maxY = Math.Max(P0.Y, P3.Y);
+
+        foreach (var t in ExtremaOfCubicDerivative(P0.X, P1.X, P2.X, P3.X))
+        {
+            var px = Evaluate(t);
+            minX = Math.Min(minX, px.X);
+            maxX = Math.Max(maxX, px.X);
+        }
+
+        foreach (var t in ExtremaOfCubicDerivative(P0.Y, P1.Y, P2.Y, P3.Y))
+        {
+            var py = Evaluate(t);
+            minY = Math.Min(minY, py.Y);
+            maxY = Math.Max(maxY, py.Y);
+        }
+
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    private static void EnsureTolerance(double tolerance)
+    {
+        if (!double.IsFinite(tolerance) || tolerance < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "tolerance must be finite and non-negative");
+        }
+    }
+
+    private static IReadOnlyList<double> ExtremaOfCubicDerivative(double v0, double v1, double v2, double v3)
+    {
+        var a = -3.0 * v0 + 9.0 * v1 - 9.0 * v2 + 3.0 * v3;
+        var b = 6.0 * v0 - 12.0 * v1 + 6.0 * v2;
+        var c = -3.0 * v0 + 3.0 * v1;
+        var roots = new List<double>();
+
+        if (Math.Abs(a) < 1e-12)
+        {
+            if (Math.Abs(b) > 1e-12)
+            {
+                var t = -c / b;
+                if (t is > 0.0 and < 1.0)
+                {
+                    roots.Add(t);
+                }
+            }
+        }
+        else
+        {
+            var discriminant = b * b - 4.0 * a * c;
+            if (discriminant >= 0.0)
+            {
+                var squareRoot = CodingAdventures.Trig.Trig.Sqrt(discriminant);
+                var t1 = (-b + squareRoot) / (2.0 * a);
+                var t2 = (-b - squareRoot) / (2.0 * a);
+
+                if (t1 is > 0.0 and < 1.0)
+                {
+                    roots.Add(t1);
+                }
+
+                if (t2 is > 0.0 and < 1.0)
+                {
+                    roots.Add(t2);
+                }
+            }
+        }
+
+        return roots;
+    }
+}
+
+public static class Bezier2D
+{
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/bezier2d/CHANGELOG.md
+++ b/code/packages/csharp/bezier2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add C# quadratic and cubic Bezier curves with evaluation, derivatives, splitting, polyline approximation, bounding boxes, and quadratic degree elevation.

--- a/code/packages/csharp/bezier2d/CodingAdventures.Bezier2D.csproj
+++ b/code/packages/csharp/bezier2d/CodingAdventures.Bezier2D.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Bezier2D.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Quadratic and cubic Bezier curves over shared 2D point primitives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.csproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/bezier2d/README.md
+++ b/code/packages/csharp/bezier2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Bezier2D.CSharp
+
+Quadratic and cubic Bezier curves over the shared 2D point primitives.

--- a/code/packages/csharp/bezier2d/required_capabilities.json
+++ b/code/packages/csharp/bezier2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/bezier2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point and trig packages."
+}

--- a/code/packages/csharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/Bezier2DTests.cs
+++ b/code/packages/csharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/Bezier2DTests.cs
@@ -1,0 +1,103 @@
+using CodingAdventures.Point2D;
+
+namespace CodingAdventures.Bezier2D.Tests;
+
+public sealed class Bezier2DTests
+{
+    private const double Epsilon = 1e-9;
+
+    [Fact]
+    public void VersionExists()
+    {
+        Assert.Equal("0.1.0", Bezier2D.Version);
+    }
+
+    [Fact]
+    public void QuadraticEvaluateDerivativeSplitAndElevateWork()
+    {
+        var curve = new QuadraticBezier(new Point(0, 0), new Point(1, 2), new Point(2, 0));
+
+        Assert.True(PointClose(curve.Evaluate(0), curve.P0));
+        Assert.True(PointClose(curve.Evaluate(1), curve.P2));
+        Assert.True(PointClose(curve.Evaluate(0.5), new Point(1, 1)));
+        Assert.True(PointClose(curve.Derivative(0), new Point(2, 4)));
+
+        var (left, right) = curve.Split(0.5);
+        var splitPoint = curve.Evaluate(0.5);
+        Assert.True(PointClose(left.P2, splitPoint));
+        Assert.True(PointClose(right.P0, splitPoint));
+
+        var cubic = curve.Elevate();
+        foreach (var t in new[] { 0.0, 0.25, 0.5, 0.75, 1.0 })
+        {
+            Assert.True(PointClose(curve.Evaluate(t), cubic.Evaluate(t)));
+        }
+    }
+
+    [Fact]
+    public void QuadraticPolylineAndBoundingBoxWork()
+    {
+        var straight = new QuadraticBezier(new Point(0, 0), new Point(1, 0), new Point(2, 0));
+        Assert.Equal(2, straight.ToPolyline(0.1).Count);
+
+        var curve = new QuadraticBezier(new Point(0, 0), new Point(0, 10), new Point(10, 0));
+        var points = curve.ToPolyline(0.1);
+        Assert.True(points.Count > 2);
+        Assert.True(PointClose(points[0], curve.P0));
+        Assert.True(PointClose(points[^1], curve.P2));
+
+        var bounds = curve.BoundingBox();
+        Assert.True(bounds.X <= 0);
+        Assert.True(bounds.Y <= 0);
+        Assert.True(bounds.X + bounds.Width >= 10);
+        Assert.True(bounds.Height > 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => curve.ToPolyline(-0.1));
+    }
+
+    [Fact]
+    public void CubicEvaluateDerivativeAndSplitWork()
+    {
+        var curve = new CubicBezier(new Point(0, 0), new Point(1, 2), new Point(3, 2), new Point(4, 0));
+
+        Assert.True(PointClose(curve.Evaluate(0), curve.P0));
+        Assert.True(PointClose(curve.Evaluate(1), curve.P3));
+        Assert.True(Close(curve.Evaluate(0.5).X, 2.0));
+
+        var straight = new CubicBezier(new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0));
+        Assert.True(PointClose(straight.Derivative(0), new Point(3, 0)));
+
+        var (left, right) = curve.Split(0.5);
+        var splitPoint = curve.Evaluate(0.5);
+        Assert.True(PointClose(left.P3, splitPoint));
+        Assert.True(PointClose(right.P0, splitPoint));
+    }
+
+    [Fact]
+    public void CubicPolylineAndBoundingBoxWork()
+    {
+        var straight = new CubicBezier(new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0));
+        Assert.Equal(2, straight.ToPolyline(0.1).Count);
+
+        var curve = new CubicBezier(new Point(0, 0), new Point(0, 10), new Point(10, 10), new Point(10, 0));
+        var points = curve.ToPolyline(0.1);
+        Assert.True(points.Count > 2);
+        Assert.True(PointClose(points[0], curve.P0));
+        Assert.True(PointClose(points[^1], curve.P3));
+
+        var bounds = curve.BoundingBox();
+        for (var index = 0; index <= 20; index++)
+        {
+            var point = curve.Evaluate(index / 20.0);
+            Assert.True(point.X >= bounds.X - 1e-6 && point.X <= bounds.X + bounds.Width + 1e-6);
+            Assert.True(point.Y >= bounds.Y - 1e-6 && point.Y <= bounds.Y + bounds.Height + 1e-6);
+        }
+
+        var flatBounds = straight.BoundingBox();
+        Assert.Equal(new Rect(0, 0, 3, 0), flatBounds);
+        Assert.Throws<ArgumentOutOfRangeException>(() => curve.ToPolyline(double.NaN));
+    }
+
+    private static bool Close(double left, double right) => Math.Abs(left - right) < Epsilon;
+
+    private static bool PointClose(Point left, Point right) => Close(left.X, right.X) && Close(left.Y, right.Y);
+}

--- a/code/packages/csharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.csproj
+++ b/code/packages/csharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Bezier2D]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Bezier2D.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/affine2d/Affine2D.fs
+++ b/code/packages/fsharp/affine2d/Affine2D.fs
@@ -1,0 +1,109 @@
+namespace CodingAdventures.Affine2D.FSharp
+
+open System
+open CodingAdventures.Point2D
+open CodingAdventures.Trig
+
+type Affine2D =
+    {
+        A: float
+        B: float
+        C: float
+        D: float
+        E: float
+        F: float
+    }
+
+    static member New(a: float, b: float, c: float, d: float, e: float, f: float) =
+        { A = a; B = b; C = c; D = d; E = e; F = f }
+
+    static member Identity() =
+        Affine2D.New(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+
+    static member Translate(tx: float, ty: float) =
+        Affine2D.New(1.0, 0.0, 0.0, 1.0, tx, ty)
+
+    static member Rotate(angle: float) =
+        let cosine = Trig.cos angle
+        let sine = Trig.sin angle
+        Affine2D.New(cosine, sine, -sine, cosine, 0.0, 0.0)
+
+    static member RotateAround(center: Point, angle: float) =
+        let movedToOrigin: Affine2D = Affine2D.Translate(-center.X, -center.Y)
+        let rotated: Affine2D = movedToOrigin.Then(Affine2D.Rotate angle)
+        rotated.Then(Affine2D.Translate(center.X, center.Y))
+
+    static member Scale(sx: float, sy: float) =
+        Affine2D.New(sx, 0.0, 0.0, sy, 0.0, 0.0)
+
+    static member ScaleUniform(scale: float) =
+        Affine2D.Scale(scale, scale)
+
+    static member SkewX(angle: float) =
+        Affine2D.New(1.0, 0.0, Trig.tan angle, 1.0, 0.0, 0.0)
+
+    static member SkewY(angle: float) =
+        Affine2D.New(1.0, Trig.tan angle, 0.0, 1.0, 0.0, 0.0)
+
+    member this.Then(next: Affine2D) =
+        next.Multiply this
+
+    member this.Multiply(other: Affine2D) =
+        Affine2D.New(
+            this.A * other.A + this.C * other.B,
+            this.B * other.A + this.D * other.B,
+            this.A * other.C + this.C * other.D,
+            this.B * other.C + this.D * other.D,
+            this.A * other.E + this.C * other.F + this.E,
+            this.B * other.E + this.D * other.F + this.F)
+
+    member this.ApplyToPoint(point: Point) =
+        Point.New(
+            this.A * point.X + this.C * point.Y + this.E,
+            this.B * point.X + this.D * point.Y + this.F)
+
+    member this.ApplyToVector(vector: Point) =
+        Point.New(
+            this.A * vector.X + this.C * vector.Y,
+            this.B * vector.X + this.D * vector.Y)
+
+    member this.Determinant() =
+        this.A * this.D - this.B * this.C
+
+    member this.Invert() =
+        let determinant = this.Determinant()
+        if abs determinant < 1e-12 then
+            None
+        else
+            Some(
+                Affine2D.New(
+                    this.D / determinant,
+                    -this.B / determinant,
+                    -this.C / determinant,
+                    this.A / determinant,
+                    (this.C * this.F - this.D * this.E) / determinant,
+                    (this.B * this.E - this.A * this.F) / determinant))
+
+    member this.IsIdentity() =
+        let epsilon = 1e-10
+        abs (this.A - 1.0) < epsilon
+        && abs this.B < epsilon
+        && abs this.C < epsilon
+        && abs (this.D - 1.0) < epsilon
+        && abs this.E < epsilon
+        && abs this.F < epsilon
+
+    member this.IsTranslationOnly() =
+        let epsilon = 1e-10
+        abs (this.A - 1.0) < epsilon
+        && abs this.B < epsilon
+        && abs this.C < epsilon
+        && abs (this.D - 1.0) < epsilon
+
+    member this.ToArray() =
+        [| this.A; this.B; this.C; this.D; this.E; this.F |]
+
+[<RequireQualifiedAccess>]
+module Affine2DPackage =
+    [<Literal>]
+    let VERSION = "0.1.0"

--- a/code/packages/fsharp/affine2d/BUILD
+++ b/code/packages/fsharp/affine2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/affine2d/BUILD_windows
+++ b/code/packages/fsharp/affine2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/affine2d/CHANGELOG.md
+++ b/code/packages/fsharp/affine2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# affine transform factories, composition, point/vector application, inversion, predicates, and array export.

--- a/code/packages/fsharp/affine2d/CodingAdventures.Affine2D.fsproj
+++ b/code/packages/fsharp/affine2d/CodingAdventures.Affine2D.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Affine2D.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Affine2D.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>2D affine transformation matrix for translate, rotate, scale, and skew operations</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.fsproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Affine2D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/affine2d/README.md
+++ b/code/packages/fsharp/affine2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Affine2D.FSharp
+
+2D affine transformation matrix using the SVG/Canvas six-component convention.

--- a/code/packages/fsharp/affine2d/required_capabilities.json
+++ b/code/packages/fsharp/affine2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/affine2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point and trig packages."
+}

--- a/code/packages/fsharp/affine2d/tests/CodingAdventures.Affine2D.Tests/Affine2DTests.fs
+++ b/code/packages/fsharp/affine2d/tests/CodingAdventures.Affine2D.Tests/Affine2DTests.fs
@@ -1,0 +1,70 @@
+namespace CodingAdventures.Affine2D.Tests
+
+open System
+open CodingAdventures.Affine2D.FSharp
+open CodingAdventures.Point2D
+open CodingAdventures.Trig
+open Xunit
+
+module Affine2DTests =
+    let epsilon = 1e-9
+
+    let close left right =
+        abs (left - right) < epsilon
+
+    let pointClose (left: Point) (right: Point) =
+        close left.X right.X && close left.Y right.Y
+
+    let affineClose (left: Affine2D) (right: Affine2D) =
+        Array.zip (left.ToArray()) (right.ToArray())
+        |> Array.forall (fun (a, b) -> close a b)
+
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Affine2DPackage.VERSION)
+
+    [<Fact>]
+    let ``factories apply expected transforms`` () =
+        let identity = Affine2D.Identity()
+        Assert.True(Array.zip (identity.ToArray()) [| 1.0; 0.0; 0.0; 1.0; 0.0; 0.0 |] |> Array.forall (fun (a, b) -> close a b))
+        Assert.True(pointClose (identity.ApplyToPoint(Point.New(3.0, 4.0))) (Point.New(3.0, 4.0)))
+
+        Assert.True(pointClose (Affine2D.Translate(5.0, -3.0).ApplyToPoint(Point.New(1.0, 2.0))) (Point.New(6.0, -1.0)))
+        Assert.True(pointClose (Affine2D.Translate(5.0, -3.0).ApplyToVector(Point.New(1.0, 2.0))) (Point.New(1.0, 2.0)))
+        Assert.True(pointClose (Affine2D.Scale(2.0, 3.0).ApplyToPoint(Point.New(1.0, 1.0))) (Point.New(2.0, 3.0)))
+        Assert.True(pointClose (Affine2D.ScaleUniform(5.0).ApplyToPoint(Point.New(2.0, 3.0))) (Point.New(10.0, 15.0)))
+
+    [<Fact>]
+    let ``rotation and skew factories work`` () =
+        Assert.True(pointClose (Affine2D.Rotate(Trig.PI / 2.0).ApplyToPoint(Point.New(1.0, 0.0))) (Point.New(0.0, 1.0)))
+        Assert.True(Affine2D.Rotate(2.0 * Trig.PI).IsIdentity())
+
+        let center = Point.New(1.0, 0.0)
+        Assert.True(pointClose (Affine2D.RotateAround(center, Trig.PI / 2.0).ApplyToPoint(center)) center)
+        Assert.True(pointClose (Affine2D.SkewX(Trig.PI / 4.0).ApplyToPoint(Point.New(0.0, 1.0))) (Point.New(1.0, 1.0)))
+        Assert.True(pointClose (Affine2D.SkewY(Trig.PI / 4.0).ApplyToPoint(Point.New(1.0, 0.0))) (Point.New(1.0, 1.0)))
+
+    [<Fact>]
+    let ``composition determinant and invert work`` () =
+        let scale = Affine2D.ScaleUniform 2.0
+        let translate = Affine2D.Translate(10.0, 0.0)
+        let composed = translate.Multiply scale
+        Assert.True(pointClose (composed.ApplyToPoint(Point.New(1.0, 1.0))) (Point.New(12.0, 2.0)))
+
+        Assert.True(affineClose (Affine2D.Identity().Multiply translate) translate)
+        Assert.True(affineClose (scale.Then translate) composed)
+        Assert.True(close (Affine2D.Scale(2.0, 3.0).Determinant()) 6.0)
+        Assert.True(close (Affine2D.Rotate(Trig.PI / 3.0).Determinant()) 1.0)
+
+        let inverse = translate.Invert()
+        Assert.True(inverse.IsSome)
+        Assert.True((translate.Multiply inverse.Value).IsIdentity())
+        Assert.True((Affine2D.New(0.0, 0.0, 0.0, 0.0, 0.0, 0.0).Invert()).IsNone)
+
+    [<Fact>]
+    let ``predicates distinguish transform kinds`` () =
+        Assert.True(Affine2D.Identity().IsIdentity())
+        Assert.False(Affine2D.Translate(1.0, 0.0).IsIdentity())
+        Assert.True(Affine2D.Translate(5.0, 3.0).IsTranslationOnly())
+        Assert.False(Affine2D.Rotate(0.1).IsTranslationOnly())
+        Assert.False(Affine2D.Scale(2.0, 1.0).IsTranslationOnly())

--- a/code/packages/fsharp/affine2d/tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.fsproj
+++ b/code/packages/fsharp/affine2d/tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Affine2D.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Affine2D.fsproj" />
+    <Compile Include="Affine2DTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/arc2d/Arc2D.fs
+++ b/code/packages/fsharp/arc2d/Arc2D.fs
@@ -1,0 +1,195 @@
+namespace CodingAdventures.Arc2D.FSharp
+
+open System
+open CodingAdventures.Bezier2D.FSharp
+open CodingAdventures.Point2D
+open CodingAdventures.Trig
+
+module private ArcHelpers =
+    let angleBetween ux uy vx vy =
+        Trig.atan2 (ux * vy - uy * vx) (ux * vx + uy * vy)
+
+type CenterArc =
+    {
+        Center: Point
+        Rx: float
+        Ry: float
+        StartAngle: float
+        SweepAngle: float
+        XRotation: float
+    }
+
+    static member New(center: Point, rx: float, ry: float, startAngle: float, sweepAngle: float, xRotation: float) =
+        {
+            Center = center
+            Rx = rx
+            Ry = ry
+            StartAngle = startAngle
+            SweepAngle = sweepAngle
+            XRotation = xRotation
+        }
+
+    member this.Evaluate(t: float) =
+        let angle = this.StartAngle + t * this.SweepAngle
+        let xp = this.Rx * Trig.cos angle
+        let yp = this.Ry * Trig.sin angle
+        let cosineRotation = Trig.cos this.XRotation
+        let sineRotation = Trig.sin this.XRotation
+
+        Point.New(
+            cosineRotation * xp - sineRotation * yp + this.Center.X,
+            sineRotation * xp + cosineRotation * yp + this.Center.Y)
+
+    member this.Tangent(t: float) =
+        let angle = this.StartAngle + t * this.SweepAngle
+        let dxp = -this.Rx * Trig.sin angle * this.SweepAngle
+        let dyp = this.Ry * Trig.cos angle * this.SweepAngle
+        let cosineRotation = Trig.cos this.XRotation
+        let sineRotation = Trig.sin this.XRotation
+
+        Point.New(
+            cosineRotation * dxp - sineRotation * dyp,
+            sineRotation * dxp + cosineRotation * dyp)
+
+    member this.BoundingBox() =
+        let samples = 100
+        let mutable minX = Double.PositiveInfinity
+        let mutable minY = Double.PositiveInfinity
+        let mutable maxX = Double.NegativeInfinity
+        let mutable maxY = Double.NegativeInfinity
+
+        for index in 0 .. samples do
+            let point = this.Evaluate(float index / float samples)
+            minX <- min minX point.X
+            maxX <- max maxX point.X
+            minY <- min minY point.Y
+            maxY <- max maxY point.Y
+
+        Rect.New(minX, minY, maxX - minX, maxY - minY)
+
+    member this.ToCubicBeziers() =
+        let maxSegment = Trig.PI / 2.0
+        let segmentCount = max 1 (int (Math.Ceiling(abs this.SweepAngle / maxSegment)))
+        let segmentSweep = this.SweepAngle / float segmentCount
+        let cosineRotation = Trig.cos this.XRotation
+        let sineRotation = Trig.sin this.XRotation
+        let k = (4.0 / 3.0) * Trig.tan (segmentSweep / 4.0)
+
+        let rotateTranslate localX localY =
+            Point.New(
+                cosineRotation * localX - sineRotation * localY + this.Center.X,
+                sineRotation * localX + cosineRotation * localY + this.Center.Y)
+
+        [ for index in 0 .. segmentCount - 1 do
+            let alpha = this.StartAngle + float index * segmentSweep
+            let beta = alpha + segmentSweep
+            let cosAlpha = Trig.cos alpha
+            let sinAlpha = Trig.sin alpha
+            let cosBeta = Trig.cos beta
+            let sinBeta = Trig.sin beta
+
+            let p0Local = this.Rx * cosAlpha, this.Ry * sinAlpha
+            let p3Local = this.Rx * cosBeta, this.Ry * sinBeta
+            let p1Local = fst p0Local + k * (-this.Rx * sinAlpha), snd p0Local + k * (this.Ry * cosAlpha)
+            let p2Local = fst p3Local - k * (-this.Rx * sinBeta), snd p3Local - k * (this.Ry * cosBeta)
+
+            CubicBezier.New(
+                rotateTranslate (fst p0Local) (snd p0Local),
+                rotateTranslate (fst p1Local) (snd p1Local),
+                rotateTranslate (fst p2Local) (snd p2Local),
+                rotateTranslate (fst p3Local) (snd p3Local)) ]
+
+type SvgArc =
+    {
+        From: Point
+        To: Point
+        Rx: float
+        Ry: float
+        XRotation: float
+        LargeArc: bool
+        Sweep: bool
+    }
+
+    static member New(fromPoint: Point, toPoint: Point, rx: float, ry: float, xRotation: float, largeArc: bool, sweep: bool) =
+        {
+            From = fromPoint
+            To = toPoint
+            Rx = rx
+            Ry = ry
+            XRotation = xRotation
+            LargeArc = largeArc
+            Sweep = sweep
+        }
+
+    member this.ToCenterArc() =
+        if abs (this.From.X - this.To.X) < 1e-12 && abs (this.From.Y - this.To.Y) < 1e-12 then
+            None
+        elif abs this.Rx < 1e-12 || abs this.Ry < 1e-12 then
+            None
+        else
+            let cosineRotation = Trig.cos this.XRotation
+            let sineRotation = Trig.sin this.XRotation
+            let dx = (this.From.X - this.To.X) / 2.0
+            let dy = (this.From.Y - this.To.Y) / 2.0
+            let x1Prime = cosineRotation * dx + sineRotation * dy
+            let y1Prime = -sineRotation * dx + cosineRotation * dy
+            let mutable rx = abs this.Rx
+            let mutable ry = abs this.Ry
+
+            let lambda = (x1Prime / rx) * (x1Prime / rx) + (y1Prime / ry) * (y1Prime / ry)
+            if lambda > 1.0 then
+                let squareRootLambda = Trig.sqrt lambda
+                rx <- rx * squareRootLambda
+                ry <- ry * squareRootLambda
+
+            let rxSquared = rx * rx
+            let rySquared = ry * ry
+            let x1PrimeSquared = x1Prime * x1Prime
+            let y1PrimeSquared = y1Prime * y1Prime
+            let numerator = rxSquared * rySquared - rxSquared * y1PrimeSquared - rySquared * x1PrimeSquared
+            let denominator = rxSquared * y1PrimeSquared + rySquared * x1PrimeSquared
+
+            let squareRoot =
+                if abs denominator < 1e-12 then
+                    0.0
+                else
+                    Trig.sqrt (max 0.0 (numerator / denominator))
+
+            let sign = if this.LargeArc = this.Sweep then -1.0 else 1.0
+            let cxPrime = sign * squareRoot * (rx * y1Prime / ry)
+            let cyPrime = sign * squareRoot * -(ry * x1Prime / rx)
+            let midX = (this.From.X + this.To.X) / 2.0
+            let midY = (this.From.Y + this.To.Y) / 2.0
+            let cx = cosineRotation * cxPrime - sineRotation * cyPrime + midX
+            let cy = sineRotation * cxPrime + cosineRotation * cyPrime + midY
+
+            let ux = (x1Prime - cxPrime) / rx
+            let uy = (y1Prime - cyPrime) / ry
+            let vx = (-x1Prime - cxPrime) / rx
+            let vy = (-y1Prime - cyPrime) / ry
+            let startAngle = ArcHelpers.angleBetween 1.0 0.0 ux uy
+            let mutable sweepAngle = ArcHelpers.angleBetween ux uy vx vy
+
+            if not this.Sweep && sweepAngle > 0.0 then
+                sweepAngle <- sweepAngle - 2.0 * Trig.PI
+
+            if this.Sweep && sweepAngle < 0.0 then
+                sweepAngle <- sweepAngle + 2.0 * Trig.PI
+
+            Some(CenterArc.New(Point.New(cx, cy), rx, ry, startAngle, sweepAngle, this.XRotation))
+
+    member this.ToCubicBeziers() =
+        match this.ToCenterArc() with
+        | Some arc -> arc.ToCubicBeziers()
+        | None -> []
+
+    member this.Evaluate(t: float) =
+        this.ToCenterArc() |> Option.map (fun arc -> arc.Evaluate t)
+
+    member this.BoundingBox() =
+        this.ToCenterArc() |> Option.map _.BoundingBox()
+
+[<RequireQualifiedAccess>]
+module Arc2D =
+    [<Literal>]
+    let VERSION = "0.1.0"

--- a/code/packages/fsharp/arc2d/BUILD
+++ b/code/packages/fsharp/arc2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/arc2d/BUILD_windows
+++ b/code/packages/fsharp/arc2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/arc2d/CHANGELOG.md
+++ b/code/packages/fsharp/arc2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# center-form and SVG endpoint-form elliptical arcs with cubic Bezier conversion.

--- a/code/packages/fsharp/arc2d/CodingAdventures.Arc2D.fsproj
+++ b/code/packages/fsharp/arc2d/CodingAdventures.Arc2D.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Arc2D.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Arc2D.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Elliptical arcs with SVG endpoint conversion and cubic Bezier approximation</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../bezier2d/CodingAdventures.Bezier2D.fsproj" />
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.fsproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Arc2D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/arc2d/README.md
+++ b/code/packages/fsharp/arc2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Arc2D.FSharp
+
+Elliptical arcs with SVG endpoint conversion, center-form evaluation, bounds, tangents, and cubic Bezier approximation.

--- a/code/packages/fsharp/arc2d/required_capabilities.json
+++ b/code/packages/fsharp/arc2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/arc2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point, trig, and Bezier packages."
+}

--- a/code/packages/fsharp/arc2d/tests/CodingAdventures.Arc2D.Tests/Arc2DTests.fs
+++ b/code/packages/fsharp/arc2d/tests/CodingAdventures.Arc2D.Tests/Arc2DTests.fs
@@ -1,0 +1,83 @@
+namespace CodingAdventures.Arc2D.Tests
+
+open System
+open CodingAdventures.Arc2D.FSharp
+open CodingAdventures.Point2D
+open CodingAdventures.Trig
+open Xunit
+
+module Arc2DTests =
+    let epsilon = 1e-5
+
+    let close left right =
+        abs (left - right) < epsilon
+
+    let pointClose (left: Point) (right: Point) =
+        close left.X right.X && close left.Y right.Y
+
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Arc2D.VERSION)
+
+    [<Fact>]
+    let ``center arc evaluates tangents and bounds`` () =
+        let arc = CenterArc.New(Point.Origin(), 1.0, 1.0, 0.0, Trig.PI / 2.0, 0.0)
+
+        Assert.True(pointClose (arc.Evaluate 0.0) (Point.New(1.0, 0.0)))
+        Assert.True(pointClose (arc.Evaluate 1.0) (Point.New(0.0, 1.0)))
+        Assert.True(close (arc.Tangent 0.0).X 0.0)
+        Assert.True((arc.Tangent 0.0).Y > 0.0)
+
+        let fullCircle = CenterArc.New(Point.Origin(), 1.0, 1.0, 0.0, 2.0 * Trig.PI, 0.0)
+        let bounds = fullCircle.BoundingBox()
+        Assert.True(abs (bounds.X + 1.0) < 0.05)
+        Assert.True(abs (bounds.Width - 2.0) < 0.05)
+
+    [<Fact>]
+    let ``center arc builds cubic beziers`` () =
+        let quarter = CenterArc.New(Point.Origin(), 1.0, 1.0, 0.0, Trig.PI / 2.0, 0.0)
+        let quarterBeziers = quarter.ToCubicBeziers()
+        Assert.Single(quarterBeziers) |> ignore
+        Assert.True((quarter.Evaluate 0.5).Distance(quarterBeziers[0].Evaluate 0.5) < 0.001)
+
+        let fullCircle = CenterArc.New(Point.Origin(), 1.0, 1.0, 0.0, 2.0 * Trig.PI, 0.0)
+        let beziers = fullCircle.ToCubicBeziers()
+        Assert.Equal(4, beziers.Length)
+        for index in 0 .. beziers.Length - 2 do
+            Assert.True(beziers[index].P3.Distance(beziers[index + 1].P0) < 1e-6)
+
+    [<Fact>]
+    let ``svg arc handles degenerate inputs`` () =
+        Assert.True((SvgArc.New(Point.Origin(), Point.Origin(), 1.0, 1.0, 0.0, false, true).ToCenterArc()).IsNone)
+        Assert.True((SvgArc.New(Point.New(0.0, 0.0), Point.New(1.0, 0.0), 0.0, 1.0, 0.0, false, true).ToCenterArc()).IsNone)
+        Assert.Empty(SvgArc.New(Point.Origin(), Point.Origin(), 1.0, 1.0, 0.0, false, true).ToCubicBeziers())
+        Assert.True((SvgArc.New(Point.Origin(), Point.Origin(), 1.0, 1.0, 0.0, false, true).Evaluate 0.0).IsNone)
+        Assert.True((SvgArc.New(Point.Origin(), Point.Origin(), 1.0, 1.0, 0.0, false, true).BoundingBox()).IsNone)
+
+    [<Fact>]
+    let ``svg arc converts endpoint form`` () =
+        let arc = SvgArc.New(Point.New(1.0, 0.0), Point.New(0.0, 1.0), 1.0, 1.0, 0.0, false, true)
+        let centerArc = arc.ToCenterArc()
+        Assert.True(centerArc.IsSome)
+        Assert.True(close centerArc.Value.Center.X 0.0)
+        Assert.True(close centerArc.Value.Center.Y 0.0)
+        Assert.True(centerArc.Value.SweepAngle > 0.0)
+
+        let start = arc.Evaluate 0.0
+        Assert.True(start.IsSome)
+        Assert.True(pointClose start.Value (Point.New(1.0, 0.0)))
+        Assert.NotEmpty(arc.ToCubicBeziers())
+        Assert.True((arc.BoundingBox()).IsSome)
+
+    [<Fact>]
+    let ``svg arc flags select different sweeps`` () =
+        let ccw = SvgArc.New(Point.New(1.0, 0.0), Point.New(0.0, 1.0), 1.0, 1.0, 0.0, false, true).ToCenterArc()
+        let cw = SvgArc.New(Point.New(1.0, 0.0), Point.New(0.0, 1.0), 1.0, 1.0, 0.0, false, false).ToCenterArc()
+        Assert.True(ccw.IsSome)
+        Assert.True(cw.IsSome)
+        Assert.True(ccw.Value.SweepAngle > 0.0)
+        Assert.True(cw.Value.SweepAngle < 0.0)
+
+        let large = SvgArc.New(Point.New(1.0, 0.0), Point.New(-1.0, 0.0), 1.0, 1.0, 0.0, true, true).ToCenterArc()
+        Assert.True(large.IsSome)
+        Assert.True(abs large.Value.SweepAngle > Trig.PI - 1e-6)

--- a/code/packages/fsharp/arc2d/tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.fsproj
+++ b/code/packages/fsharp/arc2d/tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Arc2D.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Arc2D.fsproj" />
+    <Compile Include="Arc2DTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bezier2d/BUILD
+++ b/code/packages/fsharp/bezier2d/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bezier2d/BUILD_windows
+++ b/code/packages/fsharp/bezier2d/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bezier2d/Bezier2D.fs
+++ b/code/packages/fsharp/bezier2d/Bezier2D.fs
@@ -1,0 +1,178 @@
+namespace CodingAdventures.Bezier2D.FSharp
+
+open System
+open CodingAdventures.Point2D
+open CodingAdventures.Trig
+
+module private BezierHelpers =
+    let validateTolerance tolerance =
+        if not (Double.IsFinite tolerance) || tolerance < 0.0 then
+            raise (ArgumentOutOfRangeException("tolerance", tolerance, "tolerance must be finite and non-negative"))
+
+    let extremaOfCubicDerivative v0 v1 v2 v3 =
+        let a = -3.0 * v0 + 9.0 * v1 - 9.0 * v2 + 3.0 * v3
+        let b = 6.0 * v0 - 12.0 * v1 + 6.0 * v2
+        let c = -3.0 * v0 + 3.0 * v1
+        let roots = ResizeArray<float>()
+
+        if abs a < 1e-12 then
+            if abs b > 1e-12 then
+                let t = -c / b
+                if t > 0.0 && t < 1.0 then
+                    roots.Add t
+        else
+            let discriminant = b * b - 4.0 * a * c
+            if discriminant >= 0.0 then
+                let squareRoot = Trig.sqrt discriminant
+                let t1 = (-b + squareRoot) / (2.0 * a)
+                let t2 = (-b - squareRoot) / (2.0 * a)
+                if t1 > 0.0 && t1 < 1.0 then
+                    roots.Add t1
+                if t2 > 0.0 && t2 < 1.0 then
+                    roots.Add t2
+
+        List.ofSeq roots
+
+type QuadraticBezier =
+    {
+        P0: Point
+        P1: Point
+        P2: Point
+    }
+
+    static member New(p0: Point, p1: Point, p2: Point) =
+        { P0 = p0; P1 = p1; P2 = p2 }
+
+    member this.Evaluate(t: float) =
+        let q0 = this.P0.Lerp(this.P1, t)
+        let q1 = this.P1.Lerp(this.P2, t)
+        q0.Lerp(q1, t)
+
+    member this.Derivative(t: float) =
+        let d0 = this.P1.Subtract this.P0
+        let d1 = this.P2.Subtract this.P1
+        (d0.Lerp(d1, t)).Scale(2.0)
+
+    member this.Split(t: float) =
+        let q0 = this.P0.Lerp(this.P1, t)
+        let q1 = this.P1.Lerp(this.P2, t)
+        let midpoint = q0.Lerp(q1, t)
+        QuadraticBezier.New(this.P0, q0, midpoint), QuadraticBezier.New(midpoint, q1, this.P2)
+
+    member this.ToPolyline(tolerance: float) =
+        BezierHelpers.validateTolerance tolerance
+        let chordMid = this.P0.Lerp(this.P2, 0.5)
+        let curveMid = this.Evaluate 0.5
+
+        if chordMid.Distance curveMid <= tolerance then
+            [ this.P0; this.P2 ]
+        else
+            let left, right = this.Split 0.5
+            let leftPoints = left.ToPolyline tolerance
+            let rightPoints = right.ToPolyline tolerance
+            leftPoints @ (rightPoints |> List.tail)
+
+    member this.BoundingBox() =
+        let mutable minX = min this.P0.X this.P2.X
+        let mutable maxX = max this.P0.X this.P2.X
+        let mutable minY = min this.P0.Y this.P2.Y
+        let mutable maxY = max this.P0.Y this.P2.Y
+
+        let denomX = this.P0.X - 2.0 * this.P1.X + this.P2.X
+        if abs denomX > 1e-12 then
+            let tx = (this.P0.X - this.P1.X) / denomX
+            if tx > 0.0 && tx < 1.0 then
+                let px = this.Evaluate tx
+                minX <- min minX px.X
+                maxX <- max maxX px.X
+
+        let denomY = this.P0.Y - 2.0 * this.P1.Y + this.P2.Y
+        if abs denomY > 1e-12 then
+            let ty = (this.P0.Y - this.P1.Y) / denomY
+            if ty > 0.0 && ty < 1.0 then
+                let py = this.Evaluate ty
+                minY <- min minY py.Y
+                maxY <- max maxY py.Y
+
+        Rect.New(minX, minY, maxX - minX, maxY - minY)
+
+    member this.Elevate() =
+        let q1 = (this.P0.Scale(1.0 / 3.0)).Add(this.P1.Scale(2.0 / 3.0))
+        let q2 = (this.P1.Scale(2.0 / 3.0)).Add(this.P2.Scale(1.0 / 3.0))
+        CubicBezier.New(this.P0, q1, q2, this.P2)
+
+and CubicBezier =
+    {
+        P0: Point
+        P1: Point
+        P2: Point
+        P3: Point
+    }
+
+    static member New(p0: Point, p1: Point, p2: Point, p3: Point) =
+        { P0 = p0; P1 = p1; P2 = p2; P3 = p3 }
+
+    member this.Evaluate(t: float) =
+        let p01 = this.P0.Lerp(this.P1, t)
+        let p12 = this.P1.Lerp(this.P2, t)
+        let p23 = this.P2.Lerp(this.P3, t)
+        let p012 = p01.Lerp(p12, t)
+        let p123 = p12.Lerp(p23, t)
+        p012.Lerp(p123, t)
+
+    member this.Derivative(t: float) =
+        let d0 = this.P1.Subtract this.P0
+        let d1 = this.P2.Subtract this.P1
+        let d2 = this.P3.Subtract this.P2
+        let oneMinusT = 1.0 - t
+
+        d0.Scale(oneMinusT * oneMinusT)
+            .Add(d1.Scale(2.0 * oneMinusT * t))
+            .Add(d2.Scale(t * t))
+            .Scale(3.0)
+
+    member this.Split(t: float) =
+        let p01 = this.P0.Lerp(this.P1, t)
+        let p12 = this.P1.Lerp(this.P2, t)
+        let p23 = this.P2.Lerp(this.P3, t)
+        let p012 = p01.Lerp(p12, t)
+        let p123 = p12.Lerp(p23, t)
+        let p0123 = p012.Lerp(p123, t)
+
+        CubicBezier.New(this.P0, p01, p012, p0123), CubicBezier.New(p0123, p123, p23, this.P3)
+
+    member this.ToPolyline(tolerance: float) =
+        BezierHelpers.validateTolerance tolerance
+        let chordMid = this.P0.Lerp(this.P3, 0.5)
+        let curveMid = this.Evaluate 0.5
+
+        if chordMid.Distance curveMid <= tolerance then
+            [ this.P0; this.P3 ]
+        else
+            let left, right = this.Split 0.5
+            let leftPoints = left.ToPolyline tolerance
+            let rightPoints = right.ToPolyline tolerance
+            leftPoints @ (rightPoints |> List.tail)
+
+    member this.BoundingBox() =
+        let mutable minX = min this.P0.X this.P3.X
+        let mutable maxX = max this.P0.X this.P3.X
+        let mutable minY = min this.P0.Y this.P3.Y
+        let mutable maxY = max this.P0.Y this.P3.Y
+
+        for t in BezierHelpers.extremaOfCubicDerivative this.P0.X this.P1.X this.P2.X this.P3.X do
+            let px = this.Evaluate t
+            minX <- min minX px.X
+            maxX <- max maxX px.X
+
+        for t in BezierHelpers.extremaOfCubicDerivative this.P0.Y this.P1.Y this.P2.Y this.P3.Y do
+            let py = this.Evaluate t
+            minY <- min minY py.Y
+            maxY <- max maxY py.Y
+
+        Rect.New(minX, minY, maxX - minX, maxY - minY)
+
+[<RequireQualifiedAccess>]
+module Bezier2D =
+    [<Literal>]
+    let VERSION = "0.1.0"

--- a/code/packages/fsharp/bezier2d/CHANGELOG.md
+++ b/code/packages/fsharp/bezier2d/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add F# quadratic and cubic Bezier curves with evaluation, derivatives, splitting, polyline approximation, bounding boxes, and quadratic degree elevation.

--- a/code/packages/fsharp/bezier2d/CodingAdventures.Bezier2D.fsproj
+++ b/code/packages/fsharp/bezier2d/CodingAdventures.Bezier2D.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>CodingAdventures.Bezier2D.FSharp</AssemblyName>
+    <PackageId>CodingAdventures.Bezier2D.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Quadratic and cubic Bezier curves over shared 2D point primitives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../point2d/CodingAdventures.Point2D.fsproj" />
+    <ProjectReference Include="../trig/CodingAdventures.Trig.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Bezier2D.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bezier2d/README.md
+++ b/code/packages/fsharp/bezier2d/README.md
@@ -1,0 +1,3 @@
+# CodingAdventures.Bezier2D.FSharp
+
+Quadratic and cubic Bezier curves over the shared 2D point primitives.

--- a/code/packages/fsharp/bezier2d/required_capabilities.json
+++ b/code/packages/fsharp/bezier2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/bezier2d",
+  "capabilities": [],
+  "justification": "Pure geometry arithmetic over local point and trig packages."
+}

--- a/code/packages/fsharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/Bezier2DTests.fs
+++ b/code/packages/fsharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/Bezier2DTests.fs
@@ -1,0 +1,91 @@
+namespace CodingAdventures.Bezier2D.Tests
+
+open System
+open CodingAdventures.Bezier2D.FSharp
+open CodingAdventures.Point2D
+open Xunit
+
+module Bezier2DTests =
+    let epsilon = 1e-9
+
+    let close left right =
+        abs (left - right) < epsilon
+
+    let pointClose (left: Point) (right: Point) =
+        close left.X right.X && close left.Y right.Y
+
+    [<Fact>]
+    let ``version exists`` () =
+        Assert.Equal("0.1.0", Bezier2D.VERSION)
+
+    [<Fact>]
+    let ``quadratic evaluate derivative split and elevate work`` () =
+        let curve = QuadraticBezier.New(Point.New(0.0, 0.0), Point.New(1.0, 2.0), Point.New(2.0, 0.0))
+
+        Assert.True(pointClose (curve.Evaluate 0.0) curve.P0)
+        Assert.True(pointClose (curve.Evaluate 1.0) curve.P2)
+        Assert.True(pointClose (curve.Evaluate 0.5) (Point.New(1.0, 1.0)))
+        Assert.True(pointClose (curve.Derivative 0.0) (Point.New(2.0, 4.0)))
+
+        let left, right = curve.Split 0.5
+        let splitPoint = curve.Evaluate 0.5
+        Assert.True(pointClose left.P2 splitPoint)
+        Assert.True(pointClose right.P0 splitPoint)
+
+        let cubic = curve.Elevate()
+        for t in [ 0.0; 0.25; 0.5; 0.75; 1.0 ] do
+            Assert.True(pointClose (curve.Evaluate t) (cubic.Evaluate t))
+
+    [<Fact>]
+    let ``quadratic polyline and bounding box work`` () =
+        let straight = QuadraticBezier.New(Point.New(0.0, 0.0), Point.New(1.0, 0.0), Point.New(2.0, 0.0))
+        Assert.Equal(2, (straight.ToPolyline 0.1).Length)
+
+        let curve = QuadraticBezier.New(Point.New(0.0, 0.0), Point.New(0.0, 10.0), Point.New(10.0, 0.0))
+        let points = curve.ToPolyline 0.1
+        Assert.True(points.Length > 2)
+        Assert.True(pointClose points[0] curve.P0)
+        Assert.True(pointClose points[points.Length - 1] curve.P2)
+
+        let bounds = curve.BoundingBox()
+        Assert.True(bounds.X <= 0.0)
+        Assert.True(bounds.Y <= 0.0)
+        Assert.True(bounds.X + bounds.Width >= 10.0)
+        Assert.True(bounds.Height > 0.0)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> curve.ToPolyline -0.1 |> ignore) |> ignore
+
+    [<Fact>]
+    let ``cubic evaluate derivative and split work`` () =
+        let curve = CubicBezier.New(Point.New(0.0, 0.0), Point.New(1.0, 2.0), Point.New(3.0, 2.0), Point.New(4.0, 0.0))
+
+        Assert.True(pointClose (curve.Evaluate 0.0) curve.P0)
+        Assert.True(pointClose (curve.Evaluate 1.0) curve.P3)
+        Assert.True(close (curve.Evaluate 0.5).X 2.0)
+
+        let straight = CubicBezier.New(Point.New(0.0, 0.0), Point.New(1.0, 0.0), Point.New(2.0, 0.0), Point.New(3.0, 0.0))
+        Assert.True(pointClose (straight.Derivative 0.0) (Point.New(3.0, 0.0)))
+
+        let left, right = curve.Split 0.5
+        let splitPoint = curve.Evaluate 0.5
+        Assert.True(pointClose left.P3 splitPoint)
+        Assert.True(pointClose right.P0 splitPoint)
+
+    [<Fact>]
+    let ``cubic polyline and bounding box work`` () =
+        let straight = CubicBezier.New(Point.New(0.0, 0.0), Point.New(1.0, 0.0), Point.New(2.0, 0.0), Point.New(3.0, 0.0))
+        Assert.Equal(2, (straight.ToPolyline 0.1).Length)
+
+        let curve = CubicBezier.New(Point.New(0.0, 0.0), Point.New(0.0, 10.0), Point.New(10.0, 10.0), Point.New(10.0, 0.0))
+        let points = curve.ToPolyline 0.1
+        Assert.True(points.Length > 2)
+        Assert.True(pointClose points[0] curve.P0)
+        Assert.True(pointClose points[points.Length - 1] curve.P3)
+
+        let bounds = curve.BoundingBox()
+        for index in 0 .. 20 do
+            let point = curve.Evaluate(float index / 20.0)
+            Assert.True(point.X >= bounds.X - 1e-6 && point.X <= bounds.X + bounds.Width + 1e-6)
+            Assert.True(point.Y >= bounds.Y - 1e-6 && point.Y <= bounds.Y + bounds.Height + 1e-6)
+
+        Assert.Equal(Rect.New(0.0, 0.0, 3.0, 0.0), straight.BoundingBox())
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> curve.ToPolyline Double.NaN |> ignore) |> ignore

--- a/code/packages/fsharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.fsproj
+++ b/code/packages/fsharp/bezier2d/tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.Bezier2D.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Bezier2D.fsproj" />
+    <Compile Include="Bezier2DTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# and F# affine2d packages with translate/rotate/scale/skew factories, composition, inversion, and point/vector application
- add C# and F# bezier2d packages with quadratic/cubic evaluation, derivatives, splitting, bounds, polyline approximation, and degree elevation
- add C# and F# arc2d packages with center-form arcs, SVG endpoint conversion, bounds/tangents, and cubic Bezier approximation

## Verification
- dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Bezier2D.Tests/CodingAdventures.Bezier2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Affine2D.Tests/CodingAdventures.Affine2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Arc2D.Tests/CodingAdventures.Arc2D.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line