### PR TITLE
feat(parity): add dotnet arithmetic packages

### DIFF
--- a/code/packages/csharp/arithmetic/Arithmetic.cs
+++ b/code/packages/csharp/arithmetic/Arithmetic.cs
@@ -1,0 +1,221 @@
+using Gates = CodingAdventures.LogicGates.LogicGates;
+
+namespace CodingAdventures.Arithmetic;
+
+/// <summary>
+/// Result of a ripple-carry addition.
+/// </summary>
+public sealed record RippleCarryResult(IReadOnlyList<int> Sum, int CarryOut, bool Overflow);
+
+/// <summary>
+/// Adder circuits built from logic gates.
+/// </summary>
+public static class Adders
+{
+    /// <summary>Add two bits and return sum and carry.</summary>
+    public static (int Sum, int Carry) HalfAdder(int a, int b) =>
+        (Gates.Xor(a, b), Gates.And(a, b));
+
+    /// <summary>Add two bits plus carry-in and return sum and carry-out.</summary>
+    public static (int Sum, int CarryOut) FullAdder(int a, int b, int carryIn)
+    {
+        var (partialSum, partialCarry) = HalfAdder(a, b);
+        var (sum, carry2) = HalfAdder(partialSum, carryIn);
+        return (sum, Gates.Or(partialCarry, carry2));
+    }
+
+    /// <summary>Add two same-width bit vectors with an optional carry-in.</summary>
+    public static RippleCarryResult RippleCarryAdder(
+        IReadOnlyList<int> a,
+        IReadOnlyList<int> b,
+        int carryIn = 0)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+        if (a.Count != b.Count)
+        {
+            throw new ArgumentException($"a and b must have the same length, got {a.Count} and {b.Count}.");
+        }
+
+        if (a.Count == 0)
+        {
+            throw new ArgumentException("bit lists must not be empty.");
+        }
+
+        var sum = new List<int>(a.Count);
+        var carry = carryIn;
+        for (var i = 0; i < a.Count; i++)
+        {
+            var (sumBit, carryOut) = FullAdder(a[i], b[i], carry);
+            sum.Add(sumBit);
+            carry = carryOut;
+        }
+
+        var aSign = a[^1];
+        var bSign = b[^1];
+        var resultSign = sum[^1];
+        var overflow = aSign == bSign && resultSign != aSign;
+
+        return new RippleCarryResult(sum.AsReadOnly(), carry, overflow);
+    }
+}
+
+/// <summary>
+/// ALU operation codes.
+/// </summary>
+public enum AluOp
+{
+    /// <summary>Add A and B.</summary>
+    Add,
+    /// <summary>Subtract B from A.</summary>
+    Sub,
+    /// <summary>Bitwise AND.</summary>
+    And,
+    /// <summary>Bitwise OR.</summary>
+    Or,
+    /// <summary>Bitwise XOR.</summary>
+    Xor,
+    /// <summary>Bitwise NOT of A.</summary>
+    Not,
+}
+
+/// <summary>
+/// Result of an ALU operation and its status flags.
+/// </summary>
+public sealed record AluResult(
+    IReadOnlyList<int> Value,
+    bool Zero,
+    bool Carry,
+    bool Negative,
+    bool Overflow)
+{
+    /// <summary>Alias for consumers following the Rust package name.</summary>
+    public IReadOnlyList<int> Result => Value;
+}
+
+/// <summary>
+/// N-bit arithmetic logic unit.
+/// </summary>
+public sealed class Alu
+{
+    /// <summary>Create an ALU with the requested bit width.</summary>
+    public Alu(int bitWidth = 8)
+    {
+        if (bitWidth < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitWidth), "bit_width must be at least 1.");
+        }
+
+        BitWidth = bitWidth;
+    }
+
+    /// <summary>The number of bits expected in operands.</summary>
+    public int BitWidth { get; }
+
+    /// <summary>Execute an operation over LSB-first bit vectors.</summary>
+    public AluResult Execute(AluOp op, IReadOnlyList<int> a, IReadOnlyList<int> b)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+        if (a.Count != BitWidth)
+        {
+            throw new ArgumentException($"a must have {BitWidth} bits, got {a.Count}.", nameof(a));
+        }
+
+        if (op != AluOp.Not && b.Count != BitWidth)
+        {
+            throw new ArgumentException($"b must have {BitWidth} bits, got {b.Count}.", nameof(b));
+        }
+
+        bool carry;
+        IReadOnlyList<int> value;
+        switch (op)
+        {
+            case AluOp.Add:
+            {
+                var result = Adders.RippleCarryAdder(a, b);
+                value = result.Sum;
+                carry = result.CarryOut == 1;
+                break;
+            }
+
+            case AluOp.Sub:
+            {
+                var notB = b.Select(Gates.Not).ToArray();
+                var result = Adders.RippleCarryAdder(a, notB, carryIn: 1);
+                value = result.Sum;
+                carry = result.CarryOut == 1;
+                break;
+            }
+
+            case AluOp.And:
+                value = Bitwise(a, b, Gates.And);
+                carry = false;
+                break;
+
+            case AluOp.Or:
+                value = Bitwise(a, b, Gates.Or);
+                carry = false;
+                break;
+
+            case AluOp.Xor:
+                value = Bitwise(a, b, Gates.Xor);
+                carry = false;
+                break;
+
+            case AluOp.Not:
+                value = a.Select(Gates.Not).ToArray();
+                carry = false;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(op), op, "Unknown ALU operation.");
+        }
+
+        var zero = value.All(bit => bit == 0);
+        var negative = value.Count > 0 && value[^1] == 1;
+        var overflow = SignedOverflow(op, a, b, value);
+
+        return new AluResult(value, zero, carry, negative, overflow);
+    }
+
+    private static IReadOnlyList<int> Bitwise(
+        IReadOnlyList<int> a,
+        IReadOnlyList<int> b,
+        Func<int, int, int> gate)
+    {
+        var result = new int[a.Count];
+        for (var i = 0; i < a.Count; i++)
+        {
+            result[i] = gate(a[i], b[i]);
+        }
+
+        return result;
+    }
+
+    private static bool SignedOverflow(
+        AluOp op,
+        IReadOnlyList<int> a,
+        IReadOnlyList<int> b,
+        IReadOnlyList<int> result)
+    {
+        if (op is not (AluOp.Add or AluOp.Sub))
+        {
+            return false;
+        }
+
+        var aSign = a[^1];
+        var bSign = op == AluOp.Add ? b[^1] : Gates.Not(b[^1]);
+        var resultSign = result[^1];
+        return aSign == bSign && resultSign != aSign;
+    }
+}
+
+/// <summary>
+/// Package metadata.
+/// </summary>
+public static class ArithmeticPackage
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/arithmetic/BUILD
+++ b/code/packages/csharp/arithmetic/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/arithmetic/BUILD_windows
+++ b/code/packages/csharp/arithmetic/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/arithmetic/CHANGELOG.md
+++ b/code/packages/csharp/arithmetic/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add half adder, full adder, ripple-carry adder, and ALU helpers.

