### PR TITLE
fix(dotnet): implement aes packages without platform crypto

### DIFF
--- a/code/packages/csharp/aes-modes/AesModes.cs
+++ b/code/packages/csharp/aes-modes/AesModes.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+using System.Buffers.Binary;
 using CodingAdventures.Aes;
 
 namespace CodingAdventures.AesModes;
@@ -193,9 +193,9 @@ public static class AesModes
         ValidateLength(iv, GcmNonceSizeBytes, nameof(iv), "GCM IV");
 
         var ciphertext = new byte[plaintext.Length];
-        var tag = new byte[GcmTagSizeBytes];
-        using var gcm = new AesGcm(key, GcmTagSizeBytes);
-        gcm.Encrypt(iv, plaintext, ciphertext, tag, aad ?? Array.Empty<byte>());
+        var keystreamed = Gctr(key, iv, 2, plaintext);
+        Buffer.BlockCopy(keystreamed, 0, ciphertext, 0, ciphertext.Length);
+        var tag = ComputeGcmTag(key, iv, aad ?? Array.Empty<byte>(), ciphertext);
         return (ciphertext, tag);
     }
 
@@ -212,10 +212,13 @@ public static class AesModes
         ValidateLength(iv, GcmNonceSizeBytes, nameof(iv), "GCM IV");
         ValidateLength(tag, GcmTagSizeBytes, nameof(tag), "GCM tag");
 
-        var plaintext = new byte[ciphertext.Length];
-        using var gcm = new AesGcm(key, GcmTagSizeBytes);
-        gcm.Decrypt(iv, ciphertext, tag, plaintext, aad ?? Array.Empty<byte>());
-        return plaintext;
+        var expectedTag = ComputeGcmTag(key, iv, aad ?? Array.Empty<byte>(), ciphertext);
+        if (!FixedTimeEquals(tag, expectedTag))
+        {
+            throw new InvalidOperationException("AES-GCM authentication tag mismatch.");
+        }
+
+        return Gctr(key, iv, 2, ciphertext);
     }
 
     private static byte[] ReadBlock(byte[] data, int offset)
@@ -234,6 +237,122 @@ public static class AesModes
         block[14] = (byte)(counter >> 8);
         block[15] = (byte)counter;
         return block;
