### PR TITLE
feat(parity): add dotnet compiler source map packages

### DIFF
--- a/code/packages/csharp/compiler-source-map/BUILD
+++ b/code/packages/csharp/compiler-source-map/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/compiler-source-map/BUILD_windows
+++ b/code/packages/csharp/compiler-source-map/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/compiler-source-map/CHANGELOG.md
+++ b/code/packages/csharp/compiler-source-map/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add compiler source-map chain data structures and composite lookup helpers.

--- a/code/packages/csharp/compiler-source-map/CodingAdventures.CompilerSourceMap.csproj
+++ b/code/packages/csharp/compiler-source-map/CodingAdventures.CompilerSourceMap.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CompilerSourceMap.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Compiler source-map chain sidecar for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/compiler-source-map/CompilerSourceMap.cs
+++ b/code/packages/csharp/compiler-source-map/CompilerSourceMap.cs
@@ -1,0 +1,327 @@
+namespace CodingAdventures.CompilerSourceMap;
+
+/// <summary>
+/// A span of characters in a source file.
+/// </summary>
+public sealed record SourcePosition(string File, int Line, int Column, int Length)
+{
+    /// <summary>Return a debugger-friendly source span label.</summary>
+    public override string ToString() => $"{File}:{Line}:{Column} (len={Length})";
+}
+
+/// <summary>
+/// One mapping from a source position to an AST node ID.
+/// </summary>
+public sealed record SourceToAstEntry(SourcePosition Position, int AstNodeId);
+
+/// <summary>
+/// Segment 1: source positions to AST node IDs.
+/// </summary>
+public sealed class SourceToAst
+{
+    private readonly List<SourceToAstEntry> _entries = [];
+
+    /// <summary>All source-position to AST-node mappings.</summary>
+    public IReadOnlyList<SourceToAstEntry> Entries => _entries.AsReadOnly();
+
+    /// <summary>Add a source-position to AST-node mapping.</summary>
+    public void Add(SourcePosition position, int astNodeId)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        _entries.Add(new SourceToAstEntry(position, astNodeId));
+    }
+
+    /// <summary>Return the source position for an AST node ID, if known.</summary>
+    public SourcePosition? LookupByNodeId(int astNodeId) =>
+        _entries.FirstOrDefault(entry => entry.AstNodeId == astNodeId)?.Position;
+}
+
+/// <summary>
+/// One mapping from an AST node to the IR instruction IDs it produced.
+/// </summary>
+public sealed record AstToIrEntry(int AstNodeId, IReadOnlyList<long> IrIds);
+
+/// <summary>
+/// Segment 2: AST node IDs to IR instruction IDs.
+/// </summary>
+public sealed class AstToIr
+{
+    private readonly List<AstToIrEntry> _entries = [];
+
+    /// <summary>All AST-node to IR-ID mappings.</summary>
+    public IReadOnlyList<AstToIrEntry> Entries => _entries.AsReadOnly();
+
+    /// <summary>Add the IR instruction IDs produced by an AST node.</summary>
+    public void Add(int astNodeId, IEnumerable<long> irIds)
+    {
+        ArgumentNullException.ThrowIfNull(irIds);
+        _entries.Add(new AstToIrEntry(astNodeId, irIds.ToArray()));
+    }
+
+    /// <summary>Return the IR IDs produced by an AST node, if known.</summary>
+    public IReadOnlyList<long>? LookupByAstNodeId(int astNodeId) =>
+        _entries.FirstOrDefault(entry => entry.AstNodeId == astNodeId)?.IrIds;
+
+    /// <summary>Return the AST node that produced an IR ID, or -1 if unknown.</summary>
+    public int LookupByIrId(long irId)
+    {
+        foreach (var entry in _entries)
+        {
+            if (entry.IrIds.Contains(irId))
+            {
+                return entry.AstNodeId;
+            }
+        }
+
+        return -1;
+    }
+}
+
+/// <summary>
+/// One optimizer mapping from an original IR ID to replacement IR IDs.
+/// </summary>
+public sealed record IrToIrEntry(long OriginalId, IReadOnlyList<long> NewIds);
+
+/// <summary>
+/// Segment 3: one optimizer pass from original IR IDs to optimized IR IDs.
+/// </summary>
+public sealed class IrToIr
+{
+    private readonly HashSet<long> _deleted = [];
+    private readonly List<IrToIrEntry> _entries = [];
+
+    /// <summary>Create an optimizer-pass segment.</summary>
+    public IrToIr(string passName = "")
+    {
+        PassName = passName;
+    }
+
+    /// <summary>All original-IR to new-IR mappings.</summary>
+    public IReadOnlyList<IrToIrEntry> Entries => _entries.AsReadOnly();
+
+    /// <summary>Original IR IDs deleted by this pass.</summary>
+    public IReadOnlySet<long> Deleted => _deleted;
+
+    /// <summary>The optimizer pass name.</summary>
+    public string PassName { get; }
+
+    /// <summary>Add a mapping from one original IR ID to replacement IR IDs.</summary>
+    public void AddMapping(long originalId, IEnumerable<long> newIds)
+    {
+        ArgumentNullException.ThrowIfNull(newIds);
+        _entries.Add(new IrToIrEntry(originalId, newIds.ToArray()));
+    }
+
+    /// <summary>Record that an original IR ID was deleted.</summary>
+    public void AddDeletion(long originalId)
+    {
+        _deleted.Add(originalId);
+        _entries.Add(new IrToIrEntry(originalId, Array.Empty<long>()));
+    }
+
+    /// <summary>Return replacement IR IDs for an original ID, or null when deleted or unknown.</summary>
+    public IReadOnlyList<long>? LookupByOriginalId(long originalId)
+    {
+        if (_deleted.Contains(originalId))
+        {
+            return null;
+        }
+
+        return _entries.FirstOrDefault(entry => entry.OriginalId == originalId)?.NewIds;
+    }
+
+    /// <summary>Return the original IR ID that produced a new ID, or -1 if unknown.</summary>
+    public long LookupByNewId(long newId)
+    {
+        foreach (var entry in _entries)
+        {
+            if (entry.NewIds.Contains(newId))
+            {
+                return entry.OriginalId;
+            }
+        }
+
+        return -1;
+    }
+}
+
+/// <summary>
+/// One mapping from an IR instruction to a machine-code byte range.
+/// </summary>
+public sealed record IrToMachineCodeEntry(long IrId, long MachineCodeOffset, long MachineCodeLength);
+
+/// <summary>
+/// Segment 4: IR instruction IDs to machine-code byte offsets.
+/// </summary>
+public sealed class IrToMachineCode
+{
+    private readonly List<IrToMachineCodeEntry> _entries = [];
+
+    /// <summary>All IR to machine-code range mappings.</summary>
+    public IReadOnlyList<IrToMachineCodeEntry> Entries => _entries.AsReadOnly();
+
+    /// <summary>Add a machine-code byte range for an IR instruction.</summary>
+    public void Add(long irId, long machineCodeOffset, long machineCodeLength)
+    {
+        _entries.Add(new IrToMachineCodeEntry(irId, machineCodeOffset, machineCodeLength));
+    }
+
+    /// <summary>Return the machine-code range for an IR ID, or (-1, 0) if unknown.</summary>
+    public (long Offset, long Length) LookupByIrId(long irId)
+    {
+        var entry = _entries.FirstOrDefault(item => item.IrId == irId);
+        return entry is null ? (-1, 0) : (entry.MachineCodeOffset, entry.MachineCodeLength);
+    }
+
+    /// <summary>Return the IR ID whose machine-code range contains the offset, or -1.</summary>
+    public long LookupByMachineCodeOffset(long offset)
+    {
+        foreach (var entry in _entries)
+        {
+            if (entry.MachineCodeOffset <= offset && offset < entry.MachineCodeOffset + entry.MachineCodeLength)
+            {
+                return entry.IrId;
+            }
+        }
+
+        return -1;
+    }
+}
+
+/// <summary>
+/// Full source-map sidecar composed from the compiler pipeline segments.
+/// </summary>
+public sealed class SourceMapChain
+{
+    /// <summary>Create an empty source-map chain.</summary>
+    public SourceMapChain()
+    {
+        SourceToAst = new SourceToAst();
+        AstToIr = new AstToIr();
+    }
+
+    /// <summary>Source-position to AST-node segment.</summary>
+    public SourceToAst SourceToAst { get; }
+
+    /// <summary>AST-node to IR-ID segment.</summary>
+    public AstToIr AstToIr { get; }
+
+    /// <summary>Optimizer pass segments in pipeline order.</summary>
+    public List<IrToIr> IrToIr { get; } = [];
+
+    /// <summary>IR to machine-code segment, filled by the backend.</summary>
+    public IrToMachineCode? IrToMachineCode { get; set; }
+
+    /// <summary>Create an empty source-map chain.</summary>
+    public static SourceMapChain New() => new();
+
+    /// <summary>Append an optimizer-pass segment.</summary>
+    public void AddOptimizerPass(IrToIr segment)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+        IrToIr.Add(segment);
+    }
+
+    /// <summary>Compose the chain from source position to machine-code ranges.</summary>
+    public IReadOnlyList<IrToMachineCodeEntry>? SourceToMc(SourcePosition position)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        if (IrToMachineCode is null)
+        {
+            return null;
+        }
+
+        var astNodeId = SourceToAst.Entries
+            .FirstOrDefault(entry =>
+                entry.Position.File == position.File
+                && entry.Position.Line == position.Line
+                && entry.Position.Column == position.Column)
+            ?.AstNodeId;
+        if (astNodeId is null)
+        {
+            return null;
+        }
+
+        var irIds = AstToIr.LookupByAstNodeId(astNodeId.Value);
+        if (irIds is null)
+        {
+            return null;
+        }
+
+        var currentIds = irIds.ToList();
+        foreach (var pass in IrToIr)
+        {
+            var nextIds = new List<long>();
+            foreach (var irId in currentIds)
+            {
+                if (pass.Deleted.Contains(irId))
+                {
+                    continue;
+                }
+
+                var newIds = pass.LookupByOriginalId(irId);
+                if (newIds is not null)
+                {
+                    nextIds.AddRange(newIds);
+                }
+            }
+
+            currentIds = nextIds;
+        }
+
+        if (currentIds.Count == 0)
+        {
+            return null;
+        }
+
+        var results = new List<IrToMachineCodeEntry>();
+        foreach (var irId in currentIds)
+        {
+            var (offset, length) = IrToMachineCode.LookupByIrId(irId);
+            if (offset >= 0)
+            {
+                results.Add(new IrToMachineCodeEntry(irId, offset, length));
+            }
+        }
+
+        return results.Count == 0 ? null : results;
+    }
+
+    /// <summary>Compose the chain from machine-code offset back to source position.</summary>
+    public SourcePosition? McToSource(long machineCodeOffset)
+    {
+        if (IrToMachineCode is null)
+        {
+            return null;
+        }
+
+        var currentId = IrToMachineCode.LookupByMachineCodeOffset(machineCodeOffset);
+        if (currentId == -1)
+        {
+            return null;
+        }
+
+        for (var i = IrToIr.Count - 1; i >= 0; i--)
+        {
+            var originalId = IrToIr[i].LookupByNewId(currentId);
+            if (originalId == -1)
+            {
+                return null;
+            }
+
+            currentId = originalId;
+        }
+
+        var astNodeId = AstToIr.LookupByIrId(currentId);
+        return astNodeId == -1 ? null : SourceToAst.LookupByNodeId(astNodeId);
+    }
+}
+
+/// <summary>
+/// Package metadata.
+/// </summary>
+public static class CompilerSourceMapPackage
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/compiler-source-map/README.md
+++ b/code/packages/csharp/compiler-source-map/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.CompilerSourceMap.CSharp
+
+Compiler source-map chain sidecar for .NET.
+
+The package models source positions, source-to-AST mappings, AST-to-IR mappings, optimizer IR-to-IR mappings, and IR-to-machine-code mappings. `SourceMapChain` composes those segments for forward source-to-machine-code lookups and reverse machine-code-to-source lookups.

