### PR TITLE
fix(dotnet): implement hash primitives without platform crypto

### DIFF
--- a/code/packages/csharp/sha1/CHANGELOG.md
+++ b/code/packages/csharp/sha1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# SHA-1 package backed by `System.Security.Cryptography`.
+- Add a native C# SHA-1 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha1/README.md
+++ b/code/packages/csharp/sha1/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha1.CSharp
 
-SHA-1 helpers for .NET, backed by `System.Security.Cryptography.SHA1`.
+SHA-1 helpers for .NET, implemented directly from FIPS 180-4.
 
 SHA-1 is included for compatibility and learning parity with the repository's hash-function packages. New security-sensitive systems should prefer SHA-256 or stronger hashes.
 

--- a/code/packages/csharp/sha1/Sha1.cs
+++ b/code/packages/csharp/sha1/Sha1.cs
@@ -1,25 +1,134 @@
-using System.Security.Cryptography;
+using System.Buffers.Binary;
+using System.Numerics;
 
 namespace CodingAdventures.Sha1;
 
 /// <summary>
-/// SHA-1 one-shot and streaming helpers.
+/// SHA-1 one-shot and streaming helpers implemented from FIPS 180-4.
 /// </summary>
 public static class Sha1
 {
     /// <summary>SHA-1 digest length in bytes.</summary>
     public const int DigestLength = 20;
 
+    private static readonly uint[] InitialState =
+    [
+        0x67452301u,
+        0xefcdab89u,
+        0x98badcfeu,
+        0x10325476u,
+        0xc3d2e1f0u,
+    ];
+
+    private static readonly uint[] RoundConstants =
+    [
+        0x5a827999u,
+        0x6ed9eba1u,
+        0x8f1bbcdcu,
+        0xca62c1d6u,
+    ];
+
     /// <summary>Compute the SHA-1 digest for a complete byte array.</summary>
     public static byte[] Hash(byte[] data)
     {
         ArgumentNullException.ThrowIfNull(data);
-        return SHA1.HashData(data);
+        var padded = Pad(data);
+        var state = InitialState.ToArray();
+
+        for (var offset = 0; offset < padded.Length; offset += 64)
+        {
+            Compress(state, padded.AsSpan(offset, 64));
+        }
+
+        return StateToBytes(state);
     }
 
     /// <summary>Compute SHA-1 and return a lowercase hexadecimal digest.</summary>
     public static string HashHex(byte[] data) =>
         Convert.ToHexString(Hash(data)).ToLowerInvariant();
+
+    private static byte[] Pad(ReadOnlySpan<byte> data)
+    {
+        var bitLength = (ulong)data.Length * 8UL;
+        var afterBit = (data.Length + 1) % 64;
+        var zeroCount = afterBit <= 56 ? 56 - afterBit : 64 + 56 - afterBit;
+        var result = new byte[data.Length + 1 + zeroCount + 8];
+
+        data.CopyTo(result);
+        result[data.Length] = 0x80;
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength);
+        return result;
+    }
+
+    private static void Compress(uint[] state, ReadOnlySpan<byte> block)
+    {
+        Span<uint> w = stackalloc uint[80];
+        for (var index = 0; index < 16; index++)
+        {
+            w[index] = BinaryPrimitives.ReadUInt32BigEndian(block.Slice(index * 4, 4));
+        }
+
+        for (var index = 16; index < 80; index++)
+        {
+            w[index] = BitOperations.RotateLeft(w[index - 3] ^ w[index - 8] ^ w[index - 14] ^ w[index - 16], 1);
+        }
+
+        var a = state[0];
+        var b = state[1];
+        var c = state[2];
+        var d = state[3];
+        var e = state[4];
+
+        for (var index = 0; index < 80; index++)
+        {
+            uint f;
+            uint k;
+            if (index < 20)
+            {
+                f = (b & c) | (~b & d);
+                k = RoundConstants[0];
+            }
+            else if (index < 40)
+            {
+                f = b ^ c ^ d;
+                k = RoundConstants[1];
+            }
+            else if (index < 60)
+            {
+                f = (b & c) | (b & d) | (c & d);
+                k = RoundConstants[2];
+            }
+            else
+            {
+                f = b ^ c ^ d;
+                k = RoundConstants[3];
+            }
+
+            var temp = unchecked(BitOperations.RotateLeft(a, 5) + f + e + k + w[index]);
+            e = d;
+            d = c;
+            c = BitOperations.RotateLeft(b, 30);
+            b = a;
+            a = temp;
+        }
+
+        state[0] = unchecked(state[0] + a);
+        state[1] = unchecked(state[1] + b);
+        state[2] = unchecked(state[2] + c);
+        state[3] = unchecked(state[3] + d);
+        state[4] = unchecked(state[4] + e);
+    }
+
+    private static byte[] StateToBytes(uint[] state)
+    {
+        var digest = new byte[DigestLength];
+        for (var index = 0; index < state.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(digest.AsSpan(index * 4, 4), state[index]);
+        }
+
+        return digest;
+    }
 }
 
 /// <summary>
@@ -38,11 +147,10 @@ public sealed class Sha1Hasher
     }
 
     /// <summary>Return the current 20-byte digest without modifying this hasher.</summary>