--- a/code/packages/csharp/arithmetic/CodingAdventures.Arithmetic.csproj
+++ b/code/packages/csharp/arithmetic/CodingAdventures.Arithmetic.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Arithmetic.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Adder circuits and ALU helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\logic-gates\CodingAdventures.LogicGates.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/arithmetic/README.md
+++ b/code/packages/csharp/arithmetic/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Arithmetic.CSharp
+
+Adder circuits and ALU helpers for .NET.
+
+The package builds half adders, full adders, ripple-carry adders, and an N-bit ALU on top of the existing logic-gates package. Bits are represented as LSB-first integer lists.

--- a/code/packages/csharp/arithmetic/required_capabilities.json
+++ b/code/packages/csharp/arithmetic/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/arithmetic",
+  "capabilities": [],
+  "justification": "Pure in-memory arithmetic circuits built on the logic-gates package. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/ArithmeticTests.cs
+++ b/code/packages/csharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/ArithmeticTests.cs
@@ -1,0 +1,115 @@
+namespace CodingAdventures.Arithmetic.Tests;
+
+public sealed class ArithmeticTests
+{
+    private static int[] IntToBits(int value, int width) =>
+        Enumerable.Range(0, width).Select(i => (value >> i) & 1).ToArray();
+
+    private static int BitsToInt(IReadOnlyList<int> bits) =>
+        bits.Select((bit, i) => bit << i).Sum();
+
+    [Theory]
+    [InlineData(0, 0, 0, 0)]
+    [InlineData(0, 1, 1, 0)]
+    [InlineData(1, 0, 1, 0)]
+    [InlineData(1, 1, 0, 1)]
+    public void HalfAdderMatchesTruthTable(int a, int b, int expectedSum, int expectedCarry)
+    {
+        Assert.Equal((expectedSum, expectedCarry), Adders.HalfAdder(a, b));
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 0, 0)]
+    [InlineData(0, 0, 1, 1, 0)]
+    [InlineData(0, 1, 1, 0, 1)]
+    [InlineData(1, 0, 1, 0, 1)]
+    [InlineData(1, 1, 0, 0, 1)]
+    [InlineData(1, 1, 1, 1, 1)]
+    public void FullAdderMatchesTruthTable(int a, int b, int carryIn, int expectedSum, int expectedCarry)
+    {
+        Assert.Equal((expectedSum, expectedCarry), Adders.FullAdder(a, b, carryIn));
+    }
+
+    [Fact]
+    public void RippleCarryAdderAddsAndCarries()
+    {
+        var result = Adders.RippleCarryAdder(IntToBits(15, 4), IntToBits(1, 4));
+
+        Assert.Equal(0, BitsToInt(result.Sum));
+        Assert.Equal(1, result.CarryOut);
+    }
+
+    [Fact]
+    public void RippleCarryAdderSupportsCarryIn()
+    {
+        var result = Adders.RippleCarryAdder(IntToBits(1, 4), IntToBits(1, 4), carryIn: 1);
+
+        Assert.Equal(3, BitsToInt(result.Sum));
+        Assert.Equal(0, result.CarryOut);
+    }
+
+    [Fact]
+    public void RippleCarryAdderValidatesInputs()
+    {
+        Assert.Throws<ArgumentException>(() => Adders.RippleCarryAdder([0, 1], [0, 1, 0]));
+        Assert.Throws<ArgumentException>(() => Adders.RippleCarryAdder([], []));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Adders.RippleCarryAdder([2], [0]));
+    }
+
+    [Fact]
+    public void AluAddsSubtractsAndSetsFlags()
+    {
+        var alu = new Alu(8);
+
+        var add = alu.Execute(AluOp.Add, IntToBits(255, 8), IntToBits(1, 8));
+        var sub = alu.Execute(AluOp.Sub, IntToBits(5, 8), IntToBits(3, 8));
+
+        Assert.Equal(0, BitsToInt(add.Value));
+        Assert.True(add.Carry);
+        Assert.True(add.Zero);
+        Assert.Equal(2, BitsToInt(sub.Value));
+        Assert.False(sub.Zero);
+    }
+
+    [Theory]
+    [InlineData(AluOp.And, 0xCC, 0xAA, 0x88)]
+    [InlineData(AluOp.Or, 0xCC, 0xAA, 0xEE)]
+    [InlineData(AluOp.Xor, 0xCC, 0xAA, 0x66)]
+    public void AluBitwiseOperations(AluOp op, int a, int b, int expected)
+    {
+        var result = new Alu(8).Execute(op, IntToBits(a, 8), IntToBits(b, 8));
+
+        Assert.Equal(expected, BitsToInt(result.Value));
+        Assert.False(result.Carry);
+        Assert.False(result.Overflow);
+    }
+
+    [Fact]
+    public void AluNotIgnoresB()
+    {
+        var result = new Alu(8).Execute(AluOp.Not, IntToBits(0, 8), []);
+
+        Assert.Equal(255, BitsToInt(result.Value));
+        Assert.True(result.Negative);
+    }
+
+    [Fact]
+    public void AluDetectsSignedOverflow()
+    {
+        var result = new Alu(8).Execute(AluOp.Add, IntToBits(127, 8), IntToBits(1, 8));
+
+        Assert.True(result.Overflow);
+        Assert.True(result.Negative);
+        Assert.Same(result.Value, result.Result);
+    }
+
+    [Fact]
+    public void AluValidatesWidth()
+    {
+        var alu = new Alu(8);
+
+        Assert.Throws<ArgumentException>(() => alu.Execute(AluOp.Add, [0, 1], [0, 1]));
+        Assert.Throws<ArgumentException>(() => alu.Execute(AluOp.And, IntToBits(1, 8), [1]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Alu(0));
+    }
+}

