### PR TITLE
fix(dotnet): implement hmac and kdf packages without platform crypto

### DIFF
--- a/code/packages/csharp/hkdf/CodingAdventures.Hkdf.csproj
+++ b/code/packages/csharp/hkdf/CodingAdventures.Hkdf.csproj
@@ -16,4 +16,10 @@
     <EmbeddedResource Remove="tests\**" />
     <None Remove="tests\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../hmac/CodingAdventures.Hmac.csproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.csproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.csproj" />
+  </ItemGroup>
 </Project>

--- a/code/packages/csharp/hkdf/Hkdf.cs
+++ b/code/packages/csharp/hkdf/Hkdf.cs
@@ -1,4 +1,6 @@
-using System.Security.Cryptography;
+using HmacAlgorithm = CodingAdventures.Hmac.Hmac;
+using Sha256Algorithm = CodingAdventures.Sha256.Sha256;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
 
 namespace CodingAdventures.Hkdf;
 
@@ -25,8 +27,7 @@ public static class Hkdf
 
         var hashLength = HashLength(hash);
         var actualSalt = salt.Length == 0 ? new byte[hashLength] : salt;
-        using var hmac = CreateHmac(hash, actualSalt);
-        return hmac.ComputeHash(ikm);
+        return ComputeHmac(hash, actualSalt, ikm);
     }
 
     /// <summary>HKDF-Expand: derive output keying material from a pseudorandom key.</summary>