-    public byte[] Digest() => SHA1.HashData(_data.ToArray());
+    public byte[] Digest() => Sha1.Hash(_data.ToArray());
 
     /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
-    public string HexDigest() =>
-        Convert.ToHexString(Digest()).ToLowerInvariant();
+    public string HexDigest() => Convert.ToHexString(Digest()).ToLowerInvariant();
 
     /// <summary>Return an independent copy of the current hasher state.</summary>
     public Sha1Hasher Copy()

--- a/code/packages/csharp/sha256/CHANGELOG.md
+++ b/code/packages/csharp/sha256/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# SHA-256 package backed by `System.Security.Cryptography`.
+- Add a native C# SHA-256 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha256/README.md
+++ b/code/packages/csharp/sha256/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha256.CSharp
 
-SHA-256 helpers for .NET, backed by `System.Security.Cryptography.SHA256`.
+SHA-256 helpers for .NET, implemented directly from FIPS 180-4.
 
 The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
 

--- a/code/packages/csharp/sha256/Sha256.cs
+++ b/code/packages/csharp/sha256/Sha256.cs
@@ -1,25 +1,134 @@
-using System.Security.Cryptography;
+using System.Buffers.Binary;
+using System.Numerics;
 
 namespace CodingAdventures.Sha256;
 
 /// <summary>
-/// SHA-256 one-shot and streaming helpers.
+/// SHA-256 one-shot and streaming helpers implemented from FIPS 180-4.
 /// </summary>
 public static class Sha256
 {
     /// <summary>SHA-256 digest length in bytes.</summary>
     public const int DigestLength = 32;
 
+    private static readonly uint[] InitialState =
+    [
+        0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+        0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+    ];
+
+    private static readonly uint[] K =
+    [
+        0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+        0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+        0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+        0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+        0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+        0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+        0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+        0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+    ];
+
     /// <summary>Compute the SHA-256 digest for a complete byte array.</summary>
     public static byte[] Hash(byte[] data)
     {
         ArgumentNullException.ThrowIfNull(data);
-        return SHA256.HashData(data);
+        var padded = Pad(data);
+        var state = InitialState.ToArray();
+
+        for (var offset = 0; offset < padded.Length; offset += 64)
+        {
+            Compress(state, padded.AsSpan(offset, 64));
+        }
+
+        return StateToBytes(state);
     }
 
     /// <summary>Compute SHA-256 and return a lowercase hexadecimal digest.</summary>
     public static string HashHex(byte[] data) =>
         Convert.ToHexString(Hash(data)).ToLowerInvariant();
+
+    private static byte[] Pad(ReadOnlySpan<byte> data)
+    {
+        var bitLength = (ulong)data.Length * 8UL;
+        var afterBit = (data.Length + 1) % 64;
+        var zeroCount = afterBit <= 56 ? 56 - afterBit : 64 + 56 - afterBit;
+        var result = new byte[data.Length + 1 + zeroCount + 8];
+
+        data.CopyTo(result);
+        result[data.Length] = 0x80;
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength);
+        return result;
+    }
+
+    private static void Compress(uint[] state, ReadOnlySpan<byte> block)
+    {
+        Span<uint> w = stackalloc uint[64];
+        for (var index = 0; index < 16; index++)
+        {
+            w[index] = BinaryPrimitives.ReadUInt32BigEndian(block.Slice(index * 4, 4));
+        }
+
+        for (var index = 16; index < 64; index++)
+        {
+            w[index] = unchecked(SmallSigma1(w[index - 2]) + w[index - 7] + SmallSigma0(w[index - 15]) + w[index - 16]);
+        }
+
+        var a = state[0];
+        var b = state[1];
+        var c = state[2];
+        var d = state[3];
+        var e = state[4];
+        var f = state[5];
+        var g = state[6];
+        var h = state[7];
+
+        for (var index = 0; index < 64; index++)
+        {
+            var t1 = unchecked(h + BigSigma1(e) + Ch(e, f, g) + K[index] + w[index]);
+            var t2 = unchecked(BigSigma0(a) + Maj(a, b, c));
+            h = g;
+            g = f;
+            f = e;
+            e = unchecked(d + t1);
+            d = c;
+            c = b;
+            b = a;
+            a = unchecked(t1 + t2);
+        }
+
+        state[0] = unchecked(state[0] + a);
+        state[1] = unchecked(state[1] + b);
+        state[2] = unchecked(state[2] + c);
+        state[3] = unchecked(state[3] + d);
+        state[4] = unchecked(state[4] + e);
+        state[5] = unchecked(state[5] + f);
+        state[6] = unchecked(state[6] + g);
+        state[7] = unchecked(state[7] + h);
+    }
+
+    private static uint BigSigma0(uint x) => BitOperations.RotateRight(x, 2) ^ BitOperations.RotateRight(x, 13) ^ BitOperations.RotateRight(x, 22);
+
+    private static uint BigSigma1(uint x) => BitOperations.RotateRight(x, 6) ^ BitOperations.RotateRight(x, 11) ^ BitOperations.RotateRight(x, 25);
+
+    private static uint SmallSigma0(uint x) => BitOperations.RotateRight(x, 7) ^ BitOperations.RotateRight(x, 18) ^ (x >> 3);
+
+    private static uint SmallSigma1(uint x) => BitOperations.RotateRight(x, 17) ^ BitOperations.RotateRight(x, 19) ^ (x >> 10);
+
+    private static uint Ch(uint x, uint y, uint z) => (x & y) ^ (~x & z);
+
+    private static uint Maj(uint x, uint y, uint z) => (x & y) ^ (x & z) ^ (y & z);
+
+    private static byte[] StateToBytes(uint[] state)
+    {
+        var digest = new byte[DigestLength];
+        for (var index = 0; index < state.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(digest.AsSpan(index * 4, 4), state[index]);
+        }
+
+        return digest;
+    }
 }
 
 /// <summary>
