### PR TITLE
feat(dotnet): add native assembler packages

### DIFF
--- a/code/packages/csharp/assembler/Assembler.cs
+++ b/code/packages/csharp/assembler/Assembler.cs
@@ -1,0 +1,354 @@
+namespace CodingAdventures.Assembler;
+
+/// <summary>ARM data-processing opcode values.</summary>
+public enum ArmOpcode : uint
+{
+    /// <summary>Bitwise AND.</summary>
+    And = 0x0,
+    /// <summary>Bitwise exclusive OR.</summary>
+    Eor = 0x1,
+    /// <summary>Subtract.</summary>
+    Sub = 0x2,
+    /// <summary>Reverse subtract.</summary>
+    Rsb = 0x3,
+    /// <summary>Add.</summary>
+    Add = 0x4,
+    /// <summary>Compare and set flags.</summary>
+    Cmp = 0xA,
+    /// <summary>Bitwise OR.</summary>
+    Orr = 0xC,
+    /// <summary>Move.</summary>
+    Mov = 0xD,
+}
+
+/// <summary>Second operand for ARM data-processing instructions.</summary>
+public abstract record Operand2
+{
+    /// <summary>A register operand.</summary>
+    public sealed record Register(uint Number) : Operand2;
+
+    /// <summary>An immediate operand.</summary>
+    public sealed record Immediate(uint Value) : Operand2;
+}
+
+/// <summary>Parsed ARM assembly instruction.</summary>
+public abstract record ArmInstruction
+{
+    /// <summary>A data-processing instruction such as MOV, ADD, SUB, or CMP.</summary>
+    public sealed record DataProcessing(ArmOpcode Opcode, uint? Rd, uint? Rn, Operand2 Operand2, bool SetFlags) : ArmInstruction;
+
+    /// <summary>Load a word from [Rn] into Rd.</summary>
+    public sealed record Load(uint Rd, uint Rn) : ArmInstruction;
+
+    /// <summary>Store Rd into [Rn].</summary>
+    public sealed record Store(uint Rd, uint Rn) : ArmInstruction;
+
+    /// <summary>No operation.</summary>
+    public sealed record Nop : ArmInstruction;
+
+    /// <summary>A symbolic label. Labels do not emit binary words.</summary>
+    public sealed record Label(string Name) : ArmInstruction;
+}
+
+/// <summary>Raised when assembly source cannot be parsed or encoded.</summary>
+public sealed class AssemblerException : Exception
+{
+    /// <summary>Create an assembler exception with a message.</summary>
+    public AssemblerException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>ARM assembly parser and 32-bit instruction encoder.</summary>
+public sealed class Assembler
+{
+    /// <summary>Label-to-instruction-address table built during parsing.</summary>
+    public Dictionary<string, int> Labels { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>Parse assembly source into structured instructions.</summary>
+    public ArmInstruction[] Parse(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        Labels.Clear();
+        var instructions = new List<ArmInstruction>();
+        var address = 0;
+
+        foreach (var rawLine in source.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            var line = StripComment(rawLine).Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (line.EndsWith(':'))
+            {
+                var label = line[..^1].Trim();
+                Labels[label] = address;
+                instructions.Add(new ArmInstruction.Label(label));
+                continue;
+            }
+
+            var instruction = ParseInstruction(line);
+            if (instruction is not ArmInstruction.Label)
+            {
+                address++;
+            }
+
+            instructions.Add(instruction);
+        }
+
+        return instructions.ToArray();
+    }
+
+    /// <summary>Encode structured instructions into ARM 32-bit words.</summary>
+    public uint[] Encode(IEnumerable<ArmInstruction> instructions)
+    {
+        ArgumentNullException.ThrowIfNull(instructions);
+
+        var words = new List<uint>();
+        foreach (var instruction in instructions)
+        {
+            switch (instruction)
+            {
+                case ArmInstruction.Label:
+                    break;
+
+                case ArmInstruction.Nop:
+                    words.Add(0xE1A0_0000u);
+                    break;
+
+                case ArmInstruction.DataProcessing data:
+                    words.Add(EncodeDataProcessing(data));
+                    break;
+
+                case ArmInstruction.Load load:
+                    words.Add(0xE590_0000u | (load.Rn << 16) | (load.Rd << 12));
+                    break;
+
+                case ArmInstruction.Store store:
+                    words.Add(0xE580_0000u | (store.Rn << 16) | (store.Rd << 12));
+                    break;
+
+                default:
+                    throw new AssemblerException($"Unsupported instruction: {instruction.GetType().Name}.");
+            }
+        }
+
+        return words.ToArray();
+    }
+
+    /// <summary>Parse and encode assembly source in one call.</summary>
+    public uint[] Assemble(string source) => Encode(Parse(source));
+
+    /// <summary>Try to parse an ARM register name such as R0, R15, SP, LR, or PC.</summary>
+    public static bool TryParseRegister(string text, out uint register)
+    {
+        register = 0;
+        if (text is null)
+        {
+            return false;
+        }
+
+        var value = text.Trim().ToUpperInvariant();
+        switch (value)
+        {
+            case "SP":
+                register = 13;
+                return true;
+            case "LR":
+                register = 14;
+                return true;
+            case "PC":
+                register = 15;
+                return true;
+        }
+
+        if (value.Length >= 2 && value[0] == 'R' && uint.TryParse(value[1..], out var parsed) && parsed <= 15)
+        {
+            register = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Try to parse a decimal or hexadecimal immediate, with or without #.</summary>
+    public static bool TryParseImmediate(string text, out uint value)
+    {
+        value = 0;
+        if (text is null)
+        {
+            return false;
+        }
+
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith('#'))
+        {
+            trimmed = trimmed[1..].Trim();
+        }
+
+        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return uint.TryParse(trimmed[2..], System.Globalization.NumberStyles.HexNumber, null, out value);
+        }
+
+        return uint.TryParse(trimmed, out value);
+    }
+
+    private ArmInstruction ParseInstruction(string line)
+    {
+        var firstSpace = line.IndexOfAny([' ', '\t']);
+        var mnemonic = firstSpace < 0 ? line.ToUpperInvariant() : line[..firstSpace].Trim().ToUpperInvariant();
+        var operandsText = firstSpace < 0 ? string.Empty : line[(firstSpace + 1)..].Trim();
+
+        return mnemonic switch
+        {
+            "NOP" => new ArmInstruction.Nop(),
+            "MOV" or "MOVS" => ParseMov(mnemonic, operandsText),
+            "CMP" => ParseCmp(operandsText),
+            "LDR" => ParseLoadStore(mnemonic, operandsText, isLoad: true),
+            "STR" => ParseLoadStore(mnemonic, operandsText, isLoad: false),
+            "ADD" or "ADDS" or "SUB" or "SUBS" or "AND" or "ANDS" or "ORR" or "ORRS" or "EOR" or "EORS" or "RSB" or "RSBS" =>
+                ParseThreeOperandDataProcessing(mnemonic, operandsText),
+            _ => throw new AssemblerException($"Unknown mnemonic: {mnemonic}."),
+        };
+    }
+
+    private static ArmInstruction ParseMov(string mnemonic, string operandsText)
+    {
+        var operands = SplitOperands(operandsText);
+        RequireOperandCount(mnemonic, operands, 2);
+        return new ArmInstruction.DataProcessing(
+            ArmOpcode.Mov,
+            ParseRegisterOrThrow(operands[0]),
+            null,
+            ParseOperand2(operands[1]),
+            mnemonic == "MOVS");
+    }
+
+    private static ArmInstruction ParseCmp(string operandsText)
+    {
+        var operands = SplitOperands(operandsText);
+        RequireOperandCount("CMP", operands, 2);
+        return new ArmInstruction.DataProcessing(
+            ArmOpcode.Cmp,
+            null,
+            ParseRegisterOrThrow(operands[0]),
+            ParseOperand2(operands[1]),
+            SetFlags: true);
+    }
+
+    private static ArmInstruction ParseThreeOperandDataProcessing(string mnemonic, string operandsText)
+    {
+        var baseMnemonic = mnemonic.TrimEnd('S');
+        var operands = SplitOperands(operandsText);
+        RequireOperandCount(mnemonic, operands, 3);
+
+        return new ArmInstruction.DataProcessing(
+            MnemonicToOpcode(baseMnemonic),
+            ParseRegisterOrThrow(operands[0]),
+            ParseRegisterOrThrow(operands[1]),
+            ParseOperand2(operands[2]),
+            mnemonic.Length > baseMnemonic.Length);
+    }
+
+    private static ArmInstruction ParseLoadStore(string mnemonic, string operandsText, bool isLoad)
+    {
+        var operands = SplitOperands(operandsText);
+        RequireOperandCount(mnemonic, operands, 2);
+
+        var rd = ParseRegisterOrThrow(operands[0]);
+        var baseRegister = operands[1].Trim().TrimStart('[').TrimEnd(']').Trim();
+        var rn = ParseRegisterOrThrow(baseRegister);
+
+        return isLoad ? new ArmInstruction.Load(rd, rn) : new ArmInstruction.Store(rd, rn);
+    }
+
+    private static Operand2 ParseOperand2(string text)
+    {
+        if (text.Trim().StartsWith('#'))
+        {
+            return TryParseImmediate(text, out var immediate)
+                ? new Operand2.Immediate(immediate)
+                : throw new AssemblerException($"Invalid immediate: {text}.");
+        }
+
+        if (TryParseRegister(text, out var register))
+        {
+            return new Operand2.Register(register);
+        }
+
+        return TryParseImmediate(text, out var bareImmediate)
+            ? new Operand2.Immediate(bareImmediate)
+            : throw new AssemblerException($"Cannot parse operand: {text}.");
+    }
+
+    private static uint ParseRegisterOrThrow(string text) =>
+        TryParseRegister(text, out var register) ? register : throw new AssemblerException($"Invalid register: {text}.");
+
+    private static ArmOpcode MnemonicToOpcode(string mnemonic) =>
+        mnemonic switch
+        {
+            "AND" => ArmOpcode.And,
+            "EOR" => ArmOpcode.Eor,
+            "SUB" => ArmOpcode.Sub,
+            "RSB" => ArmOpcode.Rsb,
+            "ADD" => ArmOpcode.Add,
+            "CMP" => ArmOpcode.Cmp,
+            "ORR" => ArmOpcode.Orr,
+            "MOV" => ArmOpcode.Mov,
+            _ => throw new AssemblerException($"Unknown mnemonic: {mnemonic}."),
+        };
+
+    private static uint EncodeDataProcessing(ArmInstruction.DataProcessing instruction)
+    {
+        const uint cond = 0xEu;
+        var rd = instruction.Rd ?? 0;
+        var rn = instruction.Rn ?? 0;
+        var setFlags = instruction.SetFlags ? 1u : 0u;
+        var opcode = (uint)instruction.Opcode;
+
+        var (immediateBit, operand2) = instruction.Operand2 switch
+        {
+            Operand2.Immediate imm => (1u, imm.Value & 0xFFFu),
+            Operand2.Register reg => (0u, reg.Number & 0xFu),
+            _ => throw new AssemblerException("Unsupported operand2."),
+        };
+
+        return (cond << 28) | (immediateBit << 25) | (opcode << 21) | (setFlags << 20) | (rn << 16) | (rd << 12) | operand2;
+    }
+
+    private static string[] SplitOperands(string text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? []
+            : text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+    private static void RequireOperandCount(string mnemonic, string[] operands, int expected)
+    {
+        if (operands.Length != expected)
+        {
+            throw new AssemblerException($"{mnemonic}: expected {expected} operands, got {operands.Length}.");
+        }
+    }
+
+    private static string StripComment(string line)
+    {
+        var semicolon = line.IndexOf(';');
+        var slashSlash = line.IndexOf("//", StringComparison.Ordinal);
+        var cut = line.Length;
+        if (semicolon >= 0)
+        {
+            cut = Math.Min(cut, semicolon);
+        }
+
+        if (slashSlash >= 0)
+        {
+            cut = Math.Min(cut, slashSlash);
+        }
+
+        return line[..cut];
+    }
+}

--- a/code/packages/csharp/assembler/BUILD
+++ b/code/packages/csharp/assembler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/assembler/BUILD_windows
+++ b/code/packages/csharp/assembler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/assembler/CHANGELOG.md
+++ b/code/packages/csharp/assembler/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native C# ARM assembly parser and instruction encoder.
+- Include register/immediate parsing, labels, comments, data-processing ops, load/store, NOP, and xUnit coverage.

--- a/code/packages/csharp/assembler/CodingAdventures.Assembler.csproj
+++ b/code/packages/csharp/assembler/CodingAdventures.Assembler.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Assembler.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ARM assembly parser and instruction encoder for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/assembler/README.md
+++ b/code/packages/csharp/assembler/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Assembler.CSharp
+
+ARM assembly parser and 32-bit instruction encoder for .NET.
+
+The package supports a compact ARM subset: `MOV`, `ADD`, `SUB`, `AND`, `ORR`,
+`EOR`, `RSB`, `CMP`, `LDR`, `STR`, `NOP`, labels, and line comments.
+
+```csharp
+using CodingAdventures.Assembler;
+
+var assembler = new Assembler();
+uint[] words = assembler.Assemble("""
+MOV R0, #42
+ADD R2, R0, R1
+STR R2, [R3]
+""");
+```

--- a/code/packages/csharp/assembler/required_capabilities.json
+++ b/code/packages/csharp/assembler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/assembler",
+  "capabilities": [],
+  "justification": "Pure in-memory assembly parsing and instruction encoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/assembler/tests/CodingAdventures.Assembler.Tests/AssemblerTests.cs
+++ b/code/packages/csharp/assembler/tests/CodingAdventures.Assembler.Tests/AssemblerTests.cs
@@ -1,0 +1,119 @@
+namespace CodingAdventures.Assembler.Tests;
+
+public sealed class AssemblerTests
+{
+    [Fact]
+    public void ParsesRegistersAndImmediates()
+    {
+        Assert.True(Assembler.TryParseRegister("R0", out var r0));
+        Assert.True(Assembler.TryParseRegister("sp", out var sp));
+        Assert.True(Assembler.TryParseImmediate("#0xFF", out var hex));
+        Assert.True(Assembler.TryParseImmediate("42", out var bare));
+
+        Assert.Equal(0u, r0);
+        Assert.Equal(13u, sp);
+        Assert.Equal(255u, hex);
+        Assert.Equal(42u, bare);
+        Assert.False(Assembler.TryParseRegister("R16", out _));
+        Assert.False(Assembler.TryParseRegister("X0", out _));
+    }
+
+    [Fact]
+    public void ParsesDataProcessingInstructions()
+    {
+        var asm = new Assembler();
+        var instructions = asm.Parse("MOV R0, #42\nADD R2, R0, R1\nCMP R0, R1");
+
+        var mov = Assert.IsType<ArmInstruction.DataProcessing>(instructions[0]);
+        var add = Assert.IsType<ArmInstruction.DataProcessing>(instructions[1]);
+        var cmp = Assert.IsType<ArmInstruction.DataProcessing>(instructions[2]);
+
+        Assert.Equal(ArmOpcode.Mov, mov.Opcode);
+        Assert.Equal(0u, mov.Rd);
+        Assert.IsType<Operand2.Immediate>(mov.Operand2);
+        Assert.Equal(ArmOpcode.Add, add.Opcode);
+        Assert.Equal(2u, add.Rd);
+        Assert.Equal(0u, add.Rn);
+        Assert.IsType<Operand2.Register>(add.Operand2);
+        Assert.Equal(ArmOpcode.Cmp, cmp.Opcode);
+        Assert.Null(cmp.Rd);
+        Assert.True(cmp.SetFlags);
+    }
+
+    [Fact]
+    public void ParsesMemoryInstructionsNopLabelsAndComments()
+    {
+        var asm = new Assembler();
+        var instructions = asm.Parse("; full line comment\nstart:\nLDR R0, [R1] ; load\nSTR R2, [SP] // store\nNOP");
+
+        Assert.IsType<ArmInstruction.Label>(instructions[0]);
+        var load = Assert.IsType<ArmInstruction.Load>(instructions[1]);
+        var store = Assert.IsType<ArmInstruction.Store>(instructions[2]);
+        Assert.IsType<ArmInstruction.Nop>(instructions[3]);
+        Assert.Equal(0, asm.Labels["start"]);
+        Assert.Equal(0u, load.Rd);
+        Assert.Equal(1u, load.Rn);
+        Assert.Equal(2u, store.Rd);
+        Assert.Equal(13u, store.Rn);
+    }
+
+    [Fact]
+    public void EncodesDataProcessingInstructions()
+    {
+        var asm = new Assembler();
+        var words = asm.Assemble("MOV R0, 42\nADD R2, R0, R1\nCMP R0, #1");
+
+        Assert.Equal(3, words.Length);
+        Assert.Equal(0xEu, words[0] >> 28);
+        Assert.Equal(1u, (words[0] >> 25) & 1u);
+        Assert.Equal(0xDu, (words[0] >> 21) & 0xFu);
+        Assert.Equal(42u, words[0] & 0xFFFu);
+        Assert.Equal(0x4u, (words[1] >> 21) & 0xFu);
+        Assert.Equal(2u, (words[1] >> 12) & 0xFu);
+        Assert.Equal(1u, words[1] & 0xFu);
+        Assert.Equal(1u, (words[2] >> 20) & 1u);
+    }
+
+    [Fact]
+    public void EncodesNopLoadStoreAndSkipsLabels()
+    {
+        var asm = new Assembler();
+        var words = asm.Assemble("start:\nNOP\nLDR R0, [R1]\nSTR R0, [R1]");
+
+        Assert.Equal([0xE1A00000u, 0xE5900000u | (1u << 16), 0xE5800000u | (1u << 16)], words);
+        Assert.Equal(1u, (words[1] >> 20) & 1u);
+        Assert.Equal(0u, (words[2] >> 20) & 1u);
+    }
+
+    [Fact]
+    public void SupportsFlagSettingSuffixesAndLogicalOps()
+    {
+        var asm = new Assembler();
+        var instructions = asm.Parse("ADDS R1, R2, #3\nANDS R0, R0, R1\nORR R3, R1, R2\nEOR R4, R4, R5\nRSB R6, R7, R8");
+
+        var adds = Assert.IsType<ArmInstruction.DataProcessing>(instructions[0]);
+        var ands = Assert.IsType<ArmInstruction.DataProcessing>(instructions[1]);
+        var orr = Assert.IsType<ArmInstruction.DataProcessing>(instructions[2]);
+        var eor = Assert.IsType<ArmInstruction.DataProcessing>(instructions[3]);
+        var rsb = Assert.IsType<ArmInstruction.DataProcessing>(instructions[4]);
+
+        Assert.True(adds.SetFlags);
+        Assert.True(ands.SetFlags);
+        Assert.Equal(ArmOpcode.Orr, orr.Opcode);
+        Assert.Equal(ArmOpcode.Eor, eor.Opcode);
+        Assert.Equal(ArmOpcode.Rsb, rsb.Opcode);
+    }
+
+    [Fact]
+    public void RejectsInvalidSource()
+    {
+        var asm = new Assembler();
+
+        Assert.Throws<AssemblerException>(() => asm.Parse("BLAH R0, R1"));
+        Assert.Throws<AssemblerException>(() => asm.Parse("MOV X0, #1"));
+        Assert.Throws<AssemblerException>(() => asm.Parse("ADD R0, R1"));
+        Assert.Throws<AssemblerException>(() => asm.Parse("MOV R0, #nope"));
+        Assert.Throws<ArgumentNullException>(() => asm.Parse(null!));
+        Assert.Throws<ArgumentNullException>(() => asm.Encode(null!));
+    }
+}

--- a/code/packages/csharp/assembler/tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.csproj
+++ b/code/packages/csharp/assembler/tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Assembler.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/assembler/Assembler.fs
+++ b/code/packages/fsharp/assembler/Assembler.fs
@@ -1,0 +1,243 @@
+namespace CodingAdventures.Assembler.FSharp
+
+open System
+open System.Collections.Generic
+
+/// ARM data-processing opcode values.
+type ArmOpcode =
+    | And = 0x0
+    | Eor = 0x1
+    | Sub = 0x2
+    | Rsb = 0x3
+    | Add = 0x4
+    | Cmp = 0xA
+    | Orr = 0xC
+    | Mov = 0xD
+
+/// Second operand for ARM data-processing instructions.
+type Operand2 =
+    | Register of uint32
+    | Immediate of uint32
+
+/// Parsed ARM assembly instruction.
+type ArmInstruction =
+    | DataProcessing of opcode: ArmOpcode * rd: uint32 option * rn: uint32 option * operand2: Operand2 * setFlags: bool
+    | Load of rd: uint32 * rn: uint32
+    | Store of rd: uint32 * rn: uint32
+    | Nop
+    | Label of string
+
+/// Raised when assembly source cannot be parsed or encoded.
+exception AssemblerException of string
+
+[<RequireQualifiedAccess>]
+module ArmParsing =
+    /// Try to parse an ARM register name such as R0, R15, SP, LR, or PC.
+    let tryParseRegister (text: string) =
+        if isNull text then
+            None
+        else
+            match text.Trim().ToUpperInvariant() with
+            | "SP" -> Some 13u
+            | "LR" -> Some 14u
+            | "PC" -> Some 15u
+            | value when value.Length >= 2 && value[0] = 'R' ->
+                match UInt32.TryParse(value[1..]) with
+                | true, parsed when parsed <= 15u -> Some parsed
+                | _ -> None
+            | _ -> None
+
+    /// Try to parse a decimal or hexadecimal immediate, with or without #.
+    let tryParseImmediate (text: string) =
+        if isNull text then
+            None
+        else
+            let mutable trimmed = text.Trim()
+            if trimmed.StartsWith("#", StringComparison.Ordinal) then
+                trimmed <- trimmed[1..].Trim()
+
+            if trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase) then
+                match UInt32.TryParse(trimmed[2..], Globalization.NumberStyles.HexNumber, null) with
+                | true, value -> Some value
+                | _ -> None
+            else
+                match UInt32.TryParse(trimmed) with
+                | true, value -> Some value
+                | _ -> None
+
+type Assembler() =
+    let labels = Dictionary<string, int>(StringComparer.Ordinal)
+
+    /// Label-to-instruction-address table built during parsing.
+    member _.Labels = labels
+
+    /// Parse assembly source into structured instructions.
+    member this.Parse(source: string) =
+        if isNull source then
+            nullArg "source"
+
+        labels.Clear()
+        let instructions = ResizeArray<ArmInstruction>()
+        let mutable address = 0
+
+        let normalizedSource = source.Replace("\r\n", "\n", StringComparison.Ordinal)
+        for (rawLine: string) in normalizedSource.Split([| '\n' |], StringSplitOptions.None) do
+            let line = this.StripComment(rawLine).Trim()
+            if line.Length > 0 then
+                if line.EndsWith(":", StringComparison.Ordinal) then
+                    let label = line.Substring(0, line.Length - 1).Trim()
+                    labels[label] <- address
+                    instructions.Add(Label label)
+                else
+                    let instruction = this.ParseInstruction(line)
+                    match instruction with
+                    | Label _ -> ()
+                    | _ -> address <- address + 1
+                    instructions.Add instruction
+
+        instructions.ToArray()
+
+    /// Encode structured instructions into ARM 32-bit words.
+    member this.Encode(instructions: ArmInstruction seq) =
+        if isNull (box instructions) then
+            nullArg "instructions"
+
+        let words = ResizeArray<uint32>()
+        for instruction in instructions do
+            match instruction with
+            | Label _ -> ()
+            | Nop -> words.Add 0xE1A0_0000u
+            | DataProcessing(opcode, rd, rn, operand2, setFlags) ->
+                words.Add(this.EncodeDataProcessing(opcode, rd, rn, operand2, setFlags))
+            | Load(rd, rn) ->
+                words.Add(0xE590_0000u ||| (rn <<< 16) ||| (rd <<< 12))
+            | Store(rd, rn) ->
+                words.Add(0xE580_0000u ||| (rn <<< 16) ||| (rd <<< 12))
+
+        words.ToArray()
+
+    /// Parse and encode assembly source in one call.
+    member this.Assemble(source: string) =
+        this.Parse(source) |> this.Encode
+
+    member private _.StripComment(line: string) : string =
+        let semicolon = line.IndexOf(';')
+        let slashSlash = line.IndexOf("//", StringComparison.Ordinal)
+        let mutable cut = line.Length
+        if semicolon >= 0 then
+            cut <- min cut semicolon
+        if slashSlash >= 0 then
+            cut <- min cut slashSlash
+        if cut = 0 then "" else line[.. cut - 1]
+
+    member private this.ParseInstruction(line: string) =
+        let firstSpace = line.IndexOfAny([| ' '; '\t' |])
+        let mnemonic =
+            if firstSpace < 0 then
+                line.ToUpperInvariant()
+            else
+                line[.. firstSpace - 1].Trim().ToUpperInvariant()
+        let operandsText =
+            if firstSpace < 0 then
+                ""
+            else
+                line[firstSpace + 1 ..].Trim()
+
+        match mnemonic with
+        | "NOP" -> Nop
+        | "MOV" | "MOVS" -> this.ParseMov(mnemonic, operandsText)
+        | "CMP" -> this.ParseCmp operandsText
+        | "LDR" -> this.ParseLoadStore(mnemonic, operandsText, true)
+        | "STR" -> this.ParseLoadStore(mnemonic, operandsText, false)
+        | "ADD" | "ADDS" | "SUB" | "SUBS" | "AND" | "ANDS" | "ORR" | "ORRS" | "EOR" | "EORS" | "RSB" | "RSBS" ->
+            this.ParseThreeOperandDataProcessing(mnemonic, operandsText)
+        | _ -> raise (AssemblerException (sprintf "Unknown mnemonic: %s." mnemonic))
+
+    member private _.SplitOperands(text: string) =
+        if String.IsNullOrWhiteSpace text then
+            [||]
+        else
+            text.Split([| ',' |], StringSplitOptions.TrimEntries ||| StringSplitOptions.RemoveEmptyEntries)
+
+    member private this.ParseMov(mnemonic: string, operandsText: string) =
+        let operands = this.SplitOperands operandsText
+        this.RequireOperandCount(mnemonic, operands, 2)
+        DataProcessing(ArmOpcode.Mov, Some(this.ParseRegisterOrThrow operands[0]), None, this.ParseOperand2 operands[1], mnemonic = "MOVS")
+
+    member private this.ParseCmp(operandsText: string) =
+        let operands = this.SplitOperands operandsText
+        this.RequireOperandCount("CMP", operands, 2)
+        DataProcessing(ArmOpcode.Cmp, None, Some(this.ParseRegisterOrThrow operands[0]), this.ParseOperand2 operands[1], true)
+
+    member private this.ParseThreeOperandDataProcessing(mnemonic: string, operandsText: string) =
+        let baseMnemonic = mnemonic.TrimEnd([| 'S' |])
+        let operands = this.SplitOperands operandsText
+        this.RequireOperandCount(mnemonic, operands, 3)
+        DataProcessing(
+            this.MnemonicToOpcode baseMnemonic,
+            Some(this.ParseRegisterOrThrow operands[0]),
+            Some(this.ParseRegisterOrThrow operands[1]),
+            this.ParseOperand2 operands[2],
+            mnemonic.Length > baseMnemonic.Length)
+
+    member private this.ParseLoadStore(mnemonic: string, operandsText: string, isLoad: bool) =
+        let operands = this.SplitOperands operandsText
+        this.RequireOperandCount(mnemonic, operands, 2)
+        let rd = this.ParseRegisterOrThrow operands[0]
+        let baseRegister = operands[1].Trim().TrimStart('[').TrimEnd(']').Trim()
+        let rn = this.ParseRegisterOrThrow baseRegister
+        if isLoad then Load(rd, rn) else Store(rd, rn)
+
+    member private _.RequireOperandCount(mnemonic: string, operands: string array, expected: int) =
+        if operands.Length <> expected then
+            raise (AssemblerException (sprintf "%s: expected %d operands, got %d." mnemonic expected operands.Length))
+
+    member private _.ParseRegisterOrThrow(text: string) =
+        match ArmParsing.tryParseRegister text with
+        | Some register -> register
+        | None -> raise (AssemblerException (sprintf "Invalid register: %s." text))
+
+    member private this.ParseOperand2(text: string) =
+        if text.Trim().StartsWith("#", StringComparison.Ordinal) then
+            match ArmParsing.tryParseImmediate text with
+            | Some value -> Immediate value
+            | None -> raise (AssemblerException (sprintf "Invalid immediate: %s." text))
+        else
+            match ArmParsing.tryParseRegister text with
+            | Some register -> Register register
+            | None ->
+                match ArmParsing.tryParseImmediate text with
+                | Some value -> Immediate value
+                | None -> raise (AssemblerException (sprintf "Cannot parse operand: %s." text))
+
+    member private _.MnemonicToOpcode(mnemonic: string) =
+        match mnemonic with
+        | "AND" -> ArmOpcode.And
+        | "EOR" -> ArmOpcode.Eor
+        | "SUB" -> ArmOpcode.Sub
+        | "RSB" -> ArmOpcode.Rsb
+        | "ADD" -> ArmOpcode.Add
+        | "CMP" -> ArmOpcode.Cmp
+        | "ORR" -> ArmOpcode.Orr
+        | "MOV" -> ArmOpcode.Mov
+        | _ -> raise (AssemblerException (sprintf "Unknown mnemonic: %s." mnemonic))
+
+    member private _.EncodeDataProcessing(opcode: ArmOpcode, rd: uint32 option, rn: uint32 option, operand2: Operand2, setFlags: bool) =
+        let cond = 0xEu
+        let rdValue = defaultArg rd 0u
+        let rnValue = defaultArg rn 0u
+        let setFlagsBit = if setFlags then 1u else 0u
+        let opcodeValue = uint32 opcode
+
+        let immediateBit, operand2Value =
+            match operand2 with
+            | Immediate value -> 1u, value &&& 0xFFFu
+            | Register register -> 0u, register &&& 0xFu
+
+        (cond <<< 28)
+        ||| (immediateBit <<< 25)
+        ||| (opcodeValue <<< 21)
+        ||| (setFlagsBit <<< 20)
+        ||| (rnValue <<< 16)
+        ||| (rdValue <<< 12)
+        ||| operand2Value

--- a/code/packages/fsharp/assembler/BUILD
+++ b/code/packages/fsharp/assembler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/assembler/BUILD_windows
+++ b/code/packages/fsharp/assembler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/assembler/CHANGELOG.md
+++ b/code/packages/fsharp/assembler/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native F# ARM assembly parser and instruction encoder.
+- Include register/immediate parsing, labels, comments, data-processing ops, load/store, NOP, and xUnit coverage.

--- a/code/packages/fsharp/assembler/CodingAdventures.Assembler.fsproj
+++ b/code/packages/fsharp/assembler/CodingAdventures.Assembler.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Assembler.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ARM assembly parser and instruction encoder for .NET</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Assembler.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/assembler/README.md
+++ b/code/packages/fsharp/assembler/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.Assembler.FSharp
+
+ARM assembly parser and 32-bit instruction encoder for .NET.
+
+The package supports a compact ARM subset: `MOV`, `ADD`, `SUB`, `AND`, `ORR`,
+`EOR`, `RSB`, `CMP`, `LDR`, `STR`, `NOP`, labels, and line comments.
+
+```fsharp
+open CodingAdventures.Assembler.FSharp
+
+let assembler = Assembler()
+let words =
+    assembler.Assemble(
+        "MOV R0, #42\n" +
+        "ADD R2, R0, R1\n" +
+        "STR R2, [R3]")
+```

--- a/code/packages/fsharp/assembler/required_capabilities.json
+++ b/code/packages/fsharp/assembler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/assembler",
+  "capabilities": [],
+  "justification": "Pure in-memory assembly parsing and instruction encoding. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/assembler/tests/CodingAdventures.Assembler.Tests/AssemblerTests.fs
+++ b/code/packages/fsharp/assembler/tests/CodingAdventures.Assembler.Tests/AssemblerTests.fs
@@ -1,0 +1,105 @@
+namespace CodingAdventures.Assembler.Tests
+
+open System
+open Xunit
+open CodingAdventures.Assembler.FSharp
+
+module AssemblerTests =
+    [<Fact>]
+    let ``parses registers and immediates`` () =
+        Assert.Equal(Some 0u, ArmParsing.tryParseRegister "R0")
+        Assert.Equal(Some 13u, ArmParsing.tryParseRegister "sp")
+        Assert.Equal(Some 255u, ArmParsing.tryParseImmediate "#0xFF")
+        Assert.Equal(Some 42u, ArmParsing.tryParseImmediate "42")
+        Assert.Equal(None, ArmParsing.tryParseRegister "R16")
+        Assert.Equal(None, ArmParsing.tryParseRegister "X0")
+
+    [<Fact>]
+    let ``parses data processing instructions`` () =
+        let asm = Assembler()
+        let instructions = asm.Parse("MOV R0, #42\nADD R2, R0, R1\nCMP R0, R1")
+
+        match instructions[0] with
+        | DataProcessing(opcode, Some rd, None, Immediate value, false) ->
+            Assert.Equal(ArmOpcode.Mov, opcode)
+            Assert.Equal(0u, rd)
+            Assert.Equal(42u, value)
+        | other -> Assert.Fail(sprintf "Expected MOV, got %A" other)
+
+        match instructions[1] with
+        | DataProcessing(opcode, Some rd, Some rn, Register rm, false) ->
+            Assert.Equal(ArmOpcode.Add, opcode)
+            Assert.Equal(2u, rd)
+            Assert.Equal(0u, rn)
+            Assert.Equal(1u, rm)
+        | other -> Assert.Fail(sprintf "Expected ADD, got %A" other)
+
+        match instructions[2] with
+        | DataProcessing(opcode, None, Some rn, Register rm, true) ->
+            Assert.Equal(ArmOpcode.Cmp, opcode)
+            Assert.Equal(0u, rn)
+            Assert.Equal(1u, rm)
+        | other -> Assert.Fail(sprintf "Expected CMP, got %A" other)
+
+    [<Fact>]
+    let ``parses memory instructions nop labels and comments`` () =
+        let asm = Assembler()
+        let instructions = asm.Parse("; full line comment\nstart:\nLDR R0, [R1] ; load\nSTR R2, [SP] // store\nNOP")
+
+        Assert.Equal(Label "start", instructions[0])
+        Assert.Equal(Load(0u, 1u), instructions[1])
+        Assert.Equal(Store(2u, 13u), instructions[2])
+        Assert.Equal(Nop, instructions[3])
+        Assert.Equal(0, asm.Labels["start"])
+
+    [<Fact>]
+    let ``encodes data processing instructions`` () =
+        let asm = Assembler()
+        let words = asm.Assemble("MOV R0, 42\nADD R2, R0, R1\nCMP R0, #1")
+
+        Assert.Equal(3, words.Length)
+        Assert.Equal(0xEu, words[0] >>> 28)
+        Assert.Equal(1u, (words[0] >>> 25) &&& 1u)
+        Assert.Equal(0xDu, (words[0] >>> 21) &&& 0xFu)
+        Assert.Equal(42u, words[0] &&& 0xFFFu)
+        Assert.Equal(0x4u, (words[1] >>> 21) &&& 0xFu)
+        Assert.Equal(2u, (words[1] >>> 12) &&& 0xFu)
+        Assert.Equal(1u, words[1] &&& 0xFu)
+        Assert.Equal(1u, (words[2] >>> 20) &&& 1u)
+
+    [<Fact>]
+    let ``encodes nop load store and skips labels`` () =
+        let asm = Assembler()
+        let words = asm.Assemble("start:\nNOP\nLDR R0, [R1]\nSTR R0, [R1]")
+
+        Assert.Equal<uint32 array>([| 0xE1A00000u; 0xE5900000u ||| (1u <<< 16); 0xE5800000u ||| (1u <<< 16) |], words)
+        Assert.Equal(1u, (words[1] >>> 20) &&& 1u)
+        Assert.Equal(0u, (words[2] >>> 20) &&& 1u)
+
+    [<Fact>]
+    let ``supports flag suffixes and logical ops`` () =
+        let asm = Assembler()
+        let instructions = asm.Parse("ADDS R1, R2, #3\nANDS R0, R0, R1\nORR R3, R1, R2\nEOR R4, R4, R5\nRSB R6, R7, R8")
+
+        match instructions[0] with
+        | DataProcessing(_, _, _, _, true) -> ()
+        | other -> Assert.Fail(sprintf "Expected flag-setting instruction, got %A" other)
+
+        match instructions[1] with
+        | DataProcessing(_, _, _, _, true) -> ()
+        | other -> Assert.Fail(sprintf "Expected flag-setting instruction, got %A" other)
+
+        match instructions[2], instructions[3], instructions[4] with
+        | DataProcessing(ArmOpcode.Orr, _, _, _, _), DataProcessing(ArmOpcode.Eor, _, _, _, _), DataProcessing(ArmOpcode.Rsb, _, _, _, _) -> ()
+        | other -> Assert.Fail(sprintf "Unexpected opcodes: %A" other)
+
+    [<Fact>]
+    let ``rejects invalid source`` () =
+        let asm = Assembler()
+
+        Assert.Throws<AssemblerException>(fun () -> asm.Parse("BLAH R0, R1") |> ignore) |> ignore
+        Assert.Throws<AssemblerException>(fun () -> asm.Parse("MOV X0, #1") |> ignore) |> ignore
+        Assert.Throws<AssemblerException>(fun () -> asm.Parse("ADD R0, R1") |> ignore) |> ignore
+        Assert.Throws<AssemblerException>(fun () -> asm.Parse("MOV R0, #nope") |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> asm.Parse(null) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> asm.Encode(null) |> ignore) |> ignore

--- a/code/packages/fsharp/assembler/tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.fsproj
+++ b/code/packages/fsharp/assembler/tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Assembler.fsproj" />
+    <Compile Include="AssemblerTests.fs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add native C# and F# ARM assembler packages
- support a compact instruction subset: data-processing ops, CMP, LDR/STR, NOP, labels, and line comments
- include package docs, capability metadata, Bazel build files, and focused xUnit coverage

## Verification
- `dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line`
- `dotnet test tests/CodingAdventures.Assembler.Tests/CodingAdventures.Assembler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line`
- `git diff --check`
- wrapper scan for platform crypto APIs in the new assembler packages