### PR TITLE
docs(music): spec portable music machine ports and instrument models

### DIFF
--- a/code/specs/MUS04-portable-music-machine.md
+++ b/code/specs/MUS04-portable-music-machine.md
@@ -1,0 +1,461 @@
+# MUS04: Portable Music Machine and Multi-Track Score Format
+
+## 1. Overview
+
+`MUS03` proved the first end-to-end path:
+
+```text
+text score -> note/rest events -> PCM -> audio device
+```
+
+That format is intentionally beginner-sized: one melody line, one global sound,
+and one global tempo. `MUS04` defines the next layer:
+
+```text
+portable score text -> multi-track score model -> render/playback backends
+```
+
+The goals are:
+
+- make scores easy for humans to read
+- make scores easy for programs to generate
+- support multiple instruments playing different parts at the same time
+- give every language package the same parse/render/play contract
+- use native bridges or C FFI where sharing a Rust core is the safest path
+- use browser Web Audio for browser playback instead of pretending browsers can
+  load the same native audio sink as Node.js
+
+## 2. Beginner Mental Model
+
+A `MUS03` score is like one person humming a melody.
+
+A `MUS04` score is like a small band:
+
+- the score says the song title, tempo map, and meter
+- instruments describe what kind of sound a track should use
+- tracks describe who plays what
+- events describe when notes start, how long they last, and how loud they are
+
+For example:
+
+```text
+format: music-machine-score/v2
+title: Tiny Duet
+ppq: 480
+tempo 0 120
+meter 0 4/4
+
+instrument lead kind=sine gain=0.08
+instrument bass kind=sine gain=0.05
+
+track melody instrument=lead
+event melody 0 480 note C5 velocity=0.8
+event melody 480 480 note D5 velocity=0.8
+
+track bassline instrument=bass
+event bassline 0 960 note C3 velocity=0.7
+```
+
+The melody and bassline are separate tracks. Their events can overlap because
+each event has an explicit start time.
+
+## 3. Why a New Text Format?
+
+`MUS03` has a friendly shorthand:
+
+```text
+C4/q D4/q E4/q
+```
+
+That is wonderful to type by hand, but not ideal for future tools that detect
+notes from audio samples. A sample-to-sheet pipeline will naturally produce
+records such as:
+
+```text
+track = melody
+start_tick = 1920
+duration_tick = 240
+pitch = E5
+confidence = 0.91
+```
+
+`MUS04` therefore defines a canonical event form that is easy to emit from
+programs, plus optional human shorthand that packages may add later. The
+canonical form is the required interchange format.
+
+## 4. Canonical Text Format
+
+Files are UTF-8 text. Blank lines are ignored. Lines starting with `#` are
+comments.
+
+The first non-comment directive must identify the format:
+
+```text
+format: music-machine-score/v2
+```
+
+Global directives:
+
+```text
+title: Fur Elise Sketch
+ppq: 480
+sample_rate: 44100
+```
+
+`ppq` means pulses per quarter note. It is the integer time grid used by the
+canonical event format. At `ppq: 480`, a quarter note is `480` ticks, an eighth
+note is `240` ticks, and a half note is `960` ticks.
+
+Tempo changes:
+
+```text
+tempo <start_tick> <bpm>
+```
+
+Meter changes:
+
+```text
+meter <start_tick> <numerator>/<denominator>
+```
+
+Instrument declarations:
+
+```text
+instrument <instrument_id> kind=<kind> gain=<0.0..1.0>
+```
+
+Required V2 instrument kinds:
+
+| Kind | Meaning |
+|------|---------|
+| `sine` | pure sine oscillator, same musical model as the current stack |
+| `silence` | useful for parser and scheduler tests |
+| `external` | placeholder for host-specific instruments not modeled yet |
+
+Track declarations:
+
+```text
+track <track_id> instrument=<instrument_id>
+```
+
+Events:
+
+```text
+event <track_id> <start_tick> <duration_tick> note <pitch-list> [velocity=<0.0..1.0>]
+event <track_id> <start_tick> <duration_tick> rest
+```
+
+Examples:
+
+```text
+event melody 0 240 note E5 velocity=0.65
+event melody 240 240 note D#5 velocity=0.65
+event piano_left 0 960 note A2,C3,E3 velocity=0.50
+event drums 480 120 rest
+```
+
+Rules:
+
+- identifiers must match `[A-Za-z_][A-Za-z0-9_-]*`
+- tick values must be non-negative integers
+- durations must be positive integers
+- `pitch-list` is one or more `MUS00` note names separated by commas
+- multiple pitches in one event form a chord
+- events may overlap
+- event order in the file does not define timing; `start_tick` does
+- renderers should preserve source order only as a stable tie-breaker when two
+  events have the same start tick
+
+## 5. Score Model
+
+Every language should expose equivalent data shapes:
+
+```text
+PortableScore(
+    format_version,
+    title,
+    ppq,
+    sample_rate_hz,
+    tempo_events,
+    meter_events,
+    instruments,
+    tracks,
+    events,
+)
+```
+
+Tempo event:
+
+```text
+TempoEvent(start_tick, bpm)
+```
+
+Meter event:
+
+```text
+MeterEvent(start_tick, numerator, denominator)
+```
+
+Instrument:
+
+```text
+Instrument(id, kind, gain)
+```
+
+Track:
+
+```text
+Track(id, instrument_id)
+```
+
+Score event:
+
+```text
+ScoreEvent(
+    track_id,
+    start_tick,
+    duration_tick,
+    kind = note | rest,
+    pitches,
+    velocity,
+)
+```
+
+The model should be serializable to deterministic JSON so golden fixtures can
+be shared across languages.
+
+## 6. Rendering Semantics
+
+The renderer lowers score events to PCM in three phases:
+
+1. Convert ticks to seconds using the tempo map.
+2. Render each note event with the referenced instrument.
+3. Mix all tracks into one PCM buffer.
+
+V2 requirements:
+
+- renderers must support `sine` instruments
+- renderers must support chords by rendering each pitch and summing samples
+- renderers must support overlapping events across tracks
+- renderers must clamp or otherwise safely bound mixed samples to signed
+  16-bit PCM
+- renderers must enforce a maximum event count and maximum rendered sample count
+- renderers must reject unknown instruments, tracks, notes, meters, and tempo
+  events with useful errors
+
+Future instrument work can add harmonic tables, envelopes, samples, and physical
+models. V2 deliberately keeps the sound model simple so the cross-language
+contract lands first.
+
+## 7. Playback Semantics
+
+Playback is separate from parsing and rendering.
+
+Required API shape:
+
+```text
+parse_score_text(text) -> PortableScore
+render_score_to_pcm(score, options) -> PCMBuffer
+play_score_text(text, options) -> PlaybackReport
+```
+
+Packages may omit `play_score_text` when their runtime cannot access audio
+devices. They should still provide parse and render behavior when possible.
+
+## 8. Rust Core and FFI Strategy
+
+The preferred shared implementation path is a Rust core crate:
+
+```text
+music-machine-core
+```
+
+It should own:
+
+- canonical text parsing
+- validation
+- deterministic JSON serialization of the score model
+- sine/chord/multi-track rendering to PCM
+- resource-limit enforcement
+
+A C ABI facade should be added only after the Rust core is stable:
+
+```text
+music-machine-ffi
+```
+
+The ABI must avoid Rust enum values in caller-controlled structs. Use primitive
+integer status codes and opaque handles instead.
+
+Suggested ABI shape:
+
+```text
+music_machine_parse(
+    text_ptr,
+    text_len,
+    options_json_ptr,
+    options_json_len,
+    out_score_handle,
+) -> status_code
+
+music_machine_score_to_json(score_handle, out_bytes) -> status_code
+music_machine_render_pcm16(score_handle, options_json, out_pcm_buffer) -> status_code
+music_machine_free_score(score_handle)
+music_machine_free_bytes(bytes_handle)
+music_machine_last_error_json(out_bytes) -> status_code
+```
+
+All byte buffers returned across the ABI must have one obvious free function.
+All input sizes must be validated before allocation.
+
+## 9. Language Porting Plan
+
+Porting should happen in small PRs, grouped by risk and toolchain behavior.
+
+Tier 0: shared fixtures
+
+- add canonical `.mmscore` fixtures
+- add expected JSON model fixtures
+- add expected PCM metadata fixtures
+
+Tier 1: Rust foundation
+
+- implement `music-machine-core`
+- implement `music-machine-ffi`
+- implement Rust playback by composing with `audio-device-sink`
+
+Tier 2: native bridge languages already present in the repo
+
+- Python can either keep the existing pure package or switch to the Rust core
+- Ruby should use `ruby-bridge`
+- Lua should use `lua-bridge`
+- Perl should use `perl-bridge`
+- Elixir should use `erl-nif-bridge`
+- Node.js should use `node-bridge`
+
+Tier 3: managed and compiled language ports
+
+- C#, F#, Java, Kotlin, Swift, Go, Haskell, Dart, and C-style consumers should
+  prefer the C ABI where practical
+- pure educational implementations are acceptable when the language has no
+  stable native bridge yet, but they must match shared fixtures
+
+Tier 4: browser and WebAssembly
+
+- TypeScript browser playback should use Web Audio
+- WebAssembly can share parser/rendering logic with Rust later
+- browser audio output must remain Web Audio, because browsers do not load the
+  native OS audio sink used by Node.js
+
+Starlark may support parser-only behavior if the repository keeps it sandboxed
+and intentionally unable to play audio.
+
+## 10. Node.js Package
+
+Node.js should get a native package:
+
+```text
+@coding-adventures/music-machine-node
+```
+
+It should:
+
+- load a Rust N-API addon through `node-bridge`
+- parse scores through the Rust core
+- render PCM through the Rust core
+- play PCM through the Rust audio-device sink
+- expose explicit parse/render/play functions
+
+Node.js should not use browser Web Audio as its primary backend. Node does not
+provide a built-in browser `AudioContext`; the stable path in this repo is the
+Rust native audio sink.
+
+## 11. Browser Package
+
+Browsers should get a separate package:
+
+```text
+@coding-adventures/music-machine-web
+```
+
+It should:
+
+- parse the canonical V2 text format in TypeScript or WebAssembly
+- create or receive an `AudioContext`
+- schedule `OscillatorNode`s for `sine` instruments
+- control volume through `GainNode`
+- require callers to start playback from a user gesture when browsers require
+  it
+- expose offline rendering later through `OfflineAudioContext`
+- consider `AudioWorklet` later for custom sample-by-sample rendering
+
+The Web Audio API is widely available in modern browsers. `AudioContext` owns
+the audio graph, `OscillatorNode` can synthesize periodic tones, and
+`OfflineAudioContext` can render audio into a buffer without sending it to the
+speakers. Browser implementations must avoid deprecated `ScriptProcessorNode`
+for new sample-processing work; `AudioWorklet` is the future path for custom
+processing.
+
+References:
+
+- W3C Web Audio API: `https://www.w3.org/TR/webaudio/`
+- MDN Web Audio API: `https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API`
+- MDN AudioContext: `https://developer.mozilla.org/en-US/docs/Web/API/AudioContext`
+- MDN OscillatorNode: `https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode`
+
+## 12. Safety and Resource Limits
+
+All implementations must reject:
+
+- score text above the package maximum
+- individual lines above the package maximum
+- event counts above the package maximum
+- track counts above the package maximum
+- instrument counts above the package maximum
+- render requests above the maximum sample count
+- tempo values that are non-finite or not positive
+- gain and velocity values outside `[0.0, 1.0]`
+- unknown instrument references
+- unknown track references
+- malformed note spellings
+
+Playback APIs must be explicit. Importing or parsing a score must never open an
+audio device.
+
+## 13. Testing Requirements
+
+Every implementation must test:
+
+- parsing global directives
+- parsing instruments
+- parsing tracks
+- parsing note, rest, and chord events
+- rejecting malformed identifiers and unknown references
+- converting ticks to seconds at known tempos
+- rendering overlapping tracks
+- clipping or bounding mixed samples
+- enforcing parser and renderer resource limits
+- serializing the score model to deterministic JSON
+
+Packages with playback must test delegation without requiring real audio output
+in unit tests.
+
+Browser packages must test scheduling against fake or mocked Web Audio objects
+rather than making CI produce sound.
+
+## 14. PR Slicing
+
+Do not port all languages in one PR.
+
+Recommended sequence:
+
+1. `MUS04` spec and shared fixtures.
+2. Rust `music-machine-core`.
+3. Rust `music-machine-ffi`.
+4. Node native package.
+5. Browser Web Audio package.
+6. Python alignment with V2.
+7. Ruby/Lua/Perl/Elixir bridge packages.
+8. Go/Swift/.NET/JVM/Haskell/Dart packages in small groups.
+
+Each PR should build only the packages it owns plus direct prerequisites.

