### PR TITLE
feat(dotnet): add native brainfuck packages

### DIFF
--- a/code/packages/csharp/brainfuck/BUILD
+++ b/code/packages/csharp/brainfuck/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/brainfuck/BUILD_windows
+++ b/code/packages/csharp/brainfuck/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/brainfuck/Brainfuck.cs
+++ b/code/packages/csharp/brainfuck/Brainfuck.cs
@@ -1,0 +1,239 @@
+using System.Text;
+
+namespace CodingAdventures.Brainfuck;
+
+/// <summary>Brainfuck opcodes plus an internal halt marker.</summary>
+public enum BrainfuckOpcode
+{
+    /// <summary>Move the data pointer one cell to the right.</summary>
+    Right,
+    /// <summary>Move the data pointer one cell to the left.</summary>
+    Left,
+    /// <summary>Increment the byte at the data pointer.</summary>
+    Increment,
+    /// <summary>Decrement the byte at the data pointer.</summary>
+    Decrement,
+    /// <summary>Output the byte at the data pointer as a character.</summary>
+    Output,
+    /// <summary>Read one input byte into the cell at the data pointer.</summary>
+    Input,
+    /// <summary>Jump forward when the current cell is zero.</summary>
+    LoopStart,
+    /// <summary>Jump backward when the current cell is nonzero.</summary>
+    LoopEnd,
+    /// <summary>Stop execution.</summary>
+    Halt,
+}
+
+/// <summary>A translated Brainfuck instruction.</summary>
+public readonly record struct BrainfuckInstruction(BrainfuckOpcode Opcode, int? Operand = null);
+
+/// <summary>The result of executing a Brainfuck program.</summary>
+public sealed class BrainfuckResult
+{
+    internal BrainfuckResult(string output, byte[] tape, int pointer, int steps)
+    {
+        Output = output;
+        Tape = tape;
+        Pointer = pointer;
+        Steps = steps;
+    }
+
+    /// <summary>Text emitted by output commands.</summary>
+    public string Output { get; }
+
+    /// <summary>Final 30,000-cell tape snapshot.</summary>
+    public byte[] Tape { get; }
+
+    /// <summary>Final data pointer position.</summary>
+    public int Pointer { get; }
+
+    /// <summary>Number of translated instructions executed, including halt.</summary>
+    public int Steps { get; }
+}
+
+/// <summary>Base exception for Brainfuck translation and execution errors.</summary>
+public class BrainfuckException : Exception
+{
+    /// <summary>Create a Brainfuck exception with a message.</summary>
+    public BrainfuckException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>Raised when Brainfuck source has mismatched brackets.</summary>
+public sealed class BrainfuckTranslationException : BrainfuckException
+{
+    /// <summary>Create a Brainfuck translation exception with a message.</summary>
+    public BrainfuckTranslationException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>Raised when execution leaves the fixed tape bounds or sees invalid bytecode.</summary>
+public sealed class BrainfuckExecutionException : BrainfuckException
+{
+    /// <summary>Create a Brainfuck execution exception with a message.</summary>
+    public BrainfuckExecutionException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>Standalone Brainfuck translator and interpreter.</summary>
+public static class Brainfuck
+{
+    /// <summary>The classic Brainfuck tape size.</summary>
+    public const int TapeSize = 30_000;
+
+    /// <summary>Translate Brainfuck source to instructions with matched loop jump targets.</summary>
+    public static BrainfuckInstruction[] Translate(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var instructions = new List<BrainfuckInstruction>();
+        var loopStarts = new Stack<int>();
+
+        foreach (var ch in source)
+        {
+            switch (ch)
+            {
+                case '>':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Right));
+                    break;
+                case '<':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Left));
+                    break;
+                case '+':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Increment));
+                    break;
+                case '-':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Decrement));
+                    break;
+                case '.':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Output));
+                    break;
+                case ',':
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Input));
+                    break;
+                case '[':
+                    loopStarts.Push(instructions.Count);
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.LoopStart, 0));
+                    break;
+                case ']':
+                    if (loopStarts.Count == 0)
+                    {
+                        throw new BrainfuckTranslationException("Unmatched ']' found without a matching '['.");
+                    }
+
+                    var start = loopStarts.Pop();
+                    var end = instructions.Count;
+                    instructions[start] = new BrainfuckInstruction(BrainfuckOpcode.LoopStart, end + 1);
+                    instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.LoopEnd, start));
+                    break;
+            }
+        }
+
+        if (loopStarts.Count > 0)
+        {
+            throw new BrainfuckTranslationException($"Unmatched '[' found: {loopStarts.Count} unclosed bracket(s).");
+        }
+
+        instructions.Add(new BrainfuckInstruction(BrainfuckOpcode.Halt));
+        return instructions.ToArray();
+    }
+
+    /// <summary>Execute Brainfuck source with optional UTF-8 input text.</summary>
+    public static BrainfuckResult Execute(string source, string input = "")
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(input);
+
+        var program = Translate(source);
+        return Execute(program, Encoding.UTF8.GetBytes(input));
+    }
+
+    /// <summary>Execute translated Brainfuck instructions with optional raw input bytes.</summary>
+    public static BrainfuckResult Execute(IReadOnlyList<BrainfuckInstruction> program, byte[]? input = null)
+    {
+        ArgumentNullException.ThrowIfNull(program);
+
+        var tape = new byte[TapeSize];
+        var inputBytes = input ?? [];
+        var inputPosition = 0;
+        var pointer = 0;
+        var pc = 0;
+        var steps = 0;
+        var output = new StringBuilder();
+
+        while (pc >= 0 && pc < program.Count)
+        {
+            var instruction = program[pc];
+            steps++;
+
+            switch (instruction.Opcode)
+            {
+                case BrainfuckOpcode.Right:
+                    pointer++;
+                    if (pointer >= TapeSize)
+                    {
+                        throw new BrainfuckExecutionException($"Data pointer moved past end of tape at position {pointer}.");
+                    }
+
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.Left:
+                    pointer--;
+                    if (pointer < 0)
+                    {
+                        throw new BrainfuckExecutionException("Data pointer moved before start of tape at position -1.");
+                    }
+
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.Increment:
+                    tape[pointer] = unchecked((byte)(tape[pointer] + 1));
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.Decrement:
+                    tape[pointer] = unchecked((byte)(tape[pointer] - 1));
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.Output:
+                    output.Append((char)tape[pointer]);
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.Input:
+                    tape[pointer] = inputPosition < inputBytes.Length ? inputBytes[inputPosition++] : (byte)0;
+                    pc++;
+                    break;
+
+                case BrainfuckOpcode.LoopStart:
+                    pc = tape[pointer] == 0 ? RequireOperand(instruction) : pc + 1;
+                    break;
+
+                case BrainfuckOpcode.LoopEnd:
+                    pc = tape[pointer] != 0 ? RequireOperand(instruction) : pc + 1;
+                    break;
+
+                case BrainfuckOpcode.Halt:
+                    return new BrainfuckResult(output.ToString(), tape.ToArray(), pointer, steps);
+
+                default:
+                    throw new BrainfuckExecutionException($"Unknown Brainfuck opcode: {instruction.Opcode}.");
+            }
+        }
+
+        return new BrainfuckResult(output.ToString(), tape.ToArray(), pointer, steps);
+    }
+
+    private static int RequireOperand(BrainfuckInstruction instruction) =>
+        instruction.Operand ?? throw new BrainfuckExecutionException($"{instruction.Opcode} requires a jump target.");
+}