--- a/code/packages/csharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.csproj
+++ b/code/packages/csharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.LogicGates]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Arithmetic.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/arithmetic/Arithmetic.fs
+++ b/code/packages/fsharp/arithmetic/Arithmetic.fs
@@ -1,0 +1,135 @@
+namespace CodingAdventures.Arithmetic.FSharp
+
+open System
+open CodingAdventures.LogicGates
+
+type RippleCarryResult =
+    { Sum: int list
+      CarryOut: int
+      Overflow: bool }
+
+[<RequireQualifiedAccess>]
+module Adders =
+    let halfAdder a b =
+        LogicGates.xorGate a b, LogicGates.andGate a b
+
+    let fullAdder a b carryIn =
+        let partialSum, partialCarry = halfAdder a b
+        let sum, carry2 = halfAdder partialSum carryIn
+        sum, LogicGates.orGate partialCarry carry2
+
+    let rippleCarryAdder (a: int list) (b: int list) (carryIn: int) =
+        if isNull (box a) then
+            nullArg "a"
+
+        if isNull (box b) then
+            nullArg "b"
+
+        if a.Length <> b.Length then
+            invalidArg "b" $"a and b must have the same length, got {a.Length} and {b.Length}."
+
+        if List.isEmpty a then
+            invalidArg "a" "bit lists must not be empty."
+
+        let mutable carry = carryIn
+        let sum = ResizeArray<int>()
+
+        List.zip a b
+        |> List.iter (fun (ai, bi) ->
+            let sumBit, carryOut = fullAdder ai bi carry
+            sum.Add sumBit
+            carry <- carryOut)
+
+        let aSign = List.last a
+        let bSign = List.last b
+        let resultSign = sum[sum.Count - 1]
+        let overflow = aSign = bSign && resultSign <> aSign
+
+        { Sum = sum |> Seq.toList
+          CarryOut = carry
+          Overflow = overflow }
+
+type AluOp =
+    | Add
+    | Sub
+    | And
+    | Or
+    | Xor
+    | Not
+
+type AluResult =
+    { Value: int list
+      Zero: bool
+      Carry: bool
+      Negative: bool
+      Overflow: bool }
+
+    member this.Result = this.Value
+
+type Alu(?bitWidth: int) =
+    let bitWidth = defaultArg bitWidth 8
+
+    do
+        if bitWidth < 1 then
+            invalidArg "bitWidth" "bit_width must be at least 1."
+
+    member _.BitWidth = bitWidth
+
+    member _.Execute(op: AluOp, a: int list, b: int list) =
+        if isNull (box a) then
+            nullArg "a"
+
+        if isNull (box b) then
+            nullArg "b"
+
+        if a.Length <> bitWidth then
+            invalidArg "a" $"a must have {bitWidth} bits, got {a.Length}."
+
+        if op <> AluOp.Not && b.Length <> bitWidth then
+            invalidArg "b" $"b must have {bitWidth} bits, got {b.Length}."
+
+        let value, carry =
+            match op with
+            | AluOp.Add ->
+                let result = Adders.rippleCarryAdder a b 0
+                result.Sum, result.CarryOut = 1
+            | AluOp.Sub ->
+                let notB = b |> List.map LogicGates.notGate
+                let result = Adders.rippleCarryAdder a notB 1
+                result.Sum, result.CarryOut = 1
+            | AluOp.And ->
+                List.map2 LogicGates.andGate a b, false
+            | AluOp.Or ->
+                List.map2 LogicGates.orGate a b, false
+            | AluOp.Xor ->
+                List.map2 LogicGates.xorGate a b, false
+            | AluOp.Not ->
+                a |> List.map LogicGates.notGate, false
+
+        let zero = value |> List.forall ((=) 0)
+        let negative = value |> List.last = 1
+
+        let overflow =
+            match op with
+            | AluOp.Add ->
+                let aSign = List.last a
+                let bSign = List.last b
+                let resultSign = List.last value
+                aSign = bSign && resultSign <> aSign
+            | AluOp.Sub ->
+                let aSign = List.last a
+                let bSign = b |> List.last |> LogicGates.notGate
+                let resultSign = List.last value
+                aSign = bSign && resultSign <> aSign
+            | _ -> false
+
+        { Value = value
+          Zero = zero
+          Carry = carry
+          Negative = negative
+          Overflow = overflow }
+
+[<RequireQualifiedAccess>]
+module ArithmeticPackage =
+    [<Literal>]
+    let Version = "0.1.0"