--- a/code/specs/MUS05-naive-instrument-models.md
+++ b/code/specs/MUS05-naive-instrument-models.md
@@ -1,0 +1,507 @@
+# MUS05: Naive Instrument Models and Timbre
+
+## 1. Overview
+
+`MUS00` maps note names to frequencies. `MUS01` turns one frequency into a
+simple sine tone. `MUS04` introduces named instruments and multiple tracks.
+
+This spec defines the first instrument model:
+
+```text
+note frequency + instrument profile -> shaped waveform
+```
+
+The goal is not realism yet. The goal is to make a virtual keyboard and virtual
+orchestra possible with a beginner-friendly model:
+
+- the same note keeps the same fundamental frequency across instruments
+- instruments differ by harmonic content, envelope, gain, and small variation
+- every layer remains inspectable and deterministic by default
+- later packages can replace the naive model with physical simulations
+
+## 2. Beginner Mental Model
+
+Pressing `A4` on different instruments still means:
+
+```text
+fundamental_frequency = 440 Hz
+```
+
+But the sound is not only one sine wave. A simple instrument tone is a sum of
+related sine waves:
+
+```text
+1 * 440 Hz   -> fundamental
+2 * 440 Hz   -> second harmonic
+3 * 440 Hz   -> third harmonic
+4 * 440 Hz   -> fourth harmonic
+...
+```
+
+The instrument decides how loud each harmonic is.
+
+For example:
+
+```text
+flute A4 ~= 1.00 * sine(440 Hz)
+          + 0.10 * sine(880 Hz)
+          + 0.03 * sine(1320 Hz)
+
+violin A4 ~= 1.00 * sine(440 Hz)
+           + 0.55 * sine(880 Hz)
+           + 0.35 * sine(1320 Hz)
+           + 0.20 * sine(1760 Hz)
+```
+
+Both are still `A4`. They differ because their wave shapes differ.
+
+## 3. Timbre
+
+Timbre is the part of sound that lets us hear two instruments as different even
+when they play the same note at the same loudness.
+
+For the first model, timbre is:
+
+```text
+timbre = harmonic_profile + envelope_profile + variation_profile
+```
+
+`harmonic_profile` answers:
+
+> Which sine waves are mixed together?
+
+`envelope_profile` answers:
+
+> How does the loudness change over the life of the note?
+
+`variation_profile` answers:
+
+> What small imperfections make repeated notes less machine-perfect?
+
+V1 may implement harmonics and a simple envelope only. Variation should be
+specified now so future implementations do not need to redesign the model.
+
+## 4. Instrument Model
+
+Every implementation should expose this conceptual type:
+
+```text
+InstrumentProfile(
+    id,
+    display_name,
+    synthesis_kind,
+    gain,
+    harmonic_profile,
+    envelope_profile,
+    variation_profile,
+)
+```
+
+Fields:
+
+| Field | Meaning |
+|-------|---------|
+| `id` | stable machine-readable name such as `flute_naive` |
+| `display_name` | friendly name such as `Naive Flute` |
+| `synthesis_kind` | `sine`, `additive`, `sample`, or `physical` |
+| `gain` | normalized output gain in `[0.0, 1.0]` |
+| `harmonic_profile` | harmonic multipliers and amplitudes |
+| `envelope_profile` | attack/decay/sustain/release shape |
+| `variation_profile` | optional deterministic or seeded imperfections |
+
+Required V1 synthesis kinds:
+
+| Kind | Meaning |
+|------|---------|
+| `sine` | one pure sine at the note frequency |
+| `additive` | a sum of sine partials derived from the note frequency |
+| `silence` | produces no sound; useful for tests and muted tracks |
+
+Reserved future synthesis kinds:
+
+| Kind | Meaning |
+|------|---------|
+| `sample` | playback from recorded or generated sample data |
+| `physical` | sound from a simulated physical model |
+| `external` | host/runtime-provided instrument |
+
+## 5. Harmonic Profile
+
+A harmonic profile is a list of partials:
+
+```text
+HarmonicPartial(
+    frequency_multiplier,
+    amplitude,
+    phase_cycles = 0.0
+)
+```
+
+For ordinary harmonic instruments, `frequency_multiplier` is an integer:
+
+```text
+1.0, 2.0, 3.0, 4.0, ...
+```
+
+The rendered signal before envelope is:
+
+```text
+raw(t) =
+    sum(
+        partial.amplitude
+      * sin(2*pi*(fundamental_hz * partial.frequency_multiplier * t
+      + partial.phase_cycles))
+    )
+```
+
+Rules:
+
+- `frequency_multiplier` must be finite and greater than zero
+- `amplitude` must be finite and non-negative
+- `phase_cycles` must be finite
+- the profile must contain at least one partial unless the instrument is
+  `silence`
+- implementations must normalize or otherwise safely bound the sum before PCM
+  encoding
+- renderers must skip or reject partials above Nyquist for the active sample
+  rate
+
+Skipping high partials is acceptable for V1 because a high note played through a
+rich instrument may have upper harmonics that cannot be represented at the
+chosen sample rate.
+
+## 6. Envelope Profile
+
+An envelope is a loudness shape over the lifetime of a note.
+
+Required V1 envelope:
+
+```text
+ADSREnvelope(
+    attack_seconds,
+    decay_seconds,
+    sustain_level,
+    release_seconds
+)
+```
+
+The sustain section lasts for the remaining note body:
+
+```text
+body_seconds = max(0, duration_seconds - attack_seconds - decay_seconds)
+```
+
+The release section is a tail after the notated duration. Renderers may either:
+
+- include release samples in the rendered event, or
+- mix release into the following timeline when a note-off model exists
+
+V1 should use the simpler rule:
+
+```text
+rendered_duration = duration_seconds + release_seconds
+```
+
+Envelope stages:
+
+| Stage | Meaning |
+|-------|---------|
+| attack | fade from `0.0` to `1.0` |
+| decay | fade from `1.0` to `sustain_level` |
+| sustain | hold `sustain_level` |
+| release | fade from current level to `0.0` |
+
+Rules:
+
+- times must be finite and non-negative
+- `sustain_level` must be in `[0.0, 1.0]`
+- envelopes must never return negative gain
+- zero-length attack/decay/release are allowed
+- release tails must count against sample budgets
+
+Beginner examples:
+
+```text
+piano:  fast attack, medium decay, low sustain, medium release
+flute:  slow attack, short decay, high sustain, short release
+violin: medium attack, short decay, high sustain, medium release
+pluck:  fast attack, long decay, low sustain, short release
+```
+
+## 7. Variation Profile
+
+Real instruments are imperfect. The same player pressing the same note twice
+will not produce bit-identical audio.
+
+V1 does not need variation, but the model reserves it:
+
+```text
+VariationProfile(
+    pitch_jitter_cents = 0.0,
+    amplitude_jitter = 0.0,
+    timing_jitter_seconds = 0.0,
+    harmonic_jitter = 0.0,
+    seed = optional integer
+)
+```
+
+Rules:
+
+- all jitter amounts must be finite and non-negative
+- default variation is exactly zero for deterministic tests
+- seeded variation must be reproducible
+- unseeded variation must not be used in unit tests
+
+Variation is where future virtual instruments can gain life without immediately
+needing a physical model.
+
+## 8. Required Naive Presets
+
+Every implementation should provide the same small preset library. The numbers
+below are deliberately simple teaching values, not claims about real instrument
+acoustics.
+
+### Pure Sine
+
+```text
+id: sine
+kind: sine
+harmonics: 1:1.00
+envelope: attack=0.005 decay=0.010 sustain=0.90 release=0.030
+```
+
+### Naive Flute
+
+```text
+id: flute_naive
+kind: additive
+harmonics: 1:1.00, 2:0.10, 3:0.03
+envelope: attack=0.080 decay=0.050 sustain=0.85 release=0.080
+```
+
+### Naive Clarinet
+
+```text
+id: clarinet_naive
+kind: additive
+harmonics: 1:1.00, 3:0.45, 5:0.20, 7:0.08
+envelope: attack=0.040 decay=0.060 sustain=0.75 release=0.070
+```
+
+### Naive Violin
+
+```text
+id: violin_naive
+kind: additive
+harmonics: 1:1.00, 2:0.55, 3:0.35, 4:0.20, 5:0.12
+envelope: attack=0.070 decay=0.080 sustain=0.80 release=0.120
+```
+
+### Naive Piano
+
+```text
+id: piano_naive
+kind: additive
+harmonics: 1:1.00, 2:0.45, 3:0.25, 4:0.14, 5:0.08
+envelope: attack=0.005 decay=0.350 sustain=0.18 release=0.180
+```
+
+### Naive Plucked String
+
+```text
+id: pluck_naive
+kind: additive
+harmonics: 1:1.00, 2:0.60, 3:0.38, 4:0.22, 5:0.13, 6:0.08
+envelope: attack=0.003 decay=0.450 sustain=0.05 release=0.080
+```
+
+## 9. Text Score Integration
+
+`MUS04` instrument declarations should accept a profile reference:
+
+```text
+instrument lead profile=violin_naive gain=0.08
+instrument bass profile=pluck_naive gain=0.06
+```
+
+For custom inline additive instruments, use explicit properties:
+
+```text
+instrument bell kind=additive gain=0.06 harmonics=1:1.0,2:0.4,3:0.2 envelope=0.002,0.6,0.1,0.4
+```
+
+The `envelope` shorthand means:
+
+```text
+attack_seconds,decay_seconds,sustain_level,release_seconds
+```
+
+Rules:
+
+- `profile=<id>` references a known preset or user-defined instrument profile
+- `kind=sine` may omit `harmonics`
+- `kind=additive` must provide `harmonics` unless `profile` supplies them
+- `gain` multiplies the instrument profile gain
+- event `velocity` multiplies the instrument event loudness
+
+Final gain before PCM is:
+
+```text
+score_gain * track_gain * instrument_gain * event_velocity * envelope(t)
+```
+
+If a package does not yet support score or track gain, it should treat the
+missing values as `1.0`.
+
+## 10. Rendering Pipeline
+
+For each note event:
+
+1. Convert the note to a fundamental frequency using `MUS00`.
+2. Resolve the track's instrument profile.
+3. Build one oscillator per harmonic partial.
+4. Evaluate and sum the oscillators at each sample time.
+5. Apply the envelope at each sample time.
+6. Apply gain and velocity.
+7. Mix the event into the score timeline.
+8. Clamp or normalize to PCM safely.
+
+The conceptual signal is:
+
+```text
+instrument_note(t) =
+    envelope(t)
+  * gain
+  * sum(partial_i(t))
+```
+
+Where:
+
+```text
+partial_i(t) =
+    partial_i.amplitude
+  * sin(2*pi*(fundamental_hz * partial_i.frequency_multiplier * t
+  + partial_i.phase_cycles))
+```
+
+## 11. Virtual Keyboard Integration
+
+A virtual keyboard should be able to say:
+
+```text
+keyboard.set_instrument("violin_naive")
+keyboard.note_on("A4", velocity=0.8)
+keyboard.note_off("A4")
+```
+
+This requires a runtime note state model:
+
+```text
+ActiveVoice(
+    voice_id,
+    note,
+    instrument_id,
+    start_time_seconds,
+    velocity,
+    phase_state,
+    envelope_state
+)
+```
+
+V1 package implementations may render fixed-duration score events first. A
+real-time keyboard package will later need note-on/note-off, voice allocation,
+voice stealing, and release tails.
+
+## 12. Virtual Orchestra Integration
+
+A virtual orchestra is the same model at a larger scale:
+
+```text
+Conductor(
+    score,
+    tempo_map,
+    tracks,
+    instruments,
+    transport_position,
+)
+```
+
+The conductor's job is scheduling, not sound physics:
+
+- decide when each event should begin
+- send the event to the correct instrument
+- apply tempo changes
+- mix tracks
+- expose play, pause, seek, and stop
+
+Instrument profiles should remain independent of the conductor so a flute can
+be reused by a keyboard, a score renderer, or a sequencer.
+
+## 13. Future Physical Models
+
+This spec intentionally leaves a bridge to physical modeling.
+
+Future `physical` instruments may model:
+
+- string displacement and tension
+- fret position and string length
+- bow pressure and bow velocity
+- reed stiffness and airflow
+- tube resonance
+- soundboard coupling
+- body resonance
+- microphone or pickup position
+- material imperfections
+
+These models may need symbolic computation, differential equations, numerical
+integration, or finite-difference simulation. They should still lower into the
+same shared signal contract:
+
+```text
+InstrumentVoice.value_at(time_seconds) -> float
+```
+
+That means a physical violin can eventually replace `violin_naive` without
+changing the score, keyboard, conductor, DAC, or audio sink layers.
+
+## 14. Safety and Resource Limits
+
+Implementations must enforce:
+
+- maximum partial count per instrument
+- maximum rendered sample count including release tails
+- maximum simultaneous voices
+- maximum track count
+- maximum event count
+- finite numeric values for all gains, times, phases, and jitter settings
+- gain and velocity bounds before mixing
+
+Renderers should reject profiles that would create unbounded work. For example,
+an additive instrument with 100,000 harmonics must fail during validation rather
+than during rendering.
+
+## 15. Testing Requirements
+
+Every implementation should test:
+
+- same note has the same fundamental frequency for all instruments
+- different harmonic profiles produce different sample sequences
+- additive synthesis sums partials correctly on a tiny known example
+- ADSR envelope values at attack, decay, sustain, and release points
+- preset profiles are present and valid
+- high harmonics above Nyquist are skipped or rejected deterministically
+- release tails contribute to rendered duration and sample budgets
+- invalid profiles fail before rendering
+- seeded variation is deterministic when variation is implemented
+
+Golden fixtures should include:
+
+- one pure sine note
+- one flute-like note
+- one violin-like note
+- one piano-like note
+- one two-instrument score
+
+The tests should compare broad numerical properties and small deterministic
+fixtures. They should not claim that the naive presets sound exactly like real
+instruments.


### PR DESCRIPTION
## Summary

- Adds specification for **portable music machine ports** covering cross-platform audio I/O abstractions
- Adds specification for **naive instrument models** covering basic synthesizer/instrument simulation

## Commits

- `b9dbc3d4e` docs(music): spec portable music machine ports
- `336f14474` docs(music): spec naive instrument models

## Test plan

- [ ] Spec documents are well-formed and complete
- [ ] Specs describe the intended API surface and data flow
- [ ] No implementation code included (spec-only branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)