--- a/code/packages/csharp/compiler-source-map/required_capabilities.json
+++ b/code/packages/csharp/compiler-source-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/compiler-source-map",
+  "capabilities": [],
+  "justification": "Pure in-memory compiler source-map data structures and lookup helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.csproj
+++ b/code/packages/csharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CompilerSourceMap.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CompilerSourceMapTests.cs
+++ b/code/packages/csharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CompilerSourceMapTests.cs
@@ -1,0 +1,217 @@
+namespace CodingAdventures.CompilerSourceMap.Tests;
+
+public sealed class CompilerSourceMapTests
+{
+    private static SourceMapChain BuildTestChain()
+    {
+        var chain = SourceMapChain.New();
+        chain.SourceToAst.Add(new SourcePosition("hello.bf", 1, 1, 1), 0);
+        chain.SourceToAst.Add(new SourcePosition("hello.bf", 1, 2, 1), 1);
+        chain.AstToIr.Add(0, [2, 3, 4, 5]);
+        chain.AstToIr.Add(1, [6, 7]);
+
+        var identity = new IrToIr("identity");
+        for (var i = 0L; i < 8; i++)
+        {
+            identity.AddMapping(i, [i]);
+        }
+
+        chain.AddOptimizerPass(identity);
+
+        var machineCode = new IrToMachineCode();
+        machineCode.Add(0, 0x00, 8);
+        machineCode.Add(1, 0x08, 4);
+        machineCode.Add(2, 0x0C, 8);
+        machineCode.Add(3, 0x14, 4);
+        machineCode.Add(4, 0x18, 4);
+        machineCode.Add(5, 0x1C, 8);
+        machineCode.Add(6, 0x24, 8);
+        machineCode.Add(7, 0x2C, 8);
+        chain.IrToMachineCode = machineCode;
+        return chain;
+    }
+
+    [Fact]
+    public void SourcePositionFormatsAndCompares()
+    {
+        var position = new SourcePosition("hello.bf", 1, 3, 1);
+
+        Assert.Equal("hello.bf:1:3 (len=1)", position.ToString());
+        Assert.Equal(position, new SourcePosition("hello.bf", 1, 3, 1));
+        Assert.NotEqual(position, new SourcePosition("hello.bf", 1, 4, 1));
+    }
+
+    [Fact]
+    public void SourceToAstAddsAndLooksUpNodeIds()
+    {
+        var segment = new SourceToAst();
+        var position = new SourcePosition("a.bf", 1, 1, 1);
+
+        segment.Add(position, 42);
+
+        Assert.Equal(position, segment.LookupByNodeId(42));
+        Assert.Null(segment.LookupByNodeId(999));
+    }
+
+    [Fact]
+    public void AstToIrSupportsForwardAndReverseLookup()
+    {
+        var segment = new AstToIr();
+
+        segment.Add(5, [20, 21]);
+        segment.Add(6, [22]);
+
+        Assert.Equal([20L, 21L], segment.LookupByAstNodeId(5));
+        Assert.Equal(5, segment.LookupByIrId(21));
+        Assert.Equal(6, segment.LookupByIrId(22));
+        Assert.Equal(-1, segment.LookupByIrId(999));
+    }
+
+    [Fact]
+    public void IrToIrHandlesMappingsDeletionAndReverseLookup()
+    {
+        var segment = new IrToIr("contraction");
+
+        segment.AddMapping(7, [100]);
+        segment.AddMapping(8, [100]);
+        segment.AddDeletion(9);
+
+        Assert.Equal([100L], segment.LookupByOriginalId(7));
+        Assert.Equal(7, segment.LookupByNewId(100));
+        Assert.Null(segment.LookupByOriginalId(9));
+        Assert.Contains(9, segment.Deleted);
+        Assert.Equal("contraction", segment.PassName);
+    }
+
+    [Fact]
+    public void IrToMachineCodeFindsInstructionRanges()
+    {
+        var segment = new IrToMachineCode();
+
+        segment.Add(5, 0x20, 4);
+        segment.Add(6, 0x24, 8);
+
+        Assert.Equal((0x20L, 4L), segment.LookupByIrId(5));
+        Assert.Equal((-1L, 0L), segment.LookupByIrId(999));
+        Assert.Equal(5, segment.LookupByMachineCodeOffset(0x23));
+        Assert.Equal(6, segment.LookupByMachineCodeOffset(0x24));
+        Assert.Equal(-1, segment.LookupByMachineCodeOffset(0xFF));
+    }
+
+    [Fact]
+    public void NewChainStartsEmpty()
+    {
+        var chain = SourceMapChain.New();
+
+        Assert.Empty(chain.SourceToAst.Entries);
+        Assert.Empty(chain.AstToIr.Entries);
+        Assert.Empty(chain.IrToIr);
+        Assert.Null(chain.IrToMachineCode);
+    }
+
+    [Fact]
+    public void ForwardLookupComposesAllSegments()
+    {
+        var chain = BuildTestChain();
+
+        var results = chain.SourceToMc(new SourcePosition("hello.bf", 1, 1, 1));
+
+        Assert.NotNull(results);
+        Assert.Equal([2L, 3L, 4L, 5L], results.Select(entry => entry.IrId));
+        Assert.Equal(0x0C, results[0].MachineCodeOffset);
+    }
+
+    [Fact]
+    public void ReverseLookupComposesSegmentsBackToSource()
+    {
+        var chain = BuildTestChain();
+
+        var plus = chain.McToSource(0x14);
+        var dot = chain.McToSource(0x2C);
+
+        Assert.Equal(new SourcePosition("hello.bf", 1, 1, 1), plus);
+        Assert.Equal(new SourcePosition("hello.bf", 1, 2, 1), dot);
+    }
+
+    [Fact]
+    public void IncompleteOrMissingMappingsReturnNull()
+    {
+        var chain = SourceMapChain.New();
+        chain.SourceToAst.Add(new SourcePosition("a.bf", 1, 1, 1), 0);
+        chain.AstToIr.Add(0, [1, 2]);
+
+        Assert.Null(chain.SourceToMc(new SourcePosition("a.bf", 1, 1, 1)));
+        Assert.Null(chain.McToSource(0));
+
+        chain.IrToMachineCode = new IrToMachineCode();
+        Assert.Null(chain.SourceToMc(new SourcePosition("a.bf", 9, 1, 1)));
+    }
+
+    [Fact]
+    public void OptimizerContractionFeedsForwardLookup()
+    {
+        var chain = SourceMapChain.New();
+        var position = new SourcePosition("t.bf", 1, 1, 1);
+        chain.SourceToAst.Add(position, 0);
+        chain.AstToIr.Add(0, [1, 2, 3]);
+
+        var pass = new IrToIr("contraction");
+        pass.AddMapping(1, [100]);
+        pass.AddMapping(2, [100]);
+        pass.AddMapping(3, [100]);
+        chain.AddOptimizerPass(pass);
+
+        var machineCode = new IrToMachineCode();
+        machineCode.Add(100, 0, 4);
+        chain.IrToMachineCode = machineCode;
+
+        var results = chain.SourceToMc(position);
+
+        Assert.NotNull(results);
+        Assert.Equal(3, results.Count);
+        Assert.All(results, entry => Assert.Equal(100, entry.IrId));
+    }
+
+    [Fact]
+    public void OptimizerDeletionDropsForwardResults()
+    {
+        var chain = SourceMapChain.New();
+        var position = new SourcePosition("t.bf", 1, 1, 1);
+        chain.SourceToAst.Add(position, 0);
+        chain.AstToIr.Add(0, [1, 2]);
+
+        var pass = new IrToIr("dead-store");
+        pass.AddMapping(1, [1]);
+        pass.AddDeletion(2);
+        chain.AddOptimizerPass(pass);
+
+        var machineCode = new IrToMachineCode();
+        machineCode.Add(1, 0, 4);
+        machineCode.Add(2, 4, 4);
+        chain.IrToMachineCode = machineCode;
+
+        var results = chain.SourceToMc(position);
+
+        Assert.NotNull(results);
+        Assert.Single(results);
+        Assert.Equal(1, results[0].IrId);
+    }
+
+    [Fact]
+    public void ReverseLookupFailsWhenOptimizerTraceIsMissing()
+    {
+        var chain = SourceMapChain.New();
+        chain.SourceToAst.Add(new SourcePosition("t.bf", 1, 1, 1), 0);
+        chain.AstToIr.Add(0, [1]);
+
+        var pass = new IrToIr("renumber");
+        pass.AddMapping(1, [100]);
+        chain.AddOptimizerPass(pass);
+
+        var machineCode = new IrToMachineCode();
+        machineCode.Add(200, 0, 4);
+        chain.IrToMachineCode = machineCode;
+
+        Assert.Null(chain.McToSource(0));
+    }
+}