--- a/code/packages/fsharp/arithmetic/BUILD
+++ b/code/packages/fsharp/arithmetic/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/arithmetic/BUILD_windows
+++ b/code/packages/fsharp/arithmetic/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/arithmetic/CHANGELOG.md
+++ b/code/packages/fsharp/arithmetic/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add half adder, full adder, ripple-carry adder, and ALU helpers.

--- a/code/packages/fsharp/arithmetic/CodingAdventures.Arithmetic.fsproj
+++ b/code/packages/fsharp/arithmetic/CodingAdventures.Arithmetic.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Arithmetic.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Adder circuits and ALU helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\logic-gates\CodingAdventures.LogicGates.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Arithmetic.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/arithmetic/README.md
+++ b/code/packages/fsharp/arithmetic/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.Arithmetic.FSharp
+
+Adder circuits and ALU helpers for .NET.
+
+The package builds half adders, full adders, ripple-carry adders, and an N-bit ALU on top of the existing logic-gates package. Bits are represented as LSB-first integer lists.

--- a/code/packages/fsharp/arithmetic/required_capabilities.json
+++ b/code/packages/fsharp/arithmetic/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/arithmetic",
+  "capabilities": [],
+  "justification": "Pure in-memory arithmetic circuits built on the logic-gates package. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/ArithmeticTests.fs
+++ b/code/packages/fsharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/ArithmeticTests.fs
@@ -1,0 +1,99 @@
+namespace CodingAdventures.Arithmetic.Tests
+
+open Xunit
+open CodingAdventures.Arithmetic.FSharp
+
+module ArithmeticTests =
+    let private intToBits value width =
+        [ for i in 0 .. width - 1 -> (value >>> i) &&& 1 ]
+
+    let private bitsToInt bits =
+        bits |> List.mapi (fun i bit -> bit <<< i) |> List.sum
+
+    [<Theory>]
+    [<InlineData(0, 0, 0, 0)>]
+    [<InlineData(0, 1, 1, 0)>]
+    [<InlineData(1, 0, 1, 0)>]
+    [<InlineData(1, 1, 0, 1)>]
+    let ``half adder matches truth table`` a b expectedSum expectedCarry =
+        Assert.Equal((expectedSum, expectedCarry), Adders.halfAdder a b)
+
+    [<Theory>]
+    [<InlineData(0, 0, 0, 0, 0)>]
+    [<InlineData(0, 0, 1, 1, 0)>]
+    [<InlineData(0, 1, 1, 0, 1)>]
+    [<InlineData(1, 0, 1, 0, 1)>]
+    [<InlineData(1, 1, 0, 0, 1)>]
+    [<InlineData(1, 1, 1, 1, 1)>]
+    let ``full adder matches truth table`` a b carryIn expectedSum expectedCarry =
+        Assert.Equal((expectedSum, expectedCarry), Adders.fullAdder a b carryIn)
+
+    [<Fact>]
+    let ``ripple carry adder adds and carries`` () =
+        let result = Adders.rippleCarryAdder (intToBits 15 4) (intToBits 1 4) 0
+
+        Assert.Equal(0, bitsToInt result.Sum)
+        Assert.Equal(1, result.CarryOut)
+
+    [<Fact>]
+    let ``ripple carry adder supports carry in`` () =
+        let result = Adders.rippleCarryAdder (intToBits 1 4) (intToBits 1 4) 1
+
+        Assert.Equal(3, bitsToInt result.Sum)
+        Assert.Equal(0, result.CarryOut)
+
+    [<Fact>]
+    let ``ripple carry adder validates inputs`` () =
+        Assert.Throws<System.ArgumentException>(fun () -> Adders.rippleCarryAdder [ 0; 1 ] [ 0; 1; 0 ] 0 |> ignore) |> ignore
+        Assert.Throws<System.ArgumentException>(fun () -> Adders.rippleCarryAdder [] [] 0 |> ignore) |> ignore
+        Assert.Throws<System.ArgumentOutOfRangeException>(fun () -> Adders.rippleCarryAdder [ 2 ] [ 0 ] 0 |> ignore) |> ignore
+
+    [<Fact>]
+    let ``alu adds subtracts and sets flags`` () =
+        let alu = Alu 8
+
+        let add = alu.Execute(AluOp.Add, intToBits 255 8, intToBits 1 8)
+        let sub = alu.Execute(AluOp.Sub, intToBits 5 8, intToBits 3 8)
+
+        Assert.Equal(0, bitsToInt add.Value)
+        Assert.True add.Carry
+        Assert.True add.Zero
+        Assert.Equal(2, bitsToInt sub.Value)
+        Assert.False sub.Zero
+
+    [<Fact>]
+    let ``alu bitwise operations`` () =
+        let cases =
+            [ AluOp.And, 0xCC, 0xAA, 0x88
+              AluOp.Or, 0xCC, 0xAA, 0xEE
+              AluOp.Xor, 0xCC, 0xAA, 0x66 ]
+
+        for op, a, b, expected in cases do
+            let result = (Alu 8).Execute(op, intToBits a 8, intToBits b 8)
+
+            Assert.Equal(expected, bitsToInt result.Value)
+            Assert.False result.Carry
+            Assert.False result.Overflow
+
+    [<Fact>]
+    let ``alu not ignores b`` () =
+        let result = (Alu 8).Execute(AluOp.Not, intToBits 0 8, [])
+
+        Assert.Equal(255, bitsToInt result.Value)
+        Assert.True result.Negative
+
+    [<Fact>]
+    let ``alu detects signed overflow`` () =
+        let result = (Alu 8).Execute(AluOp.Add, intToBits 127 8, intToBits 1 8)
+
+        Assert.True result.Overflow
+        Assert.True result.Negative
+        Assert.Equal<int list>(result.Value, result.Result)
+
+    [<Fact>]
+    let ``alu validates width`` () =
+        let alu = Alu 8
+
+        Assert.Throws<System.ArgumentException>(fun () -> alu.Execute(AluOp.Add, [ 0; 1 ], [ 0; 1 ]) |> ignore) |> ignore
+        Assert.Throws<System.ArgumentException>(fun () -> alu.Execute(AluOp.And, intToBits 1 8, [ 1 ]) |> ignore) |> ignore
+        Assert.Throws<System.ArgumentException>(fun () -> Alu 0 |> ignore) |> ignore

--- a/code/packages/fsharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.fsproj
+++ b/code/packages/fsharp/arithmetic/tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.LogicGates]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Arithmetic.fsproj" />
+    <Compile Include="ArithmeticTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add C# arithmetic package with half/full adders, ripple-carry adder, and ALU
- add F# arithmetic package with matching adder and ALU behavior
- wire both packages to the existing logic-gates packages and exclude dependency assemblies from package coverage gates

## Tests
- dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (20 passed, 99% line)
- dotnet test tests/CodingAdventures.Arithmetic.Tests/CodingAdventures.Arithmetic.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (18 passed, 92.42% line)