@@ -38,11 +147,10 @@ public sealed class Sha256Hasher
     }
 
     /// <summary>Return the current 32-byte digest without modifying this hasher.</summary>
-    public byte[] Digest() => SHA256.HashData(_data.ToArray());
+    public byte[] Digest() => Sha256.Hash(_data.ToArray());
 
     /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
-    public string HexDigest() =>
-        Convert.ToHexString(Digest()).ToLowerInvariant();
+    public string HexDigest() => Convert.ToHexString(Digest()).ToLowerInvariant();
 
     /// <summary>Return an independent copy of the current hasher state.</summary>
     public Sha256Hasher Copy()

--- a/code/packages/csharp/sha512/CHANGELOG.md
+++ b/code/packages/csharp/sha512/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# SHA-512 package backed by `System.Security.Cryptography`.
+- Add a native C# SHA-512 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/sha512/README.md
+++ b/code/packages/csharp/sha512/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha512.CSharp
 
-SHA-512 helpers for .NET, backed by `System.Security.Cryptography.SHA512`.
+SHA-512 helpers for .NET, implemented directly from FIPS 180-4.
 
 The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
 

--- a/code/packages/csharp/sha512/Sha512.cs
+++ b/code/packages/csharp/sha512/Sha512.cs
@@ -1,25 +1,146 @@
-using System.Security.Cryptography;
+using System.Buffers.Binary;
+using System.Numerics;
 
 namespace CodingAdventures.Sha512;
 
 /// <summary>
-/// SHA-512 one-shot and streaming helpers.
+/// SHA-512 one-shot and streaming helpers implemented from FIPS 180-4.
 /// </summary>
 public static class Sha512
 {
     /// <summary>SHA-512 digest length in bytes.</summary>
     public const int DigestLength = 64;
 
+    private static readonly ulong[] InitialState =
+    [
+        0x6a09e667f3bcc908UL, 0xbb67ae8584caa73bUL, 0x3c6ef372fe94f82bUL, 0xa54ff53a5f1d36f1UL,
+        0x510e527fade682d1UL, 0x9b05688c2b3e6c1fUL, 0x1f83d9abfb41bd6bUL, 0x5be0cd19137e2179UL,
+    ];
+
+    private static readonly ulong[] K =
+    [
+        0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
+        0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
+        0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
+        0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
+        0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
+        0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
+        0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
+        0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
+        0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
+        0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
+        0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
+        0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
+        0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
+        0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
+        0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
+        0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
+        0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
+        0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
+        0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
+        0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL,
+    ];
+
     /// <summary>Compute the SHA-512 digest for a complete byte array.</summary>
     public static byte[] Hash(byte[] data)
     {
         ArgumentNullException.ThrowIfNull(data);
-        return SHA512.HashData(data);
+        var padded = Pad(data);
+        var state = InitialState.ToArray();
+
+        for (var offset = 0; offset < padded.Length; offset += 128)
+        {
+            Compress(state, padded.AsSpan(offset, 128));
+        }
+
+        return StateToBytes(state);
     }
 
     /// <summary>Compute SHA-512 and return a lowercase hexadecimal digest.</summary>
     public static string HashHex(byte[] data) =>
         Convert.ToHexString(Hash(data)).ToLowerInvariant();
+
+    private static byte[] Pad(ReadOnlySpan<byte> data)
+    {
+        var bitLength = (ulong)data.Length * 8UL;
+        var afterBit = (data.Length + 1) % 128;
+        var zeroCount = afterBit <= 112 ? 112 - afterBit : 128 + 112 - afterBit;
+        var result = new byte[data.Length + 1 + zeroCount + 16];
+
+        data.CopyTo(result);
+        result[data.Length] = 0x80;
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength);
+        return result;
+    }
+
+    private static void Compress(ulong[] state, ReadOnlySpan<byte> block)
+    {
+        Span<ulong> w = stackalloc ulong[80];
+        for (var index = 0; index < 16; index++)
+        {
+            w[index] = BinaryPrimitives.ReadUInt64BigEndian(block.Slice(index * 8, 8));
+        }
+
+        for (var index = 16; index < 80; index++)
+        {
+            w[index] = unchecked(SmallSigma1(w[index - 2]) + w[index - 7] + SmallSigma0(w[index - 15]) + w[index - 16]);
+        }
+
+        var a = state[0];
+        var b = state[1];
+        var c = state[2];
+        var d = state[3];
+        var e = state[4];
+        var f = state[5];
+        var g = state[6];
+        var h = state[7];
+
+        for (var index = 0; index < 80; index++)
+        {
+            var t1 = unchecked(h + BigSigma1(e) + Ch(e, f, g) + K[index] + w[index]);
+            var t2 = unchecked(BigSigma0(a) + Maj(a, b, c));
+            h = g;
+            g = f;
+            f = e;
+            e = unchecked(d + t1);
+            d = c;
+            c = b;
+            b = a;
+            a = unchecked(t1 + t2);
+        }
+
+        state[0] = unchecked(state[0] + a);
+        state[1] = unchecked(state[1] + b);
+        state[2] = unchecked(state[2] + c);
+        state[3] = unchecked(state[3] + d);
+        state[4] = unchecked(state[4] + e);
+        state[5] = unchecked(state[5] + f);
+        state[6] = unchecked(state[6] + g);
+        state[7] = unchecked(state[7] + h);
+    }
+
+    private static ulong BigSigma0(ulong x) => BitOperations.RotateRight(x, 28) ^ BitOperations.RotateRight(x, 34) ^ BitOperations.RotateRight(x, 39);
+
+    private static ulong BigSigma1(ulong x) => BitOperations.RotateRight(x, 14) ^ BitOperations.RotateRight(x, 18) ^ BitOperations.RotateRight(x, 41);
+
+    private static ulong SmallSigma0(ulong x) => BitOperations.RotateRight(x, 1) ^ BitOperations.RotateRight(x, 8) ^ (x >> 7);
+
+    private static ulong SmallSigma1(ulong x) => BitOperations.RotateRight(x, 19) ^ BitOperations.RotateRight(x, 61) ^ (x >> 6);
+
+    private static ulong Ch(ulong x, ulong y, ulong z) => (x & y) ^ (~x & z);
+
+    private static ulong Maj(ulong x, ulong y, ulong z) => (x & y) ^ (x & z) ^ (y & z);
+
+    private static byte[] StateToBytes(ulong[] state)
+    {
+        var digest = new byte[DigestLength];
+        for (var index = 0; index < state.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(digest.AsSpan(index * 8, 8), state[index]);
+        }
+
+        return digest;
+    }
 }
 
 /// <summary>
