### PR TITLE
feat(parity): add dotnet irc proto packages

### DIFF
--- a/code/packages/csharp/irc-proto/BUILD
+++ b/code/packages/csharp/irc-proto/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/irc-proto/BUILD_windows
+++ b/code/packages/csharp/irc-proto/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/irc-proto/CHANGELOG.md
+++ b/code/packages/csharp/irc-proto/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure IRC message parser and serializer.

--- a/code/packages/csharp/irc-proto/CodingAdventures.IrcProto.csproj
+++ b/code/packages/csharp/irc-proto/CodingAdventures.IrcProto.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.IrcProto.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure IRC message parsing and serialization for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/irc-proto/IrcProto.cs
+++ b/code/packages/csharp/irc-proto/IrcProto.cs
@@ -1,0 +1,121 @@
+using System.Text;
+
+namespace CodingAdventures.IrcProto;
+
+/// <summary>
+/// A single parsed IRC protocol message.
+/// </summary>
+public sealed record Message(string? Prefix, string Command, IReadOnlyList<string> Params);
+
+/// <summary>
+/// Raised when a raw line cannot be parsed as an IRC message.
+/// </summary>
+public sealed class ParseError : Exception
+{
+    /// <summary>Create a parse error with a human-readable message.</summary>
+    public ParseError(string message) : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Pure IRC message parsing and serialization helpers.
+/// </summary>
+public static class IrcProto
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+
+    private const int MaxParams = 15;
+
+    /// <summary>Parse one IRC line with any trailing CRLF already stripped.</summary>
+    public static Message Parse(string line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        if (line.Length == 0 || string.IsNullOrWhiteSpace(line))
+        {
+            throw new ParseError($"empty or whitespace-only line: {line}");
+        }
+
+        var rest = line;
+        string? prefix = null;
+        if (rest.StartsWith(':'))
+        {
+            var spacePosition = rest.IndexOf(' ', StringComparison.Ordinal);
+            if (spacePosition == -1)
+            {
+                throw new ParseError($"line has prefix but no command: {line}");
+            }
+
+            prefix = rest[1..spacePosition];
+            rest = rest[(spacePosition + 1)..];
+        }
+
+        var commandEnd = rest.IndexOf(' ', StringComparison.Ordinal);
+        string commandRaw;
+        if (commandEnd == -1)
+        {
+            commandRaw = rest;
+            rest = string.Empty;
+        }
+        else
+        {
+            commandRaw = rest[..commandEnd];
+            rest = rest[(commandEnd + 1)..];
+        }
+
+        var command = commandRaw.ToUpperInvariant();
+        if (command.Length == 0)
+        {
+            throw new ParseError($"could not extract command from line: {line}");
+        }
+
+        var parameters = new List<string>();
+        while (rest.Length > 0)
+        {
+            if (rest.StartsWith(':'))
+            {
+                parameters.Add(rest[1..]);
+                break;
+            }
+
+            var spacePosition = rest.IndexOf(' ', StringComparison.Ordinal);
+            if (spacePosition == -1)
+            {
+                parameters.Add(rest);
+                break;
+            }
+
+            parameters.Add(rest[..spacePosition]);
+            rest = rest[(spacePosition + 1)..];
+
+            if (parameters.Count == MaxParams)
+            {
+                break;
+            }
+        }
+
+        return new Message(prefix, command, parameters.AsReadOnly());
+    }
+
+    /// <summary>Serialize a message to CRLF-terminated UTF-8 IRC wire bytes.</summary>
+    public static byte[] Serialize(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        var parts = new List<string>();
+        if (message.Prefix is not null)
+        {
+            parts.Add($":{message.Prefix}");
+        }
+
+        parts.Add(message.Command);
+        for (var i = 0; i < message.Params.Count; i++)
+        {
+            var parameter = message.Params[i];
+            var isLast = i == message.Params.Count - 1;
+            parts.Add(isLast && parameter.Contains(' ') ? $":{parameter}" : parameter);
+        }
+
+        return Encoding.UTF8.GetBytes(string.Join(" ", parts) + "\r\n");
+    }
+}

--- a/code/packages/csharp/irc-proto/README.md
+++ b/code/packages/csharp/irc-proto/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.IrcProto.CSharp
+
+Pure IRC message parsing and serialization for .NET.
+
+The package converts stripped IRC protocol lines into `Message` records and serializes messages back to CRLF-terminated UTF-8 wire bytes. It performs no socket or buffer I/O.

