### PR TITLE
feat(dotnet): add native blake2b packages

### DIFF
--- a/code/packages/csharp/blake2b/BUILD
+++ b/code/packages/csharp/blake2b/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/blake2b/BUILD_windows
+++ b/code/packages/csharp/blake2b/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/blake2b/Blake2b.cs
+++ b/code/packages/csharp/blake2b/Blake2b.cs
@@ -1,0 +1,314 @@
+using System.Buffers.Binary;
+using System.Numerics;
+
+namespace CodingAdventures.Blake2b;
+
+/// <summary>
+/// BLAKE2b one-shot and streaming helpers implemented from RFC 7693.
+/// </summary>
+public static class Blake2b
+{
+    /// <summary>BLAKE2b block size in bytes.</summary>
+    public const int BlockSize = 128;
+
+    /// <summary>Maximum BLAKE2b digest length in bytes.</summary>
+    public const int MaxDigestLength = 64;
+
+    /// <summary>Maximum BLAKE2b key length in bytes.</summary>
+    public const int MaxKeyLength = 64;
+
+    private static readonly ulong[] Iv =
+    [
+        0x6A09_E667_F3BC_C908UL,
+        0xBB67_AE85_84CA_A73BUL,
+        0x3C6E_F372_FE94_F82BUL,
+        0xA54F_F53A_5F1D_36F1UL,
+        0x510E_527F_ADE6_82D1UL,
+        0x9B05_688C_2B3E_6C1FUL,
+        0x1F83_D9AB_FB41_BD6BUL,
+        0x5BE0_CD19_137E_2179UL,
+    ];
+
+    private static readonly int[][] Sigma =
+    [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+        [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+        [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+        [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+        [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+        [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+        [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+        [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+        [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+    ];
+
+    /// <summary>Compute a BLAKE2b digest for a complete byte array.</summary>
+    public static byte[] Hash(byte[] data, Blake2bOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var hasher = new Blake2bHasher(options);
+        hasher.Update(data);
+        return hasher.Digest();
+    }
+
+    /// <summary>Compute BLAKE2b and return a lowercase hexadecimal digest.</summary>
+    public static string HashHex(byte[] data, Blake2bOptions? options = null) =>
+        Convert.ToHexString(Hash(data, options)).ToLowerInvariant();
+
+    internal static void Validate(Blake2bOptions options)
+    {
+        if (options.DigestSize < 1 || options.DigestSize > MaxDigestLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), options.DigestSize, "Digest size must be in [1, 64].");
+        }
+
+        if (options.Key.Length > MaxKeyLength)
+        {
+            throw new ArgumentException("Key length must be in [0, 64].", nameof(options));
+        }
+
+        if (options.Salt.Length is not 0 and not 16)
+        {
+            throw new ArgumentException("Salt must be empty or exactly 16 bytes.", nameof(options));
+        }
+
+        if (options.Personal.Length is not 0 and not 16)
+        {
+            throw new ArgumentException("Personal must be empty or exactly 16 bytes.", nameof(options));
+        }
+    }
+
+    internal static ulong[] InitialState(Blake2bOptions options)
+    {
+        var parameter = new byte[64];
+        parameter[0] = checked((byte)options.DigestSize);
+        parameter[1] = checked((byte)options.Key.Length);
+        parameter[2] = 1;
+        parameter[3] = 1;
+
+        if (options.Salt.Length > 0)
+        {
+            options.Salt.CopyTo(parameter.AsSpan(32, 16));
+        }
+
+        if (options.Personal.Length > 0)
+        {
+            options.Personal.CopyTo(parameter.AsSpan(48, 16));
+        }
+
+        var state = Iv.ToArray();
+        for (var index = 0; index < state.Length; index++)
+        {
+            state[index] ^= BinaryPrimitives.ReadUInt64LittleEndian(parameter.AsSpan(index * 8, 8));
+        }
+
+        return state;
+    }
+
+    internal static void Compress(ulong[] state, ReadOnlySpan<byte> block, ulong counterLow, ulong counterHigh, bool isFinal)
+    {
+        Span<ulong> m = stackalloc ulong[16];
+        for (var index = 0; index < m.Length; index++)
+        {
+            m[index] = BinaryPrimitives.ReadUInt64LittleEndian(block.Slice(index * 8, 8));
+        }
+
+        Span<ulong> v = stackalloc ulong[16];
+        for (var index = 0; index < 8; index++)
+        {
+            v[index] = state[index];
+            v[index + 8] = Iv[index];
+        }
+
+        v[12] ^= counterLow;
+        v[13] ^= counterHigh;
+        if (isFinal)
+        {
+            v[14] ^= ulong.MaxValue;
+        }
+
+        for (var round = 0; round < 12; round++)
+        {
+            var s = Sigma[round % 10];
+            Mix(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+            Mix(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+            Mix(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+            Mix(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+            Mix(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+            Mix(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+            Mix(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+            Mix(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+        }
+
+        for (var index = 0; index < 8; index++)
+        {
+            state[index] ^= v[index] ^ v[index + 8];
+        }
+    }
+
+    internal static void WriteDigest(ulong[] state, Span<byte> destination)
+    {
+        Span<byte> full = stackalloc byte[MaxDigestLength];
+        for (var index = 0; index < state.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(full.Slice(index * 8, 8), state[index]);
+        }
+
+        full[..destination.Length].CopyTo(destination);
+    }
+
+    private static void Mix(Span<ulong> v, int a, int b, int c, int d, ulong x, ulong y)
+    {
+        v[a] = unchecked(v[a] + v[b] + x);
+        v[d] = BitOperations.RotateRight(v[d] ^ v[a], 32);
+        v[c] = unchecked(v[c] + v[d]);
+        v[b] = BitOperations.RotateRight(v[b] ^ v[c], 24);
+        v[a] = unchecked(v[a] + v[b] + y);
+        v[d] = BitOperations.RotateRight(v[d] ^ v[a], 16);
+        v[c] = unchecked(v[c] + v[d]);
+        v[b] = BitOperations.RotateRight(v[b] ^ v[c], 63);
+    }
+}
+
+/// <summary>BLAKE2b parameter block options for sequential mode.</summary>
+public sealed class Blake2bOptions
+{
+    /// <summary>Create BLAKE2b options. Arrays are defensively copied.</summary>
+    public Blake2bOptions(int digestSize = Blake2b.MaxDigestLength, byte[]? key = null, byte[]? salt = null, byte[]? personal = null)
+    {
+        DigestSize = digestSize;
+        Key = key?.ToArray() ?? [];
+        Salt = salt?.ToArray() ?? [];
+        Personal = personal?.ToArray() ?? [];
+    }
+
+    /// <summary>Requested digest length in bytes.</summary>
+    public int DigestSize { get; }
+
+    /// <summary>Optional key for MAC mode.</summary>
+    public byte[] Key { get; }
+
+    /// <summary>Optional 16-byte salt.</summary>
+    public byte[] Salt { get; }
+
+    /// <summary>Optional 16-byte personalization string.</summary>
+    public byte[] Personal { get; }
+
+    /// <summary>Default BLAKE2b options: 64-byte digest, unkeyed, no salt, no personalization.</summary>
+    public static Blake2bOptions Default => new();
+
+    /// <summary>Return a copy with a different digest size.</summary>
+    public Blake2bOptions WithDigestSize(int digestSize) => new(digestSize, Key, Salt, Personal);
+
+    /// <summary>Return a copy with a different key.</summary>
+    public Blake2bOptions WithKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return new Blake2bOptions(DigestSize, key, Salt, Personal);
+    }
+
+    /// <summary>Return a copy with a different salt.</summary>
+    public Blake2bOptions WithSalt(byte[] salt)
+    {
+        ArgumentNullException.ThrowIfNull(salt);
+        return new Blake2bOptions(DigestSize, Key, salt, Personal);
+    }
+
+    /// <summary>Return a copy with a different personalization string.</summary>
+    public Blake2bOptions WithPersonal(byte[] personal)
+    {
+        ArgumentNullException.ThrowIfNull(personal);
+        return new Blake2bOptions(DigestSize, Key, Salt, personal);
+    }
+}
+
+/// <summary>Streaming BLAKE2b hasher with non-destructive digest snapshots.</summary>
+public sealed class Blake2bHasher
+{
+    private readonly List<byte> _buffer;
+    private readonly int _digestSize;
+    private readonly ulong[] _state;
+    private ulong _counterLow;
+    private ulong _counterHigh;
+
+    /// <summary>Create a hasher with optional BLAKE2b parameters.</summary>
+    public Blake2bHasher(Blake2bOptions? options = null)
+    {
+        options ??= Blake2bOptions.Default;
+        Blake2b.Validate(options);
+
+        _digestSize = options.DigestSize;
+        _state = Blake2b.InitialState(options);
+        _buffer = new List<byte>(Blake2b.BlockSize * 2);
+
+        if (options.Key.Length > 0)
+        {
+            var keyBlock = new byte[Blake2b.BlockSize];
+            options.Key.CopyTo(keyBlock.AsSpan());
+            _buffer.AddRange(keyBlock);
+        }
+    }
+
+    private Blake2bHasher(ulong[] state, byte[] buffer, ulong counterLow, ulong counterHigh, int digestSize)
+    {
+        _state = state.ToArray();
+        _buffer = new List<byte>(buffer);
+        _counterLow = counterLow;
+        _counterHigh = counterHigh;
+        _digestSize = digestSize;
+    }
+
+    /// <summary>Append bytes and return this hasher for chaining.</summary>
+    public Blake2bHasher Update(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        _buffer.AddRange(data);
+
+        while (_buffer.Count > Blake2b.BlockSize)
+        {
+            AddCount(Blake2b.BlockSize);
+            var block = new byte[Blake2b.BlockSize];
+            _buffer.CopyTo(0, block, 0, Blake2b.BlockSize);
+            Blake2b.Compress(_state, block, _counterLow, _counterHigh, isFinal: false);
+            _buffer.RemoveRange(0, Blake2b.BlockSize);
+        }
+
+        return this;
+    }
+
+    /// <summary>Return the current digest without modifying this hasher.</summary>
+    public byte[] Digest()
+    {
+        var state = _state.ToArray();
+        var finalBlock = new byte[Blake2b.BlockSize];
+        _buffer.CopyTo(finalBlock);
+
+        var finalLow = _counterLow;
+        var finalHigh = _counterHigh;
+        AddToCount(ref finalLow, ref finalHigh, checked((ulong)_buffer.Count));
+        Blake2b.Compress(state, finalBlock, finalLow, finalHigh, isFinal: true);
+
+        var digest = new byte[_digestSize];
+        Blake2b.WriteDigest(state, digest);
+        return digest;
+    }
+
+    /// <summary>Return the current digest as lowercase hexadecimal text.</summary>
+    public string HexDigest() => Convert.ToHexString(Digest()).ToLowerInvariant();
+
+    /// <summary>Return an independent copy of the current hasher state.</summary>
+    public Blake2bHasher Copy() => new(_state, _buffer.ToArray(), _counterLow, _counterHigh, _digestSize);
+
+    private void AddCount(ulong value) => AddToCount(ref _counterLow, ref _counterHigh, value);
+
+    private static void AddToCount(ref ulong low, ref ulong high, ulong value)
+    {
+        var previous = low;
+        low = unchecked(low + value);
+        if (low < previous)
+        {
+            high = unchecked(high + 1);
+        }
+    }
+}

--- a/code/packages/csharp/blake2b/CHANGELOG.md
+++ b/code/packages/csharp/blake2b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# BLAKE2b package implemented directly from RFC 7693.
+- Include one-shot hashing, keyed mode, salt/personal parameters, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/csharp/blake2b/CodingAdventures.Blake2b.csproj
+++ b/code/packages/csharp/blake2b/CodingAdventures.Blake2b.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Blake2b.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>BLAKE2b one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/blake2b/README.md
+++ b/code/packages/csharp/blake2b/README.md
@@ -1,0 +1,24 @@
+# CodingAdventures.Blake2b.CSharp
+
+BLAKE2b helpers for .NET, implemented directly from RFC 7693.
+
+The package exposes one-shot hashing, keyed MAC mode, salt and personalization
+parameters, plus a streaming-style hasher whose `Digest` calls are
+non-destructive.
+
+```csharp
+using CodingAdventures.Blake2b;
+
+byte[] digest = Blake2b.Hash("abc"u8.ToArray());
+string hex = Blake2b.HashHex("abc"u8.ToArray());
+
+var keyed = Blake2bOptions.Default
+    .WithDigestSize(32)
+    .WithKey("shared secret"u8.ToArray());
+
+byte[] tag = Blake2b.Hash("message"u8.ToArray(), keyed);
+
+var hasher = new Blake2bHasher(Blake2bOptions.Default.WithDigestSize(32));
+hasher.Update("partial "u8.ToArray()).Update("payload"u8.ToArray());
+string streamed = hasher.HexDigest();
+```

--- a/code/packages/csharp/blake2b/required_capabilities.json
+++ b/code/packages/csharp/blake2b/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/blake2b",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using .NET numeric and binary primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/blake2b/tests/CodingAdventures.Blake2b.Tests/Blake2bTests.cs
+++ b/code/packages/csharp/blake2b/tests/CodingAdventures.Blake2b.Tests/Blake2bTests.cs
@@ -1,0 +1,180 @@
+using System.Text;
+using Blake2bAlgorithm = CodingAdventures.Blake2b.Blake2b;
+
+namespace CodingAdventures.Blake2b.Tests;
+
+public sealed class Blake2bTests
+{
+    [Theory]
+    [InlineData("", "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce")]
+    [InlineData("abc", "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923")]
+    [InlineData("The quick brown fox jumps over the lazy dog", "a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918")]
+    public void HashMatchesCanonicalVectors(string input, string expected)
+    {
+        Assert.Equal(Blake2bAlgorithm.MaxDigestLength, Blake2bAlgorithm.Hash(Encoding.ASCII.GetBytes(input)).Length);
+        Assert.Equal(expected, Blake2bAlgorithm.HashHex(Encoding.ASCII.GetBytes(input)));
+    }
+
+    [Fact]
+    public void TruncatedDigestMatchesVector()
+    {
+        var options = Blake2bOptions.Default.WithDigestSize(32);
+
+        Assert.Equal(
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+            Blake2bAlgorithm.HashHex([], options));
+    }
+
+    [Fact]
+    public void KeyedLongVectorMatchesReference()
+    {
+        var key = BytesFromRange(1, 65);
+        var data = BytesFromRange(0, 256);
+
+        Assert.Equal(
+            "402fa70e35f026c9bfc1202805e931b995647fe479e1701ad8b7203cddad5927ee7950b898a5a8229443d93963e4f6f27136b2b56f6845ab18f59bc130db8bf3",
+            Blake2bAlgorithm.HashHex(data, Blake2bOptions.Default.WithKey(key)));
+    }
+
+    [Theory]
+    [InlineData(0, "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce")]
+    [InlineData(1, "4fe4da61bcc756071b226843361d74944c72245d23e8245ea678c13fdcd7fe2ae529cf999ad99cc24f7a73416a18ba53e76c0afef83b16a568b12fbfc1a2674d")]
+    [InlineData(63, "70b2a0e6daecac22c7a2df82c06e3fc0b4c66bd5ef8098e4ed54e723b393d79ef3bceba079a01a14c6ef2ae2ed1171df1662cd14ef38e6f77b01c7f48144dd09")]
+    [InlineData(64, "3db7bb5c40745f0c975ac6bb8578f590e2cd2cc1fc6d13533ef725325c9fddff5cca24e7a591a0f6032a24fad0e09f6df873c4ff314628391f78df7f09cb7ed7")]
+    [InlineData(65, "149c114a3e8c6e06bafee27c9d0de0e39ef28294fa0d9f81876dcceb10bb41101e256593587e46b844819ed7ded90d56c0843df06c95d1695c3de635cd7a888e")]
+    [InlineData(127, "71546bbf9110ad184cc60f2eb120fcfd9b4dbbca7a7f1270045b8a23a6a4f4330f65c1f030dd2f5fabc6c57617242c37cf427bd90407fac5b9deffd3ae888c39")]
+    [InlineData(128, "2d9e329f42afa3601d646692b81c13e87fcaff5bf15972e9813d7373cb6d181f9599f4d513d4af4fd6ebd37497aceb29aba5ee23ed764d8510b552bd088814fb")]
+    [InlineData(129, "47889df9eb4d717afc5019df5c6a83df00a0b8677395e078cd5778ace0f338a618e68b7d9afb065d9e6a01ccd31d109447e7fae771c3ee3e105709194122ba2b")]
+    [InlineData(255, "1a5199ac66a00e8a87ad1c7fbad30b33137dd8312bf6d98602dacf8f40ea2cb623a7fbc63e5a6bfa434d337ae7da5ca1a52502a215a3fe0297a151be85d88789")]
+    [InlineData(256, "91019c558584980249ca43eceed27e19f1c3c24161b93eed1eee2a6a774f60bf8a81b43750870bee1698feac9c5336ae4d5c842e7ead159bf3916387e8ded9ae")]
+    [InlineData(257, "9f1975efca45e7b74b020975d4d2c22802906ed8bfefca51ac497bd23147fc8f303890d8e5471ab6caaa02362e831a9e8d3435279912ccd4842c7806b096c348")]
+    [InlineData(1024, "eddc3f3af9392eff065b359ce5f2b28f71e9f3a3a50e60ec27787b9fa623094d17b046c1dfce89bc5cdfc951b95a9a9c05fb8cc2361c905db01dd237fe56efb3")]
+    [InlineData(4096, "31404c9c7ed64c59112579f300f2afef181ee6283c3918bf026c4ed4bcde0697a7834f3a3410396622ef3d4f432602528a689498141c184cc2063554ba688dc7")]
+    [InlineData(9999, "b4a5808e65d7424b517bde11e04075a09b1343148e3ab2c8b13ff35c542e0a2beff6309ecc54b59ac046f6d65a9e3680c6372a033607709c95d5fd8070be6069")]
+    public void BlockBoundaryVectorsMatchReference(int size, string expected)
+    {
+        var data = Enumerable.Range(0, size).Select(index => (byte)((index * 7 + 3) & 0xff)).ToArray();
+
+        Assert.Equal(expected, Blake2bAlgorithm.HashHex(data));
+    }
+
+    [Theory]
+    [InlineData(1, "b5")]
+    [InlineData(16, "249df9a49f517ddcd37f5c897620ec73")]
+    [InlineData(20, "3c523ed102ab45a37d54f5610d5a983162fde84f")]
+    [InlineData(32, "01718cec35cd3d796dd00020e0bfecb473ad23457d063b75eff29c0ffa2e58a9")]
+    [InlineData(48, "b7c81b228b6bd912930e8f0b5387989691c1cee1e65aade4da3b86a3c9f678fc8018f6ed9e2906720c8d2a3aeda9c03d")]
+    [InlineData(64, "a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918")]
+    public void VariableDigestSizesMatchReference(int digestSize, string expected)
+    {
+        var data = Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog");
+        var options = Blake2bOptions.Default.WithDigestSize(digestSize);
+        var digest = Blake2bAlgorithm.Hash(data, options);
+
+        Assert.Equal(digestSize, digest.Length);
+        Assert.Equal(expected, Convert.ToHexString(digest).ToLowerInvariant());
+    }
+
+    [Theory]
+    [InlineData(1, "affd4e429aa2fb18da276f6ecff16f7d048769cacefe1a7ac75184448e082422")]
+    [InlineData(16, "5f8510d05dac42e8b6fc542af93f349d41ae4ebaf5cecae4af43fae54c7ca618")]
+    [InlineData(32, "88a78036d5890e91b5e3d70ba4738d2be302b76e0857d8ee029dc56dfa04fe67")]
+    [InlineData(64, "df7eab2ec9135ab8c58f48c288cdc873bac245a7fa46ca9f047cab672bd1eabb")]
+    public void KeyedVariantsMatchReference(int keyLength, string expected)
+    {
+        var key = BytesFromRange(1, keyLength + 1);
+        var options = Blake2bOptions.Default.WithDigestSize(32).WithKey(key);
+
+        Assert.Equal(expected, Blake2bAlgorithm.HashHex("secret message body"u8.ToArray(), options));
+    }
+
+    [Fact]
+    public void SaltAndPersonalMatchReference()
+    {
+        var options = Blake2bOptions.Default
+            .WithSalt(BytesFromRange(0, 16))
+            .WithPersonal(BytesFromRange(16, 32));
+
+        Assert.Equal(
+            "a2185d648fc63f3d363871a76360330c9b238af5466a20f94bb64d363289b95da0453438eea300cd6f31521274ec001011fa29e91a603fabf00f2b454e30bf3d",
+            Blake2bAlgorithm.HashHex("parameterized hash"u8.ToArray(), options));
+    }
+
+    [Fact]
+    public void StreamingMatchesOneShotAcrossChunking()
+    {
+        var data = BytesFromRange(0, 200);
+        var hasher = new Blake2bHasher(Blake2bOptions.Default.WithDigestSize(32));
+
+        foreach (var value in data)
+        {
+            hasher.Update([value]);
+        }
+
+        Assert.Equal(Blake2bAlgorithm.Hash(data, Blake2bOptions.Default.WithDigestSize(32)), hasher.Digest());
+    }
+
+    [Fact]
+    public void StreamingHandlesExactBlockThenMore()
+    {
+        var data = BytesFromRange(0, 132);
+        var hasher = new Blake2bHasher();
+
+        hasher.Update(data[..128]);
+        hasher.Update(data[128..]);
+
+        Assert.Equal(Blake2bAlgorithm.Hash(data), hasher.Digest());
+    }
+
+    [Fact]
+    public void DigestIsNonDestructiveAndUpdateCanContinue()
+    {
+        var hasher = new Blake2bHasher(Blake2bOptions.Default.WithDigestSize(32));
+
+        var result = hasher.Update("hello "u8.ToArray());
+        var first = hasher.HexDigest();
+        var second = hasher.HexDigest();
+        hasher.Update("world"u8.ToArray());
+
+        Assert.Same(hasher, result);
+        Assert.Equal(first, second);
+        Assert.Equal(Blake2bAlgorithm.HashHex("hello world"u8.ToArray(), Blake2bOptions.Default.WithDigestSize(32)), hasher.HexDigest());
+    }
+
+    [Fact]
+    public void CopyIsIndependent()
+    {
+        var hasher = new Blake2bHasher();
+        hasher.Update("prefix "u8.ToArray());
+
+        var copy = hasher.Copy();
+        hasher.Update("path A"u8.ToArray());
+        copy.Update("path B"u8.ToArray());
+
+        Assert.Equal(Blake2bAlgorithm.Hash("prefix path A"u8.ToArray()), hasher.Digest());
+        Assert.Equal(Blake2bAlgorithm.Hash("prefix path B"u8.ToArray()), copy.Digest());
+    }
+
+    [Fact]
+    public void RejectsInvalidOptionsAndNulls()
+    {
+        Assert.Throws<ArgumentNullException>(() => Blake2bAlgorithm.Hash(null!));
+        Assert.Throws<ArgumentNullException>(() => new Blake2bHasher().Update(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Blake2bAlgorithm.Hash([], Blake2bOptions.Default.WithDigestSize(0)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Blake2bAlgorithm.Hash([], Blake2bOptions.Default.WithDigestSize(65)));
+        Assert.Throws<ArgumentException>(() => Blake2bAlgorithm.Hash([], Blake2bOptions.Default.WithKey(new byte[65])));
+        Assert.Throws<ArgumentException>(() => Blake2bAlgorithm.Hash([], Blake2bOptions.Default.WithSalt(new byte[8])));
+        Assert.Throws<ArgumentException>(() => Blake2bAlgorithm.Hash([], Blake2bOptions.Default.WithPersonal(new byte[20])));
+    }
+
+    [Fact]
+    public void AcceptsMaximumKeyLength()
+    {
+        var digest = Blake2bAlgorithm.Hash("x"u8.ToArray(), Blake2bOptions.Default.WithKey(Enumerable.Repeat((byte)'k', 64).ToArray()));
+
+        Assert.Equal(Blake2bAlgorithm.MaxDigestLength, digest.Length);
+    }
+
+    private static byte[] BytesFromRange(int startInclusive, int endExclusive) =>
+        Enumerable.Range(startInclusive, endExclusive - startInclusive).Select(value => (byte)(value & 0xff)).ToArray();
+}

--- a/code/packages/csharp/blake2b/tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.csproj
+++ b/code/packages/csharp/blake2b/tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Blake2b.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/blake2b/BUILD
+++ b/code/packages/fsharp/blake2b/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/blake2b/BUILD_windows
+++ b/code/packages/fsharp/blake2b/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/blake2b/Blake2b.fs
+++ b/code/packages/fsharp/blake2b/Blake2b.fs
@@ -1,0 +1,300 @@
+namespace CodingAdventures.Blake2b.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+open System.Numerics
+
+/// BLAKE2b parameter block options for sequential mode.
+type Blake2bOptions =
+    {
+        /// Requested digest length in bytes.
+        DigestSize: int
+        /// Optional key for MAC mode.
+        Key: byte array
+        /// Optional 16-byte salt.
+        Salt: byte array
+        /// Optional 16-byte personalization string.
+        Personal: byte array
+    }
+
+    /// Default BLAKE2b options: 64-byte digest, unkeyed, no salt, no personalization.
+    static member Default =
+        {
+            DigestSize = 64
+            Key = [||]
+            Salt = [||]
+            Personal = [||]
+        }
+
+    /// Return a copy with a different digest size.
+    member this.WithDigestSize(digestSize: int) =
+        { this with DigestSize = digestSize }
+
+    /// Return a copy with a different key.
+    member this.WithKey(key: byte array) =
+        if isNull key then
+            nullArg "key"
+
+        { this with Key = Array.copy key }
+
+    /// Return a copy with a different salt.
+    member this.WithSalt(salt: byte array) =
+        if isNull salt then
+            nullArg "salt"
+
+        { this with Salt = Array.copy salt }
+
+    /// Return a copy with a different personalization string.
+    member this.WithPersonal(personal: byte array) =
+        if isNull personal then
+            nullArg "personal"
+
+        { this with Personal = Array.copy personal }
+
+module private Blake2bCore =
+    [<Literal>]
+    let blockSize = 128
+
+    [<Literal>]
+    let maxDigestLength = 64
+
+    [<Literal>]
+    let maxKeyLength = 64
+
+    let private iv =
+        [|
+            0x6A09_E667_F3BC_C908UL
+            0xBB67_AE85_84CA_A73BUL
+            0x3C6E_F372_FE94_F82BUL
+            0xA54F_F53A_5F1D_36F1UL
+            0x510E_527F_ADE6_82D1UL
+            0x9B05_688C_2B3E_6C1FUL
+            0x1F83_D9AB_FB41_BD6BUL
+            0x5BE0_CD19_137E_2179UL
+        |]
+
+    let private sigma =
+        [|
+            [| 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 |]
+            [| 14; 10; 4; 8; 9; 15; 13; 6; 1; 12; 0; 2; 11; 7; 5; 3 |]
+            [| 11; 8; 12; 0; 5; 2; 15; 13; 10; 14; 3; 6; 7; 1; 9; 4 |]
+            [| 7; 9; 3; 1; 13; 12; 11; 14; 2; 6; 5; 10; 4; 0; 15; 8 |]
+            [| 9; 0; 5; 7; 2; 4; 10; 15; 14; 1; 11; 12; 6; 8; 3; 13 |]
+            [| 2; 12; 6; 10; 0; 11; 8; 3; 4; 13; 7; 5; 15; 14; 1; 9 |]
+            [| 12; 5; 1; 15; 14; 13; 4; 10; 0; 7; 6; 3; 9; 2; 8; 11 |]
+            [| 13; 11; 7; 14; 12; 1; 3; 9; 5; 0; 15; 4; 8; 6; 2; 10 |]
+            [| 6; 15; 14; 9; 11; 3; 0; 8; 12; 2; 13; 7; 1; 4; 10; 5 |]
+            [| 10; 2; 8; 4; 7; 6; 1; 5; 15; 11; 9; 14; 3; 12; 13; 0 |]
+        |]
+
+    let private copyOrEmpty (bytes: byte array) =
+        if isNull bytes then
+            [||]
+        else
+            Array.copy bytes
+
+    let normalizeAndValidate (options: Blake2bOptions) =
+        if Object.ReferenceEquals(options, null) then
+            nullArg "options"
+
+        let normalized =
+            {
+                DigestSize = options.DigestSize
+                Key = copyOrEmpty options.Key
+                Salt = copyOrEmpty options.Salt
+                Personal = copyOrEmpty options.Personal
+            }
+
+        if normalized.DigestSize < 1 || normalized.DigestSize > maxDigestLength then
+            raise (ArgumentOutOfRangeException("options", normalized.DigestSize, "Digest size must be in [1, 64]."))
+
+        if normalized.Key.Length > maxKeyLength then
+            invalidArg "options" "Key length must be in [0, 64]."
+
+        if normalized.Salt.Length <> 0 && normalized.Salt.Length <> 16 then
+            invalidArg "options" "Salt must be empty or exactly 16 bytes."
+
+        if normalized.Personal.Length <> 0 && normalized.Personal.Length <> 16 then
+            invalidArg "options" "Personal must be empty or exactly 16 bytes."
+
+        normalized
+
+    let initialState (options: Blake2bOptions) =
+        let parameter = Array.zeroCreate<byte> 64
+        parameter[0] <- byte options.DigestSize
+        parameter[1] <- byte options.Key.Length
+        parameter[2] <- 1uy
+        parameter[3] <- 1uy
+
+        if options.Salt.Length > 0 then
+            Array.Copy(options.Salt, 0, parameter, 32, 16)
+
+        if options.Personal.Length > 0 then
+            Array.Copy(options.Personal, 0, parameter, 48, 16)
+
+        let state = Array.copy iv
+
+        for index in 0 .. state.Length - 1 do
+            state[index] <- state[index] ^^^ BinaryPrimitives.ReadUInt64LittleEndian(parameter.AsSpan(index * 8, 8))
+
+        state
+
+    let addToCount (low: uint64) (high: uint64) (value: uint64) =
+        let newLow = low + value
+        let newHigh =
+            if newLow < low then
+                high + 1UL
+            else
+                high
+
+        newLow, newHigh
+
+    let private mix (v: uint64 array) a b c d x y =
+        v[a] <- v[a] + v[b] + x
+        v[d] <- BitOperations.RotateRight(v[d] ^^^ v[a], 32)
+        v[c] <- v[c] + v[d]
+        v[b] <- BitOperations.RotateRight(v[b] ^^^ v[c], 24)
+        v[a] <- v[a] + v[b] + y
+        v[d] <- BitOperations.RotateRight(v[d] ^^^ v[a], 16)
+        v[c] <- v[c] + v[d]
+        v[b] <- BitOperations.RotateRight(v[b] ^^^ v[c], 63)
+
+    let compress (state: uint64 array) (block: ReadOnlySpan<byte>) (counterLow: uint64) (counterHigh: uint64) (isFinal: bool) =
+        let m = Array.zeroCreate<uint64> 16
+
+        for index in 0 .. m.Length - 1 do
+            m[index] <- BinaryPrimitives.ReadUInt64LittleEndian(block.Slice(index * 8, 8))
+
+        let v = Array.zeroCreate<uint64> 16
+
+        for index in 0 .. 7 do
+            v[index] <- state[index]
+            v[index + 8] <- iv[index]
+
+        v[12] <- v[12] ^^^ counterLow
+        v[13] <- v[13] ^^^ counterHigh
+
+        if isFinal then
+            v[14] <- v[14] ^^^ UInt64.MaxValue
+
+        for round in 0 .. 11 do
+            let s = sigma[round % 10]
+            mix v 0 4 8 12 m[s[0]] m[s[1]]
+            mix v 1 5 9 13 m[s[2]] m[s[3]]
+            mix v 2 6 10 14 m[s[4]] m[s[5]]
+            mix v 3 7 11 15 m[s[6]] m[s[7]]
+            mix v 0 5 10 15 m[s[8]] m[s[9]]
+            mix v 1 6 11 12 m[s[10]] m[s[11]]
+            mix v 2 7 8 13 m[s[12]] m[s[13]]
+            mix v 3 4 9 14 m[s[14]] m[s[15]]
+
+        for index in 0 .. 7 do
+            state[index] <- state[index] ^^^ v[index] ^^^ v[index + 8]
+
+    let writeDigest (state: uint64 array) (destination: Span<byte>) =
+        let full = Array.zeroCreate<byte> maxDigestLength
+
+        for index in 0 .. state.Length - 1 do
+            BinaryPrimitives.WriteUInt64LittleEndian(full.AsSpan(index * 8, 8), state[index])
+
+        full.AsSpan(0, destination.Length).CopyTo(destination)
+
+/// Streaming BLAKE2b hasher with non-destructive digest snapshots.
+type Blake2bHasher private (initialState: uint64 array, initialBuffer: byte array, initialLow: uint64, initialHigh: uint64, digestSize: int) =
+    let state = Array.copy initialState
+    let buffer = List<byte>(initialBuffer)
+    let mutable counterLow = initialLow
+    let mutable counterHigh = initialHigh
+
+    /// Create a hasher with optional BLAKE2b parameters.
+    new(?options: Blake2bOptions) =
+        let normalized = defaultArg options Blake2bOptions.Default |> Blake2bCore.normalizeAndValidate
+        let state = Blake2bCore.initialState normalized
+
+        let initialBuffer =
+            if normalized.Key.Length = 0 then
+                [||]
+            else
+                let keyBlock = Array.zeroCreate<byte> Blake2bCore.blockSize
+                Array.Copy(normalized.Key, keyBlock, normalized.Key.Length)
+                keyBlock
+
+        Blake2bHasher(state, initialBuffer, 0UL, 0UL, normalized.DigestSize)
+
+    /// Append bytes and return this hasher for chaining.
+    member this.Update(data: byte array) =
+        if isNull data then
+            nullArg "data"
+
+        buffer.AddRange(data)
+
+        while buffer.Count > Blake2bCore.blockSize do
+            let nextLow, nextHigh = Blake2bCore.addToCount counterLow counterHigh (uint64 Blake2bCore.blockSize)
+            counterLow <- nextLow
+            counterHigh <- nextHigh
+
+            let block = Array.zeroCreate<byte> Blake2bCore.blockSize
+            buffer.CopyTo(0, block, 0, Blake2bCore.blockSize)
+            Blake2bCore.compress state (ReadOnlySpan<byte>(block)) counterLow counterHigh false
+            buffer.RemoveRange(0, Blake2bCore.blockSize)
+
+        this
+
+    /// Return the current digest without modifying this hasher.
+    member _.Digest() =
+        let snapshot = Array.copy state
+        let finalBlock = Array.zeroCreate<byte> Blake2bCore.blockSize
+        buffer.CopyTo(finalBlock)
+
+        let finalLow, finalHigh = Blake2bCore.addToCount counterLow counterHigh (uint64 buffer.Count)
+        Blake2bCore.compress snapshot (ReadOnlySpan<byte>(finalBlock)) finalLow finalHigh true
+
+        let digest = Array.zeroCreate<byte> digestSize
+        Blake2bCore.writeDigest snapshot (digest.AsSpan())
+        digest
+
+    /// Return the current digest as lowercase hexadecimal text.
+    member this.HexDigest() =
+        this.Digest() |> Convert.ToHexString |> fun value -> value.ToLowerInvariant()
+
+    /// Return an independent copy of the current hasher state.
+    member _.Copy() =
+        Blake2bHasher(state, buffer.ToArray(), counterLow, counterHigh, digestSize)
+
+[<RequireQualifiedAccess>]
+module Blake2b =
+    /// BLAKE2b block size in bytes.
+    [<Literal>]
+    let BlockSize = 128
+
+    /// Maximum BLAKE2b digest length in bytes.
+    [<Literal>]
+    let MaxDigestLength = 64
+
+    /// Maximum BLAKE2b key length in bytes.
+    [<Literal>]
+    let MaxKeyLength = 64
+
+    /// Compute a BLAKE2b digest for a complete byte array with explicit options.
+    let hashWithOptions (options: Blake2bOptions) (data: byte array) =
+        if isNull data then
+            nullArg "data"
+
+        let hasher = Blake2bHasher(options)
+        hasher.Update(data) |> ignore
+        hasher.Digest()
+
+    /// Compute a BLAKE2b digest for a complete byte array.
+    let hash (data: byte array) =
+        hashWithOptions Blake2bOptions.Default data
+
+    /// Compute BLAKE2b and return a lowercase hexadecimal digest with explicit options.
+    let hashHexWithOptions (options: Blake2bOptions) (data: byte array) =
+        hashWithOptions options data
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    /// Compute BLAKE2b and return a lowercase hexadecimal digest.
+    let hashHex (data: byte array) =
+        hashHexWithOptions Blake2bOptions.Default data

--- a/code/packages/fsharp/blake2b/CHANGELOG.md
+++ b/code/packages/fsharp/blake2b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# BLAKE2b package implemented directly from RFC 7693.
+- Include one-shot hashing, keyed mode, salt/personal parameters, streaming snapshots, copy support, and xUnit coverage.

--- a/code/packages/fsharp/blake2b/CodingAdventures.Blake2b.fsproj
+++ b/code/packages/fsharp/blake2b/CodingAdventures.Blake2b.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Blake2b.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>BLAKE2b one-shot and streaming hash helpers for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Blake2b.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/blake2b/README.md
+++ b/code/packages/fsharp/blake2b/README.md
@@ -1,0 +1,25 @@
+# CodingAdventures.Blake2b.FSharp
+
+BLAKE2b helpers for .NET, implemented directly from RFC 7693.
+
+The package exposes one-shot hashing, keyed MAC mode, salt and personalization
+parameters, plus a streaming-style hasher whose `Digest` calls are
+non-destructive.
+
+```fsharp
+open CodingAdventures.Blake2b.FSharp
+
+let digest = Blake2b.hash "abc"B
+let hex = Blake2b.hashHex "abc"B
+
+let keyed =
+    Blake2bOptions.Default
+        .WithDigestSize(32)
+        .WithKey("shared secret"B)
+
+let tag = Blake2b.hashWithOptions keyed "message"B
+
+let hasher = Blake2bHasher(Blake2bOptions.Default.WithDigestSize(32))
+hasher.Update("partial "B).Update("payload"B) |> ignore
+let streamed = hasher.HexDigest()
+```

--- a/code/packages/fsharp/blake2b/required_capabilities.json
+++ b/code/packages/fsharp/blake2b/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/blake2b",
+  "capabilities": [],
+  "justification": "Pure in-memory cryptographic hashing using .NET numeric and binary primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/blake2b/tests/CodingAdventures.Blake2b.Tests/Blake2bTests.fs
+++ b/code/packages/fsharp/blake2b/tests/CodingAdventures.Blake2b.Tests/Blake2bTests.fs
@@ -1,0 +1,160 @@
+namespace CodingAdventures.Blake2b.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.Blake2b.FSharp
+
+module Blake2bTests =
+    let private bytesFromRange startInclusive endExclusive =
+        [| startInclusive .. endExclusive - 1 |]
+        |> Array.map (fun value -> byte (value &&& 0xff))
+
+    [<Theory>]
+    [<InlineData("", "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce")>]
+    [<InlineData("abc", "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923")>]
+    [<InlineData("The quick brown fox jumps over the lazy dog", "a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918")>]
+    let ``hash matches canonical vectors`` (input: string) (expected: string) =
+        let data = Encoding.ASCII.GetBytes input
+
+        Assert.Equal(Blake2b.MaxDigestLength, (Blake2b.hash data).Length)
+        Assert.Equal(expected, Blake2b.hashHex data)
+
+    [<Fact>]
+    let ``truncated digest matches vector`` () =
+        let options = Blake2bOptions.Default.WithDigestSize(32)
+
+        Assert.Equal(
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+            Blake2b.hashHexWithOptions options [||])
+
+    [<Fact>]
+    let ``keyed long vector matches reference`` () =
+        let key = bytesFromRange 1 65
+        let data = bytesFromRange 0 256
+
+        Assert.Equal(
+            "402fa70e35f026c9bfc1202805e931b995647fe479e1701ad8b7203cddad5927ee7950b898a5a8229443d93963e4f6f27136b2b56f6845ab18f59bc130db8bf3",
+            Blake2b.hashHexWithOptions (Blake2bOptions.Default.WithKey key) data)
+
+    [<Theory>]
+    [<InlineData(0, "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce")>]
+    [<InlineData(1, "4fe4da61bcc756071b226843361d74944c72245d23e8245ea678c13fdcd7fe2ae529cf999ad99cc24f7a73416a18ba53e76c0afef83b16a568b12fbfc1a2674d")>]
+    [<InlineData(63, "70b2a0e6daecac22c7a2df82c06e3fc0b4c66bd5ef8098e4ed54e723b393d79ef3bceba079a01a14c6ef2ae2ed1171df1662cd14ef38e6f77b01c7f48144dd09")>]
+    [<InlineData(64, "3db7bb5c40745f0c975ac6bb8578f590e2cd2cc1fc6d13533ef725325c9fddff5cca24e7a591a0f6032a24fad0e09f6df873c4ff314628391f78df7f09cb7ed7")>]
+    [<InlineData(65, "149c114a3e8c6e06bafee27c9d0de0e39ef28294fa0d9f81876dcceb10bb41101e256593587e46b844819ed7ded90d56c0843df06c95d1695c3de635cd7a888e")>]
+    [<InlineData(127, "71546bbf9110ad184cc60f2eb120fcfd9b4dbbca7a7f1270045b8a23a6a4f4330f65c1f030dd2f5fabc6c57617242c37cf427bd90407fac5b9deffd3ae888c39")>]
+    [<InlineData(128, "2d9e329f42afa3601d646692b81c13e87fcaff5bf15972e9813d7373cb6d181f9599f4d513d4af4fd6ebd37497aceb29aba5ee23ed764d8510b552bd088814fb")>]
+    [<InlineData(129, "47889df9eb4d717afc5019df5c6a83df00a0b8677395e078cd5778ace0f338a618e68b7d9afb065d9e6a01ccd31d109447e7fae771c3ee3e105709194122ba2b")>]
+    [<InlineData(255, "1a5199ac66a00e8a87ad1c7fbad30b33137dd8312bf6d98602dacf8f40ea2cb623a7fbc63e5a6bfa434d337ae7da5ca1a52502a215a3fe0297a151be85d88789")>]
+    [<InlineData(256, "91019c558584980249ca43eceed27e19f1c3c24161b93eed1eee2a6a774f60bf8a81b43750870bee1698feac9c5336ae4d5c842e7ead159bf3916387e8ded9ae")>]
+    [<InlineData(257, "9f1975efca45e7b74b020975d4d2c22802906ed8bfefca51ac497bd23147fc8f303890d8e5471ab6caaa02362e831a9e8d3435279912ccd4842c7806b096c348")>]
+    [<InlineData(1024, "eddc3f3af9392eff065b359ce5f2b28f71e9f3a3a50e60ec27787b9fa623094d17b046c1dfce89bc5cdfc951b95a9a9c05fb8cc2361c905db01dd237fe56efb3")>]
+    [<InlineData(4096, "31404c9c7ed64c59112579f300f2afef181ee6283c3918bf026c4ed4bcde0697a7834f3a3410396622ef3d4f432602528a689498141c184cc2063554ba688dc7")>]
+    [<InlineData(9999, "b4a5808e65d7424b517bde11e04075a09b1343148e3ab2c8b13ff35c542e0a2beff6309ecc54b59ac046f6d65a9e3680c6372a033607709c95d5fd8070be6069")>]
+    let ``block boundary vectors match reference`` (size: int) (expected: string) =
+        let data =
+            [| 0 .. size - 1 |]
+            |> Array.map (fun index -> byte ((index * 7 + 3) &&& 0xff))
+
+        Assert.Equal(expected, Blake2b.hashHex data)
+
+    [<Theory>]
+    [<InlineData(1, "b5")>]
+    [<InlineData(16, "249df9a49f517ddcd37f5c897620ec73")>]
+    [<InlineData(20, "3c523ed102ab45a37d54f5610d5a983162fde84f")>]
+    [<InlineData(32, "01718cec35cd3d796dd00020e0bfecb473ad23457d063b75eff29c0ffa2e58a9")>]
+    [<InlineData(48, "b7c81b228b6bd912930e8f0b5387989691c1cee1e65aade4da3b86a3c9f678fc8018f6ed9e2906720c8d2a3aeda9c03d")>]
+    [<InlineData(64, "a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918")>]
+    let ``variable digest sizes match reference`` (digestSize: int) (expected: string) =
+        let data = Encoding.ASCII.GetBytes "The quick brown fox jumps over the lazy dog"
+        let options = Blake2bOptions.Default.WithDigestSize(digestSize)
+        let digest = Blake2b.hashWithOptions options data
+
+        Assert.Equal(digestSize, digest.Length)
+        Assert.Equal(expected, Convert.ToHexString(digest).ToLowerInvariant())
+
+    [<Theory>]
+    [<InlineData(1, "affd4e429aa2fb18da276f6ecff16f7d048769cacefe1a7ac75184448e082422")>]
+    [<InlineData(16, "5f8510d05dac42e8b6fc542af93f349d41ae4ebaf5cecae4af43fae54c7ca618")>]
+    [<InlineData(32, "88a78036d5890e91b5e3d70ba4738d2be302b76e0857d8ee029dc56dfa04fe67")>]
+    [<InlineData(64, "df7eab2ec9135ab8c58f48c288cdc873bac245a7fa46ca9f047cab672bd1eabb")>]
+    let ``keyed variants match reference`` (keyLength: int) (expected: string) =
+        let key = bytesFromRange 1 (keyLength + 1)
+        let options = Blake2bOptions.Default.WithDigestSize(32).WithKey(key)
+
+        Assert.Equal(expected, Blake2b.hashHexWithOptions options "secret message body"B)
+
+    [<Fact>]
+    let ``salt and personal match reference`` () =
+        let options =
+            Blake2bOptions.Default
+                .WithSalt(bytesFromRange 0 16)
+                .WithPersonal(bytesFromRange 16 32)
+
+        Assert.Equal(
+            "a2185d648fc63f3d363871a76360330c9b238af5466a20f94bb64d363289b95da0453438eea300cd6f31521274ec001011fa29e91a603fabf00f2b454e30bf3d",
+            Blake2b.hashHexWithOptions options "parameterized hash"B)
+
+    [<Fact>]
+    let ``streaming matches one shot across chunking`` () =
+        let data = bytesFromRange 0 200
+        let options = Blake2bOptions.Default.WithDigestSize(32)
+        let hasher = Blake2bHasher(options)
+
+        for value in data do
+            hasher.Update([| value |]) |> ignore
+
+        Assert.Equal<byte array>(Blake2b.hashWithOptions options data, hasher.Digest())
+
+    [<Fact>]
+    let ``streaming handles exact block then more`` () =
+        let data = bytesFromRange 0 132
+        let hasher = Blake2bHasher()
+
+        hasher.Update(data[0..127]) |> ignore
+        hasher.Update(data[128..]) |> ignore
+
+        Assert.Equal<byte array>(Blake2b.hash data, hasher.Digest())
+
+    [<Fact>]
+    let ``digest is nondestructive and update can continue`` () =
+        let options = Blake2bOptions.Default.WithDigestSize(32)
+        let hasher = Blake2bHasher(options)
+
+        let result = hasher.Update("hello "B)
+        let first = hasher.HexDigest()
+        let second = hasher.HexDigest()
+        hasher.Update("world"B) |> ignore
+
+        Assert.Same(hasher, result)
+        Assert.Equal(first, second)
+        Assert.Equal(Blake2b.hashHexWithOptions options "hello world"B, hasher.HexDigest())
+
+    [<Fact>]
+    let ``copy is independent`` () =
+        let hasher = Blake2bHasher()
+        hasher.Update("prefix "B) |> ignore
+
+        let copy = hasher.Copy()
+        hasher.Update("path A"B) |> ignore
+        copy.Update("path B"B) |> ignore
+
+        Assert.Equal<byte array>(Blake2b.hash "prefix path A"B, hasher.Digest())
+        Assert.Equal<byte array>(Blake2b.hash "prefix path B"B, copy.Digest())
+
+    [<Fact>]
+    let ``rejects invalid options and nulls`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Blake2b.hash null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Blake2bHasher().Update(null) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> Blake2b.hashWithOptions (Blake2bOptions.Default.WithDigestSize(0)) [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> Blake2b.hashWithOptions (Blake2bOptions.Default.WithDigestSize(65)) [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Blake2b.hashWithOptions (Blake2bOptions.Default.WithKey(Array.zeroCreate 65)) [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Blake2b.hashWithOptions (Blake2bOptions.Default.WithSalt(Array.zeroCreate 8)) [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> Blake2b.hashWithOptions (Blake2bOptions.Default.WithPersonal(Array.zeroCreate 20)) [||] |> ignore) |> ignore
+
+    [<Fact>]
+    let ``accepts maximum key length`` () =
+        let digest = Blake2b.hashWithOptions (Blake2bOptions.Default.WithKey(Array.create 64 (byte 'k'))) "x"B
+
+        Assert.Equal(Blake2b.MaxDigestLength, digest.Length)

--- a/code/packages/fsharp/blake2b/tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.fsproj
+++ b/code/packages/fsharp/blake2b/tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Blake2b.fsproj" />
+    <Compile Include="Blake2bTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add pure C# and pure F# BLAKE2b packages implemented directly from RFC 7693
- Include one-shot hashing, keyed mode, salt/personal parameters, streaming snapshots, and copy support
- Mirror fixed reference vectors and block-boundary tests from the Rust/Python implementations
- Keep the new packages free of System.Security.Cryptography and other platform crypto wrappers

## Tests
- dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Blake2b.Tests/CodingAdventures.Blake2b.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- git diff --check
- scanned new C#/F# BLAKE2b files for direct platform crypto APIs