### PR TITLE
feat(parity): add dotnet clock packages

### DIFF
--- a/code/packages/csharp/clock/BUILD
+++ b/code/packages/csharp/clock/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/clock/BUILD_windows
+++ b/code/packages/csharp/clock/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/clock/CHANGELOG.md
+++ b/code/packages/csharp/clock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add clock, clock divider, and multi-phase clock simulation helpers.

--- a/code/packages/csharp/clock/Clock.cs
+++ b/code/packages/csharp/clock/Clock.cs
@@ -1,0 +1,251 @@
+namespace CodingAdventures.Clock;
+
+/// <summary>
+/// Record of one clock transition.
+/// </summary>
+public sealed record ClockEdge(long Cycle, int Value, bool IsRising, bool IsFalling);
+
+/// <summary>
+/// Square-wave clock generator for digital circuit simulations.
+/// </summary>
+public sealed class Clock
+{
+    private readonly List<Action<ClockEdge>> _listeners = [];
+    private long _totalTicks;
+
+    /// <summary>
+    /// Create a clock with the requested frequency in Hz.
+    /// </summary>
+    public Clock(long frequencyHz = 1_000_000)
+    {
+        if (frequencyHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frequencyHz), "frequency_hz must be > 0.");
+        }
+
+        FrequencyHz = frequencyHz;
+    }
+
+    /// <summary>The clock frequency in Hz.</summary>
+    public long FrequencyHz { get; }
+
+    /// <summary>The current cycle number, incremented on rising edges.</summary>
+    public long Cycle { get; private set; }
+
+    /// <summary>The current signal value, either 0 or 1.</summary>
+    public int Value { get; private set; }
+
+    /// <summary>Total half-cycles elapsed since construction or reset.</summary>
+    public long TotalTicks => _totalTicks;
+
+    /// <summary>The period of one complete clock cycle in nanoseconds.</summary>
+    public double PeriodNs => 1_000_000_000d / FrequencyHz;
+
+    /// <summary>
+    /// Advance one half-cycle and notify all registered listeners.
+    /// </summary>
+    public ClockEdge Tick()
+    {
+        var oldValue = Value;
+        Value = 1 - Value;
+        _totalTicks++;
+
+        var isRising = oldValue == 0 && Value == 1;
+        var isFalling = oldValue == 1 && Value == 0;
+        if (isRising)
+        {
+            Cycle++;
+        }
+
+        var edge = new ClockEdge(Cycle, Value, isRising, isFalling);
+        foreach (var listener in _listeners.ToArray())
+        {
+            listener(edge);
+        }
+
+        return edge;
+    }
+
+    /// <summary>
+    /// Execute a complete cycle, returning the rising and falling edges.
+    /// </summary>
+    public (ClockEdge Rising, ClockEdge Falling) FullCycle()
+    {
+        var rising = Tick();
+        var falling = Tick();
+        return (rising, falling);
+    }
+
+    /// <summary>
+    /// Run the clock for the requested number of full cycles.
+    /// </summary>
+    public IReadOnlyList<ClockEdge> Run(long cycles)
+    {
+        if (cycles < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(cycles), "cycles must be >= 0.");
+        }
+
+        var edges = new List<ClockEdge>();
+        for (var i = 0L; i < cycles; i++)
+        {
+            var (rising, falling) = FullCycle();
+            edges.Add(rising);
+            edges.Add(falling);
+        }
+
+        return edges;
+    }
+
+    /// <summary>
+    /// Register a callback that receives every clock edge.
+    /// </summary>
+    public void RegisterListener(Action<ClockEdge> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        _listeners.Add(callback);
+    }
+
+    /// <summary>
+    /// Remove a previously registered callback.
+    /// </summary>
+    public void UnregisterListener(Action<ClockEdge> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        if (!_listeners.Remove(callback))
+        {
+            throw new ArgumentException("Listener was not registered.", nameof(callback));
+        }
+    }
+
+    /// <summary>
+    /// Reset timing state while preserving registered listeners and frequency.
+    /// </summary>
+    public void Reset()
+    {
+        Cycle = 0;
+        Value = 0;
+        _totalTicks = 0;
+    }
+}
+
+/// <summary>
+/// Generates a slower output clock from a faster source clock.
+/// </summary>
+public sealed class ClockDivider
+{
+    private long _counter;
+
+    /// <summary>
+    /// Create a divider that registers itself on the source clock.
+    /// </summary>
+    public ClockDivider(Clock source, long divisor)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        if (divisor < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(divisor), $"Divisor must be >= 2, got {divisor}.");
+        }
+
+        Divisor = divisor;
+        Output = new Clock(source.FrequencyHz / divisor);
+        Source.RegisterListener(OnEdge);
+    }
+
+    /// <summary>The source clock being divided.</summary>
+    public Clock Source { get; }
+
+    /// <summary>The integer division factor.</summary>
+    public long Divisor { get; }
+
+    /// <summary>The generated output clock.</summary>
+    public Clock Output { get; }
+
+    private void OnEdge(ClockEdge edge)
+    {
+        if (!edge.IsRising)
+        {
+            return;
+        }
+
+        _counter++;
+        if (_counter < Divisor)
+        {
+            return;
+        }
+
+        _counter = 0;
+        Output.Tick();
+        Output.Tick();
+    }
+}
+
+/// <summary>
+/// Rotates one active phase across a set of non-overlapping clock phases.
+/// </summary>
+public sealed class MultiPhaseClock
+{
+    private readonly int[] _phaseValues;
+
+    /// <summary>
+    /// Create a multi-phase clock generator registered on the source clock.
+    /// </summary>
+    public MultiPhaseClock(Clock source, int phases = 4)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        if (phases < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(phases), $"Phases must be >= 2, got {phases}.");
+        }
+
+        Phases = phases;
+        _phaseValues = new int[phases];
+        Source.RegisterListener(OnEdge);
+    }
+
+    /// <summary>The source clock driving the phase rotation.</summary>
+    public Clock Source { get; }
+
+    /// <summary>The number of generated phases.</summary>
+    public int Phases { get; }
+
+    /// <summary>The phase index that will be activated by the next rising edge.</summary>
+    public int ActivePhase { get; private set; }
+
+    /// <summary>
+    /// Return the current value of a phase, either 0 or 1.
+    /// </summary>
+    public int GetPhase(int index)
+    {
+        if (index < 0 || index >= Phases)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        return _phaseValues[index];
+    }
+
+    /// <summary>A snapshot of the current phase values.</summary>
+    public IReadOnlyList<int> PhaseValues => Array.AsReadOnly((int[])_phaseValues.Clone());
+
+    private void OnEdge(ClockEdge edge)
+    {
+        if (!edge.IsRising)
+        {
+            return;
+        }
+
+        Array.Fill(_phaseValues, 0);
+        _phaseValues[ActivePhase] = 1;
+        ActivePhase = (ActivePhase + 1) % Phases;
+    }
+}
+
+/// <summary>
+/// Package metadata.
+/// </summary>
+public static class ClockPackage
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/clock/CodingAdventures.Clock.csproj
+++ b/code/packages/csharp/clock/CodingAdventures.Clock.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Clock.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Digital clock simulation helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/clock/README.md
+++ b/code/packages/csharp/clock/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Clock.CSharp
+
+Digital clock simulation helpers for .NET.
+
+The package models a square-wave clock with rising and falling edges, listener callbacks, frequency dividers, and non-overlapping multi-phase clocks. It follows the Python clock package's automatic listener wiring while using .NET delegates for callbacks.