--- a/code/packages/csharp/irc-proto/required_capabilities.json
+++ b/code/packages/csharp/irc-proto/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/irc-proto",
+  "capabilities": [],
+  "justification": "Pure IRC line parsing and serialization. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.csproj
+++ b/code/packages/csharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.IrcProto.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/IrcProtoTests.cs
+++ b/code/packages/csharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/IrcProtoTests.cs
@@ -1,0 +1,106 @@
+using System.Text;
+
+namespace CodingAdventures.IrcProto.Tests;
+
+public sealed class IrcProtoTests
+{
+    private static Message RoundTrip(string line)
+    {
+        var first = IrcProto.Parse(line);
+        var wire = IrcProto.Serialize(first);
+        return IrcProto.Parse(Encoding.UTF8.GetString(wire).TrimEnd('\r', '\n'));
+    }
+
+    [Fact]
+    public void VersionIsStable()
+    {
+        Assert.Equal("0.1.0", IrcProto.Version);
+    }
+
+    [Theory]
+    [InlineData("NICK alice", null, "NICK", new[] { "alice" })]
+    [InlineData("join #general", null, "JOIN", new[] { "#general" })]
+    [InlineData(":irc.local 001 alice :Welcome!", "irc.local", "001", new[] { "alice", "Welcome!" })]
+    [InlineData(":alice!alice@host PRIVMSG #general :hello world", "alice!alice@host", "PRIVMSG", new[] { "#general", "hello world" })]
+    [InlineData("PING", null, "PING", new string[] { })]
+    public void ParseHappyPaths(string line, string? prefix, string command, string[] parameters)
+    {
+        var message = IrcProto.Parse(line);
+
+        Assert.Equal(prefix, message.Prefix);
+        Assert.Equal(command, message.Command);
+        Assert.Equal(parameters, message.Params);
+    }
+
+    [Fact]
+    public void ParsePreservesTrailingSpacesAndEmptyTrailing()
+    {
+        Assert.Equal(["#c", "hello   world"], IrcProto.Parse("PRIVMSG #c :hello   world").Params);
+        Assert.Equal(["#c", ""], IrcProto.Parse("PRIVMSG #c :").Params);
+    }
+
+    [Fact]
+    public void ParseCapsParametersAtFifteen()
+    {
+        var parameters = string.Join(" ", Enumerable.Range(0, 16));
+
+        var message = IrcProto.Parse($"CMD {parameters}");
+
+        Assert.Equal(15, message.Params.Count);
+        Assert.Equal("14", message.Params.Last());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData(":irc.local")]
+    [InlineData(":irc.local ")]
+    public void ParseRejectsMalformedLines(string line)
+    {
+        Assert.Throws<ParseError>(() => IrcProto.Parse(line));
+    }
+
+    [Fact]
+    public void SerializeWritesCrlfAndTrailingParams()
+    {
+        var message = new Message(null, "PRIVMSG", ["#chan", "hello world"]);
+
+        var wire = IrcProto.Serialize(message);
+
+        Assert.Equal("PRIVMSG #chan :hello world\r\n", Encoding.UTF8.GetString(wire));
+        Assert.EndsWith("\r\n", Encoding.UTF8.GetString(wire));
+    }
+
+    [Fact]
+    public void SerializeHandlesPrefixesParamsAndEmptyLastParam()
+    {
+        Assert.Equal(
+            ":irc.local 001 alice Welcome!\r\n",
+            Encoding.UTF8.GetString(IrcProto.Serialize(new Message("irc.local", "001", ["alice", "Welcome!"]))));
+        Assert.Equal(
+            "PRIVMSG #c \r\n",
+            Encoding.UTF8.GetString(IrcProto.Serialize(new Message(null, "PRIVMSG", ["#c", ""]))));
+    }
+
+    [Fact]
+    public void SerializeUsesUtf8()
+    {
+        var wire = IrcProto.Serialize(new Message(null, "PRIVMSG", ["#ch", "H\u00e9llo"]));
+
+        Assert.Contains((byte)0xC3, wire);
+    }
+
+    [Theory]
+    [InlineData("NICK alice", null, "NICK", new[] { "alice" })]
+    [InlineData("PRIVMSG #general :Hello everyone!", null, "PRIVMSG", new[] { "#general", "Hello everyone!" })]
+    [InlineData(":srv 433 * nick :Nick in use", "srv", "433", new[] { "*", "nick", "Nick in use" })]
+    public void RoundTripsCanonicalMessages(string line, string? prefix, string command, string[] parameters)
+    {
+        var message = RoundTrip(line);
+
+        Assert.Equal(prefix, message.Prefix);
+        Assert.Equal(command, message.Command);
+        Assert.Equal(parameters, message.Params);
+    }
+}