--- a/code/packages/csharp/brainfuck/CHANGELOG.md
+++ b/code/packages/csharp/brainfuck/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# Brainfuck translator and interpreter.
+- Include bracket validation, fixed byte tape execution, input/output helpers, and xUnit coverage.

--- a/code/packages/csharp/brainfuck/CodingAdventures.Brainfuck.csproj
+++ b/code/packages/csharp/brainfuck/CodingAdventures.Brainfuck.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Brainfuck.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Standalone Brainfuck translator and interpreter for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/brainfuck/README.md
+++ b/code/packages/csharp/brainfuck/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Brainfuck.CSharp
+
+Standalone Brainfuck translator and interpreter for .NET.
+
+The package ignores non-command characters as comments, validates bracket
+matching during translation, executes on a classic 30,000-cell byte tape, and
+sets input EOF reads to zero.
+
+```csharp
+using CodingAdventures.Brainfuck;
+
+BrainfuckResult result = Brainfuck.Execute("+++++++++[>++++++++<-]>.");
+string output = result.Output; // "H"
+
+BrainfuckInstruction[] program = Brainfuck.Translate("++[>+<-]");
+BrainfuckResult moved = Brainfuck.Execute(program);
+```

--- a/code/packages/csharp/brainfuck/required_capabilities.json
+++ b/code/packages/csharp/brainfuck/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/brainfuck",
+  "capabilities": [],
+  "justification": "Pure in-memory source translation and byte-tape interpretation. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/BrainfuckTests.cs
+++ b/code/packages/csharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/BrainfuckTests.cs
@@ -1,0 +1,147 @@
+using BrainfuckEngine = CodingAdventures.Brainfuck.Brainfuck;
+
+namespace CodingAdventures.Brainfuck.Tests;
+
+public sealed class BrainfuckTests
+{
+    [Fact]
+    public void TranslateMapsCommandsAndIgnoresComments()
+    {
+        var program = BrainfuckEngine.Translate("hello + world -><.,");
+
+        Assert.Equal(
+            [
+                BrainfuckOpcode.Increment,
+                BrainfuckOpcode.Decrement,
+                BrainfuckOpcode.Right,
+                BrainfuckOpcode.Left,
+                BrainfuckOpcode.Output,
+                BrainfuckOpcode.Input,
+                BrainfuckOpcode.Halt,
+            ],
+            program.Select(instruction => instruction.Opcode));
+    }
+
+    [Fact]
+    public void TranslatePatchesLoopTargets()
+    {
+        var program = BrainfuckEngine.Translate("[>+<-]");
+
+        Assert.Equal(BrainfuckOpcode.LoopStart, program[0].Opcode);
+        Assert.Equal(6, program[0].Operand);
+        Assert.Equal(BrainfuckOpcode.LoopEnd, program[5].Opcode);
+        Assert.Equal(0, program[5].Operand);
+    }
+
+    [Fact]
+    public void TranslatePatchesNestedLoops()
+    {
+        var program = BrainfuckEngine.Translate("[[]]");
+
+        Assert.Equal(4, program[0].Operand);
+        Assert.Equal(3, program[1].Operand);
+        Assert.Equal(1, program[2].Operand);
+        Assert.Equal(0, program[3].Operand);
+    }
+
+    [Fact]
+    public void TranslateRejectsMismatchedBrackets()
+    {
+        Assert.Throws<BrainfuckTranslationException>(() => BrainfuckEngine.Translate("["));
+        Assert.Throws<BrainfuckTranslationException>(() => BrainfuckEngine.Translate("]"));
+        Assert.Throws<BrainfuckTranslationException>(() => BrainfuckEngine.Translate("[[]"));
+    }
+
+    [Fact]
+    public void ExecuteHandlesEmptyProgramAndComments()
+    {
+        var empty = BrainfuckEngine.Execute("");
+        var comments = BrainfuckEngine.Execute("this is all comments");
+
+        Assert.Equal("", empty.Output);
+        Assert.Equal(0, empty.Pointer);
+        Assert.Equal(1, empty.Steps);
+        Assert.Equal("", comments.Output);
+        Assert.Equal(1, comments.Steps);
+    }
+
+    [Fact]
+    public void ExecuteSupportsCellArithmeticAndWrapping()
+    {
+        Assert.Equal(1, BrainfuckEngine.Execute("+").Tape[0]);
+        Assert.Equal(255, BrainfuckEngine.Execute("-").Tape[0]);
+        Assert.Equal(0, BrainfuckEngine.Execute(new string('+', 256)).Tape[0]);
+    }
+
+    [Fact]
+    public void ExecuteSupportsPointerMovementAndBoundsErrors()
+    {
+        Assert.Equal(3, BrainfuckEngine.Execute(">>>").Pointer);
+        Assert.Throws<BrainfuckExecutionException>(() => BrainfuckEngine.Execute("<"));
+        Assert.Throws<BrainfuckExecutionException>(() => BrainfuckEngine.Execute(new string('>', BrainfuckEngine.TapeSize)));
+    }
+
+    [Fact]
+    public void ExecuteSupportsLoops()
+    {
+        var addition = BrainfuckEngine.Execute("++>+++++[<+>-]");
+        var move = BrainfuckEngine.Execute("+++++[>+<-]");
+        var skipped = BrainfuckEngine.Execute("[]+++");
+
+        Assert.Equal(7, addition.Tape[0]);
+        Assert.Equal(0, addition.Tape[1]);
+        Assert.Equal(0, move.Tape[0]);
+        Assert.Equal(5, move.Tape[1]);
+        Assert.Equal(3, skipped.Tape[0]);
+    }
+
+    [Fact]
+    public void ExecuteSupportsNestedLoops()
+    {
+        var result = BrainfuckEngine.Execute("++>+++<[>[>+>+<<-]>>[<<+>>-]<<<-]");
+
+        Assert.Equal(6, result.Tape[2]);
+        Assert.Equal(0, result.Tape[0]);
+    }
+
+    [Fact]
+    public void ExecuteSupportsOutputAndInput()
+    {
+        var h = BrainfuckEngine.Execute("+++++++++[>++++++++<-]>.");
+        var echo = BrainfuckEngine.Execute(",.,.,.", "ABC");
+        var eof = BrainfuckEngine.Execute(",,", "A");
+
+        Assert.Equal("H", h.Output);
+        Assert.Equal("ABC", echo.Output);
+        Assert.Equal(0, eof.Tape[0]);
+    }
+
+    [Fact]
+    public void ExecuteRunsHelloWorld()
+    {
+        const string helloWorld =
+            "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]" +
+            ">>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.";
+
+        Assert.Equal("Hello World!\n", BrainfuckEngine.Execute(helloWorld).Output);
+    }
+
+    [Fact]
+    public void ExecuteAcceptsTranslatedProgram()
+    {
+        var program = BrainfuckEngine.Translate("+++.");
+        var result = BrainfuckEngine.Execute(program);
+
+        Assert.Equal(3, result.Output[0]);
+        Assert.Equal(5, result.Steps);
+    }
+
+    [Fact]
+    public void NullInputsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => BrainfuckEngine.Translate(null!));
+        Assert.Throws<ArgumentNullException>(() => BrainfuckEngine.Execute((string)null!));
+        Assert.Throws<ArgumentNullException>(() => BrainfuckEngine.Execute("+", null!));
+        Assert.Throws<ArgumentNullException>(() => BrainfuckEngine.Execute((IReadOnlyList<BrainfuckInstruction>)null!));
+    }
+}