--- a/code/packages/csharp/clock/required_capabilities.json
+++ b/code/packages/csharp/clock/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/clock",
+  "capabilities": [],
+  "justification": "Pure in-memory digital clock simulation. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/clock/tests/CodingAdventures.Clock.Tests/ClockTests.cs
+++ b/code/packages/csharp/clock/tests/CodingAdventures.Clock.Tests/ClockTests.cs
@@ -1,0 +1,161 @@
+namespace CodingAdventures.Clock.Tests;
+
+public sealed class ClockTests
+{
+    [Fact]
+    public void ClockStartsInKnownState()
+    {
+        var clock = new Clock();
+
+        Assert.Equal(1_000_000, clock.FrequencyHz);
+        Assert.Equal(0, clock.Cycle);
+        Assert.Equal(0, clock.Value);
+        Assert.Equal(0, clock.TotalTicks);
+    }
+
+    [Fact]
+    public void TickAlternatesEdgesAndCycles()
+    {
+        var clock = new Clock();
+
+        var first = clock.Tick();
+        var second = clock.Tick();
+        var third = clock.Tick();
+
+        Assert.Equal(new ClockEdge(1, 1, true, false), first);
+        Assert.Equal(new ClockEdge(1, 0, false, true), second);
+        Assert.Equal(new ClockEdge(2, 1, true, false), third);
+        Assert.Equal(3, clock.TotalTicks);
+    }
+
+    [Fact]
+    public void FullCycleReturnsRisingThenFalling()
+    {
+        var clock = new Clock();
+
+        var (rising, falling) = clock.FullCycle();
+
+        Assert.True(rising.IsRising);
+        Assert.True(falling.IsFalling);
+        Assert.Equal(0, clock.Value);
+        Assert.Equal(1, clock.Cycle);
+        Assert.Equal(2, clock.TotalTicks);
+    }
+
+    [Fact]
+    public void RunProducesTwoEdgesPerCycle()
+    {
+        var clock = new Clock();
+
+        var edges = clock.Run(5);
+
+        Assert.Equal(10, edges.Count);
+        Assert.Equal(5, clock.Cycle);
+        Assert.Empty(clock.Run(0));
+    }
+
+    [Fact]
+    public void ListenersReceiveEdgesAndCanBeRemoved()
+    {
+        var clock = new Clock();
+        var received = new List<ClockEdge>();
+        void Listener(ClockEdge edge) => received.Add(edge);
+
+        clock.RegisterListener(Listener);
+        clock.Run(2);
+        clock.UnregisterListener(Listener);
+        clock.Tick();
+
+        Assert.Equal(4, received.Count);
+        Assert.Throws<ArgumentException>(() => clock.UnregisterListener(Listener));
+    }
+
+    [Fact]
+    public void ResetPreservesListenersAndFrequency()
+    {
+        var clock = new Clock(5_000_000);
+        var received = new List<ClockEdge>();
+        clock.RegisterListener(received.Add);
+
+        clock.Run(3);
+        clock.Reset();
+        clock.Tick();
+
+        Assert.Equal(5_000_000, clock.FrequencyHz);
+        Assert.Equal(1, received.Last().Cycle);
+        Assert.Equal(1, clock.Cycle);
+        Assert.Equal(1, clock.TotalTicks);
+    }
+
+    [Theory]
+    [InlineData(1_000_000, 1000.0)]
+    [InlineData(1_000_000_000, 1.0)]
+    public void PeriodUsesFrequency(long frequency, double expectedPeriodNs)
+    {
+        var clock = new Clock(frequency);
+
+        Assert.Equal(expectedPeriodNs, clock.PeriodNs, precision: 10);
+    }
+
+    [Fact]
+    public void ClockRejectsInvalidFrequency()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Clock(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Clock(-1));
+    }
+
+    [Fact]
+    public void DividerProducesOutputCyclesFromRisingEdges()
+    {
+        var master = new Clock(1_000_000_000);
+        var divider = new ClockDivider(master, 4);
+
+        master.Run(8);
+
+        Assert.Equal(250_000_000, divider.Output.FrequencyHz);
+        Assert.Equal(2, divider.Output.Cycle);
+        Assert.Equal(0, divider.Output.Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    public void DividerRejectsInvalidDivisor(long divisor)
+    {
+        var master = new Clock();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ClockDivider(master, divisor));
+    }
+
+    [Fact]
+    public void MultiPhaseClockRotatesOneActivePhase()
+    {
+        var master = new Clock();
+        var phases = new MultiPhaseClock(master, 4);
+
+        for (var expected = 0; expected < 4; expected++)
+        {
+            master.Tick();
+
+            for (var phase = 0; phase < 4; phase++)
+            {
+                Assert.Equal(phase == expected ? 1 : 0, phases.GetPhase(phase));
+            }
+
+            master.Tick();
+        }
+
+        master.Tick();
+        Assert.Equal(1, phases.GetPhase(0));
+    }
+
+    [Fact]
+    public void MultiPhaseClockRejectsInvalidPhaseCounts()
+    {
+        var master = new Clock();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MultiPhaseClock(master, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MultiPhaseClock(master, 0));
+    }
+}