@@ -38,11 +159,10 @@ public sealed class Sha512Hasher
     }
 
     /// <summary>Return the current 64-byte digest without modifying this hasher.</summary>
-    public byte[] Digest() => SHA512.HashData(_data.ToArray());
+    public byte[] Digest() => Sha512.Hash(_data.ToArray());
 
     /// <summary>Return the current digest as a lowercase hexadecimal string.</summary>
-    public string HexDigest() =>
-        Convert.ToHexString(Digest()).ToLowerInvariant();
+    public string HexDigest() => Convert.ToHexString(Digest()).ToLowerInvariant();
 
     /// <summary>Return an independent copy of the current hasher state.</summary>
     public Sha512Hasher Copy()

--- a/code/packages/fsharp/sha1/CHANGELOG.md
+++ b/code/packages/fsharp/sha1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# SHA-1 package backed by `System.Security.Cryptography`.
+- Add a native F# SHA-1 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha1/README.md
+++ b/code/packages/fsharp/sha1/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha1.FSharp
 
-SHA-1 helpers for .NET, backed by `System.Security.Cryptography.SHA1`.
+SHA-1 helpers for .NET, implemented directly from FIPS 180-4.
 
 SHA-1 is included for compatibility and learning parity with the repository's hash-function packages. New security-sensitive systems should prefer SHA-256 or stronger hashes.
 

--- a/code/packages/fsharp/sha1/Sha1.fs
+++ b/code/packages/fsharp/sha1/Sha1.fs
@@ -1,17 +1,110 @@
 namespace CodingAdventures.Sha1.FSharp
 
 open System
+open System.Buffers.Binary
 open System.Collections.Generic
-open System.Security.Cryptography
+open System.Numerics
 
 [<RequireQualifiedAccess>]
 module Sha1 =
     [<Literal>]
     let DigestLength = 20
 
