### PR TITLE
feat: add missing BUILD_windows files for all packages

### DIFF
--- a/code/packages/elixir/arm1_gatelevel/BUILD_windows
+++ b/code/packages/elixir/arm1_gatelevel/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test

--- a/code/packages/elixir/arm1_simulator/BUILD_windows
+++ b/code/packages/elixir/arm1_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test

--- a/code/packages/elixir/arm_simulator/BUILD_windows
+++ b/code/packages/elixir/arm_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/assembler/BUILD_windows
+++ b/code/packages/elixir/assembler/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/blas_library/BUILD_windows
+++ b/code/packages/elixir/blas_library/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/cache/BUILD_windows
+++ b/code/packages/elixir/cache/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/clock/BUILD_windows
+++ b/code/packages/elixir/clock/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/clr_simulator/BUILD_windows
+++ b/code/packages/elixir/clr_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/compute_runtime/BUILD_windows
+++ b/code/packages/elixir/compute_runtime/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/compute_unit/BUILD_windows
+++ b/code/packages/elixir/compute_unit/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/css_lexer/BUILD_windows
+++ b/code/packages/elixir/css_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/device_simulator/BUILD_windows
+++ b/code/packages/elixir/device_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/fp_arithmetic/BUILD_windows
+++ b/code/packages/elixir/fp_arithmetic/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/gpu_core/BUILD_windows
+++ b/code/packages/elixir/gpu_core/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/hazard_detection/BUILD_windows
+++ b/code/packages/elixir/hazard_detection/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/javascript_lexer/BUILD_windows
+++ b/code/packages/elixir/javascript_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/javascript_parser/BUILD_windows
+++ b/code/packages/elixir/javascript_parser/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/jvm_simulator/BUILD_windows
+++ b/code/packages/elixir/jvm_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/parallel_execution_engine/BUILD_windows
+++ b/code/packages/elixir/parallel_execution_engine/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/python_lexer/BUILD_windows
+++ b/code/packages/elixir/python_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/ruby_lexer/BUILD_windows
+++ b/code/packages/elixir/ruby_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/starlark_lexer/BUILD_windows
+++ b/code/packages/elixir/starlark_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/starlark_parser/BUILD_windows
+++ b/code/packages/elixir/starlark_parser/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/typescript_lexer/BUILD_windows
+++ b/code/packages/elixir/typescript_lexer/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/typescript_parser/BUILD_windows
+++ b/code/packages/elixir/typescript_parser/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/vendor_api_simulators/BUILD_windows
+++ b/code/packages/elixir/vendor_api_simulators/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/wasm_simulator/BUILD_windows
+++ b/code/packages/elixir/wasm_simulator/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/go/arm1-gatelevel/BUILD_windows
+++ b/code/packages/go/arm1-gatelevel/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/arm1-simulator/BUILD_windows
+++ b/code/packages/go/arm1-simulator/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/verilog-lexer/BUILD_windows
+++ b/code/packages/go/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/verilog-parser/BUILD_windows
+++ b/code/packages/go/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/vhdl-lexer/BUILD_windows
+++ b/code/packages/go/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/vhdl-parser/BUILD_windows
+++ b/code/packages/go/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/ruby/arm1_gatelevel/BUILD_windows
+++ b/code/packages/ruby/arm1_gatelevel/BUILD_windows
@@ -1,0 +1,3 @@
+cd ../logic_gates && bundle install --quiet && cd ../arithmetic && bundle install --quiet && cd ../arm1_simulator && bundle install --quiet && cd ../arm1_gatelevel
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/rust/arm1-gatelevel/BUILD_windows
+++ b/code/packages/rust/arm1-gatelevel/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p arm1-gatelevel --verbose

--- a/code/packages/rust/arm1-simulator/BUILD_windows
+++ b/code/packages/rust/arm1-simulator/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p arm1-simulator --verbose

--- a/code/packages/typescript/arm1-gatelevel/BUILD_windows
+++ b/code/packages/typescript/arm1-gatelevel/BUILD_windows
@@ -1,0 +1,1 @@
+cd ../clock && npm install --silent && cd ../logic-gates && npm install --silent && cd ../arithmetic && npm install --silent && cd ../arm1-simulator && npm install --silent && cd ../arm1-gatelevel && npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/arm1-simulator/BUILD_windows
+++ b/code/packages/typescript/arm1-simulator/BUILD_windows
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage


### PR DESCRIPTION
## Summary

- Adds missing `BUILD_windows` files across all packages to enable Windows CI builds
- Ensures every package that has a `BUILD` file also has a corresponding `BUILD_windows` file with the appropriate Windows test command

## Commits

- `947260750` feat: add missing BUILD_windows files for all packages

## Test plan

- [ ] All packages now have BUILD_windows files
- [ ] Windows CI pipeline picks up and runs the new build files
- [ ] No existing Linux/macOS builds are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)