--- a/code/packages/fsharp/compiler-source-map/BUILD
+++ b/code/packages/fsharp/compiler-source-map/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/compiler-source-map/BUILD_windows
+++ b/code/packages/fsharp/compiler-source-map/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/compiler-source-map/CHANGELOG.md
+++ b/code/packages/fsharp/compiler-source-map/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add compiler source-map chain data structures and composite lookup helpers.

--- a/code/packages/fsharp/compiler-source-map/CodingAdventures.CompilerSourceMap.fsproj
+++ b/code/packages/fsharp/compiler-source-map/CodingAdventures.CompilerSourceMap.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CompilerSourceMap.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Compiler source-map chain sidecar for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CompilerSourceMap.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/compiler-source-map/CompilerSourceMap.fs
+++ b/code/packages/fsharp/compiler-source-map/CompilerSourceMap.fs
@@ -1,0 +1,229 @@
+namespace CodingAdventures.CompilerSourceMap.FSharp
+
+open System
+open System.Collections.Generic
+
+type SourcePosition =
+    { File: string
+      Line: int
+      Column: int
+      Length: int }
+
+    override this.ToString() =
+        $"{this.File}:{this.Line}:{this.Column} (len={this.Length})"
+
+type SourceToAstEntry =
+    { Position: SourcePosition
+      AstNodeId: int }
+
+type SourceToAst() =
+    let entries = ResizeArray<SourceToAstEntry>()
+
+    member _.Entries = entries |> Seq.toList
+
+    member _.Add(position: SourcePosition, astNodeId: int) =
+        entries.Add({ Position = position; AstNodeId = astNodeId })
+
+    member _.LookupByNodeId(astNodeId: int) =
+        entries
+        |> Seq.tryFind (fun entry -> entry.AstNodeId = astNodeId)
+        |> Option.map _.Position
+
+type AstToIrEntry =
+    { AstNodeId: int
+      IrIds: int64 list }
+
+type AstToIr() =
+    let entries = ResizeArray<AstToIrEntry>()
+
+    member _.Entries = entries |> Seq.toList
+
+    member _.Add(astNodeId: int, irIds: seq<int64>) =
+        if isNull (box irIds) then
+            nullArg "irIds"
+
+        entries.Add({ AstNodeId = astNodeId; IrIds = irIds |> Seq.toList })
+
+    member _.LookupByAstNodeId(astNodeId: int) =
+        entries
+        |> Seq.tryFind (fun entry -> entry.AstNodeId = astNodeId)
+        |> Option.map _.IrIds
+
+    member _.LookupByIrId(irId: int64) =
+        match entries |> Seq.tryFind (fun entry -> entry.IrIds |> List.contains irId) with
+        | Some entry -> entry.AstNodeId
+        | None -> -1
+
+type IrToIrEntry =
+    { OriginalId: int64
+      NewIds: int64 list }
+
+type IrToIr(?passName: string) =
+    let entries = ResizeArray<IrToIrEntry>()
+    let deleted = HashSet<int64>()
+    let passName = defaultArg passName ""
+
+    member _.Entries = entries |> Seq.toList
+    member _.Deleted = deleted
+    member _.PassName = passName
+
+    member _.AddMapping(originalId: int64, newIds: seq<int64>) =
+        if isNull (box newIds) then
+            nullArg "newIds"
+
+        entries.Add({ OriginalId = originalId; NewIds = newIds |> Seq.toList })
+
+    member _.AddDeletion(originalId: int64) =
+        deleted.Add originalId |> ignore
+        entries.Add({ OriginalId = originalId; NewIds = [] })
+
+    member _.LookupByOriginalId(originalId: int64) =
+        if deleted.Contains originalId then
+            None
+        else
+            entries
+            |> Seq.tryFind (fun entry -> entry.OriginalId = originalId)
+            |> Option.map _.NewIds
+
+    member _.LookupByNewId(newId: int64) =
+        match entries |> Seq.tryFind (fun entry -> entry.NewIds |> List.contains newId) with
+        | Some entry -> entry.OriginalId
+        | None -> -1L
+
+type IrToMachineCodeEntry =
+    { IrId: int64
+      MachineCodeOffset: int64
+      MachineCodeLength: int64 }
+
+type IrToMachineCode() =
+    let entries = ResizeArray<IrToMachineCodeEntry>()
+
+    member _.Entries = entries |> Seq.toList
+
+    member _.Add(irId: int64, machineCodeOffset: int64, machineCodeLength: int64) =
+        entries.Add(
+            { IrId = irId
+              MachineCodeOffset = machineCodeOffset
+              MachineCodeLength = machineCodeLength }
+        )
+
+    member _.LookupByIrId(irId: int64) =
+        match entries |> Seq.tryFind (fun entry -> entry.IrId = irId) with
+        | Some entry -> entry.MachineCodeOffset, entry.MachineCodeLength
+        | None -> -1L, 0L
+
+    member _.LookupByMachineCodeOffset(offset: int64) =
+        match
+            entries
+            |> Seq.tryFind (fun entry ->
+                entry.MachineCodeOffset <= offset
+                && offset < entry.MachineCodeOffset + entry.MachineCodeLength)
+        with
+        | Some entry -> entry.IrId
+        | None -> -1L
+
+type SourceMapChain() =
+    let sourceToAst = SourceToAst()
+    let astToIr = AstToIr()
+    let irToIr = ResizeArray<IrToIr>()
+    let mutable irToMachineCode: IrToMachineCode option = None
+
+    member _.SourceToAst = sourceToAst
+    member _.AstToIr = astToIr
+    member _.IrToIr = irToIr |> Seq.toList
+
+    member _.IrToMachineCode
+        with get () = irToMachineCode
+        and set value = irToMachineCode <- value
+
+    static member New() = SourceMapChain()
+
+    member _.AddOptimizerPass(segment: IrToIr) =
+        if isNull (box segment) then
+            nullArg "segment"
+
+        irToIr.Add segment
+
+    member _.SourceToMc(position: SourcePosition) =
+        match irToMachineCode with
+        | None -> None
+        | Some machineCode ->
+            let astNodeId =
+                sourceToAst.Entries
+                |> List.tryFind (fun entry ->
+                    entry.Position.File = position.File
+                    && entry.Position.Line = position.Line
+                    && entry.Position.Column = position.Column)
+                |> Option.map _.AstNodeId
+
+            match astNodeId with
+            | None -> None
+            | Some nodeId ->
+                match astToIr.LookupByAstNodeId nodeId with
+                | None -> None
+                | Some irIds ->
+                    let mutable currentIds = irIds
+
+                    for passSegment in irToIr do
+                        currentIds <-
+                            currentIds
+                            |> List.collect (fun irId ->
+                                if passSegment.Deleted.Contains irId then
+                                    []
+                                else
+                                    match passSegment.LookupByOriginalId irId with
+                                    | Some newIds -> newIds
+                                    | None -> [])
+
+                    if List.isEmpty currentIds then
+                        None
+                    else
+                        let results =
+                            currentIds
+                            |> List.choose (fun irId ->
+                                let offset, length = machineCode.LookupByIrId irId
+
+                                if offset >= 0L then
+                                    Some
+                                        { IrId = irId
+                                          MachineCodeOffset = offset
+                                          MachineCodeLength = length }
+                                else
+                                    None)
+
+                        if List.isEmpty results then None else Some results
+
+    member _.McToSource(machineCodeOffset: int64) =
+        match irToMachineCode with
+        | None -> None
+        | Some machineCode ->
+            let mutable currentId = machineCode.LookupByMachineCodeOffset machineCodeOffset
+
+            if currentId = -1L then
+                None
+            else
+                let mutable traced = true
+
+                for passSegment in irToIr |> Seq.rev do
+                    if traced then
+                        let originalId = passSegment.LookupByNewId currentId
+
+                        if originalId = -1L then
+                            traced <- false
+                        else
+                            currentId <- originalId
+
+                if not traced then
+                    None
+                else
+                    let astNodeId = astToIr.LookupByIrId currentId
+
+                    if astNodeId = -1 then
+                        None
+                    else
+                        sourceToAst.LookupByNodeId astNodeId
+
+[<RequireQualifiedAccess>]
+module CompilerSourceMapPackage =
+    [<Literal>]
+    let Version = "0.1.0"

