### PR TITLE
feat(directed-graph-native): PyO3 wrapper + Ruby, Node.js, and WASM wrappers

### DIFF
--- a/code/packages/ruby/directed_graph_native/BUILD
+++ b/code/packages/ruby/directed_graph_native/BUILD
@@ -1,0 +1,3 @@
+bundle install --quiet
+bundle exec rake compile
+bundle exec rake test

--- a/code/packages/ruby/directed_graph_native/Cargo.toml
+++ b/code/packages/ruby/directed_graph_native/Cargo.toml
@@ -1,0 +1,33 @@
+# Cargo.toml -- Rust build configuration for the Ruby native extension
+# =====================================================================
+#
+# This crate compiles into a C-compatible dynamic library (.so on Linux,
+# .bundle on macOS, .dll on Windows) that Ruby can load via `require`.
+# Magnus handles all the FFI plumbing: it generates the `Init_` function
+# that Ruby expects, marshals types between Rust and Ruby, and provides
+# a safe wrapper around Ruby's C API.
+#
+# The crate type is `cdylib` because Ruby native extensions are shared
+# libraries loaded at runtime, not statically linked Rust libraries.
+
+[package]
+name = "directed-graph-native-ruby"
+version = "0.1.0"
+edition = "2021"
+description = "Ruby native extension wrapping the Rust directed-graph crate via Magnus"
+
+[lib]
+# The library name must match what Ruby expects when it does
+# `require "directed_graph_native/directed_graph_native"`.
+name = "directed_graph_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# Magnus is the Rust <-> Ruby bridge, analogous to PyO3 for Python.
+# The "rb-sys-interop" feature enables compatibility with the rb-sys gem,
+# which provides Ruby header files and build configuration.
+magnus = { version = "0.7", features = ["rb-sys-interop"] }
+
+# The core directed-graph crate -- all algorithms live here.
+# This wrapper contains zero algorithm logic; it's pure glue code.
+directed-graph = { path = "../../rust/directed-graph" }

--- a/code/packages/ruby/directed_graph_native/Gemfile
+++ b/code/packages/ruby/directed_graph_native/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/directed_graph_native/extconf.rb
+++ b/code/packages/ruby/directed_graph_native/extconf.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# --------------------------------------------------------------------------
+# extconf.rb -- Native extension build configuration
+# --------------------------------------------------------------------------
+#
+# For Rust-based Ruby extensions using rb_sys, this file serves as the
+# bridge between Ruby's extension build system and Cargo. The rb_sys gem
+# provides `create_rust_makefile` which generates a Makefile that:
+#
+# 1. Invokes `cargo build` with the correct target and flags
+# 2. Copies the resulting .so/.bundle/.dll to the right location
+# 3. Sets up the correct linker flags for the current Ruby installation
+#
+# This is simpler than a traditional C extension's extconf.rb because
+# Cargo handles all the Rust compilation details.
+# --------------------------------------------------------------------------
+
+require "mkmf"
+require "rb_sys/mkmf"
+
+create_rust_makefile("directed_graph_native/directed_graph_native")

--- a/code/packages/ruby/directed_graph_native/lib/directed_graph_native.rb
+++ b/code/packages/ruby/directed_graph_native/lib/directed_graph_native.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# --------------------------------------------------------------------------
+# directed_graph_native.rb -- Native extension loader
+# --------------------------------------------------------------------------
+#
+# This file is the entry point for the native extension. When Ruby does:
+#
+#   require "directed_graph_native"
+#
+# it loads this file, which in turn loads the compiled Rust shared library.
+# The shared library registers the CodingAdventures::DirectedGraphNative
+# module and the DirectedGraph class within it.
+#
+# The native extension is compiled from Rust source in src/lib.rs using
+# Magnus (the Rust-Ruby bridge). The compiled shared library has a
+# platform-specific name:
+#   - Linux:   directed_graph_native.so
+#   - macOS:   directed_graph_native.bundle
+#   - Windows: directed_graph_native.dll
+#
+# Usage:
+#   require "directed_graph_native"
+#
+#   g = CodingAdventures::DirectedGraphNative::DirectedGraph.new
+#   g.add_edge("A", "B")
+#   g.add_edge("B", "C")
+#   g.topological_sort  # => ["A", "B", "C"]
+# --------------------------------------------------------------------------
+
+begin
+  # Try to load the precompiled native extension from the lib directory.
+  # rb_sys and rake-compiler place the compiled .so/.bundle here after
+  # `rake compile`.
+  require_relative "directed_graph_native/directed_graph_native"
+rescue LoadError
+  # If the extension hasn't been compiled yet, raise a helpful error.
+  raise LoadError,
+    "Could not load the directed_graph_native native extension. " \
+    "Make sure you have compiled it with `rake compile`. " \
+    "See the README for build instructions."
+end