--- a/code/packages/csharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.csproj
+++ b/code/packages/csharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Brainfuck.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brainfuck/BUILD
+++ b/code/packages/fsharp/brainfuck/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/brainfuck/BUILD_windows
+++ b/code/packages/fsharp/brainfuck/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/brainfuck/Brainfuck.fs
+++ b/code/packages/fsharp/brainfuck/Brainfuck.fs
@@ -1,0 +1,194 @@
+namespace CodingAdventures.Brainfuck.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text
+
+/// Brainfuck opcodes plus an internal halt marker.
+type BrainfuckOpcode =
+    | Right
+    | Left
+    | Increment
+    | Decrement
+    | Output
+    | Input
+    | LoopStart
+    | LoopEnd
+    | Halt
+
+/// A translated Brainfuck instruction.
+type BrainfuckInstruction =
+    {
+        Opcode: BrainfuckOpcode
+        Operand: int option
+    }
+
+/// The result of executing a Brainfuck program.
+type BrainfuckResult =
+    {
+        /// Text emitted by output commands.
+        Output: string
+        /// Final 30,000-cell tape snapshot.
+        Tape: byte array
+        /// Final data pointer position.
+        Pointer: int
+        /// Number of translated instructions executed, including halt.
+        Steps: int
+    }
+
+/// Raised when Brainfuck source has mismatched brackets.
+exception BrainfuckTranslationException of string
+
+/// Raised when execution leaves the fixed tape bounds or sees invalid bytecode.
+exception BrainfuckExecutionException of string
+
+[<RequireQualifiedAccess>]
+module Brainfuck =
+    /// The classic Brainfuck tape size.
+    [<Literal>]
+    let TapeSize = 30_000
+
+    let private instruction opcode operand =
+        { Opcode = opcode; Operand = operand }
+
+    let private commandToInstruction = function
+        | '>' -> Some (instruction Right None)
+        | '<' -> Some (instruction Left None)
+        | '+' -> Some (instruction Increment None)
+        | '-' -> Some (instruction Decrement None)
+        | '.' -> Some (instruction Output None)
+        | ',' -> Some (instruction Input None)
+        | _ -> None
+
+    /// Translate Brainfuck source to instructions with matched loop jump targets.
+    let translate (source: string) =
+        if isNull source then
+            nullArg "source"
+
+        let instructions = ResizeArray<BrainfuckInstruction>()
+        let loopStarts = Stack<int>()
+
+        for ch in source do
+            match ch with
+            | '[' ->
+                loopStarts.Push(instructions.Count)
+                instructions.Add(instruction LoopStart (Some 0))
+            | ']' ->
+                if loopStarts.Count = 0 then
+                    raise (BrainfuckTranslationException "Unmatched ']' found without a matching '['.")
+
+                let start = loopStarts.Pop()
+                let ending = instructions.Count
+                instructions[start] <- instruction LoopStart (Some (ending + 1))
+                instructions.Add(instruction LoopEnd (Some start))
+            | _ ->
+                match commandToInstruction ch with
+                | Some inst -> instructions.Add inst
+                | None -> ()
+
+        if loopStarts.Count > 0 then
+            raise (BrainfuckTranslationException (sprintf "Unmatched '[' found: %d unclosed bracket(s)." loopStarts.Count))
+
+        instructions.Add(instruction Halt None)
+        instructions.ToArray()
+
+    let private requireOperand instruction =
+        match instruction.Operand with
+        | Some target -> target
+        | None -> raise (BrainfuckExecutionException (sprintf "%A requires a jump target." instruction.Opcode))
+
+    /// Execute translated Brainfuck instructions with optional raw input bytes.
+    let executeProgram (program: BrainfuckInstruction array) (input: byte array) =
+        if isNull program then
+            nullArg "program"
+
+        let inputBytes =
+            if isNull input then
+                [||]
+            else
+                Array.copy input
+
+        let tape = Array.zeroCreate<byte> TapeSize
+        let output = StringBuilder()
+        let mutable inputPosition = 0
+        let mutable pointer = 0
+        let mutable pc = 0
+        let mutable steps = 0
+        let mutable halted = false
+
+        while not halted && pc >= 0 && pc < program.Length do
+            let current = program[pc]
+            steps <- steps + 1
+
+            match current.Opcode with
+            | Right ->
+                pointer <- pointer + 1
+                if pointer >= TapeSize then
+                    raise (BrainfuckExecutionException (sprintf "Data pointer moved past end of tape at position %d." pointer))
+                pc <- pc + 1
+
+            | Left ->
+                pointer <- pointer - 1
+                if pointer < 0 then
+                    raise (BrainfuckExecutionException "Data pointer moved before start of tape at position -1.")
+                pc <- pc + 1
+
+            | Increment ->
+                tape[pointer] <- byte ((int tape[pointer] + 1) &&& 0xff)
+                pc <- pc + 1
+
+            | Decrement ->
+                tape[pointer] <- byte ((int tape[pointer] - 1) &&& 0xff)
+                pc <- pc + 1
+
+            | Output ->
+                output.Append(char tape[pointer]) |> ignore
+                pc <- pc + 1
+
+            | Input ->
+                tape[pointer] <-
+                    if inputPosition < inputBytes.Length then
+                        let value = inputBytes[inputPosition]
+                        inputPosition <- inputPosition + 1
+                        value
+                    else
+                        0uy
+                pc <- pc + 1
+
+            | LoopStart ->
+                pc <-
+                    if tape[pointer] = 0uy then
+                        requireOperand current
+                    else
+                        pc + 1
+
+            | LoopEnd ->
+                pc <-
+                    if tape[pointer] <> 0uy then
+                        requireOperand current
+                    else
+                        pc + 1
+
+            | Halt ->
+                halted <- true
+
+        {
+            Output = output.ToString()
+            Tape = Array.copy tape
+            Pointer = pointer
+            Steps = steps
+        }
+
+    /// Execute Brainfuck source with explicit UTF-8 input text.
+    let executeWithInput (source: string) (input: string) =
+        if isNull source then
+            nullArg "source"
+
+        if isNull input then
+            nullArg "input"
+
+        executeProgram (translate source) (Encoding.UTF8.GetBytes input)
+
+    /// Execute Brainfuck source with empty input.
+    let execute (source: string) =
+        executeWithInput source ""