--- a/code/packages/csharp/clock/tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.csproj
+++ b/code/packages/csharp/clock/tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Clock.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/clock/BUILD
+++ b/code/packages/fsharp/clock/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/clock/BUILD_windows
+++ b/code/packages/fsharp/clock/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/clock/CHANGELOG.md
+++ b/code/packages/fsharp/clock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add clock, clock divider, and multi-phase clock simulation helpers.

--- a/code/packages/fsharp/clock/Clock.fs
+++ b/code/packages/fsharp/clock/Clock.fs
@@ -1,0 +1,160 @@
+namespace CodingAdventures.Clock.FSharp
+
+open System
+open System.Collections.Generic
+
+[<CLIMutable>]
+type ClockEdge =
+    { Cycle: int64
+      Value: int
+      IsRising: bool
+      IsFalling: bool }
+
+[<AllowNullLiteral>]
+type Clock(?frequencyHz: int64) =
+    let frequencyHz = defaultArg frequencyHz 1_000_000L
+    do
+        if frequencyHz <= 0L then
+            invalidArg "frequencyHz" "frequency_hz must be > 0."
+
+    let listeners = ResizeArray<Action<ClockEdge>>()
+    let mutable cycle = 0L
+    let mutable value = 0
+    let mutable totalTicks = 0L
+
+    member _.FrequencyHz = frequencyHz
+    member _.Cycle = cycle
+    member _.Value = value
+    member _.TotalTicks = totalTicks
+    member _.PeriodNs = 1_000_000_000.0 / float frequencyHz
+
+    member _.Tick() =
+        let oldValue = value
+        value <- 1 - value
+        totalTicks <- totalTicks + 1L
+
+        let isRising = oldValue = 0 && value = 1
+        let isFalling = oldValue = 1 && value = 0
+
+        if isRising then
+            cycle <- cycle + 1L
+
+        let edge =
+            { Cycle = cycle
+              Value = value
+              IsRising = isRising
+              IsFalling = isFalling }
+
+        for listener in listeners |> Seq.toArray do
+            listener.Invoke edge
+
+        edge
+
+    member this.FullCycle() =
+        let rising = this.Tick()
+        let falling = this.Tick()
+        rising, falling
+
+    member this.Run(cycles: int64) =
+        if cycles < 0L then
+            invalidArg "cycles" "cycles must be >= 0."
+
+        let edges = ResizeArray<ClockEdge>()
+        let mutable remaining = cycles
+
+        while remaining > 0L do
+            let rising, falling = this.FullCycle()
+            edges.Add rising
+            edges.Add falling
+            remaining <- remaining - 1L
+
+        edges |> Seq.toList
+
+    member _.RegisterListener(callback: Action<ClockEdge>) =
+        if isNull callback then
+            nullArg "callback"
+
+        listeners.Add callback
+
+    member _.UnregisterListener(callback: Action<ClockEdge>) =
+        if isNull callback then
+            nullArg "callback"
+
+        if not (listeners.Remove callback) then
+            raise (ArgumentException("Listener was not registered.", "callback"))
+
+    member _.Reset() =
+        cycle <- 0L
+        value <- 0
+        totalTicks <- 0L
+
+type ClockDivider(source: Clock, divisor: int64) =
+    let source =
+        if isNull source then
+            nullArg "source"
+        else
+            source
+
+    do
+        if divisor < 2L then
+            invalidArg "divisor" $"Divisor must be >= 2, got {divisor}."
+
+    let output = Clock(source.FrequencyHz / divisor)
+    let mutable counter = 0L
+
+    let listener =
+        Action<ClockEdge>(fun edge ->
+            if edge.IsRising then
+                counter <- counter + 1L
+
+                if counter >= divisor then
+                    counter <- 0L
+                    output.Tick() |> ignore
+                    output.Tick() |> ignore)
+
+    do source.RegisterListener listener
+
+    member _.Source = source
+    member _.Divisor = divisor
+    member _.Output = output
+
+type MultiPhaseClock(source: Clock, ?phases: int) =
+    let source =
+        if isNull source then
+            nullArg "source"
+        else
+            source
+
+    let phases = defaultArg phases 4
+
+    do
+        if phases < 2 then
+            invalidArg "phases" $"Phases must be >= 2, got {phases}."
+
+    let phaseValues = Array.zeroCreate<int> phases
+    let mutable activePhase = 0
+
+    let listener =
+        Action<ClockEdge>(fun edge ->
+            if edge.IsRising then
+                Array.Fill(phaseValues, 0)
+                phaseValues[activePhase] <- 1
+                activePhase <- (activePhase + 1) % phases)
+
+    do source.RegisterListener listener
+
+    member _.Source = source
+    member _.Phases = phases
+    member _.ActivePhase = activePhase
+    member _.GetPhase(index: int) =
+        if index < 0 || index >= phases then
+            invalidArg "index" "index is outside the configured phase range."
+
+        phaseValues[index]
+
+    member _.PhaseValues = phaseValues |> Array.copy
+
+[<RequireQualifiedAccess>]
+module ClockPackage =
+    [<Literal>]
+    let Version = "0.1.0"

