### PR TITLE
fix(dotnet): remove platform crypto from utility packages

### DIFF
--- a/code/packages/csharp/hash-functions/HashFunctions.cs
+++ b/code/packages/csharp/hash-functions/HashFunctions.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace CodingAdventures.HashFunctions;
@@ -265,12 +264,13 @@ public static class HashFunctions
         }
 
         var input = new byte[8];
+        var sampleState = 0x9E3779B97F4A7C15UL;
         ulong totalBitFlips = 0;
         ulong totalTrials = 0;
 
         for (var sample = 0; sample < sampleSize; sample++)
         {
-            RandomNumberGenerator.Fill(input);
+            FillDeterministicSample(input, ref sampleState);
             var h1 = hashFunction(input);
 
             for (var bitPosition = 0; bitPosition < input.Length * 8; bitPosition++)
@@ -328,6 +328,28 @@ public static class HashFunctions
         hash = unchecked(hash * 0xC2B2AE35);
         hash ^= hash >> 16;
         return hash;
+    }
+
+    private static void FillDeterministicSample(byte[] input, ref ulong state)
+    {
+        var offset = 0;
+        while (offset < input.Length)
+        {
+            var value = NextSplitMix64(ref state);
+            for (var index = 0; index < 8 && offset < input.Length; index++)
+            {
+                input[offset++] = (byte)(value >> (index * 8));
+            }
+        }
+    }
+
+    private static ulong NextSplitMix64(ref ulong state)
+    {
+        state = unchecked(state + 0x9E3779B97F4A7C15UL);
+        var value = state;
+        value = unchecked((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9UL);
+        value = unchecked((value ^ (value >> 27)) * 0x94D049BB133111EBUL);
+        return value ^ (value >> 31);
     }
 
     private static void SipRound(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3)

--- a/code/packages/csharp/zeroize/Zeroize.cs
+++ b/code/packages/csharp/zeroize/Zeroize.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-
 namespace CodingAdventures.Zeroize;
 
 /// <summary>
@@ -11,7 +9,10 @@ public static class Zeroize
     public static void ZeroizeBytes(byte[] buffer)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-        CryptographicOperations.ZeroMemory(buffer.AsSpan());
+        for (var index = 0; index < buffer.Length; index++)
+        {
+            buffer[index] = 0;
+        }
     }
 
     /// <summary>Clear a character buffer.</summary>

--- a/code/packages/fsharp/hash-functions/HashFunctions.fs
+++ b/code/packages/fsharp/hash-functions/HashFunctions.fs
@@ -2,7 +2,6 @@ namespace CodingAdventures.HashFunctions.FSharp
 
 open System
 open System.Numerics
-open System.Security.Cryptography
 open System.Text
 
 type HashFunction =
@@ -113,6 +112,25 @@ module HashFunctions =
         hash <- hash * 0xC2B2AE35u
         hash <- hash ^^^ (hash >>> 16)
         hash
+
+    let private nextSplitMix64 (state: byref<uint64>) =
+        state <- state + 0x9E3779B97F4A7C15UL
+        let mutable value = state
+        value <- (value ^^^ (value >>> 30)) * 0xBF58476D1CE4E5B9UL
+        value <- (value ^^^ (value >>> 27)) * 0x94D049BB133111EBUL
+        value ^^^ (value >>> 31)
+
+    let private fillDeterministicSample (input: byte array) (state: byref<uint64>) =
+        let mutable offset = 0
+
+        while offset < input.Length do
+            let value = nextSplitMix64 &state
+            let mutable index = 0
+
+            while index < 8 && offset < input.Length do
+                input[offset] <- byte ((value >>> (index * 8)) &&& 0xffUL)
+                offset <- offset + 1
+                index <- index + 1
 
     let murmur3_32BytesWithSeed (data: byte array) (seed: uint32) =
         requireBytes "data" data
@@ -242,10 +260,11 @@ module HashFunctions =
             invalidArg "sampleSize" "Sample size must be positive."
 
         let input = Array.zeroCreate<byte> 8
+        let mutable sampleState = 0x9E3779B97F4A7C15UL
         let mutable totalBitFlips = 0UL
         let mutable totalTrials = 0UL
         for _ in 1 .. sampleSize do
-            RandomNumberGenerator.Fill input
+            fillDeterministicSample input &sampleState
             let h1 = hashFunction input
 
             for bitPosition in 0 .. input.Length * 8 - 1 do

--- a/code/packages/fsharp/zeroize/Zeroize.fs
+++ b/code/packages/fsharp/zeroize/Zeroize.fs
@@ -1,13 +1,14 @@
 namespace CodingAdventures.Zeroize.FSharp
 
 open System
-open System.Security.Cryptography
 
 [<RequireQualifiedAccess>]
 module Zeroize =
     let zeroizeBytes (buffer: byte array) =
         if isNull buffer then nullArg "buffer"
-        CryptographicOperations.ZeroMemory(buffer.AsSpan())
+
+        for index in 0 .. buffer.Length - 1 do
+            buffer[index] <- 0uy
 
     let zeroizeChars (buffer: char array) =
         if isNull buffer then nullArg "buffer"


### PR DESCRIPTION
## Summary
- replace C# and F# zeroize byte clearing with direct in-place zero loops
- replace C# and F# hash-functions avalanche sampling with deterministic SplitMix64 input generation instead of RandomNumberGenerator
- keep public APIs stable and remove remaining platform-crypto references from these utility packages

## Verification
- dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Zeroize.Tests/CodingAdventures.Zeroize.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.HashFunctions.Tests/CodingAdventures.HashFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- scan zeroize/hash-functions source and docs for System.Security/RandomNumberGenerator/CryptographicOperations references