### PR TITLE
fix(system-board): npm install in system-board, not os-kernel

### DIFF
--- a/code/packages/typescript/system-board/BUILD
+++ b/code/packages/typescript/system-board/BUILD
@@ -8,5 +8,5 @@ cd ../arithmetic && npm install --silent
 cd ../cpu-simulator && npm install --silent
 cd ../riscv-simulator && npm install --silent
 cd ../os-kernel && npm install --silent
-npm install --silent
+cd ../system-board && npm install --silent
 npx vitest run --coverage

--- a/code/packages/typescript/system-board/BUILD_windows
+++ b/code/packages/typescript/system-board/BUILD_windows
@@ -8,5 +8,5 @@ cd ../arithmetic && npm install --silent
 cd ../cpu-simulator && npm install --silent
 cd ../riscv-simulator && npm install --silent
 cd ../os-kernel && npm install --silent
-npm install --silent
+cd ../system-board && npm install --silent
 npx vitest run --coverage


### PR DESCRIPTION
## Summary

The system-board BUILD chain installs deps for transitive packages with a series of `cd ../<pkg> && npm install` commands. After the final `cd ../os-kernel && npm install`, the bare `npm install` that followed ran in `os-kernel/` instead of `system-board/`, so system-board's own dependencies were never installed.

Fix: replace the bare `npm install` with `cd ../system-board && npm install` so the working directory lands in the right place.

## Files
- `code/packages/typescript/system-board/BUILD` (1 line)
- `code/packages/typescript/system-board/BUILD_windows` (1 line)

## Notes

Earlier versions of this PR also bundled a Windows MSVC linker pin (CI tweak) and a partial removal of `capability-cage` from two go.mod files. Both were dropped:
- The MSVC linker pin was untested benefit (the existing `ilammy/msvc-dev-cmd@v1` step on main was already keeping Windows green).
- The capability-cage removal was incomplete (sql-parser still has the same indirect dep) and the go.mod change marked `sql-execution-engine` as affected, exposing 25+ pre-existing test failures unrelated to this PR.