--- a/code/packages/fsharp/clock/CodingAdventures.Clock.fsproj
+++ b/code/packages/fsharp/clock/CodingAdventures.Clock.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Clock.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Digital clock simulation helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Clock.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/clock/README.md
+++ b/code/packages/fsharp/clock/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Clock.FSharp
+
+Digital clock simulation helpers for .NET.
+
+The package models a square-wave clock with rising and falling edges, listener callbacks, frequency dividers, and non-overlapping multi-phase clocks. It follows the Python clock package's automatic listener wiring while using .NET delegates for callbacks.

--- a/code/packages/fsharp/clock/required_capabilities.json
+++ b/code/packages/fsharp/clock/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/clock",
+  "capabilities": [],
+  "justification": "Pure in-memory digital clock simulation. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/clock/tests/CodingAdventures.Clock.Tests/ClockTests.fs
+++ b/code/packages/fsharp/clock/tests/CodingAdventures.Clock.Tests/ClockTests.fs
@@ -1,0 +1,136 @@
+namespace CodingAdventures.Clock.Tests
+
+open System
+open System.Collections.Generic
+open Xunit
+open CodingAdventures.Clock.FSharp
+
+module ClockTests =
+    [<Fact>]
+    let ``clock starts in known state`` () =
+        let clock = Clock()
+
+        Assert.Equal(1_000_000L, clock.FrequencyHz)
+        Assert.Equal(0L, clock.Cycle)
+        Assert.Equal(0, clock.Value)
+        Assert.Equal(0L, clock.TotalTicks)
+
+    [<Fact>]
+    let ``tick alternates edges and cycles`` () =
+        let clock = Clock()
+
+        let first = clock.Tick()
+        let second = clock.Tick()
+        let third = clock.Tick()
+
+        Assert.Equal({ Cycle = 1L; Value = 1; IsRising = true; IsFalling = false }, first)
+        Assert.Equal({ Cycle = 1L; Value = 0; IsRising = false; IsFalling = true }, second)
+        Assert.Equal({ Cycle = 2L; Value = 1; IsRising = true; IsFalling = false }, third)
+        Assert.Equal(3L, clock.TotalTicks)
+
+    [<Fact>]
+    let ``full cycle returns rising then falling`` () =
+        let clock = Clock()
+
+        let rising, falling = clock.FullCycle()
+
+        Assert.True rising.IsRising
+        Assert.True falling.IsFalling
+        Assert.Equal(0, clock.Value)
+        Assert.Equal(1L, clock.Cycle)
+        Assert.Equal(2L, clock.TotalTicks)
+
+    [<Fact>]
+    let ``run produces two edges per cycle`` () =
+        let clock = Clock()
+
+        let edges = clock.Run 5L
+
+        Assert.Equal(10, edges.Length)
+        Assert.Equal(5L, clock.Cycle)
+        Assert.Empty(clock.Run 0L)
+
+    [<Fact>]
+    let ``listeners receive edges and can be removed`` () =
+        let clock = Clock()
+        let received = List<ClockEdge>()
+        let listener = Action<ClockEdge>(fun edge -> received.Add edge)
+
+        clock.RegisterListener listener
+        clock.Run 2L |> ignore
+        clock.UnregisterListener listener
+        clock.Tick() |> ignore
+
+        Assert.Equal(4, received.Count)
+        Assert.Throws<ArgumentException>(fun () -> clock.UnregisterListener listener) |> ignore
+
+    [<Fact>]
+    let ``reset preserves listeners and frequency`` () =
+        let clock = Clock(5_000_000L)
+        let received = List<ClockEdge>()
+        clock.RegisterListener(Action<ClockEdge>(fun edge -> received.Add edge))
+
+        clock.Run 3L |> ignore
+        clock.Reset()
+        clock.Tick() |> ignore
+
+        Assert.Equal(5_000_000L, clock.FrequencyHz)
+        Assert.Equal(1L, received[received.Count - 1].Cycle)
+        Assert.Equal(1L, clock.Cycle)
+        Assert.Equal(1L, clock.TotalTicks)
+
+    [<Theory>]
+    [<InlineData(1_000_000L, 1000.0)>]
+    [<InlineData(1_000_000_000L, 1.0)>]
+    let ``period uses frequency`` (frequency: int64) (expectedPeriodNs: double) =
+        let clock = Clock frequency
+
+        Assert.Equal(expectedPeriodNs, clock.PeriodNs, 10)
+
+    [<Fact>]
+    let ``clock rejects invalid frequency`` () =
+        Assert.Throws<ArgumentException>(fun () -> Clock(0L) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Clock(-1L) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``divider produces output cycles from rising edges`` () =
+        let master = Clock 1_000_000_000L
+        let divider = ClockDivider(master, 4L)
+
+        master.Run 8L |> ignore
+
+        Assert.Equal(250_000_000L, divider.Output.FrequencyHz)
+        Assert.Equal(2L, divider.Output.Cycle)
+        Assert.Equal(0, divider.Output.Value)
+
+    [<Theory>]
+    [<InlineData(0L)>]
+    [<InlineData(1L)>]
+    [<InlineData(-1L)>]
+    let ``divider rejects invalid divisors`` (divisor: int64) =
+        let master = Clock()
+
+        Assert.Throws<ArgumentException>(fun () -> ClockDivider(master, divisor) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``multi phase clock rotates one active phase`` () =
+        let master = Clock()
+        let phases = MultiPhaseClock(master, 4)
+
+        for expected in 0 .. 3 do
+            master.Tick() |> ignore
+
+            for phase in 0 .. 3 do
+                Assert.Equal((if phase = expected then 1 else 0), phases.GetPhase phase)
+
+            master.Tick() |> ignore
+
+        master.Tick() |> ignore
+        Assert.Equal(1, phases.GetPhase 0)
+
+    [<Fact>]
+    let ``multi phase clock rejects invalid phase counts`` () =
+        let master = Clock()
+
+        Assert.Throws<ArgumentException>(fun () -> MultiPhaseClock(master, 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> MultiPhaseClock(master, 0) |> ignore) |> ignore

--- a/code/packages/fsharp/clock/tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.fsproj
+++ b/code/packages/fsharp/clock/tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Clock.fsproj" />
+    <Compile Include="ClockTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# clock, clock divider, and multi-phase clock package
- add F# clock, clock divider, and multi-phase clock package
- include package metadata, capability declarations, and coverage-gated xUnit tests

## Tests
- dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (15 passed, 95.72% line)
- dotnet test tests/CodingAdventures.Clock.Tests/CodingAdventures.Clock.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (15 passed, 86.95% line)