### PR TITLE
feat(parity): add dotnet type checker protocol packages

### DIFF
--- a/code/packages/csharp/type-checker-protocol/BUILD
+++ b/code/packages/csharp/type-checker-protocol/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/type-checker-protocol/BUILD_windows
+++ b/code/packages/csharp/type-checker-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/type-checker-protocol/CHANGELOG.md
+++ b/code/packages/csharp/type-checker-protocol/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add type-checker diagnostics, result type, interface, and generic hook framework.

--- a/code/packages/csharp/type-checker-protocol/CodingAdventures.TypeCheckerProtocol.csproj
+++ b/code/packages/csharp/type-checker-protocol/CodingAdventures.TypeCheckerProtocol.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeCheckerProtocol.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared type-checker protocol and hook framework for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/type-checker-protocol/README.md
+++ b/code/packages/csharp/type-checker-protocol/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.TypeCheckerProtocol.CSharp
+
+Shared type-checker protocol and hook framework for .NET.
+
+The package provides immutable diagnostics, type-check results, a generic checker interface, and a reusable hook-driven base checker for AST-oriented language packages.

--- a/code/packages/csharp/type-checker-protocol/TypeCheckerProtocol.cs
+++ b/code/packages/csharp/type-checker-protocol/TypeCheckerProtocol.cs
@@ -1,0 +1,147 @@
+using System.Text.RegularExpressions;
+
+namespace CodingAdventures.TypeCheckerProtocol;
+
+/// <summary>
+/// A single type-checking diagnostic with a source location.
+/// </summary>
+public sealed record TypeErrorDiagnostic(string Message, int Line, int Column);
+
+/// <summary>
+/// The result of a type-checking pass.
+/// </summary>
+public sealed class TypeCheckResult<TAst>
+{
+    /// <summary>Create a result with an AST and optional diagnostics.</summary>
+    public TypeCheckResult(TAst typedAst, IEnumerable<TypeErrorDiagnostic>? errors = null)
+    {
+        TypedAst = typedAst;
+        Errors = (errors ?? []).ToArray();
+    }
+
+    /// <summary>The typed or partially typed AST.</summary>
+    public TAst TypedAst { get; }
+
+    /// <summary>Diagnostics collected during checking.</summary>
+    public IReadOnlyList<TypeErrorDiagnostic> Errors { get; }
+
+    /// <summary>True when no diagnostics were reported.</summary>
+    public bool Ok => Errors.Count == 0;
+}
+
+/// <summary>
+/// Generic contract for language-specific type checkers.
+/// </summary>
+public interface ITypeChecker<TAstIn, TAstOut>
+{
+    /// <summary>Type-check an AST and return its typed form plus diagnostics.</summary>
+    TypeCheckResult<TAstOut> Check(TAstIn ast);
+}
+
+/// <summary>
+/// Marker value a hook may return to ask dispatch to keep searching.
+/// </summary>
+public sealed class NotHandled
+{
+    private NotHandled()
+    {
+    }
+
+    /// <summary>The singleton marker value.</summary>
+    public static NotHandled Value { get; } = new();
+}
+
+/// <summary>
+/// Reusable base class for AST-driven type checkers.
+/// </summary>
+public abstract class GenericTypeChecker<TAst> : ITypeChecker<TAst, TAst>
+{
+    private readonly List<TypeErrorDiagnostic> _errors = [];
+    private readonly Dictionary<(string Phase, string Kind), List<Func<TAst, object?[], object?>>> _hooks = [];
+
+    /// <summary>Run the checker and return the AST plus collected diagnostics.</summary>
+    public TypeCheckResult<TAst> Check(TAst ast)
+    {
+        _errors.Clear();
+        Run(ast);
+        return new TypeCheckResult<TAst>(ast, _errors);
+    }
+
+    /// <summary>Register a hook for a phase and normalized node kind.</summary>
+    public void RegisterHook(string phase, string kind, Func<TAst, object?[], object?> hook)
+    {
+        ArgumentNullException.ThrowIfNull(phase);
+        ArgumentNullException.ThrowIfNull(kind);
+        ArgumentNullException.ThrowIfNull(hook);
+
+        var key = (phase, NormalizeKind(kind));
+        if (!_hooks.TryGetValue(key, out var hooks))
+        {
+            hooks = [];
+            _hooks[key] = hooks;
+        }
+
+        hooks.Add(hook);
+    }
+
+    /// <summary>Dispatch a node to the first matching hook.</summary>
+    public object? Dispatch(string phase, TAst node, object?[]? args = null, object? defaultValue = null)
+    {
+        ArgumentNullException.ThrowIfNull(phase);
+        var normalized = NormalizeKind(NodeKind(node));
+        foreach (var key in new[] { (phase, normalized), (phase, "*") })
+        {
+            if (!_hooks.TryGetValue(key, out var hooks))
+            {
+                continue;
+            }
+
+            foreach (var hook in hooks)
+            {
+                var result = hook(node, args ?? []);
+                if (!ReferenceEquals(result, NotHandled.Value))
+                {
+                    return result;
+                }
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>Normalize a node kind for hook lookup.</summary>
+    public static string NormalizeKind(string? kind)
+    {
+        if (string.IsNullOrEmpty(kind))
+        {
+            return string.Empty;
+        }
+
+        return Regex.Replace(kind, @"\W+", "_").Trim('_');
+    }
+
+    /// <summary>Run concrete type-checking logic.</summary>
+    protected abstract void Run(TAst ast);
+
+    /// <summary>Return a language-specific kind label for a node.</summary>
+    protected abstract string? NodeKind(TAst node);
+
+    /// <summary>Return the diagnostic location for a subject.</summary>
+    protected virtual (int Line, int Column) Locate(object subject) => (1, 1);
+
+    /// <summary>Append one diagnostic for a subject.</summary>
+    protected void Error(string message, object subject)
+    {
+        var (line, column) = Locate(subject);
+        _errors.Add(new TypeErrorDiagnostic(message, line, column));
+    }
+}
+
+/// <summary>
+/// Package metadata.
+/// </summary>
+public static class TypeCheckerProtocolPackage
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+}

--- a/code/packages/csharp/type-checker-protocol/required_capabilities.json
+++ b/code/packages/csharp/type-checker-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/type-checker-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory type-checking protocol types and dispatch helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.csproj
+++ b/code/packages/csharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.TypeCheckerProtocol.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/TypeCheckerProtocolTests.cs
+++ b/code/packages/csharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/TypeCheckerProtocolTests.cs
@@ -1,0 +1,119 @@
+namespace CodingAdventures.TypeCheckerProtocol.Tests;
+
+public sealed record SimpleNode(string Kind, string Value = "");
+
+public sealed record TypedNode(string Kind, string Value = "", string ResolvedType = "unknown");
+
+public sealed class GoodTypeChecker : ITypeChecker<SimpleNode, TypedNode>
+{
+    public TypeCheckResult<TypedNode> Check(SimpleNode ast) =>
+        new(new TypedNode(ast.Kind, ast.Value, "int"));
+}
+
+public sealed class BadTypeChecker : ITypeChecker<SimpleNode, TypedNode>
+{
+    public TypeCheckResult<TypedNode> Check(SimpleNode ast) =>
+        new(
+            new TypedNode(ast.Kind, ast.Value, "error"),
+            [new TypeErrorDiagnostic($"Unknown kind: {ast.Kind}", 1, 1)]);
+}
+
+public sealed class RuleDrivenTypeChecker : GenericTypeChecker<SimpleNode>
+{
+    public RuleDrivenTypeChecker()
+    {
+        RegisterHook("node", "literal", (node, _) => new TypedNode(node.Kind, "checked", "int"));
+        RegisterHook("node", "broken", (node, _) =>
+        {
+            Error($"bad node: {node.Kind}", node);
+            return null;
+        });
+        RegisterHook("node", "*", (_, _) => NotHandled.Value);
+    }
+
+    protected override void Run(SimpleNode ast) => Dispatch("node", ast);
+
+    protected override string? NodeKind(SimpleNode node) => node.Kind;
+
+    protected override (int Line, int Column) Locate(object subject) => (7, 9);
+}
+
+public sealed class TypeCheckerProtocolTests
+{
+    [Fact]
+    public void DiagnosticsAreImmutableComparableAndHashable()
+    {
+        var diagnostic = new TypeErrorDiagnostic("Type mismatch", 3, 7);
+
+        Assert.Equal(new TypeErrorDiagnostic("Type mismatch", 3, 7), diagnostic);
+        Assert.NotEqual(new TypeErrorDiagnostic("Type mismatch", 4, 7), diagnostic);
+        Assert.Contains(diagnostic, new HashSet<TypeErrorDiagnostic> { diagnostic });
+        Assert.Contains("Type mismatch", diagnostic.ToString());
+    }
+
+    [Fact]
+    public void TypeCheckResultReportsOkState()
+    {
+        var ok = new TypeCheckResult<TypedNode>(new TypedNode("literal"));
+        var bad = new TypeCheckResult<TypedNode>(
+            new TypedNode("bad", ResolvedType: "error"),
+            [new TypeErrorDiagnostic("bad", 1, 1)]);
+
+        Assert.True(ok.Ok);
+        Assert.Empty(ok.Errors);
+        Assert.False(bad.Ok);
+        Assert.Equal("error", bad.TypedAst.ResolvedType);
+    }
+
+    [Fact]
+    public void InterfaceAcceptsDifferentCheckers()
+    {
+        ITypeChecker<SimpleNode, TypedNode> good = new GoodTypeChecker();
+        ITypeChecker<SimpleNode, TypedNode> bad = new BadTypeChecker();
+
+        Assert.True(good.Check(new SimpleNode("literal")).Ok);
+        var result = bad.Check(new SimpleNode("??"));
+        Assert.False(result.Ok);
+        Assert.Contains("??", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public void GenericCheckerDispatchesRegisteredHooks()
+    {
+        var checker = new RuleDrivenTypeChecker();
+
+        var result = checker.Check(new SimpleNode("literal", "before"));
+
+        Assert.True(result.Ok);
+        Assert.Equal("literal", result.TypedAst.Kind);
+    }
+
+    [Fact]
+    public void GenericCheckerRecordsErrorsWithLocation()
+    {
+        var result = new RuleDrivenTypeChecker().Check(new SimpleNode("broken"));
+
+        Assert.False(result.Ok);
+        Assert.Equal(new TypeErrorDiagnostic("bad node: broken", 7, 9), result.Errors[0]);
+    }
+
+    [Fact]
+    public void DispatchFallsThroughToDefault()
+    {
+        var checker = new RuleDrivenTypeChecker();
+
+        var result = checker.Check(new SimpleNode("unknown", "unchanged"));
+
+        Assert.True(result.Ok);
+        Assert.Equal("unchanged", result.TypedAst.Value);
+    }
+
+    [Theory]
+    [InlineData("expr:add", "expr_add")]
+    [InlineData("  fn decl ", "fn_decl")]
+    [InlineData(null, "")]
+    public void NormalizeKindCollapsesPunctuation(string? input, string expected)
+    {
+        Assert.Equal(expected, GenericTypeChecker<SimpleNode>.NormalizeKind(input));
+    }
+}

--- a/code/packages/fsharp/type-checker-protocol/BUILD
+++ b/code/packages/fsharp/type-checker-protocol/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/type-checker-protocol/BUILD_windows
+++ b/code/packages/fsharp/type-checker-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/type-checker-protocol/CHANGELOG.md
+++ b/code/packages/fsharp/type-checker-protocol/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add type-checker diagnostics, result type, interface, and generic hook framework.

--- a/code/packages/fsharp/type-checker-protocol/CodingAdventures.TypeCheckerProtocol.fsproj
+++ b/code/packages/fsharp/type-checker-protocol/CodingAdventures.TypeCheckerProtocol.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.TypeCheckerProtocol.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Shared type-checker protocol and hook framework for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TypeCheckerProtocol.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/type-checker-protocol/README.md
+++ b/code/packages/fsharp/type-checker-protocol/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.TypeCheckerProtocol.FSharp
+
+Shared type-checker protocol and hook framework for .NET.
+
+The package provides immutable diagnostics, type-check results, a generic checker interface, and a reusable hook-driven base checker for AST-oriented language packages.

--- a/code/packages/fsharp/type-checker-protocol/TypeCheckerProtocol.fs
+++ b/code/packages/fsharp/type-checker-protocol/TypeCheckerProtocol.fs
@@ -1,0 +1,99 @@
+namespace CodingAdventures.TypeCheckerProtocol.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text.RegularExpressions
+
+type TypeErrorDiagnostic =
+    { Message: string
+      Line: int
+      Column: int }
+
+type TypeCheckResult<'Ast> =
+    { TypedAst: 'Ast
+      Errors: TypeErrorDiagnostic list }
+
+    member this.Ok = List.isEmpty this.Errors
+
+type ITypeChecker<'AstIn, 'AstOut> =
+    abstract Check: 'AstIn -> TypeCheckResult<'AstOut>
+
+[<Sealed>]
+type NotHandled private () =
+    static member val Value = NotHandled()
+
+[<AbstractClass>]
+type GenericTypeChecker<'Ast>() =
+    let errors = ResizeArray<TypeErrorDiagnostic>()
+    let hooks = Dictionary<string, ResizeArray<'Ast -> obj array -> obj>>()
+
+    static member NormalizeKind(kind: string option) =
+        match kind with
+        | None
+        | Some "" -> ""
+        | Some value -> Regex.Replace(value, @"\W+", "_").Trim('_')
+
+    member _.RegisterHook(phase: string, kind: string, hook: 'Ast -> obj array -> obj) =
+        if isNull phase then nullArg "phase"
+        if isNull kind then nullArg "kind"
+        if isNull (box hook) then nullArg "hook"
+
+        let key = $"{phase}:{GenericTypeChecker<'Ast>.NormalizeKind(Some kind)}"
+
+        let bucket =
+            match hooks.TryGetValue key with
+            | true, existing -> existing
+            | false, _ ->
+                let created = ResizeArray()
+                hooks[key] <- created
+                created
+
+        bucket.Add hook
+
+    member this.Dispatch(phase: string, node: 'Ast, ?args: obj array, ?defaultValue: obj) =
+        if isNull phase then nullArg "phase"
+
+        let args = defaultArg args [||]
+        let defaultValue = defaultArg defaultValue null
+        let normalized = this.NodeKind node |> GenericTypeChecker<'Ast>.NormalizeKind
+        let keys = [ $"{phase}:{normalized}"; $"{phase}:*" ]
+        let mutable handled = false
+        let mutable output = defaultValue
+
+        for key in keys do
+            if not handled then
+                match hooks.TryGetValue key with
+                | true, bucket ->
+                    for hook in bucket do
+                        if not handled then
+                            let result = hook node args
+                            if not (Object.ReferenceEquals(result, NotHandled.Value)) then
+                                output <- result
+                                handled <- true
+                | false, _ -> ()
+
+        output
+
+    member this.Check(ast: 'Ast) =
+        errors.Clear()
+        this.Run ast
+
+        { TypedAst = ast
+          Errors = errors |> Seq.toList }
+
+    member this.Error(message: string, subject: obj) =
+        let line, column = this.Locate subject
+        errors.Add({ Message = message; Line = line; Column = column })
+
+    abstract Run: 'Ast -> unit
+    abstract NodeKind: 'Ast -> string option
+    abstract Locate: obj -> int * int
+    default _.Locate(_subject: obj) = 1, 1
+
+    interface ITypeChecker<'Ast, 'Ast> with
+        member this.Check ast = this.Check ast
+
+[<RequireQualifiedAccess>]
+module TypeCheckerProtocolPackage =
+    [<Literal>]
+    let Version = "0.1.0"

--- a/code/packages/fsharp/type-checker-protocol/required_capabilities.json
+++ b/code/packages/fsharp/type-checker-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/type-checker-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory type-checking protocol types and dispatch helpers. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.fsproj
+++ b/code/packages/fsharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.TypeCheckerProtocol.fsproj" />
+    <Compile Include="TypeCheckerProtocolTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/TypeCheckerProtocolTests.fs
+++ b/code/packages/fsharp/type-checker-protocol/tests/CodingAdventures.TypeCheckerProtocol.Tests/TypeCheckerProtocolTests.fs
@@ -1,0 +1,125 @@
+namespace CodingAdventures.TypeCheckerProtocol.Tests
+
+open Xunit
+open CodingAdventures.TypeCheckerProtocol.FSharp
+
+type SimpleNode =
+    { Kind: string
+      mutable Value: string }
+
+type TypedNode =
+    { Kind: string
+      Value: string
+      ResolvedType: string }
+
+type GoodTypeChecker() =
+    interface ITypeChecker<SimpleNode, TypedNode> with
+        member _.Check ast =
+            { TypedAst =
+                { Kind = ast.Kind
+                  Value = ast.Value
+                  ResolvedType = "int" }
+              Errors = [] }
+
+type BadTypeChecker() =
+    interface ITypeChecker<SimpleNode, TypedNode> with
+        member _.Check ast =
+            { TypedAst =
+                { Kind = ast.Kind
+                  Value = ast.Value
+                  ResolvedType = "error" }
+              Errors = [ { Message = $"Unknown kind: {ast.Kind}"; Line = 1; Column = 1 } ] }
+
+type RuleDrivenTypeChecker() as this =
+    inherit GenericTypeChecker<SimpleNode>()
+
+    do
+        this.RegisterHook("node", "literal", fun node _ ->
+            node.Value <- "checked"
+            null)
+
+        this.RegisterHook("node", "broken", fun node _ ->
+            this.Error($"bad node: {node.Kind}", node)
+            null)
+
+        this.RegisterHook("node", "*", fun _ _ -> NotHandled.Value :> obj)
+
+    override this.Run ast =
+        this.Dispatch("node", ast, defaultValue = null) |> ignore
+
+    override _.NodeKind node = Some node.Kind
+
+    override _.Locate _ = 7, 9
+
+module TypeCheckerProtocolTests =
+    [<Fact>]
+    let ``diagnostics are immutable comparable and hashable`` () =
+        let diagnostic = { Message = "Type mismatch"; Line = 3; Column = 7 }
+
+        Assert.Equal({ Message = "Type mismatch"; Line = 3; Column = 7 }, diagnostic)
+        Assert.NotEqual({ Message = "Type mismatch"; Line = 4; Column = 7 }, diagnostic)
+        Assert.Contains(diagnostic, set [ diagnostic ])
+        Assert.Contains("Type mismatch", diagnostic.ToString())
+
+    [<Fact>]
+    let ``type check result reports ok state`` () =
+        let ok =
+            { TypedAst = { Kind = "literal"; Value = ""; ResolvedType = "int" }
+              Errors = [] }
+
+        let bad =
+            { TypedAst = { Kind = "bad"; Value = ""; ResolvedType = "error" }
+              Errors = [ { Message = "bad"; Line = 1; Column = 1 } ] }
+
+        Assert.True ok.Ok
+        Assert.Empty ok.Errors
+        Assert.False bad.Ok
+        Assert.Equal("error", bad.TypedAst.ResolvedType)
+
+    [<Fact>]
+    let ``interface accepts different checkers`` () =
+        let good = GoodTypeChecker() :> ITypeChecker<SimpleNode, TypedNode>
+        let bad = BadTypeChecker() :> ITypeChecker<SimpleNode, TypedNode>
+
+        Assert.True((good.Check { Kind = "literal"; Value = "" }).Ok)
+        let result = bad.Check { Kind = "??"; Value = "" }
+        Assert.False result.Ok
+        Assert.Contains("??", result.Errors.Head.Message)
+
+    [<Fact>]
+    let ``generic checker dispatches registered hooks`` () =
+        let node = { Kind = "literal"; Value = "before" }
+
+        let result = RuleDrivenTypeChecker().Check node
+
+        Assert.True result.Ok
+        Assert.Equal("checked", result.TypedAst.Value)
+
+    [<Fact>]
+    let ``generic checker records errors with location`` () =
+        let result = RuleDrivenTypeChecker().Check { Kind = "broken"; Value = "" }
+
+        Assert.False result.Ok
+        Assert.Equal({ Message = "bad node: broken"; Line = 7; Column = 9 }, result.Errors.Head)
+
+    [<Fact>]
+    let ``dispatch falls through to default`` () =
+        let node = { Kind = "unknown"; Value = "unchanged" }
+
+        let result = RuleDrivenTypeChecker().Check node
+
+        Assert.True result.Ok
+        Assert.Equal("unchanged", result.TypedAst.Value)
+
+    [<Theory>]
+    [<InlineData("expr:add", "expr_add")>]
+    [<InlineData("  fn decl ", "fn_decl")>]
+    [<InlineData(null, "")>]
+    let ``normalize kind collapses punctuation`` input expected =
+        let normalized =
+            if isNull input then
+                GenericTypeChecker<SimpleNode>.NormalizeKind None
+            else
+                GenericTypeChecker<SimpleNode>.NormalizeKind(Some input)
+
+        Assert.Equal(expected, normalized)


### PR DESCRIPTION
## Summary
- add C# type-checker protocol package with diagnostics, results, interface, and generic hook framework
- add F# type-checker protocol package with matching protocol and dispatch helpers
- include package metadata, capability declarations, and coverage-gated xUnit tests

## Tests
- dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (9 passed, 95.08% line)
- dotnet test tests/CodingAdventures.TypeCheckerProtocol.Tests/CodingAdventures.TypeCheckerProtocol.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line (9 passed, 93.47% line)