+    let private init =
+        [|
+            0x67452301u
+            0xefcdab89u
+            0x98badcfeu
+            0x10325476u
+            0xc3d2e1f0u
+        |]
+
+    let private k =
+        [| 0x5a827999u; 0x6ed9eba1u; 0x8f1bbcdcu; 0xca62c1d6u |]
+
+    let private wrap32 value =
+        uint32 (value &&& 0xffffffffUL)
+
+    let private add32_2 a b =
+        wrap32 (uint64 a + uint64 b)
+
+    let private add32_5 a b c d e =
+        wrap32 (uint64 a + uint64 b + uint64 c + uint64 d + uint64 e)
+
+    let private pad (data: byte array) =
+        let bitLength = uint64 data.Length * 8UL
+        let afterBit = (data.Length + 1) % 64
+
+        let zeroCount =
+            if afterBit <= 56 then
+                56 - afterBit
+            else
+                64 + 56 - afterBit
+
+        let result = Array.zeroCreate<byte> (data.Length + 1 + zeroCount + 8)
+        Array.Copy(data, result, data.Length)
+        result[data.Length] <- 0x80uy
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength)
+        result
+
+    let private stateToBytes (state: uint32 array) =
+        let digest = Array.zeroCreate<byte> DigestLength
+
+        for index in 0 .. state.Length - 1 do
+            BinaryPrimitives.WriteUInt32BigEndian(digest.AsSpan(index * 4, 4), state[index])
+
+        digest
+
+    let private compress (state: uint32 array) (block: ReadOnlySpan<byte>) =
+        let w = Array.zeroCreate<uint32> 80
+
+        for index in 0 .. 15 do
+            w[index] <- BinaryPrimitives.ReadUInt32BigEndian(block.Slice(index * 4, 4))
+
+        for index in 16 .. 79 do
+            w[index] <- BitOperations.RotateLeft(w[index - 3] ^^^ w[index - 8] ^^^ w[index - 14] ^^^ w[index - 16], 1)
+
+        let mutable a = state[0]
+        let mutable b = state[1]
+        let mutable c = state[2]
+        let mutable d = state[3]
+        let mutable e = state[4]
+
+        for index in 0 .. 79 do
+            let f, roundK =
+                if index < 20 then
+                    (b &&& c) ||| ((~~~b) &&& d), k[0]
+                elif index < 40 then
+                    b ^^^ c ^^^ d, k[1]
+                elif index < 60 then
+                    (b &&& c) ||| (b &&& d) ||| (c &&& d), k[2]
+                else
+                    b ^^^ c ^^^ d, k[3]
+
+            let temp = add32_5 (BitOperations.RotateLeft(a, 5)) f e roundK w[index]
+            e <- d
+            d <- c
+            c <- BitOperations.RotateLeft(b, 30)
+            b <- a
+            a <- temp
+
+        state[0] <- add32_2 state[0] a
+        state[1] <- add32_2 state[1] b
+        state[2] <- add32_2 state[2] c
+        state[3] <- add32_2 state[3] d
+        state[4] <- add32_2 state[4] e
+
     let hash (data: byte array) =
-        if isNull data then nullArg "data"
-        SHA1.HashData(data)
+        if isNull data then
+            nullArg "data"
+
+        let padded = pad data
+        let state = Array.copy init
+
+        for offset in 0 .. 64 .. padded.Length - 64 do
+            compress state (ReadOnlySpan<byte>(padded, offset, 64))
+
+        stateToBytes state
 
     let hashHex (data: byte array) =
         hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
@@ -20,12 +113,14 @@ type Sha1Hasher() =
     let data = List<byte>()
 
     member this.Update(bytes: byte array) =
-        if isNull bytes then nullArg "bytes"
+        if isNull bytes then
+            nullArg "bytes"
+
         data.AddRange(bytes)
         this
 
     member _.Digest() =
-        data.ToArray() |> SHA1.HashData
+        data.ToArray() |> Sha1.hash
 
     member this.HexDigest() =
         this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()

--- a/code/packages/fsharp/sha256/CHANGELOG.md
+++ b/code/packages/fsharp/sha256/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# SHA-256 package backed by `System.Security.Cryptography`.
+- Add a native F# SHA-256 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha256/README.md
+++ b/code/packages/fsharp/sha256/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha256.FSharp
 
-SHA-256 helpers for .NET, backed by `System.Security.Cryptography.SHA256`.
+SHA-256 helpers for .NET, implemented directly from FIPS 180-4.
 
 The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
 

--- a/code/packages/fsharp/sha256/Sha256.fs
+++ b/code/packages/fsharp/sha256/Sha256.fs
@@ -1,17 +1,135 @@
 namespace CodingAdventures.Sha256.FSharp
 
 open System
+open System.Buffers.Binary
 open System.Collections.Generic
-open System.Security.Cryptography
+open System.Numerics
 
 [<RequireQualifiedAccess>]
 module Sha256 =
     [<Literal>]
     let DigestLength = 32
 