@@ -54,13 +55,12 @@ public static class Hkdf
 
         while (offset < length)
         {
-            using var hmac = CreateHmac(hash, prk);
             var input = new byte[previous.Length + info.Length + 1];
             Buffer.BlockCopy(previous, 0, input, 0, previous.Length);
             Buffer.BlockCopy(info, 0, input, previous.Length, info.Length);
             input[^1] = (byte)counter;
 
-            previous = hmac.ComputeHash(input);
+            previous = ComputeHmac(hash, prk, input);
             var toCopy = Math.Min(previous.Length, length - offset);
             Buffer.BlockCopy(previous, 0, okm, offset, toCopy);
             offset += toCopy;
@@ -98,11 +98,11 @@ public static class Hkdf
     public static byte[] DeriveSha512(byte[] salt, byte[] ikm, byte[] info, int length) =>
         Derive(salt, ikm, info, length, HkdfHash.Sha512);
 
-    private static HMAC CreateHmac(HkdfHash hash, byte[] key) =>
+    private static byte[] ComputeHmac(HkdfHash hash, byte[] key, byte[] message) =>
         hash switch
         {
-            HkdfHash.Sha256 => new HMACSHA256(key),
-            HkdfHash.Sha512 => new HMACSHA512(key),
+            HkdfHash.Sha256 => HmacAlgorithm.ComputeAllowEmptyKey(Sha256Algorithm.Hash, 64, key, message),
+            HkdfHash.Sha512 => HmacAlgorithm.ComputeAllowEmptyKey(Sha512Algorithm.Hash, 128, key, message),
             _ => throw new ArgumentOutOfRangeException(nameof(hash), "Unsupported HKDF hash algorithm."),
         };
 

--- a/code/packages/csharp/hkdf/README.md
+++ b/code/packages/csharp/hkdf/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Hkdf.CSharp
 
-HKDF extract-and-expand helpers for .NET.
+HKDF extract-and-expand helpers for .NET, implemented directly with package-local HMAC and hash primitives.
 
 ```csharp
 using CodingAdventures.Hkdf;

--- a/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj
+++ b/code/packages/csharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Xunit" />
     <ProjectReference Include="../../CodingAdventures.Hkdf.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Hmac]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/csharp/hmac/CodingAdventures.Hmac.csproj
+++ b/code/packages/csharp/hmac/CodingAdventures.Hmac.csproj
@@ -16,4 +16,11 @@
     <EmbeddedResource Remove="tests\**" />
     <None Remove="tests\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../md5/CodingAdventures.Md5.csproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.csproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.csproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.csproj" />
+  </ItemGroup>
 </Project>

--- a/code/packages/csharp/hmac/Hmac.cs
+++ b/code/packages/csharp/hmac/Hmac.cs
@@ -1,4 +1,7 @@
-using System.Security.Cryptography;
+using Md5Algorithm = CodingAdventures.Md5.Md5;
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
+using Sha256Algorithm = CodingAdventures.Sha256.Sha256;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
 
 namespace CodingAdventures.Hmac;
 
@@ -13,6 +16,14 @@ public static class Hmac
     /// <summary>Compute the RFC 2104 HMAC construction using a supplied hash function.</summary>
     public static byte[] Compute(Func<byte[], byte[]> hashFunction, int blockSize, byte[] key, byte[] message)
     {
+        ArgumentNullException.ThrowIfNull(key);
+        EnsureNonEmptyKey(key);
+        return ComputeAllowEmptyKey(hashFunction, blockSize, key, message);
+    }
+
+    /// <summary>Compute the RFC 2104 HMAC construction using a supplied hash function, allowing an empty key.</summary>
+    public static byte[] ComputeAllowEmptyKey(Func<byte[], byte[]> hashFunction, int blockSize, byte[] key, byte[] message)
+    {
         ArgumentNullException.ThrowIfNull(hashFunction);
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(message);
@@ -21,8 +32,6 @@ public static class Hmac
         {
             throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be positive.");
         }
-
-        EnsureNonEmptyKey(key);
 
         var keyPrime = NormalizeKey(hashFunction, blockSize, key);
         var innerKey = new byte[blockSize];
@@ -41,19 +50,19 @@ public static class Hmac
 
     /// <summary>Compute HMAC-MD5.</summary>
     public static byte[] HmacMd5(byte[] key, byte[] message) =>
-        Compute(MD5.HashData, 64, key, message);
+        Compute(data => Md5Algorithm.SumMd5(data), 64, key, message);
 
     /// <summary>Compute HMAC-SHA1.</summary>
     public static byte[] HmacSha1(byte[] key, byte[] message) =>
-        Compute(SHA1.HashData, 64, key, message);
+        Compute(Sha1Algorithm.Hash, 64, key, message);
 
     /// <summary>Compute HMAC-SHA256.</summary>
     public static byte[] HmacSha256(byte[] key, byte[] message) =>
-        Compute(SHA256.HashData, 64, key, message);
+        Compute(Sha256Algorithm.Hash, 64, key, message);
 
     /// <summary>Compute HMAC-SHA512.</summary>
     public static byte[] HmacSha512(byte[] key, byte[] message) =>
-        Compute(SHA512.HashData, 128, key, message);
+        Compute(Sha512Algorithm.Hash, 128, key, message);
 
     /// <summary>Compute HMAC-MD5 and return lowercase hex.</summary>
     public static string HmacMd5Hex(byte[] key, byte[] message) =>
@@ -76,7 +85,19 @@ public static class Hmac
     {
         ArgumentNullException.ThrowIfNull(expected);
         ArgumentNullException.ThrowIfNull(actual);
-        return CryptographicOperations.FixedTimeEquals(expected, actual);
+
+        if (expected.Length != actual.Length)
+        {
+            return false;
+        }
+
+        var diff = 0;
+        for (var i = 0; i < expected.Length; i++)
+        {
+            diff |= expected[i] ^ actual[i];
+        }
+
+        return diff == 0;
     }
 
     private static byte[] NormalizeKey(Func<byte[], byte[]> hashFunction, int blockSize, byte[] key)

--- a/code/packages/csharp/hmac/README.md
+++ b/code/packages/csharp/hmac/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Hmac.CSharp
 
-HMAC helpers for .NET.
+HMAC helpers for .NET, implemented directly with package-local hash primitives.
 
 The package provides named HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512, plus a generic RFC 2104 `Compute` helper and constant-time tag verification.
 

--- a/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj
+++ b/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Xunit" />
     <ProjectReference Include="../../CodingAdventures.Hmac.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.cs
+++ b/code/packages/csharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.cs
@@ -1,6 +1,7 @@
-using System.Security.Cryptography;
 using System.Text;
 using HmacAlgorithm = CodingAdventures.Hmac.Hmac;
+using Sha256Algorithm = CodingAdventures.Sha256.Sha256;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
 
 namespace CodingAdventures.Hmac.Tests;
 
@@ -59,8 +60,8 @@ public sealed class HmacTests
         var key = Enumerable.Repeat((byte)0x01, 100).ToArray();
         var message = "msg"u8.ToArray();
 
-        Assert.Equal(HmacAlgorithm.HmacSha256(key, message), HmacAlgorithm.Compute(SHA256.HashData, 64, key, message));
-        Assert.Equal(HmacAlgorithm.HmacSha512(key, message), HmacAlgorithm.Compute(SHA512.HashData, 128, key, message));
+        Assert.Equal(HmacAlgorithm.HmacSha256(key, message), HmacAlgorithm.Compute(Sha256Algorithm.Hash, 64, key, message));
+        Assert.Equal(HmacAlgorithm.HmacSha512(key, message), HmacAlgorithm.Compute(Sha512Algorithm.Hash, 128, key, message));
     }
 
     [Fact]
@@ -77,6 +78,7 @@ public sealed class HmacTests
     public void EmptyKeyIsRejectedButEmptyMessageIsAllowed()
     {
         Assert.Throws<ArgumentException>(() => HmacAlgorithm.HmacSha256([], "message"u8.ToArray()));
+        Assert.Equal(32, HmacAlgorithm.ComputeAllowEmptyKey(Sha256Algorithm.Hash, 64, [], "message"u8.ToArray()).Length);
         Assert.Equal(32, HmacAlgorithm.HmacSha256("key"u8.ToArray(), []).Length);
     }
 
@@ -94,6 +96,6 @@ public sealed class HmacTests
     public void InvalidBlockSizeIsRejected()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            HmacAlgorithm.Compute(SHA256.HashData, 0, "key"u8.ToArray(), "message"u8.ToArray()));
+            HmacAlgorithm.Compute(Sha256Algorithm.Hash, 0, "key"u8.ToArray(), "message"u8.ToArray()));
     }
 }

--- a/code/packages/csharp/pbkdf2/CHANGELOG.md
+++ b/code/packages/csharp/pbkdf2/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# PBKDF2 package backed by `Rfc2898DeriveBytes.Pbkdf2`.
+- Add a native C# PBKDF2 package implemented directly with package-local HMAC and hash primitives.
 - Include SHA-1, SHA-256, SHA-512, hex helpers, validation, and xUnit coverage.

--- a/code/packages/csharp/pbkdf2/CodingAdventures.Pbkdf2.csproj
+++ b/code/packages/csharp/pbkdf2/CodingAdventures.Pbkdf2.csproj
@@ -16,4 +16,11 @@
     <EmbeddedResource Remove="tests\**" />
     <None Remove="tests\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../hmac/CodingAdventures.Hmac.csproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.csproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.csproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.csproj" />
+  </ItemGroup>
 </Project>

--- a/code/packages/csharp/pbkdf2/Pbkdf2.cs
+++ b/code/packages/csharp/pbkdf2/Pbkdf2.cs
@@ -1,6 +1,23 @@
-using System.Security.Cryptography;
+using System.Buffers.Binary;
+using HmacAlgorithm = CodingAdventures.Hmac.Hmac;
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
+using Sha256Algorithm = CodingAdventures.Sha256.Sha256;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
 
 namespace CodingAdventures.Pbkdf2;
+
+/// <summary>Hash families supported by the PBKDF2 helpers.</summary>
+public enum Pbkdf2Hash
+{
+    /// <summary>PBKDF2-HMAC-SHA1.</summary>
+    Sha1,
+
+    /// <summary>PBKDF2-HMAC-SHA256.</summary>
+    Sha256,
+
+    /// <summary>PBKDF2-HMAC-SHA512.</summary>
+    Sha512,
+}
 
 /// <summary>
 /// PBKDF2 key derivation helpers for HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512.
@@ -15,7 +32,7 @@ public static class Pbkdf2
         byte[] salt,
         int iterations,
         int keyLength,
-        HashAlgorithmName hashAlgorithm,
+        Pbkdf2Hash hashAlgorithm,
         bool allowEmptyPassword = false)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -41,12 +58,23 @@ public static class Pbkdf2
             throw new ArgumentOutOfRangeException(nameof(keyLength), "Key length must not exceed 2^20 bytes.");
         }
 
-        return Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keyLength);
+        var digestLength = HashLength(hashAlgorithm);
+        var blockCount = (keyLength + digestLength - 1) / digestLength;
+        var derived = new byte[blockCount * digestLength];
+
+        for (var blockIndex = 1; blockIndex <= blockCount; blockIndex++)
+        {
+            var block = DeriveBlock(password, salt, iterations, hashAlgorithm, blockIndex);
+            Buffer.BlockCopy(block, 0, derived, (blockIndex - 1) * digestLength, digestLength);
+        }
+
+        Array.Resize(ref derived, keyLength);
+        return derived;
     }
 
     /// <summary>Derive key material using PBKDF2-HMAC-SHA1.</summary>
     public static byte[] Pbkdf2HmacSha1(byte[] password, byte[] salt, int iterations, int keyLength) =>
-        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA1);
+        Derive(password, salt, iterations, keyLength, Pbkdf2Hash.Sha1);
 
     /// <summary>Derive key material using PBKDF2-HMAC-SHA256.</summary>
     public static byte[] Pbkdf2HmacSha256(
@@ -55,11 +83,11 @@ public static class Pbkdf2
         int iterations,
         int keyLength,
         bool allowEmptyPassword = false) =>
-        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA256, allowEmptyPassword);
+        Derive(password, salt, iterations, keyLength, Pbkdf2Hash.Sha256, allowEmptyPassword);
 
     /// <summary>Derive key material using PBKDF2-HMAC-SHA512.</summary>
     public static byte[] Pbkdf2HmacSha512(byte[] password, byte[] salt, int iterations, int keyLength) =>
-        Derive(password, salt, iterations, keyLength, HashAlgorithmName.SHA512);
+        Derive(password, salt, iterations, keyLength, Pbkdf2Hash.Sha512);
 
     /// <summary>Derive PBKDF2-HMAC-SHA1 and return lowercase hex.</summary>
     public static string Pbkdf2HmacSha1Hex(byte[] password, byte[] salt, int iterations, int keyLength) =>
@@ -75,4 +103,44 @@ public static class Pbkdf2
 
     private static string ToHex(byte[] data) =>
         Convert.ToHexString(data).ToLowerInvariant();
+
+    private static byte[] DeriveBlock(byte[] password, byte[] salt, int iterations, Pbkdf2Hash hashAlgorithm, int blockIndex)
+    {
+        var firstInput = new byte[salt.Length + 4];
+        Buffer.BlockCopy(salt, 0, firstInput, 0, salt.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(firstInput.AsSpan(salt.Length, 4), (uint)blockIndex);
+
+        var u = ComputeHmac(hashAlgorithm, password, firstInput);
+        var block = u.ToArray();
+
+        for (var iteration = 1; iteration < iterations; iteration++)
+        {
+            u = ComputeHmac(hashAlgorithm, password, u);
+
+            for (var index = 0; index < block.Length; index++)
+            {
+                block[index] ^= u[index];
+            }
+        }
+
+        return block;
+    }
+
+    private static byte[] ComputeHmac(Pbkdf2Hash hashAlgorithm, byte[] key, byte[] message) =>
+        hashAlgorithm switch
+        {
+            Pbkdf2Hash.Sha1 => HmacAlgorithm.ComputeAllowEmptyKey(Sha1Algorithm.Hash, 64, key, message),
+            Pbkdf2Hash.Sha256 => HmacAlgorithm.ComputeAllowEmptyKey(Sha256Algorithm.Hash, 64, key, message),
+            Pbkdf2Hash.Sha512 => HmacAlgorithm.ComputeAllowEmptyKey(Sha512Algorithm.Hash, 128, key, message),
+            _ => throw new ArgumentOutOfRangeException(nameof(hashAlgorithm), "Unsupported PBKDF2 hash algorithm."),
+        };
+
+    private static int HashLength(Pbkdf2Hash hashAlgorithm) =>
+        hashAlgorithm switch
+        {
+            Pbkdf2Hash.Sha1 => 20,
+            Pbkdf2Hash.Sha256 => 32,
+            Pbkdf2Hash.Sha512 => 64,
+            _ => throw new ArgumentOutOfRangeException(nameof(hashAlgorithm), "Unsupported PBKDF2 hash algorithm."),
+        };
 }

--- a/code/packages/csharp/pbkdf2/README.md
+++ b/code/packages/csharp/pbkdf2/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Pbkdf2.CSharp
 
-PBKDF2 key derivation helpers for .NET, backed by `Rfc2898DeriveBytes.Pbkdf2`.
+PBKDF2 key derivation helpers for .NET, implemented directly with package-local HMAC and hash primitives.
 
 ```csharp
 using CodingAdventures.Pbkdf2;

--- a/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj
+++ b/code/packages/csharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Xunit" />
     <ProjectReference Include="../../CodingAdventures.Pbkdf2.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Hmac]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/fsharp/hkdf/CodingAdventures.Hkdf.fsproj
+++ b/code/packages/fsharp/hkdf/CodingAdventures.Hkdf.fsproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../hmac/CodingAdventures.Hmac.fsproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.fsproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.fsproj" />
     <Compile Include="Hkdf.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/hkdf/Hkdf.fs
+++ b/code/packages/fsharp/hkdf/Hkdf.fs
@@ -1,7 +1,7 @@
 namespace CodingAdventures.Hkdf.FSharp
 
 open System
-open System.Security.Cryptography
+open CodingAdventures.Hmac.FSharp
 
 type HkdfHash =
     | Sha256
@@ -14,10 +14,10 @@ module Hkdf =
         | Sha256 -> 32
         | Sha512 -> 64
 
-    let private createHmac hash key =
+    let private computeHmac hash key message =
         match hash with
-        | Sha256 -> new HMACSHA256(key) :> HMAC
-        | Sha512 -> new HMACSHA512(key) :> HMAC
+        | Sha256 -> Hmac.computeAllowEmptyKey CodingAdventures.Sha256.FSharp.Sha256.hash 64 key message
+        | Sha512 -> Hmac.computeAllowEmptyKey CodingAdventures.Sha512.FSharp.Sha512.hash 128 key message
 
     let extract (salt: byte array) (ikm: byte array) hash =
         if isNull salt then nullArg "salt"
@@ -29,8 +29,7 @@ module Hkdf =
             else
                 salt
 
-        use hmac = createHmac hash actualSalt
-        hmac.ComputeHash(ikm)
+        computeHmac hash actualSalt ikm
 
     let expand (prk: byte array) (info: byte array) length hash =
         if isNull prk then nullArg "prk"
@@ -46,9 +45,8 @@ module Hkdf =
         let mutable counter = 1
 
         while offset < length do
-            use hmac = createHmac hash prk
             let input = Array.concat [ previous; info; [| byte counter |] ]
-            previous <- hmac.ComputeHash(input)
+            previous <- computeHmac hash prk input
             let toCopy = min previous.Length (length - offset)
             Buffer.BlockCopy(previous, 0, okm, offset, toCopy)
             offset <- offset + toCopy

--- a/code/packages/fsharp/hkdf/README.md
+++ b/code/packages/fsharp/hkdf/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Hkdf.FSharp
 
-HKDF extract-and-expand helpers for .NET.
+HKDF extract-and-expand helpers for .NET, implemented directly with package-local HMAC and hash primitives.
 
 ```fsharp
 open CodingAdventures.Hkdf.FSharp

--- a/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj
+++ b/code/packages/fsharp/hkdf/tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="../../CodingAdventures.Hkdf.fsproj" />
     <Compile Include="HkdfTests.fs" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Hmac]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/fsharp/hmac/CodingAdventures.Hmac.fsproj
+++ b/code/packages/fsharp/hmac/CodingAdventures.Hmac.fsproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../md5/CodingAdventures.Md5.fsproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.fsproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.fsproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.fsproj" />
     <Compile Include="Hmac.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/hmac/Hmac.fs
+++ b/code/packages/fsharp/hmac/Hmac.fs
@@ -1,7 +1,10 @@
 namespace CodingAdventures.Hmac.FSharp
 
 open System
-open System.Security.Cryptography
+open CodingAdventures.Md5
+open CodingAdventures.Sha1.FSharp
+open CodingAdventures.Sha256.FSharp
+open CodingAdventures.Sha512.FSharp
 
 [<RequireQualifiedAccess>]
 module Hmac =
@@ -26,12 +29,11 @@ module Hmac =
 
         Array.append normalized (Array.zeroCreate (blockSize - normalized.Length))
 
-    let compute (hashFunction: byte array -> byte array) blockSize (key: byte array) (message: byte array) =
+    let computeAllowEmptyKey (hashFunction: byte array -> byte array) blockSize (key: byte array) (message: byte array) =
         if isNull (box hashFunction) then nullArg "hashFunction"
         if isNull key then nullArg "key"
         if isNull message then nullArg "message"
         if blockSize <= 0 then invalidArg "blockSize" "Block size must be positive."
-        ensureNonEmptyKey key
 
         let keyPrime = normalizeKey hashFunction blockSize key
         let innerKey = keyPrime |> Array.map (fun value -> value ^^^ ipad)
@@ -39,13 +41,18 @@ module Hmac =
         let inner = hashFunction (concat innerKey message)
         hashFunction (concat outerKey inner)
 
-    let hmacMd5 key message = compute MD5.HashData 64 key message
+    let compute (hashFunction: byte array -> byte array) blockSize (key: byte array) (message: byte array) =
+        if isNull key then nullArg "key"
+        ensureNonEmptyKey key
+        computeAllowEmptyKey hashFunction blockSize key message
 
-    let hmacSha1 key message = compute SHA1.HashData 64 key message
+    let hmacMd5 key message = compute Md5.sumMd5 64 key message
 
-    let hmacSha256 key message = compute SHA256.HashData 64 key message
+    let hmacSha1 key message = compute Sha1.hash 64 key message
 
-    let hmacSha512 key message = compute SHA512.HashData 128 key message
+    let hmacSha256 key message = compute Sha256.hash 64 key message
+
+    let hmacSha512 key message = compute Sha512.hash 128 key message
 
     let private toHex (data: byte array) =
         Convert.ToHexString(data).ToLowerInvariant()
@@ -61,4 +68,13 @@ module Hmac =
     let verify (expected: byte array) (actual: byte array) =
         if isNull expected then nullArg "expected"
         if isNull actual then nullArg "actual"
-        CryptographicOperations.FixedTimeEquals(expected, actual)
+
+        if expected.Length <> actual.Length then
+            false
+        else
+            let mutable diff = 0
+
+            for index in 0 .. expected.Length - 1 do
+                diff <- diff ||| (int expected[index] ^^^ int actual[index])
+
+            diff = 0

--- a/code/packages/fsharp/hmac/README.md
+++ b/code/packages/fsharp/hmac/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Hmac.FSharp
 
-HMAC helpers for .NET.
+HMAC helpers for .NET, implemented directly with package-local hash primitives.
 
 The package provides named HMAC helpers for MD5, SHA-1, SHA-256, and SHA-512, plus a generic RFC 2104 `compute` helper and constant-time tag verification.
 

--- a/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj
+++ b/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="../../CodingAdventures.Hmac.fsproj" />
     <Compile Include="HmacTests.fs" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.fs
+++ b/code/packages/fsharp/hmac/tests/CodingAdventures.Hmac.Tests/HmacTests.fs
@@ -1,10 +1,11 @@
 namespace CodingAdventures.Hmac.Tests
 
 open System
-open System.Security.Cryptography
 open System.Text
 open Xunit
 open CodingAdventures.Hmac.FSharp
+open CodingAdventures.Sha256.FSharp
+open CodingAdventures.Sha512.FSharp
 
 module HmacTests =
     [<Fact>]
@@ -48,8 +49,8 @@ module HmacTests =
         let key = Array.create 100 0x01uy
         let message = "msg"B
 
-        Assert.Equal<byte array>(Hmac.hmacSha256 key message, Hmac.compute SHA256.HashData 64 key message)
-        Assert.Equal<byte array>(Hmac.hmacSha512 key message, Hmac.compute SHA512.HashData 128 key message)
+        Assert.Equal<byte array>(Hmac.hmacSha256 key message, Hmac.compute Sha256.hash 64 key message)
+        Assert.Equal<byte array>(Hmac.hmacSha512 key message, Hmac.compute Sha512.hash 128 key message)
 
     [<Fact>]
     let ``verify uses constant time comparison semantics`` () =
@@ -62,6 +63,7 @@ module HmacTests =
     [<Fact>]
     let ``empty key is rejected but empty message is allowed`` () =
         Assert.Throws<ArgumentException>(fun () -> Hmac.hmacSha256 [||] "message"B |> ignore) |> ignore
+        Assert.Equal(32, (Hmac.computeAllowEmptyKey Sha256.hash 64 [||] "message"B).Length)
         Assert.Equal(32, (Hmac.hmacSha256 "key"B [||]).Length)
 
     [<Fact>]
@@ -75,5 +77,5 @@ module HmacTests =
 
     [<Fact>]
     let ``invalid block size is rejected`` () =
-        Assert.Throws<ArgumentException>(fun () -> Hmac.compute SHA256.HashData 0 "key"B "message"B |> ignore)
+        Assert.Throws<ArgumentException>(fun () -> Hmac.compute Sha256.hash 0 "key"B "message"B |> ignore)
         |> ignore

--- a/code/packages/fsharp/pbkdf2/CHANGELOG.md
+++ b/code/packages/fsharp/pbkdf2/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# PBKDF2 package backed by `Rfc2898DeriveBytes.Pbkdf2`.
+- Add a native F# PBKDF2 package implemented directly with package-local HMAC and hash primitives.
 - Include SHA-1, SHA-256, SHA-512, hex helpers, validation, and xUnit coverage.

--- a/code/packages/fsharp/pbkdf2/CodingAdventures.Pbkdf2.fsproj
+++ b/code/packages/fsharp/pbkdf2/CodingAdventures.Pbkdf2.fsproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../hmac/CodingAdventures.Hmac.fsproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.fsproj" />
+    <ProjectReference Include="../sha256/CodingAdventures.Sha256.fsproj" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.fsproj" />
     <Compile Include="Pbkdf2.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/pbkdf2/Pbkdf2.fs
+++ b/code/packages/fsharp/pbkdf2/Pbkdf2.fs
@@ -1,11 +1,45 @@
 namespace CodingAdventures.Pbkdf2.FSharp
 
 open System
-open System.Security.Cryptography
+open System.Buffers.Binary
+open CodingAdventures.Hmac.FSharp
+
+type Pbkdf2Hash =
+    | Sha1
+    | Sha256
+    | Sha512
 
 [<RequireQualifiedAccess>]
 module Pbkdf2 =
     let private maxKeyLength = 1 <<< 20
+
+    let private hashLength hashAlgorithm =
+        match hashAlgorithm with
+        | Sha1 -> 20
+        | Sha256 -> 32
+        | Sha512 -> 64
+
+    let private computeHmac hashAlgorithm key message =
+        match hashAlgorithm with
+        | Sha1 -> Hmac.computeAllowEmptyKey CodingAdventures.Sha1.FSharp.Sha1.hash 64 key message
+        | Sha256 -> Hmac.computeAllowEmptyKey CodingAdventures.Sha256.FSharp.Sha256.hash 64 key message
+        | Sha512 -> Hmac.computeAllowEmptyKey CodingAdventures.Sha512.FSharp.Sha512.hash 128 key message
+
+    let private deriveBlock (password: byte array) (salt: byte array) iterations hashAlgorithm blockIndex =
+        let firstInput = Array.zeroCreate<byte> (salt.Length + 4)
+        Buffer.BlockCopy(salt, 0, firstInput, 0, salt.Length)
+        BinaryPrimitives.WriteUInt32BigEndian(firstInput.AsSpan(salt.Length, 4), uint32 blockIndex)
+
+        let mutable u = computeHmac hashAlgorithm password firstInput
+        let block = Array.copy u
+
+        for _iteration in 1 .. iterations - 1 do
+            u <- computeHmac hashAlgorithm password u
+
+            for index in 0 .. block.Length - 1 do
+                block[index] <- block[index] ^^^ u[index]
+
+        block
 
     let derive (password: byte array) (salt: byte array) iterations keyLength hashAlgorithm allowEmptyPassword =
         if isNull password then nullArg "password"
@@ -16,19 +50,27 @@ module Pbkdf2 =
         if keyLength <= 0 then invalidArg "keyLength" "Key length must be positive."
         if keyLength > maxKeyLength then invalidArg "keyLength" "Key length must not exceed 2^20 bytes."
 
-        Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keyLength)
+        let digestLength = hashLength hashAlgorithm
+        let blockCount = (keyLength + digestLength - 1) / digestLength
+        let derived = Array.zeroCreate<byte> (blockCount * digestLength)
+
+        for blockIndex in 1 .. blockCount do
+            let block = deriveBlock password salt iterations hashAlgorithm blockIndex
+            Buffer.BlockCopy(block, 0, derived, (blockIndex - 1) * digestLength, digestLength)
+
+        derived[0 .. keyLength - 1]
 
     let pbkdf2HmacSha1 password salt iterations keyLength =
-        derive password salt iterations keyLength HashAlgorithmName.SHA1 false
+        derive password salt iterations keyLength Sha1 false
 
     let pbkdf2HmacSha256 password salt iterations keyLength =
-        derive password salt iterations keyLength HashAlgorithmName.SHA256 false
+        derive password salt iterations keyLength Sha256 false
 
     let pbkdf2HmacSha256AllowEmptyPassword password salt iterations keyLength =
-        derive password salt iterations keyLength HashAlgorithmName.SHA256 true
+        derive password salt iterations keyLength Sha256 true
 
     let pbkdf2HmacSha512 password salt iterations keyLength =
-        derive password salt iterations keyLength HashAlgorithmName.SHA512 false
+        derive password salt iterations keyLength Sha512 false
 
     let private toHex (data: byte array) =
         Convert.ToHexString(data).ToLowerInvariant()

--- a/code/packages/fsharp/pbkdf2/README.md
+++ b/code/packages/fsharp/pbkdf2/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Pbkdf2.FSharp
 
-PBKDF2 key derivation helpers for .NET, backed by `Rfc2898DeriveBytes.Pbkdf2`.
+PBKDF2 key derivation helpers for .NET, implemented directly with package-local HMAC and hash primitives.
 
 ```fsharp
 open CodingAdventures.Pbkdf2.FSharp

--- a/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj
+++ b/code/packages/fsharp/pbkdf2/tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="../../CodingAdventures.Pbkdf2.fsproj" />
     <Compile Include="Pbkdf2Tests.fs" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Hmac]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*,[CodingAdventures.Sha256]*,[CodingAdventures.Sha512]*</Exclude>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- replace C# and F# HMAC helpers with package-local MD5/SHA-1/SHA-256/SHA-512 implementations and manual tag comparison
- route C# and F# HKDF through the pure HMAC package instead of HMACSHA256/HMACSHA512
- replace C# and F# PBKDF2 Rfc2898DeriveBytes usage with direct PBKDF2 block derivation using the pure HMAC package
- add project references/test coverage excludes and update docs to remove platform-crypto wording

## Verification
- dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Hmac.Tests/CodingAdventures.Hmac.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Hkdf.Tests/CodingAdventures.Hkdf.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Pbkdf2.Tests/CodingAdventures.Pbkdf2.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- scan touched HMAC/HKDF/PBKDF2 package files for System.Security.Cryptography/Rfc2898/HashData/HMACSHA/CryptographicOperations references