### PR TITLE
feat(parity): add dotnet content addressable storage packages

### DIFF
--- a/code/packages/csharp/content-addressable-storage/BUILD
+++ b/code/packages/csharp/content-addressable-storage/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/content-addressable-storage/BUILD_windows
+++ b/code/packages/csharp/content-addressable-storage/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/content-addressable-storage/CHANGELOG.md
+++ b/code/packages/csharp/content-addressable-storage/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial C# content-addressable storage package with SHA-1 integrity checks, prefix lookup, and a local disk blob store.

--- a/code/packages/csharp/content-addressable-storage/CodingAdventures.ContentAddressableStorage.csproj
+++ b/code/packages/csharp/content-addressable-storage/CodingAdventures.ContentAddressableStorage.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ContentAddressableStorage.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Content-addressable storage helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\sha1\CodingAdventures.Sha1.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/content-addressable-storage/ContentAddressableStorage.cs
+++ b/code/packages/csharp/content-addressable-storage/ContentAddressableStorage.cs
@@ -1,0 +1,420 @@
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
+
+namespace CodingAdventures.ContentAddressableStorage;
+
+/// <summary>Package metadata for content-addressable storage.</summary>
+public static class ContentAddressableStoragePackage
+{
+    /// <summary>The package version.</summary>
+    public const string Version = "0.1.0";
+}
+
+/// <summary>Key conversion helpers for SHA-1 content-addressable storage.</summary>
+public static class Cas
+{
+    /// <summary>The SHA-1 key length in bytes.</summary>
+    public const int KeyLength = 20;
+
+    /// <summary>Convert a 20-byte key to a lowercase 40-character hex string.</summary>
+    public static string KeyToHex(byte[] key)
+    {
+        ValidateKey(key);
+        return Convert.ToHexString(key).ToLowerInvariant();
+    }
+
+    /// <summary>Parse a 40-character hex string into a 20-byte key.</summary>
+    public static byte[] HexToKey(string hex)
+    {
+        ArgumentNullException.ThrowIfNull(hex);
+        if (hex.Length != KeyLength * 2)
+        {
+            throw new ArgumentException($"expected 40 hex chars, got {hex.Length}", nameof(hex));
+        }
+
+        try
+        {
+            return Convert.FromHexString(hex);
+        }
+        catch (FormatException exception)
+        {
+            throw new ArgumentException($"invalid hex string: {hex}", nameof(hex), exception);
+        }
+    }
+
+    /// <summary>
+    /// Decode a non-empty hexadecimal prefix. Odd-length prefixes are padded on the right.
+    /// </summary>
+    public static byte[] DecodeHexPrefix(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (prefix.Length == 0)
+        {
+            throw new ArgumentException("prefix cannot be empty", nameof(prefix));
+        }
+
+        if (prefix.Length > KeyLength * 2)
+        {
+            throw new ArgumentException($"prefix cannot be longer than 40 hex chars, got {prefix.Length}", nameof(prefix));
+        }
+
+        foreach (var ch in prefix)
+        {
+            if (!Uri.IsHexDigit(ch))
+            {
+                throw new ArgumentException($"invalid hex character: {ch}", nameof(prefix));
+            }
+        }
+
+        var padded = prefix.Length % 2 == 0 ? prefix : prefix + "0";
+        return Convert.FromHexString(padded);
+    }
+
+    internal static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeyLength)
+        {
+            throw new ArgumentException($"key must be exactly 20 bytes, got {key.Length}", nameof(key));
+        }
+    }
+}
+
+/// <summary>Base class for all errors raised by this package.</summary>
+public class CasError : Exception
+{
+    /// <summary>Create a CAS error.</summary>
+    public CasError(string message) : base(message)
+    {
+    }
+
+    /// <summary>Create a CAS error with an inner exception.</summary>
+    public CasError(string message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>The underlying blob store raised an unexpected exception.</summary>
+public sealed class CasStoreError : CasError
+{
+    /// <summary>Create a store error wrapping the original exception.</summary>
+    public CasStoreError(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>A requested object key does not exist in the store.</summary>
+public sealed class CasNotFoundError : CasError
+{
+    /// <summary>Create a not-found error for a key.</summary>
+    public CasNotFoundError(byte[] key) : this(key, null)
+    {
+    }
+
+    internal CasNotFoundError(byte[] key, Exception? innerException) : base($"object not found: {Cas.KeyToHex(key)}", innerException)
+    {
+        Key = key.ToArray();
+    }
+
+    /// <summary>The missing key.</summary>
+    public byte[] Key { get; }
+}
+
+/// <summary>Stored bytes do not hash to the requested key.</summary>
+public sealed class CasCorruptedError : CasError
+{
+    /// <summary>Create a corruption error for a key.</summary>
+    public CasCorruptedError(byte[] key) : base($"object corrupted: {Cas.KeyToHex(key)}")
+    {
+        Key = key.ToArray();
+    }
+
+    /// <summary>The requested key.</summary>
+    public byte[] Key { get; }
+}
+
+/// <summary>An abbreviated key matched more than one object.</summary>
+public sealed class CasAmbiguousPrefixError : CasError
+{
+    /// <summary>Create an ambiguous-prefix error.</summary>
+    public CasAmbiguousPrefixError(string prefix) : base($"ambiguous prefix: {prefix}")
+    {
+        Prefix = prefix;
+    }
+
+    /// <summary>The unresolved prefix.</summary>
+    public string Prefix { get; }
+}
+
+/// <summary>An abbreviated key matched no objects.</summary>
+public sealed class CasPrefixNotFoundError : CasError
+{
+    /// <summary>Create a prefix-not-found error.</summary>
+    public CasPrefixNotFoundError(string prefix) : base($"object not found for prefix: {prefix}")
+    {
+        Prefix = prefix;
+    }
+
+    /// <summary>The missing prefix.</summary>
+    public string Prefix { get; }
+}
+
+/// <summary>An abbreviated key is empty, too long, or not valid hexadecimal.</summary>
+public sealed class CasInvalidPrefixError : CasError
+{
+    /// <summary>Create an invalid-prefix error.</summary>
+    public CasInvalidPrefixError(string prefix) : this(prefix, null)
+    {
+    }
+
+    internal CasInvalidPrefixError(string prefix, Exception? innerException) : base($"invalid hex prefix: {prefix}", innerException)
+    {
+        Prefix = prefix;
+    }
+
+    /// <summary>The invalid prefix.</summary>
+    public string Prefix { get; }
+}
+
+/// <summary>A pluggable raw blob backend for content-addressable storage.</summary>
+public interface IBlobStore
+{
+    /// <summary>Persist data under a 20-byte SHA-1 key.</summary>
+    void Put(byte[] key, byte[] data);
+
+    /// <summary>Retrieve raw bytes by key.</summary>
+    byte[] Get(byte[] key);
+
+    /// <summary>Return whether a key exists.</summary>
+    bool Exists(byte[] key);
+
+    /// <summary>Return all keys whose first bytes match the prefix.</summary>
+    IReadOnlyList<byte[]> KeysWithPrefix(byte[] prefix);
+}
+
+/// <summary>Hashes content, delegates storage, verifies reads, and resolves prefixes.</summary>
+public sealed class ContentAddressableStore
+{
+    /// <summary>Create a CAS wrapper around a blob store.</summary>
+    public ContentAddressableStore(IBlobStore store)
+    {
+        Store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>The wrapped blob store.</summary>
+    public IBlobStore Store { get; }
+
+    /// <summary>Hash and store data, returning its SHA-1 key.</summary>
+    public byte[] Put(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var key = Sha1Algorithm.Hash(data);
+        try
+        {
+            Store.Put(key, data);
+        }
+        catch (Exception exception)
+        {
+            throw new CasStoreError(exception.Message, exception);
+        }
+
+        return key;
+    }
+
+    /// <summary>Retrieve data by key and verify it hashes back to that key.</summary>
+    public byte[] Get(byte[] key)
+    {
+        Cas.ValidateKey(key);
+        byte[] data;
+        try
+        {
+            data = Store.Get(key);
+        }
+        catch (FileNotFoundException exception)
+        {
+            throw new CasNotFoundError(key, exception);
+        }
+        catch (KeyNotFoundException exception)
+        {
+            throw new CasNotFoundError(key, exception);
+        }
+        catch (Exception exception)
+        {
+            throw new CasStoreError(exception.Message, exception);
+        }
+
+        if (!Sha1Algorithm.Hash(data).SequenceEqual(key))
+        {
+            throw new CasCorruptedError(key);
+        }
+
+        return data;
+    }
+
+    /// <summary>Return whether a key exists in the store.</summary>
+    public bool Exists(byte[] key)
+    {
+        Cas.ValidateKey(key);
+        try
+        {
+            return Store.Exists(key);
+        }
+        catch (Exception exception)
+        {
+            throw new CasStoreError(exception.Message, exception);
+        }
+    }
+
+    /// <summary>Resolve an abbreviated hexadecimal key prefix to a unique full key.</summary>
+    public byte[] FindByPrefix(string hexPrefix)
+    {
+        byte[] prefix;
+        try
+        {
+            prefix = Cas.DecodeHexPrefix(hexPrefix);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new CasInvalidPrefixError(hexPrefix, exception);
+        }
+
+        IReadOnlyList<byte[]> matches;
+        try
+        {
+            matches = Store.KeysWithPrefix(prefix);
+        }
+        catch (Exception exception)
+        {
+            throw new CasStoreError(exception.Message, exception);
+        }
+
+        var ordered = matches
+            .Select(key => key.ToArray())
+            .OrderBy(Cas.KeyToHex, StringComparer.Ordinal)
+            .ToList();
+
+        return ordered.Count switch
+        {
+            0 => throw new CasPrefixNotFoundError(hexPrefix),
+            1 => ordered[0],
+            _ => throw new CasAmbiguousPrefixError(hexPrefix),
+        };
+    }
+}
+
+/// <summary>Filesystem-backed blob store using Git's two-character fanout layout.</summary>
+public sealed class LocalDiskStore : IBlobStore
+{
+    private readonly string _root;
+
+    /// <summary>Create a disk store rooted at a directory.</summary>
+    public LocalDiskStore(string root)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        _root = root;
+        Directory.CreateDirectory(_root);
+    }
+
+    /// <summary>Return the object path for a key.</summary>
+    public string ObjectPath(byte[] key)
+    {
+        var hex = Cas.KeyToHex(key);
+        return Path.Combine(_root, hex[..2], hex[2..]);
+    }
+
+    /// <inheritdoc />
+    public void Put(byte[] key, byte[] data)
+    {
+        Cas.ValidateKey(key);
+        ArgumentNullException.ThrowIfNull(data);
+        var finalPath = ObjectPath(key);
+        if (File.Exists(finalPath))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(finalPath)!;
+        Directory.CreateDirectory(directory);
+        var tempPath = Path.Combine(
+            directory,
+            $"{Path.GetFileName(finalPath)}.{Environment.ProcessId}.{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            File.WriteAllBytes(tempPath, data);
+            try
+            {
+                File.Move(tempPath, finalPath);
+            }
+            catch (IOException) when (File.Exists(finalPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public byte[] Get(byte[] key)
+    {
+        Cas.ValidateKey(key);
+        return File.ReadAllBytes(ObjectPath(key));
+    }
+
+    /// <inheritdoc />
+    public bool Exists(byte[] key)
+    {
+        Cas.ValidateKey(key);
+        return File.Exists(ObjectPath(key));
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<byte[]> KeysWithPrefix(byte[] prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (prefix.Length == 0)
+        {
+            return [];
+        }
+
+        var bucket = Path.Combine(_root, prefix[0].ToString("x2"));
+        if (!Directory.Exists(bucket))
+        {
+            return [];
+        }
+
+        var keys = new List<byte[]>();
+        foreach (var path in Directory.EnumerateFiles(bucket))
+        {
+            var name = Path.GetFileName(path);
+            if (name.Length != 38)
+            {
+                continue;
+            }
+
+            byte[] key;
+            try
+            {
+                key = Cas.HexToKey(prefix[0].ToString("x2") + name);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            if (key.Take(prefix.Length).SequenceEqual(prefix))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+}

--- a/code/packages/csharp/content-addressable-storage/README.md
+++ b/code/packages/csharp/content-addressable-storage/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.ContentAddressableStorage.CSharp
+
+Content-addressable storage helpers for .NET.
+
+The package wraps a pluggable `IBlobStore` with SHA-1 keying, integrity verification on reads, abbreviated hash lookup, and a filesystem-backed `LocalDiskStore` using Git's `<root>/<xx>/<38-hex-chars>` object layout.

--- a/code/packages/csharp/content-addressable-storage/required_capabilities.json
+++ b/code/packages/csharp/content-addressable-storage/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/content-addressable-storage",
+  "capabilities": ["filesystem"],
+  "justification": "LocalDiskStore reads and writes files in a configurable root directory. Tests create temporary directories. No network, process, or environment access needed."
+}

--- a/code/packages/csharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj
+++ b/code/packages/csharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.Sha1]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ContentAddressableStorage.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/ContentAddressableStorageTests.cs
+++ b/code/packages/csharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/ContentAddressableStorageTests.cs
@@ -1,0 +1,234 @@
+using System.Text;
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
+
+namespace CodingAdventures.ContentAddressableStorage.Tests;
+
+public sealed class ContentAddressableStorageTests
+{
+    [Fact]
+    public void VersionIsStable()
+    {
+        Assert.Equal("0.1.0", ContentAddressableStoragePackage.Version);
+    }
+
+    [Fact]
+    public void HexHelpersValidateAndRoundTrip()
+    {
+        var hex = "a3f4b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5";
+        var key = Cas.HexToKey(hex);
+
+        Assert.Equal(20, key.Length);
+        Assert.Equal(hex, Cas.KeyToHex(key));
+        Assert.Equal("0000000000000000000000000000000000000000", Cas.KeyToHex(new byte[20]));
+        Assert.Throws<ArgumentException>(() => Cas.HexToKey("abc"));
+        Assert.Throws<ArgumentException>(() => Cas.HexToKey(new string('z', 40)));
+        Assert.Throws<ArgumentException>(() => Cas.KeyToHex([1, 2, 3]));
+    }
+
+    [Fact]
+    public void DecodeHexPrefixPadsOddLengthOnRight()
+    {
+        Assert.Equal([0xa3, 0xf4], Cas.DecodeHexPrefix("a3f4"));
+        Assert.Equal([0xa3, 0xf0], Cas.DecodeHexPrefix("a3f"));
+        Assert.Equal([0xa0], Cas.DecodeHexPrefix("a"));
+        Assert.Equal(Cas.HexToKey("a3f4b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5"), Cas.DecodeHexPrefix("A3F4B2C1D0E9F8A7B6C5D4E3F2A1B0C9D8E7F6A5"));
+        Assert.Throws<ArgumentException>(() => Cas.DecodeHexPrefix(""));
+        Assert.Throws<ArgumentException>(() => Cas.DecodeHexPrefix("xyz"));
+        Assert.Throws<ArgumentException>(() => Cas.DecodeHexPrefix(new string('a', 41)));
+    }
+
+    [Fact]
+    public void MemoryStoreRoundTripsAndDeduplicates()
+    {
+        var cas = new ContentAddressableStore(new MemoryStore());
+        var data = Encoding.UTF8.GetBytes("hello, world");
+
+        var firstKey = cas.Put(data);
+        var secondKey = cas.Put(data);
+
+        Assert.Equal(firstKey, secondKey);
+        Assert.Equal(Sha1Algorithm.Hash(data), firstKey);
+        Assert.Equal(data, cas.Get(firstKey));
+        Assert.True(cas.Exists(firstKey));
+        Assert.False(cas.Exists(Sha1Algorithm.Hash("missing"u8.ToArray())));
+    }
+
+    [Fact]
+    public void SupportsEmptyAndLargeBlobs()
+    {
+        var cas = new ContentAddressableStore(new MemoryStore());
+        var emptyKey = cas.Put([]);
+        var large = Enumerable.Repeat((byte)'x', 1024 * 1024).ToArray();
+        var largeKey = cas.Put(large);
+
+        Assert.Empty(cas.Get(emptyKey));
+        Assert.Equal(large, cas.Get(largeKey));
+    }
+
+    [Fact]
+    public void MissingAndCorruptedObjectsRaiseTypedErrors()
+    {
+        var store = new MemoryStore();
+        var cas = new ContentAddressableStore(store);
+        var key = cas.Put("original"u8.ToArray());
+        store.Put(key, "tampered"u8.ToArray());
+
+        var corrupted = Assert.Throws<CasCorruptedError>(() => cas.Get(key));
+        Assert.Equal(key, corrupted.Key);
+        Assert.Contains(Cas.KeyToHex(key), corrupted.Message);
+
+        var missing = Sha1Algorithm.Hash("missing"u8.ToArray());
+        var notFound = Assert.Throws<CasNotFoundError>(() => cas.Get(missing));
+        Assert.Equal(missing, notFound.Key);
+        Assert.IsAssignableFrom<CasError>(notFound);
+    }
+
+    [Fact]
+    public void FindByPrefixResolvesUniqueMissingAmbiguousAndInvalidPrefixes()
+    {
+        var store = new MemoryStore();
+        var key1 = Cas.HexToKey("abcd123400000000000000000000000000000000");
+        var key2 = Cas.HexToKey("abcd1234ffffffffffffffffffffffffffffffff");
+        store.Put(key1, []);
+        store.Put(key2, []);
+        var cas = new ContentAddressableStore(store);
+
+        Assert.Equal(key1, cas.FindByPrefix(Cas.KeyToHex(key1)));
+        Assert.Throws<CasAmbiguousPrefixError>(() => cas.FindByPrefix("abcd1234"));
+        Assert.Throws<CasPrefixNotFoundError>(() => cas.FindByPrefix("0000"));
+        var invalid = Assert.Throws<CasInvalidPrefixError>(() => cas.FindByPrefix("zzz"));
+        Assert.Equal("zzz", invalid.Prefix);
+    }
+
+    [Fact]
+    public void BackendErrorsAreWrapped()
+    {
+        var cas = new ContentAddressableStore(new FailingStore());
+
+        Assert.Throws<CasStoreError>(() => cas.Put([1]));
+        Assert.Throws<CasStoreError>(() => cas.Get(Sha1Algorithm.Hash([2])));
+        Assert.Throws<CasStoreError>(() => cas.Exists(Sha1Algorithm.Hash([3])));
+        Assert.Throws<CasStoreError>(() => cas.FindByPrefix("abcd"));
+    }
+
+    [Fact]
+    public void StorePropertyReturnsWrappedStore()
+    {
+        var inner = new MemoryStore();
+        var cas = new ContentAddressableStore(inner);
+
+        Assert.Same(inner, cas.Store);
+    }
+
+    [Fact]
+    public void LocalDiskStoreRoundTripsWithGitStyleLayout()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new LocalDiskStore(temp.Path);
+        var cas = new ContentAddressableStore(store);
+        var data = "persisted to disk"u8.ToArray();
+
+        var key = cas.Put(data);
+        var hex = Cas.KeyToHex(key);
+        var expectedPath = Path.Combine(temp.Path, hex[..2], hex[2..]);
+
+        Assert.Equal(expectedPath, store.ObjectPath(key));
+        Assert.True(File.Exists(expectedPath));
+        Assert.Equal(data, cas.Get(key));
+        Assert.True(cas.Exists(key));
+        Assert.Equal(key, cas.FindByPrefix(hex[..10]));
+        Assert.Empty(Directory.EnumerateFiles(temp.Path, "*.tmp", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public void LocalDiskStoreCreatesRootSkipsArtifactsAndHandlesEmptyPrefix()
+    {
+        using var temp = new TemporaryDirectory();
+        var root = Path.Combine(temp.Path, "deep", "objects");
+        var store = new LocalDiskStore(root);
+        var key = Sha1Algorithm.Hash("real object"u8.ToArray());
+        store.Put(key, "real object"u8.ToArray());
+        var hex = Cas.KeyToHex(key);
+        var bucket = Path.Combine(root, hex[..2]);
+
+        File.WriteAllBytes(Path.Combine(bucket, "some-temp.tmp"), []);
+        File.WriteAllBytes(Path.Combine(bucket, new string('z', 38)), []);
+        Directory.CreateDirectory(Path.Combine(bucket, new string('a', 38)));
+
+        Assert.True(Directory.Exists(root));
+        Assert.Empty(store.KeysWithPrefix([]));
+        Assert.Empty(store.KeysWithPrefix([0x00]));
+        Assert.Contains(store.KeysWithPrefix([key[0]]), candidate => candidate.SequenceEqual(key));
+    }
+
+    [Fact]
+    public void LocalDiskStoreSecondPutSkipsExistingFile()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new LocalDiskStore(temp.Path);
+        var data = "idempotent"u8.ToArray();
+        var key = Sha1Algorithm.Hash(data);
+
+        store.Put(key, data);
+        var path = store.ObjectPath(key);
+        var before = File.GetLastWriteTimeUtc(path);
+        store.Put(key, data);
+
+        Assert.Equal(before, File.GetLastWriteTimeUtc(path));
+    }
+
+    private sealed class MemoryStore : IBlobStore
+    {
+        private readonly Dictionary<string, byte[]> _data = [];
+
+        public void Put(byte[] key, byte[] data)
+        {
+            _data[Cas.KeyToHex(key)] = data.ToArray();
+        }
+
+        public byte[] Get(byte[] key)
+        {
+            return _data.TryGetValue(Cas.KeyToHex(key), out var value)
+                ? value.ToArray()
+                : throw new FileNotFoundException(Cas.KeyToHex(key));
+        }
+
+        public bool Exists(byte[] key) => _data.ContainsKey(Cas.KeyToHex(key));
+
+        public IReadOnlyList<byte[]> KeysWithPrefix(byte[] prefix) =>
+            _data.Keys
+                .Select(Cas.HexToKey)
+                .Where(key => key.Take(prefix.Length).SequenceEqual(prefix))
+                .ToList();
+    }
+
+    private sealed class FailingStore : IBlobStore
+    {
+        public void Put(byte[] key, byte[] data) => throw new IOException("put failed");
+
+        public byte[] Get(byte[] key) => throw new IOException("get failed");
+
+        public bool Exists(byte[] key) => throw new IOException("exists failed");
+
+        public IReadOnlyList<byte[]> KeysWithPrefix(byte[] prefix) => throw new IOException("prefix failed");
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"ca-cas-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/code/packages/fsharp/content-addressable-storage/BUILD
+++ b/code/packages/fsharp/content-addressable-storage/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/content-addressable-storage/BUILD_windows
+++ b/code/packages/fsharp/content-addressable-storage/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/content-addressable-storage/CHANGELOG.md
+++ b/code/packages/fsharp/content-addressable-storage/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial F# content-addressable storage package with SHA-1 integrity checks, prefix lookup, and a local disk blob store.

--- a/code/packages/fsharp/content-addressable-storage/CodingAdventures.ContentAddressableStorage.fsproj
+++ b/code/packages/fsharp/content-addressable-storage/CodingAdventures.ContentAddressableStorage.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ContentAddressableStorage.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Content-addressable storage helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\sha1\CodingAdventures.Sha1.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="ContentAddressableStorage.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/content-addressable-storage/ContentAddressableStorage.fs
+++ b/code/packages/fsharp/content-addressable-storage/ContentAddressableStorage.fs
@@ -1,0 +1,252 @@
+namespace CodingAdventures.ContentAddressableStorage.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open CodingAdventures.Sha1.FSharp
+
+module ContentAddressableStoragePackage =
+    [<Literal>]
+    let Version = "0.1.0"
+
+[<RequireQualifiedAccess>]
+module Cas =
+    [<Literal>]
+    let KeyLength = 20
+
+    let validateKey (key: byte array) =
+        if isNull key then
+            nullArg "key"
+
+        if key.Length <> KeyLength then
+            invalidArg "key" $"key must be exactly 20 bytes, got {key.Length}"
+
+    let keyToHex (key: byte array) =
+        validateKey key
+        Convert.ToHexString(key).ToLowerInvariant()
+
+    let hexToKey (hex: string) =
+        if isNull hex then
+            nullArg "hex"
+
+        if hex.Length <> KeyLength * 2 then
+            invalidArg "hex" $"expected 40 hex chars, got {hex.Length}"
+
+        try
+            Convert.FromHexString hex
+        with :? FormatException as ex ->
+            raise (ArgumentException($"invalid hex string: {hex}", "hex", ex))
+
+    let decodeHexPrefix (prefix: string) =
+        if isNull prefix then
+            nullArg "prefix"
+
+        if prefix.Length = 0 then
+            invalidArg "prefix" "prefix cannot be empty"
+
+        if prefix.Length > KeyLength * 2 then
+            invalidArg "prefix" $"prefix cannot be longer than 40 hex chars, got {prefix.Length}"
+
+        for ch in prefix do
+            if not (Uri.IsHexDigit ch) then
+                invalidArg "prefix" $"invalid hex character: {ch}"
+
+        let padded =
+            if prefix.Length % 2 = 0 then
+                prefix
+            else
+                prefix + "0"
+
+        Convert.FromHexString padded
+
+type CasError =
+    inherit Exception
+
+    new(message: string) = { inherit Exception(message) }
+
+    new(message: string, innerException: Exception) =
+        { inherit Exception(message, innerException) }
+
+type CasStoreError(message: string, innerException: Exception) =
+    inherit CasError(message, innerException)
+
+type CasNotFoundError(key: byte array) =
+    inherit CasError($"object not found: {Cas.keyToHex key}")
+
+    member _.Key = Array.copy key
+
+type CasCorruptedError(key: byte array) =
+    inherit CasError($"object corrupted: {Cas.keyToHex key}")
+
+    member _.Key = Array.copy key
+
+type CasAmbiguousPrefixError(prefix: string) =
+    inherit CasError($"ambiguous prefix: {prefix}")
+
+    member _.Prefix = prefix
+
+type CasPrefixNotFoundError(prefix: string) =
+    inherit CasError($"object not found for prefix: {prefix}")
+
+    member _.Prefix = prefix
+
+type CasInvalidPrefixError(prefix: string) =
+    inherit CasError($"invalid hex prefix: {prefix}")
+
+    member _.Prefix = prefix
+
+type IBlobStore =
+    abstract Put: key: byte array * data: byte array -> unit
+    abstract Get: key: byte array -> byte array
+    abstract Exists: key: byte array -> bool
+    abstract KeysWithPrefix: prefix: byte array -> byte array list
+
+type ContentAddressableStore(store: IBlobStore) =
+    do
+        if isNull (box store) then
+            nullArg "store"
+
+    member _.Store = store
+
+    member _.Put(data: byte array) =
+        if isNull data then
+            nullArg "data"
+
+        let key = Sha1.hash data
+
+        try
+            store.Put(key, data)
+        with ex ->
+            raise (CasStoreError(ex.Message, ex))
+
+        key
+
+    member _.Get(key: byte array) =
+        Cas.validateKey key
+
+        let data =
+            try
+                store.Get key
+            with
+            | :? FileNotFoundException as ex -> raise (CasNotFoundError key)
+            | :? KeyNotFoundException as ex -> raise (CasNotFoundError key)
+            | ex -> raise (CasStoreError(ex.Message, ex))
+
+        if Sha1.hash data <> key then
+            raise (CasCorruptedError key)
+
+        data
+
+    member _.Exists(key: byte array) =
+        Cas.validateKey key
+
+        try
+            store.Exists key
+        with ex ->
+            raise (CasStoreError(ex.Message, ex))
+
+    member _.FindByPrefix(hexPrefix: string) =
+        let prefix =
+            try
+                Cas.decodeHexPrefix hexPrefix
+            with :? ArgumentException ->
+                raise (CasInvalidPrefixError hexPrefix)
+
+        let matches =
+            try
+                store.KeysWithPrefix prefix
+            with ex ->
+                raise (CasStoreError(ex.Message, ex))
+
+        match matches |> List.map Array.copy |> List.sortBy Cas.keyToHex with
+        | [] -> raise (CasPrefixNotFoundError hexPrefix)
+        | [ key ] -> key
+        | _ -> raise (CasAmbiguousPrefixError hexPrefix)
+
+type LocalDiskStore(root: string) =
+    do
+        if String.IsNullOrWhiteSpace root then
+            invalidArg "root" "root cannot be empty"
+
+        Directory.CreateDirectory root |> ignore
+
+    member _.ObjectPath(key: byte array) =
+        let hex = Cas.keyToHex key
+        Path.Combine(root, hex.Substring(0, 2), hex.Substring(2))
+
+    member this.Put(key: byte array, data: byte array) =
+        Cas.validateKey key
+
+        if isNull data then
+            nullArg "data"
+
+        let finalPath = this.ObjectPath key
+
+        if not (File.Exists finalPath) then
+            let directory = Path.GetDirectoryName finalPath
+            Directory.CreateDirectory directory |> ignore
+
+            let tempPath =
+                Path.Combine(
+                    directory,
+                    $"{Path.GetFileName finalPath}.{Environment.ProcessId}.{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}.{Guid.NewGuid():N}.tmp"
+                )
+
+            try
+                File.WriteAllBytes(tempPath, data)
+
+                try
+                    File.Move(tempPath, finalPath)
+                with :? IOException when File.Exists finalPath ->
+                    File.Delete tempPath
+            with _ ->
+                if File.Exists tempPath then
+                    File.Delete tempPath
+
+                reraise()
+
+    member this.Get(key: byte array) =
+        Cas.validateKey key
+        File.ReadAllBytes(this.ObjectPath key)
+
+    member this.Exists(key: byte array) =
+        Cas.validateKey key
+        File.Exists(this.ObjectPath key)
+
+    member _.KeysWithPrefix(prefix: byte array) =
+        if isNull prefix then
+            nullArg "prefix"
+
+        if prefix.Length = 0 then
+            []
+        else
+            let firstByteHex = prefix[0].ToString "x2"
+            let bucket = Path.Combine(root, firstByteHex)
+
+            if not (Directory.Exists bucket) then
+                []
+            else
+                Directory.EnumerateFiles bucket
+                |> Seq.choose (fun path ->
+                    let name = Path.GetFileName path
+
+                    if name.Length <> 38 then
+                        None
+                    else
+                        try
+                            let key = Cas.hexToKey (firstByteHex + name)
+                            let startsWithPrefix = key |> Seq.take prefix.Length |> Seq.toArray = prefix
+
+                            if startsWithPrefix then
+                                Some key
+                            else
+                                None
+                        with :? ArgumentException ->
+                            None)
+                |> Seq.toList
+
+    interface IBlobStore with
+        member this.Put(key, data) = this.Put(key, data)
+        member this.Get key = this.Get key
+        member this.Exists key = this.Exists key
+        member this.KeysWithPrefix prefix = this.KeysWithPrefix prefix

--- a/code/packages/fsharp/content-addressable-storage/README.md
+++ b/code/packages/fsharp/content-addressable-storage/README.md
@@ -1,0 +1,5 @@
+# CodingAdventures.ContentAddressableStorage.FSharp
+
+Content-addressable storage helpers for .NET.
+
+The package wraps a pluggable `IBlobStore` with SHA-1 keying, integrity verification on reads, abbreviated hash lookup, and a filesystem-backed `LocalDiskStore` using Git's `<root>/<xx>/<38-hex-chars>` object layout.

--- a/code/packages/fsharp/content-addressable-storage/required_capabilities.json
+++ b/code/packages/fsharp/content-addressable-storage/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/content-addressable-storage",
+  "capabilities": ["filesystem"],
+  "justification": "LocalDiskStore reads and writes files in a configurable root directory. Tests create temporary directories. No network, process, or environment access needed."
+}

--- a/code/packages/fsharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj
+++ b/code/packages/fsharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.Sha1]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ContentAddressableStorage.fsproj" />
+    <Compile Include="ContentAddressableStorageTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/ContentAddressableStorageTests.fs
+++ b/code/packages/fsharp/content-addressable-storage/tests/CodingAdventures.ContentAddressableStorage.Tests/ContentAddressableStorageTests.fs
@@ -1,0 +1,203 @@
+namespace CodingAdventures.ContentAddressableStorage.Tests
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open Xunit
+open CodingAdventures.ContentAddressableStorage.FSharp
+open CodingAdventures.Sha1.FSharp
+
+type MemoryStore() =
+    let objects = Dictionary<string, byte array>()
+
+    member _.Put(key: byte array, data: byte array) =
+        objects[Cas.keyToHex key] <- Array.copy data
+
+    member _.Get(key: byte array) =
+        match objects.TryGetValue(Cas.keyToHex key) with
+        | true, value -> Array.copy value
+        | false, _ -> raise (FileNotFoundException(Cas.keyToHex key))
+
+    member _.Exists(key: byte array) =
+        objects.ContainsKey(Cas.keyToHex key)
+
+    member _.KeysWithPrefix(prefix: byte array) =
+        objects.Keys
+        |> Seq.map Cas.hexToKey
+        |> Seq.filter (fun key -> key |> Seq.take prefix.Length |> Seq.toArray = prefix)
+        |> Seq.toList
+
+    interface IBlobStore with
+        member this.Put(key, data) = this.Put(key, data)
+        member this.Get key = this.Get key
+        member this.Exists key = this.Exists key
+        member this.KeysWithPrefix prefix = this.KeysWithPrefix prefix
+
+type FailingStore() =
+    interface IBlobStore with
+        member _.Put(_, _) = raise (IOException "put failed")
+        member _.Get _ = raise (IOException "get failed")
+        member _.Exists _ = raise (IOException "exists failed")
+        member _.KeysWithPrefix _ = raise (IOException "prefix failed")
+
+type TemporaryDirectory() =
+    let path = Path.Combine(Path.GetTempPath(), $"ca-cas-{Guid.NewGuid():N}")
+
+    do Directory.CreateDirectory path |> ignore
+
+    member _.Path = path
+
+    interface IDisposable with
+        member _.Dispose() =
+            if Directory.Exists path then
+                Directory.Delete(path, true)
+
+module ContentAddressableStorageTests =
+    [<Fact>]
+    let ``version is stable`` () =
+        Assert.Equal("0.1.0", ContentAddressableStoragePackage.Version)
+
+    [<Fact>]
+    let ``hex helpers validate and round trip`` () =
+        let hex = "a3f4b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5"
+        let key = Cas.hexToKey hex
+
+        Assert.Equal(20, key.Length)
+        Assert.Equal(hex, Cas.keyToHex key)
+        Assert.Equal(String.replicate 40 "0", Cas.keyToHex (Array.zeroCreate 20))
+        Assert.Throws<ArgumentException>(fun () -> Cas.hexToKey "abc" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Cas.hexToKey (String.replicate 40 "z") |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Cas.keyToHex [| 1uy; 2uy; 3uy |] |> ignore) |> ignore
+
+    [<Fact>]
+    let ``decode hex prefix pads odd length on right`` () =
+        Assert.Equal<byte>([| 0xa3uy; 0xf4uy |], Cas.decodeHexPrefix "a3f4")
+        Assert.Equal<byte>([| 0xa3uy; 0xf0uy |], Cas.decodeHexPrefix "a3f")
+        Assert.Equal<byte>([| 0xa0uy |], Cas.decodeHexPrefix "a")
+        Assert.Equal<byte>(Cas.hexToKey "a3f4b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5", Cas.decodeHexPrefix "A3F4B2C1D0E9F8A7B6C5D4E3F2A1B0C9D8E7F6A5")
+        Assert.Throws<ArgumentException>(fun () -> Cas.decodeHexPrefix "" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Cas.decodeHexPrefix "xyz" |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Cas.decodeHexPrefix (String.replicate 41 "a") |> ignore) |> ignore
+
+    [<Fact>]
+    let ``memory store round trips and deduplicates`` () =
+        let cas = ContentAddressableStore(MemoryStore())
+        let data = Encoding.UTF8.GetBytes "hello, world"
+
+        let firstKey = cas.Put data
+        let secondKey = cas.Put data
+
+        Assert.Equal<byte>(firstKey, secondKey)
+        Assert.Equal<byte>(Sha1.hash data, firstKey)
+        Assert.Equal<byte>(data, cas.Get firstKey)
+        Assert.True(cas.Exists firstKey)
+        Assert.False(cas.Exists(Sha1.hash "missing"B))
+
+    [<Fact>]
+    let ``supports empty and large blobs`` () =
+        let cas = ContentAddressableStore(MemoryStore())
+        let emptyKey = cas.Put [||]
+        let large = Array.create (1024 * 1024) (byte 'x')
+        let largeKey = cas.Put large
+
+        Assert.Empty(cas.Get emptyKey)
+        Assert.Equal<byte>(large, cas.Get largeKey)
+
+    [<Fact>]
+    let ``missing and corrupted objects raise typed errors`` () =
+        let store = MemoryStore()
+        let cas = ContentAddressableStore(store)
+        let key = cas.Put "original"B
+        store.Put(key, "tampered"B)
+
+        let corrupted = Assert.Throws<CasCorruptedError>(fun () -> cas.Get key |> ignore)
+        Assert.Equal<byte>(key, corrupted.Key)
+        Assert.Contains(Cas.keyToHex key, corrupted.Message)
+
+        let missing = Sha1.hash "missing"B
+        let notFound = Assert.Throws<CasNotFoundError>(fun () -> cas.Get missing |> ignore)
+        Assert.Equal<byte>(missing, notFound.Key)
+        Assert.IsAssignableFrom<CasError>(notFound) |> ignore
+
+    [<Fact>]
+    let ``find by prefix resolves unique missing ambiguous and invalid prefixes`` () =
+        let store = MemoryStore()
+        let key1 = Cas.hexToKey "abcd123400000000000000000000000000000000"
+        let key2 = Cas.hexToKey "abcd1234ffffffffffffffffffffffffffffffff"
+        store.Put(key1, [||])
+        store.Put(key2, [||])
+        let cas = ContentAddressableStore(store)
+
+        Assert.Equal<byte>(key1, cas.FindByPrefix(Cas.keyToHex key1))
+        Assert.Throws<CasAmbiguousPrefixError>(fun () -> cas.FindByPrefix "abcd1234" |> ignore) |> ignore
+        Assert.Throws<CasPrefixNotFoundError>(fun () -> cas.FindByPrefix "0000" |> ignore) |> ignore
+        let invalid = Assert.Throws<CasInvalidPrefixError>(fun () -> cas.FindByPrefix "zzz" |> ignore)
+        Assert.Equal("zzz", invalid.Prefix)
+
+    [<Fact>]
+    let ``backend errors are wrapped`` () =
+        let cas = ContentAddressableStore(FailingStore())
+
+        Assert.Throws<CasStoreError>(fun () -> cas.Put [| 1uy |] |> ignore) |> ignore
+        Assert.Throws<CasStoreError>(fun () -> cas.Get(Sha1.hash [| 2uy |]) |> ignore) |> ignore
+        Assert.Throws<CasStoreError>(fun () -> cas.Exists(Sha1.hash [| 3uy |]) |> ignore) |> ignore
+        Assert.Throws<CasStoreError>(fun () -> cas.FindByPrefix "abcd" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``store property returns wrapped store`` () =
+        let inner = MemoryStore()
+        let cas = ContentAddressableStore(inner)
+
+        Assert.Same(inner, cas.Store)
+
+    [<Fact>]
+    let ``local disk store round trips with git style layout`` () =
+        use temp = new TemporaryDirectory()
+        let store = LocalDiskStore temp.Path
+        let cas = ContentAddressableStore(store)
+        let data = "persisted to disk"B
+
+        let key = cas.Put data
+        let hex = Cas.keyToHex key
+        let expectedPath = Path.Combine(temp.Path, hex.Substring(0, 2), hex.Substring(2))
+
+        Assert.Equal(expectedPath, store.ObjectPath key)
+        Assert.True(File.Exists expectedPath)
+        Assert.Equal<byte>(data, cas.Get key)
+        Assert.True(cas.Exists key)
+        Assert.Equal<byte>(key, cas.FindByPrefix(hex.Substring(0, 10)))
+        Assert.Empty(Directory.EnumerateFiles(temp.Path, "*.tmp", SearchOption.AllDirectories))
+
+    [<Fact>]
+    let ``local disk store creates root skips artifacts and handles empty prefix`` () =
+        use temp = new TemporaryDirectory()
+        let root = Path.Combine(temp.Path, "deep", "objects")
+        let store = LocalDiskStore root
+        let key = Sha1.hash "real object"B
+        store.Put(key, "real object"B)
+        let hex = Cas.keyToHex key
+        let bucket = Path.Combine(root, hex.Substring(0, 2))
+
+        File.WriteAllBytes(Path.Combine(bucket, "some-temp.tmp"), [||])
+        File.WriteAllBytes(Path.Combine(bucket, String.replicate 38 "z"), [||])
+        Directory.CreateDirectory(Path.Combine(bucket, String.replicate 38 "a")) |> ignore
+
+        Assert.True(Directory.Exists root)
+        Assert.Empty(store.KeysWithPrefix [||])
+        Assert.Empty(store.KeysWithPrefix [| 0x00uy |])
+        Assert.Contains(store.KeysWithPrefix [| key[0] |], fun candidate -> candidate = key)
+
+    [<Fact>]
+    let ``local disk store second put skips existing file`` () =
+        use temp = new TemporaryDirectory()
+        let store = LocalDiskStore temp.Path
+        let data = "idempotent"B
+        let key = Sha1.hash data
+
+        store.Put(key, data)
+        let path = store.ObjectPath key
+        let before = File.GetLastWriteTimeUtc path
+        store.Put(key, data)
+
+        Assert.Equal(before, File.GetLastWriteTimeUtc path)


### PR DESCRIPTION
## Summary
- add C# content-addressable storage package with SHA-1 keys, typed CAS errors, prefix lookup, and LocalDiskStore fanout layout
- add F# content-addressable storage package with matching behavior and filesystem capability metadata
- add xUnit coverage for hex helpers, round trips, corruption detection, prefix lookup, backend error wrapping, and disk layout

## Tests
- `dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (12 passed, 90.09% line)
- `dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (12 passed, 87.05% line)