--- a/code/packages/fsharp/irc-proto/BUILD
+++ b/code/packages/fsharp/irc-proto/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/irc-proto/BUILD_windows
+++ b/code/packages/fsharp/irc-proto/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/irc-proto/CHANGELOG.md
+++ b/code/packages/fsharp/irc-proto/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure IRC message parser and serializer.

--- a/code/packages/fsharp/irc-proto/CodingAdventures.IrcProto.fsproj
+++ b/code/packages/fsharp/irc-proto/CodingAdventures.IrcProto.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.IrcProto.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure IRC message parsing and serialization for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="IrcProto.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/irc-proto/IrcProto.fs
+++ b/code/packages/fsharp/irc-proto/IrcProto.fs
@@ -1,0 +1,97 @@
+namespace CodingAdventures.IrcProto.FSharp
+
+open System
+open System.Text
+
+type Message =
+    { Prefix: string option
+      Command: string
+      Params: string list }
+
+exception ParseError of string
+
+[<RequireQualifiedAccess>]
+module IrcProto =
+    [<Literal>]
+    let Version = "0.1.0"
+
+    let private maxParams = 15
+
+    let parse (line: string) =
+        if isNull line then
+            nullArg "line"
+
+        if line.Length = 0 || String.IsNullOrWhiteSpace line then
+            raise (ParseError $"empty or whitespace-only line: {line}")
+
+        let mutable rest = line
+
+        let prefix =
+            if rest.StartsWith ":" then
+                let spacePosition = rest.IndexOf ' '
+
+                if spacePosition = -1 then
+                    raise (ParseError $"line has prefix but no command: {line}")
+
+                let value = rest.Substring(1, spacePosition - 1)
+                rest <- rest.Substring(spacePosition + 1)
+                Some value
+            else
+                None
+
+        let commandRaw =
+            let commandEnd = rest.IndexOf ' '
+
+            if commandEnd = -1 then
+                let value = rest
+                rest <- ""
+                value
+            else
+                let value = rest.Substring(0, commandEnd)
+                rest <- rest.Substring(commandEnd + 1)
+                value
+
+        let command = commandRaw.ToUpperInvariant()
+
+        if command.Length = 0 then
+            raise (ParseError $"could not extract command from line: {line}")
+
+        let parameters = ResizeArray<string>()
+
+        while rest.Length > 0 do
+            if rest.StartsWith ":" then
+                parameters.Add(rest.Substring 1)
+                rest <- ""
+            else
+                let spacePosition = rest.IndexOf ' '
+
+                if spacePosition = -1 then
+                    parameters.Add rest
+                    rest <- ""
+                else
+                    parameters.Add(rest.Substring(0, spacePosition))
+                    rest <- rest.Substring(spacePosition + 1)
+
+                    if parameters.Count = maxParams then
+                        rest <- ""
+
+        { Prefix = prefix
+          Command = command
+          Params = parameters |> Seq.toList }
+
+    let serialize (message: Message) =
+        let parts = ResizeArray<string>()
+
+        match message.Prefix with
+        | Some prefix -> parts.Add($":{prefix}")
+        | None -> ()
+
+        parts.Add message.Command
+
+        message.Params
+        |> List.iteri (fun index parameter ->
+            let isLast = index = message.Params.Length - 1
+            parts.Add(if isLast && parameter.Contains " " then $":{parameter}" else parameter))
+
+        String.concat " " parts + "\r\n"
+        |> Encoding.UTF8.GetBytes

--- a/code/packages/fsharp/irc-proto/README.md
+++ b/code/packages/fsharp/irc-proto/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.IrcProto.FSharp
+
+Pure IRC message parsing and serialization for .NET.
+
+The package converts stripped IRC protocol lines into `Message` records and serializes messages back to CRLF-terminated UTF-8 wire bytes. It performs no socket or buffer I/O.