--- a/code/packages/fsharp/brainfuck/CHANGELOG.md
+++ b/code/packages/fsharp/brainfuck/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# Brainfuck translator and interpreter.
+- Include bracket validation, fixed byte tape execution, input/output helpers, and xUnit coverage.

--- a/code/packages/fsharp/brainfuck/CodingAdventures.Brainfuck.fsproj
+++ b/code/packages/fsharp/brainfuck/CodingAdventures.Brainfuck.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Brainfuck.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Standalone Brainfuck translator and interpreter for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Brainfuck.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brainfuck/README.md
+++ b/code/packages/fsharp/brainfuck/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Brainfuck.FSharp
+
+Standalone Brainfuck translator and interpreter for .NET.
+
+The package ignores non-command characters as comments, validates bracket
+matching during translation, executes on a classic 30,000-cell byte tape, and
+sets input EOF reads to zero.
+
+```fsharp
+open CodingAdventures.Brainfuck.FSharp
+
+let result = Brainfuck.execute "+++++++++[>++++++++<-]>."
+let output = result.Output // "H"
+
+let program = Brainfuck.translate "++[>+<-]"
+let moved = Brainfuck.executeProgram program [||]
+```

--- a/code/packages/fsharp/brainfuck/required_capabilities.json
+++ b/code/packages/fsharp/brainfuck/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/brainfuck",
+  "capabilities": [],
+  "justification": "Pure in-memory source translation and byte-tape interpretation. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/BrainfuckTests.fs
+++ b/code/packages/fsharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/BrainfuckTests.fs
@@ -1,0 +1,122 @@
+namespace CodingAdventures.Brainfuck.Tests
+
+open System
+open Xunit
+open CodingAdventures.Brainfuck.FSharp
+
+module BrainfuckTests =
+    [<Fact>]
+    let ``translate maps commands and ignores comments`` () =
+        let program = Brainfuck.translate "hello + world -><.,"
+        let opcodes = program |> Array.map (fun instruction -> instruction.Opcode)
+
+        Assert.Equal<BrainfuckOpcode array>(
+            [|
+                Increment
+                Decrement
+                Right
+                Left
+                Output
+                Input
+                Halt
+            |],
+            opcodes)
+
+    [<Fact>]
+    let ``translate patches loop targets`` () =
+        let program = Brainfuck.translate "[>+<-]"
+
+        Assert.Equal(LoopStart, program[0].Opcode)
+        Assert.Equal(Some 6, program[0].Operand)
+        Assert.Equal(LoopEnd, program[5].Opcode)
+        Assert.Equal(Some 0, program[5].Operand)
+
+    [<Fact>]
+    let ``translate patches nested loops`` () =
+        let program = Brainfuck.translate "[[]]"
+
+        Assert.Equal(Some 4, program[0].Operand)
+        Assert.Equal(Some 3, program[1].Operand)
+        Assert.Equal(Some 1, program[2].Operand)
+        Assert.Equal(Some 0, program[3].Operand)
+
+    [<Fact>]
+    let ``translate rejects mismatched brackets`` () =
+        Assert.Throws<BrainfuckTranslationException>(fun () -> Brainfuck.translate "[" |> ignore) |> ignore
+        Assert.Throws<BrainfuckTranslationException>(fun () -> Brainfuck.translate "]" |> ignore) |> ignore
+        Assert.Throws<BrainfuckTranslationException>(fun () -> Brainfuck.translate "[[]" |> ignore) |> ignore
+
+    [<Fact>]
+    let ``execute handles empty program and comments`` () =
+        let empty = Brainfuck.execute ""
+        let comments = Brainfuck.execute "this is all comments"
+
+        Assert.Equal("", empty.Output)
+        Assert.Equal(0, empty.Pointer)
+        Assert.Equal(1, empty.Steps)
+        Assert.Equal("", comments.Output)
+        Assert.Equal(1, comments.Steps)
+
+    [<Fact>]
+    let ``execute supports cell arithmetic and wrapping`` () =
+        Assert.Equal(1uy, (Brainfuck.execute "+").Tape[0])
+        Assert.Equal(255uy, (Brainfuck.execute "-").Tape[0])
+        Assert.Equal(0uy, (Brainfuck.execute (String('+', 256))).Tape[0])
+
+    [<Fact>]
+    let ``execute supports pointer movement and bounds errors`` () =
+        Assert.Equal(3, (Brainfuck.execute ">>>").Pointer)
+        Assert.Throws<BrainfuckExecutionException>(fun () -> Brainfuck.execute "<" |> ignore) |> ignore
+        Assert.Throws<BrainfuckExecutionException>(fun () -> Brainfuck.execute (String('>', Brainfuck.TapeSize)) |> ignore) |> ignore
+
+    [<Fact>]
+    let ``execute supports loops`` () =
+        let addition = Brainfuck.execute "++>+++++[<+>-]"
+        let move = Brainfuck.execute "+++++[>+<-]"
+        let skipped = Brainfuck.execute "[]+++"
+
+        Assert.Equal(7uy, addition.Tape[0])
+        Assert.Equal(0uy, addition.Tape[1])
+        Assert.Equal(0uy, move.Tape[0])
+        Assert.Equal(5uy, move.Tape[1])
+        Assert.Equal(3uy, skipped.Tape[0])
+
+    [<Fact>]
+    let ``execute supports nested loops`` () =
+        let result = Brainfuck.execute "++>+++<[>[>+>+<<-]>>[<<+>>-]<<<-]"
+
+        Assert.Equal(6uy, result.Tape[2])
+        Assert.Equal(0uy, result.Tape[0])
+
+    [<Fact>]
+    let ``execute supports output and input`` () =
+        let h = Brainfuck.execute "+++++++++[>++++++++<-]>."
+        let echo = Brainfuck.executeWithInput ",.,.,." "ABC"
+        let eof = Brainfuck.executeWithInput ",," "A"
+
+        Assert.Equal("H", h.Output)
+        Assert.Equal("ABC", echo.Output)
+        Assert.Equal(0uy, eof.Tape[0])
+
+    [<Fact>]
+    let ``execute runs hello world`` () =
+        let helloWorld =
+            "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]" +
+            ">>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."
+
+        Assert.Equal("Hello World!\n", (Brainfuck.execute helloWorld).Output)
+
+    [<Fact>]
+    let ``execute accepts translated program`` () =
+        let program = Brainfuck.translate "+++."
+        let result = Brainfuck.executeProgram program [||]
+
+        Assert.Equal(char 3, result.Output[0])
+        Assert.Equal(5, result.Steps)
+
+    [<Fact>]
+    let ``null inputs are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Brainfuck.translate null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Brainfuck.execute null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Brainfuck.executeWithInput "+" null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Brainfuck.executeProgram null [||] |> ignore) |> ignore

--- a/code/packages/fsharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.fsproj
+++ b/code/packages/fsharp/brainfuck/tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Brainfuck.fsproj" />
+    <Compile Include="BrainfuckTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add pure C# and pure F# Brainfuck packages
- Include source translation with bracket matching, standalone byte-tape execution, input/output handling, and EOF-as-zero behavior
- Cover comments, nested loops, wrapping arithmetic, pointer bounds, translated-program execution, and Hello World

## Tests
- dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- dotnet test tests/CodingAdventures.Brainfuck.Tests/CodingAdventures.Brainfuck.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- reran C# suite after XML-doc cleanup
- git diff --check
- scanned new C#/F# Brainfuck files for direct platform crypto APIs