--- a/code/packages/fsharp/compiler-source-map/README.md
+++ b/code/packages/fsharp/compiler-source-map/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.CompilerSourceMap.FSharp
+
+Compiler source-map chain sidecar for .NET.
+
+The package models source positions, source-to-AST mappings, AST-to-IR mappings, optimizer IR-to-IR mappings, and IR-to-machine-code mappings. `SourceMapChain` composes those segments for forward source-to-machine-code lookups and reverse machine-code-to-source lookups.

--- a/code/packages/fsharp/compiler-source-map/required_capabilities.json
+++ b/code/packages/fsharp/compiler-source-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/compiler-source-map",
+  "capabilities": [],
+  "justification": "Pure in-memory compiler source-map data structures and lookup helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.fsproj
+++ b/code/packages/fsharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CompilerSourceMap.fsproj" />
+    <Compile Include="CompilerSourceMapTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CompilerSourceMapTests.fs
+++ b/code/packages/fsharp/compiler-source-map/tests/CodingAdventures.CompilerSourceMap.Tests/CompilerSourceMapTests.fs
@@ -1,0 +1,193 @@
+namespace CodingAdventures.CompilerSourceMap.Tests
+
+open Xunit
+open CodingAdventures.CompilerSourceMap.FSharp
+
+module CompilerSourceMapTests =
+    let private buildTestChain () =
+        let chain = SourceMapChain.New()
+        chain.SourceToAst.Add({ File = "hello.bf"; Line = 1; Column = 1; Length = 1 }, 0)
+        chain.SourceToAst.Add({ File = "hello.bf"; Line = 1; Column = 2; Length = 1 }, 1)
+        chain.AstToIr.Add(0, [ 2L; 3L; 4L; 5L ])
+        chain.AstToIr.Add(1, [ 6L; 7L ])
+
+        let identity = IrToIr("identity")
+
+        for i in 0L .. 7L do
+            identity.AddMapping(i, [ i ])
+
+        chain.AddOptimizerPass identity
+
+        let machineCode = IrToMachineCode()
+        machineCode.Add(0L, 0x00L, 8L)
+        machineCode.Add(1L, 0x08L, 4L)
+        machineCode.Add(2L, 0x0CL, 8L)
+        machineCode.Add(3L, 0x14L, 4L)
+        machineCode.Add(4L, 0x18L, 4L)
+        machineCode.Add(5L, 0x1CL, 8L)
+        machineCode.Add(6L, 0x24L, 8L)
+        machineCode.Add(7L, 0x2CL, 8L)
+        chain.IrToMachineCode <- Some machineCode
+        chain
+
+    [<Fact>]
+    let ``source position formats and compares`` () =
+        let position = { File = "hello.bf"; Line = 1; Column = 3; Length = 1 }
+
+        Assert.Equal("hello.bf:1:3 (len=1)", position.ToString())
+        Assert.Equal(position, { File = "hello.bf"; Line = 1; Column = 3; Length = 1 })
+        Assert.NotEqual(position, { File = "hello.bf"; Line = 1; Column = 4; Length = 1 })
+
+    [<Fact>]
+    let ``source to ast adds and looks up node ids`` () =
+        let segment = SourceToAst()
+        let position = { File = "a.bf"; Line = 1; Column = 1; Length = 1 }
+
+        segment.Add(position, 42)
+
+        Assert.Equal(Some position, segment.LookupByNodeId 42)
+        Assert.Equal(None, segment.LookupByNodeId 999)
+
+    [<Fact>]
+    let ``ast to ir supports forward and reverse lookup`` () =
+        let segment = AstToIr()
+
+        segment.Add(5, [ 20L; 21L ])
+        segment.Add(6, [ 22L ])
+
+        Assert.Equal(Some [ 20L; 21L ], segment.LookupByAstNodeId 5)
+        Assert.Equal(5, segment.LookupByIrId 21L)
+        Assert.Equal(6, segment.LookupByIrId 22L)
+        Assert.Equal(-1, segment.LookupByIrId 999L)
+
+    [<Fact>]
+    let ``ir to ir handles mappings deletion and reverse lookup`` () =
+        let segment = IrToIr("contraction")
+
+        segment.AddMapping(7L, [ 100L ])
+        segment.AddMapping(8L, [ 100L ])
+        segment.AddDeletion 9L
+
+        Assert.Equal(Some [ 100L ], segment.LookupByOriginalId 7L)
+        Assert.Equal(7L, segment.LookupByNewId 100L)
+        Assert.Equal(None, segment.LookupByOriginalId 9L)
+        Assert.Contains(9L, segment.Deleted)
+        Assert.Equal("contraction", segment.PassName)
+
+    [<Fact>]
+    let ``ir to machine code finds instruction ranges`` () =
+        let segment = IrToMachineCode()
+
+        segment.Add(5L, 0x20L, 4L)
+        segment.Add(6L, 0x24L, 8L)
+
+        Assert.Equal((0x20L, 4L), segment.LookupByIrId 5L)
+        Assert.Equal((-1L, 0L), segment.LookupByIrId 999L)
+        Assert.Equal(5L, segment.LookupByMachineCodeOffset 0x23L)
+        Assert.Equal(6L, segment.LookupByMachineCodeOffset 0x24L)
+        Assert.Equal(-1L, segment.LookupByMachineCodeOffset 0xFFL)
+
+    [<Fact>]
+    let ``new chain starts empty`` () =
+        let chain = SourceMapChain.New()
+
+        Assert.Empty(chain.SourceToAst.Entries)
+        Assert.Empty(chain.AstToIr.Entries)
+        Assert.Empty(chain.IrToIr)
+        Assert.Equal(None, chain.IrToMachineCode)
+
+    [<Fact>]
+    let ``forward lookup composes all segments`` () =
+        let chain = buildTestChain ()
+
+        let results = chain.SourceToMc({ File = "hello.bf"; Line = 1; Column = 1; Length = 1 })
+
+        match results with
+        | None -> failwith "expected machine-code entries"
+        | Some entries ->
+            Assert.Equal<int64 list>([ 2L; 3L; 4L; 5L ], entries |> List.map _.IrId)
+            Assert.Equal(0x0CL, entries.Head.MachineCodeOffset)
+
+    [<Fact>]
+    let ``reverse lookup composes segments back to source`` () =
+        let chain = buildTestChain ()
+
+        let plus = chain.McToSource 0x14L
+        let dot = chain.McToSource 0x2CL
+
+        Assert.Equal(Some { File = "hello.bf"; Line = 1; Column = 1; Length = 1 }, plus)
+        Assert.Equal(Some { File = "hello.bf"; Line = 1; Column = 2; Length = 1 }, dot)
+
+    [<Fact>]
+    let ``incomplete or missing mappings return none`` () =
+        let chain = SourceMapChain.New()
+        chain.SourceToAst.Add({ File = "a.bf"; Line = 1; Column = 1; Length = 1 }, 0)
+        chain.AstToIr.Add(0, [ 1L; 2L ])
+
+        Assert.Equal(None, chain.SourceToMc({ File = "a.bf"; Line = 1; Column = 1; Length = 1 }))
+        Assert.Equal(None, chain.McToSource 0L)
+
+        chain.IrToMachineCode <- Some(IrToMachineCode())
+        Assert.Equal(None, chain.SourceToMc({ File = "a.bf"; Line = 9; Column = 1; Length = 1 }))
+
+    [<Fact>]
+    let ``optimizer contraction feeds forward lookup`` () =
+        let chain = SourceMapChain.New()
+        let position = { File = "t.bf"; Line = 1; Column = 1; Length = 1 }
+        chain.SourceToAst.Add(position, 0)
+        chain.AstToIr.Add(0, [ 1L; 2L; 3L ])
+
+        let pass = IrToIr("contraction")
+        pass.AddMapping(1L, [ 100L ])
+        pass.AddMapping(2L, [ 100L ])
+        pass.AddMapping(3L, [ 100L ])
+        chain.AddOptimizerPass pass
+
+        let machineCode = IrToMachineCode()
+        machineCode.Add(100L, 0L, 4L)
+        chain.IrToMachineCode <- Some machineCode
+
+        match chain.SourceToMc position with
+        | None -> failwith "expected machine-code entries"
+        | Some results ->
+            Assert.Equal(3, results.Length)
+            Assert.All(results, fun entry -> Assert.Equal(100L, entry.IrId))
+
+    [<Fact>]
+    let ``optimizer deletion drops forward results`` () =
+        let chain = SourceMapChain.New()
+        let position = { File = "t.bf"; Line = 1; Column = 1; Length = 1 }
+        chain.SourceToAst.Add(position, 0)
+        chain.AstToIr.Add(0, [ 1L; 2L ])
+
+        let pass = IrToIr("dead-store")
+        pass.AddMapping(1L, [ 1L ])
+        pass.AddDeletion 2L
+        chain.AddOptimizerPass pass
+
+        let machineCode = IrToMachineCode()
+        machineCode.Add(1L, 0L, 4L)
+        machineCode.Add(2L, 4L, 4L)
+        chain.IrToMachineCode <- Some machineCode
+
+        match chain.SourceToMc position with
+        | None -> failwith "expected one machine-code entry"
+        | Some results ->
+            Assert.Single(results) |> ignore
+            Assert.Equal(1L, results.Head.IrId)
+
+    [<Fact>]
+    let ``reverse lookup fails when optimizer trace is missing`` () =
+        let chain = SourceMapChain.New()
+        chain.SourceToAst.Add({ File = "t.bf"; Line = 1; Column = 1; Length = 1 }, 0)
+        chain.AstToIr.Add(0, [ 1L ])
+
+        let pass = IrToIr("renumber")
+        pass.AddMapping(1L, [ 100L ])
+        chain.AddOptimizerPass pass
+
+        let machineCode = IrToMachineCode()
+        machineCode.Add(200L, 0L, 4L)
+        chain.IrToMachineCode <- Some machineCode
+
+        Assert.Equal(None, chain.McToSource 0L)


### PR DESCRIPTION
## Summary
- add C# compiler-source-map package with source/AST/IR/machine-code segments
- add F# compiler-source-map package with the same forward and reverse chain composition
- include package metadata, capability declarations, and coverage-gated xUnit tests

## Tests
- dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (12 passed, 95.03% line)
- dotnet test tests/CodingAdventures.CompilerSourceMap.Tests/CodingAdventures.CompilerSourceMap.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (12 passed, 92.68% line)