+    }
+
+    private static byte[] Gctr(byte[] key, byte[] nonce, uint initialCounter, byte[] input)
+    {
+        var result = new byte[input.Length];
+        var counter = initialCounter;
+
+        for (var offset = 0; offset < input.Length; offset += BlockSizeBytes)
+        {
+            var keystream = AesBlock.EncryptBlock(BuildCounterBlock(nonce, counter), key);
+            var count = Math.Min(BlockSizeBytes, input.Length - offset);
+            for (var index = 0; index < count; index++)
+            {
+                result[offset + index] = (byte)(input[offset + index] ^ keystream[index]);
+            }
+
+            counter++;
+        }
+
+        return result;
+    }
+
+    private static byte[] ComputeGcmTag(byte[] key, byte[] iv, byte[] aad, byte[] ciphertext)
+    {
+        var hashSubkey = AesBlock.EncryptBlock(new byte[BlockSizeBytes], key);
+        var ghash = GHash(hashSubkey, aad, ciphertext);
+        var encryptedCounter = AesBlock.EncryptBlock(BuildCounterBlock(iv, 1), key);
+        XorInPlace(encryptedCounter, ghash);
+        return encryptedCounter;
+    }
+
+    private static byte[] GHash(byte[] hashSubkey, byte[] aad, byte[] ciphertext)
+    {
+        var value = new byte[BlockSizeBytes];
+        GHashBlocks(value, hashSubkey, aad);
+        GHashBlocks(value, hashSubkey, ciphertext);
+
+        var lengthBlock = new byte[BlockSizeBytes];
+        BinaryPrimitives.WriteUInt64BigEndian(lengthBlock.AsSpan(0, 8), (ulong)aad.Length * 8);
+        BinaryPrimitives.WriteUInt64BigEndian(lengthBlock.AsSpan(8, 8), (ulong)ciphertext.Length * 8);
+        XorInPlace(value, lengthBlock);
+        return MultiplyGf128(value, hashSubkey);
+    }
+
+    private static void GHashBlocks(byte[] value, byte[] hashSubkey, byte[] data)
+    {
+        for (var offset = 0; offset < data.Length; offset += BlockSizeBytes)
+        {
+            var block = new byte[BlockSizeBytes];
+            var count = Math.Min(BlockSizeBytes, data.Length - offset);
+            Buffer.BlockCopy(data, offset, block, 0, count);
+            XorInPlace(value, block);
+            var multiplied = MultiplyGf128(value, hashSubkey);
+            Buffer.BlockCopy(multiplied, 0, value, 0, BlockSizeBytes);
+        }
+    }
+
+    private static byte[] MultiplyGf128(byte[] left, byte[] right)
+    {
+        var result = new byte[BlockSizeBytes];
+        var value = left.ToArray();
+
+        for (var bit = 0; bit < 128; bit++)
+        {
+            if (GetBit(right, bit))
+            {
+                XorInPlace(result, value);
+            }
+
+            var lsbSet = (value[^1] & 1) != 0;
+            ShiftRightOne(value);
+            if (lsbSet)
+            {
+                value[0] ^= 0xe1;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool GetBit(byte[] value, int bitIndex) =>
+        (value[bitIndex / 8] & (1 << (7 - bitIndex % 8))) != 0;
+
+    private static void ShiftRightOne(byte[] value)
+    {
+        var carry = 0;
+        for (var index = 0; index < value.Length; index++)
+        {
+            var nextCarry = value[index] & 1;
+            value[index] = (byte)((value[index] >> 1) | (carry << 7));
+            carry = nextCarry;
+        }
+    }
+
+    private static void XorInPlace(byte[] left, byte[] right)
+    {
+        for (var index = 0; index < left.Length; index++)
+        {
+            left[index] ^= right[index];
+        }
+    }
+
+    private static bool FixedTimeEquals(byte[] expected, byte[] actual)
+    {
+        if (expected.Length != actual.Length)
+        {
+            return false;
+        }
+
+        var diff = 0;
+        for (var index = 0; index < expected.Length; index++)
+        {
+            diff |= expected[index] ^ actual[index];
+        }
+
+        return diff == 0;
     }
 
     private static void ValidateCiphertext(byte[] ciphertext, string paramName, string label)

--- a/code/packages/csharp/aes-modes/CHANGELOG.md
+++ b/code/packages/csharp/aes-modes/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- Initial C# package for AES ECB, CBC, CTR, and GCM helpers.
+- Initial C# package for AES ECB, CBC, CTR, and GCM helpers implemented with package-local primitives.

--- a/code/packages/csharp/aes-modes/README.md
+++ b/code/packages/csharp/aes-modes/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.AesModes.CSharp
 
-AES modes of operation helpers for .NET.
+AES modes of operation helpers for .NET, implemented with the package-local AES block primitive and GHASH.
 
 This package mirrors the repository's AES modes API with PKCS#7 padding, XOR helpers, ECB, CBC, CTR, and GCM. ECB is included for educational parity only; prefer GCM for authenticated encryption.
 

--- a/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.cs
+++ b/code/packages/csharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-
 namespace CodingAdventures.AesModes.Tests;
 
 public sealed class AesModesTests
@@ -126,7 +124,7 @@ public sealed class AesModesTests
         var (ciphertext, tag) = AesModes.GcmEncrypt("secret"u8.ToArray(), key, iv);
 
         ciphertext[0] ^= 1;
-        Assert.Throws<AuthenticationTagMismatchException>(() => AesModes.GcmDecrypt(ciphertext, key, iv, null, tag));
+        Assert.Throws<InvalidOperationException>(() => AesModes.GcmDecrypt(ciphertext, key, iv, null, tag));
         Assert.Throws<ArgumentException>(() => AesModes.GcmEncrypt("test"u8.ToArray(), key, new byte[16]));
         Assert.Throws<ArgumentException>(() => AesModes.GcmDecrypt(Array.Empty<byte>(), key, iv, null, new byte[8]));
     }

--- a/code/packages/csharp/aes/AesBlock.cs
+++ b/code/packages/csharp/aes/AesBlock.cs
@@ -1,22 +1,44 @@
-using System.Security.Cryptography;
-
 namespace CodingAdventures.Aes;
 
 /// <summary>
-/// AES single-block encryption and decryption helpers.
+/// AES single-block encryption and decryption helpers implemented from FIPS 197.
 /// </summary>
 public static class AesBlock
 {
     private const int BlockSizeBytes = 16;
+    private static readonly byte[] Rcon = [0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d];
+    private static readonly byte[] SBox;
+    private static readonly byte[] InvSBox;
+
+    static AesBlock()
+    {
+        (SBox, InvSBox) = BuildSBoxes();
+    }
 
     /// <summary>Encrypt one 16-byte block with a 16-, 24-, or 32-byte AES key.</summary>
     public static byte[] EncryptBlock(byte[] block, byte[] key)
     {
         ValidateBlock(block);
         ValidateKey(key);
-        using var aes = CreateAes(key);
-        using var encryptor = aes.CreateEncryptor();
-        return encryptor.TransformFinalBlock(block, 0, block.Length);
+
+        var expandedKey = ExpandKey(key);
+        var rounds = expandedKey.Length / BlockSizeBytes - 1;
+        var state = block.ToArray();
+
+        AddRoundKey(state, expandedKey, 0);
+
+        for (var round = 1; round < rounds; round++)
+        {
+            SubBytes(state);
+            ShiftRows(state);
+            MixColumns(state);
+            AddRoundKey(state, expandedKey, round);
+        }
+
+        SubBytes(state);
+        ShiftRows(state);
+        AddRoundKey(state, expandedKey, rounds);
+        return state;
     }
 
     /// <summary>Decrypt one 16-byte block with a 16-, 24-, or 32-byte AES key.</summary>
@@ -24,19 +46,235 @@ public static class AesBlock
     {
         ValidateBlock(block);
         ValidateKey(key);
-        using var aes = CreateAes(key);
-        using var decryptor = aes.CreateDecryptor();
-        return decryptor.TransformFinalBlock(block, 0, block.Length);
+
+        var expandedKey = ExpandKey(key);
+        var rounds = expandedKey.Length / BlockSizeBytes - 1;
+        var state = block.ToArray();
+
+        AddRoundKey(state, expandedKey, rounds);
+
+        for (var round = rounds - 1; round >= 1; round--)
+        {
+            InvShiftRows(state);
+            InvSubBytes(state);
+            AddRoundKey(state, expandedKey, round);
+            InvMixColumns(state);
+        }
+
+        InvShiftRows(state);
+        InvSubBytes(state);
+        AddRoundKey(state, expandedKey, 0);
+        return state;
     }
 
-    private static System.Security.Cryptography.Aes CreateAes(byte[] key)
+    private static byte[] ExpandKey(byte[] key)
     {
-        var aes = System.Security.Cryptography.Aes.Create();
-        aes.Mode = CipherMode.ECB;
-        aes.Padding = PaddingMode.None;
-        aes.Key = key.ToArray();
-        return aes;
+        var keyWords = key.Length / 4;
+        var rounds = keyWords switch
+        {
+            4 => 10,
+            6 => 12,
+            8 => 14,
+            _ => throw new ArgumentException("AES key must be 16, 24, or 32 bytes.", nameof(key)),
+        };
+
+        var expanded = new byte[BlockSizeBytes * (rounds + 1)];
+        Buffer.BlockCopy(key, 0, expanded, 0, key.Length);
+
+        Span<byte> temp = stackalloc byte[4];
+        var bytesGenerated = key.Length;
+        var rconIndex = 1;
+
+        while (bytesGenerated < expanded.Length)
+        {
+            for (var index = 0; index < 4; index++)
+            {
+                temp[index] = expanded[bytesGenerated - 4 + index];
+            }
+
+            if (bytesGenerated % key.Length == 0)
+            {
+                RotWord(temp);
+                SubWord(temp);
+                temp[0] ^= Rcon[rconIndex++];
+            }
+            else if (key.Length == 32 && bytesGenerated % key.Length == 16)
+            {
+                SubWord(temp);
+            }
+
+            for (var index = 0; index < 4; index++)
+            {
+                expanded[bytesGenerated] = (byte)(expanded[bytesGenerated - key.Length] ^ temp[index]);
+                bytesGenerated++;
+            }
+        }
+
+        return expanded;
     }
+
+    private static void AddRoundKey(byte[] state, byte[] expandedKey, int round)
+    {
+        var offset = round * BlockSizeBytes;
+        for (var index = 0; index < BlockSizeBytes; index++)
+        {
+            state[index] ^= expandedKey[offset + index];
+        }
+    }
+
+    private static void SubBytes(byte[] state)
+    {
+        for (var index = 0; index < state.Length; index++)
+        {
+            state[index] = SBox[state[index]];
+        }
+    }
+
+    private static void InvSubBytes(byte[] state)
+    {
+        for (var index = 0; index < state.Length; index++)
+        {
+            state[index] = InvSBox[state[index]];
+        }
+    }
+
+    private static void ShiftRows(byte[] state)
+    {
+        var copy = state.ToArray();
+        for (var row = 0; row < 4; row++)
+        {
+            for (var column = 0; column < 4; column++)
+            {
+                state[row + 4 * column] = copy[row + 4 * ((column + row) & 3)];
+            }
+        }
+    }
+
+    private static void InvShiftRows(byte[] state)
+    {
+        var copy = state.ToArray();
+        for (var row = 0; row < 4; row++)
+        {
+            for (var column = 0; column < 4; column++)
+            {
+                state[row + 4 * column] = copy[row + 4 * ((column - row + 4) & 3)];
+            }
+        }
+    }
+
+    private static void MixColumns(byte[] state)
+    {
+        for (var column = 0; column < 4; column++)
+        {
+            var offset = 4 * column;
+            var s0 = state[offset];
+            var s1 = state[offset + 1];
+            var s2 = state[offset + 2];
+            var s3 = state[offset + 3];
+
+            state[offset] = (byte)(Multiply(0x02, s0) ^ Multiply(0x03, s1) ^ s2 ^ s3);
+            state[offset + 1] = (byte)(s0 ^ Multiply(0x02, s1) ^ Multiply(0x03, s2) ^ s3);
+            state[offset + 2] = (byte)(s0 ^ s1 ^ Multiply(0x02, s2) ^ Multiply(0x03, s3));
+            state[offset + 3] = (byte)(Multiply(0x03, s0) ^ s1 ^ s2 ^ Multiply(0x02, s3));
+        }
+    }
+
+    private static void InvMixColumns(byte[] state)
+    {
+        for (var column = 0; column < 4; column++)
+        {
+            var offset = 4 * column;
+            var s0 = state[offset];
+            var s1 = state[offset + 1];
+            var s2 = state[offset + 2];
+            var s3 = state[offset + 3];
+
+            state[offset] = (byte)(Multiply(0x0e, s0) ^ Multiply(0x0b, s1) ^ Multiply(0x0d, s2) ^ Multiply(0x09, s3));
+            state[offset + 1] = (byte)(Multiply(0x09, s0) ^ Multiply(0x0e, s1) ^ Multiply(0x0b, s2) ^ Multiply(0x0d, s3));
+            state[offset + 2] = (byte)(Multiply(0x0d, s0) ^ Multiply(0x09, s1) ^ Multiply(0x0e, s2) ^ Multiply(0x0b, s3));
+            state[offset + 3] = (byte)(Multiply(0x0b, s0) ^ Multiply(0x0d, s1) ^ Multiply(0x09, s2) ^ Multiply(0x0e, s3));
+        }
+    }
+
+    private static void RotWord(Span<byte> word)
+    {
+        var first = word[0];
+        word[0] = word[1];
+        word[1] = word[2];
+        word[2] = word[3];
+        word[3] = first;
+    }
+
+    private static void SubWord(Span<byte> word)
+    {
+        for (var index = 0; index < word.Length; index++)
+        {
+            word[index] = SBox[word[index]];
+        }
+    }
+
+    private static (byte[] SBox, byte[] InvSBox) BuildSBoxes()
+    {
+        var sbox = new byte[256];
+        var invSbox = new byte[256];
+
+        for (var value = 0; value < 256; value++)
+        {
+            var substituted = AffineTransform(MultiplicativeInverse((byte)value));
+            sbox[value] = substituted;
+            invSbox[substituted] = (byte)value;
+        }
+
+        return (sbox, invSbox);
+    }
+
+    private static byte AffineTransform(byte value) =>
+        (byte)(value ^ RotateLeft(value, 1) ^ RotateLeft(value, 2) ^ RotateLeft(value, 3) ^ RotateLeft(value, 4) ^ 0x63);
+
+    private static byte MultiplicativeInverse(byte value)
+    {
+        if (value == 0)
+        {
+            return 0;
+        }
+
+        var result = (byte)1;
+        for (var index = 0; index < 254; index++)
+        {
+            result = Multiply(result, value);
+        }
+
+        return result;
+    }
+
+    private static byte Multiply(byte left, byte right)
+    {
+        var result = 0;
+        var a = left;
+        var b = right;
+
+        for (var index = 0; index < 8; index++)
+        {
+            if ((b & 1) != 0)
+            {
+                result ^= a;
+            }
+
+            var carry = (a & 0x80) != 0;
+            a = (byte)(a << 1);
+            if (carry)
+            {
+                a ^= 0x1b;
+            }
+
+            b >>= 1;
+        }
+
+        return (byte)result;
+    }
+
+    private static byte RotateLeft(byte value, int count) =>
+        (byte)(((value << count) | (value >> (8 - count))) & 0xff);
 
     private static void ValidateBlock(byte[] block)
     {

--- a/code/packages/csharp/aes/CHANGELOG.md
+++ b/code/packages/csharp/aes/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# AES block package backed by `System.Security.Cryptography.Aes`.
+- Add a native C# AES block package implemented directly from FIPS 197.
 - Include AES-128, AES-192, AES-256 vectors, validation, and xUnit coverage.

--- a/code/packages/csharp/aes/README.md
+++ b/code/packages/csharp/aes/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Aes.CSharp
 
-AES single-block helpers for .NET.
+AES single-block helpers for .NET, implemented directly from FIPS 197.
 
 This package mirrors the repository's low-level AES block API. It encrypts or decrypts exactly one 16-byte block with a 16-, 24-, or 32-byte key.
 

--- a/code/packages/fsharp/aes-modes/AesModes.fs
+++ b/code/packages/fsharp/aes-modes/AesModes.fs
@@ -1,7 +1,7 @@
 namespace CodingAdventures.AesModes.FSharp
 
 open System
-open System.Security.Cryptography
+open System.Buffers.Binary
 open CodingAdventures.Aes.FSharp
 
 [<RequireQualifiedAccess>]
@@ -158,15 +158,102 @@ module AesModes =
     let ctrDecrypt (ciphertext: byte array) (key: byte array) (nonce: byte array) =
         ctrEncrypt ciphertext key nonce
 
+    let private xorInPlace (left: byte array) (right: byte array) =
+        for index in 0 .. left.Length - 1 do
+            left[index] <- left[index] ^^^ right[index]
+
+    let private getBit (value: byte array) bitIndex =
+        (int value[bitIndex / 8] &&& (1 <<< (7 - bitIndex % 8))) <> 0
+
+    let private shiftRightOne (value: byte array) =
+        let mutable carry = 0
+
+        for index in 0 .. value.Length - 1 do
+            let nextCarry = int value[index] &&& 1
+            value[index] <- byte (((int value[index] >>> 1) ||| (carry <<< 7)) &&& 0xff)
+            carry <- nextCarry
+
+    let private multiplyGf128 (left: byte array) (right: byte array) =
+        let result = Array.zeroCreate<byte> blockSizeBytes
+        let value = Array.copy left
+
+        for bit in 0 .. 127 do
+            if getBit right bit then
+                xorInPlace result value
+
+            let lsbSet = (value[value.Length - 1] &&& 1uy) <> 0uy
+            shiftRightOne value
+
+            if lsbSet then
+                value[0] <- value[0] ^^^ 0xe1uy
+
+        result
+
+    let private ghashBlocks (value: byte array) (hashSubkey: byte array) (data: byte array) =
+        let mutable offset = 0
+
+        while offset < data.Length do
+            let block = Array.zeroCreate<byte> blockSizeBytes
+            let count = min blockSizeBytes (data.Length - offset)
+            Buffer.BlockCopy(data, offset, block, 0, count)
+            xorInPlace value block
+            let multiplied = multiplyGf128 value hashSubkey
+            Buffer.BlockCopy(multiplied, 0, value, 0, blockSizeBytes)
+            offset <- offset + blockSizeBytes
+
+    let private ghash hashSubkey aad ciphertext =
+        let value = Array.zeroCreate<byte> blockSizeBytes
+        ghashBlocks value hashSubkey aad
+        ghashBlocks value hashSubkey ciphertext
+
+        let lengthBlock = Array.zeroCreate<byte> blockSizeBytes
+        BinaryPrimitives.WriteUInt64BigEndian(lengthBlock.AsSpan(0, 8), uint64 aad.Length * 8UL)
+        BinaryPrimitives.WriteUInt64BigEndian(lengthBlock.AsSpan(8, 8), uint64 ciphertext.Length * 8UL)
+        xorInPlace value lengthBlock
+        multiplyGf128 value hashSubkey
+
+    let private gctr key nonce initialCounter (input: byte array) =
+        let result = Array.zeroCreate<byte> input.Length
+        let mutable counter = initialCounter
+        let mutable offset = 0
+
+        while offset < input.Length do
+            let keystream = AesBlock.encryptBlock (buildCounterBlock nonce counter) key
+            let count = min blockSizeBytes (input.Length - offset)
+
+            for index in 0 .. count - 1 do
+                result[offset + index] <- input[offset + index] ^^^ keystream[index]
+
+            counter <- counter + 1u
+            offset <- offset + blockSizeBytes
+
+        result
+
+    let private computeGcmTag key iv aad ciphertext =
+        let hashSubkey = AesBlock.encryptBlock (Array.zeroCreate<byte> blockSizeBytes) key
+        let tagMask = AesBlock.encryptBlock (buildCounterBlock iv 1u) key
+        let authentication = ghash hashSubkey aad ciphertext
+        xorInPlace tagMask authentication
+        tagMask
+
+    let private fixedTimeEquals (expected: byte array) (actual: byte array) =
+        if expected.Length <> actual.Length then
+            false
+        else
+            let mutable diff = 0
+
+            for index in 0 .. expected.Length - 1 do
+                diff <- diff ||| (int expected[index] ^^^ int actual[index])
+
+            diff = 0
+
     let gcmEncrypt (plaintext: byte array) (key: byte array) (iv: byte array) (aad: byte array) =
         requireBytes "plaintext" plaintext
         validateKey key
         validateLength "iv" "GCM IV" gcmNonceSizeBytes iv
         let aadValue = if isNull aad then Array.empty<byte> else aad
-        let ciphertext = Array.zeroCreate<byte> plaintext.Length
-        let tag = Array.zeroCreate<byte> gcmTagSizeBytes
-        use gcm = new AesGcm(key, gcmTagSizeBytes)
-        gcm.Encrypt(iv, plaintext, ciphertext, tag, aadValue)
+        let ciphertext = gctr key iv 2u plaintext
+        let tag = computeGcmTag key iv aadValue ciphertext
         ciphertext, tag
 
     let gcmDecrypt (ciphertext: byte array) (key: byte array) (iv: byte array) (aad: byte array) (tag: byte array) =
@@ -175,7 +262,9 @@ module AesModes =
         validateLength "iv" "GCM IV" gcmNonceSizeBytes iv
         validateLength "tag" "GCM tag" gcmTagSizeBytes tag
         let aadValue = if isNull aad then Array.empty<byte> else aad
-        let plaintext = Array.zeroCreate<byte> ciphertext.Length
-        use gcm = new AesGcm(key, gcmTagSizeBytes)
-        gcm.Decrypt(iv, ciphertext, tag, plaintext, aadValue)
-        plaintext
+        let expectedTag = computeGcmTag key iv aadValue ciphertext
+
+        if not (fixedTimeEquals tag expectedTag) then
+            raise (InvalidOperationException "AES-GCM authentication tag mismatch.")
+
+        gctr key iv 2u ciphertext

--- a/code/packages/fsharp/aes-modes/CHANGELOG.md
+++ b/code/packages/fsharp/aes-modes/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- Initial F# package for AES ECB, CBC, CTR, and GCM helpers.
+- Initial F# package for AES ECB, CBC, CTR, and GCM helpers implemented with package-local primitives.

--- a/code/packages/fsharp/aes-modes/README.md
+++ b/code/packages/fsharp/aes-modes/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.AesModes.FSharp
 
-AES modes of operation helpers for .NET.
+AES modes of operation helpers for .NET, implemented with the package-local AES block primitive and GHASH.
 
 This package mirrors the repository's AES modes API with PKCS#7 padding, XOR helpers, ECB, CBC, CTR, and GCM. ECB is included for educational parity only; prefer GCM for authenticated encryption.
 

--- a/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.fs
+++ b/code/packages/fsharp/aes-modes/tests/CodingAdventures.AesModes.Tests/AesModesTests.fs
@@ -1,7 +1,6 @@
 namespace CodingAdventures.AesModes.Tests
 
 open System
-open System.Security.Cryptography
 open Xunit
 open CodingAdventures.AesModes.FSharp
 
@@ -121,6 +120,6 @@ module AesModesTests =
         let ciphertext, tag = AesModes.gcmEncrypt (utf8 "secret") key iv null
 
         ciphertext.[0] <- ciphertext.[0] ^^^ 1uy
-        Assert.Throws<AuthenticationTagMismatchException>(fun () -> AesModes.gcmDecrypt ciphertext key iv null tag |> ignore) |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> AesModes.gcmDecrypt ciphertext key iv null tag |> ignore) |> ignore
         Assert.Throws<ArgumentException>(fun () -> AesModes.gcmEncrypt (utf8 "test") key (Array.zeroCreate<byte> 16) null |> ignore) |> ignore
         Assert.Throws<ArgumentException>(fun () -> AesModes.gcmDecrypt Array.empty<byte> key iv null (Array.zeroCreate<byte> 8) |> ignore) |> ignore

--- a/code/packages/fsharp/aes/AesBlock.fs
+++ b/code/packages/fsharp/aes/AesBlock.fs
@@ -1,11 +1,66 @@
 namespace CodingAdventures.Aes.FSharp
 
 open System
-open System.Security.Cryptography
 
 [<RequireQualifiedAccess>]
 module AesBlock =
     let private blockSizeBytes = 16
+
+    let private rcon =
+        [| 0x00uy; 0x01uy; 0x02uy; 0x04uy; 0x08uy; 0x10uy; 0x20uy; 0x40uy; 0x80uy; 0x1buy; 0x36uy; 0x6cuy; 0xd8uy; 0xabuy; 0x4duy |]
+
+    let private multiply (left: byte) (right: byte) =
+        let mutable result = 0
+        let mutable a = left
+        let mutable b = right
+
+        for _ in 0 .. 7 do
+            if (b &&& 1uy) <> 0uy then
+                result <- result ^^^ int a
+
+            let carry = (a &&& 0x80uy) <> 0uy
+            a <- byte ((int a <<< 1) &&& 0xff)
+            if carry then
+                a <- a ^^^ 0x1buy
+
+            b <- b >>> 1
+
+        byte result
+
+    let private rotateLeft (value: byte) count =
+        byte (((int value <<< count) ||| (int value >>> (8 - count))) &&& 0xff)
+
+    let private multiplicativeInverse value =
+        if value = 0uy then
+            0uy
+        else
+            let mutable result = 1uy
+
+            for _ in 0 .. 253 do
+                result <- multiply result value
+
+            result
+
+    let private affineTransform value =
+        value
+        ^^^ rotateLeft value 1
+        ^^^ rotateLeft value 2
+        ^^^ rotateLeft value 3
+        ^^^ rotateLeft value 4
+        ^^^ 0x63uy
+
+    let private buildSBoxes () =
+        let sbox = Array.zeroCreate<byte> 256
+        let invSbox = Array.zeroCreate<byte> 256
+
+        for value in 0 .. 255 do
+            let substituted = affineTransform (multiplicativeInverse (byte value))
+            sbox[value] <- substituted
+            invSbox[int substituted] <- byte value
+
+        sbox, invSbox
+
+    let private sbox, invSbox = buildSBoxes ()
 
     let private validateBlock (block: byte array) =
         if isNull block then nullArg "block"
@@ -17,23 +72,142 @@ module AesBlock =
         if key.Length <> 16 && key.Length <> 24 && key.Length <> 32 then
             invalidArg "key" "AES key must be 16, 24, or 32 bytes."
 
-    let private createAes (key: byte array) =
-        let aes = Aes.Create()
-        aes.Mode <- CipherMode.ECB
-        aes.Padding <- PaddingMode.None
-        aes.Key <- Array.copy key
-        aes
+    let private rotWord (word: byte array) =
+        let first = word[0]
+        word[0] <- word[1]
+        word[1] <- word[2]
+        word[2] <- word[3]
+        word[3] <- first
+
+    let private subWord (word: byte array) =
+        for index in 0 .. word.Length - 1 do
+            word[index] <- sbox[int word[index]]
+
+    let private roundsForKeyLength keyLength =
+        match keyLength with
+        | 16 -> 10
+        | 24 -> 12
+        | 32 -> 14
+        | _ -> invalidArg "key" "AES key must be 16, 24, or 32 bytes."
+
+    let private expandKey (key: byte array) =
+        let rounds = roundsForKeyLength key.Length
+        let expanded = Array.zeroCreate<byte> (blockSizeBytes * (rounds + 1))
+        Buffer.BlockCopy(key, 0, expanded, 0, key.Length)
+        let temp = Array.zeroCreate<byte> 4
+        let mutable bytesGenerated = key.Length
+        let mutable rconIndex = 1
+
+        while bytesGenerated < expanded.Length do
+            for index in 0 .. 3 do
+                temp[index] <- expanded[bytesGenerated - 4 + index]
+
+            if bytesGenerated % key.Length = 0 then
+                rotWord temp
+                subWord temp
+                temp[0] <- temp[0] ^^^ rcon[rconIndex]
+                rconIndex <- rconIndex + 1
+            elif key.Length = 32 && bytesGenerated % key.Length = 16 then
+                subWord temp
+
+            for index in 0 .. 3 do
+                expanded[bytesGenerated] <- expanded[bytesGenerated - key.Length] ^^^ temp[index]
+                bytesGenerated <- bytesGenerated + 1
+
+        expanded
+
+    let private addRoundKey (state: byte array) (expandedKey: byte array) round =
+        let offset = round * blockSizeBytes
+
+        for index in 0 .. blockSizeBytes - 1 do
+            state[index] <- state[index] ^^^ expandedKey[offset + index]
+
+    let private subBytes (state: byte array) =
+        for index in 0 .. state.Length - 1 do
+            state[index] <- sbox[int state[index]]
+
+    let private invSubBytes (state: byte array) =
+        for index in 0 .. state.Length - 1 do
+            state[index] <- invSbox[int state[index]]
+
+    let private shiftRows (state: byte array) =
+        let copy = Array.copy state
+
+        for row in 0 .. 3 do
+            for column in 0 .. 3 do
+                state[row + 4 * column] <- copy[row + 4 * ((column + row) &&& 3)]
+
+    let private invShiftRows (state: byte array) =
+        let copy = Array.copy state
+
+        for row in 0 .. 3 do
+            for column in 0 .. 3 do
+                state[row + 4 * column] <- copy[row + 4 * ((column - row + 4) &&& 3)]
+
+    let private mixColumns (state: byte array) =
+        for column in 0 .. 3 do
+            let offset = 4 * column
+            let s0 = state[offset]
+            let s1 = state[offset + 1]
+            let s2 = state[offset + 2]
+            let s3 = state[offset + 3]
+
+            state[offset] <- multiply 0x02uy s0 ^^^ multiply 0x03uy s1 ^^^ s2 ^^^ s3
+            state[offset + 1] <- s0 ^^^ multiply 0x02uy s1 ^^^ multiply 0x03uy s2 ^^^ s3
+            state[offset + 2] <- s0 ^^^ s1 ^^^ multiply 0x02uy s2 ^^^ multiply 0x03uy s3
+            state[offset + 3] <- multiply 0x03uy s0 ^^^ s1 ^^^ s2 ^^^ multiply 0x02uy s3
+
+    let private invMixColumns (state: byte array) =
+        for column in 0 .. 3 do
+            let offset = 4 * column
+            let s0 = state[offset]
+            let s1 = state[offset + 1]
+            let s2 = state[offset + 2]
+            let s3 = state[offset + 3]
+
+            state[offset] <- multiply 0x0euy s0 ^^^ multiply 0x0buy s1 ^^^ multiply 0x0duy s2 ^^^ multiply 0x09uy s3
+            state[offset + 1] <- multiply 0x09uy s0 ^^^ multiply 0x0euy s1 ^^^ multiply 0x0buy s2 ^^^ multiply 0x0duy s3
+            state[offset + 2] <- multiply 0x0duy s0 ^^^ multiply 0x09uy s1 ^^^ multiply 0x0euy s2 ^^^ multiply 0x0buy s3
+            state[offset + 3] <- multiply 0x0buy s0 ^^^ multiply 0x0duy s1 ^^^ multiply 0x09uy s2 ^^^ multiply 0x0euy s3
 
     let encryptBlock (block: byte array) (key: byte array) =
         validateBlock block
         validateKey key
-        use aes = createAes key
-        use encryptor = aes.CreateEncryptor()
-        encryptor.TransformFinalBlock(block, 0, block.Length)
+
+        let expandedKey = expandKey key
+        let rounds = expandedKey.Length / blockSizeBytes - 1
+        let state = Array.copy block
+
+        addRoundKey state expandedKey 0
+
+        for round in 1 .. rounds - 1 do
+            subBytes state
+            shiftRows state
+            mixColumns state
+            addRoundKey state expandedKey round
+
+        subBytes state
+        shiftRows state
+        addRoundKey state expandedKey rounds
+        state
 
     let decryptBlock (block: byte array) (key: byte array) =
         validateBlock block
         validateKey key
-        use aes = createAes key
-        use decryptor = aes.CreateDecryptor()
-        decryptor.TransformFinalBlock(block, 0, block.Length)
+
+        let expandedKey = expandKey key
+        let rounds = expandedKey.Length / blockSizeBytes - 1
+        let state = Array.copy block
+
+        addRoundKey state expandedKey rounds
+
+        for round in rounds - 1 .. -1 .. 1 do
+            invShiftRows state
+            invSubBytes state
+            addRoundKey state expandedKey round
+            invMixColumns state
+
+        invShiftRows state
+        invSubBytes state
+        addRoundKey state expandedKey 0
+        state

--- a/code/packages/fsharp/aes/CHANGELOG.md
+++ b/code/packages/fsharp/aes/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# AES block package backed by `System.Security.Cryptography.Aes`.
+- Add a native F# AES block package implemented directly from FIPS 197.
 - Include AES-128, AES-192, AES-256 vectors, validation, and xUnit coverage.

--- a/code/packages/fsharp/aes/README.md
+++ b/code/packages/fsharp/aes/README.md
@@ -1,6 +1,6 @@
 # CodingAdventures.Aes.FSharp
 
-AES single-block helpers for .NET.
+AES single-block helpers for .NET, implemented directly from FIPS 197.
 
 This package mirrors the repository's low-level AES block API. It encrypts or decrypts exactly one 16-byte block with a 16-, 24-, or 32-byte key.
 


### PR DESCRIPTION
## Summary
- replace C# and F# AES block wrappers with package-local FIPS 197 key expansion, round functions, and inverse rounds
- replace C# and F# AES-GCM wrappers with package-local CTR, GHASH over GF(2^128), tag generation, and tag verification
- keep ECB/CBC/CTR/GCM public APIs stable except tamper failure now raises InvalidOperationException instead of the platform crypto exception
- update package docs/changelogs to remove System.Security.Cryptography wording

## Verification
- dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Aes.Tests/CodingAdventures.Aes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.AesModes.Tests/CodingAdventures.AesModes.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- scan AES/AES-modes source and docs for System.Security/AesGcm/Aes.Create/CipherMode/PaddingMode references