+    let private init =
+        [|
+            0x6a09e667u; 0xbb67ae85u; 0x3c6ef372u; 0xa54ff53au
+            0x510e527fu; 0x9b05688cu; 0x1f83d9abu; 0x5be0cd19u
+        |]
+
+    let private k =
+        [|
+            0x428a2f98u; 0x71374491u; 0xb5c0fbcfu; 0xe9b5dba5u; 0x3956c25bu; 0x59f111f1u; 0x923f82a4u; 0xab1c5ed5u
+            0xd807aa98u; 0x12835b01u; 0x243185beu; 0x550c7dc3u; 0x72be5d74u; 0x80deb1feu; 0x9bdc06a7u; 0xc19bf174u
+            0xe49b69c1u; 0xefbe4786u; 0x0fc19dc6u; 0x240ca1ccu; 0x2de92c6fu; 0x4a7484aau; 0x5cb0a9dcu; 0x76f988dau
+            0x983e5152u; 0xa831c66du; 0xb00327c8u; 0xbf597fc7u; 0xc6e00bf3u; 0xd5a79147u; 0x06ca6351u; 0x14292967u
+            0x27b70a85u; 0x2e1b2138u; 0x4d2c6dfcu; 0x53380d13u; 0x650a7354u; 0x766a0abbu; 0x81c2c92eu; 0x92722c85u
+            0xa2bfe8a1u; 0xa81a664bu; 0xc24b8b70u; 0xc76c51a3u; 0xd192e819u; 0xd6990624u; 0xf40e3585u; 0x106aa070u
+            0x19a4c116u; 0x1e376c08u; 0x2748774cu; 0x34b0bcb5u; 0x391c0cb3u; 0x4ed8aa4au; 0x5b9cca4fu; 0x682e6ff3u
+            0x748f82eeu; 0x78a5636fu; 0x84c87814u; 0x8cc70208u; 0x90befffau; 0xa4506cebu; 0xbef9a3f7u; 0xc67178f2u
+        |]
+
+    let private wrap32 value =
+        uint32 (value &&& 0xffffffffUL)
+
+    let private add2 a b =
+        wrap32 (uint64 a + uint64 b)
+
+    let private add4 a b c d =
+        wrap32 (uint64 a + uint64 b + uint64 c + uint64 d)
+
+    let private add5 a b c d e =
+        wrap32 (uint64 a + uint64 b + uint64 c + uint64 d + uint64 e)
+
+    let private bigSigma0 (x: uint32) =
+        BitOperations.RotateRight(x, 2) ^^^ BitOperations.RotateRight(x, 13) ^^^ BitOperations.RotateRight(x, 22)
+
+    let private bigSigma1 (x: uint32) =
+        BitOperations.RotateRight(x, 6) ^^^ BitOperations.RotateRight(x, 11) ^^^ BitOperations.RotateRight(x, 25)
+
+    let private smallSigma0 (x: uint32) =
+        BitOperations.RotateRight(x, 7) ^^^ BitOperations.RotateRight(x, 18) ^^^ (x >>> 3)
+
+    let private smallSigma1 (x: uint32) =
+        BitOperations.RotateRight(x, 17) ^^^ BitOperations.RotateRight(x, 19) ^^^ (x >>> 10)
+
+    let private ch (x: uint32) (y: uint32) (z: uint32) = (x &&& y) ^^^ ((~~~x) &&& z)
+
+    let private maj (x: uint32) (y: uint32) (z: uint32) = (x &&& y) ^^^ (x &&& z) ^^^ (y &&& z)
+
+    let private pad (data: byte array) =
+        let bitLength = uint64 data.Length * 8UL
+        let afterBit = (data.Length + 1) % 64
+
+        let zeroCount =
+            if afterBit <= 56 then
+                56 - afterBit
+            else
+                64 + 56 - afterBit
+
+        let result = Array.zeroCreate<byte> (data.Length + 1 + zeroCount + 8)
+        Array.Copy(data, result, data.Length)
+        result[data.Length] <- 0x80uy
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength)
+        result
+
+    let private stateToBytes (state: uint32 array) =
+        let digest = Array.zeroCreate<byte> DigestLength
+
+        for index in 0 .. state.Length - 1 do
+            BinaryPrimitives.WriteUInt32BigEndian(digest.AsSpan(index * 4, 4), state[index])
+
+        digest
+
+    let private compress (state: uint32 array) (block: ReadOnlySpan<byte>) =
+        let w = Array.zeroCreate<uint32> 64
+
+        for index in 0 .. 15 do
+            w[index] <- BinaryPrimitives.ReadUInt32BigEndian(block.Slice(index * 4, 4))
+
+        for index in 16 .. 63 do
+            w[index] <- add4 (smallSigma1 w[index - 2]) w[index - 7] (smallSigma0 w[index - 15]) w[index - 16]
+
+        let mutable a = state[0]
+        let mutable b = state[1]
+        let mutable c = state[2]
+        let mutable d = state[3]
+        let mutable e = state[4]
+        let mutable f = state[5]
+        let mutable g = state[6]
+        let mutable h = state[7]
+
+        for index in 0 .. 63 do
+            let t1 = add5 h (bigSigma1 e) (ch e f g) k[index] w[index]
+            let t2 = add2 (bigSigma0 a) (maj a b c)
+            h <- g
+            g <- f
+            f <- e
+            e <- add2 d t1
+            d <- c
+            c <- b
+            b <- a
+            a <- add2 t1 t2
+
+        state[0] <- add2 state[0] a
+        state[1] <- add2 state[1] b
+        state[2] <- add2 state[2] c
+        state[3] <- add2 state[3] d
+        state[4] <- add2 state[4] e
+        state[5] <- add2 state[5] f
+        state[6] <- add2 state[6] g
+        state[7] <- add2 state[7] h
+
     let hash (data: byte array) =
-        if isNull data then nullArg "data"
-        SHA256.HashData(data)
+        if isNull data then
+            nullArg "data"
+
+        let padded = pad data
+        let state = Array.copy init
+
+        for offset in 0 .. 64 .. padded.Length - 64 do
+            compress state (ReadOnlySpan<byte>(padded, offset, 64))
+
+        stateToBytes state
 
     let hashHex (data: byte array) =
         hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
@@ -20,12 +138,14 @@ type Sha256Hasher() =
     let data = List<byte>()
 
     member this.Update(bytes: byte array) =
-        if isNull bytes then nullArg "bytes"
+        if isNull bytes then
+            nullArg "bytes"
+
         data.AddRange(bytes)
         this
 
     member _.Digest() =
-        data.ToArray() |> SHA256.HashData
+        data.ToArray() |> Sha256.hash
 
     member this.HexDigest() =
         this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()

