### PR TITLE
fix(dotnet): route uuid crypto through package primitives

### DIFF
--- a/code/packages/csharp/uuid/CHANGELOG.md
+++ b/code/packages/csharp/uuid/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- Initial C# UUID package with RFC 4122 and RFC 9562 helpers.
+- Initial C# UUID package with RFC 4122 and RFC 9562 helpers backed by package-local hash and CSPRNG packages.

--- a/code/packages/csharp/uuid/CodingAdventures.Uuid.csproj
+++ b/code/packages/csharp/uuid/CodingAdventures.Uuid.csproj
@@ -16,4 +16,10 @@
     <EmbeddedResource Remove="tests\**" />
     <None Remove="tests\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csprng/CodingAdventures.Csprng.csproj" />
+    <ProjectReference Include="../md5/CodingAdventures.Md5.csproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.csproj" />
+  </ItemGroup>
 </Project>

--- a/code/packages/csharp/uuid/README.md
+++ b/code/packages/csharp/uuid/README.md
@@ -2,3 +2,6 @@
 
 RFC 4122 and RFC 9562 UUID parsing, formatting, byte conversion, comparison,
 namespace constants, and v1/v3/v4/v5/v7 generation helpers.
+
+Name-based UUIDs use package-local MD5/SHA-1 implementations, and random UUIDs
+draw bytes through the repository CSPRNG package.

--- a/code/packages/csharp/uuid/Uuid.cs
+++ b/code/packages/csharp/uuid/Uuid.cs
@@ -1,8 +1,10 @@
 using System.Buffers.Binary;
 using System.Globalization;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using CsprngAlgorithm = CodingAdventures.Csprng.Csprng;
+using Md5Algorithm = CodingAdventures.Md5.Md5;
+using Sha1Algorithm = CodingAdventures.Sha1.Sha1;
 
 namespace CodingAdventures.Uuid;
 
@@ -186,7 +188,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
     /// </summary>
     public static Uuid V4()
     {
-        var bytes = RandomNumberGenerator.GetBytes(16);
+        var bytes = CsprngAlgorithm.RandomBytes(16);
         return StampVersionVariant(bytes, 4);
     }
 
@@ -196,7 +198,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
     public static Uuid V7()
     {
         var timestampMs = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        var random = RandomNumberGenerator.GetBytes(10);
+        var random = CsprngAlgorithm.RandomBytes(10);
         var raw = new byte[16];
         raw[0] = (byte)((timestampMs >> 40) & 0xFFUL);
         raw[1] = (byte)((timestampMs >> 32) & 0xFFUL);
@@ -224,7 +226,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
 
         var clockSeqHi = 0x80UL | ((uint)ClockSequence >> 8);
         var clockSeqLow = (uint)ClockSequence & 0xFFU;
-        var nodeBytes = RandomNumberGenerator.GetBytes(6);
+        var nodeBytes = CsprngAlgorithm.RandomBytes(6);
         nodeBytes[0] = (byte)(nodeBytes[0] | 0x01);
 
         var node = 0UL;
@@ -243,7 +245,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
     public static Uuid V5(Uuid namespaceId, string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        var digest = SHA1.HashData(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name)));
+        var digest = Sha1Algorithm.Hash(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name)));
         var raw = new byte[16];
         digest.AsSpan(0, 16).CopyTo(raw);
         return StampVersionVariant(raw, 5);
@@ -255,7 +257,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
     public static Uuid V3(Uuid namespaceId, string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        return StampVersionVariant(MD5.HashData(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name))), 3);
+        return StampVersionVariant(Md5Algorithm.SumMd5(Concat(namespaceId.ToBytes(), Encoding.UTF8.GetBytes(name))), 3);
     }
 
     private static Uuid StampVersionVariant(byte[] bytes, int version)
@@ -275,8 +277,7 @@ public readonly record struct Uuid(ulong Msb, ulong Lsb) : IComparable<Uuid>
 
     private static int CreateClockSequence()
     {
-        Span<byte> bytes = stackalloc byte[2];
-        RandomNumberGenerator.Fill(bytes);
+        var bytes = CsprngAlgorithm.RandomBytes(2);
         return (((bytes[0] << 8) | bytes[1]) & 0x3FFF);
     }
 }

--- a/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj
+++ b/code/packages/csharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Xunit" />
     <ProjectReference Include="../../CodingAdventures.Uuid.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Csprng]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*</Exclude>
+  </PropertyGroup>
 </Project>

--- a/code/packages/fsharp/uuid/CHANGELOG.md
+++ b/code/packages/fsharp/uuid/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- Initial F# UUID package with RFC 4122 and RFC 9562 helpers.
+- Initial F# UUID package with RFC 4122 and RFC 9562 helpers backed by package-local hash and CSPRNG packages.