--- a/code/packages/ruby/directed_graph_native/src/lib.rs
+++ b/code/packages/ruby/directed_graph_native/src/lib.rs
@@ -1,0 +1,416 @@
+// lib.rs -- Magnus wrapper for the Rust directed-graph crate
+// ===========================================================
+//
+// This is a thin wrapper that exposes the Rust `directed_graph::Graph` type
+// to Ruby via Magnus. The wrapper handles type conversion at the boundary:
+//
+// - Rust `String` <-> Ruby `String`
+// - Rust `Vec<String>` <-> Ruby `Array` of `String`
+// - Rust `Vec<Vec<String>>` <-> Ruby `Array` of `Array` of `String`
+// - Rust `HashSet<String>` <-> Ruby `Array` of `String` (input/output)
+// - Rust `GraphError` -> Ruby exceptions
+//
+// The core algorithms (topological sort, cycle detection, transitive closure,
+// independent groups, affected nodes) all live in the Rust crate. This file
+// contains zero algorithm logic -- it's pure glue code.
+//
+// # Why a native extension?
+//
+// The pure Ruby `directed_graph` package works fine, but for large graphs
+// (thousands of nodes) the Rust implementation is significantly faster because:
+//
+// 1. No GC pressure -- Rust manages memory directly.
+// 2. Cache-friendly data structures -- BTreeSet for sorted iteration.
+// 3. Zero-cost abstractions -- iterators compile to tight loops.
+//
+// # Architecture comparison: PyO3 vs Magnus
+//
+// PyO3 (Python) uses `#[pymethods]` on an impl block with `&mut self`.
+// Magnus (Ruby) uses `#[magnus::wrap]` on a struct and defines methods via
+// `RefCell` for interior mutability, since Ruby's object model doesn't have
+// Rust's ownership semantics. We borrow the inner `Graph` mutably only
+// when needed, and immutably for read-only operations.
+//
+// # Usage from Ruby
+//
+// ```ruby
+// require "coding_adventures_directed_graph_native"
+//
+// g = CodingAdventures::DirectedGraphNative::DirectedGraph.new
+// g.add_edge("A", "B")
+// g.add_edge("B", "C")
+//
+// g.topological_sort    # => ["A", "B", "C"]
+// g.independent_groups  # => [["A"], ["B"], ["C"]]
+// ```
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+use directed_graph::graph::{Graph, GraphError};
+use magnus::{
+    define_module, exception, function, method,
+    prelude::*, Error, ExceptionClass, Ruby, Value,
+};
+
+// ---------------------------------------------------------------------------
+// Error conversion
+// ---------------------------------------------------------------------------
+//
+// Magnus uses `magnus::Error` for all Ruby exceptions. We define helper
+// functions to create errors with the appropriate Ruby exception class.
+//
+// Unlike PyO3 where you define exception types with macros, Magnus requires
+// us to look up or define exception classes at init time and store them.
+// For simplicity, we look up the classes each time we need them via the
+// module hierarchy. This is slightly less efficient than caching, but it's
+// only called on error paths, so it doesn't matter.
+
+/// Convert a Rust `GraphError` into a `magnus::Error` with the appropriate
+/// Ruby exception class under `CodingAdventures::DirectedGraphNative`.
+fn to_rb_err(ruby: &Ruby, err: GraphError) -> Error {
+    // Look up the module and exception classes. If these fail, we fall back
+    // to RuntimeError (which should never happen if init ran correctly).
+    let module = ruby
+        .class_object()
+        .funcall::<_, _, Value>("const_get", ("CodingAdventures",))
+        .and_then(|m| m.funcall::<_, _, Value>("const_get", ("DirectedGraphNative",)));
+
+    match err {
+        GraphError::CycleError => {
+            let cls = module
+                .and_then(|m| m.funcall::<_, _, Value>("const_get", ("CycleError",)))
+                .ok();
+            if let Some(c) = cls {
+                // Safety: we know CycleError is an exception class because we defined it.
+                let exc_class = unsafe { ExceptionClass::from_value_unchecked(c) };
+                Error::new(exc_class, "graph contains a cycle")
+            } else {
+                Error::new(exception::runtime_error(), "graph contains a cycle")
+            }
+        }
+        GraphError::NodeNotFound(node) => {
+            let msg = format!("node not found: {}", node);
+            let cls = module
+                .and_then(|m| m.funcall::<_, _, Value>("const_get", ("NodeNotFoundError",)))
+                .ok();
+            if let Some(c) = cls {
+                let exc_class = unsafe { ExceptionClass::from_value_unchecked(c) };
+                Error::new(exc_class, msg)
+            } else {
+                Error::new(exception::runtime_error(), msg)
+            }
+        }
+        GraphError::EdgeNotFound(from, to) => {
+            let msg = format!("edge not found: {} -> {}", from, to);
+            let cls = module
+                .and_then(|m| m.funcall::<_, _, Value>("const_get", ("EdgeNotFoundError",)))
+                .ok();
+            if let Some(c) = cls {
+                let exc_class = unsafe { ExceptionClass::from_value_unchecked(c) };
+                Error::new(exc_class, msg)
+            } else {
+                Error::new(exception::runtime_error(), msg)
+            }
+        }
+        GraphError::SelfLoop(node) => {
+            let msg = format!("self-loop not allowed: {}", node);
+            Error::new(exception::arg_error(), msg)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RbDirectedGraph -- the main Ruby class
+// ---------------------------------------------------------------------------
+//
+// We wrap the Rust `Graph` in a `RefCell` to provide interior mutability.
+// Ruby's object model allows any method to mutate the receiver, but Rust's
+// borrow checker requires us to be explicit about mutability. `RefCell`
+// gives us runtime borrow checking: we call `.borrow()` for read-only
+// access and `.borrow_mut()` for mutable access.
+//
+// This is safe because Ruby is single-threaded (GVL), so we'll never have
+// concurrent borrows. If someone somehow manages to re-enter a method
+// while a borrow is active, `RefCell` will panic -- which is better than
+// undefined behavior.
+
+/// A directed graph backed by Rust's directed-graph crate.
+///
+/// This class provides the same API as the pure Ruby `DirectedGraph::Graph`,
+/// but the algorithms run in Rust for better performance on large graphs.
+#[magnus::wrap(class = "CodingAdventures::DirectedGraphNative::DirectedGraph")]
+struct RbDirectedGraph {
+    inner: RefCell<Graph>,
+}
+
+impl RbDirectedGraph {
+    // -- Constructor -------------------------------------------------------
+
+    /// Create a new empty directed graph.
+    fn new() -> Self {
+        RbDirectedGraph {
+            inner: RefCell::new(Graph::new()),
+        }
+    }
+
+    // -- Node operations ---------------------------------------------------
+
+    /// Add a node to the graph. If the node already exists, this is a no-op.
+    fn add_node(&self, node: String) {
+        self.inner.borrow_mut().add_node(&node);
+    }
+
+    /// Remove a node and all its edges from the graph.
+    ///
+    /// Raises `NodeNotFoundError` if the node does not exist.
+    fn remove_node(&self, ruby: &Ruby, node: String) -> Result<(), Error> {
+        self.inner
+            .borrow_mut()
+            .remove_node(&node)
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Check whether a node exists in the graph.
+    fn has_node(&self, node: String) -> bool {
+        self.inner.borrow().has_node(&node)
+    }
+
+    /// Return a sorted list of all nodes in the graph.
+    fn nodes(&self) -> Vec<String> {
+        self.inner.borrow().nodes()
+    }
+
+    // -- Edge operations ---------------------------------------------------
+
+    /// Add a directed edge from `from_node` to `to_node`.
+    ///
+    /// Both nodes are created if they don't exist yet.
+    ///
+    /// Raises `ArgumentError` if `from_node == to_node` (self-loops not allowed).
+    fn add_edge(&self, ruby: &Ruby, from_node: String, to_node: String) -> Result<(), Error> {
+        self.inner
+            .borrow_mut()
+            .add_edge(&from_node, &to_node)
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Remove a directed edge from `from_node` to `to_node`.
+    ///
+    /// Raises `EdgeNotFoundError` if the edge does not exist.
+    fn remove_edge(&self, ruby: &Ruby, from_node: String, to_node: String) -> Result<(), Error> {
+        self.inner
+            .borrow_mut()
+            .remove_edge(&from_node, &to_node)
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Check whether a directed edge exists from `from_node` to `to_node`.
+    fn has_edge(&self, from_node: String, to_node: String) -> bool {
+        self.inner.borrow().has_edge(&from_node, &to_node)
+    }
+
+    /// Return a list of all edges as `[from, to]` arrays, sorted.
+    fn edges(&self) -> Vec<(String, String)> {
+        self.inner.borrow().edges()
+    }
+
+    // -- Neighbor queries --------------------------------------------------
+
+    /// Return the predecessors (parents) of a node -- nodes that point TO it.
+    ///
+    /// Raises `NodeNotFoundError` if the node does not exist.
+    fn predecessors(&self, ruby: &Ruby, node: String) -> Result<Vec<String>, Error> {
+        self.inner
+            .borrow()
+            .predecessors(&node)
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Return the successors (children) of a node -- nodes it points TO.
+    ///
+    /// Raises `NodeNotFoundError` if the node does not exist.
+    fn successors(&self, ruby: &Ruby, node: String) -> Result<Vec<String>, Error> {
+        self.inner
+            .borrow()
+            .successors(&node)
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    // -- Graph properties --------------------------------------------------
+
+    /// Return the number of nodes in the graph.
+    fn size(&self) -> usize {
+        self.inner.borrow().size()
+    }
+
+    /// Return a human-readable representation of the graph.
+    fn inspect(&self) -> String {
+        let g = self.inner.borrow();
+        format!(
+            "#<CodingAdventures::DirectedGraphNative::DirectedGraph nodes={} edges={}>",
+            g.size(),
+            g.edges().len()
+        )
+    }
+
+    /// Return a string representation (same as inspect for debugging).
+    fn to_s(&self) -> String {
+        self.inspect()
+    }
+
+    // -- Algorithms --------------------------------------------------------
+
+    /// Return a topological ordering of the graph (Kahn's algorithm).
+    ///
+    /// Every node appears after all of its dependencies. This gives a valid
+    /// build order for the dependency graph.
+    ///
+    /// Raises `CycleError` if the graph contains a cycle.
+    fn topological_sort(&self, ruby: &Ruby) -> Result<Vec<String>, Error> {
+        self.inner
+            .borrow()
+            .topological_sort()
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Check whether the graph contains a cycle (DFS with 3-color marking).
+    fn has_cycle(&self) -> bool {
+        self.inner.borrow().has_cycle()
+    }
+
+    /// Return the set of all nodes reachable from `node` (transitive closure).
+    ///
+    /// Does NOT include the node itself. Returns an Array of strings.
+    ///
+    /// Raises `NodeNotFoundError` if the node does not exist.
+    fn transitive_closure(&self, ruby: &Ruby, node: String) -> Result<Vec<String>, Error> {
+        self.inner
+            .borrow()
+            .transitive_closure(&node)
+            .map(|set| {
+                let mut v: Vec<String> = set.into_iter().collect();
+                v.sort();
+                v
+            })
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+
+    /// Given an array of changed nodes, return all nodes that are transitively
+    /// affected (the changed nodes plus everything that depends on them).
+    ///
+    /// This is the core of incremental build detection: "if these packages
+    /// changed, what else needs rebuilding?"
+    ///
+    /// Returns an Array of strings, sorted.
+    fn affected_nodes(&self, changed: Vec<String>) -> Vec<String> {
+        let changed_set: HashSet<String> = changed.into_iter().collect();
+        let result = self.inner.borrow().affected_nodes(&changed_set);
+        let mut v: Vec<String> = result.into_iter().collect();
+        v.sort();
+        v
+    }
+
+    /// Partition the graph into independent groups (parallel execution levels).
+    ///
+    /// Level 0 contains nodes with no dependencies. Level 1 depends only on
+    /// level 0. And so on. Nodes within the same level can be executed in
+    /// parallel because they have no dependencies between them.
+    ///
+    /// Raises `CycleError` if the graph contains a cycle.
+    fn independent_groups(&self, ruby: &Ruby) -> Result<Vec<Vec<String>>, Error> {
+        self.inner
+            .borrow()
+            .independent_groups()
+            .map_err(|e| to_rb_err(ruby, e))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module registration
+// ---------------------------------------------------------------------------
+//
+// The `#[magnus::init]` function is called when Ruby loads the shared library.
+// It's analogous to PyO3's `#[pymodule]` function.
+//
+// We set up:
+// 1. The module hierarchy: CodingAdventures::DirectedGraphNative
+// 2. The DirectedGraph class with all its methods
+// 3. Custom exception classes (CycleError, NodeNotFoundError, EdgeNotFoundError)
+
+#[magnus::init]
+fn init(ruby: &Ruby) -> Result<(), Error> {
+    // -----------------------------------------------------------------------
+    // Module hierarchy
+    // -----------------------------------------------------------------------
+    //
+    // We nest under CodingAdventures to match the pure Ruby gem's namespace.
+    // The full class path is:
+    //   CodingAdventures::DirectedGraphNative::DirectedGraph
+    //
+    // This lets users choose between the pure Ruby and native implementations:
+    //   CodingAdventures::DirectedGraph::Graph       (pure Ruby)
+    //   CodingAdventures::DirectedGraphNative::DirectedGraph  (Rust-backed)
+
+    let coding_adventures = define_module(ruby, "CodingAdventures")?;
+    let module = coding_adventures.define_module("DirectedGraphNative")?;
+
+    // -----------------------------------------------------------------------
+    // DirectedGraph class
+    // -----------------------------------------------------------------------
+    //
+    // We define the class inside the module and register all methods.
+    // Magnus uses `define_method` for instance methods.
+
+    let klass = module.define_class("DirectedGraph", ruby.class_object())?;
+
+    // Constructor
+    klass.define_singleton_method("new", function!(RbDirectedGraph::new, 0))?;
+
+    // Node operations
+    klass.define_method("add_node", method!(RbDirectedGraph::add_node, 1))?;
+    klass.define_method("remove_node", method!(RbDirectedGraph::remove_node, 1))?;
+    klass.define_method("has_node?", method!(RbDirectedGraph::has_node, 1))?;
+    klass.define_method("nodes", method!(RbDirectedGraph::nodes, 0))?;
+
+    // Edge operations
+    klass.define_method("add_edge", method!(RbDirectedGraph::add_edge, 2))?;
+    klass.define_method("remove_edge", method!(RbDirectedGraph::remove_edge, 2))?;
+    klass.define_method("has_edge?", method!(RbDirectedGraph::has_edge, 2))?;
+    klass.define_method("edges", method!(RbDirectedGraph::edges, 0))?;
+
+    // Neighbor queries
+    klass.define_method("predecessors", method!(RbDirectedGraph::predecessors, 1))?;
+    klass.define_method("successors", method!(RbDirectedGraph::successors, 1))?;
+
+    // Graph properties
+    klass.define_method("size", method!(RbDirectedGraph::size, 0))?;
+    klass.define_method("inspect", method!(RbDirectedGraph::inspect, 0))?;
+    klass.define_method("to_s", method!(RbDirectedGraph::to_s, 0))?;
+
+    // Algorithms
+    klass.define_method("topological_sort", method!(RbDirectedGraph::topological_sort, 0))?;
+    klass.define_method("has_cycle?", method!(RbDirectedGraph::has_cycle, 0))?;
+    klass.define_method("transitive_closure", method!(RbDirectedGraph::transitive_closure, 1))?;
+    klass.define_method("affected_nodes", method!(RbDirectedGraph::affected_nodes, 1))?;
+    klass.define_method("independent_groups", method!(RbDirectedGraph::independent_groups, 0))?;
+
+    // -----------------------------------------------------------------------
+    // Exception classes
+    // -----------------------------------------------------------------------
+    //
+    // We define custom Ruby exception classes that mirror the Rust error
+    // variants. These allow Ruby users to rescue specific errors:
+    //
+    //     begin
+    //       g.topological_sort
+    //     rescue CodingAdventures::DirectedGraphNative::CycleError
+    //       puts "graph has a cycle!"
+    //     end
+
+    module.define_class("CycleError", ruby.exception_standard_error())?;
+    module.define_class("NodeNotFoundError", ruby.exception_standard_error())?;
+    module.define_class("EdgeNotFoundError", ruby.exception_standard_error())?;
+
+    Ok(())
+}

--- a/code/packages/ruby/directed_graph_native/test/test_graph.rb
+++ b/code/packages/ruby/directed_graph_native/test/test_graph.rb
@@ -1,0 +1,635 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# --------------------------------------------------------------------------
+# test_graph.rb -- Tests for the Rust-backed DirectedGraph native extension
+# --------------------------------------------------------------------------
+#
+# These tests mirror the pure Ruby directed_graph test suite and the Python
+# directed-graph-native test suite to ensure the native extension provides
+# identical behavior. If these tests pass, the native extension is a valid
+# drop-in replacement for the pure Ruby implementation.
+#
+# We organise tests into logical groups:
+#   1. Empty graph behaviour
+#   2. Node operations (add, remove, has_node?, nodes)
+#   3. Edge operations (add, remove, has_edge?, edges, self-loops)
+#   4. Neighbor queries (predecessors, successors)
+#   5. Graph properties (size, inspect, to_s)
+#   6. Topological sort (Kahn's algorithm)
+#   7. Cycle detection (has_cycle?)
+#   8. Transitive closure
+#   9. Affected nodes (incremental build detection)
+#   10. Independent groups (parallel execution levels)
+#   11. Real-world repo graph (integration test)
+# --------------------------------------------------------------------------
+
+module CodingAdventures
+  module DirectedGraphNative
+    # ======================================================================
+    # 1. Empty Graph
+    # ======================================================================
+
+    class TestEmptyGraph < Minitest::Test
+      def test_empty_graph_has_no_nodes
+        g = DirectedGraph.new
+        assert_equal [], g.nodes
+      end
+
+      def test_empty_graph_has_no_edges
+        g = DirectedGraph.new
+        assert_equal [], g.edges
+      end
+
+      def test_empty_graph_size_is_zero
+        g = DirectedGraph.new
+        assert_equal 0, g.size
+      end
+
+      def test_empty_graph_has_no_cycle
+        g = DirectedGraph.new
+        refute g.has_cycle?
+      end
+
+      def test_empty_graph_topological_sort_is_empty
+        g = DirectedGraph.new
+        assert_equal [], g.topological_sort
+      end
+
+      def test_empty_graph_independent_groups_is_empty
+        g = DirectedGraph.new
+        assert_equal [], g.independent_groups
+      end
+    end
+
+    # ======================================================================
+    # 2. Node Operations
+    # ======================================================================
+
+    class TestNodeOperations < Minitest::Test
+      def test_add_single_node
+        g = DirectedGraph.new
+        g.add_node("A")
+        assert_equal ["A"], g.nodes
+        assert_equal 1, g.size
+      end
+
+      def test_add_duplicate_node_is_noop
+        g = DirectedGraph.new
+        g.add_node("A")
+        g.add_node("A")
+        assert_equal ["A"], g.nodes
+        assert_equal 1, g.size
+      end
+
+      def test_has_node_returns_true_for_existing
+        g = DirectedGraph.new
+        g.add_node("X")
+        assert g.has_node?("X")
+      end
+
+      def test_has_node_returns_false_for_missing
+        g = DirectedGraph.new
+        refute g.has_node?("X")
+      end
+
+      def test_nodes_returns_sorted_list
+        g = DirectedGraph.new
+        g.add_node("C")
+        g.add_node("A")
+        g.add_node("B")
+        assert_equal %w[A B C], g.nodes
+      end
+
+      def test_remove_node_deletes_node
+        g = DirectedGraph.new
+        g.add_node("A")
+        g.remove_node("A")
+        refute g.has_node?("A")
+        assert_equal 0, g.size
+      end
+
+      def test_remove_missing_node_raises_error
+        g = DirectedGraph.new
+        assert_raises(NodeNotFoundError) { g.remove_node("Z") }
+      end
+
+      def test_remove_node_cleans_up_outgoing_edges
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.remove_node("A")
+        refute g.has_edge?("A", "B")
+      end
+
+      def test_remove_node_cleans_up_incoming_edges
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.remove_node("B")
+        refute g.has_edge?("A", "B")
+      end
+
+      def test_remove_node_keeps_other_nodes
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        g.remove_node("B")
+        assert g.has_node?("A")
+        assert g.has_node?("C")
+        refute g.has_edge?("A", "B")
+        refute g.has_edge?("B", "C")
+      end
+    end
+
+    # ======================================================================
+    # 3. Edge Operations
+    # ======================================================================
+
+    class TestEdgeOperations < Minitest::Test
+      def test_add_edge_creates_both_nodes
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert g.has_node?("A")
+        assert g.has_node?("B")
+        assert_equal 2, g.size
+      end
+
+      def test_add_edge_creates_directed_connection
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert g.has_edge?("A", "B")
+        refute g.has_edge?("B", "A")
+      end
+
+      def test_add_duplicate_edge_is_noop
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "B")
+        assert_equal [["A", "B"]], g.edges
+      end
+
+      def test_self_loop_raises_argument_error
+        g = DirectedGraph.new
+        assert_raises(ArgumentError) { g.add_edge("A", "A") }
+      end
+
+      def test_self_loop_error_message_includes_node
+        g = DirectedGraph.new
+        error = assert_raises(ArgumentError) { g.add_edge("A", "A") }
+        assert_match(/self-loop/, error.message)
+      end
+
+      def test_remove_edge
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.remove_edge("A", "B")
+        refute g.has_edge?("A", "B")
+        # Both nodes should still exist after edge removal.
+        assert g.has_node?("A")
+        assert g.has_node?("B")
+      end
+
+      def test_remove_nonexistent_edge_raises
+        g = DirectedGraph.new
+        g.add_node("A")
+        g.add_node("B")
+        assert_raises(EdgeNotFoundError) { g.remove_edge("A", "B") }
+      end
+
+      def test_remove_edge_missing_source_raises
+        g = DirectedGraph.new
+        g.add_node("B")
+        assert_raises { g.remove_edge("A", "B") }
+      end
+
+      def test_edges_returns_sorted_list
+        g = DirectedGraph.new
+        g.add_edge("B", "C")
+        g.add_edge("A", "B")
+        assert_equal [["A", "B"], ["B", "C"]], g.edges
+      end
+
+      def test_has_edge_returns_false_for_missing_source
+        g = DirectedGraph.new
+        g.add_node("B")
+        refute g.has_edge?("A", "B")
+      end
+
+      def test_has_edge_returns_false_for_missing_target
+        g = DirectedGraph.new
+        g.add_node("A")
+        refute g.has_edge?("A", "B")
+      end
+    end
+
+    # ======================================================================
+    # 4. Neighbor Queries
+    # ======================================================================
+
+    class TestNeighborQueries < Minitest::Test
+      def test_predecessors
+        g = DirectedGraph.new
+        g.add_edge("A", "C")
+        g.add_edge("B", "C")
+        assert_equal %w[A B], g.predecessors("C").sort
+      end
+
+      def test_successors
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        assert_equal %w[B C], g.successors("A").sort
+      end
+
+      def test_predecessors_missing_node_raises
+        g = DirectedGraph.new
+        assert_raises(NodeNotFoundError) { g.predecessors("Z") }
+      end
+
+      def test_successors_missing_node_raises
+        g = DirectedGraph.new
+        assert_raises(NodeNotFoundError) { g.successors("Z") }
+      end
+
+      def test_predecessors_of_root_is_empty
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert_equal [], g.predecessors("A")
+      end
+
+      def test_successors_of_leaf_is_empty
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert_equal [], g.successors("B")
+      end
+    end
+
+    # ======================================================================
+    # 5. Graph Properties
+    # ======================================================================
+
+    class TestGraphProperties < Minitest::Test
+      def test_size_tracks_nodes
+        g = DirectedGraph.new
+        assert_equal 0, g.size
+        g.add_node("A")
+        assert_equal 1, g.size
+        g.add_node("B")
+        assert_equal 2, g.size
+      end
+
+      def test_inspect_includes_class_name
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        result = g.inspect
+        assert_match(/DirectedGraph/, result)
+        assert_match(/nodes=2/, result)
+        assert_match(/edges=1/, result)
+      end
+
+      def test_to_s_returns_string
+        g = DirectedGraph.new
+        assert_kind_of String, g.to_s
+      end
+    end
+
+    # ======================================================================
+    # 6. Topological Sort
+    # ======================================================================
+
+    class TestTopologicalSort < Minitest::Test
+      def test_single_node
+        g = DirectedGraph.new
+        g.add_node("A")
+        assert_equal ["A"], g.topological_sort
+      end
+
+      def test_linear_chain
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        assert_equal %w[A B C], g.topological_sort
+      end
+
+      def test_diamond
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        result = g.topological_sort
+
+        # A must come before B and C; B and C must come before D.
+        assert_equal "A", result.first
+        assert_equal "D", result.last
+        assert_equal %w[B C], result[1..2].sort
+      end
+
+      def test_multiple_roots
+        g = DirectedGraph.new
+        g.add_edge("A", "C")
+        g.add_edge("B", "C")
+        result = g.topological_sort
+        assert_operator result.index("A"), :<, result.index("C")
+        assert_operator result.index("B"), :<, result.index("C")
+      end
+
+      def test_disconnected_nodes
+        g = DirectedGraph.new
+        g.add_node("A")
+        g.add_node("B")
+        g.add_node("C")
+        # Any order is valid; just check all are present.
+        assert_equal %w[A B C], g.topological_sort.sort
+      end
+
+      def test_cycle_raises_error
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        g.add_edge("C", "A")
+        assert_raises(CycleError) { g.topological_sort }
+      end
+
+      def test_cycle_error_message
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "A")
+        error = assert_raises(CycleError) { g.topological_sort }
+        assert_match(/cycle/, error.message.downcase)
+      end
+    end
+
+    # ======================================================================
+    # 7. Cycle Detection
+    # ======================================================================
+
+    class TestCycleDetection < Minitest::Test
+      def test_acyclic_graph
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        refute g.has_cycle?
+      end
+
+      def test_simple_cycle
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "A")
+        assert g.has_cycle?
+      end
+
+      def test_longer_cycle
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        g.add_edge("C", "A")
+        assert g.has_cycle?
+      end
+
+      def test_diamond_has_no_cycle
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        refute g.has_cycle?
+      end
+    end
+
+    # ======================================================================
+    # 8. Transitive Closure
+    # ======================================================================
+
+    class TestTransitiveClosure < Minitest::Test
+      def test_linear_chain
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        closure = g.transitive_closure("A")
+        assert_equal %w[B C], closure.sort
+      end
+
+      def test_diamond
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        closure = g.transitive_closure("A")
+        assert_equal %w[B C D], closure.sort
+      end
+
+      def test_leaf_node_has_empty_closure
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        closure = g.transitive_closure("B")
+        assert_equal [], closure
+      end
+
+      def test_single_node_has_empty_closure
+        g = DirectedGraph.new
+        g.add_node("A")
+        closure = g.transitive_closure("A")
+        assert_equal [], closure
+      end
+
+      def test_nonexistent_node_raises
+        g = DirectedGraph.new
+        assert_raises(NodeNotFoundError) { g.transitive_closure("X") }
+      end
+    end
+
+    # ======================================================================
+    # 9. Affected Nodes
+    # ======================================================================
+
+    class TestAffectedNodes < Minitest::Test
+      def test_single_changed_node_with_no_dependents
+        g = DirectedGraph.new
+        g.add_node("A")
+        assert_equal ["A"], g.affected_nodes(["A"])
+      end
+
+      def test_single_change_propagates
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        assert_equal %w[A B C], g.affected_nodes(["A"]).sort
+      end
+
+      def test_leaf_change_affects_only_itself
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert_equal ["B"], g.affected_nodes(["B"])
+      end
+
+      def test_middle_node_changed
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        assert_equal %w[B C], g.affected_nodes(["B"]).sort
+      end
+
+      def test_diamond_change_at_root
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        assert_equal %w[A B C D], g.affected_nodes(["A"]).sort
+      end
+
+      def test_multiple_changed_nodes
+        g = DirectedGraph.new
+        g.add_edge("A", "C")
+        g.add_edge("B", "C")
+        g.add_edge("C", "D")
+        assert_equal %w[A B C D], g.affected_nodes(%w[A B]).sort
+      end
+
+      def test_unknown_nodes_ignored
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        # "X" doesn't exist -- Rust implementation skips unknown nodes.
+        affected = g.affected_nodes(["X"])
+        refute_includes affected, "X"
+      end
+
+      def test_empty_changed_set
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        assert_equal [], g.affected_nodes([])
+      end
+    end
+
+    # ======================================================================
+    # 10. Independent Groups
+    # ======================================================================
+
+    class TestIndependentGroups < Minitest::Test
+      def test_single_node
+        g = DirectedGraph.new
+        g.add_node("A")
+        assert_equal [["A"]], g.independent_groups
+      end
+
+      def test_linear_chain
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        assert_equal [["A"], ["B"], ["C"]], g.independent_groups
+      end
+
+      def test_diamond
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        groups = g.independent_groups
+        assert_equal 3, groups.length
+        assert_equal ["A"], groups[0]
+        assert_equal %w[B C], groups[1].sort
+        assert_equal ["D"], groups[2]
+      end
+
+      def test_parallel_roots
+        g = DirectedGraph.new
+        g.add_node("A")
+        g.add_node("B")
+        g.add_node("C")
+        groups = g.independent_groups
+        assert_equal 1, groups.length
+        assert_equal %w[A B C], groups[0].sort
+      end
+
+      def test_two_independent_chains
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("C", "D")
+        groups = g.independent_groups
+        assert_equal [%w[A C], %w[B D]], groups.map(&:sort)
+      end
+
+      def test_cycle_raises_error
+        g = DirectedGraph.new
+        g.add_edge("A", "B")
+        g.add_edge("B", "A")
+        assert_raises(CycleError) { g.independent_groups }
+      end
+    end
+
+    # ======================================================================
+    # 11. Real-world Repo Graph (Integration Test)
+    # ======================================================================
+    #
+    # This simulates a real package dependency graph similar to this
+    # repository's computing stack:
+    #
+    #   logic_gates -> arithmetic -> cpu -> assembler -> vm -> compiler -> ...
+    #
+    # It tests that the algorithms work on a larger, more realistic graph.
+
+    class TestRealRepoGraph < Minitest::Test
+      def setup
+        @g = DirectedGraph.new
+        @g.add_edge("logic_gates", "arithmetic")
+        @g.add_edge("arithmetic", "cpu")
+        @g.add_edge("cpu", "assembler")
+        @g.add_edge("assembler", "riscv_sim")
+        @g.add_edge("assembler", "vm")
+        @g.add_edge("vm", "jit")
+        @g.add_edge("vm", "compiler")
+        @g.add_edge("compiler", "parser")
+        @g.add_edge("parser", "lexer")
+      end
+
+      def test_size
+        assert_equal 10, @g.size
+      end
+
+      def test_topological_sort_valid
+        sorted = @g.topological_sort
+        # Every edge must go forward in the sorted order.
+        @g.edges.each do |src, tgt|
+          assert_operator sorted.index(src), :<, sorted.index(tgt),
+                          "#{src} should come before #{tgt}"
+        end
+      end
+
+      def test_no_cycle
+        refute @g.has_cycle?
+      end
+
+      def test_independent_groups_first_is_root
+        groups = @g.independent_groups
+        assert_equal ["logic_gates"], groups.first
+      end
+
+      def test_independent_groups_last_contains_leaves
+        groups = @g.independent_groups
+        assert_includes groups.last, "lexer"
+      end
+
+      def test_affected_by_assembler_change
+        affected = @g.affected_nodes(["assembler"]).sort
+        expected = %w[assembler compiler jit lexer parser riscv_sim vm]
+        assert_equal expected, affected
+      end
+
+      def test_predecessors_of_vm
+        assert_equal ["assembler"], @g.predecessors("vm")
+      end
+
+      def test_successors_of_vm
+        assert_equal %w[compiler jit], @g.successors("vm").sort
+      end
+
+      def test_transitive_closure_of_vm
+        closure = @g.transitive_closure("vm").sort
+        assert_equal %w[compiler jit lexer parser], closure
+      end
+    end
+  end
+end

--- a/code/packages/ruby/directed_graph_native/test/test_helper.rb
+++ b/code/packages/ruby/directed_graph_native/test/test_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# --------------------------------------------------------------------------
+# test_helper.rb -- Test configuration and shared setup
+# --------------------------------------------------------------------------
+#
+# This file is required by every test file. It configures:
+#
+# 1. SimpleCov for code coverage measurement (must come first!)
+# 2. Minitest as the test framework
+# 3. The native extension under test
+#
+# SimpleCov must be started before any application code is loaded,
+# otherwise it can't track which lines are executed.
+# --------------------------------------------------------------------------
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 95
+end
+
+require "minitest/autorun"
+require "coding_adventures_directed_graph_native"

--- a/code/packages/typescript/directed-graph-native/.gitignore
+++ b/code/packages/typescript/directed-graph-native/.gitignore
@@ -1,0 +1,4 @@
+target/
+node_modules/
+*.node
+package-lock.json

--- a/code/packages/typescript/directed-graph-native/.npmignore
+++ b/code/packages/typescript/directed-graph-native/.npmignore
@@ -1,0 +1,11 @@
+# Rust source and build artifacts -- only the compiled .node file ships
+src/
+target/
+Cargo.toml
+Cargo.lock
+build.rs
+tests/
+vitest.config.ts
+tsconfig.json
+BUILD
+.cargo/

--- a/code/packages/typescript/directed-graph-native/BUILD
+++ b/code/packages/typescript/directed-graph-native/BUILD
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx napi build --release --platform
+npx vitest run

--- a/code/packages/typescript/directed-graph-native/CHANGELOG.md
+++ b/code/packages/typescript/directed-graph-native/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-03-21
+
+### Added
+
+- Initial release of `@coding-adventures/directed-graph-native`.
+- napi-rs wrapper around the Rust `directed-graph` crate for Node.js.
+- `DirectedGraph` class with full API: `addNode`, `removeNode`, `hasNode`, `nodes`,
+  `addEdge`, `removeEdge`, `hasEdge`, `edges`, `predecessors`, `successors`,
+  `size`, `edgeCount`, `toStringRepr`, `topologicalSort`, `hasCycle`,
+  `transitiveClosure`, `affectedNodes`, `independentGroups`.
+- TypeScript type definitions in `index.d.ts`.
+- Error handling: `CycleError`, `NodeNotFoundError`, `EdgeNotFoundError`,
+  `SelfLoopError` mapped to JavaScript `Error` with descriptive message prefixes.
+- 45 Vitest tests mirroring the Python test suite, including a real repo
+  integration test with 21 packages.
+- BUILD file for the build system.

--- a/code/packages/typescript/directed-graph-native/README.md
+++ b/code/packages/typescript/directed-graph-native/README.md
@@ -1,0 +1,96 @@
+# @coding-adventures/directed-graph-native
+
+A Rust-backed directed graph library for Node.js via napi-rs. Drop-in native replacement for `@coding-adventures/directed-graph` with the same API but native performance.
+
+## What is this?
+
+This package wraps the Rust `directed-graph` crate and exposes it to Node.js as a native addon. All algorithms (topological sort, cycle detection, transitive closure, independent groups, affected nodes) run in Rust -- only the method call boundary crosses between JavaScript and Rust via N-API.
+
+This is the Node.js counterpart to the Python native extension at `code/packages/python/directed-graph-native/`. Both wrap the same Rust crate and provide identical behavior.
+
+## Installation
+
+```bash
+npm install @coding-adventures/directed-graph-native
+```
+
+Requires a Rust toolchain for building from source.
+
+## Usage
+
+```typescript
+import { DirectedGraph } from '@coding-adventures/directed-graph-native';
+
+const g = new DirectedGraph();
+g.addEdge("compile", "link");
+g.addEdge("link", "package");
+
+// Topological sort (Kahn's algorithm)
+console.log(g.topologicalSort());    // ['compile', 'link', 'package']
+
+// Parallel execution levels
+console.log(g.independentGroups());  // [['compile'], ['link'], ['package']]
+
+// Cycle detection
+console.log(g.hasCycle());           // false
+
+// Incremental builds: what's affected by a change?
+const affected = g.affectedNodes(["compile"]);
+console.log(affected);               // ['compile', 'link', 'package']
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `addNode(name)` | Add a node |
+| `removeNode(name)` | Remove a node and its edges |
+| `hasNode(name)` | Check if node exists |
+| `nodes()` | Sorted list of all nodes |
+| `addEdge(from, to)` | Add directed edge |
+| `removeEdge(from, to)` | Remove edge |
+| `hasEdge(from, to)` | Check if edge exists |
+| `edges()` | Sorted list of `[from, to]` pairs |
+| `predecessors(node)` | Nodes pointing to this node |
+| `successors(node)` | Nodes this node points to |
+| `size()` | Number of nodes |
+| `edgeCount()` | Number of edges |
+| `toStringRepr()` | Human-readable description |
+| `topologicalSort()` | Kahn's algorithm |
+| `hasCycle()` | DFS 3-color cycle detection |
+| `transitiveClosure(node)` | All reachable nodes |
+| `affectedNodes(changed)` | Changed + transitive dependents |
+| `independentGroups()` | Parallel execution levels |
+
+## Error handling
+
+Errors are thrown as plain JavaScript `Error` objects with descriptive message prefixes:
+
+- `"CycleError: ..."` -- topological sort or independent groups on a cyclic graph
+- `"NodeNotFoundError: ..."` -- operation on a nonexistent node
+- `"EdgeNotFoundError: ..."` -- removing a nonexistent edge
+- `"SelfLoopError: ..."` -- adding an edge from a node to itself
+
+## How it fits in the stack
+
+This is the Node.js counterpart to the Python native extension. Both wrap the same Rust `directed-graph` crate, demonstrating how a single Rust library can serve multiple language ecosystems:
+
+- **Rust core**: `code/packages/rust/directed-graph/` -- all algorithms
+- **Python wrapper**: `code/packages/python/directed-graph-native/` -- PyO3
+- **Node.js wrapper**: `code/packages/typescript/directed-graph-native/` -- napi-rs
+- **Pure TypeScript**: `code/packages/typescript/directed-graph/` -- educational reimplementation
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build the native addon
+npx napi build --release --platform
+
+# Run tests
+npx vitest run
+```
+
+Requires Rust toolchain (`rustup`) and Node.js 16+.

--- a/code/packages/typescript/directed-graph-native/build.rs
+++ b/code/packages/typescript/directed-graph-native/build.rs
@@ -1,0 +1,15 @@
+// build.rs -- napi-rs build script
+// =================================
+//
+// This is a required build script for napi-rs native addons. It generates
+// the C header file and linker configuration that Node.js needs to load
+// the shared library as a native addon.
+//
+// Without this, the compiled .so/.dylib/.dll won't have the right symbol
+// exports and Node.js won't recognize it as a valid addon.
+
+extern crate napi_build;
+
+fn main() {
+    napi_build::setup();
+}

--- a/code/packages/typescript/directed-graph-native/index.d.ts
+++ b/code/packages/typescript/directed-graph-native/index.d.ts
@@ -1,0 +1,144 @@
+// index.d.ts -- TypeScript type definitions for the native addon
+// ===============================================================
+//
+// These type definitions describe the JavaScript API exposed by the Rust
+// native addon. They provide IntelliSense, type checking, and documentation
+// for TypeScript users.
+//
+// The actual implementation is in src/lib.rs (Rust). These types must be
+// kept in sync with the Rust #[napi] annotations manually.
+//
+// Error types:
+// - CycleError: thrown when topological sort or independent groups encounters a cycle.
+//   The error message starts with "CycleError:".
+// - NodeNotFoundError: thrown when an operation references a nonexistent node.
+//   The error message starts with "NodeNotFoundError:".
+// - EdgeNotFoundError: thrown when removeEdge references a nonexistent edge.
+//   The error message starts with "EdgeNotFoundError:".
+// - SelfLoopError: thrown when addEdge is called with fromNode === toNode.
+//   The error message starts with "SelfLoopError:".
+
+/**
+ * A directed graph backed by Rust's directed-graph crate.
+ *
+ * This class provides the same API as the pure TypeScript `Graph` class from
+ * `@coding-adventures/directed-graph`, but the algorithms run in Rust for
+ * better performance on large graphs.
+ *
+ * @example
+ * ```typescript
+ * const g = new DirectedGraph();
+ * g.addEdge("compile", "link");
+ * g.addEdge("link", "package");
+ *
+ * g.topologicalSort();    // ["compile", "link", "package"]
+ * g.independentGroups();  // [["compile"], ["link"], ["package"]]
+ * ```
+ */
+export class DirectedGraph {
+  /** Create a new empty directed graph. */
+  constructor();
+
+  // -- Node operations ---------------------------------------------------
+
+  /** Add a node to the graph. If the node already exists, this is a no-op. */
+  addNode(node: string): void;
+
+  /**
+   * Remove a node and all its edges from the graph.
+   * @throws {Error} NodeNotFoundError if the node does not exist.
+   */
+  removeNode(node: string): void;
+
+  /** Check whether a node exists in the graph. */
+  hasNode(node: string): boolean;
+
+  /** Return a sorted list of all nodes in the graph. */
+  nodes(): string[];
+
+  // -- Edge operations ---------------------------------------------------
+
+  /**
+   * Add a directed edge from `fromNode` to `toNode`.
+   * Both nodes are created if they don't exist yet.
+   * @throws {Error} SelfLoopError if fromNode === toNode.
+   */
+  addEdge(fromNode: string, toNode: string): void;
+
+  /**
+   * Remove a directed edge from `fromNode` to `toNode`.
+   * @throws {Error} EdgeNotFoundError if the edge does not exist.
+   */
+  removeEdge(fromNode: string, toNode: string): void;
+
+  /** Check whether a directed edge exists from `fromNode` to `toNode`. */
+  hasEdge(fromNode: string, toNode: string): boolean;
+
+  /**
+   * Return a list of all edges as `[from, to]` pairs, sorted.
+   * Each edge is a two-element array: `[fromNode, toNode]`.
+   */
+  edges(): [string, string][];
+
+  // -- Neighbor queries --------------------------------------------------
+
+  /**
+   * Return the predecessors (parents) of a node -- nodes that point TO it.
+   * @throws {Error} NodeNotFoundError if the node does not exist.
+   */
+  predecessors(node: string): string[];
+
+  /**
+   * Return the successors (children) of a node -- nodes it points TO.
+   * @throws {Error} NodeNotFoundError if the node does not exist.
+   */
+  successors(node: string): string[];
+
+  // -- Graph properties --------------------------------------------------
+
+  /** Return the number of nodes in the graph. */
+  size(): number;
+
+  /** Return the number of edges in the graph. */
+  edgeCount(): number;
+
+  /**
+   * Return a human-readable string representation of the graph.
+   * Format: `DirectedGraph(nodes=N, edges=M)`
+   */
+  toStringRepr(): string;
+
+  // -- Algorithms --------------------------------------------------------
+
+  /**
+   * Return a topological ordering of the graph (Kahn's algorithm).
+   * Every node appears after all of its dependencies.
+   * @throws {Error} CycleError if the graph contains a cycle.
+   */
+  topologicalSort(): string[];
+
+  /** Check whether the graph contains a cycle (DFS with 3-color marking). */
+  hasCycle(): boolean;
+
+  /**
+   * Return all nodes reachable from `node` (transitive closure).
+   * Does NOT include the node itself. Returns a sorted array.
+   * @throws {Error} NodeNotFoundError if the node does not exist.
+   */
+  transitiveClosure(node: string): string[];
+
+  /**
+   * Given a list of changed nodes, return all nodes that are transitively
+   * affected (the changed nodes plus everything that depends on them).
+   * Unknown nodes are silently ignored.
+   */
+  affectedNodes(changed: string[]): string[];
+
+  /**
+   * Partition the graph into independent groups (parallel execution levels).
+   * Level 0 contains nodes with no dependencies. Level 1 depends only on
+   * level 0. And so on. Nodes within the same level can be executed in parallel.
+   * @throws {Error} CycleError if the graph contains a cycle.
+   */
+  independentGroups(): string[][];
+}

--- a/code/packages/typescript/directed-graph-native/index.js
+++ b/code/packages/typescript/directed-graph-native/index.js
@@ -1,0 +1,23 @@
+// index.js -- JavaScript entry point for the native addon
+// ========================================================
+//
+// This file loads the compiled Rust native addon (.node file) and re-exports
+// the DirectedGraph class. The napi-rs build step compiles Rust code into a
+// platform-specific .node file (e.g., directed-graph-native.win32-x64-msvc.node).
+//
+// The @napi-rs/cli `napi build` command generates the .node file and a
+// loader that picks the right binary for the current platform.
+//
+// If you're reading this and wondering "where's the actual code?", it's in
+// src/lib.rs -- this file is just the loading mechanism.
+//
+// We use createRequire because the package is ESM ("type": "module") but
+// .node files can only be loaded via require(). This is the standard pattern
+// for loading native addons from ESM packages.
+
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { DirectedGraph } = require("./directed-graph-native.node");
+
+export { DirectedGraph };

--- a/code/packages/typescript/directed-graph-native/package.json
+++ b/code/packages/typescript/directed-graph-native/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@coding-adventures/directed-graph-native",
+  "version": "0.1.0",
+  "description": "Rust-backed directed graph for Node.js via napi-rs — drop-in native replacement for @coding-adventures/directed-graph",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "build": "cargo build --release && napi build --release --platform",
+    "build:debug": "napi build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "license": "MIT",
+  "author": "Adhithya Rajasekaran",
+  "napi": {
+    "name": "directed-graph-native",
+    "triples": {}
+  },
+  "devDependencies": {
+    "@napi-rs/cli": "^2.18.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/directed-graph-native/tests/graph.test.ts
+++ b/code/packages/typescript/directed-graph-native/tests/graph.test.ts
@@ -1,0 +1,650 @@
+/**
+ * graph.test.ts -- Tests for the native (Rust-backed) directed graph
+ * ===================================================================
+ *
+ * These tests mirror the Python directed_graph_native test suite to ensure
+ * the napi-rs extension provides identical behavior to the PyO3 extension.
+ * If these tests pass, the native extension is a valid drop-in replacement
+ * for the pure TypeScript directed-graph package.
+ *
+ * The tests are organized from simplest to most complex:
+ *
+ * 1. Node operations (add, remove, has, nodes, len)
+ * 2. Edge operations (add, remove, has, edges, self-loops)
+ * 3. Neighbor queries (predecessors, successors)
+ * 4. Topological sort
+ * 5. Cycle detection
+ * 6. Transitive closure
+ * 7. Affected nodes
+ * 8. Independent groups
+ * 9. String representation
+ * 10. Real repo graph integration test
+ *
+ * Error handling:
+ * - The Rust wrapper throws plain Error objects with descriptive messages.
+ * - Error messages start with a type prefix: "CycleError:", "NodeNotFoundError:",
+ *   "EdgeNotFoundError:", or "SelfLoopError:".
+ * - Tests match on these prefixes to verify the correct error type.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// The native addon is loaded from the compiled .node file.
+// The index.js ESM entry point uses createRequire to load the .node binary.
+import { DirectedGraph } from "../index.js";
+
+// ======================================================================
+// Helper: error message matching
+// ======================================================================
+//
+// Since napi-rs throws plain Error objects (not custom subclasses), we
+// match on the error message prefix to verify the error type.
+
+function expectErrorContaining(fn: () => void, substring: string): void {
+  try {
+    fn();
+    expect.unreachable(`Expected error containing "${substring}"`);
+  } catch (e: any) {
+    expect(e.message).toContain(substring);
+  }
+}
+
+// ======================================================================
+// 1. Node Operations
+// ======================================================================
+
+describe("Node Operations", () => {
+  it("add and has node", () => {
+    /** After addNode, hasNode should return true for that node. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    expect(g.hasNode("A")).toBe(true);
+    expect(g.hasNode("B")).toBe(false);
+  });
+
+  it("add duplicate node is noop", () => {
+    /** Adding the same node twice should not create duplicates. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    g.addNode("A");
+    expect(g.size()).toBe(1);
+  });
+
+  it("remove node", () => {
+    /** After removeNode, hasNode should return false. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    g.removeNode("A");
+    expect(g.hasNode("A")).toBe(false);
+  });
+
+  it("remove nonexistent node throws", () => {
+    /** Removing a node that doesn't exist should throw NodeNotFoundError. */
+    const g = new DirectedGraph();
+    expectErrorContaining(() => g.removeNode("X"), "NodeNotFoundError");
+  });
+
+  it("remove node cleans up edges", () => {
+    /** Removing a node should remove all its incoming and outgoing edges. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    g.removeNode("B");
+    expect(g.hasEdge("A", "B")).toBe(false);
+    expect(g.hasEdge("B", "C")).toBe(false);
+    expect(g.hasNode("A")).toBe(true);
+    expect(g.hasNode("C")).toBe(true);
+  });
+
+  it("nodes returns sorted list", () => {
+    /** nodes() should return all nodes in alphabetical order. */
+    const g = new DirectedGraph();
+    g.addNode("C");
+    g.addNode("A");
+    g.addNode("B");
+    expect(g.nodes()).toEqual(["A", "B", "C"]);
+  });
+
+  it("size reflects node count", () => {
+    /** size() should track the number of nodes. */
+    const g = new DirectedGraph();
+    expect(g.size()).toBe(0);
+    g.addNode("A");
+    expect(g.size()).toBe(1);
+    g.addNode("B");
+    expect(g.size()).toBe(2);
+  });
+});
+
+// ======================================================================
+// 2. Edge Operations
+// ======================================================================
+
+describe("Edge Operations", () => {
+  it("add and has edge", () => {
+    /** After addEdge, hasEdge should return true for that direction only. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    expect(g.hasEdge("A", "B")).toBe(true);
+    expect(g.hasEdge("B", "A")).toBe(false); // directed!
+  });
+
+  it("add edge creates nodes", () => {
+    /** addEdge should implicitly create both endpoint nodes. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    expect(g.hasNode("A")).toBe(true);
+    expect(g.hasNode("B")).toBe(true);
+  });
+
+  it("remove edge", () => {
+    /** After removeEdge, hasEdge should return false but nodes remain. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.removeEdge("A", "B");
+    expect(g.hasEdge("A", "B")).toBe(false);
+    expect(g.hasNode("A")).toBe(true);
+    expect(g.hasNode("B")).toBe(true);
+  });
+
+  it("remove nonexistent edge throws", () => {
+    /** Removing an edge that doesn't exist should throw EdgeNotFoundError. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    g.addNode("B");
+    expectErrorContaining(() => g.removeEdge("A", "B"), "EdgeNotFoundError");
+  });
+
+  it("self loop throws", () => {
+    /** Self-loops (A -> A) should be rejected with SelfLoopError. */
+    const g = new DirectedGraph();
+    expectErrorContaining(() => g.addEdge("A", "A"), "SelfLoopError");
+  });
+
+  it("edges returns sorted list", () => {
+    /** edges() should return all edges sorted lexicographically. */
+    const g = new DirectedGraph();
+    g.addEdge("B", "C");
+    g.addEdge("A", "B");
+    const edges = g.edges();
+    expect(edges).toEqual([["A", "B"], ["B", "C"]]);
+  });
+
+  it("duplicate edge is idempotent", () => {
+    /** Adding the same edge twice should not create duplicates. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "B");
+    expect(g.edges()).toEqual([["A", "B"]]);
+  });
+});
+
+// ======================================================================
+// 3. Neighbor Queries
+// ======================================================================
+
+describe("Neighbor Queries", () => {
+  it("predecessors", () => {
+    /** predecessors returns nodes that point TO the given node. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "C");
+    g.addEdge("B", "C");
+    const preds = g.predecessors("C");
+    expect(preds.sort()).toEqual(["A", "B"]);
+  });
+
+  it("successors", () => {
+    /** successors returns nodes that the given node points TO. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "C");
+    const succs = g.successors("A");
+    expect(succs.sort()).toEqual(["B", "C"]);
+  });
+
+  it("predecessors of nonexistent node throws", () => {
+    /** predecessors on a missing node should throw NodeNotFoundError. */
+    const g = new DirectedGraph();
+    expectErrorContaining(() => g.predecessors("X"), "NodeNotFoundError");
+  });
+
+  it("successors of nonexistent node throws", () => {
+    /** successors on a missing node should throw NodeNotFoundError. */
+    const g = new DirectedGraph();
+    expectErrorContaining(() => g.successors("X"), "NodeNotFoundError");
+  });
+
+  it("predecessors of isolated node is empty", () => {
+    /** An isolated node has no predecessors. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    expect(g.predecessors("A")).toEqual([]);
+  });
+
+  it("successors of isolated node is empty", () => {
+    /** An isolated node has no successors. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    expect(g.successors("A")).toEqual([]);
+  });
+});
+
+// ======================================================================
+// 4. Topological Sort
+// ======================================================================
+
+describe("Topological Sort", () => {
+  it("linear chain", () => {
+    /** A -> B -> C must sort to [A, B, C]. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    expect(g.topologicalSort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("diamond", () => {
+    /** The diamond A->{B,C}->D: A first, D last, B and C in middle. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "C");
+    g.addEdge("B", "D");
+    g.addEdge("C", "D");
+    const order = g.topologicalSort();
+    expect(order[0]).toBe("A");
+    expect(order[order.length - 1]).toBe("D");
+    expect(new Set(order.slice(1, 3))).toEqual(new Set(["B", "C"]));
+  });
+
+  it("cycle throws CycleError", () => {
+    /** A graph with a cycle should throw CycleError. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    g.addEdge("C", "A");
+    expectErrorContaining(() => g.topologicalSort(), "CycleError");
+  });
+
+  it("empty graph", () => {
+    /** Topological sort of an empty graph is an empty list. */
+    const g = new DirectedGraph();
+    expect(g.topologicalSort()).toEqual([]);
+  });
+
+  it("single node", () => {
+    /** A single node topo-sorts to a one-element list. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    expect(g.topologicalSort()).toEqual(["A"]);
+  });
+
+  it("disconnected components", () => {
+    /** Disconnected components should all appear in the sort. */
+    const g = new DirectedGraph();
+    g.addEdge("X", "Y");
+    g.addEdge("A", "B");
+    const result = g.topologicalSort();
+    expect(result.length).toBe(4);
+    expect(result.indexOf("X")).toBeLessThan(result.indexOf("Y"));
+    expect(result.indexOf("A")).toBeLessThan(result.indexOf("B"));
+  });
+});
+
+// ======================================================================
+// 5. Cycle Detection
+// ======================================================================
+
+describe("Cycle Detection", () => {
+  it("no cycle in linear chain", () => {
+    /** A linear chain is a DAG -- no cycles. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    expect(g.hasCycle()).toBe(false);
+  });
+
+  it("has cycle in two-node cycle", () => {
+    /** A -> B -> A is a cycle. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "A");
+    expect(g.hasCycle()).toBe(true);
+  });
+
+  it("empty graph has no cycle", () => {
+    /** An empty graph trivially has no cycle. */
+    const g = new DirectedGraph();
+    expect(g.hasCycle()).toBe(false);
+  });
+
+  it("three-node cycle", () => {
+    /** A -> B -> C -> A is a cycle. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    g.addEdge("C", "A");
+    expect(g.hasCycle()).toBe(true);
+  });
+});
+
+// ======================================================================
+// 6. Transitive Closure
+// ======================================================================
+
+describe("Transitive Closure", () => {
+  it("linear chain", () => {
+    /** From A in A->B->C, reachable nodes are B and C. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    const closure = g.transitiveClosure("A");
+    expect(new Set(closure)).toEqual(new Set(["B", "C"]));
+  });
+
+  it("diamond", () => {
+    /** From A in the diamond, all of B, C, D are reachable. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "C");
+    g.addEdge("B", "D");
+    g.addEdge("C", "D");
+    const closure = g.transitiveClosure("A");
+    expect(new Set(closure)).toEqual(new Set(["B", "C", "D"]));
+  });
+
+  it("leaf node has empty closure", () => {
+    /** A leaf node has no downstream nodes. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    expect(g.transitiveClosure("B")).toEqual([]);
+  });
+
+  it("nonexistent node throws", () => {
+    /** transitiveClosure on a missing node should throw. */
+    const g = new DirectedGraph();
+    expectErrorContaining(() => g.transitiveClosure("X"), "NodeNotFoundError");
+  });
+
+  it("isolated node has empty closure", () => {
+    /** An isolated node has empty transitive closure. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    expect(g.transitiveClosure("A")).toEqual([]);
+  });
+});
+
+// ======================================================================
+// 7. Affected Nodes
+// ======================================================================
+
+describe("Affected Nodes", () => {
+  it("single change propagates", () => {
+    /** Changing A in A->B->C should affect A, B, C. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    const affected = new Set(g.affectedNodes(["A"]));
+    expect(affected).toEqual(new Set(["A", "B", "C"]));
+  });
+
+  it("leaf change affects only itself", () => {
+    /** Changing a leaf node affects only that node. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    const affected = new Set(g.affectedNodes(["B"]));
+    expect(affected).toEqual(new Set(["B"]));
+  });
+
+  it("diamond change at root", () => {
+    /** Changing A in the diamond affects all four nodes. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "C");
+    g.addEdge("B", "D");
+    g.addEdge("C", "D");
+    const affected = new Set(g.affectedNodes(["A"]));
+    expect(affected).toEqual(new Set(["A", "B", "C", "D"]));
+  });
+
+  it("unknown nodes are ignored", () => {
+    /** Nodes not in the graph should be silently ignored. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    const affected = g.affectedNodes(["X"]);
+    expect(affected).not.toContain("X");
+  });
+
+  it("mixed known and unknown nodes", () => {
+    /** Only known nodes should appear in the result. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    const affected = new Set(g.affectedNodes(["A", "X"]));
+    expect(affected.has("A")).toBe(true);
+    expect(affected.has("X")).toBe(false);
+  });
+});
+
+// ======================================================================
+// 8. Independent Groups
+// ======================================================================
+
+describe("Independent Groups", () => {
+  it("linear chain", () => {
+    /** A -> B -> C should be three separate levels. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
+    expect(g.independentGroups()).toEqual([["A"], ["B"], ["C"]]);
+  });
+
+  it("diamond", () => {
+    /** Diamond should have B and C in the same parallel level. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("A", "C");
+    g.addEdge("B", "D");
+    g.addEdge("C", "D");
+    const groups = g.independentGroups();
+    expect(groups.length).toBe(3);
+    expect(groups[0]).toEqual(["A"]);
+    expect([...groups[1]].sort()).toEqual(["B", "C"]);
+    expect(groups[2]).toEqual(["D"]);
+  });
+
+  it("parallel roots", () => {
+    /** Three isolated nodes should all be in one group. */
+    const g = new DirectedGraph();
+    g.addNode("A");
+    g.addNode("B");
+    g.addNode("C");
+    const groups = g.independentGroups();
+    expect(groups.length).toBe(1);
+    expect([...groups[0]].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("cycle throws CycleError", () => {
+    /** independentGroups should throw CycleError on cyclic graphs. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("B", "A");
+    expectErrorContaining(() => g.independentGroups(), "CycleError");
+  });
+
+  it("empty graph", () => {
+    /** An empty graph should return no groups. */
+    const g = new DirectedGraph();
+    expect(g.independentGroups()).toEqual([]);
+  });
+
+  it("two independent chains", () => {
+    /** Two disconnected chains should interleave at each level. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    g.addEdge("X", "Y");
+    const groups = g.independentGroups();
+    expect(groups.length).toBe(2);
+    expect([...groups[0]].sort()).toEqual(["A", "X"]);
+    expect([...groups[1]].sort()).toEqual(["B", "Y"]);
+  });
+
+  it("wide graph with fan-out", () => {
+    /** A root fanning out to many children creates two levels. */
+    const g = new DirectedGraph();
+    for (const child of ["A", "B", "C", "D", "E"]) {
+      g.addEdge("ROOT", child);
+    }
+    const groups = g.independentGroups();
+    expect(groups.length).toBe(2);
+    expect(groups[0]).toEqual(["ROOT"]);
+    expect([...groups[1]].sort()).toEqual(["A", "B", "C", "D", "E"]);
+  });
+});
+
+// ======================================================================
+// 9. String Representation
+// ======================================================================
+
+describe("String Representation", () => {
+  it("toStringRepr shows counts", () => {
+    /** toStringRepr should show node and edge counts. */
+    const g = new DirectedGraph();
+    g.addEdge("A", "B");
+    const repr = g.toStringRepr();
+    expect(repr).toContain("DirectedGraph");
+    expect(repr).toContain("nodes=2");
+    expect(repr).toContain("edges=1");
+  });
+
+  it("edge count tracks edges", () => {
+    /** edgeCount() should reflect the number of edges. */
+    const g = new DirectedGraph();
+    expect(g.edgeCount()).toBe(0);
+    g.addEdge("A", "B");
+    expect(g.edgeCount()).toBe(1);
+    g.addEdge("B", "C");
+    expect(g.edgeCount()).toBe(2);
+  });
+});
+
+// ======================================================================
+// 10. Real Repo Graph Integration Test
+// ======================================================================
+//
+// This models the actual dependency graph of packages in the
+// coding-adventures repository. It serves as a comprehensive integration
+// test to ensure all algorithms work together on a realistic graph.
+
+describe("Real Repo Graph", () => {
+  function makeRepoGraph() {
+    const g = new DirectedGraph();
+
+    // Layer 1 -> 2
+    g.addEdge("arithmetic", "logic-gates");
+
+    // Layer 3 -> 4
+    g.addEdge("lexer", "grammar-tools");
+
+    // Layer 4 -> 5
+    g.addEdge("parser", "lexer");
+    g.addEdge("parser", "grammar-tools");
+
+    // Layer 5 -> 6
+    g.addEdge("cpu-simulator", "arithmetic");
+    g.addEdge("cpu-simulator", "logic-gates");
+    g.addEdge("intel4004-simulator", "arithmetic");
+    g.addEdge("pipeline", "parser");
+    g.addEdge("pipeline", "lexer");
+
+    // Layer 6 -> 7
+    g.addEdge("assembler", "parser");
+    g.addEdge("assembler", "grammar-tools");
+    g.addEdge("virtual-machine", "cpu-simulator");
+    g.addEdge("arm-simulator", "cpu-simulator");
+    g.addEdge("arm-simulator", "assembler");
+
+    // Layer 7 -> 8
+    g.addEdge("jvm-simulator", "virtual-machine");
+    g.addEdge("clr-simulator", "virtual-machine");
+    g.addEdge("wasm-simulator", "virtual-machine");
+    g.addEdge("riscv-simulator", "cpu-simulator");
+
+    // Layer 8 -> 9
+    g.addEdge("bytecode-compiler", "jvm-simulator");
+    g.addEdge("bytecode-compiler", "clr-simulator");
+    g.addEdge("bytecode-compiler", "wasm-simulator");
+    g.addEdge("bytecode-compiler", "parser");
+    g.addEdge("html-renderer", "parser");
+    g.addEdge("html-renderer", "lexer");
+    g.addEdge("jit-compiler", "virtual-machine");
+    g.addEdge("jit-compiler", "assembler");
+
+    // Ruby-related packages
+    g.addEdge("ruby-lexer", "grammar-tools");
+    g.addEdge("ruby-parser", "ruby-lexer");
+    g.addEdge("ruby-parser", "grammar-tools");
+
+    // directed-graph has no dependencies
+    g.addNode("directed-graph");
+
+    return g;
+  }
+
+  it("has 21 packages", () => {
+    /** The repository has 21 packages. */
+    const g = makeRepoGraph();
+    expect(g.size()).toBe(21);
+  });
+
+  it("is acyclic", () => {
+    /** The repo dependency graph should be a DAG. */
+    const g = makeRepoGraph();
+    expect(g.hasCycle()).toBe(false);
+  });
+
+  it("topological sort includes all packages", () => {
+    /** Topological sort should produce a valid ordering of all 21 packages. */
+    const g = makeRepoGraph();
+    const order = g.topologicalSort();
+    expect(order.length).toBe(21);
+
+    // Verify ordering: for every edge, from must appear before to.
+    const position = new Map<string, number>();
+    order.forEach((node: string, i: number) => position.set(node, i));
+
+    for (const [fromNode, toNode] of g.edges()) {
+      expect(position.get(fromNode)!).toBeLessThan(position.get(toNode)!);
+    }
+  });
+
+  it("independent groups partition all packages", () => {
+    /** Independent groups should contain all 21 packages. */
+    const g = makeRepoGraph();
+    const groups = g.independentGroups();
+    const allNodes = groups.flat();
+    expect(allNodes.length).toBe(21);
+    expect(new Set(allNodes)).toEqual(new Set(g.nodes()));
+  });
+
+  it("transitive closure of logic-gates is empty", () => {
+    /** logic-gates has no dependencies. */
+    const g = makeRepoGraph();
+    expect(g.transitiveClosure("logic-gates")).toEqual([]);
+  });
+
+  it("affected by grammar-tools change", () => {
+    /** Changing grammar-tools should affect lexer, parser, assembler, etc. */
+    const g = makeRepoGraph();
+    const affected = new Set(g.affectedNodes(["grammar-tools"]));
+    expect(affected.has("grammar-tools")).toBe(true);
+    expect(affected.has("lexer")).toBe(true);
+    expect(affected.has("parser")).toBe(true);
+    expect(affected.has("assembler")).toBe(true);
+    expect(affected.has("pipeline")).toBe(true);
+  });
+
+  it("affected by leaf change", () => {
+    /** Changing bytecode-compiler (a leaf) affects only itself. */
+    const g = makeRepoGraph();
+    const affected = new Set(g.affectedNodes(["bytecode-compiler"]));
+    expect(affected).toEqual(new Set(["bytecode-compiler"]));
+  });
+});

--- a/code/packages/typescript/directed-graph-native/tsconfig.json
+++ b/code/packages/typescript/directed-graph-native/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.base.json"
+}

--- a/code/packages/typescript/directed-graph-native/vitest.config.ts
+++ b/code/packages/typescript/directed-graph-native/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/code/packages/wasm/directed-graph/CHANGELOG.md
+++ b/code/packages/wasm/directed-graph/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the directed-graph-wasm package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+### Added
+- wasm-bindgen wrapper around the Rust `directed-graph` crate
+- `DirectedGraph` class with full API (camelCase JS convention)
+- All algorithms: topologicalSort, hasCycle, transitiveClosure, affectedNodes, independentGroups
+- serde-wasm-bindgen for complex type conversion (arrays, nested arrays)
+- Unit tests via `cargo test`
+- Supports all wasm-pack targets: web, nodejs, bundler

--- a/code/packages/wasm/directed-graph/README.md
+++ b/code/packages/wasm/directed-graph/README.md
@@ -1,0 +1,82 @@
+# directed-graph-wasm
+
+WASM-compiled directed graph — runs in browsers, Node.js, Deno, and any WASM runtime.
+
+## What is this?
+
+This package compiles the Rust `directed-graph` crate to WebAssembly via wasm-bindgen. The result is a `.wasm` file + JavaScript glue code that works anywhere WASM is supported:
+
+- **Browsers** — Chrome, Firefox, Safari, Edge
+- **Node.js** — via the generated JS bindings
+- **Deno** — native WASM support
+- **Edge runtimes** — Cloudflare Workers, Vercel Edge Functions
+- **Standalone** — wasmtime, wasmer (can be loaded from Python, Ruby, etc.)
+
+## Usage
+
+```javascript
+import init, { DirectedGraph } from './directed_graph_wasm.js';
+
+await init();  // load the WASM module
+
+const g = new DirectedGraph();
+g.addEdge("compile", "link");
+g.addEdge("link", "package");
+
+console.log(g.topologicalSort());    // ['compile', 'link', 'package']
+console.log(g.independentGroups());  // [['compile'], ['link'], ['package']]
+console.log(g.hasCycle());           // false
+
+const affected = g.affectedNodes(["compile"]);
+console.log(affected);               // ['compile', 'link', 'package']
+```
+
+## Building
+
+```bash
+# Install wasm-pack
+cargo install wasm-pack
+
+# Build for browser
+wasm-pack build --target web
+
+# Build for Node.js
+wasm-pack build --target nodejs
+
+# Build for bundlers (webpack, vite, etc.)
+wasm-pack build --target bundler
+```
+
+## API
+
+Methods use camelCase (JavaScript convention):
+
+| Method | Description |
+|--------|-------------|
+| `addNode(name)` | Add a node |
+| `removeNode(name)` | Remove a node and its edges |
+| `hasNode(name)` | Check if node exists |
+| `nodes()` | Sorted array of all nodes |
+| `size()` | Number of nodes |
+| `addEdge(from, to)` | Add directed edge |
+| `removeEdge(from, to)` | Remove edge |
+| `hasEdge(from, to)` | Check if edge exists |
+| `edges()` | Sorted array of `[from, to]` pairs |
+| `predecessors(node)` | Nodes pointing to this node |
+| `successors(node)` | Nodes this node points to |
+| `topologicalSort()` | Kahn's algorithm |
+| `hasCycle()` | DFS 3-color cycle detection |
+| `transitiveClosure(node)` | All reachable nodes |
+| `affectedNodes(changed)` | Changed + transitive dependents |
+| `independentGroups()` | Parallel execution levels |
+
+## How it differs from native extensions
+
+| | Native (PyO3/Magnus/napi-rs) | WASM |
+|--|------------------------------|------|
+| Performance | Best (zero overhead FFI) | Good (slight WASM overhead) |
+| Platform | Need wheels per OS/arch | Universal binary |
+| Build | Per-language tooling | One build, runs everywhere |
+| Strings | Shared memory | Copied across boundary |
+
+For a graph library, the WASM overhead is negligible — algorithms are the bottleneck, not string passing.


### PR DESCRIPTION
## Summary

- Adds a PyO3 native extension wrapping the Rust directed-graph implementation for Python
- Adds Ruby, Node.js, and WASM wrappers for the native directed-graph
- Fixes BUILD file to install maturin inside the venv before use, and to use the venv-scoped maturin binary
- Aligns tests with actual Rust `affected_nodes` behavior

## Test plan

- [ ] Build the PyO3 extension and run Python directed-graph tests
- [ ] Run Ruby and Node.js wrapper tests and confirm they pass
- [ ] Verify the WASM wrapper builds and executes correctly
- [ ] Confirm `affected_nodes` output matches the Rust implementation exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)