--- a/code/packages/fsharp/irc-proto/required_capabilities.json
+++ b/code/packages/fsharp/irc-proto/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/irc-proto",
+  "capabilities": [],
+  "justification": "Pure IRC line parsing and serialization. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.fsproj
+++ b/code/packages/fsharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.IrcProto.fsproj" />
+    <Compile Include="IrcProtoTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/IrcProtoTests.fs
+++ b/code/packages/fsharp/irc-proto/tests/CodingAdventures.IrcProto.Tests/IrcProtoTests.fs
@@ -1,0 +1,98 @@
+namespace CodingAdventures.IrcProto.Tests
+
+open System.Text
+open Xunit
+open CodingAdventures.IrcProto.FSharp
+
+module IrcProtoTests =
+    let private roundTrip line =
+        let first = IrcProto.parse line
+        let wire = IrcProto.serialize first
+        Encoding.UTF8.GetString(wire).TrimEnd('\r', '\n') |> IrcProto.parse
+
+    [<Fact>]
+    let ``version is stable`` () =
+        Assert.Equal("0.1.0", IrcProto.Version)
+
+    [<Theory>]
+    [<InlineData("NICK alice", null, "NICK")>]
+    [<InlineData("join #general", null, "JOIN")>]
+    [<InlineData(":irc.local 001 alice :Welcome!", "irc.local", "001")>]
+    [<InlineData(":alice!alice@host PRIVMSG #general :hello world", "alice!alice@host", "PRIVMSG")>]
+    [<InlineData("PING", null, "PING")>]
+    let ``parse happy paths`` line prefix command =
+        let message = IrcProto.parse line
+
+        Assert.Equal((if isNull prefix then None else Some prefix), message.Prefix)
+        Assert.Equal(command, message.Command)
+
+    [<Fact>]
+    let ``parse parameters and trailing values`` () =
+        Assert.Equal<string list>([ "#c"; "hello   world" ], (IrcProto.parse "PRIVMSG #c :hello   world").Params)
+        Assert.Equal<string list>([ "#c"; "" ], (IrcProto.parse "PRIVMSG #c :").Params)
+        Assert.Equal<string list>([ "alice"; "0"; "*"; "Alice Smith" ], (IrcProto.parse "USER alice 0 * :Alice Smith").Params)
+
+    [<Fact>]
+    let ``parse caps parameters at fifteen`` () =
+        let parameters = [ 0 .. 15 ] |> List.map string |> String.concat " "
+
+        let message = IrcProto.parse $"CMD {parameters}"
+
+        Assert.Equal(15, message.Params.Length)
+        Assert.Equal("14", message.Params |> List.last)
+
+    [<Theory>]
+    [<InlineData("")>]
+    [<InlineData(" ")>]
+    [<InlineData("   ")>]
+    [<InlineData(":irc.local")>]
+    [<InlineData(":irc.local ")>]
+    let ``parse rejects malformed lines`` line =
+        Assert.Throws<ParseError>(fun () -> IrcProto.parse line |> ignore) |> ignore
+
+    [<Fact>]
+    let ``serialize writes crlf and trailing params`` () =
+        let wire =
+            IrcProto.serialize
+                { Prefix = None
+                  Command = "PRIVMSG"
+                  Params = [ "#chan"; "hello world" ] }
+            |> Encoding.UTF8.GetString
+
+        Assert.Equal("PRIVMSG #chan :hello world\r\n", wire)
+        Assert.EndsWith("\r\n", wire)
+
+    [<Fact>]
+    let ``serialize handles prefixes params and empty last param`` () =
+        let welcome =
+            IrcProto.serialize
+                { Prefix = Some "irc.local"
+                  Command = "001"
+                  Params = [ "alice"; "Welcome!" ] }
+            |> Encoding.UTF8.GetString
+
+        let empty =
+            IrcProto.serialize
+                { Prefix = None
+                  Command = "PRIVMSG"
+                  Params = [ "#c"; "" ] }
+            |> Encoding.UTF8.GetString
+
+        Assert.Equal(":irc.local 001 alice Welcome!\r\n", welcome)
+        Assert.Equal("PRIVMSG #c \r\n", empty)
+
+    [<Fact>]
+    let ``serialize uses utf8`` () =
+        let wire =
+            IrcProto.serialize
+                { Prefix = None
+                  Command = "PRIVMSG"
+                  Params = [ "#ch"; "H\u00e9llo" ] }
+
+        Assert.Contains(0xC3uy, wire)
+
+    [<Fact>]
+    let ``round trips canonical messages`` () =
+        Assert.Equal({ Prefix = None; Command = "NICK"; Params = [ "alice" ] }, roundTrip "NICK alice")
+        Assert.Equal({ Prefix = None; Command = "PRIVMSG"; Params = [ "#general"; "Hello everyone!" ] }, roundTrip "PRIVMSG #general :Hello everyone!")
+        Assert.Equal({ Prefix = Some "srv"; Command = "433"; Params = [ "*"; "nick"; "Nick in use" ] }, roundTrip ":srv 433 * nick :Nick in use")


### PR DESCRIPTION
## Summary
- add C# pure IRC protocol parser/serializer package
- add F# pure IRC protocol parser/serializer package
- include package metadata, capability declarations, and coverage-gated xUnit tests

## Tests
- dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (19 passed, 100% line)
- dotnet test tests/CodingAdventures.IrcProto.Tests/CodingAdventures.IrcProto.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (17 passed, 98.14% line)