--- a/code/packages/fsharp/sha512/CHANGELOG.md
+++ b/code/packages/fsharp/sha512/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# SHA-512 package backed by `System.Security.Cryptography`.
+- Add a native F# SHA-512 package implemented directly from FIPS 180-4.
 - Include one-shot hashing, lowercase hex output, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/sha512/README.md
+++ b/code/packages/fsharp/sha512/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Sha512.FSharp
 
-SHA-512 helpers for .NET, backed by `System.Security.Cryptography.SHA512`.
+SHA-512 helpers for .NET, implemented directly from FIPS 180-4.
 
 The package exposes one-shot hashing plus a streaming-style hasher whose `Digest` calls are non-destructive.
 

--- a/code/packages/fsharp/sha512/Sha512.fs
+++ b/code/packages/fsharp/sha512/Sha512.fs
@@ -1,17 +1,135 @@
 namespace CodingAdventures.Sha512.FSharp
 
 open System
+open System.Buffers.Binary
 open System.Collections.Generic
-open System.Security.Cryptography
+open System.Numerics
 
 [<RequireQualifiedAccess>]
 module Sha512 =
     [<Literal>]
     let DigestLength = 64
 
+    let private init =
+        [|
+            0x6a09e667f3bcc908UL; 0xbb67ae8584caa73bUL; 0x3c6ef372fe94f82bUL; 0xa54ff53a5f1d36f1UL
+            0x510e527fade682d1UL; 0x9b05688c2b3e6c1fUL; 0x1f83d9abfb41bd6bUL; 0x5be0cd19137e2179UL
+        |]
+
+    let private k =
+        [|
+            0x428a2f98d728ae22UL; 0x7137449123ef65cdUL; 0xb5c0fbcfec4d3b2fUL; 0xe9b5dba58189dbbcUL
+            0x3956c25bf348b538UL; 0x59f111f1b605d019UL; 0x923f82a4af194f9bUL; 0xab1c5ed5da6d8118UL
+            0xd807aa98a3030242UL; 0x12835b0145706fbeUL; 0x243185be4ee4b28cUL; 0x550c7dc3d5ffb4e2UL
+            0x72be5d74f27b896fUL; 0x80deb1fe3b1696b1UL; 0x9bdc06a725c71235UL; 0xc19bf174cf692694UL
+            0xe49b69c19ef14ad2UL; 0xefbe4786384f25e3UL; 0x0fc19dc68b8cd5b5UL; 0x240ca1cc77ac9c65UL
+            0x2de92c6f592b0275UL; 0x4a7484aa6ea6e483UL; 0x5cb0a9dcbd41fbd4UL; 0x76f988da831153b5UL
+            0x983e5152ee66dfabUL; 0xa831c66d2db43210UL; 0xb00327c898fb213fUL; 0xbf597fc7beef0ee4UL
+            0xc6e00bf33da88fc2UL; 0xd5a79147930aa725UL; 0x06ca6351e003826fUL; 0x142929670a0e6e70UL
+            0x27b70a8546d22ffcUL; 0x2e1b21385c26c926UL; 0x4d2c6dfc5ac42aedUL; 0x53380d139d95b3dfUL
+            0x650a73548baf63deUL; 0x766a0abb3c77b2a8UL; 0x81c2c92e47edaee6UL; 0x92722c851482353bUL
+            0xa2bfe8a14cf10364UL; 0xa81a664bbc423001UL; 0xc24b8b70d0f89791UL; 0xc76c51a30654be30UL
+            0xd192e819d6ef5218UL; 0xd69906245565a910UL; 0xf40e35855771202aUL; 0x106aa07032bbd1b8UL
+            0x19a4c116b8d2d0c8UL; 0x1e376c085141ab53UL; 0x2748774cdf8eeb99UL; 0x34b0bcb5e19b48a8UL
+            0x391c0cb3c5c95a63UL; 0x4ed8aa4ae3418acbUL; 0x5b9cca4f7763e373UL; 0x682e6ff3d6b2b8a3UL
+            0x748f82ee5defb2fcUL; 0x78a5636f43172f60UL; 0x84c87814a1f0ab72UL; 0x8cc702081a6439ecUL
+            0x90befffa23631e28UL; 0xa4506cebde82bde9UL; 0xbef9a3f7b2c67915UL; 0xc67178f2e372532bUL
+            0xca273eceea26619cUL; 0xd186b8c721c0c207UL; 0xeada7dd6cde0eb1eUL; 0xf57d4f7fee6ed178UL
+            0x06f067aa72176fbaUL; 0x0a637dc5a2c898a6UL; 0x113f9804bef90daeUL; 0x1b710b35131c471bUL
+            0x28db77f523047d84UL; 0x32caab7b40c72493UL; 0x3c9ebe0a15c9bebcUL; 0x431d67c49c100d4cUL
+            0x4cc5d4becb3e42b6UL; 0x597f299cfc657e2aUL; 0x5fcb6fab3ad6faecUL; 0x6c44198c4a475817UL
+        |]
+
+    let private bigSigma0 (x: uint64) =
+        BitOperations.RotateRight(x, 28) ^^^ BitOperations.RotateRight(x, 34) ^^^ BitOperations.RotateRight(x, 39)
+
+    let private bigSigma1 (x: uint64) =
+        BitOperations.RotateRight(x, 14) ^^^ BitOperations.RotateRight(x, 18) ^^^ BitOperations.RotateRight(x, 41)
+
+    let private smallSigma0 (x: uint64) =
+        BitOperations.RotateRight(x, 1) ^^^ BitOperations.RotateRight(x, 8) ^^^ (x >>> 7)
+
+    let private smallSigma1 (x: uint64) =
+        BitOperations.RotateRight(x, 19) ^^^ BitOperations.RotateRight(x, 61) ^^^ (x >>> 6)
+
+    let private ch (x: uint64) (y: uint64) (z: uint64) = (x &&& y) ^^^ ((~~~x) &&& z)
+
+    let private maj (x: uint64) (y: uint64) (z: uint64) = (x &&& y) ^^^ (x &&& z) ^^^ (y &&& z)
+
+    let private pad (data: byte array) =
+        let bitLength = uint64 data.Length * 8UL
+        let afterBit = (data.Length + 1) % 128
+
+        let zeroCount =
+            if afterBit <= 112 then
+                112 - afterBit
+            else
+                128 + 112 - afterBit
+
+        let result = Array.zeroCreate<byte> (data.Length + 1 + zeroCount + 16)
+        Array.Copy(data, result, data.Length)
+        result[data.Length] <- 0x80uy
+        BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(result.Length - 8), bitLength)
+        result
+
+    let private stateToBytes (state: uint64 array) =
+        let digest = Array.zeroCreate<byte> DigestLength
+
+        for index in 0 .. state.Length - 1 do
+            BinaryPrimitives.WriteUInt64BigEndian(digest.AsSpan(index * 8, 8), state[index])
+
+        digest
+
+    let private compress (state: uint64 array) (block: ReadOnlySpan<byte>) =
+        let w = Array.zeroCreate<uint64> 80
+
+        for index in 0 .. 15 do
+            w[index] <- BinaryPrimitives.ReadUInt64BigEndian(block.Slice(index * 8, 8))
+
+        for index in 16 .. 79 do
+            w[index] <- smallSigma1 w[index - 2] + w[index - 7] + smallSigma0 w[index - 15] + w[index - 16]
+
+        let mutable a = state[0]
+        let mutable b = state[1]
+        let mutable c = state[2]
+        let mutable d = state[3]
+        let mutable e = state[4]
+        let mutable f = state[5]
+        let mutable g = state[6]
+        let mutable h = state[7]
+
+        for index in 0 .. 79 do
+            let t1 = h + bigSigma1 e + ch e f g + k[index] + w[index]
+            let t2 = bigSigma0 a + maj a b c
+            h <- g
+            g <- f
+            f <- e
+            e <- d + t1
+            d <- c
+            c <- b
+            b <- a
+            a <- t1 + t2
+
+        state[0] <- state[0] + a
+        state[1] <- state[1] + b
+        state[2] <- state[2] + c
+        state[3] <- state[3] + d
+        state[4] <- state[4] + e
+        state[5] <- state[5] + f
+        state[6] <- state[6] + g
+        state[7] <- state[7] + h
+
     let hash (data: byte array) =