--- a/code/packages/fsharp/uuid/CodingAdventures.Uuid.fsproj
+++ b/code/packages/fsharp/uuid/CodingAdventures.Uuid.fsproj
@@ -9,6 +9,9 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="../csprng/CodingAdventures.Csprng.fsproj" />
+    <ProjectReference Include="../md5/CodingAdventures.Md5.fsproj" />
+    <ProjectReference Include="../sha1/CodingAdventures.Sha1.fsproj" />
     <Compile Include="Uuid.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/uuid/README.md
+++ b/code/packages/fsharp/uuid/README.md
@@ -2,3 +2,6 @@
 
 RFC 4122 and RFC 9562 UUID parsing, formatting, byte conversion, comparison,
 namespace constants, and v1/v3/v4/v5/v7 generation helpers.
+
+Name-based UUIDs use package-local MD5/SHA-1 implementations, and random UUIDs
+draw bytes through the repository CSPRNG package.

--- a/code/packages/fsharp/uuid/Uuid.fs
+++ b/code/packages/fsharp/uuid/Uuid.fs
@@ -3,9 +3,11 @@ namespace CodingAdventures.Uuid
 open System
 open System.Buffers.Binary
 open System.Globalization
-open System.Security.Cryptography
 open System.Text
 open System.Text.RegularExpressions
+open CodingAdventures.Csprng.FSharp
+open CodingAdventures.Md5
+open CodingAdventures.Sha1.FSharp
 
 type UuidException(message: string, innerException: exn) =
     inherit ArgumentException(message, innerException)
@@ -63,8 +65,7 @@ module Uuid =
     let private gregorianOffset = 122_192_928_000_000_000UL
 
     let private createClockSequence () =
-        let bytes = Array.zeroCreate<byte> 2
-        RandomNumberGenerator.Fill(bytes)
+        let bytes = Csprng.randomBytes 2
         ((int bytes[0] <<< 8) ||| int bytes[1]) &&& 0x3FFF
 
     let private clockSequence = createClockSequence ()
@@ -129,12 +130,12 @@ module Uuid =
         fromBytes bytes
 
     let v4 () =
-        let bytes = RandomNumberGenerator.GetBytes 16
+        let bytes = Csprng.randomBytes 16
         stampVersionVariant bytes 4
 
     let v7 () =
         let timestampMs = uint64 (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
-        let random = RandomNumberGenerator.GetBytes 10
+        let random = Csprng.randomBytes 10
         let raw = Array.zeroCreate<byte> 16
         raw[0] <- byte ((timestampMs >>> 40) &&& 0xFFUL)
         raw[1] <- byte ((timestampMs >>> 32) &&& 0xFFUL)
@@ -159,7 +160,7 @@ module Uuid =
         let msb = (timeLow <<< 32) ||| (timeMid <<< 16) ||| (0x1000UL ||| timeHi)
         let clockSeqHi = 0x80UL ||| (uint64 clockSequence >>> 8)
         let clockSeqLow = uint64 (clockSequence &&& 0xFF)
-        let nodeBytes = RandomNumberGenerator.GetBytes 6
+        let nodeBytes = Csprng.randomBytes 6
         nodeBytes[0] <- byte (int nodeBytes[0] ||| 0x01)
 
         let mutable node = 0UL
@@ -182,7 +183,7 @@ module Uuid =
 
         let digest =
             concat (namespaceId.ToBytes()) (Encoding.UTF8.GetBytes name)
-            |> SHA1.HashData
+            |> Sha1.hash
 
         let raw = digest[..15]
         stampVersionVariant raw 5
@@ -192,5 +193,5 @@ module Uuid =
             nullArg (nameof name)
 
         concat (namespaceId.ToBytes()) (Encoding.UTF8.GetBytes name)
-        |> MD5.HashData
+        |> Md5.sumMd5
         |> fun digest -> stampVersionVariant digest 3

--- a/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj
+++ b/code/packages/fsharp/uuid/tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="../../CodingAdventures.Uuid.fsproj" />
     <Compile Include="UuidTests.fs" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Csprng]*,[CodingAdventures.Md5]*,[CodingAdventures.Sha1]*</Exclude>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- route C# and F# UUID v4/v7/v1 random bytes through the repository CSPRNG package instead of direct RandomNumberGenerator calls
- route C# and F# UUID v3/v5 hashing through package-local MD5 and SHA-1 implementations
- add project references and coverage excludes for CSPRNG/MD5/SHA-1 dependencies
- document that UUID uses package-local hash primitives and the repository CSPRNG entropy boundary

## Verification
- dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Uuid.Tests/CodingAdventures.Uuid.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- scan UUID source/docs/projects for System.Security/RandomNumberGenerator/MD5.HashData/SHA1.HashData references