### PR TITLE
docs(dotnet): document csprng entropy boundary

### DIFF
--- a/code/packages/csharp/csprng/CHANGELOG.md
+++ b/code/packages/csharp/csprng/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native C# CSPRNG package backed by `RandomNumberGenerator`.
+- Add a native C# CSPRNG package backed by the operating system entropy boundary through `RandomNumberGenerator`.
 - Include random byte buffers, fill helpers, random `uint`/`ulong`, validation, and xUnit coverage.

--- a/code/packages/csharp/csprng/README.md
+++ b/code/packages/csharp/csprng/README.md
@@ -2,6 +2,11 @@
 
 Cryptographically secure random byte and integer helpers for .NET.
 
+This package is the repository's explicit platform entropy boundary. It reads
+from the operating system CSPRNG through `RandomNumberGenerator`; sibling
+packages should depend on this package instead of opening their own direct
+platform-randomness dependency.
+
 ```csharp
 using CodingAdventures.Csprng;
 

--- a/code/packages/fsharp/csprng/CHANGELOG.md
+++ b/code/packages/fsharp/csprng/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 0.1.0
 
-- Add a native F# CSPRNG package backed by `RandomNumberGenerator`.
+- Add a native F# CSPRNG package backed by the operating system entropy boundary through `RandomNumberGenerator`.
 - Include random byte buffers, fill helpers, random `uint32`/`uint64`, validation, and xUnit coverage.

--- a/code/packages/fsharp/csprng/README.md
+++ b/code/packages/fsharp/csprng/README.md
@@ -2,6 +2,11 @@
 
 Cryptographically secure random byte and integer helpers for .NET.
 
+This package is the repository's explicit platform entropy boundary. It reads
+from the operating system CSPRNG through `RandomNumberGenerator`; sibling
+packages should depend on this package instead of opening their own direct
+platform-randomness dependency.
+
 ```fsharp
 open CodingAdventures.Csprng.FSharp
 


### PR DESCRIPTION
## Summary
- Document C# and F# CSPRNG packages as the repository's explicit platform entropy boundary
- Clarify that sibling packages should route randomness through CSPRNG instead of opening their own direct platform-randomness dependency
- Update changelog wording to distinguish the intentional OS entropy boundary from pure package-local crypto implementations

## Tests
- Not run (documentation-only change)