-        if isNull data then nullArg "data"
-        SHA512.HashData(data)
+        if isNull data then
+            nullArg "data"
+
+        let padded = pad data
+        let state = Array.copy init
+
+        for offset in 0 .. 128 .. padded.Length - 128 do
+            compress state (ReadOnlySpan<byte>(padded, offset, 128))
+
+        stateToBytes state
 
     let hashHex (data: byte array) =
         hash data |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
@@ -20,12 +138,14 @@ type Sha512Hasher() =
     let data = List<byte>()
 
     member this.Update(bytes: byte array) =
-        if isNull bytes then nullArg "bytes"
+        if isNull bytes then
+            nullArg "bytes"
+
         data.AddRange(bytes)
         this
 
     member _.Digest() =
-        data.ToArray() |> SHA512.HashData
+        data.ToArray() |> Sha512.hash
 
     member this.HexDigest() =
         this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()


### PR DESCRIPTION
## Summary
- replace C# SHA-1, SHA-256, and SHA-512 System.Security.Cryptography wrappers with direct FIPS 180-4 block implementations
- replace F# SHA-1, SHA-256, and SHA-512 platform wrappers with independent F# implementations
- update README/changelog text to remove the stale platform-crypto claims

## Survey Notes
- .NET package parity is currently 159 C# packages and 161 F# packages on main
- normalized against the Python/Rust union, C# is missing 375 packages and F# is missing 373 packages
- only current C#/F# package-count asymmetry is F#-only aztec-code and qr-code
- remaining production wrapper cleanup targets include aes, aes-modes, csprng, hash-functions, hmac, hkdf, pbkdf2, uuid, and zeroize

## Tests
- `dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.Sha1.Tests/CodingAdventures.Sha1.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.Sha256.Tests/CodingAdventures.Sha256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.Sha512.Tests/CodingAdventures.Sha512.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (11 passed, 100% line)
- `dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (12 passed, 90.09% line)
- `dotnet test tests/CodingAdventures.ContentAddressableStorage.Tests/CodingAdventures.ContentAddressableStorage.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` (12 passed, 87.05% line)