### PR TITLE
feat(ecmascript): add ES1/ES3/ES5 lexer+parser packages for Java, Kotlin, and Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       needs_elixir: ${{ steps.toolchains.outputs.needs_elixir }}
       needs_lua: ${{ steps.toolchains.outputs.needs_lua }}
       needs_perl: ${{ steps.toolchains.outputs.needs_perl }}
+      needs_java: ${{ steps.toolchains.outputs.needs_java }}
+      needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
     steps:
@@ -116,7 +118,9 @@ jobs:
               'needs_rust=true' \
               'needs_elixir=true' \
               'needs_lua=true' \
-              'needs_perl=true' >> "$GITHUB_OUTPUT"
+              'needs_perl=true' \
+              'needs_java=true' \
+              'needs_kotlin=true' >> "$GITHUB_OUTPUT"
           else
             printf '%s\n' \
               'needs_python=${{ steps.detect.outputs.needs_python }}' \
@@ -126,7 +130,9 @@ jobs:
               'needs_rust=${{ steps.detect.outputs.needs_rust }}' \
               'needs_elixir=${{ steps.detect.outputs.needs_elixir }}' \
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
-              'needs_perl=${{ steps.detect.outputs.needs_perl }}' >> "$GITHUB_OUTPUT"
+              'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
+              'needs_java=${{ steps.detect.outputs.needs_java }}' \
+              'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload build plan
@@ -325,6 +331,22 @@ jobs:
         with:
           name: build-plan
         continue-on-error: true
+
+      # ── Java/Kotlin (JDK 21 + Gradle) ────────────────────────
+      #
+      # Both Java and Kotlin packages use Gradle as their build system.
+      # JDK 21 is required because the source code uses Java 21 features
+      # (sealed interfaces, records, pattern matching in switch).
+      - name: Set up JDK 21
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: gradle/actions/setup-gradle@v4
 
       # ── Build the build tool ──────────────────────────────────
       - name: Compile build tool

--- a/code/grammars/ecmascript/es1.grammar
+++ b/code/grammars/ecmascript/es1.grammar
@@ -1,0 +1,312 @@
+# ECMAScript 1 (1997) — Parser Grammar
+# @version 1
+# @ecmascript_edition 1
+#
+# ECMA-262, 1st Edition — June 1997
+#
+# This grammar defines the syntactic structure of ES1 JavaScript. It covers
+# the complete language as specified in the first ECMAScript standard:
+# variable declarations, function declarations/expressions, all statement
+# types, and the full expression precedence chain.
+#
+# Format:
+#   rule_name = definition ;
+#
+# UPPERCASE names reference tokens from es1.tokens.
+# lowercase names reference other grammar rules.
+#
+# Notation:
+#   |       alternation (ordered choice — PEG semantics, first match wins)
+#   { x }   zero or more repetitions
+#   [ x ]   optional
+#   ( x )   grouping
+#   "lit"   match a keyword (lexer emits KEYWORD token with this value)
+#
+# IMPORTANT: The lexer reclassifies all keyword names as KEYWORD tokens.
+# Grammar rules must therefore use "keyword_value" (quoted literals) to
+# match specific keywords, not a KEYWORD token type directly.
+#
+# IMPORTANT: No left recursion allowed. The parser uses PEG semantics with
+# packrat memoization. Use iterative form: `a { op b }` instead of `a = a op b`.
+
+# ============================================================================
+# Program
+# ============================================================================
+#
+# An ES1 program is a sequence of source elements. Each source element is
+# either a function declaration or a statement. There is no module system —
+# that comes in ES2015.
+
+program = { source_element } ;
+
+source_element = function_declaration
+               | statement ;
+
+# ============================================================================
+# Declarations
+# ============================================================================
+#
+# ES1 has only two kinds of declarations: `var` and `function`.
+# There is no `let`, `const`, `class`, `import`, or `export` yet.
+
+function_declaration = "function" NAME LPAREN [ formal_parameter_list ] RPAREN
+                       LBRACE function_body RBRACE ;
+
+formal_parameter_list = NAME { COMMA NAME } ;
+
+function_body = { source_element } ;
+
+# ============================================================================
+# Statements
+# ============================================================================
+#
+# ES1 supports 14 statement types. Notable absences compared to later versions:
+# - No try/catch/finally/throw (added in ES3)
+# - No for-of (added in ES2015)
+# - No debugger (added in ES5)
+#
+# The `with` statement is included (it was later deprecated in strict mode).
+
+statement = block
+          | variable_statement
+          | empty_statement
+          | if_statement
+          | while_statement
+          | do_while_statement
+          | for_statement
+          | for_in_statement
+          | continue_statement
+          | break_statement
+          | return_statement
+          | with_statement
+          | switch_statement
+          | labelled_statement
+          | expression_statement ;
+
+# A block is a sequence of statements enclosed in curly braces.
+# Unlike Python, JavaScript uses braces for blocks, not indentation.
+
+block = LBRACE { statement } RBRACE ;
+
+# Variable declarations: `var x = 1, y = 2;`
+# ES1 only has `var` — no `let` or `const`.
+
+variable_statement = "var" variable_declaration_list SEMICOLON ;
+
+variable_declaration_list = variable_declaration { COMMA variable_declaration } ;
+
+variable_declaration = NAME [ EQUALS assignment_expression ] ;
+
+# Empty statement: just a semicolon.
+
+empty_statement = SEMICOLON ;
+
+# Expression statement: any expression followed by a semicolon.
+# This is the catch-all for function calls, assignments via operators, etc.
+
+expression_statement = expression SEMICOLON ;
+
+# If/else: the dangling-else ambiguity is resolved by PEG's ordered choice —
+# the `else` always binds to the nearest `if`.
+
+if_statement = "if" LPAREN expression RPAREN statement [ "else" statement ] ;
+
+# While loop
+
+while_statement = "while" LPAREN expression RPAREN statement ;
+
+# Do-while loop: the body executes at least once.
+
+do_while_statement = "do" statement "while" LPAREN expression RPAREN SEMICOLON ;
+
+# For loop: the classic C-style three-part header.
+
+for_statement = "for" LPAREN
+                  ( "var" variable_declaration_list | [ expression ] ) SEMICOLON
+                  [ expression ] SEMICOLON
+                  [ expression ]
+                RPAREN statement ;
+
+# For-in loop: iterates over enumerable properties of an object.
+
+for_in_statement = "for" LPAREN
+                     ( "var" variable_declaration | left_hand_side_expression ) "in" expression
+                   RPAREN statement ;
+
+# Continue and break: optionally target a label.
+
+continue_statement = "continue" [ NAME ] SEMICOLON ;
+
+break_statement = "break" [ NAME ] SEMICOLON ;
+
+# Return: only valid inside a function body (semantic check, not grammar).
+
+return_statement = "return" [ expression ] SEMICOLON ;
+
+# With statement: extends the scope chain. Deprecated in strict mode (ES5+),
+# but legal in ES1.
+
+with_statement = "with" LPAREN expression RPAREN statement ;
+
+# Switch statement: fall-through semantics like C.
+
+switch_statement = "switch" LPAREN expression RPAREN
+                   LBRACE { case_clause } [ default_clause { case_clause } ] RBRACE ;
+
+case_clause = "case" expression COLON { statement } ;
+
+default_clause = "default" COLON { statement } ;
+
+# Labelled statement: any statement can be labelled for break/continue targeting.
+
+labelled_statement = NAME COLON statement ;
+
+# ============================================================================
+# Expressions
+# ============================================================================
+#
+# Operator precedence is encoded by rule nesting, from lowest to highest:
+#
+#   comma < assignment < conditional (ternary) < logical_or < logical_and
+#   < bitwise_or < bitwise_xor < bitwise_and < equality < relational
+#   < shift < additive < multiplicative < unary < postfix
+#   < call/member < primary
+#
+# This is the iterative (non-left-recursive) encoding required by PEG parsers.
+# Each level uses `{ operator operand }` to handle left-associativity.
+
+# Comma expression: `a, b, c` evaluates all, returns last.
+
+expression = assignment_expression { COMMA assignment_expression } ;
+
+# Assignment: right-associative. Left side must be a valid target (semantic check).
+
+assignment_expression = conditional_expression
+                      | left_hand_side_expression assignment_operator assignment_expression ;
+
+assignment_operator = EQUALS | PLUS_EQUALS | MINUS_EQUALS | STAR_EQUALS
+                    | SLASH_EQUALS | PERCENT_EQUALS | AMPERSAND_EQUALS
+                    | PIPE_EQUALS | CARET_EQUALS | LEFT_SHIFT_EQUALS
+                    | RIGHT_SHIFT_EQUALS | UNSIGNED_RIGHT_SHIFT_EQUALS ;
+
+# Ternary conditional: `condition ? then : else`
+
+conditional_expression = logical_or_expression
+                         [ QUESTION assignment_expression COLON assignment_expression ] ;
+
+# Logical OR and AND
+
+logical_or_expression = logical_and_expression { OR_OR logical_and_expression } ;
+
+logical_and_expression = bitwise_or_expression { AND_AND bitwise_or_expression } ;
+
+# Bitwise operators: OR, XOR, AND
+
+bitwise_or_expression = bitwise_xor_expression { PIPE bitwise_xor_expression } ;
+
+bitwise_xor_expression = bitwise_and_expression { CARET bitwise_and_expression } ;
+
+bitwise_and_expression = equality_expression { AMPERSAND equality_expression } ;
+
+# Equality: ES1 only has == and != (no === or !==).
+
+equality_expression = relational_expression
+                      { ( EQUALS_EQUALS | NOT_EQUALS ) relational_expression } ;
+
+# Relational: <, >, <=, >=, in, instanceof
+# Note: `in` is a keyword used both here and in for-in loops.
+
+relational_expression = shift_expression
+                        { ( LESS_THAN | GREATER_THAN | LESS_EQUALS | GREATER_EQUALS
+                          | "in" ) shift_expression } ;
+
+# Shift operators: <<, >>, >>> (unsigned right shift is unique to JS)
+
+shift_expression = additive_expression
+                   { ( LEFT_SHIFT | RIGHT_SHIFT | UNSIGNED_RIGHT_SHIFT ) additive_expression } ;
+
+# Addition and subtraction
+
+additive_expression = multiplicative_expression
+                      { ( PLUS | MINUS ) multiplicative_expression } ;
+
+# Multiplication, division, modulo
+
+multiplicative_expression = unary_expression
+                            { ( STAR | SLASH | PERCENT ) unary_expression } ;
+
+# Unary operators: prefix operators applied right-to-left.
+
+unary_expression = postfix_expression
+                 | "delete" unary_expression
+                 | "void" unary_expression
+                 | "typeof" unary_expression
+                 | PLUS_PLUS unary_expression
+                 | MINUS_MINUS unary_expression
+                 | PLUS unary_expression
+                 | MINUS unary_expression
+                 | TILDE unary_expression
+                 | BANG unary_expression ;
+
+# Postfix: increment and decrement after the operand.
+
+postfix_expression = left_hand_side_expression [ PLUS_PLUS | MINUS_MINUS ] ;
+
+# Left-hand side: anything that can appear on the left of an assignment.
+# This includes function calls, property accesses, and computed accesses.
+
+left_hand_side_expression = call_expression | new_expression ;
+
+# Call expression: member access followed by arguments, with further
+# property access or calls chained after.
+
+call_expression = member_expression arguments
+                  { arguments | DOT NAME | LBRACKET expression RBRACKET } ;
+
+# New expression: `new Foo()` or `new new Foo()` (rare but legal).
+
+new_expression = member_expression
+               | "new" new_expression ;
+
+# Member expression: property access via dot or bracket notation.
+
+member_expression = primary_expression { DOT NAME | LBRACKET expression RBRACKET }
+                  | "new" member_expression arguments ;
+
+# Arguments: the parenthesized argument list of a function call.
+
+arguments = LPAREN [ assignment_expression { COMMA assignment_expression } ] RPAREN ;
+
+# Primary expressions: the atoms of the expression grammar.
+
+primary_expression = "this"
+                   | NAME
+                   | NUMBER
+                   | STRING
+                   | "true"
+                   | "false"
+                   | "null"
+                   | array_literal
+                   | object_literal
+                   | function_expression
+                   | LPAREN expression RPAREN ;
+
+# Array literal: `[1, 2, 3]` or `[1, , 3]` (elision / holes allowed).
+
+array_literal = LBRACKET [ element_list ] RBRACKET ;
+
+element_list = [ assignment_expression ] { COMMA [ assignment_expression ] } ;
+
+# Object literal: `{ key: value }`. In ES1, property names are identifiers,
+# strings, or numbers. No computed properties, no shorthand, no methods.
+
+object_literal = LBRACE [ property_assignment { COMMA property_assignment } [ COMMA ] ] RBRACE ;
+
+property_assignment = property_name COLON assignment_expression ;
+
+property_name = NAME | STRING | NUMBER ;
+
+# Function expression: like a declaration but can be anonymous and used as a value.
+
+function_expression = "function" [ NAME ] LPAREN [ formal_parameter_list ] RPAREN
+                      LBRACE function_body RBRACE ;

--- a/code/grammars/ecmascript/es1.tokens
+++ b/code/grammars/ecmascript/es1.tokens
@@ -1,0 +1,192 @@
+# ECMAScript 1 (1997) — Lexical Grammar
+# @version 1
+# @ecmascript_edition 1
+#
+# ECMA-262, 1st Edition — June 1997
+#
+# This is the very first standardized version of JavaScript. Brendan Eich
+# created the language for Netscape Navigator in 1995; two years later,
+# ECMA International published this specification.
+#
+# What ES1 has:
+#   - 26 keywords (break, case, continue, default, delete, do, else, for,
+#     function, if, in, new, return, switch, this, typeof, var, void, while, with)
+#   - Basic operators: arithmetic, bitwise, logical, comparison, assignment
+#   - String literals (single and double quoted)
+#   - Numeric literals (decimal integers, floats, hex with 0x prefix)
+#   - The $ character is valid in identifiers (unusual for 1997)
+#
+# What ES1 does NOT have:
+#   - No === or !== (strict equality — added in ES3)
+#   - No try/catch/finally/throw (error handling — added in ES3)
+#   - No regex literals (implementation-defined in ES1 — formalized in ES3)
+#   - No template literals (added in ES2015)
+#   - No arrow functions (added in ES2015)
+#   - No let/const (added in ES2015)
+#   - No binary (0b) or octal (0o) numeric literals (added in ES2015)
+#
+# Format:
+#   TOKEN_NAME = /regex/     — regex-based token pattern
+#   TOKEN_NAME = "literal"   — exact literal match
+#
+# Order matters: first match wins. Multi-character operators
+# must come before single-character ones (e.g., == before =).
+
+# ============================================================================
+# Literals
+# ============================================================================
+#
+# Identifiers in JavaScript can contain letters, digits, underscores, and
+# the dollar sign ($). The $ was included for generated code (like Java's
+# inner class naming) and later became famous through jQuery.
+
+NAME = /[a-zA-Z_$][a-zA-Z0-9_$]*/
+
+# Numbers: decimal integers, floating point, and hex integers.
+# ES1 does not have binary (0b) or formal octal (0o) prefixes.
+# Leading-dot floats like .5 are supported.
+# Scientific notation (1e10, 2.5E-3) is supported.
+
+HEX_NUMBER = /0[xX][0-9a-fA-F]+/ -> NUMBER
+FLOAT_NUMBER = /[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?/ -> NUMBER
+LEADING_DOT_FLOAT = /\.[0-9]+([eE][+-]?[0-9]+)?/ -> NUMBER
+SCI_NUMBER = /[0-9]+[eE][+-]?[0-9]+/ -> NUMBER
+INT_NUMBER = /[0-9]+/ -> NUMBER
+
+# Strings: both single-quoted and double-quoted, with backslash escapes.
+# ES1 supports: \\, \', \", \n, \r, \t, \b, \f, \0, \xHH, \uHHHH
+
+STRING_DQ = /"([^"\\]|\\.)*"/ -> STRING
+STRING_SQ = /'([^'\\]|\\.)*'/ -> STRING
+
+# ============================================================================
+# Multi-character operators (must come before single-character versions)
+# ============================================================================
+#
+# ES1 has == and != but NOT === and !== (those are ES3).
+# The unsigned right shift >>> is unique to JavaScript — most languages
+# only have >> (signed/arithmetic right shift).
+
+UNSIGNED_RIGHT_SHIFT_EQUALS = ">>>="
+UNSIGNED_RIGHT_SHIFT = ">>>"
+LEFT_SHIFT_EQUALS    = "<<="
+RIGHT_SHIFT_EQUALS   = ">>="
+EQUALS_EQUALS        = "=="
+NOT_EQUALS           = "!="
+LESS_EQUALS          = "<="
+GREATER_EQUALS       = ">="
+PLUS_EQUALS          = "+="
+MINUS_EQUALS         = "-="
+STAR_EQUALS          = "*="
+SLASH_EQUALS         = "/="
+PERCENT_EQUALS       = "%="
+AMPERSAND_EQUALS     = "&="
+PIPE_EQUALS          = "|="
+CARET_EQUALS         = "^="
+LEFT_SHIFT           = "<<"
+RIGHT_SHIFT          = ">>"
+AND_AND              = "&&"
+OR_OR                = "||"
+PLUS_PLUS            = "++"
+MINUS_MINUS          = "--"
+
+# ============================================================================
+# Single-character operators
+# ============================================================================
+
+EQUALS       = "="
+PLUS         = "+"
+MINUS        = "-"
+STAR         = "*"
+SLASH        = "/"
+PERCENT      = "%"
+LESS_THAN    = "<"
+GREATER_THAN = ">"
+BANG         = "!"
+AMPERSAND    = "&"
+PIPE         = "|"
+CARET        = "^"
+TILDE        = "~"
+QUESTION     = "?"
+
+# ============================================================================
+# Delimiters
+# ============================================================================
+
+LPAREN    = "("
+RPAREN    = ")"
+LBRACE    = "{"
+RBRACE    = "}"
+LBRACKET  = "["
+RBRACKET  = "]"
+SEMICOLON = ";"
+COMMA     = ","
+COLON     = ":"
+DOT       = "."
+
+# ============================================================================
+# Keywords
+# ============================================================================
+#
+# ES1 has 26 keywords. These are reclassified from NAME to KEYWORD by the
+# lexer. Note: `class`, `const`, `let`, `import`, `export` are NOT keywords
+# in ES1 — they are future reserved words (see reserved section below).
+
+keywords:
+  break
+  case
+  continue
+  default
+  delete
+  do
+  else
+  for
+  function
+  if
+  in
+  new
+  return
+  switch
+  this
+  typeof
+  var
+  void
+  while
+  with
+  true
+  false
+  null
+
+# ============================================================================
+# Future reserved words
+# ============================================================================
+#
+# These identifiers are reserved for future use. Using them as variable
+# names is a syntax error. Many of these became actual keywords in later
+# versions (class in ES2015, const in ES2015, etc.).
+
+reserved:
+  class
+  const
+  enum
+  export
+  extends
+  import
+  super
+
+# ============================================================================
+# Skip patterns (whitespace and comments)
+# ============================================================================
+
+skip:
+  WHITESPACE    = /[ \t\r\n\v\f]+/
+  LINE_COMMENT  = /\/\/[^\n]*/
+  BLOCK_COMMENT = /\/\*([^*]|\*[^\/])*\*\//
+
+# ============================================================================
+# Error recovery tokens
+# ============================================================================
+
+errors:
+  BAD_STRING_DQ = /"[^"]*$/
+  BAD_STRING_SQ = /'[^']*$/

--- a/code/grammars/ecmascript/es3.grammar
+++ b/code/grammars/ecmascript/es3.grammar
@@ -1,0 +1,250 @@
+# ECMAScript 3 (1999) — Parser Grammar
+# @version 1
+# @ecmascript_edition 3
+#
+# ECMA-262, 3rd Edition — December 1999
+#
+# ES3 adds structured error handling (try/catch/finally/throw), strict equality
+# operators (=== and !==), the `instanceof` operator, and regex literals to
+# the ES1 grammar.
+#
+# Changes from ES1:
+#   - Added: try_statement, throw_statement
+#   - Added: catch_clause, finally_clause
+#   - Added: REGEX as a primary expression
+#   - Added: === and !== to equality_expression
+#   - Added: `instanceof` to relational_expression
+#   - Statement list gains try_statement and throw_statement
+
+# ============================================================================
+# Program
+# ============================================================================
+
+program = { source_element } ;
+
+source_element = function_declaration
+               | statement ;
+
+# ============================================================================
+# Declarations
+# ============================================================================
+
+function_declaration = "function" NAME LPAREN [ formal_parameter_list ] RPAREN
+                       LBRACE function_body RBRACE ;
+
+formal_parameter_list = NAME { COMMA NAME } ;
+
+function_body = { source_element } ;
+
+# ============================================================================
+# Statements
+# ============================================================================
+#
+# ES3 adds try_statement and throw_statement to ES1's 14 statement types.
+
+statement = block
+          | variable_statement
+          | empty_statement
+          | if_statement
+          | while_statement
+          | do_while_statement
+          | for_statement
+          | for_in_statement
+          | continue_statement
+          | break_statement
+          | return_statement
+          | with_statement
+          | switch_statement
+          | labelled_statement
+          | try_statement
+          | throw_statement
+          | expression_statement ;
+
+block = LBRACE { statement } RBRACE ;
+
+variable_statement = "var" variable_declaration_list SEMICOLON ;
+
+variable_declaration_list = variable_declaration { COMMA variable_declaration } ;
+
+variable_declaration = NAME [ EQUALS assignment_expression ] ;
+
+empty_statement = SEMICOLON ;
+
+expression_statement = expression SEMICOLON ;
+
+if_statement = "if" LPAREN expression RPAREN statement [ "else" statement ] ;
+
+while_statement = "while" LPAREN expression RPAREN statement ;
+
+do_while_statement = "do" statement "while" LPAREN expression RPAREN SEMICOLON ;
+
+for_statement = "for" LPAREN
+                  ( "var" variable_declaration_list | [ expression ] ) SEMICOLON
+                  [ expression ] SEMICOLON
+                  [ expression ]
+                RPAREN statement ;
+
+for_in_statement = "for" LPAREN
+                     ( "var" variable_declaration | left_hand_side_expression ) "in" expression
+                   RPAREN statement ;
+
+continue_statement = "continue" [ NAME ] SEMICOLON ;
+
+break_statement = "break" [ NAME ] SEMICOLON ;
+
+return_statement = "return" [ expression ] SEMICOLON ;
+
+with_statement = "with" LPAREN expression RPAREN statement ;
+
+switch_statement = "switch" LPAREN expression RPAREN
+                   LBRACE { case_clause } [ default_clause { case_clause } ] RBRACE ;
+
+case_clause = "case" expression COLON { statement } ;
+
+default_clause = "default" COLON { statement } ;
+
+labelled_statement = NAME COLON statement ;
+
+# --- NEW IN ES3: Error Handling ---
+#
+# try/catch/finally provides structured error handling. Before ES3, the only
+# way to handle errors was through the `onerror` global event handler.
+#
+# The catch clause binds the thrown value to a variable name. This variable
+# is scoped to the catch block (one of the few block-scoped bindings in pre-ES2015).
+#
+# You can have:
+#   - try { } catch (e) { }
+#   - try { } finally { }
+#   - try { } catch (e) { } finally { }
+# But NOT:
+#   - try { } alone (must have at least one of catch or finally)
+
+try_statement = "try" block ( catch_clause [ finally_clause ] | finally_clause ) ;
+
+catch_clause = "catch" LPAREN NAME RPAREN block ;
+
+finally_clause = "finally" block ;
+
+# throw must be followed by an expression on the SAME LINE (ASI restricted).
+# In a full implementation, this would use !NEWLINE lookahead.
+
+throw_statement = "throw" expression SEMICOLON ;
+
+# ============================================================================
+# Expressions
+# ============================================================================
+
+expression = assignment_expression { COMMA assignment_expression } ;
+
+assignment_expression = conditional_expression
+                      | left_hand_side_expression assignment_operator assignment_expression ;
+
+assignment_operator = EQUALS | PLUS_EQUALS | MINUS_EQUALS | STAR_EQUALS
+                    | SLASH_EQUALS | PERCENT_EQUALS | AMPERSAND_EQUALS
+                    | PIPE_EQUALS | CARET_EQUALS | LEFT_SHIFT_EQUALS
+                    | RIGHT_SHIFT_EQUALS | UNSIGNED_RIGHT_SHIFT_EQUALS ;
+
+conditional_expression = logical_or_expression
+                         [ QUESTION assignment_expression COLON assignment_expression ] ;
+
+logical_or_expression = logical_and_expression { OR_OR logical_and_expression } ;
+
+logical_and_expression = bitwise_or_expression { AND_AND bitwise_or_expression } ;
+
+bitwise_or_expression = bitwise_xor_expression { PIPE bitwise_xor_expression } ;
+
+bitwise_xor_expression = bitwise_and_expression { CARET bitwise_and_expression } ;
+
+bitwise_and_expression = equality_expression { AMPERSAND equality_expression } ;
+
+# --- CHANGED IN ES3: Strict equality operators ---
+#
+# ES1 only had == and != (abstract equality, with type coercion).
+# ES3 adds === and !== (strict equality, no type coercion).
+#
+# The strict operators are generally preferred because they avoid surprising
+# type coercion rules. For example:
+#   "" == 0     // true  (abstract equality coerces types)
+#   "" === 0    // false (strict equality, different types)
+
+equality_expression = relational_expression
+                      { ( STRICT_EQUALS | STRICT_NOT_EQUALS
+                        | EQUALS_EQUALS | NOT_EQUALS ) relational_expression } ;
+
+# --- CHANGED IN ES3: instanceof operator ---
+#
+# ES3 adds `instanceof` to the relational operators. It checks whether an
+# object's prototype chain includes a constructor's prototype:
+#   myArray instanceof Array  // true
+
+relational_expression = shift_expression
+                        { ( LESS_THAN | GREATER_THAN | LESS_EQUALS | GREATER_EQUALS
+                          | "instanceof" | "in" ) shift_expression } ;
+
+shift_expression = additive_expression
+                   { ( LEFT_SHIFT | RIGHT_SHIFT | UNSIGNED_RIGHT_SHIFT ) additive_expression } ;
+
+additive_expression = multiplicative_expression
+                      { ( PLUS | MINUS ) multiplicative_expression } ;
+
+multiplicative_expression = unary_expression
+                            { ( STAR | SLASH | PERCENT ) unary_expression } ;
+
+unary_expression = postfix_expression
+                 | "delete" unary_expression
+                 | "void" unary_expression
+                 | "typeof" unary_expression
+                 | PLUS_PLUS unary_expression
+                 | MINUS_MINUS unary_expression
+                 | PLUS unary_expression
+                 | MINUS unary_expression
+                 | TILDE unary_expression
+                 | BANG unary_expression ;
+
+postfix_expression = left_hand_side_expression [ PLUS_PLUS | MINUS_MINUS ] ;
+
+left_hand_side_expression = call_expression | new_expression ;
+
+call_expression = member_expression arguments
+                  { arguments | DOT NAME | LBRACKET expression RBRACKET } ;
+
+new_expression = member_expression
+               | "new" new_expression ;
+
+member_expression = primary_expression { DOT NAME | LBRACKET expression RBRACKET }
+                  | "new" member_expression arguments ;
+
+arguments = LPAREN [ assignment_expression { COMMA assignment_expression } ] RPAREN ;
+
+# --- CHANGED IN ES3: Regex literal as primary expression ---
+#
+# ES1 left regex literals as implementation-defined. ES3 formalizes them
+# as a primary expression alternative, giving them equal footing with
+# string and number literals.
+
+primary_expression = "this"
+                   | NAME
+                   | NUMBER
+                   | STRING
+                   | REGEX
+                   | "true"
+                   | "false"
+                   | "null"
+                   | array_literal
+                   | object_literal
+                   | function_expression
+                   | LPAREN expression RPAREN ;
+
+array_literal = LBRACKET [ element_list ] RBRACKET ;
+
+element_list = [ assignment_expression ] { COMMA [ assignment_expression ] } ;
+
+object_literal = LBRACE [ property_assignment { COMMA property_assignment } [ COMMA ] ] RBRACE ;
+
+property_assignment = property_name COLON assignment_expression ;
+
+property_name = NAME | STRING | NUMBER ;
+
+function_expression = "function" [ NAME ] LPAREN [ formal_parameter_list ] RPAREN
+                      LBRACE function_body RBRACE ;

--- a/code/grammars/ecmascript/es3.tokens
+++ b/code/grammars/ecmascript/es3.tokens
@@ -1,0 +1,222 @@
+# ECMAScript 3 (1999) — Lexical Grammar
+# @version 1
+# @ecmascript_edition 3
+#
+# ECMA-262, 3rd Edition — December 1999
+#
+# ES3 was the version that made JavaScript a real, complete language. It landed
+# two years after ES1 and added features that developers today consider
+# fundamental: regular expressions, error handling, and strict equality.
+#
+# What ES3 adds over ES1:
+#   - === and !== (strict equality — no type coercion)
+#   - try/catch/finally/throw (structured error handling)
+#   - Regular expression literals (/pattern/flags)
+#   - `instanceof` operator
+#   - Expanded future-reserved words
+#
+# What ES3 does NOT have:
+#   - No getters/setters in object literals (added in ES5)
+#   - No strict mode (added in ES5)
+#   - No let/const/class/arrow functions (added in ES2015)
+#   - No template literals (added in ES2015)
+#
+# Regex vs Division Ambiguity
+# ---------------------------
+# The `/` character is ambiguous in JavaScript: it could start a regex literal
+# or be the division operator. This requires context-sensitive lexing using
+# the previousToken() callback (Extension 1 from lexer-parser-extensions.md).
+#
+#   / is REGEX after:  = ( [ { , ; : ? ! & | ^ ~ + - * / % < > return
+#                      typeof void delete new in instanceof case throw
+#   / is SLASH after:  ) ] NAME NUMBER STRING ++ --
+#
+# The GrammarLexer handles this via the on_token callback mechanism.
+
+# ============================================================================
+# Literals
+# ============================================================================
+
+NAME = /[a-zA-Z_$][a-zA-Z0-9_$]*/
+
+# Numbers: same as ES1 — decimal, float, hex. No binary or octal prefixes.
+
+HEX_NUMBER = /0[xX][0-9a-fA-F]+/ -> NUMBER
+FLOAT_NUMBER = /[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?/ -> NUMBER
+LEADING_DOT_FLOAT = /\.[0-9]+([eE][+-]?[0-9]+)?/ -> NUMBER
+SCI_NUMBER = /[0-9]+[eE][+-]?[0-9]+/ -> NUMBER
+INT_NUMBER = /[0-9]+/ -> NUMBER
+
+# Strings: same as ES1 — single and double quoted with backslash escapes.
+
+STRING_DQ = /"([^"\\]|\\.)*"/ -> STRING
+STRING_SQ = /'([^'\\]|\\.)*'/ -> STRING
+
+# Regular expression literals (NEW in ES3).
+# The pattern is everything between unescaped slashes, followed by optional flags.
+# Flags: g (global), i (case-insensitive), m (multiline).
+# Note: The lexer must use previousToken() to disambiguate from division.
+
+REGEX = /\/([^\/\\\n]|\\.)+\/[gim]*/
+
+# ============================================================================
+# Multi-character operators
+# ============================================================================
+#
+# ES3 adds === and !== (strict equality). These must come BEFORE == and !=
+# in the token file because of first-match-wins ordering.
+
+STRICT_EQUALS            = "==="
+STRICT_NOT_EQUALS        = "!=="
+UNSIGNED_RIGHT_SHIFT_EQUALS = ">>>="
+UNSIGNED_RIGHT_SHIFT     = ">>>"
+LEFT_SHIFT_EQUALS        = "<<="
+RIGHT_SHIFT_EQUALS       = ">>="
+EQUALS_EQUALS            = "=="
+NOT_EQUALS               = "!="
+LESS_EQUALS              = "<="
+GREATER_EQUALS           = ">="
+PLUS_EQUALS              = "+="
+MINUS_EQUALS             = "-="
+STAR_EQUALS              = "*="
+SLASH_EQUALS             = "/="
+PERCENT_EQUALS           = "%="
+AMPERSAND_EQUALS         = "&="
+PIPE_EQUALS              = "|="
+CARET_EQUALS             = "^="
+LEFT_SHIFT               = "<<"
+RIGHT_SHIFT              = ">>"
+AND_AND                  = "&&"
+OR_OR                    = "||"
+PLUS_PLUS                = "++"
+MINUS_MINUS              = "--"
+
+# ============================================================================
+# Single-character operators
+# ============================================================================
+
+EQUALS       = "="
+PLUS         = "+"
+MINUS        = "-"
+STAR         = "*"
+SLASH        = "/"
+PERCENT      = "%"
+LESS_THAN    = "<"
+GREATER_THAN = ">"
+BANG         = "!"
+AMPERSAND    = "&"
+PIPE         = "|"
+CARET        = "^"
+TILDE        = "~"
+QUESTION     = "?"
+
+# ============================================================================
+# Delimiters
+# ============================================================================
+
+LPAREN    = "("
+RPAREN    = ")"
+LBRACE    = "{"
+RBRACE    = "}"
+LBRACKET  = "["
+RBRACKET  = "]"
+SEMICOLON = ";"
+COMMA     = ","
+COLON     = ":"
+DOT       = "."
+
+# ============================================================================
+# Keywords
+# ============================================================================
+#
+# ES3 adds 5 keywords over ES1: catch, finally, instanceof, throw, try.
+# The `instanceof` operator checks prototype chain membership.
+
+keywords:
+  break
+  case
+  catch
+  continue
+  default
+  delete
+  do
+  else
+  finally
+  for
+  function
+  if
+  in
+  instanceof
+  new
+  return
+  switch
+  this
+  throw
+  try
+  typeof
+  var
+  void
+  while
+  with
+  true
+  false
+  null
+
+# ============================================================================
+# Future reserved words
+# ============================================================================
+#
+# ES3 significantly expanded the reserved word list. Many of these eventually
+# became real keywords in ES2015 (class, const, export, extends, import, super)
+# or were used in strict mode (implements, interface, private, protected, public).
+
+reserved:
+  abstract
+  boolean
+  byte
+  char
+  class
+  const
+  debugger
+  double
+  enum
+  export
+  extends
+  final
+  float
+  goto
+  implements
+  import
+  int
+  interface
+  long
+  native
+  package
+  private
+  protected
+  public
+  short
+  static
+  super
+  synchronized
+  throws
+  transient
+  volatile
+
+# ============================================================================
+# Skip patterns
+# ============================================================================
+
+skip:
+  WHITESPACE    = /[ \t\r\n\v\f]+/
+  LINE_COMMENT  = /\/\/[^\n]*/
+  BLOCK_COMMENT = /\/\*([^*]|\*[^\/])*\*\//
+
+# ============================================================================
+# Error recovery tokens
+# ============================================================================
+
+errors:
+  BAD_STRING_DQ = /"[^"]*$/
+  BAD_STRING_SQ = /'[^']*$/
+  BAD_REGEX = /\/([^\/\\\n]|\\.)*$/

--- a/code/grammars/ecmascript/es5.grammar
+++ b/code/grammars/ecmascript/es5.grammar
@@ -1,0 +1,245 @@
+# ECMAScript 5 (2009) — Parser Grammar
+# @version 1
+# @ecmascript_edition 5
+#
+# ECMA-262, 5th Edition — December 2009
+#
+# ES5 adds getter/setter properties in object literals and the debugger
+# statement. The grammar is otherwise identical to ES3.
+#
+# Changes from ES3:
+#   - Added: getter_property, setter_property in object literals
+#   - Added: debugger_statement
+#   - Changed: property_assignment gains getter/setter alternatives
+
+# ============================================================================
+# Program
+# ============================================================================
+
+program = { source_element } ;
+
+source_element = function_declaration
+               | statement ;
+
+# ============================================================================
+# Declarations
+# ============================================================================
+
+function_declaration = "function" NAME LPAREN [ formal_parameter_list ] RPAREN
+                       LBRACE function_body RBRACE ;
+
+formal_parameter_list = NAME { COMMA NAME } ;
+
+function_body = { source_element } ;
+
+# ============================================================================
+# Statements
+# ============================================================================
+#
+# ES5 adds debugger_statement to ES3's statement list.
+
+statement = block
+          | variable_statement
+          | empty_statement
+          | if_statement
+          | while_statement
+          | do_while_statement
+          | for_statement
+          | for_in_statement
+          | continue_statement
+          | break_statement
+          | return_statement
+          | with_statement
+          | switch_statement
+          | labelled_statement
+          | try_statement
+          | throw_statement
+          | debugger_statement
+          | expression_statement ;
+
+block = LBRACE { statement } RBRACE ;
+
+variable_statement = "var" variable_declaration_list SEMICOLON ;
+
+variable_declaration_list = variable_declaration { COMMA variable_declaration } ;
+
+variable_declaration = NAME [ EQUALS assignment_expression ] ;
+
+empty_statement = SEMICOLON ;
+
+expression_statement = expression SEMICOLON ;
+
+if_statement = "if" LPAREN expression RPAREN statement [ "else" statement ] ;
+
+while_statement = "while" LPAREN expression RPAREN statement ;
+
+do_while_statement = "do" statement "while" LPAREN expression RPAREN SEMICOLON ;
+
+for_statement = "for" LPAREN
+                  ( "var" variable_declaration_list | [ expression ] ) SEMICOLON
+                  [ expression ] SEMICOLON
+                  [ expression ]
+                RPAREN statement ;
+
+for_in_statement = "for" LPAREN
+                     ( "var" variable_declaration | left_hand_side_expression ) "in" expression
+                   RPAREN statement ;
+
+continue_statement = "continue" [ NAME ] SEMICOLON ;
+
+break_statement = "break" [ NAME ] SEMICOLON ;
+
+return_statement = "return" [ expression ] SEMICOLON ;
+
+with_statement = "with" LPAREN expression RPAREN statement ;
+
+switch_statement = "switch" LPAREN expression RPAREN
+                   LBRACE { case_clause } [ default_clause { case_clause } ] RBRACE ;
+
+case_clause = "case" expression COLON { statement } ;
+
+default_clause = "default" COLON { statement } ;
+
+labelled_statement = NAME COLON statement ;
+
+try_statement = "try" block ( catch_clause [ finally_clause ] | finally_clause ) ;
+
+catch_clause = "catch" LPAREN NAME RPAREN block ;
+
+finally_clause = "finally" block ;
+
+throw_statement = "throw" expression SEMICOLON ;
+
+# --- NEW IN ES5: Debugger statement ---
+#
+# The `debugger` statement acts as a breakpoint. When a debugger is attached,
+# execution pauses at this point. When no debugger is attached, it has no effect.
+#
+# In ES3, `debugger` was a future-reserved word. ES5 promotes it to a keyword
+# with its own statement production.
+
+debugger_statement = "debugger" SEMICOLON ;
+
+# ============================================================================
+# Expressions
+# ============================================================================
+
+expression = assignment_expression { COMMA assignment_expression } ;
+
+assignment_expression = conditional_expression
+                      | left_hand_side_expression assignment_operator assignment_expression ;
+
+assignment_operator = EQUALS | PLUS_EQUALS | MINUS_EQUALS | STAR_EQUALS
+                    | SLASH_EQUALS | PERCENT_EQUALS | AMPERSAND_EQUALS
+                    | PIPE_EQUALS | CARET_EQUALS | LEFT_SHIFT_EQUALS
+                    | RIGHT_SHIFT_EQUALS | UNSIGNED_RIGHT_SHIFT_EQUALS ;
+
+conditional_expression = logical_or_expression
+                         [ QUESTION assignment_expression COLON assignment_expression ] ;
+
+logical_or_expression = logical_and_expression { OR_OR logical_and_expression } ;
+
+logical_and_expression = bitwise_or_expression { AND_AND bitwise_or_expression } ;
+
+bitwise_or_expression = bitwise_xor_expression { PIPE bitwise_xor_expression } ;
+
+bitwise_xor_expression = bitwise_and_expression { CARET bitwise_and_expression } ;
+
+bitwise_and_expression = equality_expression { AMPERSAND equality_expression } ;
+
+equality_expression = relational_expression
+                      { ( STRICT_EQUALS | STRICT_NOT_EQUALS
+                        | EQUALS_EQUALS | NOT_EQUALS ) relational_expression } ;
+
+relational_expression = shift_expression
+                        { ( LESS_THAN | GREATER_THAN | LESS_EQUALS | GREATER_EQUALS
+                          | "instanceof" | "in" ) shift_expression } ;
+
+shift_expression = additive_expression
+                   { ( LEFT_SHIFT | RIGHT_SHIFT | UNSIGNED_RIGHT_SHIFT ) additive_expression } ;
+
+additive_expression = multiplicative_expression
+                      { ( PLUS | MINUS ) multiplicative_expression } ;
+
+multiplicative_expression = unary_expression
+                            { ( STAR | SLASH | PERCENT ) unary_expression } ;
+
+unary_expression = postfix_expression
+                 | "delete" unary_expression
+                 | "void" unary_expression
+                 | "typeof" unary_expression
+                 | PLUS_PLUS unary_expression
+                 | MINUS_MINUS unary_expression
+                 | PLUS unary_expression
+                 | MINUS unary_expression
+                 | TILDE unary_expression
+                 | BANG unary_expression ;
+
+postfix_expression = left_hand_side_expression [ PLUS_PLUS | MINUS_MINUS ] ;
+
+left_hand_side_expression = call_expression | new_expression ;
+
+call_expression = member_expression arguments
+                  { arguments | DOT NAME | LBRACKET expression RBRACKET } ;
+
+new_expression = member_expression
+               | "new" new_expression ;
+
+member_expression = primary_expression { DOT NAME | LBRACKET expression RBRACKET }
+                  | "new" member_expression arguments ;
+
+arguments = LPAREN [ assignment_expression { COMMA assignment_expression } ] RPAREN ;
+
+primary_expression = "this"
+                   | NAME
+                   | NUMBER
+                   | STRING
+                   | REGEX
+                   | "true"
+                   | "false"
+                   | "null"
+                   | array_literal
+                   | object_literal
+                   | function_expression
+                   | LPAREN expression RPAREN ;
+
+array_literal = LBRACKET [ element_list ] RBRACKET ;
+
+element_list = [ assignment_expression ] { COMMA [ assignment_expression ] } ;
+
+# --- CHANGED IN ES5: Object literal property assignments ---
+#
+# ES5 adds getter and setter property definitions. Before ES5, the only way
+# to define getters/setters was through Object.defineProperty() — a runtime
+# API. ES5 adds syntactic support directly in object literals:
+#
+#   var obj = {
+#     get name() { return this._name; },
+#     set name(value) { this._name = value; },
+#     regular: 42
+#   };
+#
+# Note: `get` and `set` are NOT keywords — they are contextual. The lexer
+# still emits them as NAME tokens. The grammar recognizes the pattern
+# NAME("get") NAME LPAREN... as a getter property.
+
+object_literal = LBRACE [ property_assignment { COMMA property_assignment } [ COMMA ] ] RBRACE ;
+
+property_assignment = getter_property
+                    | setter_property
+                    | property_name COLON assignment_expression ;
+
+# Getter property: `get propertyName() { return value; }`
+# The first NAME matches "get" contextually.
+
+getter_property = NAME LPAREN RPAREN LBRACE function_body RBRACE ;
+
+# Setter property: `set propertyName(param) { this._x = param; }`
+# The first NAME matches "set" contextually.
+
+setter_property = NAME LPAREN NAME RPAREN LBRACE function_body RBRACE ;
+
+property_name = NAME | STRING | NUMBER ;
+
+function_expression = "function" [ NAME ] LPAREN [ formal_parameter_list ] RPAREN
+                      LBRACE function_body RBRACE ;

--- a/code/grammars/ecmascript/es5.tokens
+++ b/code/grammars/ecmascript/es5.tokens
@@ -1,0 +1,202 @@
+# ECMAScript 5 (2009) — Lexical Grammar
+# @version 1
+# @ecmascript_edition 5
+#
+# ECMA-262, 5th Edition — December 2009
+#
+# ES5 landed a full decade after ES3 (ES4 was abandoned after years of
+# debate). The syntactic changes are modest — the real innovations were
+# strict mode semantics, native JSON support, and property descriptors.
+#
+# What ES5 adds over ES3:
+#   - `debugger` keyword (moved from future-reserved to keyword)
+#   - Getter/setter syntax in object literals: { get x() {}, set x(v) {} }
+#   - String line continuation (backslash before newline)
+#   - Trailing commas in object literals (already in arrays since ES1)
+#
+# What ES5 does NOT have:
+#   - No let/const (added in ES2015)
+#   - No class syntax (added in ES2015)
+#   - No arrow functions (added in ES2015)
+#   - No template literals (added in ES2015)
+#   - No modules (added in ES2015)
+#   - No destructuring (added in ES2015)
+#
+# Strict Mode
+# -----------
+# ES5 introduced "use strict" directive prologue. Strict mode is a SEMANTIC
+# restriction, not a syntactic one — the grammar is identical. The parser
+# recognizes the directive and applies restrictions as post-parse validation:
+#   - No `with` statement
+#   - No duplicate parameter names
+#   - No octal literals
+#   - `arguments` and `eval` cannot be assigned to
+#   - Future-reserved words in strict mode: implements, interface, let,
+#     package, private, protected, public, static, yield
+
+# ============================================================================
+# Literals
+# ============================================================================
+
+NAME = /[a-zA-Z_$][a-zA-Z0-9_$]*/
+
+# Numbers: same as ES3.
+
+HEX_NUMBER = /0[xX][0-9a-fA-F]+/ -> NUMBER
+FLOAT_NUMBER = /[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?/ -> NUMBER
+LEADING_DOT_FLOAT = /\.[0-9]+([eE][+-]?[0-9]+)?/ -> NUMBER
+SCI_NUMBER = /[0-9]+[eE][+-]?[0-9]+/ -> NUMBER
+INT_NUMBER = /[0-9]+/ -> NUMBER
+
+# Strings: same as ES3, but ES5 adds line continuation — a backslash
+# immediately before a line terminator continues the string on the next line.
+# The regex pattern remains the same because \\ already matches escaped
+# characters; the line-continuation behavior is a lexer semantic.
+
+STRING_DQ = /"([^"\\]|\\.)*"/ -> STRING
+STRING_SQ = /'([^'\\]|\\.)*'/ -> STRING
+
+# Regular expression literals: same as ES3 (g, i, m flags).
+
+REGEX = /\/([^\/\\\n]|\\.)+\/[gim]*/
+
+# ============================================================================
+# Multi-character operators
+# ============================================================================
+#
+# Same as ES3 — no new operators in ES5.
+
+STRICT_EQUALS            = "==="
+STRICT_NOT_EQUALS        = "!=="
+UNSIGNED_RIGHT_SHIFT_EQUALS = ">>>="
+UNSIGNED_RIGHT_SHIFT     = ">>>"
+LEFT_SHIFT_EQUALS        = "<<="
+RIGHT_SHIFT_EQUALS       = ">>="
+EQUALS_EQUALS            = "=="
+NOT_EQUALS               = "!="
+LESS_EQUALS              = "<="
+GREATER_EQUALS           = ">="
+PLUS_EQUALS              = "+="
+MINUS_EQUALS             = "-="
+STAR_EQUALS              = "*="
+SLASH_EQUALS             = "/="
+PERCENT_EQUALS           = "%="
+AMPERSAND_EQUALS         = "&="
+PIPE_EQUALS              = "|="
+CARET_EQUALS             = "^="
+LEFT_SHIFT               = "<<"
+RIGHT_SHIFT              = ">>"
+AND_AND                  = "&&"
+OR_OR                    = "||"
+PLUS_PLUS                = "++"
+MINUS_MINUS              = "--"
+
+# ============================================================================
+# Single-character operators
+# ============================================================================
+
+EQUALS       = "="
+PLUS         = "+"
+MINUS        = "-"
+STAR         = "*"
+SLASH        = "/"
+PERCENT      = "%"
+LESS_THAN    = "<"
+GREATER_THAN = ">"
+BANG         = "!"
+AMPERSAND    = "&"
+PIPE         = "|"
+CARET        = "^"
+TILDE        = "~"
+QUESTION     = "?"
+
+# ============================================================================
+# Delimiters
+# ============================================================================
+
+LPAREN    = "("
+RPAREN    = ")"
+LBRACE    = "{"
+RBRACE    = "}"
+LBRACKET  = "["
+RBRACKET  = "]"
+SEMICOLON = ";"
+COMMA     = ","
+COLON     = ":"
+DOT       = "."
+
+# ============================================================================
+# Keywords
+# ============================================================================
+#
+# ES5 promotes `debugger` from future-reserved (ES3) to a full keyword.
+# All ES3 keywords are retained.
+
+keywords:
+  break
+  case
+  catch
+  continue
+  debugger
+  default
+  delete
+  do
+  else
+  finally
+  for
+  function
+  if
+  in
+  instanceof
+  new
+  return
+  switch
+  this
+  throw
+  try
+  typeof
+  var
+  void
+  while
+  with
+  true
+  false
+  null
+
+# ============================================================================
+# Future reserved words
+# ============================================================================
+#
+# ES5 significantly reduces the future-reserved list compared to ES3.
+# Many ES3 reserved words are no longer reserved in ES5 non-strict mode
+# (abstract, boolean, byte, char, etc.). In strict mode, additional words
+# are reserved (implements, interface, let, package, private, protected,
+# public, static, yield) — but that is a semantic restriction, not a
+# lexical one that we enforce here.
+
+reserved:
+  class
+  const
+  enum
+  export
+  extends
+  import
+  super
+
+# ============================================================================
+# Skip patterns
+# ============================================================================
+
+skip:
+  WHITESPACE    = /[ \t\r\n\v\f]+/
+  LINE_COMMENT  = /\/\/[^\n]*/
+  BLOCK_COMMENT = /\/\*([^*]|\*[^\/])*\*\//
+
+# ============================================================================
+# Error recovery tokens
+# ============================================================================
+
+errors:
+  BAD_STRING_DQ = /"[^"]*$/
+  BAD_STRING_SQ = /'[^']*$/
+  BAD_REGEX = /\/([^\/\\\n]|\\.)*$/

--- a/code/packages/java/document-ast/.gitignore
+++ b/code/packages/java/document-ast/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/document-ast/BUILD
+++ b/code/packages/java/document-ast/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/document-ast/BUILD_windows
+++ b/code/packages/java/document-ast/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/document-ast/CHANGELOG.md
+++ b/code/packages/java/document-ast/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Sealed interface hierarchy: Node, BlockNode, InlineNode
+- 13 block node types: Document, Heading, Paragraph, CodeBlock, Blockquote, List, ListItem, TaskItem, ThematicBreak, RawBlock, Table, TableRow, TableCell
+- 11 inline node types: Text, Emphasis, Strong, Strikethrough, CodeSpan, Link, Image, Autolink, RawInline, HardBreak, SoftBreak
+- TableAlignment enum
+- Full test suite with type tests and structural tests

--- a/code/packages/java/document-ast/README.md
+++ b/code/packages/java/document-ast/README.md
@@ -1,0 +1,30 @@
+# document-ast (Java)
+
+Universal document IR (intermediate representation) types for the coding-adventures project.
+
+## What it does
+
+Defines the Document AST type hierarchy — the format-agnostic IR for structured documents. Block nodes form the structural skeleton; inline nodes carry prose content.
+
+### Block nodes
+DocumentNode, HeadingNode, ParagraphNode, CodeBlockNode, BlockquoteNode, ListNode, ListItemNode, TaskItemNode, ThematicBreakNode, RawBlockNode, TableNode, TableRowNode, TableCellNode
+
+### Inline nodes
+TextNode, EmphasisNode, StrongNode, StrikethroughNode, CodeSpanNode, LinkNode, ImageNode, AutolinkNode, RawInlineNode, HardBreakNode, SoftBreakNode
+
+## Usage
+
+```java
+import com.codingadventures.documentast.*;
+
+var doc = new BlockNode.DocumentNode(List.of(
+    new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Hello"))),
+    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("World")))
+));
+```
+
+Uses Java sealed interfaces for exhaustive pattern matching.
+
+## Layer
+
+TE00 (text/language layer — document IR). Leaf package, zero dependencies.

--- a/code/packages/java/document-ast/build.gradle.kts
+++ b/code/packages/java/document-ast/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/document-ast/build.gradle.kts
+++ b/code/packages/java/document-ast/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/code/packages/java/document-ast/settings.gradle.kts
+++ b/code/packages/java/document-ast/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "document-ast"

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/BlockNode.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/BlockNode.java
@@ -1,0 +1,96 @@
+// ============================================================================
+// BlockNode.java — Block-level document AST nodes
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+import java.util.List;
+
+/**
+ * Block-level nodes form the structural skeleton of a document.
+ * They live inside DocumentNode, BlockquoteNode, and ListItemNode.
+ */
+public sealed interface BlockNode extends Node
+        permits BlockNode.DocumentNode, BlockNode.HeadingNode, BlockNode.ParagraphNode,
+                BlockNode.CodeBlockNode, BlockNode.BlockquoteNode, BlockNode.ListNode,
+                BlockNode.ListItemNode, BlockNode.TaskItemNode, BlockNode.ThematicBreakNode,
+                BlockNode.RawBlockNode, BlockNode.TableNode, BlockNode.TableRowNode,
+                BlockNode.TableCellNode {
+
+    /** Root of every document. An empty document has an empty children list. */
+    record DocumentNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "document"; }
+    }
+
+    /** Section heading with nesting depth 1-6. */
+    record HeadingNode(int level, List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "heading"; }
+    }
+
+    /** A block of prose containing inline nodes. */
+    record ParagraphNode(List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "paragraph"; }
+    }
+
+    /** A block of literal code or pre-formatted text. */
+    record CodeBlockNode(String language, String value) implements BlockNode {
+        @Override public String nodeType() { return "code_block"; }
+    }
+
+    /** A block of content set apart as a quotation. Can contain nested blocks. */
+    record BlockquoteNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "blockquote"; }
+    }
+
+    /**
+     * An ordered or unordered list.
+     *
+     * @param ordered true for numbered lists
+     * @param start   opening number for ordered lists (default 1; 0 for unordered)
+     * @param tight   true if no blank lines between items (rendering hint)
+     */
+    record ListNode(boolean ordered, int start, boolean tight,
+                    List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "list"; }
+    }
+
+    /** One item in a ListNode. Contains block-level content. */
+    record ListItemNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "list_item"; }
+    }
+
+    /** A task-list item with a checkbox state. */
+    record TaskItemNode(boolean checked, List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "task_item"; }
+    }
+
+    /** A horizontal rule / thematic break. Leaf node, no children. */
+    record ThematicBreakNode() implements BlockNode {
+        @Override public String nodeType() { return "thematic_break"; }
+    }
+
+    /**
+     * Raw content for a specific back-end (e.g. "html", "latex").
+     * Back-ends that don't recognise the format skip this node silently.
+     */
+    record RawBlockNode(String format, String value) implements BlockNode {
+        @Override public String nodeType() { return "raw_block"; }
+    }
+
+    /** A table with column alignments and rows. */
+    record TableNode(List<TableAlignment> align,
+                     List<TableRowNode> rows) implements BlockNode {
+        @Override public String nodeType() { return "table"; }
+    }
+
+    /** One row in a table. */
+    record TableRowNode(boolean isHeader,
+                        List<TableCellNode> cells) implements BlockNode {
+        @Override public String nodeType() { return "table_row"; }
+    }
+
+    /** A single table cell containing inline content. */
+    record TableCellNode(List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "table_cell"; }
+    }
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/InlineNode.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/InlineNode.java
@@ -1,0 +1,90 @@
+// ============================================================================
+// InlineNode.java — Inline document AST nodes
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+import java.util.List;
+
+/**
+ * Inline nodes appear inside block nodes that contain prose:
+ * headings, paragraphs, list items, and table cells.
+ */
+public sealed interface InlineNode extends Node
+        permits InlineNode.TextNode, InlineNode.EmphasisNode, InlineNode.StrongNode,
+                InlineNode.StrikethroughNode, InlineNode.CodeSpanNode, InlineNode.LinkNode,
+                InlineNode.ImageNode, InlineNode.AutolinkNode, InlineNode.RawInlineNode,
+                InlineNode.HardBreakNode, InlineNode.SoftBreakNode {
+
+    /** Plain text with no markup. Value contains decoded Unicode. */
+    record TextNode(String value) implements InlineNode {
+        @Override public String nodeType() { return "text"; }
+    }
+
+    /** Stressed emphasis — renders as <em> / italic. */
+    record EmphasisNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "emphasis"; }
+    }
+
+    /** Strong importance — renders as <strong> / bold. */
+    record StrongNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "strong"; }
+    }
+
+    /** Struck-through text. */
+    record StrikethroughNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "strikethrough"; }
+    }
+
+    /** Inline code span. Value is raw, not decoded for HTML entities. */
+    record CodeSpanNode(String value) implements InlineNode {
+        @Override public String nodeType() { return "code_span"; }
+    }
+
+    /**
+     * A hyperlink with resolved destination.
+     *
+     * @param destination fully resolved URL
+     * @param title       optional tooltip text (null if absent)
+     */
+    record LinkNode(String destination, String title,
+                    List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "link"; }
+    }
+
+    /**
+     * An embedded image.
+     *
+     * @param destination fully resolved URL
+     * @param title       optional tooltip text (null if absent)
+     * @param alt          plain-text alt description (markup stripped)
+     */
+    record ImageNode(String destination, String title, String alt) implements InlineNode {
+        @Override public String nodeType() { return "image"; }
+    }
+
+    /**
+     * A URL or email address presented as a direct link.
+     *
+     * @param destination the URL or email address
+     * @param isEmail     true for email autolinks
+     */
+    record AutolinkNode(String destination, boolean isEmail) implements InlineNode {
+        @Override public String nodeType() { return "autolink"; }
+    }
+
+    /** Raw inline content for a specific back-end format. */
+    record RawInlineNode(String format, String value) implements InlineNode {
+        @Override public String nodeType() { return "raw_inline"; }
+    }
+
+    /** Forced line break within a paragraph. */
+    record HardBreakNode() implements InlineNode {
+        @Override public String nodeType() { return "hard_break"; }
+    }
+
+    /** Soft line break — a newline that is not a hard break. */
+    record SoftBreakNode() implements InlineNode {
+        @Override public String nodeType() { return "soft_break"; }
+    }
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/Node.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/Node.java
@@ -1,0 +1,59 @@
+// ============================================================================
+// Node.java — Document AST node type hierarchy
+// ============================================================================
+//
+// The Document AST is the "LLVM IR of documents" — a format-agnostic
+// intermediate representation for structured documents. Just as LLVM IR sits
+// between many source languages and many targets, the Document AST sits
+// between document source formats (Markdown, RST, HTML) and output renderers
+// (HTML, PDF, plain text):
+//
+//   Markdown ──────────────────────────────► HTML
+//   reStructuredText ──► Document AST ──────► PDF
+//   HTML ───────────────────────────────────► Plain text
+//
+// With this shared IR, N front-ends x M back-ends requires only N+M
+// implementations instead of N*M.
+//
+// Design principles:
+//
+//   1. Semantic, not notational — nodes carry meaning (heading, emphasis),
+//      not syntax (### or ***).
+//
+//   2. Resolved, not deferred — all link references are resolved before
+//      the IR is produced.
+//
+//   3. Format-agnostic — RawBlock and RawInline carry a format tag so
+//      back-ends can selectively pass through or ignore content.
+//
+//   4. Minimal and stable — only universal document concepts appear here.
+//
+// The type hierarchy uses sealed interfaces for exhaustive pattern matching
+// in Java 21+:
+//
+//   Node (sealed)
+//     BlockNode (sealed) — structural nodes
+//       DocumentNode, HeadingNode, ParagraphNode, CodeBlockNode,
+//       BlockquoteNode, ListNode, ListItemNode, TaskItemNode,
+//       ThematicBreakNode, RawBlockNode, TableNode, TableRowNode, TableCellNode
+//     InlineNode (sealed) — inline content nodes
+//       TextNode, EmphasisNode, StrongNode, StrikethroughNode,
+//       CodeSpanNode, LinkNode, ImageNode, AutolinkNode,
+//       RawInlineNode, HardBreakNode, SoftBreakNode
+//
+// Layer: TE00 (text/language layer — document IR)
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+/**
+ * Root interface for all Document AST nodes.
+ *
+ * <p>Use pattern matching (instanceof or switch) to access concrete types.
+ */
+public sealed interface Node
+        permits BlockNode, InlineNode {
+
+    /** Returns a string tag for the node type (e.g. "heading", "paragraph"). */
+    String nodeType();
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/TableAlignment.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/TableAlignment.java
@@ -1,0 +1,15 @@
+// ============================================================================
+// TableAlignment.java — Column alignment for GFM tables
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+/**
+ * Column alignment hint for table cells.
+ */
+public enum TableAlignment {
+    NONE,
+    LEFT,
+    RIGHT,
+    CENTER
+}

--- a/code/packages/java/document-ast/src/test/java/com/codingadventures/documentast/DocumentAstTest.java
+++ b/code/packages/java/document-ast/src/test/java/com/codingadventures/documentast/DocumentAstTest.java
@@ -1,0 +1,249 @@
+package com.codingadventures.documentast;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentAstTest {
+
+    @Nested
+    class NodeTypeTests {
+
+        @Test void documentNodeType() {
+            var node = new BlockNode.DocumentNode(List.of());
+            assertEquals("document", node.nodeType());
+        }
+
+        @Test void headingNodeType() {
+            var node = new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Title")));
+            assertEquals("heading", node.nodeType());
+            assertEquals(1, node.level());
+        }
+
+        @Test void paragraphNodeType() {
+            var node = new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("Hello")));
+            assertEquals("paragraph", node.nodeType());
+        }
+
+        @Test void codeBlockNodeType() {
+            var node = new BlockNode.CodeBlockNode("java", "int x = 1;\n");
+            assertEquals("code_block", node.nodeType());
+            assertEquals("java", node.language());
+        }
+
+        @Test void blockquoteNodeType() {
+            var node = new BlockNode.BlockquoteNode(List.of());
+            assertEquals("blockquote", node.nodeType());
+        }
+
+        @Test void listNodeType() {
+            var node = new BlockNode.ListNode(true, 1, false, List.of());
+            assertEquals("list", node.nodeType());
+            assertTrue(node.ordered());
+        }
+
+        @Test void listItemNodeType() {
+            var node = new BlockNode.ListItemNode(List.of());
+            assertEquals("list_item", node.nodeType());
+        }
+
+        @Test void taskItemNodeType() {
+            var node = new BlockNode.TaskItemNode(true, List.of());
+            assertEquals("task_item", node.nodeType());
+            assertTrue(node.checked());
+        }
+
+        @Test void thematicBreakNodeType() {
+            var node = new BlockNode.ThematicBreakNode();
+            assertEquals("thematic_break", node.nodeType());
+        }
+
+        @Test void rawBlockNodeType() {
+            var node = new BlockNode.RawBlockNode("html", "<div>raw</div>");
+            assertEquals("raw_block", node.nodeType());
+            assertEquals("html", node.format());
+        }
+
+        @Test void tableNodeType() {
+            var node = new BlockNode.TableNode(List.of(), List.of());
+            assertEquals("table", node.nodeType());
+        }
+
+        @Test void tableRowNodeType() {
+            var node = new BlockNode.TableRowNode(true, List.of());
+            assertEquals("table_row", node.nodeType());
+            assertTrue(node.isHeader());
+        }
+
+        @Test void tableCellNodeType() {
+            var node = new BlockNode.TableCellNode(List.of());
+            assertEquals("table_cell", node.nodeType());
+        }
+
+        @Test void textNodeType() {
+            var node = new InlineNode.TextNode("hello");
+            assertEquals("text", node.nodeType());
+            assertEquals("hello", node.value());
+        }
+
+        @Test void emphasisNodeType() {
+            var node = new InlineNode.EmphasisNode(List.of(new InlineNode.TextNode("em")));
+            assertEquals("emphasis", node.nodeType());
+        }
+
+        @Test void strongNodeType() {
+            var node = new InlineNode.StrongNode(List.of(new InlineNode.TextNode("bold")));
+            assertEquals("strong", node.nodeType());
+        }
+
+        @Test void strikethroughNodeType() {
+            var node = new InlineNode.StrikethroughNode(List.of(new InlineNode.TextNode("del")));
+            assertEquals("strikethrough", node.nodeType());
+        }
+
+        @Test void codeSpanNodeType() {
+            var node = new InlineNode.CodeSpanNode("x = 1");
+            assertEquals("code_span", node.nodeType());
+        }
+
+        @Test void linkNodeType() {
+            var node = new InlineNode.LinkNode("https://example.com", "Example",
+                    List.of(new InlineNode.TextNode("click")));
+            assertEquals("link", node.nodeType());
+            assertEquals("https://example.com", node.destination());
+        }
+
+        @Test void imageNodeType() {
+            var node = new InlineNode.ImageNode("cat.png", null, "a cat");
+            assertEquals("image", node.nodeType());
+            assertEquals("a cat", node.alt());
+        }
+
+        @Test void autolinkNodeType() {
+            var node = new InlineNode.AutolinkNode("https://example.com", false);
+            assertEquals("autolink", node.nodeType());
+            assertFalse(node.isEmail());
+        }
+
+        @Test void autolinkEmail() {
+            var node = new InlineNode.AutolinkNode("user@example.com", true);
+            assertTrue(node.isEmail());
+        }
+
+        @Test void rawInlineNodeType() {
+            var node = new InlineNode.RawInlineNode("html", "<em>raw</em>");
+            assertEquals("raw_inline", node.nodeType());
+        }
+
+        @Test void hardBreakNodeType() {
+            var node = new InlineNode.HardBreakNode();
+            assertEquals("hard_break", node.nodeType());
+        }
+
+        @Test void softBreakNodeType() {
+            var node = new InlineNode.SoftBreakNode();
+            assertEquals("soft_break", node.nodeType());
+        }
+    }
+
+    @Nested
+    class DocumentStructureTests {
+
+        @Test void simpleDocument() {
+            var doc = new BlockNode.DocumentNode(List.of(
+                    new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Hello"))),
+                    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("World")))
+            ));
+            assertEquals(2, doc.children().size());
+            assertInstanceOf(BlockNode.HeadingNode.class, doc.children().get(0));
+            assertInstanceOf(BlockNode.ParagraphNode.class, doc.children().get(1));
+        }
+
+        @Test void nestedBlockquote() {
+            var quote = new BlockNode.BlockquoteNode(List.of(
+                    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("quoted"))),
+                    new BlockNode.BlockquoteNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("nested")))
+                    ))
+            ));
+            assertEquals(2, quote.children().size());
+        }
+
+        @Test void orderedList() {
+            var list = new BlockNode.ListNode(true, 3, false, List.of(
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("item 3")))
+                    )),
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("item 4")))
+                    ))
+            ));
+            assertTrue(list.ordered());
+            assertEquals(3, list.start());
+        }
+
+        @Test void tightUnorderedList() {
+            var list = new BlockNode.ListNode(false, 0, true, List.of(
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("a")))
+                    ))
+            ));
+            assertFalse(list.ordered());
+            assertTrue(list.tight());
+        }
+
+        @Test void richInlineContent() {
+            var para = new BlockNode.ParagraphNode(List.of(
+                    new InlineNode.TextNode("Hello "),
+                    new InlineNode.StrongNode(List.of(
+                            new InlineNode.TextNode("bold "),
+                            new InlineNode.EmphasisNode(List.of(new InlineNode.TextNode("and italic")))
+                    )),
+                    new InlineNode.TextNode(".")
+            ));
+            assertEquals(3, para.children().size());
+        }
+
+        @Test void tableStructure() {
+            var table = new BlockNode.TableNode(
+                    List.of(TableAlignment.LEFT, TableAlignment.RIGHT),
+                    List.of(
+                            new BlockNode.TableRowNode(true, List.of(
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Name"))),
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Score")))
+                            )),
+                            new BlockNode.TableRowNode(false, List.of(
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Alice"))),
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("100")))
+                            ))
+                    )
+            );
+            assertEquals(2, table.align().size());
+            assertEquals(2, table.rows().size());
+            assertTrue(table.rows().get(0).isHeader());
+            assertFalse(table.rows().get(1).isHeader());
+        }
+
+        @Test void patternMatchingOnNodes() {
+            Node node = new InlineNode.TextNode("hello");
+            String result = switch (node) {
+                case BlockNode b -> "block: " + b.nodeType();
+                case InlineNode.TextNode t -> "text: " + t.value();
+                case InlineNode i -> "inline: " + i.nodeType();
+            };
+            assertEquals("text: hello", result);
+        }
+
+        @Test void patternMatchingOnBlockNode() {
+            BlockNode node = new BlockNode.HeadingNode(2, List.of(new InlineNode.TextNode("Title")));
+            String result = switch (node) {
+                case BlockNode.HeadingNode h -> "h" + h.level();
+                default -> "other";
+            };
+            assertEquals("h2", result);
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/.gitignore
+++ b/code/packages/java/grammar-tools/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/grammar-tools/BUILD
+++ b/code/packages/java/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/grammar-tools/BUILD_windows
+++ b/code/packages/java/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/grammar-tools/CHANGELOG.md
+++ b/code/packages/java/grammar-tools/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `TokenGrammarParser` — parses `.tokens` files into `TokenGrammar`
+- `ParserGrammarParser` — parses `.grammar` files into `ParserGrammar`
+- `TokenGrammarValidator` — semantic validation for token grammars
+- `ParserGrammarValidator` — semantic validation for parser grammars
+- `CrossValidator` �� cross-validation between token and parser grammars
+- Support for magic comments (`# @version`, `# @case_insensitive`)
+- Support for all sections: keywords, reserved, skip, errors, context_keywords, groups
+- Support for all EBNF constructs: sequence, alternation, repetition, optional, group, lookaheads, separated repetition
+- Full test suite with 40+ tests

--- a/code/packages/java/grammar-tools/README.md
+++ b/code/packages/java/grammar-tools/README.md
@@ -1,0 +1,32 @@
+# grammar-tools (Java)
+
+Parser and validator for `.tokens` and `.grammar` file formats — the declarative language specifications used throughout the coding-adventures project.
+
+## What it does
+
+- **TokenGrammarParser** — Parses `.tokens` files into a `TokenGrammar` data structure
+- **ParserGrammarParser** — Parses `.grammar` files into a `ParserGrammar` data structure
+- **TokenGrammarValidator** — Lint pass for token grammars (duplicates, invalid regex, naming conventions)
+- **ParserGrammarValidator** — Lint pass for parser grammars (undefined refs, unreachable rules)
+- **CrossValidator** — Checks consistency between a `.tokens` and `.grammar` file pair
+
+## Usage
+
+```java
+import com.codingadventures.grammartools.*;
+
+// Parse a .tokens file
+TokenGrammar tokens = TokenGrammarParser.parse(tokensFileContent);
+List<String> tokenIssues = TokenGrammarValidator.validate(tokens);
+
+// Parse a .grammar file
+ParserGrammar grammar = ParserGrammarParser.parse(grammarFileContent);
+List<String> grammarIssues = ParserGrammarValidator.validate(grammar, tokens.tokenNames());
+
+// Cross-validate
+List<String> crossIssues = CrossValidator.crossValidate(tokens, grammar);
+```
+
+## Layer
+
+TE (text/language layer) — foundational infrastructure for lexer/parser generation.

--- a/code/packages/java/grammar-tools/build.gradle.kts
+++ b/code/packages/java/grammar-tools/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/grammar-tools/build.gradle.kts
+++ b/code/packages/java/grammar-tools/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/code/packages/java/grammar-tools/settings.gradle.kts
+++ b/code/packages/java/grammar-tools/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "grammar-tools"

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/CrossValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/CrossValidator.java
@@ -1,0 +1,78 @@
+// ============================================================================
+// CrossValidator.java — Cross-validates .tokens and .grammar files
+// ============================================================================
+//
+// The .grammar file references tokens by UPPERCASE name. The .tokens file
+// defines which tokens exist. This module checks that the two are consistent:
+//
+//   1. Every UPPERCASE name in the grammar must be defined in the tokens file.
+//      If not, the parser will try to match a token type the lexer never emits.
+//
+//   2. Every token in the .tokens file should ideally be used somewhere in
+//      the grammar. Unused tokens suggest typos or leftover cruft.
+//
+// Synthetic tokens (NEWLINE, INDENT, DEDENT, EOF) are always valid — the
+// lexer produces these implicitly.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * Cross-validates a {@link TokenGrammar} and {@link ParserGrammar} for consistency.
+ */
+public final class CrossValidator {
+
+    private CrossValidator() {}
+
+    /**
+     * Check that a TokenGrammar and ParserGrammar are consistent.
+     *
+     * @return list of error/warning strings; empty means fully consistent
+     */
+    public static List<String> crossValidate(TokenGrammar tokenGrammar, ParserGrammar parserGrammar) {
+        List<String> issues = new ArrayList<>();
+
+        // Build the set of all defined token names (including aliases)
+        Set<String> definedTokens = new HashSet<>(tokenGrammar.tokenNames());
+
+        // Add synthetic tokens
+        definedTokens.add("NEWLINE");
+        definedTokens.add("EOF");
+        if ("indentation".equals(tokenGrammar.getMode())) {
+            definedTokens.add("INDENT");
+            definedTokens.add("DEDENT");
+        }
+
+        Set<String> referencedTokens = parserGrammar.tokenReferences();
+
+        // Missing token references (errors)
+        for (String ref : sorted(referencedTokens)) {
+            if (!definedTokens.contains(ref)) {
+                issues.add("Error: Grammar references token '" + ref
+                        + "' which is not defined in the tokens file");
+            }
+        }
+
+        // Unused tokens (warnings)
+        for (TokenDefinition defn : tokenGrammar.getDefinitions()) {
+            boolean isUsed = referencedTokens.contains(defn.getName());
+            if (defn.getAlias() != null && referencedTokens.contains(defn.getAlias())) {
+                isUsed = true;
+            }
+            if (!isUsed) {
+                issues.add("Warning: Token '" + defn.getName() + "' (line " + defn.getLineNumber()
+                        + ") is defined but never used in the grammar");
+            }
+        }
+
+        return issues;
+    }
+
+    private static List<String> sorted(Set<String> set) {
+        List<String> list = new ArrayList<>(set);
+        Collections.sort(list);
+        return list;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarElement.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarElement.java
@@ -1,0 +1,81 @@
+// ============================================================================
+// GrammarElement.java — AST node types for .grammar file EBNF rules
+// ============================================================================
+//
+// A .grammar file uses Extended Backus-Naur Form (EBNF) to describe how tokens
+// combine into valid programs. Each grammar rule has a body composed of these
+// element types:
+//
+//   RuleReference — a named reference to another rule or token
+//   Literal       — a quoted string literal like "+" or "class"
+//   Sequence      — elements that must appear in order (A B C)
+//   Alternation   — choices separated by | (A | B | C)
+//   Repetition    — zero or more: { element }
+//   Optional      — zero or one: [ element ]
+//   Group         — parenthesized grouping: ( element )
+//   OneOrMoreRepetition  — one or more: { element }+
+//   SeparatedRepetition  — zero/one+ with separator: { element // sep }
+//   PositiveLookahead    — match without consuming: &element
+//   NegativeLookahead    — fail if matches: !element
+//
+// These types form a sealed hierarchy (via sealed interface) that exhaustive
+// pattern matching can check at compile time.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.List;
+
+/**
+ * Base interface for all grammar rule body elements.
+ *
+ * <p>Implementations are records for value semantics and pattern matching.
+ */
+public sealed interface GrammarElement
+        permits GrammarElement.RuleReference,
+                GrammarElement.Literal,
+                GrammarElement.Sequence,
+                GrammarElement.Alternation,
+                GrammarElement.Repetition,
+                GrammarElement.Optional,
+                GrammarElement.Group,
+                GrammarElement.PositiveLookahead,
+                GrammarElement.NegativeLookahead,
+                GrammarElement.OneOrMoreRepetition,
+                GrammarElement.SeparatedRepetition {
+
+    /** A reference to a rule (lowercase) or token (UPPERCASE). */
+    record RuleReference(String name, boolean isToken) implements GrammarElement {}
+
+    /** A quoted string literal in a grammar rule. */
+    record Literal(String value) implements GrammarElement {}
+
+    /** Multiple elements that must appear in sequence. */
+    record Sequence(List<GrammarElement> elements) implements GrammarElement {}
+
+    /** Alternative choices separated by |. */
+    record Alternation(List<GrammarElement> choices) implements GrammarElement {}
+
+    /** Zero or more repetitions: { element }. */
+    record Repetition(GrammarElement element) implements GrammarElement {}
+
+    /** Zero or one occurrences: [ element ]. */
+    record Optional(GrammarElement element) implements GrammarElement {}
+
+    /** Parenthesized grouping: ( element ). */
+    record Group(GrammarElement element) implements GrammarElement {}
+
+    /** Positive lookahead: &element — succeeds without consuming input. */
+    record PositiveLookahead(GrammarElement element) implements GrammarElement {}
+
+    /** Negative lookahead: !element — succeeds if element does NOT match. */
+    record NegativeLookahead(GrammarElement element) implements GrammarElement {}
+
+    /** One or more repetitions: { element }+. */
+    record OneOrMoreRepetition(GrammarElement element) implements GrammarElement {}
+
+    /** Separated repetition: { element // separator } or { element // separator }+. */
+    record SeparatedRepetition(GrammarElement element, GrammarElement separator, boolean atLeastOne) implements GrammarElement {}
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarRule.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarRule.java
@@ -1,0 +1,14 @@
+// ============================================================================
+// GrammarRule.java — A single rule from a .grammar file
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * A named rule from a .grammar file: {@code name = body ;}.
+ *
+ * @param name       the rule name (lowercase for rules, UPPERCASE for tokens)
+ * @param body       the parsed EBNF body
+ * @param lineNumber 1-based line number where the rule was defined
+ */
+public record GrammarRule(String name, GrammarElement body, int lineNumber) {}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammar.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammar.java
@@ -1,0 +1,107 @@
+// ============================================================================
+// ParserGrammar.java — Complete contents of a parsed .grammar file
+// ============================================================================
+//
+// A .grammar file uses EBNF to describe how tokens (from a .tokens file)
+// combine into valid programs. This class holds the parsed result.
+//
+// Helper methods extract useful information for cross-validation:
+//   - ruleNames()       — all defined rule names
+//   - ruleReferences()  — all lowercase names referenced in rule bodies
+//   - tokenReferences() — all UPPERCASE names referenced in rule bodies
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * The complete contents of a parsed .grammar file.
+ */
+public final class ParserGrammar {
+
+    private int version = 0;
+    private final List<GrammarRule> rules;
+
+    public ParserGrammar(List<GrammarRule> rules) {
+        this.rules = rules;
+    }
+
+    public ParserGrammar() {
+        this(new ArrayList<>());
+    }
+
+    public int getVersion() { return version; }
+    public void setVersion(int version) { this.version = version; }
+
+    public List<GrammarRule> getRules() { return rules; }
+
+    /** Return the set of all defined rule names. */
+    public Set<String> ruleNames() {
+        Set<String> names = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            names.add(rule.name());
+        }
+        return names;
+    }
+
+    /** Return all lowercase rule names referenced in rule bodies. */
+    public Set<String> ruleReferences() {
+        Set<String> refs = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            collectRuleRefs(rule.body(), refs);
+        }
+        return refs;
+    }
+
+    /** Return all UPPERCASE token names referenced in rule bodies. */
+    public Set<String> tokenReferences() {
+        Set<String> refs = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            collectTokenRefs(rule.body(), refs);
+        }
+        return refs;
+    }
+
+    // --- Tree walkers for collecting references ---
+
+    private static void collectRuleRefs(GrammarElement element, Set<String> refs) {
+        switch (element) {
+            case GrammarElement.RuleReference r -> { if (!r.isToken()) refs.add(r.name()); }
+            case GrammarElement.Sequence s -> s.elements().forEach(e -> collectRuleRefs(e, refs));
+            case GrammarElement.Alternation a -> a.choices().forEach(c -> collectRuleRefs(c, refs));
+            case GrammarElement.Repetition r -> collectRuleRefs(r.element(), refs);
+            case GrammarElement.Optional o -> collectRuleRefs(o.element(), refs);
+            case GrammarElement.Group g -> collectRuleRefs(g.element(), refs);
+            case GrammarElement.PositiveLookahead p -> collectRuleRefs(p.element(), refs);
+            case GrammarElement.NegativeLookahead n -> collectRuleRefs(n.element(), refs);
+            case GrammarElement.OneOrMoreRepetition r -> collectRuleRefs(r.element(), refs);
+            case GrammarElement.SeparatedRepetition s -> {
+                collectRuleRefs(s.element(), refs);
+                collectRuleRefs(s.separator(), refs);
+            }
+            case GrammarElement.Literal ignored -> {}
+        }
+    }
+
+    private static void collectTokenRefs(GrammarElement element, Set<String> refs) {
+        switch (element) {
+            case GrammarElement.RuleReference r -> { if (r.isToken()) refs.add(r.name()); }
+            case GrammarElement.Sequence s -> s.elements().forEach(e -> collectTokenRefs(e, refs));
+            case GrammarElement.Alternation a -> a.choices().forEach(c -> collectTokenRefs(c, refs));
+            case GrammarElement.Repetition r -> collectTokenRefs(r.element(), refs);
+            case GrammarElement.Optional o -> collectTokenRefs(o.element(), refs);
+            case GrammarElement.Group g -> collectTokenRefs(g.element(), refs);
+            case GrammarElement.PositiveLookahead p -> collectTokenRefs(p.element(), refs);
+            case GrammarElement.NegativeLookahead n -> collectTokenRefs(n.element(), refs);
+            case GrammarElement.OneOrMoreRepetition r -> collectTokenRefs(r.element(), refs);
+            case GrammarElement.SeparatedRepetition s -> {
+                collectTokenRefs(s.element(), refs);
+                collectTokenRefs(s.separator(), refs);
+            }
+            case GrammarElement.Literal ignored -> {}
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarError.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarError.java
@@ -1,0 +1,20 @@
+// ============================================================================
+// ParserGrammarError.java — Exception for .grammar file parse errors
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * Thrown when a .grammar file cannot be parsed.
+ */
+public class ParserGrammarError extends Exception {
+
+    private final int lineNumber;
+
+    public ParserGrammarError(String message, int lineNumber) {
+        super("Line " + lineNumber + ": " + message);
+        this.lineNumber = lineNumber;
+    }
+
+    public int getLineNumber() { return lineNumber; }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarParser.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarParser.java
@@ -1,0 +1,299 @@
+// ============================================================================
+// ParserGrammarParser.java — Parser for .grammar files (EBNF syntax)
+// ============================================================================
+//
+// A .grammar file describes a language's syntactic structure using EBNF:
+//
+//   program = { statement } ;
+//   statement = assignment | expression_stmt ;
+//   assignment = NAME EQUALS expression SEMI ;
+//   expression = term { (PLUS | MINUS) term } ;
+//   term = factor { (STAR | SLASH) factor } ;
+//   factor = NUMBER | NAME | LPAREN expression RPAREN ;
+//
+// The parser works in two phases:
+//
+//   1. Tokenization — the grammar text is tokenized into a flat list of
+//      internal tokens (IDENT, EQUALS, SEMI, PIPE, LBRACE, RBRACE, etc.)
+//
+//   2. Recursive descent parsing — the token list is parsed into a list of
+//      GrammarRule objects, each with a name and an EBNF body.
+//
+// EBNF constructs supported:
+//   - name = body ;           — rule definition
+//   - A B C                   — sequence
+//   - A | B                   — alternation
+//   - { A }                   — zero or more repetition
+//   - { A }+                  — one or more repetition
+//   - { A // B }              — separated repetition
+//   - [ A ]                   — optional
+//   - ( A )                   — grouping
+//   - &A                      — positive lookahead
+//   - !A                      — negative lookahead
+//   - "literal"               — string literal
+//   - UPPERCASE               — token reference
+//   - lowercase               — rule reference
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses .grammar file text into a {@link ParserGrammar}.
+ */
+public final class ParserGrammarParser {
+
+    private static final Pattern MAGIC_COMMENT = Pattern.compile("^#\\s*@(\\w+)\\s*(.*)$");
+
+    private ParserGrammarParser() {}
+
+    /**
+     * Parse a .grammar file into a ParserGrammar.
+     *
+     * @param source the complete text of a .grammar file
+     * @return the parsed ParserGrammar
+     * @throws ParserGrammarError if the grammar text is malformed
+     */
+    public static ParserGrammar parse(String source) throws ParserGrammarError {
+        ParserGrammar grammar = new ParserGrammar();
+
+        // Scan for magic comments before tokenizing
+        for (String rawLine : source.split("\n", -1)) {
+            String stripped = rawLine.strip();
+            if (!stripped.startsWith("#")) continue;
+            Matcher m = MAGIC_COMMENT.matcher(stripped);
+            if (m.matches()) {
+                String key = m.group(1);
+                String value = m.group(2).strip();
+                if ("version".equals(key)) {
+                    try { grammar.setVersion(Integer.parseInt(value)); }
+                    catch (NumberFormatException ignored) {}
+                }
+            }
+        }
+
+        List<InternalToken> tokens = tokenize(source);
+        Parser parser = new Parser(tokens);
+        List<GrammarRule> rules = parser.parseRules();
+        grammar.getRules().addAll(rules);
+        return grammar;
+    }
+
+    // =========================================================================
+    // Internal Token — A simple token for grammar file tokenization
+    // =========================================================================
+
+    private record InternalToken(String kind, String value, int line) {}
+
+    // =========================================================================
+    // Tokenizer — Converts grammar text into a flat token list
+    // =========================================================================
+
+    private static List<InternalToken> tokenize(String source) throws ParserGrammarError {
+        List<InternalToken> tokens = new ArrayList<>();
+        String[] lines = source.split("\n", -1);
+
+        for (int i = 0; i < lines.length; i++) {
+            int lineNum = i + 1;
+            String line = lines[i].stripTrailing();
+            String stripped = line.strip();
+            if (stripped.isEmpty() || stripped.startsWith("#")) continue;
+
+            int j = 0;
+            while (j < line.length()) {
+                char ch = line.charAt(j);
+                if (ch == ' ' || ch == '\t') { j++; continue; }
+                if (ch == '#') break; // inline comment
+
+                switch (ch) {
+                    case '=' -> { tokens.add(new InternalToken("EQUALS", "=", lineNum)); j++; }
+                    case ';' -> { tokens.add(new InternalToken("SEMI", ";", lineNum)); j++; }
+                    case '|' -> { tokens.add(new InternalToken("PIPE", "|", lineNum)); j++; }
+                    case '{' -> { tokens.add(new InternalToken("LBRACE", "{", lineNum)); j++; }
+                    case '}' -> { tokens.add(new InternalToken("RBRACE", "}", lineNum)); j++; }
+                    case '[' -> { tokens.add(new InternalToken("LBRACKET", "[", lineNum)); j++; }
+                    case ']' -> { tokens.add(new InternalToken("RBRACKET", "]", lineNum)); j++; }
+                    case '(' -> { tokens.add(new InternalToken("LPAREN", "(", lineNum)); j++; }
+                    case ')' -> { tokens.add(new InternalToken("RPAREN", ")", lineNum)); j++; }
+                    case '&' -> { tokens.add(new InternalToken("AMPERSAND", "&", lineNum)); j++; }
+                    case '!' -> { tokens.add(new InternalToken("BANG", "!", lineNum)); j++; }
+                    case '+' -> { tokens.add(new InternalToken("PLUS", "+", lineNum)); j++; }
+                    case '/' -> {
+                        if (j + 1 < line.length() && line.charAt(j + 1) == '/') {
+                            tokens.add(new InternalToken("DOUBLE_SLASH", "//", lineNum));
+                            j += 2;
+                        } else {
+                            throw new ParserGrammarError("Unexpected character '/'", lineNum);
+                        }
+                    }
+                    case '"' -> {
+                        int k = j + 1;
+                        while (k < line.length() && line.charAt(k) != '"') {
+                            if (line.charAt(k) == '\\') k++;
+                            k++;
+                        }
+                        if (k >= line.length()) {
+                            throw new ParserGrammarError("Unterminated string literal", lineNum);
+                        }
+                        tokens.add(new InternalToken("STRING", line.substring(j + 1, k), lineNum));
+                        j = k + 1;
+                    }
+                    default -> {
+                        if (Character.isLetter(ch) || ch == '_') {
+                            int k = j;
+                            while (k < line.length() && (Character.isLetterOrDigit(line.charAt(k)) || line.charAt(k) == '_')) {
+                                k++;
+                            }
+                            tokens.add(new InternalToken("IDENT", line.substring(j, k), lineNum));
+                            j = k;
+                        } else {
+                            throw new ParserGrammarError("Unexpected character '" + ch + "'", lineNum);
+                        }
+                    }
+                }
+            }
+        }
+        tokens.add(new InternalToken("EOF", "", lines.length));
+        return tokens;
+    }
+
+    // =========================================================================
+    // Recursive Descent Parser
+    // =========================================================================
+
+    private static class Parser {
+        private final List<InternalToken> tokens;
+        private int pos = 0;
+
+        Parser(List<InternalToken> tokens) {
+            this.tokens = tokens;
+        }
+
+        private InternalToken peek() { return tokens.get(pos); }
+
+        private InternalToken advance() { return tokens.get(pos++); }
+
+        private InternalToken expect(String kind) throws ParserGrammarError {
+            InternalToken tok = advance();
+            if (!tok.kind().equals(kind)) {
+                throw new ParserGrammarError("Expected " + kind + ", got " + tok.kind(), tok.line());
+            }
+            return tok;
+        }
+
+        List<GrammarRule> parseRules() throws ParserGrammarError {
+            List<GrammarRule> rules = new ArrayList<>();
+            while (!"EOF".equals(peek().kind())) {
+                rules.add(parseRule());
+            }
+            return rules;
+        }
+
+        private GrammarRule parseRule() throws ParserGrammarError {
+            InternalToken nameTok = expect("IDENT");
+            expect("EQUALS");
+            GrammarElement body = parseBody();
+            expect("SEMI");
+            return new GrammarRule(nameTok.value(), body, nameTok.line());
+        }
+
+        private GrammarElement parseBody() throws ParserGrammarError {
+            GrammarElement first = parseSequence();
+            List<GrammarElement> alternatives = new ArrayList<>();
+            alternatives.add(first);
+
+            while ("PIPE".equals(peek().kind())) {
+                advance();
+                alternatives.add(parseSequence());
+            }
+
+            return alternatives.size() == 1
+                    ? alternatives.get(0)
+                    : new GrammarElement.Alternation(List.copyOf(alternatives));
+        }
+
+        private GrammarElement parseSequence() throws ParserGrammarError {
+            List<GrammarElement> elements = new ArrayList<>();
+            while (true) {
+                String kind = peek().kind();
+                if ("PIPE".equals(kind) || "SEMI".equals(kind) || "RBRACE".equals(kind)
+                        || "RBRACKET".equals(kind) || "RPAREN".equals(kind)
+                        || "EOF".equals(kind) || "DOUBLE_SLASH".equals(kind)) {
+                    break;
+                }
+                elements.add(parseElement());
+            }
+            if (elements.isEmpty()) {
+                throw new ParserGrammarError("Expected at least one element in sequence", peek().line());
+            }
+            return elements.size() == 1 ? elements.get(0) : new GrammarElement.Sequence(List.copyOf(elements));
+        }
+
+        private GrammarElement parseElement() throws ParserGrammarError {
+            InternalToken tok = peek();
+
+            // Lookahead predicates
+            if ("AMPERSAND".equals(tok.kind())) {
+                advance();
+                return new GrammarElement.PositiveLookahead(parseElement());
+            }
+            if ("BANG".equals(tok.kind())) {
+                advance();
+                return new GrammarElement.NegativeLookahead(parseElement());
+            }
+
+            switch (tok.kind()) {
+                case "IDENT" -> {
+                    advance();
+                    boolean isToken = Character.isUpperCase(tok.value().charAt(0));
+                    return new GrammarElement.RuleReference(tok.value(), isToken);
+                }
+                case "STRING" -> {
+                    advance();
+                    return new GrammarElement.Literal(tok.value());
+                }
+                case "LBRACE" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+
+                    // Separated repetition: { element // separator }
+                    if ("DOUBLE_SLASH".equals(peek().kind())) {
+                        advance();
+                        GrammarElement separator = parseBody();
+                        expect("RBRACE");
+                        boolean atLeastOne = "PLUS".equals(peek().kind());
+                        if (atLeastOne) advance();
+                        return new GrammarElement.SeparatedRepetition(body, separator, atLeastOne);
+                    }
+
+                    expect("RBRACE");
+                    // One-or-more: { element }+
+                    if ("PLUS".equals(peek().kind())) {
+                        advance();
+                        return new GrammarElement.OneOrMoreRepetition(body);
+                    }
+                    return new GrammarElement.Repetition(body);
+                }
+                case "LBRACKET" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+                    expect("RBRACKET");
+                    return new GrammarElement.Optional(body);
+                }
+                case "LPAREN" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+                    expect("RPAREN");
+                    return new GrammarElement.Group(body);
+                }
+                default -> throw new ParserGrammarError("Unexpected token " + tok.kind(), tok.line());
+            }
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarValidator.java
@@ -1,0 +1,86 @@
+// ============================================================================
+// ParserGrammarValidator.java — Lint pass for parsed ParserGrammar
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * Validates a parsed {@link ParserGrammar} for semantic issues.
+ */
+public final class ParserGrammarValidator {
+
+    /** Synthetic tokens always valid — the lexer produces these implicitly. */
+    private static final Set<String> SYNTHETIC_TOKENS = Set.of("NEWLINE", "INDENT", "DEDENT", "EOF");
+
+    private ParserGrammarValidator() {}
+
+    /**
+     * Check a parsed ParserGrammar for issues.
+     *
+     * @param grammar    the grammar to validate
+     * @param tokenNames optional set of valid token names from a .tokens file; null to skip token checks
+     * @return list of issue strings; empty means no issues
+     */
+    public static List<String> validate(ParserGrammar grammar, Set<String> tokenNames) {
+        List<String> issues = new ArrayList<>();
+
+        Set<String> defined = grammar.ruleNames();
+        Set<String> referencedRules = grammar.ruleReferences();
+        Set<String> referencedTokens = grammar.tokenReferences();
+
+        // Duplicate rule names
+        Map<String, Integer> seen = new HashMap<>();
+        for (GrammarRule rule : grammar.getRules()) {
+            if (seen.containsKey(rule.name())) {
+                issues.add("Line " + rule.lineNumber() + ": Duplicate rule name '" + rule.name()
+                        + "' (first defined on line " + seen.get(rule.name()) + ")");
+            } else {
+                seen.put(rule.name(), rule.lineNumber());
+            }
+        }
+
+        // Non-lowercase rule names
+        for (GrammarRule rule : grammar.getRules()) {
+            if (!rule.name().equals(rule.name().toLowerCase())) {
+                issues.add("Line " + rule.lineNumber() + ": Rule name '" + rule.name() + "' should be lowercase");
+            }
+        }
+
+        // Undefined rule references
+        for (String ref : sorted(referencedRules)) {
+            if (!defined.contains(ref)) {
+                issues.add("Undefined rule reference: '" + ref + "'");
+            }
+        }
+
+        // Undefined token references
+        if (tokenNames != null) {
+            for (String ref : sorted(referencedTokens)) {
+                if (!tokenNames.contains(ref) && !SYNTHETIC_TOKENS.contains(ref)) {
+                    issues.add("Undefined token reference: '" + ref + "'");
+                }
+            }
+        }
+
+        // Unreachable rules
+        if (!grammar.getRules().isEmpty()) {
+            String startRule = grammar.getRules().get(0).name();
+            for (GrammarRule rule : grammar.getRules()) {
+                if (!rule.name().equals(startRule) && !referencedRules.contains(rule.name())) {
+                    issues.add("Line " + rule.lineNumber() + ": Rule '" + rule.name()
+                            + "' is defined but never referenced (unreachable)");
+                }
+            }
+        }
+
+        return issues;
+    }
+
+    private static List<String> sorted(Set<String> set) {
+        List<String> list = new ArrayList<>(set);
+        Collections.sort(list);
+        return list;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/PatternGroup.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/PatternGroup.java
@@ -1,0 +1,46 @@
+// ============================================================================
+// PatternGroup.java — A named set of token definitions for context-sensitive lexing
+// ============================================================================
+//
+// Pattern groups enable context-sensitive lexing. For example, an XML lexer
+// defines a "tag" group with patterns for attribute names, equals signs, and
+// attribute values. These patterns are only active inside tags — a callback
+// pushes the "tag" group when "<" is matched and pops it when ">" is matched.
+//
+// When a group is at the top of the lexer's group stack, only that group's
+// patterns are tried during token matching. Skip patterns remain global.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A named set of token definitions that are active together during
+ * context-sensitive lexing.
+ *
+ * @see TokenGrammar
+ */
+public final class PatternGroup {
+
+    private final String name;
+    private final List<TokenDefinition> definitions;
+
+    public PatternGroup(String name, List<TokenDefinition> definitions) {
+        this.name = Objects.requireNonNull(name);
+        this.definitions = Collections.unmodifiableList(definitions);
+    }
+
+    /** The group name, e.g. "tag" or "cdata". */
+    public String getName() { return name; }
+
+    /** Ordered list of token definitions. Order matters (first-match-wins). */
+    public List<TokenDefinition> getDefinitions() { return definitions; }
+
+    @Override
+    public String toString() {
+        return "PatternGroup(" + name + ", " + definitions.size() + " definitions)";
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenDefinition.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenDefinition.java
@@ -1,0 +1,86 @@
+// ============================================================================
+// TokenDefinition.java — A single token rule from a .tokens file
+// ============================================================================
+//
+// Each line in a .tokens file defines one token: a name paired with a pattern.
+// Patterns can be regular expressions (delimited by /slashes/) or literal
+// strings (delimited by "quotes"). An optional -> ALIAS suffix lets multiple
+// patterns emit the same token type.
+//
+// Examples from a .tokens file:
+//
+//   NUMBER  = /[0-9]+/              — regex pattern, no alias
+//   PLUS    = "+"                   — literal pattern, no alias
+//   STRING_DQ = /"[^"]*"/  -> STRING  — regex pattern with alias
+//
+// The lexer tries patterns in definition order (first match wins), so a
+// TokenDefinition's position in the list determines its priority.
+//
+// Layer: TE (text/language layer — foundational infrastructure)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.Objects;
+
+/**
+ * An immutable record of a single token rule parsed from a .tokens file.
+ *
+ * <p>Fields:
+ * <ul>
+ *   <li>{@code name} — the token name, e.g. "NUMBER" or "PLUS"</li>
+ *   <li>{@code pattern} — the pattern string (without delimiters)</li>
+ *   <li>{@code isRegex} — true if /regex/, false if "literal"</li>
+ *   <li>{@code lineNumber} — 1-based line where this definition appeared</li>
+ *   <li>{@code alias} — optional type alias (null if none)</li>
+ * </ul>
+ */
+public final class TokenDefinition {
+
+    private final String name;
+    private final String pattern;
+    private final boolean isRegex;
+    private final int lineNumber;
+    private final String alias;
+
+    public TokenDefinition(String name, String pattern, boolean isRegex, int lineNumber, String alias) {
+        this.name = Objects.requireNonNull(name);
+        this.pattern = Objects.requireNonNull(pattern);
+        this.isRegex = isRegex;
+        this.lineNumber = lineNumber;
+        this.alias = alias; // null means no alias
+    }
+
+    public TokenDefinition(String name, String pattern, boolean isRegex, int lineNumber) {
+        this(name, pattern, isRegex, lineNumber, null);
+    }
+
+    public String getName() { return name; }
+    public String getPattern() { return pattern; }
+    public boolean isRegex() { return isRegex; }
+    public int getLineNumber() { return lineNumber; }
+    public String getAlias() { return alias; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TokenDefinition that)) return false;
+        return isRegex == that.isRegex
+                && lineNumber == that.lineNumber
+                && name.equals(that.name)
+                && pattern.equals(that.pattern)
+                && Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, pattern, isRegex, lineNumber, alias);
+    }
+
+    @Override
+    public String toString() {
+        String aliasStr = alias != null ? " -> " + alias : "";
+        String patternStr = isRegex ? "/" + pattern + "/" : "\"" + pattern + "\"";
+        return "TokenDefinition(" + name + " = " + patternStr + aliasStr + ", line " + lineNumber + ")";
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammar.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammar.java
@@ -1,0 +1,112 @@
+// ============================================================================
+// TokenGrammar.java — Complete contents of a parsed .tokens file
+// ============================================================================
+//
+// A .tokens file is the lexical specification for a programming language. It
+// describes every token the lexer should recognize, organized into:
+//
+//   1. Token definitions — NAME = /regex/ or NAME = "literal"
+//   2. Keywords section — reserved words promoted from NAME tokens
+//   3. Skip section — patterns consumed silently (whitespace, comments)
+//   4. Mode directive — special lexer modes like "indentation"
+//   5. Pattern groups — context-sensitive token sets
+//
+// This class holds the parsed result of all those sections.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * The complete contents of a parsed .tokens file.
+ *
+ * <p>All fields have sensible defaults so a freshly constructed TokenGrammar
+ * represents an empty but valid grammar.
+ */
+public final class TokenGrammar {
+
+    private int version = 0;
+    private boolean caseInsensitive = false;
+    private boolean caseSensitive = true;
+    private final List<TokenDefinition> definitions = new ArrayList<>();
+    private final List<String> keywords = new ArrayList<>();
+    private String mode = null;
+    private String escapeMode = null;
+    private final List<TokenDefinition> skipDefinitions = new ArrayList<>();
+    private final List<TokenDefinition> errorDefinitions = new ArrayList<>();
+    private final List<String> reservedKeywords = new ArrayList<>();
+    private final List<String> contextKeywords = new ArrayList<>();
+    private final Map<String, PatternGroup> groups = new LinkedHashMap<>();
+
+    // --- Getters and setters ---
+
+    public int getVersion() { return version; }
+    public void setVersion(int version) { this.version = version; }
+
+    public boolean isCaseInsensitive() { return caseInsensitive; }
+    public void setCaseInsensitive(boolean v) { this.caseInsensitive = v; }
+
+    public boolean isCaseSensitive() { return caseSensitive; }
+    public void setCaseSensitive(boolean v) { this.caseSensitive = v; }
+
+    public List<TokenDefinition> getDefinitions() { return definitions; }
+    public List<String> getKeywords() { return keywords; }
+
+    public String getMode() { return mode; }
+    public void setMode(String mode) { this.mode = mode; }
+
+    public String getEscapeMode() { return escapeMode; }
+    public void setEscapeMode(String escapeMode) { this.escapeMode = escapeMode; }
+
+    public List<TokenDefinition> getSkipDefinitions() { return skipDefinitions; }
+    public List<TokenDefinition> getErrorDefinitions() { return errorDefinitions; }
+    public List<String> getReservedKeywords() { return reservedKeywords; }
+    public List<String> getContextKeywords() { return contextKeywords; }
+    public Map<String, PatternGroup> getGroups() { return groups; }
+
+    /**
+     * Return the set of all defined token names (including aliases).
+     *
+     * <p>When a definition has an alias, both the original name and the alias
+     * are included. Includes names from all pattern groups.
+     *
+     * <p>Useful for cross-validation: the parser grammar references tokens by
+     * name, and we need to check that every referenced token exists.
+     */
+    public Set<String> tokenNames() {
+        Set<String> names = new HashSet<>();
+        List<TokenDefinition> allDefs = new ArrayList<>(definitions);
+        for (PatternGroup group : groups.values()) {
+            allDefs.addAll(group.getDefinitions());
+        }
+        for (TokenDefinition d : allDefs) {
+            names.add(d.getName());
+            if (d.getAlias() != null) {
+                names.add(d.getAlias());
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Return the set of token names as the parser will see them.
+     *
+     * <p>For definitions with aliases, returns the alias (not the definition
+     * name). For definitions without aliases, returns the definition name.
+     * Includes names from all pattern groups.
+     */
+    public Set<String> effectiveTokenNames() {
+        Set<String> names = new HashSet<>();
+        List<TokenDefinition> allDefs = new ArrayList<>(definitions);
+        for (PatternGroup group : groups.values()) {
+            allDefs.addAll(group.getDefinitions());
+        }
+        for (TokenDefinition d : allDefs) {
+            names.add(d.getAlias() != null ? d.getAlias() : d.getName());
+        }
+        return names;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarError.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarError.java
@@ -1,0 +1,26 @@
+// ============================================================================
+// TokenGrammarError.java — Exception for .tokens file parse errors
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * Thrown when a .tokens file cannot be parsed.
+ */
+public class TokenGrammarError extends Exception {
+
+    private final String msg;
+    private final int lineNumber;
+
+    public TokenGrammarError(String message, int lineNumber) {
+        super("Line " + lineNumber + ": " + message);
+        this.msg = message;
+        this.lineNumber = lineNumber;
+    }
+
+    /** Human-readable description of the problem. */
+    public String getMsg() { return msg; }
+
+    /** 1-based line number where the error occurred. */
+    public int getLineNumber() { return lineNumber; }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarParser.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarParser.java
@@ -1,0 +1,397 @@
+// ============================================================================
+// TokenGrammarParser.java — Parser for .tokens files
+// ============================================================================
+//
+// A .tokens file describes the lexical grammar of a programming language:
+// which patterns the lexer should recognize, in what order, and how to
+// classify the matched text.
+//
+// The parser operates line-by-line with several modes:
+//
+//   1. Definition mode (default) — each line is a comment, blank, section
+//      header, or token definition (NAME = /pattern/ or NAME = "literal").
+//
+//   2. Keywords mode — entered on "keywords:". Indented lines are keywords.
+//
+//   3. Reserved mode — entered on "reserved:". Same format as keywords but
+//      populates reserved_keywords (which cause lex errors).
+//
+//   4. Skip mode — entered on "skip:". Indented lines define patterns that
+//      the lexer matches and consumes silently (no token produced).
+//
+//   5. Errors mode — entered on "errors:". Error recovery patterns tried
+//      when no normal token matches.
+//
+//   6. Group mode — entered on "group NAME:". Indented lines define token
+//      patterns for context-sensitive lexing groups.
+//
+// Magic comments (# @key value) configure metadata like version and
+// case-insensitivity. Unknown keys are silently ignored for forward compat.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses .tokens file text into a {@link TokenGrammar}.
+ */
+public final class TokenGrammarParser {
+
+    // Magic comment pattern: # @key value
+    private static final Pattern MAGIC_COMMENT = Pattern.compile("^#\\s*@(\\w+)\\s*(.*)$");
+
+    // Valid group name: lowercase identifier
+    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[a-z_][a-z0-9_]*$");
+
+    // Valid token name: identifier (letters, digits, underscore)
+    private static final Pattern TOKEN_NAME_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+
+    // Reserved group names that cannot be used as pattern groups
+    private static final java.util.Set<String> RESERVED_GROUP_NAMES = java.util.Set.of(
+            "default", "skip", "keywords", "reserved", "errors"
+    );
+
+    private TokenGrammarParser() {} // utility class
+
+    /**
+     * Parse the full text of a .tokens file into a TokenGrammar.
+     *
+     * @param source the complete text content of a .tokens file
+     * @return a populated TokenGrammar
+     * @throws TokenGrammarError if any line cannot be parsed
+     */
+    public static TokenGrammar parse(String source) throws TokenGrammarError {
+        TokenGrammar grammar = new TokenGrammar();
+        String[] lines = source.split("\n", -1);
+        String currentSection = null;
+
+        for (int i = 0; i < lines.length; i++) {
+            int lineNumber = i + 1;
+            String line = stripTrailing(lines[i]);
+            String stripped = line.strip();
+
+            // --- Blank lines ---
+            if (stripped.isEmpty()) continue;
+
+            // --- Comments and magic comments ---
+            if (stripped.startsWith("#")) {
+                Matcher m = MAGIC_COMMENT.matcher(stripped);
+                if (m.matches()) {
+                    String key = m.group(1);
+                    String value = m.group(2).strip();
+                    switch (key) {
+                        case "version":
+                            try { grammar.setVersion(Integer.parseInt(value)); }
+                            catch (NumberFormatException ignored) {}
+                            break;
+                        case "case_insensitive":
+                            grammar.setCaseInsensitive("true".equals(value));
+                            break;
+                        // Unknown keys silently ignored for forward compatibility
+                    }
+                }
+                continue;
+            }
+
+            // --- mode: directive ---
+            if (stripped.startsWith("mode:")) {
+                String modeValue = stripped.substring(5).strip();
+                if (modeValue.isEmpty()) {
+                    throw new TokenGrammarError("Missing value after 'mode:'", lineNumber);
+                }
+                grammar.setMode(modeValue);
+                currentSection = null;
+                continue;
+            }
+
+            // --- escapes: directive ---
+            if (stripped.startsWith("escapes:")) {
+                String escapeValue = stripped.substring(8).strip();
+                if (escapeValue.isEmpty()) {
+                    throw new TokenGrammarError("Missing value after 'escapes:'", lineNumber);
+                }
+                grammar.setEscapeMode(escapeValue);
+                currentSection = null;
+                continue;
+            }
+
+            // --- case_sensitive: directive ---
+            if (stripped.startsWith("case_sensitive:")) {
+                String csValue = stripped.substring(15).strip().toLowerCase();
+                if (!"true".equals(csValue) && !"false".equals(csValue)) {
+                    throw new TokenGrammarError(
+                            "Invalid value for 'case_sensitive:': '" + csValue + "' (expected 'true' or 'false')",
+                            lineNumber);
+                }
+                grammar.setCaseSensitive("true".equals(csValue));
+                currentSection = null;
+                continue;
+            }
+
+            // --- Group headers: "group NAME:" ---
+            if (stripped.startsWith("group ") && stripped.endsWith(":")) {
+                String groupName = stripped.substring(6, stripped.length() - 1).strip();
+                if (groupName.isEmpty()) {
+                    throw new TokenGrammarError("Missing group name after 'group'", lineNumber);
+                }
+                if (!GROUP_NAME_PATTERN.matcher(groupName).matches()) {
+                    throw new TokenGrammarError(
+                            "Invalid group name: '" + groupName + "' (must be a lowercase identifier)",
+                            lineNumber);
+                }
+                if (RESERVED_GROUP_NAMES.contains(groupName)) {
+                    throw new TokenGrammarError(
+                            "Reserved group name: '" + groupName + "'",
+                            lineNumber);
+                }
+                if (grammar.getGroups().containsKey(groupName)) {
+                    throw new TokenGrammarError("Duplicate group name: '" + groupName + "'", lineNumber);
+                }
+                grammar.getGroups().put(groupName, new PatternGroup(groupName, new ArrayList<>()));
+                currentSection = "group:" + groupName;
+                continue;
+            }
+
+            // --- Section headers ---
+            if ("keywords:".equals(stripped) || "keywords :".equals(stripped)) {
+                currentSection = "keywords"; continue;
+            }
+            if ("reserved:".equals(stripped) || "reserved :".equals(stripped)) {
+                currentSection = "reserved"; continue;
+            }
+            if ("skip:".equals(stripped) || "skip :".equals(stripped)) {
+                currentSection = "skip"; continue;
+            }
+            if ("errors:".equals(stripped) || "errors :".equals(stripped)) {
+                currentSection = "errors"; continue;
+            }
+            if ("context_keywords:".equals(stripped) || "context_keywords :".equals(stripped)) {
+                currentSection = "context_keywords"; continue;
+            }
+
+            // --- Inside a section (indented lines) ---
+            if (currentSection != null) {
+                if (!line.isEmpty() && (line.charAt(0) == ' ' || line.charAt(0) == '\t')) {
+                    handleSectionLine(grammar, currentSection, stripped, lineNumber);
+                    continue;
+                }
+                // Non-indented line exits the section
+                currentSection = null;
+            }
+
+            // --- Token definition: NAME = pattern ---
+            int eqIndex = line.indexOf('=');
+            if (eqIndex == -1) {
+                throw new TokenGrammarError(
+                        "Expected token definition (NAME = pattern), got: '" + stripped + "'",
+                        lineNumber);
+            }
+
+            String namePart = line.substring(0, eqIndex).strip();
+            String patternPart = line.substring(eqIndex + 1).strip();
+
+            if (namePart.isEmpty()) {
+                throw new TokenGrammarError("Missing token name before '='", lineNumber);
+            }
+            if (!TOKEN_NAME_PATTERN.matcher(namePart).matches()) {
+                throw new TokenGrammarError(
+                        "Invalid token name: '" + namePart + "' (must be an identifier)",
+                        lineNumber);
+            }
+            if (patternPart.isEmpty()) {
+                throw new TokenGrammarError("Missing pattern after '=' for token '" + namePart + "'", lineNumber);
+            }
+
+            grammar.getDefinitions().add(parseDefinition(patternPart, namePart, lineNumber));
+        }
+
+        return grammar;
+    }
+
+    // --- Section line handler ---
+
+    private static void handleSectionLine(
+            TokenGrammar grammar, String section, String stripped, int lineNumber
+    ) throws TokenGrammarError {
+        if (stripped.isEmpty()) return;
+
+        switch (section) {
+            case "keywords":
+                grammar.getKeywords().add(stripped);
+                break;
+            case "reserved":
+                grammar.getReservedKeywords().add(stripped);
+                break;
+            case "context_keywords":
+                grammar.getContextKeywords().add(stripped);
+                break;
+            case "skip":
+                parseAndAddDefinition(grammar.getSkipDefinitions(), stripped, lineNumber, "skip pattern");
+                break;
+            case "errors":
+                parseAndAddDefinition(grammar.getErrorDefinitions(), stripped, lineNumber, "error pattern");
+                break;
+            default:
+                if (section.startsWith("group:")) {
+                    String groupName = section.substring(6);
+                    parseAndAddGroupDefinition(grammar, groupName, stripped, lineNumber);
+                }
+                break;
+        }
+    }
+
+    private static void parseAndAddDefinition(
+            List<TokenDefinition> target, String stripped, int lineNumber, String label
+    ) throws TokenGrammarError {
+        int eqIdx = stripped.indexOf('=');
+        if (eqIdx == -1) {
+            throw new TokenGrammarError(
+                    "Expected " + label + " definition (NAME = pattern), got: '" + stripped + "'",
+                    lineNumber);
+        }
+        String name = stripped.substring(0, eqIdx).strip();
+        String pattern = stripped.substring(eqIdx + 1).strip();
+        if (name.isEmpty() || pattern.isEmpty()) {
+            throw new TokenGrammarError("Incomplete " + label + " definition: '" + stripped + "'", lineNumber);
+        }
+        target.add(parseDefinition(pattern, name, lineNumber));
+    }
+
+    private static void parseAndAddGroupDefinition(
+            TokenGrammar grammar, String groupName, String stripped, int lineNumber
+    ) throws TokenGrammarError {
+        int eqIdx = stripped.indexOf('=');
+        if (eqIdx == -1) {
+            throw new TokenGrammarError(
+                    "Expected token definition in group '" + groupName + "' (NAME = pattern), got: '" + stripped + "'",
+                    lineNumber);
+        }
+        String name = stripped.substring(0, eqIdx).strip();
+        String pattern = stripped.substring(eqIdx + 1).strip();
+        if (name.isEmpty() || pattern.isEmpty()) {
+            throw new TokenGrammarError(
+                    "Incomplete definition in group '" + groupName + "': '" + stripped + "'",
+                    lineNumber);
+        }
+        TokenDefinition defn = parseDefinition(pattern, name, lineNumber);
+
+        // Replace the group with one that has the new definition appended
+        PatternGroup oldGroup = grammar.getGroups().get(groupName);
+        List<TokenDefinition> newDefs = new ArrayList<>(oldGroup.getDefinitions());
+        newDefs.add(defn);
+        grammar.getGroups().put(groupName, new PatternGroup(groupName, newDefs));
+    }
+
+    // --- Definition parser ---
+
+    /**
+     * Parse a single token definition pattern with optional -> ALIAS suffix.
+     *
+     * <p>Supports two forms:
+     * <ul>
+     *   <li>/regex/ — regex pattern</li>
+     *   <li>"literal" — literal string pattern</li>
+     * </ul>
+     *
+     * Either form may have a {@code -> ALIAS} suffix after the closing delimiter.
+     */
+    static TokenDefinition parseDefinition(String patternPart, String namePart, int lineNumber)
+            throws TokenGrammarError {
+
+        if (patternPart.startsWith("/")) {
+            // --- Regex pattern ---
+            int lastSlash = findClosingSlash(patternPart);
+            if (lastSlash == -1) {
+                throw new TokenGrammarError("Unclosed regex pattern for token '" + namePart + "'", lineNumber);
+            }
+            String regexBody = patternPart.substring(1, lastSlash);
+            String remainder = patternPart.substring(lastSlash + 1).strip();
+
+            if (regexBody.isEmpty()) {
+                throw new TokenGrammarError("Empty regex pattern for token '" + namePart + "'", lineNumber);
+            }
+
+            String alias = parseAlias(remainder, namePart, lineNumber);
+            return new TokenDefinition(namePart, regexBody, true, lineNumber, alias);
+
+        } else if (patternPart.startsWith("\"")) {
+            // --- Literal pattern ---
+            int closeQuote = patternPart.indexOf('"', 1);
+            if (closeQuote == -1) {
+                throw new TokenGrammarError("Unclosed literal pattern for token '" + namePart + "'", lineNumber);
+            }
+            String literalBody = patternPart.substring(1, closeQuote);
+            String remainder = patternPart.substring(closeQuote + 1).strip();
+
+            if (literalBody.isEmpty()) {
+                throw new TokenGrammarError("Empty literal pattern for token '" + namePart + "'", lineNumber);
+            }
+
+            String alias = parseAlias(remainder, namePart, lineNumber);
+            return new TokenDefinition(namePart, literalBody, false, lineNumber, alias);
+
+        } else {
+            throw new TokenGrammarError(
+                    "Pattern for token '" + namePart + "' must be /regex/ or \"literal\", got: '" + patternPart + "'",
+                    lineNumber);
+        }
+    }
+
+    /** Parse optional -> ALIAS suffix from remainder text after the pattern delimiter. */
+    private static String parseAlias(String remainder, String namePart, int lineNumber) throws TokenGrammarError {
+        if (remainder.isEmpty()) return null;
+        if (remainder.startsWith("->")) {
+            String alias = remainder.substring(2).strip();
+            if (alias.isEmpty()) {
+                throw new TokenGrammarError("Missing alias after '->' for token '" + namePart + "'", lineNumber);
+            }
+            return alias;
+        }
+        throw new TokenGrammarError(
+                "Unexpected text after pattern for token '" + namePart + "': '" + remainder + "'",
+                lineNumber);
+    }
+
+    /**
+     * Find the closing / in a regex pattern, skipping escaped characters
+     * and characters inside [...] character classes.
+     *
+     * @param s the pattern string starting with /
+     * @return index of closing /, or -1 if not found
+     */
+    static int findClosingSlash(String s) {
+        boolean inBracket = false;
+        for (int i = 1; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == '\\') {
+                i++; // skip escaped character
+                continue;
+            }
+            if (ch == '[' && !inBracket) {
+                inBracket = true;
+            } else if (ch == ']' && inBracket) {
+                inBracket = false;
+            } else if (ch == '/' && !inBracket) {
+                return i;
+            }
+        }
+        // Fallback: last / as best-effort
+        int last = s.lastIndexOf('/');
+        return last > 0 ? last : -1;
+    }
+
+    /** Strip trailing whitespace (Java 8-compatible helper). */
+    private static String stripTrailing(String s) {
+        int end = s.length();
+        while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+            end--;
+        }
+        return s.substring(0, end);
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarValidator.java
@@ -1,0 +1,106 @@
+// ============================================================================
+// TokenGrammarValidator.java — Lint pass for parsed TokenGrammar
+// ============================================================================
+//
+// This validates a TokenGrammar that was already parsed successfully. We look
+// for semantic issues: duplicate names, invalid regex patterns, naming
+// convention violations, invalid modes, empty groups.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Validates a parsed {@link TokenGrammar} for common semantic problems.
+ */
+public final class TokenGrammarValidator {
+
+    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[a-z_][a-z0-9_]*$");
+
+    private TokenGrammarValidator() {}
+
+    /**
+     * Check a parsed TokenGrammar for issues.
+     *
+     * @return a list of warning/error strings; empty means no issues
+     */
+    public static List<String> validate(TokenGrammar grammar) {
+        List<String> issues = new ArrayList<>();
+
+        issues.addAll(validateDefinitions(grammar.getDefinitions(), "token"));
+        issues.addAll(validateDefinitions(grammar.getSkipDefinitions(), "skip pattern"));
+        issues.addAll(validateDefinitions(grammar.getErrorDefinitions(), "error pattern"));
+
+        // Validate mode
+        if (grammar.getMode() != null && !"indentation".equals(grammar.getMode())) {
+            issues.add("Unknown lexer mode '" + grammar.getMode() + "' (only 'indentation' is supported)");
+        }
+
+        // Validate escape mode
+        if (grammar.getEscapeMode() != null && !"none".equals(grammar.getEscapeMode())) {
+            issues.add("Unknown escape mode '" + grammar.getEscapeMode() + "' (only 'none' is supported)");
+        }
+
+        // Validate pattern groups
+        for (var entry : grammar.getGroups().entrySet()) {
+            String groupName = entry.getKey();
+            PatternGroup group = entry.getValue();
+
+            if (!GROUP_NAME_PATTERN.matcher(groupName).matches()) {
+                issues.add("Invalid group name '" + groupName + "' (must be a lowercase identifier)");
+            }
+            if (group.getDefinitions().isEmpty()) {
+                issues.add("Empty pattern group '" + groupName + "' (has no token definitions)");
+            }
+            issues.addAll(validateDefinitions(group.getDefinitions(), "group '" + groupName + "' token"));
+        }
+
+        return issues;
+    }
+
+    private static List<String> validateDefinitions(List<TokenDefinition> definitions, String label) {
+        List<String> issues = new ArrayList<>();
+        Map<String, Integer> seenNames = new HashMap<>();
+
+        for (TokenDefinition defn : definitions) {
+            // Duplicate check
+            if (seenNames.containsKey(defn.getName())) {
+                issues.add("Line " + defn.getLineNumber() + ": Duplicate " + label + " name '"
+                        + defn.getName() + "' (first defined on line " + seenNames.get(defn.getName()) + ")");
+            } else {
+                seenNames.put(defn.getName(), defn.getLineNumber());
+            }
+
+            // Empty pattern check
+            if (defn.getPattern().isEmpty()) {
+                issues.add("Line " + defn.getLineNumber() + ": Empty pattern for " + label + " '" + defn.getName() + "'");
+            }
+
+            // Invalid regex check
+            if (defn.isRegex()) {
+                try {
+                    Pattern.compile(defn.getPattern());
+                } catch (PatternSyntaxException e) {
+                    issues.add("Line " + defn.getLineNumber() + ": Invalid regex for " + label + " '"
+                            + defn.getName() + "': " + e.getDescription());
+                }
+            }
+
+            // Naming convention: UPPER_CASE
+            if (!defn.getName().equals(defn.getName().toUpperCase())) {
+                issues.add("Line " + defn.getLineNumber() + ": Token name '" + defn.getName() + "' should be UPPER_CASE");
+            }
+
+            // Alias naming convention
+            if (defn.getAlias() != null && !defn.getAlias().equals(defn.getAlias().toUpperCase())) {
+                issues.add("Line " + defn.getLineNumber() + ": Alias '" + defn.getAlias()
+                        + "' for token '" + defn.getName() + "' should be UPPER_CASE");
+            }
+        }
+
+        return issues;
+    }
+}

--- a/code/packages/java/grammar-tools/src/test/java/com/codingadventures/grammartools/GrammarToolsTest.java
+++ b/code/packages/java/grammar-tools/src/test/java/com/codingadventures/grammartools/GrammarToolsTest.java
@@ -1,0 +1,445 @@
+package com.codingadventures.grammartools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrammarToolsTest {
+
+    // =========================================================================
+    // Token Grammar Parsing
+    // =========================================================================
+
+    @Nested
+    class TokenGrammarParserTests {
+
+        @Test void emptyInput() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("");
+            assertTrue(g.getDefinitions().isEmpty());
+            assertTrue(g.getKeywords().isEmpty());
+        }
+
+        @Test void commentsAndBlanks() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# comment\n\n# another comment\n");
+            assertTrue(g.getDefinitions().isEmpty());
+        }
+
+        @Test void simpleRegexDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            assertEquals(1, g.getDefinitions().size());
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("NUMBER", d.getName());
+            assertEquals("[0-9]+", d.getPattern());
+            assertTrue(d.isRegex());
+            assertEquals(1, d.getLineNumber());
+            assertNull(d.getAlias());
+        }
+
+        @Test void simpleLiteralDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("PLUS = \"+\"\n");
+            assertEquals(1, g.getDefinitions().size());
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("PLUS", d.getName());
+            assertEquals("+", d.getPattern());
+            assertFalse(d.isRegex());
+        }
+
+        @Test void aliasDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("STRING_DQ = /\"[^\"]*\"/ -> STRING\n");
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("STRING_DQ", d.getName());
+            assertEquals("STRING", d.getAlias());
+        }
+
+        @Test void keywordsSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nkeywords:\n  if\n  else\n  while\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("if", "else", "while"), g.getKeywords());
+        }
+
+        @Test void reservedKeywords() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nreserved:\n  class\n  import\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("class", "import"), g.getReservedKeywords());
+        }
+
+        @Test void skipSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nskip:\n  WS = /[ \\t]+/\n  COMMENT = /\\/\\/.*/\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(2, g.getSkipDefinitions().size());
+            assertEquals("WS", g.getSkipDefinitions().get(0).getName());
+        }
+
+        @Test void errorsSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(1, g.getErrorDefinitions().size());
+            assertEquals("BAD_STRING", g.getErrorDefinitions().get(0).getName());
+        }
+
+        @Test void modeDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("mode: indentation\nNUMBER = /[0-9]+/\n");
+            assertEquals("indentation", g.getMode());
+        }
+
+        @Test void escapesDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("escapes: none\nSTRING = /\"[^\"]*\"/\n");
+            assertEquals("none", g.getEscapeMode());
+        }
+
+        @Test void caseSensitiveDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("case_sensitive: false\nNUMBER = /[0-9]+/\n");
+            assertFalse(g.isCaseSensitive());
+        }
+
+        @Test void magicCommentVersion() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# @version 2\nNUMBER = /[0-9]+/\n");
+            assertEquals(2, g.getVersion());
+        }
+
+        @Test void magicCommentCaseInsensitive() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# @case_insensitive true\nNUMBER = /[0-9]+/\n");
+            assertTrue(g.isCaseInsensitive());
+        }
+
+        @Test void patternGroup() throws TokenGrammarError {
+            String src = "OPEN = \"<\"\ngroup tag:\n  ATTR_NAME = /[a-zA-Z]+/\n  EQUALS = \"=\"\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertTrue(g.getGroups().containsKey("tag"));
+            assertEquals(2, g.getGroups().get("tag").getDefinitions().size());
+        }
+
+        @Test void contextKeywords() throws TokenGrammarError {
+            String src = "NAME = /[a-z]+/\ncontext_keywords:\n  async\n  await\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("async", "await"), g.getContextKeywords());
+        }
+
+        @Test void tokenNames() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nSTRING_DQ = /\".*\"/ -> STRING\n");
+            Set<String> names = g.tokenNames();
+            assertTrue(names.contains("NUMBER"));
+            assertTrue(names.contains("STRING_DQ"));
+            assertTrue(names.contains("STRING"));
+        }
+
+        @Test void effectiveTokenNames() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nSTRING_DQ = /\".*\"/ -> STRING\n");
+            Set<String> names = g.effectiveTokenNames();
+            assertTrue(names.contains("NUMBER"));
+            assertFalse(names.contains("STRING_DQ")); // replaced by alias
+            assertTrue(names.contains("STRING"));
+        }
+
+        @Test void missingModeValue() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("mode:\n"));
+        }
+
+        @Test void unclosedRegex() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("BAD = /unclosed\n"));
+        }
+
+        @Test void emptyPattern() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("BAD = //\n"));
+        }
+
+        @Test void duplicateGroupName() {
+            String src = "group tag:\n  A = \"a\"\ngroup tag:\n  B = \"b\"\n";
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse(src));
+        }
+
+        @Test void reservedGroupName() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("group default:\n  A = \"a\"\n"));
+        }
+
+        @Test void multipleDefinitions() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nPLUS = \"+\"\nMINUS = \"-\"\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(3, g.getDefinitions().size());
+        }
+
+        @Test void regexWithBrackets() throws TokenGrammarError {
+            // Regex with character class containing /
+            TokenGrammar g = TokenGrammarParser.parse("REGEX = /[a/b]+/\n");
+            assertEquals("[a/b]+", g.getDefinitions().get(0).getPattern());
+        }
+
+        @Test void findClosingSlashSkipsEscaped() {
+            assertEquals(7, TokenGrammarParser.findClosingSlash("/ab\\/cd/"));
+        }
+
+        @Test void findClosingSlashSkipsBrackets() {
+            assertEquals(6, TokenGrammarParser.findClosingSlash("/[a/b]/"));
+        }
+    }
+
+    // =========================================================================
+    // Token Grammar Validation
+    // =========================================================================
+
+    @Nested
+    class TokenGrammarValidatorTests {
+
+        @Test void validGrammar() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nPLUS = \"+\"\n");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void duplicateNames() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("NUM", "[0-9]+", true, 1));
+            g.getDefinitions().add(new TokenDefinition("NUM", "[0-9]+", true, 2));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Duplicate")));
+        }
+
+        @Test void invalidRegex() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("BAD", "[unclosed", true, 1));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Invalid regex")));
+        }
+
+        @Test void nonUpperCaseName() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("number", "[0-9]+", true, 1));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("UPPER_CASE")));
+        }
+
+        @Test void unknownMode() {
+            TokenGrammar g = new TokenGrammar();
+            g.setMode("unknown_mode");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Unknown lexer mode")));
+        }
+
+        @Test void unknownEscapeMode() {
+            TokenGrammar g = new TokenGrammar();
+            g.setEscapeMode("bad");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Unknown escape mode")));
+        }
+
+        @Test void emptyGroup() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getGroups().put("empty", new PatternGroup("empty", List.of()));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Empty pattern group")));
+        }
+    }
+
+    // =========================================================================
+    // Parser Grammar Parsing
+    // =========================================================================
+
+    @Nested
+    class ParserGrammarParserTests {
+
+        @Test void simpleRule() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = statement ;");
+            assertEquals(1, g.getRules().size());
+            assertEquals("program", g.getRules().get(0).name());
+        }
+
+        @Test void alternation() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("expr = NUMBER | NAME ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Alternation.class, body);
+            assertEquals(2, ((GrammarElement.Alternation) body).choices().size());
+        }
+
+        @Test void sequence() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER SEMI ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void repetition() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("list = { item } ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Repetition.class, body);
+        }
+
+        @Test void oneOrMore() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("list = { item }+ ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.OneOrMoreRepetition.class, body);
+        }
+
+        @Test void optional() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("call = NAME LPAREN [ args ] RPAREN ;");
+            // body is a sequence with optional inside
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void group() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("expr = term (PLUS | MINUS) term ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void literal() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("op = \"+\" ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Literal.class, body);
+            assertEquals("+", ((GrammarElement.Literal) body).value());
+        }
+
+        @Test void positiveLookahead() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("check = &NUMBER item ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void negativeLookahead() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NUMBER item ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void separatedRepetition() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("args = { expr // COMMA } ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.SeparatedRepetition.class, body);
+            GrammarElement.SeparatedRepetition sep = (GrammarElement.SeparatedRepetition) body;
+            assertFalse(sep.atLeastOne());
+        }
+
+        @Test void separatedRepetitionAtLeastOne() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("args = { expr // COMMA }+ ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.SeparatedRepetition.class, body);
+            assertTrue(((GrammarElement.SeparatedRepetition) body).atLeastOne());
+        }
+
+        @Test void multipleRules() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("a = NUMBER ;\nb = NAME ;");
+            assertEquals(2, g.getRules().size());
+        }
+
+        @Test void ruleReferences() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = { statement } ;\nstatement = expr SEMI ;");
+            assertTrue(g.ruleReferences().contains("statement"));
+            assertTrue(g.ruleReferences().contains("expr"));
+        }
+
+        @Test void tokenReferences() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER ;");
+            Set<String> refs = g.tokenReferences();
+            assertTrue(refs.contains("NAME"));
+            assertTrue(refs.contains("EQUALS"));
+            assertTrue(refs.contains("NUMBER"));
+        }
+
+        @Test void magicVersion() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("# @version 3\nexpr = NUMBER ;");
+            assertEquals(3, g.getVersion());
+        }
+
+        @Test void unexpectedToken() {
+            assertThrows(ParserGrammarError.class, () -> ParserGrammarParser.parse("123"));
+        }
+    }
+
+    // =========================================================================
+    // Parser Grammar Validation
+    // =========================================================================
+
+    @Nested
+    class ParserGrammarValidatorTests {
+
+        @Test void validGrammar() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = { statement } ;\nstatement = NUMBER ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void duplicateRuleName() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("a = NUMBER ;\na = NAME ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Duplicate rule name")));
+        }
+
+        @Test void undefinedRuleRef() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = undefined_rule ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Undefined rule reference")));
+        }
+
+        @Test void undefinedTokenRef() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = NONEXISTENT ;");
+            Set<String> tokenNames = Set.of("NUMBER", "NAME");
+            List<String> issues = ParserGrammarValidator.validate(g, tokenNames);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Undefined token reference")));
+        }
+
+        @Test void syntheticTokensAlwaysValid() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = NEWLINE EOF ;");
+            List<String> issues = ParserGrammarValidator.validate(g, Set.of());
+            assertFalse(issues.stream().anyMatch(s -> s.contains("Undefined token")));
+        }
+
+        @Test void unreachableRule() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("start = NUMBER ;\nunused = NAME ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("unreachable")));
+        }
+    }
+
+    // =========================================================================
+    // Cross Validation
+    // =========================================================================
+
+    @Nested
+    class CrossValidatorTests {
+
+        @Test void consistentGrammars() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nNAME = /[a-z]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER | NAME ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void missingToken() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER | NONEXISTENT ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.stream().anyMatch(s -> s.startsWith("Error:") && s.contains("NONEXISTENT")));
+        }
+
+        @Test void unusedToken() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nUNUSED = \"~\"\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.stream().anyMatch(s -> s.startsWith("Warning:") && s.contains("UNUSED")));
+        }
+
+        @Test void syntheticTokensValid() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("program = NUMBER NEWLINE EOF ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.contains("NEWLINE") || s.contains("EOF")));
+        }
+
+        @Test void aliasedTokenUsed() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("STRING_DQ = /\"[^\"]*\"/ -> STRING\n");
+            ParserGrammar pg = ParserGrammarParser.parse("value = STRING ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.startsWith("Warning:")));
+        }
+
+        @Test void indentDedenValidInIndentMode() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("mode: indentation\nNUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("block = INDENT { NUMBER } DEDENT ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.contains("INDENT") || s.contains("DEDENT")));
+        }
+    }
+}

--- a/code/packages/java/lexer/.gitignore
+++ b/code/packages/java/lexer/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/lexer/BUILD
+++ b/code/packages/java/lexer/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle test

--- a/code/packages/java/lexer/BUILD_windows
+++ b/code/packages/java/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lexer/CHANGELOG.md
+++ b/code/packages/java/lexer/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `Token` class with type, value, line, column, typeName, and flags
+- `TokenType` enum for standard token types
+- `GrammarLexer` — grammar-driven tokenizer using TokenGrammar
+- Keyword promotion, type aliases, reserved keyword detection
+- Context-sensitive keyword flags
+- Preceded-by-newline tracking
+- Error recovery pattern support
+- Full test suite

--- a/code/packages/java/lexer/README.md
+++ b/code/packages/java/lexer/README.md
@@ -1,0 +1,27 @@
+# lexer (Java)
+
+Generic lexer/tokenizer infrastructure for the coding-adventures project.
+
+## What it does
+
+- **Token** — Immutable token with type, value, line, column, and flags
+- **GrammarLexer** — Tokenizes source code using a TokenGrammar from a `.tokens` file
+- First-match-wins pattern matching with priority ordering
+- Keyword promotion, type aliases, reserved keyword detection
+- Context-sensitive keyword flags, newline-preceded flags
+- Error recovery patterns for graceful degradation
+
+## Usage
+
+```java
+import com.codingadventures.lexer.*;
+import com.codingadventures.grammartools.*;
+
+TokenGrammar grammar = TokenGrammarParser.parse(tokensFileContent);
+GrammarLexer lexer = new GrammarLexer(grammar);
+List<Token> tokens = lexer.tokenize("1 + 2");
+```
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools.

--- a/code/packages/java/lexer/build.gradle.kts
+++ b/code/packages/java/lexer/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/lexer/build.gradle.kts
+++ b/code/packages/java/lexer/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/code/packages/java/lexer/settings.gradle.kts
+++ b/code/packages/java/lexer/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "lexer"
+
+includeBuild("../grammar-tools")

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/GrammarLexer.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/GrammarLexer.java
@@ -1,0 +1,234 @@
+// ============================================================================
+// GrammarLexer.java — Grammar-driven tokenizer
+// ============================================================================
+//
+// Instead of hardcoding which characters map to which tokens, this lexer
+// reads token definitions from a TokenGrammar (parsed from a .tokens file)
+// and uses those definitions to drive tokenization at runtime.
+//
+// How it works:
+//
+//   1. Compile each TokenDefinition into a Java regex Pattern.
+//      Literal patterns are escaped with Pattern.quote().
+//      Regex patterns are anchored at the start with \A.
+//
+//   2. At each position in the source, try patterns in priority order
+//      (first match wins). Skip patterns are tried first; if one matches,
+//      the lexer consumes the matched text silently (no token produced).
+//
+//   3. When a definition has an alias (e.g. STRING_DQ -> STRING), the
+//      emitted token uses the alias as its type name.
+//
+//   4. After tokenization, keywords in the grammar's keyword list are
+//      promoted: a NAME token whose value matches a keyword gets its
+//      type changed to KEYWORD.
+//
+//   5. If no pattern matches at a position, the lexer raises a LexerError.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+import com.codingadventures.grammartools.TokenDefinition;
+import com.codingadventures.grammartools.TokenGrammar;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A lexer that tokenizes source code using a {@link TokenGrammar}.
+ *
+ * <p>This is the runtime equivalent of tools like Lex/Flex: it takes a
+ * declarative description of tokens and produces a token stream.
+ */
+public final class GrammarLexer {
+
+    // A compiled pattern ready for matching
+    private record CompiledPattern(String name, Pattern regex, String alias) {}
+
+    private final TokenGrammar grammar;
+    private final List<CompiledPattern> patterns;
+    private final List<CompiledPattern> skipPatterns;
+    private final List<CompiledPattern> errorPatterns;
+    private final Set<String> keywordSet;
+    private final Set<String> reservedSet;
+    private final Set<String> contextKeywordSet;
+
+    /**
+     * Create a new GrammarLexer from a TokenGrammar.
+     *
+     * @param grammar the parsed .tokens file
+     */
+    public GrammarLexer(TokenGrammar grammar) {
+        this.grammar = grammar;
+        this.patterns = compileDefinitions(grammar.getDefinitions());
+        this.skipPatterns = compileDefinitions(grammar.getSkipDefinitions());
+        this.errorPatterns = compileDefinitions(grammar.getErrorDefinitions());
+        this.keywordSet = new HashSet<>(grammar.getKeywords());
+        this.reservedSet = new HashSet<>(grammar.getReservedKeywords());
+        this.contextKeywordSet = new HashSet<>(grammar.getContextKeywords());
+    }
+
+    /**
+     * Tokenize source code into a list of tokens.
+     *
+     * <p>The returned list always ends with an EOF token.
+     *
+     * @param source the source code text
+     * @return list of tokens
+     * @throws LexerError if source cannot be tokenized
+     */
+    public List<Token> tokenize(String source) throws LexerError {
+        // Optionally lowercase source for case-insensitive languages
+        String workingSource = grammar.isCaseSensitive() ? source : source.toLowerCase();
+
+        List<Token> tokens = new ArrayList<>();
+        int pos = 0;
+        int line = 1;
+        int column = 1;
+        boolean precededByNewline = false;
+
+        while (pos < workingSource.length()) {
+            // --- Try skip patterns first ---
+            boolean skipped = false;
+            for (CompiledPattern sp : skipPatterns) {
+                Matcher m = sp.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    String matched = m.group();
+                    // Track newlines in skipped content
+                    for (char ch : matched.toCharArray()) {
+                        if (ch == '\n') {
+                            line++;
+                            column = 1;
+                            precededByNewline = true;
+                        } else {
+                            column++;
+                        }
+                    }
+                    pos += matched.length();
+                    skipped = true;
+                    break;
+                }
+            }
+            if (skipped) continue;
+
+            // --- Try token patterns ---
+            boolean matched = false;
+            for (CompiledPattern cp : patterns) {
+                Matcher m = cp.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    // Use original source for the token value (preserve case)
+                    String value = source.substring(pos, pos + m.group().length());
+                    String typeName = cp.alias != null ? cp.alias : cp.name;
+
+                    // Check for reserved keywords
+                    if ("NAME".equals(typeName) && reservedSet.contains(value)) {
+                        throw new LexerError("Reserved keyword '" + value + "'", line, column);
+                    }
+
+                    // Build flags
+                    int flags = 0;
+                    if (precededByNewline) flags |= Token.FLAG_PRECEDED_BY_NEWLINE;
+                    if ("NAME".equals(typeName) && contextKeywordSet.contains(
+                            grammar.isCaseSensitive() ? value : value.toLowerCase())) {
+                        flags |= Token.FLAG_CONTEXT_KEYWORD;
+                    }
+
+                    Token token = new Token(TokenType.GRAMMAR, value, line, column, typeName, flags);
+                    tokens.add(token);
+
+                    // Advance position and track line/column
+                    for (char ch : value.toCharArray()) {
+                        if (ch == '\n') {
+                            line++;
+                            column = 1;
+                        } else {
+                            column++;
+                        }
+                    }
+                    pos += value.length();
+                    matched = true;
+                    precededByNewline = false;
+                    break;
+                }
+            }
+            if (matched) continue;
+
+            // --- Try error recovery patterns ---
+            boolean errorMatched = false;
+            for (CompiledPattern ep : errorPatterns) {
+                Matcher m = ep.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    String value = source.substring(pos, pos + m.group().length());
+                    String typeName = ep.alias != null ? ep.alias : ep.name;
+                    Token token = new Token(TokenType.GRAMMAR, value, line, column, typeName, 0);
+                    tokens.add(token);
+
+                    for (char ch : value.toCharArray()) {
+                        if (ch == '\n') { line++; column = 1; }
+                        else column++;
+                    }
+                    pos += value.length();
+                    errorMatched = true;
+                    break;
+                }
+            }
+            if (errorMatched) continue;
+
+            // No pattern matched
+            throw new LexerError("Unexpected character '" + source.charAt(pos) + "'", line, column);
+        }
+
+        // Keyword promotion: NAME tokens whose values match keywords become KEYWORD
+        promoteKeywords(tokens);
+
+        // Add EOF token
+        tokens.add(new Token(TokenType.EOF, "", line, column, "EOF", 0));
+        return tokens;
+    }
+
+    /**
+     * Promote NAME tokens whose values match keywords to KEYWORD type.
+     */
+    private void promoteKeywords(List<Token> tokens) {
+        if (keywordSet.isEmpty()) return;
+        for (int i = 0; i < tokens.size(); i++) {
+            Token t = tokens.get(i);
+            if ("NAME".equals(t.getTypeName())) {
+                String checkValue = grammar.isCaseSensitive() ? t.getValue() : t.getValue().toLowerCase();
+                if (keywordSet.contains(checkValue)) {
+                    tokens.set(i, new Token(TokenType.KEYWORD, t.getValue(), t.getLine(), t.getColumn(),
+                            "KEYWORD", t.getFlags()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Compile a list of TokenDefinitions into regex patterns.
+     */
+    private static List<CompiledPattern> compileDefinitions(List<TokenDefinition> definitions) {
+        List<CompiledPattern> result = new ArrayList<>();
+        for (TokenDefinition defn : definitions) {
+            String regexStr;
+            if (defn.isRegex()) {
+                // Anchor regex at current position with \G
+                regexStr = "\\G(?:" + defn.getPattern() + ")";
+            } else {
+                // Escape literal and anchor
+                regexStr = "\\G" + Pattern.quote(defn.getPattern());
+            }
+            Pattern regex = Pattern.compile(regexStr);
+            result.add(new CompiledPattern(defn.getName(), regex, defn.getAlias()));
+        }
+        return result;
+    }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/LexerError.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/LexerError.java
@@ -1,0 +1,23 @@
+// ============================================================================
+// LexerError.java — Exception for tokenization errors
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+/**
+ * Thrown when the lexer encounters text it cannot tokenize.
+ */
+public class LexerError extends Exception {
+
+    private final int line;
+    private final int column;
+
+    public LexerError(String message, int line, int column) {
+        super("Lexer error at " + line + ":" + column + ": " + message);
+        this.line = line;
+        this.column = column;
+    }
+
+    public int getLine() { return line; }
+    public int getColumn() { return column; }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/Token.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/Token.java
@@ -1,0 +1,101 @@
+// ============================================================================
+// Token.java — A single token produced by a lexer
+// ============================================================================
+//
+// A token is the atomic unit of source code. Just as written English can be
+// decomposed into words, punctuation, and spaces, source code can be
+// decomposed into tokens: identifiers, numbers, operators, keywords, etc.
+//
+// Every token carries four pieces of information:
+//
+//   1. Type — what kind of token (NUMBER, PLUS, NAME, etc.)
+//   2. Value — the actual text from the source code
+//   3. Line — which line the token appeared on (1-based)
+//   4. Column — which column the token starts at (1-based)
+//
+// The type/value distinction is important: the token "42" has type NUMBER
+// and value "42". The token "+" has type PLUS and value "+". The parser
+// cares about types (it matches on NUMBER, not "42"); the code generator
+// cares about values (it needs the actual number 42).
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+import java.util.Objects;
+
+/**
+ * An immutable token from source code.
+ *
+ * <p>Grammar-driven tokens use {@code typeName} to carry the grammar-defined
+ * token name (e.g. "INT", "FLOAT_LITERAL"). Hand-written lexer tokens use
+ * the {@code type} enum and leave {@code typeName} null.
+ */
+public final class Token {
+
+    /** Bitmask flag: a line break appeared before this token. */
+    public static final int FLAG_PRECEDED_BY_NEWLINE = 1;
+
+    /** Bitmask flag: this is a context-sensitive keyword. */
+    public static final int FLAG_CONTEXT_KEYWORD = 2;
+
+    private final TokenType type;
+    private final String value;
+    private final int line;
+    private final int column;
+    private final String typeName;
+    private final int flags;
+
+    public Token(TokenType type, String value, int line, int column, String typeName, int flags) {
+        this.type = type;
+        this.value = Objects.requireNonNull(value);
+        this.line = line;
+        this.column = column;
+        this.typeName = typeName;
+        this.flags = flags;
+    }
+
+    public Token(TokenType type, String value, int line, int column) {
+        this(type, value, line, column, null, 0);
+    }
+
+    public Token(TokenType type, String value, int line, int column, String typeName) {
+        this(type, value, line, column, typeName, 0);
+    }
+
+    public TokenType getType() { return type; }
+    public String getValue() { return value; }
+    public int getLine() { return line; }
+    public int getColumn() { return column; }
+    public String getTypeName() { return typeName; }
+    public int getFlags() { return flags; }
+
+    /** Returns the effective type name: typeName if set, else the TokenType name. */
+    public String effectiveTypeName() {
+        return typeName != null ? typeName : type.name();
+    }
+
+    /** Check if a specific flag is set. */
+    public boolean hasFlag(int flag) {
+        return (flags & flag) != 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Token(" + effectiveTypeName() + ", \"" + value + "\", " + line + ":" + column + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Token that)) return false;
+        return type == that.type && line == that.line && column == that.column
+                && flags == that.flags && value.equals(that.value) && Objects.equals(typeName, that.typeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, value, line, column, typeName, flags);
+    }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/TokenType.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/TokenType.java
@@ -1,0 +1,44 @@
+// ============================================================================
+// TokenType.java — Standard token type enumeration
+// ============================================================================
+//
+// These are the built-in token types used by the hand-written lexer.
+// Grammar-driven lexers use the typeName field on Token instead, since
+// token types are defined by the .tokens file, not a fixed enum.
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+/**
+ * Standard token types for hand-written lexers.
+ *
+ * <p>Grammar-driven lexers use string type names from the .tokens file instead
+ * of this enum, but this enum is still needed for the generic Token class.
+ */
+public enum TokenType {
+    NAME,
+    NUMBER,
+    STRING,
+    KEYWORD,
+    PLUS,
+    MINUS,
+    STAR,
+    SLASH,
+    EQUALS,
+    EQUALS_EQUALS,
+    LPAREN,
+    RPAREN,
+    COMMA,
+    COLON,
+    SEMICOLON,
+    LBRACE,
+    RBRACE,
+    LBRACKET,
+    RBRACKET,
+    DOT,
+    BANG,
+    NEWLINE,
+    EOF,
+    /** Grammar-driven token — the actual type is in Token.typeName. */
+    GRAMMAR
+}

--- a/code/packages/java/lexer/src/test/java/com/codingadventures/lexer/LexerTest.java
+++ b/code/packages/java/lexer/src/test/java/com/codingadventures/lexer/LexerTest.java
@@ -1,0 +1,211 @@
+package com.codingadventures.lexer;
+
+import com.codingadventures.grammartools.TokenGrammar;
+import com.codingadventures.grammartools.TokenGrammarParser;
+import com.codingadventures.grammartools.TokenGrammarError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LexerTest {
+
+    // =========================================================================
+    // Token Tests
+    // =========================================================================
+
+    @Nested
+    class TokenTests {
+
+        @Test void construction() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals(TokenType.NUMBER, t.getType());
+            assertEquals("42", t.getValue());
+            assertEquals(1, t.getLine());
+            assertEquals(1, t.getColumn());
+        }
+
+        @Test void effectiveTypeNameWithoutTypeName() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals("NUMBER", t.effectiveTypeName());
+        }
+
+        @Test void effectiveTypeNameWithTypeName() {
+            Token t = new Token(TokenType.GRAMMAR, "42", 1, 1, "INT");
+            assertEquals("INT", t.effectiveTypeName());
+        }
+
+        @Test void flagPrecededByNewline() {
+            Token t = new Token(TokenType.GRAMMAR, "x", 2, 1, "NAME", Token.FLAG_PRECEDED_BY_NEWLINE);
+            assertTrue(t.hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+            assertFalse(t.hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void flagContextKeyword() {
+            Token t = new Token(TokenType.GRAMMAR, "async", 1, 1, "NAME", Token.FLAG_CONTEXT_KEYWORD);
+            assertTrue(t.hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void toStringFormat() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 5);
+            assertEquals("Token(NUMBER, \"42\", 1:5)", t.toString());
+        }
+
+        @Test void equality() {
+            Token a = new Token(TokenType.NUMBER, "42", 1, 1);
+            Token b = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals(a, b);
+        }
+
+        @Test void inequality() {
+            Token a = new Token(TokenType.NUMBER, "42", 1, 1);
+            Token b = new Token(TokenType.NUMBER, "43", 1, 1);
+            assertNotEquals(a, b);
+        }
+    }
+
+    // =========================================================================
+    // Grammar Lexer Tests
+    // =========================================================================
+
+    @Nested
+    class GrammarLexerTests {
+
+        private TokenGrammar parseGrammar(String source) {
+            try {
+                return TokenGrammarParser.parse(source);
+            } catch (TokenGrammarError e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test void simpleTokenization() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NUMBER = /[0-9]+/\nPLUS = \"+\"\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("42 + 7");
+
+            assertEquals(4, tokens.size()); // NUMBER, PLUS, NUMBER, EOF
+            assertEquals("NUMBER", tokens.get(0).getTypeName());
+            assertEquals("42", tokens.get(0).getValue());
+            assertEquals("PLUS", tokens.get(1).getTypeName());
+            assertEquals("NUMBER", tokens.get(2).getTypeName());
+            assertEquals("7", tokens.get(2).getValue());
+            assertEquals("EOF", tokens.get(3).getTypeName());
+        }
+
+        @Test void lineAndColumnTracking() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nNL = /\\n/\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("abc\ndef");
+
+            assertEquals("abc", tokens.get(0).getValue());
+            assertEquals(1, tokens.get(0).getLine());
+            assertEquals(1, tokens.get(0).getColumn());
+
+            // NL token
+            assertEquals(1, tokens.get(1).getLine());
+            assertEquals(4, tokens.get(1).getColumn());
+
+            assertEquals("def", tokens.get(2).getValue());
+            assertEquals(2, tokens.get(2).getLine());
+            assertEquals(1, tokens.get(2).getColumn());
+        }
+
+        @Test void keywordPromotion() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\nkeywords:\n  if\n  else\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("if x else y");
+
+            assertEquals("KEYWORD", tokens.get(0).getTypeName());
+            assertEquals("if", tokens.get(0).getValue());
+            assertEquals("NAME", tokens.get(1).getTypeName());
+            assertEquals("KEYWORD", tokens.get(2).getTypeName());
+            assertEquals("NAME", tokens.get(3).getTypeName());
+        }
+
+        @Test void aliasedToken() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "STRING_DQ = /\"[^\"]*\"/ -> STRING\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("\"hello\"");
+
+            assertEquals("STRING", tokens.get(0).getTypeName());
+            assertEquals("\"hello\"", tokens.get(0).getValue());
+        }
+
+        @Test void unexpectedCharacterError() {
+            TokenGrammar g = parseGrammar("NUMBER = /[0-9]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            assertThrows(LexerError.class, () -> lexer.tokenize("abc"));
+        }
+
+        @Test void reservedKeywordError() {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nreserved:\n  class\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            assertThrows(LexerError.class, () -> lexer.tokenize("class"));
+        }
+
+        @Test void emptyInput() throws Exception {
+            TokenGrammar g = parseGrammar("NUMBER = /[0-9]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("");
+            assertEquals(1, tokens.size());
+            assertEquals("EOF", tokens.get(0).getTypeName());
+        }
+
+        @Test void multiplePatterns() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NUMBER = /[0-9]+/\nNAME = /[a-zA-Z_][a-zA-Z0-9_]*/\nPLUS = \"+\"\nMINUS = \"-\"\n"
+                    + "skip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("x + 42 - y");
+            assertEquals(6, tokens.size()); // NAME PLUS NUMBER MINUS NAME EOF
+        }
+
+        @Test void firstMatchWins() throws Exception {
+            // When two patterns could match at the same position, the first
+            // definition in the file wins. Here FLOAT is listed before INT,
+            // so "3.14" matches FLOAT rather than INT + error.
+            TokenGrammar g = parseGrammar(
+                    "FLOAT = /[0-9]+\\.[0-9]+/\nINT = /[0-9]+/\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("3.14 42");
+            assertEquals("FLOAT", tokens.get(0).getTypeName());
+            assertEquals("3.14", tokens.get(0).getValue());
+            assertEquals("INT", tokens.get(1).getTypeName());
+            assertEquals("42", tokens.get(1).getValue());
+        }
+
+        @Test void contextKeywordFlag() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\ncontext_keywords:\n  async\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("async foo");
+            assertTrue(tokens.get(0).hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+            assertFalse(tokens.get(1).hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void errorRecoveryPatterns() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "STRING = /\"[^\"]*\"/\nskip:\n  WS = /[ \\t]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("\"unclosed");
+            assertEquals("BAD_STRING", tokens.get(0).getTypeName());
+        }
+
+        @Test void precededByNewlineFlag() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t\\n]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("a\nb");
+            assertFalse(tokens.get(0).hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+            assertTrue(tokens.get(1).hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+        }
+    }
+}

--- a/code/packages/java/parser/.gitignore
+++ b/code/packages/java/parser/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/parser/BUILD
+++ b/code/packages/java/parser/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test

--- a/code/packages/java/parser/BUILD_windows
+++ b/code/packages/java/parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/parser/CHANGELOG.md
+++ b/code/packages/java/parser/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `ASTNode` — generic AST node with position tracking
+- `GrammarParser` — recursive descent parser driven by ParserGrammar
+- Packrat memoization for all (rule, position) pairs
+- Support for all EBNF constructs
+- Full test suite

--- a/code/packages/java/parser/README.md
+++ b/code/packages/java/parser/README.md
@@ -1,0 +1,26 @@
+# parser (Java)
+
+Generic grammar-driven parser infrastructure for the coding-adventures project.
+
+## What it does
+
+- **ASTNode** — Generic AST node with rule name, children (nodes or tokens), and position tracking
+- **GrammarParser** — Recursive descent parser driven by a ParserGrammar from a `.grammar` file
+- Packrat memoization for efficient parsing
+- Supports all EBNF constructs: sequence, alternation, repetition, optional, lookaheads, separated repetition
+
+## Usage
+
+```java
+import com.codingadventures.parser.*;
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.*;
+
+ParserGrammar grammar = ParserGrammarParser.parse(grammarFileContent);
+GrammarParser parser = new GrammarParser(grammar);
+ASTNode ast = parser.parse(tokens);
+```
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools and lexer.

--- a/code/packages/java/parser/build.gradle.kts
+++ b/code/packages/java/parser/build.gradle.kts
@@ -1,0 +1,30 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    implementation("com.codingadventures:lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/parser/build.gradle.kts
+++ b/code/packages/java/parser/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/code/packages/java/parser/settings.gradle.kts
+++ b/code/packages/java/parser/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/ASTNode.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/ASTNode.java
@@ -1,0 +1,104 @@
+// ============================================================================
+// ASTNode.java — Generic AST node for grammar-driven parsing
+// ============================================================================
+//
+// When a grammar-driven parser processes a token stream, it produces a tree
+// of ASTNode objects. Each ASTNode represents either:
+//
+//   1. A rule match — a node with a rule name and child nodes/tokens
+//   2. A leaf — a node wrapping a single Token from the lexer
+//
+// The tree structure mirrors the grammar rules. For example, parsing
+// "1 + 2" with the grammar:
+//
+//   expression = term { PLUS term } ;
+//   term = NUMBER ;
+//
+// Produces:
+//
+//   ASTNode("expression")
+//     ASTNode("term")
+//       Token(NUMBER, "1")
+//     Token(PLUS, "+")
+//     ASTNode("term")
+//       Token(NUMBER, "2")
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.lexer.Token;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A generic AST node produced by grammar-driven parsing.
+ *
+ * <p>Children can be either other ASTNode instances or Token instances
+ * from the lexer. Use {@link #isLeaf()} and {@link #getToken()} to check
+ * for leaf nodes.
+ */
+public final class ASTNode {
+
+    private final String ruleName;
+    private final List<Object> children; // ASTNode or Token
+    private final int startLine;
+    private final int startColumn;
+    private final int endLine;
+    private final int endColumn;
+
+    public ASTNode(String ruleName, List<Object> children,
+                   int startLine, int startColumn, int endLine, int endColumn) {
+        this.ruleName = ruleName;
+        this.children = Collections.unmodifiableList(new ArrayList<>(children));
+        this.startLine = startLine;
+        this.startColumn = startColumn;
+        this.endLine = endLine;
+        this.endColumn = endColumn;
+    }
+
+    public ASTNode(String ruleName, List<Object> children) {
+        this(ruleName, children, 0, 0, 0, 0);
+    }
+
+    public ASTNode(String ruleName) {
+        this(ruleName, List.of());
+    }
+
+    public String getRuleName() { return ruleName; }
+    public List<Object> getChildren() { return children; }
+    public int getStartLine() { return startLine; }
+    public int getStartColumn() { return startColumn; }
+    public int getEndLine() { return endLine; }
+    public int getEndColumn() { return endColumn; }
+
+    /** True if this node wraps exactly one Token. */
+    public boolean isLeaf() {
+        return children.size() == 1 && children.get(0) instanceof Token;
+    }
+
+    /** Returns the leaf Token if isLeaf(), null otherwise. */
+    public Token getToken() {
+        return isLeaf() ? (Token) children.get(0) : null;
+    }
+
+    /** Count the total number of descendant nodes (for testing/debugging). */
+    public int descendantCount() {
+        int count = 0;
+        for (Object child : children) {
+            count++;
+            if (child instanceof ASTNode node) {
+                count += node.descendantCount();
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return "ASTNode(" + ruleName + ", " + children.size() + " children)";
+    }
+}

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParseError.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParseError.java
@@ -1,0 +1,22 @@
+// ============================================================================
+// GrammarParseError.java — Exception for grammar-driven parse failures
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.lexer.Token;
+
+/**
+ * Thrown when grammar-driven parsing fails.
+ */
+public class GrammarParseError extends Exception {
+
+    private final Token token;
+
+    public GrammarParseError(String message, Token token) {
+        super("Parse error at " + token.getLine() + ":" + token.getColumn() + ": " + message);
+        this.token = token;
+    }
+
+    public Token getToken() { return token; }
+}

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParser.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParser.java
@@ -1,0 +1,282 @@
+// ============================================================================
+// GrammarParser.java — Grammar-driven recursive descent parser
+// ============================================================================
+//
+// This parser takes a token stream (from a GrammarLexer) and a ParserGrammar
+// (from a .grammar file) and produces an AST. It implements a recursive
+// descent parser with packrat memoization for each (rule, position) pair.
+//
+// How it works:
+//
+//   1. Build a rule lookup table from the ParserGrammar's rule list.
+//
+//   2. Start parsing from the first rule (the start symbol).
+//
+//   3. For each rule, recursively match the rule body against the token
+//      stream. The body is a tree of GrammarElement nodes (Sequence,
+//      Alternation, Repetition, etc.) that we match recursively.
+//
+//   4. Each successful match returns a list of children (ASTNode and Token
+//      objects) and the new position in the token stream.
+//
+//   5. Each (rule, position) result is memoized so we never re-parse the
+//      same rule at the same position twice (packrat optimization).
+//
+// EBNF construct matching:
+//
+//   RuleReference (lowercase) — recursively parse the named rule
+//   RuleReference (UPPERCASE) — match a token with that type name
+//   Literal                   — match a token with that exact value
+//   Sequence                  — match all elements in order
+//   Alternation               — try each choice, take first that succeeds
+//   Repetition                — match zero or more times
+//   OneOrMoreRepetition       — match one or more times
+//   Optional                  — match zero or one time
+//   Group                     — match inner element (parenthesized grouping)
+//   PositiveLookahead         — succeed if element matches (no consumption)
+//   NegativeLookahead         — succeed if element does NOT match
+//   SeparatedRepetition       — match with separator between elements
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.Token;
+
+import java.util.*;
+
+/**
+ * A grammar-driven recursive descent parser with packrat memoization.
+ */
+public final class GrammarParser {
+
+    private final ParserGrammar grammar;
+    private final Map<String, GrammarRule> ruleMap;
+
+    public GrammarParser(ParserGrammar grammar) {
+        this.grammar = grammar;
+        this.ruleMap = new HashMap<>();
+        for (GrammarRule rule : grammar.getRules()) {
+            ruleMap.put(rule.name(), rule);
+        }
+    }
+
+    /**
+     * Parse a token list starting from the grammar's first rule.
+     *
+     * @param tokens the token list (must end with an EOF token)
+     * @return the root ASTNode
+     * @throws GrammarParseError if parsing fails
+     */
+    public ASTNode parse(List<Token> tokens) throws GrammarParseError {
+        if (grammar.getRules().isEmpty()) {
+            throw new GrammarParseError("No rules in grammar", tokens.get(tokens.size() - 1));
+        }
+
+        String startRule = grammar.getRules().get(0).name();
+        Map<String, Map<Integer, MemoEntry>> memo = new HashMap<>();
+
+        MatchResult result = matchRule(startRule, tokens, 0, memo);
+        if (result == null) {
+            throw new GrammarParseError("Failed to parse starting rule '" + startRule + "'",
+                    tokens.get(0));
+        }
+
+        return buildNode(startRule, result.children, tokens);
+    }
+
+    // =========================================================================
+    // Internal matching
+    // =========================================================================
+
+    private record MemoEntry(List<Object> children, int endPos, boolean ok) {}
+    private record MatchResult(List<Object> children, int endPos) {}
+
+    private MatchResult matchRule(String ruleName, List<Token> tokens, int pos,
+                                  Map<String, Map<Integer, MemoEntry>> memo) {
+        // Check memo
+        Map<Integer, MemoEntry> ruleMemo = memo.computeIfAbsent(ruleName, k -> new HashMap<>());
+        MemoEntry cached = ruleMemo.get(pos);
+        if (cached != null) {
+            return cached.ok ? new MatchResult(cached.children, cached.endPos) : null;
+        }
+
+        GrammarRule rule = ruleMap.get(ruleName);
+        if (rule == null) {
+            ruleMemo.put(pos, new MemoEntry(null, pos, false));
+            return null;
+        }
+
+        MatchResult result = matchElement(rule.body(), tokens, pos, memo);
+        if (result != null) {
+            // Wrap in a rule node
+            List<Object> wrapped = List.of(buildNode(ruleName, result.children, tokens));
+            ruleMemo.put(pos, new MemoEntry(wrapped, result.endPos, true));
+            return new MatchResult(wrapped, result.endPos);
+        }
+
+        ruleMemo.put(pos, new MemoEntry(null, pos, false));
+        return null;
+    }
+
+    private MatchResult matchElement(GrammarElement element, List<Token> tokens, int pos,
+                                     Map<String, Map<Integer, MemoEntry>> memo) {
+        return switch (element) {
+            case GrammarElement.RuleReference ref -> {
+                if (ref.isToken()) {
+                    // Match a token by type name
+                    if (pos < tokens.size()) {
+                        Token tok = tokens.get(pos);
+                        if (ref.name().equals(tok.effectiveTypeName())) {
+                            yield new MatchResult(List.of(tok), pos + 1);
+                        }
+                    }
+                    yield null;
+                } else {
+                    // Match a grammar rule
+                    yield matchRule(ref.name(), tokens, pos, memo);
+                }
+            }
+
+            case GrammarElement.Literal lit -> {
+                if (pos < tokens.size() && lit.value().equals(tokens.get(pos).getValue())) {
+                    yield new MatchResult(List.of(tokens.get(pos)), pos + 1);
+                }
+                yield null;
+            }
+
+            case GrammarElement.Sequence seq -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+                for (GrammarElement sub : seq.elements()) {
+                    MatchResult r = matchElement(sub, tokens, curPos, memo);
+                    if (r == null) yield null;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.Alternation alt -> {
+                for (GrammarElement choice : alt.choices()) {
+                    MatchResult r = matchElement(choice, tokens, pos, memo);
+                    if (r != null) yield r;
+                }
+                yield null;
+            }
+
+            case GrammarElement.Repetition rep -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+                while (true) {
+                    MatchResult r = matchElement(rep.element(), tokens, curPos, memo);
+                    if (r == null || r.endPos == curPos) break;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.OneOrMoreRepetition rep -> {
+                MatchResult first = matchElement(rep.element(), tokens, pos, memo);
+                if (first == null) yield null;
+                List<Object> children = new ArrayList<>(first.children);
+                int curPos = first.endPos;
+                while (true) {
+                    MatchResult r = matchElement(rep.element(), tokens, curPos, memo);
+                    if (r == null || r.endPos == curPos) break;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.Optional opt -> {
+                MatchResult r = matchElement(opt.element(), tokens, pos, memo);
+                yield r != null ? r : new MatchResult(List.of(), pos);
+            }
+
+            case GrammarElement.Group grp ->
+                matchElement(grp.element(), tokens, pos, memo);
+
+            case GrammarElement.PositiveLookahead la -> {
+                MatchResult r = matchElement(la.element(), tokens, pos, memo);
+                yield r != null ? new MatchResult(List.of(), pos) : null;
+            }
+
+            case GrammarElement.NegativeLookahead la -> {
+                MatchResult r = matchElement(la.element(), tokens, pos, memo);
+                yield r == null ? new MatchResult(List.of(), pos) : null;
+            }
+
+            case GrammarElement.SeparatedRepetition sep -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+
+                // First element
+                MatchResult first = matchElement(sep.element(), tokens, curPos, memo);
+                if (first == null) {
+                    yield sep.atLeastOne() ? null : new MatchResult(List.of(), pos);
+                }
+                children.addAll(first.children);
+                curPos = first.endPos;
+
+                // Subsequent: separator then element
+                while (true) {
+                    MatchResult sepMatch = matchElement(sep.separator(), tokens, curPos, memo);
+                    if (sepMatch == null) break;
+                    MatchResult elemMatch = matchElement(sep.element(), tokens, sepMatch.endPos, memo);
+                    if (elemMatch == null) break;
+                    children.addAll(sepMatch.children);
+                    children.addAll(elemMatch.children);
+                    curPos = elemMatch.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+        };
+    }
+
+    private ASTNode buildNode(String ruleName, List<Object> children, List<Token> tokens) {
+        int startLine = 0, startColumn = 0, endLine = 0, endColumn = 0;
+
+        // Find position from first and last tokens in children
+        Token firstToken = findFirstToken(children);
+        Token lastToken = findLastToken(children);
+
+        if (firstToken != null) {
+            startLine = firstToken.getLine();
+            startColumn = firstToken.getColumn();
+        }
+        if (lastToken != null) {
+            endLine = lastToken.getLine();
+            endColumn = lastToken.getColumn();
+        }
+
+        return new ASTNode(ruleName, children, startLine, startColumn, endLine, endColumn);
+    }
+
+    private Token findFirstToken(List<Object> children) {
+        for (Object child : children) {
+            if (child instanceof Token t) return t;
+            if (child instanceof ASTNode node) {
+                Token t = findFirstToken(node.getChildren());
+                if (t != null) return t;
+            }
+        }
+        return null;
+    }
+
+    private Token findLastToken(List<Object> children) {
+        for (int i = children.size() - 1; i >= 0; i--) {
+            Object child = children.get(i);
+            if (child instanceof Token t) return t;
+            if (child instanceof ASTNode node) {
+                Token t = findLastToken(node.getChildren());
+                if (t != null) return t;
+            }
+        }
+        return null;
+    }
+}

--- a/code/packages/java/parser/src/test/java/com/codingadventures/parser/ParserTest.java
+++ b/code/packages/java/parser/src/test/java/com/codingadventures/parser/ParserTest.java
@@ -1,0 +1,189 @@
+package com.codingadventures.parser;
+
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserTest {
+
+    // =========================================================================
+    // ASTNode Tests
+    // =========================================================================
+
+    @Nested
+    class ASTNodeTests {
+
+        @Test void emptyNode() {
+            ASTNode node = new ASTNode("test");
+            assertEquals("test", node.getRuleName());
+            assertTrue(node.getChildren().isEmpty());
+            assertFalse(node.isLeaf());
+            assertNull(node.getToken());
+        }
+
+        @Test void leafNode() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            ASTNode node = new ASTNode("number", List.of(t));
+            assertTrue(node.isLeaf());
+            assertEquals(t, node.getToken());
+        }
+
+        @Test void branchNode() {
+            Token t1 = new Token(TokenType.NUMBER, "1", 1, 1);
+            Token t2 = new Token(TokenType.NUMBER, "2", 1, 5);
+            ASTNode child1 = new ASTNode("num", List.of(t1));
+            ASTNode child2 = new ASTNode("num", List.of(t2));
+            ASTNode parent = new ASTNode("add", List.of(child1, child2));
+            assertFalse(parent.isLeaf());
+            assertEquals(2, parent.getChildren().size());
+        }
+
+        @Test void descendantCount() {
+            Token t = new Token(TokenType.NUMBER, "1", 1, 1);
+            ASTNode leaf = new ASTNode("num", List.of(t));
+            ASTNode parent = new ASTNode("expr", List.of(leaf));
+            assertEquals(2, parent.descendantCount()); // leaf + token
+        }
+
+        @Test void positionTracking() {
+            ASTNode node = new ASTNode("test", List.of(), 1, 5, 3, 10);
+            assertEquals(1, node.getStartLine());
+            assertEquals(5, node.getStartColumn());
+            assertEquals(3, node.getEndLine());
+            assertEquals(10, node.getEndColumn());
+        }
+    }
+
+    // =========================================================================
+    // Grammar Parser Tests
+    // =========================================================================
+
+    @Nested
+    class GrammarParserTests {
+
+        private List<Token> makeTokens(String... typesAndValues) {
+            List<Token> tokens = new java.util.ArrayList<>();
+            for (int i = 0; i < typesAndValues.length; i += 2) {
+                tokens.add(new Token(TokenType.GRAMMAR, typesAndValues[i + 1],
+                        1, tokens.size() + 1, typesAndValues[i]));
+            }
+            tokens.add(new Token(TokenType.EOF, "", 1, tokens.size() + 1, "EOF"));
+            return tokens;
+        }
+
+        @Test void singleTokenRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("program = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            List<Token> tokens = makeTokens("NUMBER", "42");
+            ASTNode ast = parser.parse(tokens);
+            assertEquals("program", ast.getRuleName());
+        }
+
+        @Test void sequenceRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            List<Token> tokens = makeTokens("NAME", "x", "EQUALS", "=", "NUMBER", "42");
+            ASTNode ast = parser.parse(tokens);
+            assertEquals("assign", ast.getRuleName());
+        }
+
+        @Test void alternationRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("value = NUMBER | NAME ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // First alternative
+            ASTNode ast1 = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("value", ast1.getRuleName());
+
+            // Second alternative
+            ASTNode ast2 = parser.parse(makeTokens("NAME", "x"));
+            assertEquals("value", ast2.getRuleName());
+        }
+
+        @Test void repetitionRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("list = { NUMBER } ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // Zero items
+            ASTNode empty = parser.parse(makeTokens());
+            assertEquals("list", empty.getRuleName());
+
+            // Multiple items
+            ASTNode multi = parser.parse(makeTokens("NUMBER", "1", "NUMBER", "2", "NUMBER", "3"));
+            assertEquals("list", multi.getRuleName());
+        }
+
+        @Test void optionalRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("maybe = [ NUMBER ] ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // Present
+            ASTNode present = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("maybe", present.getRuleName());
+
+            // Absent
+            ASTNode absent = parser.parse(makeTokens());
+            assertEquals("maybe", absent.getRuleName());
+        }
+
+        @Test void nestedRules() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse(
+                    "program = { statement } ;\nstatement = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "1", "NUMBER", "2"));
+            assertEquals("program", ast.getRuleName());
+        }
+
+        @Test void parseFailure() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("program = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens("NAME", "x")));
+        }
+
+        @Test void emptyGrammarThrows() {
+            ParserGrammar g = new ParserGrammar();
+            GrammarParser parser = new GrammarParser(g);
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens()));
+        }
+
+        @Test void positiveLookahead() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = &NUMBER NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("check", ast.getRuleName());
+        }
+
+        @Test void negativeLookahead() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NAME NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("check", ast.getRuleName());
+        }
+
+        @Test void negativeLookaheadFails() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NUMBER NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            // Negative lookahead sees NUMBER, so it fails, and the whole parse fails
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens("NUMBER", "42")));
+        }
+
+        @Test void separatedRepetition() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("args = { NUMBER // COMMA } ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "1", "COMMA", ",", "NUMBER", "2"));
+            assertEquals("args", ast.getRuleName());
+        }
+
+        @Test void literalMatch() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("op = \"+\" ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("PLUS", "+"));
+            assertEquals("op", ast.getRuleName());
+        }
+    }
+}

--- a/code/packages/kotlin/document-ast/.gitignore
+++ b/code/packages/kotlin/document-ast/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/document-ast/BUILD
+++ b/code/packages/kotlin/document-ast/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/document-ast/BUILD_windows
+++ b/code/packages/kotlin/document-ast/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/document-ast/CHANGELOG.md
+++ b/code/packages/kotlin/document-ast/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Sealed interface hierarchy: Node, BlockNode, InlineNode
+- 13 block node types, 11 inline node types
+- TableAlignment enum
+- Full test suite with exhaustive when-expression tests

--- a/code/packages/kotlin/document-ast/README.md
+++ b/code/packages/kotlin/document-ast/README.md
@@ -1,0 +1,7 @@
+# document-ast (Kotlin)
+
+Universal document IR types using Kotlin sealed interfaces and data classes.
+
+## Layer
+
+TE00 (text/language layer — document IR). Leaf package, zero dependencies.

--- a/code/packages/kotlin/document-ast/build.gradle.kts
+++ b/code/packages/kotlin/document-ast/build.gradle.kts
@@ -19,8 +19,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "23"
-    sourceCompatibility = "23"
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 dependencies {

--- a/code/packages/kotlin/document-ast/build.gradle.kts
+++ b/code/packages/kotlin/document-ast/build.gradle.kts
@@ -1,0 +1,34 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "23"
+    sourceCompatibility = "23"
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/document-ast/build.gradle.kts
+++ b/code/packages/kotlin/document-ast/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/code/packages/kotlin/document-ast/settings.gradle.kts
+++ b/code/packages/kotlin/document-ast/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "document-ast"

--- a/code/packages/kotlin/document-ast/src/main/kotlin/com/codingadventures/documentast/DocumentAst.kt
+++ b/code/packages/kotlin/document-ast/src/main/kotlin/com/codingadventures/documentast/DocumentAst.kt
@@ -1,0 +1,180 @@
+// ============================================================================
+// DocumentAst.kt — Universal document IR types
+// ============================================================================
+//
+// The Document AST is a format-agnostic intermediate representation for
+// structured documents. It sits between source formats (Markdown, RST, HTML)
+// and output renderers (HTML, PDF, plain text).
+//
+// Kotlin's sealed interfaces provide exhaustive when-expressions, ensuring
+// every node type is handled at compile time.
+//
+// Design principles:
+//   1. Semantic, not notational — nodes carry meaning, not syntax
+//   2. Resolved, not deferred — all references resolved before IR
+//   3. Format-agnostic — RawBlock/RawInline carry format tags
+//   4. Minimal and stable — only universal document concepts
+//
+// Layer: TE00 (text/language layer — document IR)
+// ============================================================================
+
+package com.codingadventures.documentast
+
+// ---------------------------------------------------------------------------
+// Root interface
+// ---------------------------------------------------------------------------
+
+/** Root interface for all Document AST nodes. */
+sealed interface Node {
+    val nodeType: String
+}
+
+// ---------------------------------------------------------------------------
+// Block nodes
+// ---------------------------------------------------------------------------
+
+/** Block-level nodes form the structural skeleton of a document. */
+sealed interface BlockNode : Node
+
+/** Root of every document. */
+data class DocumentNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "document"
+}
+
+/** Section heading with depth 1-6. */
+data class HeadingNode(val level: Int, val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "heading"
+}
+
+/** A block of prose containing inline nodes. */
+data class ParagraphNode(val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "paragraph"
+}
+
+/** A block of literal code. */
+data class CodeBlockNode(val language: String, val value: String) : BlockNode {
+    override val nodeType get() = "code_block"
+}
+
+/** Quotation or aside. Can contain nested blocks. */
+data class BlockquoteNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "blockquote"
+}
+
+/** Ordered or unordered list. */
+data class ListNode(
+    val ordered: Boolean,
+    val start: Int,
+    val tight: Boolean,
+    val children: List<BlockNode>
+) : BlockNode {
+    override val nodeType get() = "list"
+}
+
+/** One item in a list. */
+data class ListItemNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "list_item"
+}
+
+/** Task-list item with checkbox. */
+data class TaskItemNode(val checked: Boolean, val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "task_item"
+}
+
+/** Horizontal rule. Leaf node. */
+data object ThematicBreakNode : BlockNode {
+    override val nodeType get() = "thematic_break"
+}
+
+/** Raw content for a specific back-end format. */
+data class RawBlockNode(val format: String, val value: String) : BlockNode {
+    override val nodeType get() = "raw_block"
+}
+
+/** Table with column alignments and rows. */
+data class TableNode(val align: List<TableAlignment>, val rows: List<TableRowNode>) : BlockNode {
+    override val nodeType get() = "table"
+}
+
+/** One row in a table. */
+data class TableRowNode(val isHeader: Boolean, val cells: List<TableCellNode>) : BlockNode {
+    override val nodeType get() = "table_row"
+}
+
+/** Single table cell. */
+data class TableCellNode(val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "table_cell"
+}
+
+/** Column alignment for tables. */
+enum class TableAlignment { NONE, LEFT, RIGHT, CENTER }
+
+// ---------------------------------------------------------------------------
+// Inline nodes
+// ---------------------------------------------------------------------------
+
+/** Inline nodes appear inside block nodes that contain prose. */
+sealed interface InlineNode : Node
+
+/** Plain text with no markup. */
+data class TextNode(val value: String) : InlineNode {
+    override val nodeType get() = "text"
+}
+
+/** Stressed emphasis (italic). */
+data class EmphasisNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "emphasis"
+}
+
+/** Strong importance (bold). */
+data class StrongNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "strong"
+}
+
+/** Struck-through text. */
+data class StrikethroughNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "strikethrough"
+}
+
+/** Inline code span. */
+data class CodeSpanNode(val value: String) : InlineNode {
+    override val nodeType get() = "code_span"
+}
+
+/** Hyperlink with resolved destination. */
+data class LinkNode(
+    val destination: String,
+    val title: String?,
+    val children: List<InlineNode>
+) : InlineNode {
+    override val nodeType get() = "link"
+}
+
+/** Embedded image. */
+data class ImageNode(
+    val destination: String,
+    val title: String?,
+    val alt: String
+) : InlineNode {
+    override val nodeType get() = "image"
+}
+
+/** URL or email autolink. */
+data class AutolinkNode(val destination: String, val isEmail: Boolean) : InlineNode {
+    override val nodeType get() = "autolink"
+}
+
+/** Raw inline content for a specific back-end. */
+data class RawInlineNode(val format: String, val value: String) : InlineNode {
+    override val nodeType get() = "raw_inline"
+}
+
+/** Forced line break. */
+data object HardBreakNode : InlineNode {
+    override val nodeType get() = "hard_break"
+}
+
+/** Soft line break. */
+data object SoftBreakNode : InlineNode {
+    override val nodeType get() = "soft_break"
+}

--- a/code/packages/kotlin/document-ast/src/test/kotlin/com/codingadventures/documentast/DocumentAstTest.kt
+++ b/code/packages/kotlin/document-ast/src/test/kotlin/com/codingadventures/documentast/DocumentAstTest.kt
@@ -1,0 +1,125 @@
+package com.codingadventures.documentast
+
+import kotlin.test.*
+
+class DocumentAstTest {
+
+    // === Node types ===
+
+    @Test fun documentNodeType() = assertEquals("document", DocumentNode(emptyList()).nodeType)
+    @Test fun headingNodeType() = assertEquals("heading", HeadingNode(1, listOf(TextNode("T"))).nodeType)
+    @Test fun paragraphNodeType() = assertEquals("paragraph", ParagraphNode(listOf(TextNode("T"))).nodeType)
+    @Test fun codeBlockNodeType() = assertEquals("code_block", CodeBlockNode("java", "x").nodeType)
+    @Test fun blockquoteNodeType() = assertEquals("blockquote", BlockquoteNode(emptyList()).nodeType)
+    @Test fun listNodeType() = assertEquals("list", ListNode(true, 1, false, emptyList()).nodeType)
+    @Test fun listItemNodeType() = assertEquals("list_item", ListItemNode(emptyList()).nodeType)
+    @Test fun taskItemNodeType() = assertEquals("task_item", TaskItemNode(true, emptyList()).nodeType)
+    @Test fun thematicBreakNodeType() = assertEquals("thematic_break", ThematicBreakNode.nodeType)
+    @Test fun rawBlockNodeType() = assertEquals("raw_block", RawBlockNode("html", "<div>").nodeType)
+    @Test fun tableNodeType() = assertEquals("table", TableNode(emptyList(), emptyList()).nodeType)
+    @Test fun tableRowNodeType() = assertEquals("table_row", TableRowNode(true, emptyList()).nodeType)
+    @Test fun tableCellNodeType() = assertEquals("table_cell", TableCellNode(emptyList()).nodeType)
+    @Test fun textNodeType() = assertEquals("text", TextNode("hello").nodeType)
+    @Test fun emphasisNodeType() = assertEquals("emphasis", EmphasisNode(listOf(TextNode("em"))).nodeType)
+    @Test fun strongNodeType() = assertEquals("strong", StrongNode(listOf(TextNode("b"))).nodeType)
+    @Test fun strikethroughNodeType() = assertEquals("strikethrough", StrikethroughNode(listOf(TextNode("d"))).nodeType)
+    @Test fun codeSpanNodeType() = assertEquals("code_span", CodeSpanNode("x").nodeType)
+    @Test fun linkNodeType() = assertEquals("link", LinkNode("url", null, listOf(TextNode("t"))).nodeType)
+    @Test fun imageNodeType() = assertEquals("image", ImageNode("cat.png", null, "cat").nodeType)
+    @Test fun autolinkNodeType() = assertEquals("autolink", AutolinkNode("url", false).nodeType)
+    @Test fun rawInlineNodeType() = assertEquals("raw_inline", RawInlineNode("html", "<em>").nodeType)
+    @Test fun hardBreakNodeType() = assertEquals("hard_break", HardBreakNode.nodeType)
+    @Test fun softBreakNodeType() = assertEquals("soft_break", SoftBreakNode.nodeType)
+
+    // === Structure ===
+
+    @Test fun simpleDocument() {
+        val doc = DocumentNode(listOf(
+            HeadingNode(1, listOf(TextNode("Hello"))),
+            ParagraphNode(listOf(TextNode("World")))
+        ))
+        assertEquals(2, doc.children.size)
+        assertIs<HeadingNode>(doc.children[0])
+        assertIs<ParagraphNode>(doc.children[1])
+    }
+
+    @Test fun nestedBlockquote() {
+        val q = BlockquoteNode(listOf(
+            ParagraphNode(listOf(TextNode("outer"))),
+            BlockquoteNode(listOf(ParagraphNode(listOf(TextNode("inner")))))
+        ))
+        assertEquals(2, q.children.size)
+    }
+
+    @Test fun orderedList() {
+        val list = ListNode(true, 3, false, listOf(
+            ListItemNode(listOf(ParagraphNode(listOf(TextNode("item 3")))))
+        ))
+        assertTrue(list.ordered)
+        assertEquals(3, list.start)
+    }
+
+    @Test fun richInline() {
+        val p = ParagraphNode(listOf(
+            TextNode("Hello "),
+            StrongNode(listOf(TextNode("bold"), EmphasisNode(listOf(TextNode(" and italic"))))),
+            TextNode(".")
+        ))
+        assertEquals(3, p.children.size)
+    }
+
+    @Test fun tableStructure() {
+        val table = TableNode(
+            listOf(TableAlignment.LEFT, TableAlignment.RIGHT),
+            listOf(
+                TableRowNode(true, listOf(
+                    TableCellNode(listOf(TextNode("Name"))),
+                    TableCellNode(listOf(TextNode("Score")))
+                )),
+                TableRowNode(false, listOf(
+                    TableCellNode(listOf(TextNode("Alice"))),
+                    TableCellNode(listOf(TextNode("100")))
+                ))
+            )
+        )
+        assertEquals(2, table.align.size)
+        assertEquals(2, table.rows.size)
+        assertTrue(table.rows[0].isHeader)
+    }
+
+    @Test fun whenExhaustive() {
+        val node: InlineNode = TextNode("hello")
+        val result = when (node) {
+            is TextNode -> "text: ${node.value}"
+            is EmphasisNode -> "em"
+            is StrongNode -> "strong"
+            is StrikethroughNode -> "strike"
+            is CodeSpanNode -> "code"
+            is LinkNode -> "link"
+            is ImageNode -> "img"
+            is AutolinkNode -> "autolink"
+            is RawInlineNode -> "raw"
+            HardBreakNode -> "hard"
+            SoftBreakNode -> "soft"
+        }
+        assertEquals("text: hello", result)
+    }
+
+    @Test fun taskItemChecked() {
+        assertTrue(TaskItemNode(true, emptyList()).checked)
+        assertFalse(TaskItemNode(false, emptyList()).checked)
+    }
+
+    @Test fun autolinkEmail() {
+        assertTrue(AutolinkNode("user@example.com", true).isEmail)
+        assertFalse(AutolinkNode("https://example.com", false).isEmail)
+    }
+
+    @Test fun headingLevel() {
+        assertEquals(2, HeadingNode(2, listOf(TextNode("H2"))).level)
+    }
+
+    @Test fun codeBlockLanguage() {
+        assertEquals("kotlin", CodeBlockNode("kotlin", "val x = 1\n").language)
+    }
+}

--- a/code/packages/kotlin/grammar-tools/.gitignore
+++ b/code/packages/kotlin/grammar-tools/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/grammar-tools/BUILD
+++ b/code/packages/kotlin/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/grammar-tools/BUILD_windows
+++ b/code/packages/kotlin/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/grammar-tools/CHANGELOG.md
+++ b/code/packages/kotlin/grammar-tools/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Token grammar types, parser, and validator
+- Parser grammar types, recursive descent parser, and validator
+- Cross-validator for token/parser grammar consistency
+- Full test suite

--- a/code/packages/kotlin/grammar-tools/README.md
+++ b/code/packages/kotlin/grammar-tools/README.md
@@ -1,0 +1,15 @@
+# grammar-tools (Kotlin)
+
+Parser and validator for `.tokens` and `.grammar` file formats.
+
+## What it does
+
+- `parseTokenGrammar()` — Parses `.tokens` files into `TokenGrammar`
+- `parseParserGrammar()` — Parses `.grammar` files into `ParserGrammar`
+- `validateTokenGrammar()` — Lint pass for token grammars
+- `validateParserGrammar()` — Lint pass for parser grammars
+- `crossValidate()` — Checks consistency between token and parser grammars
+
+## Layer
+
+TE (text/language layer) — foundational infrastructure for lexer/parser generation.

--- a/code/packages/kotlin/grammar-tools/build.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/build.gradle.kts
@@ -19,8 +19,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "23"
-    sourceCompatibility = "23"
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 dependencies {

--- a/code/packages/kotlin/grammar-tools/build.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/build.gradle.kts
@@ -1,0 +1,34 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "23"
+    sourceCompatibility = "23"
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/grammar-tools/build.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/code/packages/kotlin/grammar-tools/settings.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "grammar-tools"

--- a/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/ParserGrammar.kt
+++ b/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/ParserGrammar.kt
@@ -1,0 +1,304 @@
+// ============================================================================
+// ParserGrammar.kt — Parser grammar types and parser for .grammar files
+// ============================================================================
+//
+// A .grammar file uses EBNF to describe how tokens combine into valid programs.
+// This file contains the grammar element sealed hierarchy, the ParserGrammar
+// data class, the tokenizer, the recursive descent parser, and the validators.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools
+
+// ---------------------------------------------------------------------------
+// Grammar element types (sealed hierarchy)
+// ---------------------------------------------------------------------------
+
+/** Base type for all grammar rule body elements. */
+sealed interface GrammarElement
+
+data class RuleReference(val name: String, val isToken: Boolean) : GrammarElement
+data class Literal(val value: String) : GrammarElement
+data class Sequence(val elements: List<GrammarElement>) : GrammarElement
+data class Alternation(val choices: List<GrammarElement>) : GrammarElement
+data class Repetition(val element: GrammarElement) : GrammarElement
+data class Optional(val element: GrammarElement) : GrammarElement
+data class Group(val element: GrammarElement) : GrammarElement
+data class PositiveLookahead(val element: GrammarElement) : GrammarElement
+data class NegativeLookahead(val element: GrammarElement) : GrammarElement
+data class OneOrMoreRepetition(val element: GrammarElement) : GrammarElement
+data class SeparatedRepetition(
+    val element: GrammarElement,
+    val separator: GrammarElement,
+    val atLeastOne: Boolean
+) : GrammarElement
+
+data class GrammarRule(val name: String, val body: GrammarElement, val lineNumber: Int)
+
+data class ParserGrammar(
+    var version: Int = 0,
+    val rules: MutableList<GrammarRule> = mutableListOf()
+) {
+    fun ruleNames(): Set<String> = rules.map { it.name }.toSet()
+
+    fun ruleReferences(): Set<String> {
+        val refs = mutableSetOf<String>()
+        rules.forEach { collectRuleRefs(it.body, refs) }
+        return refs
+    }
+
+    fun tokenReferences(): Set<String> {
+        val refs = mutableSetOf<String>()
+        rules.forEach { collectTokenRefs(it.body, refs) }
+        return refs
+    }
+}
+
+class ParserGrammarError(message: String, val line: Int) :
+    Exception("Line $line: $message")
+
+// ---------------------------------------------------------------------------
+// Reference collectors
+// ---------------------------------------------------------------------------
+
+private fun collectRuleRefs(element: GrammarElement, refs: MutableSet<String>) {
+    when (element) {
+        is RuleReference -> if (!element.isToken) refs.add(element.name)
+        is Sequence -> element.elements.forEach { collectRuleRefs(it, refs) }
+        is Alternation -> element.choices.forEach { collectRuleRefs(it, refs) }
+        is Repetition -> collectRuleRefs(element.element, refs)
+        is Optional -> collectRuleRefs(element.element, refs)
+        is Group -> collectRuleRefs(element.element, refs)
+        is PositiveLookahead -> collectRuleRefs(element.element, refs)
+        is NegativeLookahead -> collectRuleRefs(element.element, refs)
+        is OneOrMoreRepetition -> collectRuleRefs(element.element, refs)
+        is SeparatedRepetition -> { collectRuleRefs(element.element, refs); collectRuleRefs(element.separator, refs) }
+        is Literal -> {}
+    }
+}
+
+private fun collectTokenRefs(element: GrammarElement, refs: MutableSet<String>) {
+    when (element) {
+        is RuleReference -> if (element.isToken) refs.add(element.name)
+        is Sequence -> element.elements.forEach { collectTokenRefs(it, refs) }
+        is Alternation -> element.choices.forEach { collectTokenRefs(it, refs) }
+        is Repetition -> collectTokenRefs(element.element, refs)
+        is Optional -> collectTokenRefs(element.element, refs)
+        is Group -> collectTokenRefs(element.element, refs)
+        is PositiveLookahead -> collectTokenRefs(element.element, refs)
+        is NegativeLookahead -> collectTokenRefs(element.element, refs)
+        is OneOrMoreRepetition -> collectTokenRefs(element.element, refs)
+        is SeparatedRepetition -> { collectTokenRefs(element.element, refs); collectTokenRefs(element.separator, refs) }
+        is Literal -> {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+private data class InternalToken(val kind: String, val value: String, val line: Int)
+
+private fun tokenizeGrammar(source: String): List<InternalToken> {
+    val tokens = mutableListOf<InternalToken>()
+    val lines = source.split("\n")
+    for ((i, rawLine) in lines.withIndex()) {
+        val lineNum = i + 1
+        val line = rawLine.trimEnd()
+        val stripped = line.trim()
+        if (stripped.isEmpty() || stripped.startsWith("#")) continue
+
+        var j = 0
+        while (j < line.length) {
+            val ch = line[j]
+            if (ch == ' ' || ch == '\t') { j++; continue }
+            if (ch == '#') break
+            when (ch) {
+                '=' -> { tokens.add(InternalToken("EQUALS", "=", lineNum)); j++ }
+                ';' -> { tokens.add(InternalToken("SEMI", ";", lineNum)); j++ }
+                '|' -> { tokens.add(InternalToken("PIPE", "|", lineNum)); j++ }
+                '{' -> { tokens.add(InternalToken("LBRACE", "{", lineNum)); j++ }
+                '}' -> { tokens.add(InternalToken("RBRACE", "}", lineNum)); j++ }
+                '[' -> { tokens.add(InternalToken("LBRACKET", "[", lineNum)); j++ }
+                ']' -> { tokens.add(InternalToken("RBRACKET", "]", lineNum)); j++ }
+                '(' -> { tokens.add(InternalToken("LPAREN", "(", lineNum)); j++ }
+                ')' -> { tokens.add(InternalToken("RPAREN", ")", lineNum)); j++ }
+                '&' -> { tokens.add(InternalToken("AMPERSAND", "&", lineNum)); j++ }
+                '!' -> { tokens.add(InternalToken("BANG", "!", lineNum)); j++ }
+                '+' -> { tokens.add(InternalToken("PLUS", "+", lineNum)); j++ }
+                '/' -> {
+                    if (j + 1 < line.length && line[j + 1] == '/') {
+                        tokens.add(InternalToken("DOUBLE_SLASH", "//", lineNum)); j += 2
+                    } else throw ParserGrammarError("Unexpected character '/'", lineNum)
+                }
+                '"' -> {
+                    var k = j + 1
+                    while (k < line.length && line[k] != '"') {
+                        if (line[k] == '\\') k++
+                        k++
+                    }
+                    if (k >= line.length) throw ParserGrammarError("Unterminated string literal", lineNum)
+                    tokens.add(InternalToken("STRING", line.substring(j + 1, k), lineNum))
+                    j = k + 1
+                }
+                else -> {
+                    if (ch.isLetter() || ch == '_') {
+                        var k = j
+                        while (k < line.length && (line[k].isLetterOrDigit() || line[k] == '_')) k++
+                        tokens.add(InternalToken("IDENT", line.substring(j, k), lineNum))
+                        j = k
+                    } else throw ParserGrammarError("Unexpected character '$ch'", lineNum)
+                }
+            }
+        }
+    }
+    tokens.add(InternalToken("EOF", "", lines.size))
+    return tokens
+}
+
+// ---------------------------------------------------------------------------
+// Recursive descent parser
+// ---------------------------------------------------------------------------
+
+private class GrammarParserImpl(private val tokens: List<InternalToken>) {
+    private var pos = 0
+    fun peek() = tokens[pos]
+    fun advance() = tokens[pos++]
+    fun expect(kind: String): InternalToken {
+        val tok = advance()
+        if (tok.kind != kind) throw ParserGrammarError("Expected $kind, got ${tok.kind}", tok.line)
+        return tok
+    }
+
+    fun parseRules(): List<GrammarRule> {
+        val rules = mutableListOf<GrammarRule>()
+        while (peek().kind != "EOF") rules.add(parseRule())
+        return rules
+    }
+
+    private fun parseRule(): GrammarRule {
+        val nameTok = expect("IDENT")
+        expect("EQUALS")
+        val body = parseBody()
+        expect("SEMI")
+        return GrammarRule(nameTok.value, body, nameTok.line)
+    }
+
+    fun parseBody(): GrammarElement {
+        val first = parseSequence()
+        val alts = mutableListOf(first)
+        while (peek().kind == "PIPE") { advance(); alts.add(parseSequence()) }
+        return if (alts.size == 1) alts[0] else Alternation(alts.toList())
+    }
+
+    private fun parseSequence(): GrammarElement {
+        val elems = mutableListOf<GrammarElement>()
+        while (peek().kind !in listOf("PIPE", "SEMI", "RBRACE", "RBRACKET", "RPAREN", "EOF", "DOUBLE_SLASH")) {
+            elems.add(parseElement())
+        }
+        if (elems.isEmpty()) throw ParserGrammarError("Expected at least one element", peek().line)
+        return if (elems.size == 1) elems[0] else Sequence(elems.toList())
+    }
+
+    private fun parseElement(): GrammarElement {
+        val tok = peek()
+        if (tok.kind == "AMPERSAND") { advance(); return PositiveLookahead(parseElement()) }
+        if (tok.kind == "BANG") { advance(); return NegativeLookahead(parseElement()) }
+        return when (tok.kind) {
+            "IDENT" -> { advance(); RuleReference(tok.value, tok.value[0].isUpperCase()) }
+            "STRING" -> { advance(); Literal(tok.value) }
+            "LBRACE" -> {
+                advance()
+                val body = parseBody()
+                if (peek().kind == "DOUBLE_SLASH") {
+                    advance()
+                    val sep = parseBody()
+                    expect("RBRACE")
+                    val atLeast = if (peek().kind == "PLUS") { advance(); true } else false
+                    SeparatedRepetition(body, sep, atLeast)
+                } else {
+                    expect("RBRACE")
+                    if (peek().kind == "PLUS") { advance(); OneOrMoreRepetition(body) }
+                    else Repetition(body)
+                }
+            }
+            "LBRACKET" -> { advance(); val body = parseBody(); expect("RBRACKET"); Optional(body) }
+            "LPAREN" -> { advance(); val body = parseBody(); expect("RPAREN"); Group(body) }
+            else -> throw ParserGrammarError("Unexpected token ${tok.kind}", tok.line)
+        }
+    }
+}
+
+fun parseParserGrammar(source: String): ParserGrammar {
+    val grammar = ParserGrammar()
+    val magicRe = Regex("""^#\s*@(\w+)\s*(.*)$""")
+    for (line in source.split("\n")) {
+        val stripped = line.trim()
+        if (!stripped.startsWith("#")) continue
+        magicRe.matchEntire(stripped)?.let { m ->
+            if (m.groupValues[1] == "version") m.groupValues[2].trim().toIntOrNull()?.let { grammar.version = it }
+        }
+    }
+    val tokens = tokenizeGrammar(source)
+    grammar.rules.addAll(GrammarParserImpl(tokens).parseRules())
+    return grammar
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+private val SYNTHETIC_TOKENS = setOf("NEWLINE", "INDENT", "DEDENT", "EOF")
+
+fun validateParserGrammar(grammar: ParserGrammar, tokenNames: Set<String>? = null): List<String> {
+    val issues = mutableListOf<String>()
+    val defined = grammar.ruleNames()
+    val refRules = grammar.ruleReferences()
+    val refTokens = grammar.tokenReferences()
+
+    val seen = mutableMapOf<String, Int>()
+    for (rule in grammar.rules) {
+        seen[rule.name]?.let {
+            issues.add("Line ${rule.lineNumber}: Duplicate rule name '${rule.name}' (first on line $it)")
+        } ?: run { seen[rule.name] = rule.lineNumber }
+        if (rule.name != rule.name.lowercase()) issues.add("Line ${rule.lineNumber}: Rule name '${rule.name}' should be lowercase")
+    }
+    for (ref in refRules.sorted()) {
+        if (ref !in defined) issues.add("Undefined rule reference: '$ref'")
+    }
+    tokenNames?.let {
+        for (ref in refTokens.sorted()) {
+            if (ref !in it && ref !in SYNTHETIC_TOKENS) issues.add("Undefined token reference: '$ref'")
+        }
+    }
+    if (grammar.rules.isNotEmpty()) {
+        val start = grammar.rules[0].name
+        for (rule in grammar.rules) {
+            if (rule.name != start && rule.name !in refRules)
+                issues.add("Line ${rule.lineNumber}: Rule '${rule.name}' is defined but never referenced (unreachable)")
+        }
+    }
+    return issues
+}
+
+// ---------------------------------------------------------------------------
+// Cross-validator
+// ---------------------------------------------------------------------------
+
+fun crossValidate(tokenGrammar: TokenGrammar, parserGrammar: ParserGrammar): List<String> {
+    val issues = mutableListOf<String>()
+    val definedTokens = tokenGrammar.tokenNames().toMutableSet()
+    definedTokens.addAll(listOf("NEWLINE", "EOF"))
+    if (tokenGrammar.mode == "indentation") definedTokens.addAll(listOf("INDENT", "DEDENT"))
+    val refTokens = parserGrammar.tokenReferences()
+
+    for (ref in refTokens.sorted()) {
+        if (ref !in definedTokens) issues.add("Error: Grammar references token '$ref' which is not defined in the tokens file")
+    }
+    for (defn in tokenGrammar.definitions) {
+        val isUsed = defn.name in refTokens || (defn.alias != null && defn.alias in refTokens)
+        if (!isUsed) issues.add("Warning: Token '${defn.name}' (line ${defn.lineNumber}) is defined but never used in the grammar")
+    }
+    return issues
+}

--- a/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/TokenGrammar.kt
+++ b/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/TokenGrammar.kt
@@ -1,0 +1,317 @@
+// ============================================================================
+// TokenGrammar.kt — Token grammar types and parser for .tokens files
+// ============================================================================
+//
+// A .tokens file is a declarative description of a language's lexical grammar.
+// Each line defines a token pattern (regex or literal) that the lexer should
+// recognize. Sections organize keywords, skip patterns, error recovery, and
+// pattern groups for context-sensitive lexing.
+//
+// This file contains all the data types and the parser for .tokens files,
+// following the Kotlin convention of keeping related types together.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single token rule from a .tokens file.
+ *
+ * @property name       Token name, e.g. "NUMBER" or "PLUS"
+ * @property pattern    The pattern string (without delimiters)
+ * @property isRegex    true if /regex/, false if "literal"
+ * @property lineNumber 1-based line where this definition appeared
+ * @property alias      Optional type alias (e.g. STRING_DQ -> STRING)
+ */
+data class TokenDefinition(
+    val name: String,
+    val pattern: String,
+    val isRegex: Boolean,
+    val lineNumber: Int,
+    val alias: String? = null
+)
+
+/**
+ * A named set of token definitions for context-sensitive lexing.
+ */
+data class PatternGroup(
+    val name: String,
+    val definitions: List<TokenDefinition>
+)
+
+/**
+ * The complete contents of a parsed .tokens file.
+ */
+data class TokenGrammar(
+    var version: Int = 0,
+    var caseInsensitive: Boolean = false,
+    var caseSensitive: Boolean = true,
+    val definitions: MutableList<TokenDefinition> = mutableListOf(),
+    val keywords: MutableList<String> = mutableListOf(),
+    var mode: String? = null,
+    var escapeMode: String? = null,
+    val skipDefinitions: MutableList<TokenDefinition> = mutableListOf(),
+    val errorDefinitions: MutableList<TokenDefinition> = mutableListOf(),
+    val reservedKeywords: MutableList<String> = mutableListOf(),
+    val contextKeywords: MutableList<String> = mutableListOf(),
+    val groups: MutableMap<String, PatternGroup> = mutableMapOf()
+) {
+    /** All defined token names including aliases and group tokens. */
+    fun tokenNames(): Set<String> {
+        val allDefs = definitions + groups.values.flatMap { it.definitions }
+        val names = mutableSetOf<String>()
+        for (d in allDefs) {
+            names.add(d.name)
+            d.alias?.let { names.add(it) }
+        }
+        return names
+    }
+
+    /** Token names as the parser will see them (aliases replace original names). */
+    fun effectiveTokenNames(): Set<String> =
+        (definitions + groups.values.flatMap { it.definitions })
+            .map { it.alias ?: it.name }
+            .toSet()
+}
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
+
+class TokenGrammarError(val msg: String, val line: Int) :
+    Exception("Line $line: $msg")
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+private val MAGIC_COMMENT = Regex("""^#\s*@(\w+)\s*(.*)$""")
+private val GROUP_NAME_RE = Regex("""^[a-z_][a-z0-9_]*$""")
+private val TOKEN_NAME_RE = Regex("""^[a-zA-Z_][a-zA-Z0-9_]*$""")
+private val RESERVED_GROUP_NAMES = setOf("default", "skip", "keywords", "reserved", "errors")
+
+/**
+ * Parse the full text of a .tokens file into a [TokenGrammar].
+ */
+fun parseTokenGrammar(source: String): TokenGrammar {
+    val grammar = TokenGrammar()
+    val lines = source.split("\n")
+    var currentSection: String? = null
+
+    for ((i, rawLine) in lines.withIndex()) {
+        val lineNumber = i + 1
+        val line = rawLine.trimEnd()
+        val stripped = line.trim()
+
+        if (stripped.isEmpty()) continue
+
+        // Comments and magic comments
+        if (stripped.startsWith("#")) {
+            MAGIC_COMMENT.matchEntire(stripped)?.let { m ->
+                val key = m.groupValues[1]
+                val value = m.groupValues[2].trim()
+                when (key) {
+                    "version" -> value.toIntOrNull()?.let { grammar.version = it }
+                    "case_insensitive" -> grammar.caseInsensitive = (value == "true")
+                }
+            }
+            continue
+        }
+
+        // mode: directive
+        if (stripped.startsWith("mode:")) {
+            val v = stripped.removePrefix("mode:").trim()
+            if (v.isEmpty()) throw TokenGrammarError("Missing value after 'mode:'", lineNumber)
+            grammar.mode = v
+            currentSection = null
+            continue
+        }
+
+        // escapes: directive
+        if (stripped.startsWith("escapes:")) {
+            val v = stripped.removePrefix("escapes:").trim()
+            if (v.isEmpty()) throw TokenGrammarError("Missing value after 'escapes:'", lineNumber)
+            grammar.escapeMode = v
+            currentSection = null
+            continue
+        }
+
+        // case_sensitive: directive
+        if (stripped.startsWith("case_sensitive:")) {
+            val v = stripped.removePrefix("case_sensitive:").trim().lowercase()
+            if (v != "true" && v != "false")
+                throw TokenGrammarError("Invalid value for 'case_sensitive:': '$v'", lineNumber)
+            grammar.caseSensitive = (v == "true")
+            currentSection = null
+            continue
+        }
+
+        // Group headers
+        if (stripped.startsWith("group ") && stripped.endsWith(":")) {
+            val groupName = stripped.removePrefix("group ").removeSuffix(":").trim()
+            if (groupName.isEmpty()) throw TokenGrammarError("Missing group name after 'group'", lineNumber)
+            if (!GROUP_NAME_RE.matches(groupName))
+                throw TokenGrammarError("Invalid group name: '$groupName'", lineNumber)
+            if (groupName in RESERVED_GROUP_NAMES)
+                throw TokenGrammarError("Reserved group name: '$groupName'", lineNumber)
+            if (groupName in grammar.groups)
+                throw TokenGrammarError("Duplicate group name: '$groupName'", lineNumber)
+            grammar.groups[groupName] = PatternGroup(groupName, mutableListOf())
+            currentSection = "group:$groupName"
+            continue
+        }
+
+        // Section headers
+        when (stripped) {
+            "keywords:", "keywords :" -> { currentSection = "keywords"; continue }
+            "reserved:", "reserved :" -> { currentSection = "reserved"; continue }
+            "skip:", "skip :" -> { currentSection = "skip"; continue }
+            "errors:", "errors :" -> { currentSection = "errors"; continue }
+            "context_keywords:", "context_keywords :" -> { currentSection = "context_keywords"; continue }
+        }
+
+        // Inside a section
+        if (currentSection != null) {
+            if (line.isNotEmpty() && (line[0] == ' ' || line[0] == '\t')) {
+                if (stripped.isEmpty()) continue
+                when {
+                    currentSection == "keywords" -> grammar.keywords.add(stripped)
+                    currentSection == "reserved" -> grammar.reservedKeywords.add(stripped)
+                    currentSection == "context_keywords" -> grammar.contextKeywords.add(stripped)
+                    currentSection == "skip" -> parseSectionDef(stripped, lineNumber, grammar.skipDefinitions, "skip pattern")
+                    currentSection == "errors" -> parseSectionDef(stripped, lineNumber, grammar.errorDefinitions, "error pattern")
+                    currentSection!!.startsWith("group:") -> {
+                        val gName = currentSection!!.removePrefix("group:")
+                        val eqIdx = stripped.indexOf('=')
+                        if (eqIdx == -1) throw TokenGrammarError("Expected definition in group '$gName'", lineNumber)
+                        val n = stripped.substring(0, eqIdx).trim()
+                        val p = stripped.substring(eqIdx + 1).trim()
+                        if (n.isEmpty() || p.isEmpty()) throw TokenGrammarError("Incomplete definition in group '$gName'", lineNumber)
+                        val defn = parseDefinition(p, n, lineNumber)
+                        val old = grammar.groups[gName]!!
+                        grammar.groups[gName] = PatternGroup(gName, old.definitions + defn)
+                    }
+                }
+                continue
+            }
+            currentSection = null
+        }
+
+        // Token definition
+        val eqIndex = line.indexOf('=')
+        if (eqIndex == -1) throw TokenGrammarError("Expected token definition, got: '$stripped'", lineNumber)
+        val namePart = line.substring(0, eqIndex).trim()
+        val patternPart = line.substring(eqIndex + 1).trim()
+        if (namePart.isEmpty()) throw TokenGrammarError("Missing token name before '='", lineNumber)
+        if (!TOKEN_NAME_RE.matches(namePart))
+            throw TokenGrammarError("Invalid token name: '$namePart'", lineNumber)
+        if (patternPart.isEmpty()) throw TokenGrammarError("Missing pattern after '='", lineNumber)
+        grammar.definitions.add(parseDefinition(patternPart, namePart, lineNumber))
+    }
+    return grammar
+}
+
+private fun parseSectionDef(stripped: String, lineNumber: Int, target: MutableList<TokenDefinition>, label: String) {
+    val eqIdx = stripped.indexOf('=')
+    if (eqIdx == -1) throw TokenGrammarError("Expected $label definition", lineNumber)
+    val n = stripped.substring(0, eqIdx).trim()
+    val p = stripped.substring(eqIdx + 1).trim()
+    if (n.isEmpty() || p.isEmpty()) throw TokenGrammarError("Incomplete $label definition", lineNumber)
+    target.add(parseDefinition(p, n, lineNumber))
+}
+
+internal fun parseDefinition(patternPart: String, namePart: String, lineNumber: Int): TokenDefinition {
+    return when {
+        patternPart.startsWith("/") -> {
+            val lastSlash = findClosingSlash(patternPart)
+            if (lastSlash == -1) throw TokenGrammarError("Unclosed regex pattern for token '$namePart'", lineNumber)
+            val body = patternPart.substring(1, lastSlash)
+            if (body.isEmpty()) throw TokenGrammarError("Empty regex pattern for token '$namePart'", lineNumber)
+            val remainder = patternPart.substring(lastSlash + 1).trim()
+            val alias = parseAlias(remainder, namePart, lineNumber)
+            TokenDefinition(namePart, body, true, lineNumber, alias)
+        }
+        patternPart.startsWith("\"") -> {
+            val closeQuote = patternPart.indexOf('"', 1)
+            if (closeQuote == -1) throw TokenGrammarError("Unclosed literal pattern for token '$namePart'", lineNumber)
+            val body = patternPart.substring(1, closeQuote)
+            if (body.isEmpty()) throw TokenGrammarError("Empty literal pattern for token '$namePart'", lineNumber)
+            val remainder = patternPart.substring(closeQuote + 1).trim()
+            val alias = parseAlias(remainder, namePart, lineNumber)
+            TokenDefinition(namePart, body, false, lineNumber, alias)
+        }
+        else -> throw TokenGrammarError("Pattern must be /regex/ or \"literal\"", lineNumber)
+    }
+}
+
+private fun parseAlias(remainder: String, namePart: String, lineNumber: Int): String? {
+    if (remainder.isEmpty()) return null
+    if (remainder.startsWith("->")) {
+        val alias = remainder.removePrefix("->").trim()
+        if (alias.isEmpty()) throw TokenGrammarError("Missing alias after '->' for '$namePart'", lineNumber)
+        return alias
+    }
+    throw TokenGrammarError("Unexpected text after pattern for '$namePart'", lineNumber)
+}
+
+internal fun findClosingSlash(s: String): Int {
+    var inBracket = false
+    var i = 1
+    while (i < s.length) {
+        val ch = s[i]
+        if (ch == '\\') { i += 2; continue }
+        if (ch == '[' && !inBracket) inBracket = true
+        else if (ch == ']' && inBracket) inBracket = false
+        else if (ch == '/' && !inBracket) return i
+        i++
+    }
+    val last = s.lastIndexOf('/')
+    return if (last > 0) last else -1
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+fun validateTokenGrammar(grammar: TokenGrammar): List<String> {
+    val issues = mutableListOf<String>()
+    issues.addAll(validateDefs(grammar.definitions, "token"))
+    issues.addAll(validateDefs(grammar.skipDefinitions, "skip pattern"))
+    issues.addAll(validateDefs(grammar.errorDefinitions, "error pattern"))
+
+    grammar.mode?.let { if (it != "indentation") issues.add("Unknown lexer mode '$it'") }
+    grammar.escapeMode?.let { if (it != "none") issues.add("Unknown escape mode '$it'") }
+
+    for ((name, group) in grammar.groups) {
+        if (!GROUP_NAME_RE.matches(name)) issues.add("Invalid group name '$name'")
+        if (group.definitions.isEmpty()) issues.add("Empty pattern group '$name'")
+        issues.addAll(validateDefs(group.definitions, "group '$name' token"))
+    }
+    return issues
+}
+
+private fun validateDefs(definitions: List<TokenDefinition>, label: String): List<String> {
+    val issues = mutableListOf<String>()
+    val seen = mutableMapOf<String, Int>()
+    for (d in definitions) {
+        seen[d.name]?.let {
+            issues.add("Line ${d.lineNumber}: Duplicate $label name '${d.name}' (first on line $it)")
+        } ?: run { seen[d.name] = d.lineNumber }
+
+        if (d.pattern.isEmpty()) issues.add("Line ${d.lineNumber}: Empty pattern for $label '${d.name}'")
+
+        if (d.isRegex) {
+            try { Regex(d.pattern) }
+            catch (e: Exception) { issues.add("Line ${d.lineNumber}: Invalid regex for $label '${d.name}'") }
+        }
+
+        if (d.name != d.name.uppercase()) issues.add("Line ${d.lineNumber}: Token name '${d.name}' should be UPPER_CASE")
+        d.alias?.let { if (it != it.uppercase()) issues.add("Line ${d.lineNumber}: Alias '$it' should be UPPER_CASE") }
+    }
+    return issues
+}

--- a/code/packages/kotlin/grammar-tools/src/test/kotlin/com/codingadventures/grammartools/GrammarToolsTest.kt
+++ b/code/packages/kotlin/grammar-tools/src/test/kotlin/com/codingadventures/grammartools/GrammarToolsTest.kt
@@ -1,0 +1,263 @@
+package com.codingadventures.grammartools
+
+import kotlin.test.*
+
+class GrammarToolsTest {
+
+    // === Token Grammar Parsing ===
+
+    @Test fun emptyInput() {
+        val g = parseTokenGrammar("")
+        assertTrue(g.definitions.isEmpty())
+    }
+
+    @Test fun simpleRegex() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertEquals(1, g.definitions.size)
+        assertEquals("NUMBER", g.definitions[0].name)
+        assertEquals("[0-9]+", g.definitions[0].pattern)
+        assertTrue(g.definitions[0].isRegex)
+    }
+
+    @Test fun simpleLiteral() {
+        val g = parseTokenGrammar("PLUS = \"+\"\n")
+        assertEquals("+", g.definitions[0].pattern)
+        assertFalse(g.definitions[0].isRegex)
+    }
+
+    @Test fun aliasDefinition() {
+        val g = parseTokenGrammar("STRING_DQ = /\"[^\"]*\"/ -> STRING\n")
+        assertEquals("STRING", g.definitions[0].alias)
+    }
+
+    @Test fun keywordsSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nkeywords:\n  if\n  else\n")
+        assertEquals(listOf("if", "else"), g.keywords)
+    }
+
+    @Test fun reservedKeywords() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nreserved:\n  class\n")
+        assertEquals(listOf("class"), g.reservedKeywords)
+    }
+
+    @Test fun skipSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\n")
+        assertEquals(1, g.skipDefinitions.size)
+    }
+
+    @Test fun errorsSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nerrors:\n  BAD = /[^\\n]*/\n")
+        assertEquals(1, g.errorDefinitions.size)
+    }
+
+    @Test fun modeDirective() {
+        val g = parseTokenGrammar("mode: indentation\nNAME = /[a-z]+/\n")
+        assertEquals("indentation", g.mode)
+    }
+
+    @Test fun escapesDirective() {
+        val g = parseTokenGrammar("escapes: none\nSTRING = /\"[^\"]*\"/\n")
+        assertEquals("none", g.escapeMode)
+    }
+
+    @Test fun caseSensitiveDirective() {
+        val g = parseTokenGrammar("case_sensitive: false\nNAME = /[a-z]+/\n")
+        assertFalse(g.caseSensitive)
+    }
+
+    @Test fun magicCommentVersion() {
+        val g = parseTokenGrammar("# @version 2\nNUMBER = /[0-9]+/\n")
+        assertEquals(2, g.version)
+    }
+
+    @Test fun patternGroup() {
+        val g = parseTokenGrammar("OPEN = \"<\"\ngroup tag:\n  ATTR = /[a-z]+/\n")
+        assertTrue("tag" in g.groups)
+        assertEquals(1, g.groups["tag"]!!.definitions.size)
+    }
+
+    @Test fun contextKeywords() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\ncontext_keywords:\n  async\n")
+        assertEquals(listOf("async"), g.contextKeywords)
+    }
+
+    @Test fun tokenNames() {
+        val g = parseTokenGrammar("NUM = /[0-9]+/\nSTR_DQ = /\".*\"/ -> STR\n")
+        val names = g.tokenNames()
+        assertTrue("NUM" in names)
+        assertTrue("STR_DQ" in names)
+        assertTrue("STR" in names)
+    }
+
+    @Test fun effectiveTokenNames() {
+        val g = parseTokenGrammar("NUM = /[0-9]+/\nSTR_DQ = /\".*\"/ -> STR\n")
+        val names = g.effectiveTokenNames()
+        assertTrue("NUM" in names)
+        assertFalse("STR_DQ" in names)
+        assertTrue("STR" in names)
+    }
+
+    @Test fun unclosedRegex() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("BAD = /unclosed\n") }
+    }
+
+    @Test fun duplicateGroup() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("group a:\n  X = \"x\"\ngroup a:\n  Y = \"y\"\n") }
+    }
+
+    @Test fun reservedGroupName() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("group default:\n  X = \"x\"\n") }
+    }
+
+    // === Token Grammar Validation ===
+
+    @Test fun validGrammar() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertTrue(validateTokenGrammar(g).isEmpty())
+    }
+
+    @Test fun duplicateNameWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("NUM", "[0-9]+", true, 1),
+            TokenDefinition("NUM", "[0-9]+", true, 2)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "Duplicate" in it })
+    }
+
+    @Test fun invalidRegexWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("BAD", "[unclosed", true, 1)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "Invalid regex" in it })
+    }
+
+    @Test fun nonUpperCaseWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("number", "[0-9]+", true, 1)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "UPPER_CASE" in it })
+    }
+
+    @Test fun unknownMode() {
+        val g = TokenGrammar(mode = "bad")
+        assertTrue(validateTokenGrammar(g).any { "Unknown lexer mode" in it })
+    }
+
+    // === Parser Grammar Parsing ===
+
+    @Test fun simpleRule() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        assertEquals(1, g.rules.size)
+        assertEquals("program", g.rules[0].name)
+    }
+
+    @Test fun alternation() {
+        val g = parseParserGrammar("expr = NUMBER | NAME ;")
+        assertIs<Alternation>(g.rules[0].body)
+    }
+
+    @Test fun sequence() {
+        val g = parseParserGrammar("a = NAME EQUALS NUMBER ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun repetition() {
+        val g = parseParserGrammar("list = { item } ;")
+        assertIs<Repetition>(g.rules[0].body)
+    }
+
+    @Test fun oneOrMore() {
+        val g = parseParserGrammar("list = { item }+ ;")
+        assertIs<OneOrMoreRepetition>(g.rules[0].body)
+    }
+
+    @Test fun optional() {
+        val g = parseParserGrammar("call = NAME [ args ] ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun literal() {
+        val g = parseParserGrammar("op = \"+\" ;")
+        assertIs<Literal>(g.rules[0].body)
+        assertEquals("+", (g.rules[0].body as Literal).value)
+    }
+
+    @Test fun positiveLookahead() {
+        val g = parseParserGrammar("c = &NUMBER item ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun negativeLookahead() {
+        val g = parseParserGrammar("c = !NUMBER item ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun separatedRepetition() {
+        val g = parseParserGrammar("args = { expr // COMMA } ;")
+        assertIs<SeparatedRepetition>(g.rules[0].body)
+    }
+
+    @Test fun ruleReferences() {
+        val g = parseParserGrammar("p = { stmt } ;\nstmt = expr ;")
+        assertTrue("stmt" in g.ruleReferences())
+        assertTrue("expr" in g.ruleReferences())
+    }
+
+    @Test fun tokenReferences() {
+        val g = parseParserGrammar("a = NAME EQUALS NUMBER ;")
+        assertTrue("NAME" in g.tokenReferences())
+        assertTrue("EQUALS" in g.tokenReferences())
+    }
+
+    @Test fun magicVersion() {
+        val g = parseParserGrammar("# @version 3\nexpr = NUMBER ;")
+        assertEquals(3, g.version)
+    }
+
+    // === Parser Grammar Validation ===
+
+    @Test fun validParserGrammar() {
+        val g = parseParserGrammar("p = { s } ;\ns = NUMBER ;")
+        assertTrue(validateParserGrammar(g).isEmpty())
+    }
+
+    @Test fun undefinedRuleRef() {
+        val g = parseParserGrammar("p = undef ;")
+        assertTrue(validateParserGrammar(g).any { "Undefined rule" in it })
+    }
+
+    @Test fun undefinedTokenRef() {
+        val g = parseParserGrammar("p = MISSING ;")
+        assertTrue(validateParserGrammar(g, setOf("NUMBER")).any { "Undefined token" in it })
+    }
+
+    @Test fun syntheticTokensValid() {
+        val g = parseParserGrammar("p = NEWLINE EOF ;")
+        assertFalse(validateParserGrammar(g, emptySet()).any { "Undefined token" in it })
+    }
+
+    @Test fun unreachableRule() {
+        val g = parseParserGrammar("start = NUMBER ;\nunused = NAME ;")
+        assertTrue(validateParserGrammar(g).any { "unreachable" in it })
+    }
+
+    // === Cross Validation ===
+
+    @Test fun consistentGrammars() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\nNAME = /[a-z]+/\n")
+        val pg = parseParserGrammar("expr = NUMBER | NAME ;")
+        assertTrue(crossValidate(tg, pg).isEmpty())
+    }
+
+    @Test fun missingToken() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        val pg = parseParserGrammar("expr = NUMBER | MISSING ;")
+        assertTrue(crossValidate(tg, pg).any { "Error:" in it && "MISSING" in it })
+    }
+
+    @Test fun unusedToken() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\nUNUSED = \"~\"\n")
+        val pg = parseParserGrammar("expr = NUMBER ;")
+        assertTrue(crossValidate(tg, pg).any { "Warning:" in it && "UNUSED" in it })
+    }
+}

--- a/code/packages/kotlin/lexer/.gitignore
+++ b/code/packages/kotlin/lexer/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/lexer/BUILD
+++ b/code/packages/kotlin/lexer/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle test

--- a/code/packages/kotlin/lexer/BUILD_windows
+++ b/code/packages/kotlin/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lexer/CHANGELOG.md
+++ b/code/packages/kotlin/lexer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Token data class with type, value, line, column, typeName, flags
+- GrammarLexer — grammar-driven tokenizer using TokenGrammar
+- Full test suite

--- a/code/packages/kotlin/lexer/README.md
+++ b/code/packages/kotlin/lexer/README.md
@@ -1,0 +1,7 @@
+# lexer (Kotlin)
+
+Generic lexer/tokenizer infrastructure for the coding-adventures project.
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools.

--- a/code/packages/kotlin/lexer/build.gradle.kts
+++ b/code/packages/kotlin/lexer/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "23"
+    sourceCompatibility = "23"
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/lexer/build.gradle.kts
+++ b/code/packages/kotlin/lexer/build.gradle.kts
@@ -19,8 +19,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "23"
-    sourceCompatibility = "23"
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 dependencies {

--- a/code/packages/kotlin/lexer/build.gradle.kts
+++ b/code/packages/kotlin/lexer/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/code/packages/kotlin/lexer/settings.gradle.kts
+++ b/code/packages/kotlin/lexer/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "lexer"
+
+includeBuild("../grammar-tools")

--- a/code/packages/kotlin/lexer/src/main/kotlin/com/codingadventures/lexer/Lexer.kt
+++ b/code/packages/kotlin/lexer/src/main/kotlin/com/codingadventures/lexer/Lexer.kt
@@ -1,0 +1,181 @@
+// ============================================================================
+// Lexer.kt — Token types and grammar-driven lexer
+// ============================================================================
+//
+// A lexer (also called a tokenizer or scanner) breaks source code into a
+// stream of tokens. This file contains all the types and the GrammarLexer.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer
+
+import com.codingadventures.grammartools.TokenDefinition
+import com.codingadventures.grammartools.TokenGrammar
+
+// ---------------------------------------------------------------------------
+// Token types
+// ---------------------------------------------------------------------------
+
+enum class TokenType {
+    NAME, NUMBER, STRING, KEYWORD,
+    PLUS, MINUS, STAR, SLASH,
+    EQUALS, EQUALS_EQUALS,
+    LPAREN, RPAREN, COMMA, COLON, SEMICOLON,
+    LBRACE, RBRACE, LBRACKET, RBRACKET,
+    DOT, BANG, NEWLINE, EOF,
+    GRAMMAR  // Grammar-driven token — actual type is in typeName
+}
+
+/** Bitmask flag: a line break appeared before this token. */
+const val FLAG_PRECEDED_BY_NEWLINE = 1
+/** Bitmask flag: this is a context-sensitive keyword. */
+const val FLAG_CONTEXT_KEYWORD = 2
+
+/**
+ * An immutable token from source code.
+ */
+data class Token(
+    val type: TokenType,
+    val value: String,
+    val line: Int,
+    val column: Int,
+    val typeName: String? = null,
+    val flags: Int = 0
+) {
+    fun effectiveTypeName(): String = typeName ?: type.name
+    fun hasFlag(flag: Int): Boolean = (flags and flag) != 0
+    override fun toString() = "Token(${effectiveTypeName()}, \"$value\", $line:$column)"
+}
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
+
+class LexerError(message: String, val line: Int, val column: Int) :
+    Exception("Lexer error at $line:$column: $message")
+
+// ---------------------------------------------------------------------------
+// Compiled pattern
+// ---------------------------------------------------------------------------
+
+private data class CompiledPattern(val name: String, val regex: Regex, val alias: String?)
+
+// ---------------------------------------------------------------------------
+// Grammar-driven lexer
+// ---------------------------------------------------------------------------
+
+/**
+ * A lexer driven by a [TokenGrammar]. Compiles token definitions into
+ * regexes and tries them in priority order at each source position.
+ */
+class GrammarLexer(private val grammar: TokenGrammar) {
+
+    private val patterns = compileDefinitions(grammar.definitions)
+    private val skipPatterns = compileDefinitions(grammar.skipDefinitions)
+    private val errorPatterns = compileDefinitions(grammar.errorDefinitions)
+    private val keywordSet = grammar.keywords.toSet()
+    private val reservedSet = grammar.reservedKeywords.toSet()
+    private val contextKeywordSet = grammar.contextKeywords.toSet()
+
+    /**
+     * Tokenize source code into a list of tokens.
+     * The returned list always ends with an EOF token.
+     */
+    fun tokenize(source: String): List<Token> {
+        val working = if (grammar.caseSensitive) source else source.lowercase()
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+        var line = 1
+        var column = 1
+        var precededByNewline = false
+
+        while (pos < working.length) {
+            // Try skip patterns first
+            var skipped = false
+            for (sp in skipPatterns) {
+                val m = sp.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    for (ch in m.value) {
+                        if (ch == '\n') { line++; column = 1; precededByNewline = true }
+                        else column++
+                    }
+                    pos += m.value.length
+                    skipped = true
+                    break
+                }
+            }
+            if (skipped) continue
+
+            // Try token patterns
+            var matched = false
+            for (cp in patterns) {
+                val m = cp.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    val value = source.substring(pos, pos + m.value.length)
+                    val typeName = cp.alias ?: cp.name
+
+                    if (typeName == "NAME" && value in reservedSet)
+                        throw LexerError("Reserved keyword '$value'", line, column)
+
+                    var flags = 0
+                    if (precededByNewline) flags = flags or FLAG_PRECEDED_BY_NEWLINE
+                    val checkVal = if (grammar.caseSensitive) value else value.lowercase()
+                    if (typeName == "NAME" && checkVal in contextKeywordSet)
+                        flags = flags or FLAG_CONTEXT_KEYWORD
+
+                    tokens.add(Token(TokenType.GRAMMAR, value, line, column, typeName, flags))
+                    for (ch in value) {
+                        if (ch == '\n') { line++; column = 1 } else column++
+                    }
+                    pos += value.length
+                    matched = true
+                    precededByNewline = false
+                    break
+                }
+            }
+            if (matched) continue
+
+            // Try error recovery patterns
+            var errorMatched = false
+            for (ep in errorPatterns) {
+                val m = ep.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    val value = source.substring(pos, pos + m.value.length)
+                    tokens.add(Token(TokenType.GRAMMAR, value, line, column, ep.alias ?: ep.name))
+                    for (ch in value) {
+                        if (ch == '\n') { line++; column = 1 } else column++
+                    }
+                    pos += value.length
+                    errorMatched = true
+                    break
+                }
+            }
+            if (errorMatched) continue
+
+            throw LexerError("Unexpected character '${source[pos]}'", line, column)
+        }
+
+        // Keyword promotion
+        if (keywordSet.isNotEmpty()) {
+            for (i in tokens.indices) {
+                val t = tokens[i]
+                if (t.typeName == "NAME") {
+                    val checkVal = if (grammar.caseSensitive) t.value else t.value.lowercase()
+                    if (checkVal in keywordSet) {
+                        tokens[i] = Token(TokenType.KEYWORD, t.value, t.line, t.column, "KEYWORD", t.flags)
+                    }
+                }
+            }
+        }
+
+        tokens.add(Token(TokenType.EOF, "", line, column, "EOF"))
+        return tokens
+    }
+
+    private fun compileDefinitions(defs: List<TokenDefinition>): List<CompiledPattern> =
+        defs.map { defn ->
+            val pattern = if (defn.isRegex) "\\G(?:${defn.pattern})" else "\\G${Regex.escape(defn.pattern)}"
+            CompiledPattern(defn.name, Regex(pattern), defn.alias)
+        }
+}

--- a/code/packages/kotlin/lexer/src/test/kotlin/com/codingadventures/lexer/LexerTest.kt
+++ b/code/packages/kotlin/lexer/src/test/kotlin/com/codingadventures/lexer/LexerTest.kt
@@ -1,0 +1,95 @@
+package com.codingadventures.lexer
+
+import com.codingadventures.grammartools.parseTokenGrammar
+import kotlin.test.*
+
+class LexerTest {
+
+    @Test fun tokenConstruction() {
+        val t = Token(TokenType.NUMBER, "42", 1, 1)
+        assertEquals(TokenType.NUMBER, t.type)
+        assertEquals("42", t.value)
+    }
+
+    @Test fun effectiveTypeName() {
+        assertEquals("NUMBER", Token(TokenType.NUMBER, "42", 1, 1).effectiveTypeName())
+        assertEquals("INT", Token(TokenType.GRAMMAR, "42", 1, 1, "INT").effectiveTypeName())
+    }
+
+    @Test fun flags() {
+        val t = Token(TokenType.GRAMMAR, "x", 1, 1, "NAME", FLAG_PRECEDED_BY_NEWLINE)
+        assertTrue(t.hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+        assertFalse(t.hasFlag(FLAG_CONTEXT_KEYWORD))
+    }
+
+    @Test fun simpleTokenization() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\nPLUS = \"+\"\nskip:\n  WS = /[ \\t]+/\n")
+        val tokens = GrammarLexer(g).tokenize("42 + 7")
+        assertEquals(4, tokens.size)
+        assertEquals("NUMBER", tokens[0].typeName)
+        assertEquals("42", tokens[0].value)
+        assertEquals("PLUS", tokens[1].typeName)
+        assertEquals("NUMBER", tokens[2].typeName)
+        assertEquals("EOF", tokens[3].typeName)
+    }
+
+    @Test fun lineColumnTracking() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nNL = /\\n/\nskip:\n  WS = /[ \\t]+/\n")
+        val tokens = GrammarLexer(g).tokenize("abc\ndef")
+        assertEquals(1, tokens[0].line)
+        assertEquals(1, tokens[0].column)
+        assertEquals(2, tokens[2].line)
+        assertEquals(1, tokens[2].column)
+    }
+
+    @Test fun keywordPromotion() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\nkeywords:\n  if\n  else\n")
+        val tokens = GrammarLexer(g).tokenize("if x else y")
+        assertEquals("KEYWORD", tokens[0].typeName)
+        assertEquals("NAME", tokens[1].typeName)
+        assertEquals("KEYWORD", tokens[2].typeName)
+    }
+
+    @Test fun aliasedToken() {
+        val g = parseTokenGrammar("STRING_DQ = /\"[^\"]*\"/ -> STRING\n")
+        val tokens = GrammarLexer(g).tokenize("\"hello\"")
+        assertEquals("STRING", tokens[0].typeName)
+    }
+
+    @Test fun unexpectedCharacter() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertFailsWith<LexerError> { GrammarLexer(g).tokenize("abc") }
+    }
+
+    @Test fun reservedKeyword() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nreserved:\n  class\n")
+        assertFailsWith<LexerError> { GrammarLexer(g).tokenize("class") }
+    }
+
+    @Test fun emptyInput() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        val tokens = GrammarLexer(g).tokenize("")
+        assertEquals(1, tokens.size)
+        assertEquals("EOF", tokens[0].typeName)
+    }
+
+    @Test fun contextKeywordFlag() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\ncontext_keywords:\n  async\n")
+        val tokens = GrammarLexer(g).tokenize("async foo")
+        assertTrue(tokens[0].hasFlag(FLAG_CONTEXT_KEYWORD))
+        assertFalse(tokens[1].hasFlag(FLAG_CONTEXT_KEYWORD))
+    }
+
+    @Test fun errorRecovery() {
+        val g = parseTokenGrammar("STRING = /\"[^\"]*\"/\nskip:\n  WS = /[ \\t]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n")
+        val tokens = GrammarLexer(g).tokenize("\"unclosed")
+        assertEquals("BAD_STRING", tokens[0].typeName)
+    }
+
+    @Test fun precededByNewlineFlag() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t\\n]+/\n")
+        val tokens = GrammarLexer(g).tokenize("a\nb")
+        assertFalse(tokens[0].hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+        assertTrue(tokens[1].hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+    }
+}

--- a/code/packages/kotlin/parser/.gitignore
+++ b/code/packages/kotlin/parser/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/parser/BUILD
+++ b/code/packages/kotlin/parser/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test

--- a/code/packages/kotlin/parser/BUILD_windows
+++ b/code/packages/kotlin/parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/parser/CHANGELOG.md
+++ b/code/packages/kotlin/parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- ASTNode data class with position tracking
+- GrammarParser — recursive descent parser with packrat memoization
+- Full test suite

--- a/code/packages/kotlin/parser/README.md
+++ b/code/packages/kotlin/parser/README.md
@@ -1,0 +1,7 @@
+# parser (Kotlin)
+
+Generic grammar-driven parser infrastructure for the coding-adventures project.
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools and lexer.

--- a/code/packages/kotlin/parser/build.gradle.kts
+++ b/code/packages/kotlin/parser/build.gradle.kts
@@ -19,8 +19,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 }
 
 tasks.withType<JavaCompile> {
-    targetCompatibility = "23"
-    sourceCompatibility = "23"
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
 }
 
 dependencies {

--- a/code/packages/kotlin/parser/build.gradle.kts
+++ b/code/packages/kotlin/parser/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "23"
+    sourceCompatibility = "23"
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    implementation("com.codingadventures:lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/parser/build.gradle.kts
+++ b/code/packages/kotlin/parser/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/code/packages/kotlin/parser/settings.gradle.kts
+++ b/code/packages/kotlin/parser/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/kotlin/parser/src/main/kotlin/com/codingadventures/parser/Parser.kt
+++ b/code/packages/kotlin/parser/src/main/kotlin/com/codingadventures/parser/Parser.kt
@@ -1,0 +1,213 @@
+// ============================================================================
+// Parser.kt — Grammar-driven recursive descent parser with packrat memoization
+// ============================================================================
+//
+// Takes a token stream and a ParserGrammar and produces an AST.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser
+
+import com.codingadventures.grammartools.*
+import com.codingadventures.lexer.Token
+
+// ---------------------------------------------------------------------------
+// AST node
+// ---------------------------------------------------------------------------
+
+/**
+ * A generic AST node produced by grammar-driven parsing.
+ * Children can be either ASTNode or Token instances.
+ */
+data class ASTNode(
+    val ruleName: String,
+    val children: List<Any>,  // ASTNode or Token
+    val startLine: Int = 0,
+    val startColumn: Int = 0,
+    val endLine: Int = 0,
+    val endColumn: Int = 0
+) {
+    val isLeaf: Boolean get() = children.size == 1 && children[0] is Token
+    val token: Token? get() = if (isLeaf) children[0] as Token else null
+
+    fun descendantCount(): Int = children.sumOf { child ->
+        1 + if (child is ASTNode) child.descendantCount() else 0
+    }
+}
+
+class GrammarParseError(message: String, val token: Token) :
+    Exception("Parse error at ${token.line}:${token.column}: $message")
+
+// ---------------------------------------------------------------------------
+// Memo entry
+// ---------------------------------------------------------------------------
+
+private data class MemoEntry(val children: List<Any>?, val endPos: Int, val ok: Boolean)
+private data class MatchResult(val children: List<Any>, val endPos: Int)
+
+// ---------------------------------------------------------------------------
+// Grammar parser
+// ---------------------------------------------------------------------------
+
+class GrammarParser(private val grammar: ParserGrammar) {
+
+    private val ruleMap: Map<String, GrammarRule> = grammar.rules.associateBy { it.name }
+
+    fun parse(tokens: List<Token>): ASTNode {
+        if (grammar.rules.isEmpty())
+            throw GrammarParseError("No rules in grammar", tokens.last())
+
+        val startRule = grammar.rules[0].name
+        val memo = mutableMapOf<String, MutableMap<Int, MemoEntry>>()
+
+        val result = matchRule(startRule, tokens, 0, memo)
+            ?: throw GrammarParseError("Failed to parse starting rule '$startRule'", tokens[0])
+
+        return buildNode(startRule, result.children, tokens)
+    }
+
+    private fun matchRule(
+        ruleName: String, tokens: List<Token>, pos: Int,
+        memo: MutableMap<String, MutableMap<Int, MemoEntry>>
+    ): MatchResult? {
+        val ruleMemo = memo.getOrPut(ruleName) { mutableMapOf() }
+        ruleMemo[pos]?.let { cached ->
+            return if (cached.ok) MatchResult(cached.children!!, cached.endPos) else null
+        }
+
+        val rule = ruleMap[ruleName]
+        if (rule == null) {
+            ruleMemo[pos] = MemoEntry(null, pos, false)
+            return null
+        }
+
+        val result = matchElement(rule.body, tokens, pos, memo)
+        return if (result != null) {
+            val wrapped = listOf(buildNode(ruleName, result.children, tokens))
+            ruleMemo[pos] = MemoEntry(wrapped, result.endPos, true)
+            MatchResult(wrapped, result.endPos)
+        } else {
+            ruleMemo[pos] = MemoEntry(null, pos, false)
+            null
+        }
+    }
+
+    private fun matchElement(
+        element: GrammarElement, tokens: List<Token>, pos: Int,
+        memo: MutableMap<String, MutableMap<Int, MemoEntry>>
+    ): MatchResult? = when (element) {
+        is RuleReference -> if (element.isToken) {
+            if (pos < tokens.size && element.name == tokens[pos].effectiveTypeName())
+                MatchResult(listOf(tokens[pos]), pos + 1)
+            else null
+        } else matchRule(element.name, tokens, pos, memo)
+
+        is Literal -> if (pos < tokens.size && element.value == tokens[pos].value)
+            MatchResult(listOf(tokens[pos]), pos + 1) else null
+
+        is Sequence -> {
+            val children = mutableListOf<Any>()
+            var curPos = pos
+            var failed = false
+            for (sub in element.elements) {
+                val r = matchElement(sub, tokens, curPos, memo)
+                if (r == null) { failed = true; break }
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            if (failed) null else MatchResult(children, curPos)
+        }
+
+        is Alternation -> {
+            var result: MatchResult? = null
+            for (choice in element.choices) {
+                result = matchElement(choice, tokens, pos, memo)
+                if (result != null) break
+            }
+            result
+        }
+
+        is Repetition -> {
+            val children = mutableListOf<Any>()
+            var curPos = pos
+            while (true) {
+                val r = matchElement(element.element, tokens, curPos, memo) ?: break
+                if (r.endPos == curPos) break
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            MatchResult(children, curPos)
+        }
+
+        is OneOrMoreRepetition -> {
+            val first = matchElement(element.element, tokens, pos, memo) ?: return null
+            val children = first.children.toMutableList()
+            var curPos = first.endPos
+            while (true) {
+                val r = matchElement(element.element, tokens, curPos, memo) ?: break
+                if (r.endPos == curPos) break
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            MatchResult(children, curPos)
+        }
+
+        is Optional -> matchElement(element.element, tokens, pos, memo)
+            ?: MatchResult(emptyList(), pos)
+
+        is Group -> matchElement(element.element, tokens, pos, memo)
+
+        is PositiveLookahead -> if (matchElement(element.element, tokens, pos, memo) != null)
+            MatchResult(emptyList(), pos) else null
+
+        is NegativeLookahead -> if (matchElement(element.element, tokens, pos, memo) == null)
+            MatchResult(emptyList(), pos) else null
+
+        is SeparatedRepetition -> {
+            val children = mutableListOf<Any>()
+            val first = matchElement(element.element, tokens, pos, memo)
+            if (first == null) {
+                if (element.atLeastOne) null else MatchResult(emptyList(), pos)
+            } else {
+                children.addAll(first.children)
+                var curPos = first.endPos
+                while (true) {
+                    val sepMatch = matchElement(element.separator, tokens, curPos, memo) ?: break
+                    val elemMatch = matchElement(element.element, tokens, sepMatch.endPos, memo) ?: break
+                    children.addAll(sepMatch.children)
+                    children.addAll(elemMatch.children)
+                    curPos = elemMatch.endPos
+                }
+                MatchResult(children, curPos)
+            }
+        }
+    }
+
+    private fun buildNode(ruleName: String, children: List<Any>, tokens: List<Token>): ASTNode {
+        val first = findFirstToken(children)
+        val last = findLastToken(children)
+        return ASTNode(
+            ruleName, children,
+            first?.line ?: 0, first?.column ?: 0,
+            last?.line ?: 0, last?.column ?: 0
+        )
+    }
+
+    private fun findFirstToken(children: List<Any>): Token? {
+        for (child in children) {
+            if (child is Token) return child
+            if (child is ASTNode) findFirstToken(child.children)?.let { return it }
+        }
+        return null
+    }
+
+    private fun findLastToken(children: List<Any>): Token? {
+        for (i in children.indices.reversed()) {
+            val child = children[i]
+            if (child is Token) return child
+            if (child is ASTNode) findLastToken(child.children)?.let { return it }
+        }
+        return null
+    }
+}

--- a/code/packages/kotlin/parser/src/test/kotlin/com/codingadventures/parser/ParserTest.kt
+++ b/code/packages/kotlin/parser/src/test/kotlin/com/codingadventures/parser/ParserTest.kt
@@ -1,0 +1,110 @@
+package com.codingadventures.parser
+
+import com.codingadventures.grammartools.*
+import com.codingadventures.lexer.Token
+import com.codingadventures.lexer.TokenType
+import kotlin.test.*
+
+class ParserTest {
+
+    private fun makeTokens(vararg typesAndValues: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var i = 0
+        while (i < typesAndValues.size) {
+            tokens.add(Token(TokenType.GRAMMAR, typesAndValues[i + 1], 1, tokens.size + 1, typesAndValues[i]))
+            i += 2
+        }
+        tokens.add(Token(TokenType.EOF, "", 1, tokens.size + 1, "EOF"))
+        return tokens
+    }
+
+    @Test fun emptyNode() {
+        val node = ASTNode("test", emptyList())
+        assertFalse(node.isLeaf)
+        assertNull(node.token)
+    }
+
+    @Test fun leafNode() {
+        val t = Token(TokenType.NUMBER, "42", 1, 1)
+        val node = ASTNode("num", listOf(t))
+        assertTrue(node.isLeaf)
+        assertEquals(t, node.token)
+    }
+
+    @Test fun singleTokenRule() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        val ast = GrammarParser(g).parse(makeTokens("NUMBER", "42"))
+        assertEquals("program", ast.ruleName)
+    }
+
+    @Test fun sequenceRule() {
+        val g = parseParserGrammar("assign = NAME EQUALS NUMBER ;")
+        val ast = GrammarParser(g).parse(makeTokens("NAME", "x", "EQUALS", "=", "NUMBER", "42"))
+        assertEquals("assign", ast.ruleName)
+    }
+
+    @Test fun alternationRule() {
+        val g = parseParserGrammar("value = NUMBER | NAME ;")
+        assertEquals("value", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+        assertEquals("value", GrammarParser(g).parse(makeTokens("NAME", "x")).ruleName)
+    }
+
+    @Test fun repetitionRule() {
+        val g = parseParserGrammar("list = { NUMBER } ;")
+        assertEquals("list", GrammarParser(g).parse(makeTokens()).ruleName)
+        assertEquals("list", GrammarParser(g).parse(makeTokens("NUMBER", "1", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun optionalRule() {
+        val g = parseParserGrammar("maybe = [ NUMBER ] ;")
+        assertEquals("maybe", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+        assertEquals("maybe", GrammarParser(g).parse(makeTokens()).ruleName)
+    }
+
+    @Test fun nestedRules() {
+        val g = parseParserGrammar("program = { statement } ;\nstatement = NUMBER ;")
+        assertEquals("program", GrammarParser(g).parse(makeTokens("NUMBER", "1", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun parseFailure() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens("NAME", "x")) }
+    }
+
+    @Test fun emptyGrammar() {
+        val g = ParserGrammar()
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens()) }
+    }
+
+    @Test fun positiveLookahead() {
+        val g = parseParserGrammar("check = &NUMBER NUMBER ;")
+        assertEquals("check", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+    }
+
+    @Test fun negativeLookahead() {
+        val g = parseParserGrammar("check = !NAME NUMBER ;")
+        assertEquals("check", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+    }
+
+    @Test fun negativeLookaheadFails() {
+        val g = parseParserGrammar("check = !NUMBER NUMBER ;")
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens("NUMBER", "42")) }
+    }
+
+    @Test fun separatedRepetition() {
+        val g = parseParserGrammar("args = { NUMBER // COMMA } ;")
+        assertEquals("args", GrammarParser(g).parse(makeTokens("NUMBER", "1", "COMMA", ",", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun literalMatch() {
+        val g = parseParserGrammar("op = \"+\" ;")
+        assertEquals("op", GrammarParser(g).parse(makeTokens("PLUS", "+")).ruleName)
+    }
+
+    @Test fun descendantCount() {
+        val t = Token(TokenType.NUMBER, "1", 1, 1)
+        val leaf = ASTNode("num", listOf(t))
+        val parent = ASTNode("expr", listOf(leaf))
+        assertEquals(2, parent.descendantCount())
+    }
+}

--- a/code/packages/python/ecmascript-es1-lexer/BUILD
+++ b/code/packages/python/ecmascript-es1-lexer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es1-lexer/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es1-lexer/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-lexer/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es1-lexer/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 1 (1997) Lexer
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 1 (1997) lexer
+- Thin wrapper around `GrammarLexer` loading `es1.tokens`
+- Public API: `create_es1_lexer(source)`, `tokenize_es1(source)`
+- Comprehensive test suite covering keywords, operators, identifiers, literals

--- a/code/packages/python/ecmascript-es1-lexer/README.md
+++ b/code/packages/python/ecmascript-es1-lexer/README.md
@@ -1,0 +1,29 @@
+# ECMAScript 1 (1997) Lexer
+
+Tokenizes ECMAScript 1 (1997) JavaScript source code using the grammar-driven lexer.
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarLexer`. It loads
+the `es1.tokens` grammar file from `code/grammars/ecmascript/` and
+produces a stream of `Token` objects.
+
+## Usage
+
+```python
+from ecmascript_es1_lexer import tokenize_es1
+
+tokens = tokenize_es1('var x = 1 + 2;')
+for token in tokens:
+    print(f"{token.type.name}: {token.value!r}")
+```
+
+## API
+
+- `tokenize_es1(source: str) -> list[Token]` — Tokenize source code, returns list of tokens ending with EOF.
+- `create_es1_lexer(source: str) -> GrammarLexer` — Create a lexer instance for advanced usage.
+
+## Dependencies
+
+- `coding-adventures-grammar-tools` — Parses `.tokens` files
+- `coding-adventures-lexer` — Provides `GrammarLexer` engine

--- a/code/packages/python/ecmascript-es1-lexer/pyproject.toml
+++ b/code/packages/python/ecmascript-es1-lexer/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es1-lexer"
+version = "0.1.0"
+description = "Tokenizes ECMAScript 1 (1997) JavaScript source code using the grammar-driven lexer — loads es1.tokens"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es1", "lexer", "tokenizer", "grammar-driven", "computer-science", "education"]
+dependencies = ["coding-adventures-directed-graph", "coding-adventures-grammar-tools", "coding-adventures-lexer", "coding-adventures-state-machine"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es1_lexer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es1_lexer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es1_lexer"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es1-lexer/required_capabilities.json
+++ b/code/packages/python/ecmascript-es1-lexer/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es1-lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es1.tokens",
+      "justification": "Reads token grammar definition file to build the lexer DFA at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es1-lexer/src/ecmascript_es1_lexer/__init__.py
+++ b/code/packages/python/ecmascript-es1-lexer/src/ecmascript_es1_lexer/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 1 (1997) Lexer — tokenizes ES1 JavaScript source code.
+
+Public API:
+
+- ``create_es1_lexer(source)`` — creates a ``GrammarLexer`` for ES1.
+- ``tokenize_es1(source)`` — tokenizes source, returns list of ``Token`` objects.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es1_lexer.tokenizer import create_es1_lexer, tokenize_es1
+
+__all__ = [
+    "create_es1_lexer",
+    "tokenize_es1",
+]

--- a/code/packages/python/ecmascript-es1-lexer/src/ecmascript_es1_lexer/tokenizer.py
+++ b/code/packages/python/ecmascript-es1-lexer/src/ecmascript_es1_lexer/tokenizer.py
@@ -1,0 +1,93 @@
+"""ECMAScript 1 (1997) Lexer — tokenizes ES1 JavaScript using grammar-driven approach.
+
+This module is a thin wrapper around the generic ``GrammarLexer``. It loads
+the ``es1.tokens`` grammar file from ``code/grammars/ecmascript/`` and creates
+a lexer configured for the very first version of standardized JavaScript.
+
+ES1 (ECMA-262 1st Edition, June 1997) is the foundation of JavaScript:
+
+- 26 keywords: ``break``, ``case``, ``continue``, ``default``, ``delete``,
+  ``do``, ``else``, ``for``, ``function``, ``if``, ``in``, ``new``,
+  ``return``, ``switch``, ``this``, ``typeof``, ``var``, ``void``,
+  ``while``, ``with``, ``true``, ``false``, ``null``
+- No ``===`` or ``!==`` (strict equality — that's ES3)
+- No ``try``/``catch``/``finally``/``throw`` (error handling — that's ES3)
+- No regex literals (formalized in ES3)
+- No ``let``/``const``/``class``/arrow functions (that's ES2015)
+
+Locating the Grammar File
+--------------------------
+
+The ``es1.tokens`` file lives in ``code/grammars/ecmascript/`` at the
+repository root. We locate it relative to this module's file path::
+
+    tokenizer.py
+    └── ecmascript_es1_lexer/  (parent)
+        └── src/               (parent)
+            └── ecmascript-es1-lexer/ (parent)
+                └── python/           (parent)
+                    └── packages/     (parent)
+                        └── code/     (parent)
+                            └── grammars/
+                                └── ecmascript/
+                                    └── es1.tokens
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+
+# ---------------------------------------------------------------------------
+# Grammar File Location
+# ---------------------------------------------------------------------------
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES1_TOKENS_PATH = GRAMMAR_DIR / "es1.tokens"
+
+
+def create_es1_lexer(source: str) -> GrammarLexer:
+    """Create a ``GrammarLexer`` configured for ECMAScript 1 (1997).
+
+    Args:
+        source: The ES1 JavaScript source code to tokenize.
+
+    Returns:
+        A ``GrammarLexer`` instance configured with ES1 token definitions.
+
+    Example::
+
+        lexer = create_es1_lexer('var x = 1 + 2;')
+        tokens = lexer.tokenize()
+    """
+    grammar = parse_token_grammar(ES1_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_es1(source: str) -> list[Token]:
+    """Tokenize ECMAScript 1 source code and return a list of tokens.
+
+    This is the main entry point for the ES1 lexer. Pass in a string of
+    JavaScript source code (ES1-era), and get back a flat list of ``Token``
+    objects. The list always ends with an ``EOF`` token.
+
+    Args:
+        source: The ES1 JavaScript source code to tokenize.
+
+    Returns:
+        A list of ``Token`` objects.
+
+    Example::
+
+        tokens = tokenize_es1('var x = 1 + 2;')
+        # [Token(KEYWORD, 'var', 1:1), Token(NAME, 'x', 1:5),
+        #  Token(EQUALS, '=', 1:7), Token(NUMBER, '1', 1:9),
+        #  Token(PLUS, '+', 1:11), Token(NUMBER, '2', 1:13),
+        #  Token(SEMICOLON, ';', 1:14), Token(EOF, '', 1:15)]
+    """
+    lexer = create_es1_lexer(source)
+    return lexer.tokenize()

--- a/code/packages/python/ecmascript-es1-lexer/tests/test_ecmascript_es1_lexer.py
+++ b/code/packages/python/ecmascript-es1-lexer/tests/test_ecmascript_es1_lexer.py
@@ -1,0 +1,387 @@
+"""Tests for the ECMAScript 1 (1997) Lexer.
+
+These tests verify that the grammar-driven lexer, loaded with the ``es1.tokens``
+grammar file, correctly tokenizes ES1-era JavaScript source code.
+
+ES1 is the foundation of JavaScript. The key differences from later versions:
+- No ``===`` or ``!==`` (strict equality is ES3)
+- No ``try``/``catch`` (error handling is ES3)
+- No regex literals (formalized in ES3)
+- No ``let``/``const``/``class``/arrows (ES2015)
+"""
+
+from __future__ import annotations
+
+from lexer import Token, TokenType
+
+from ecmascript_es1_lexer import create_es1_lexer, tokenize_es1
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def token_types(tokens: list[Token]) -> list[str]:
+    """Extract just the type names from a token list.
+
+    Token types can be either ``TokenType`` enum members (for built-in types like
+    NAME, NUMBER, KEYWORD, EOF) or plain strings (for grammar-defined types like
+    STRICT_EQUALS, AMPERSAND, etc.). We handle both.
+    """
+    return [t.type.name if hasattr(t.type, "name") else t.type for t in tokens]
+
+
+def token_type_name(token: Token) -> str:
+    """Get the type name of a single token."""
+    return token.type.name if hasattr(token.type, "name") else token.type
+
+
+def token_values(tokens: list[Token]) -> list[str]:
+    """Extract just the values from a token list."""
+    return [t.value for t in tokens]
+
+
+# ============================================================================
+# Test: Variable Declarations
+# ============================================================================
+
+
+class TestVariableDeclarations:
+    """ES1 only has ``var`` — no ``let`` or ``const``."""
+
+    def test_var_declaration(self) -> None:
+        """Tokenize ``var x = 1;`` — the only declaration keyword in ES1."""
+        tokens = tokenize_es1("var x = 1;")
+        assert token_types(tokens) == [
+            "KEYWORD", "NAME", "EQUALS", "NUMBER", "SEMICOLON", "EOF",
+        ]
+        assert token_values(tokens) == ["var", "x", "=", "1", ";", ""]
+
+    def test_var_without_initializer(self) -> None:
+        """Tokenize ``var x;`` — declaration without assignment."""
+        tokens = tokenize_es1("var x;")
+        assert token_types(tokens) == ["KEYWORD", "NAME", "SEMICOLON", "EOF"]
+
+    def test_multiple_var_declarations(self) -> None:
+        """Tokenize ``var x = 1, y = 2;`` — comma-separated declarations."""
+        tokens = tokenize_es1("var x = 1, y = 2;")
+        assert token_values(tokens) == [
+            "var", "x", "=", "1", ",", "y", "=", "2", ";", "",
+        ]
+
+
+# ============================================================================
+# Test: ES1 Keywords
+# ============================================================================
+
+
+class TestES1Keywords:
+    """ES1 has 26 keywords (including true/false/null)."""
+
+    def test_control_flow_keywords(self) -> None:
+        """Core control flow keywords are recognized."""
+        for kw in ["if", "else", "while", "for", "do", "switch", "case",
+                    "default", "break", "continue", "return"]:
+            tokens = tokenize_es1(kw)
+            assert tokens[0].type == TokenType.KEYWORD, f"{kw} not recognized as keyword"
+            assert tokens[0].value == kw
+
+    def test_declaration_keywords(self) -> None:
+        """``var`` and ``function`` are the only declaration keywords."""
+        for kw in ["var", "function"]:
+            tokens = tokenize_es1(kw)
+            assert tokens[0].type == TokenType.KEYWORD
+
+    def test_operator_keywords(self) -> None:
+        """``delete``, ``typeof``, ``void``, ``in``, ``new`` are keywords."""
+        for kw in ["delete", "typeof", "void", "in", "new"]:
+            tokens = tokenize_es1(kw)
+            assert tokens[0].type == TokenType.KEYWORD
+
+    def test_literal_keywords(self) -> None:
+        """``true``, ``false``, ``null`` are keywords in the lexer."""
+        for kw in ["true", "false", "null"]:
+            tokens = tokenize_es1(kw)
+            assert tokens[0].type == TokenType.KEYWORD
+            assert tokens[0].value == kw
+
+    def test_this_keyword(self) -> None:
+        """``this`` refers to the current execution context."""
+        tokens = tokenize_es1("this")
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_with_keyword(self) -> None:
+        """``with`` extends the scope chain (deprecated in strict mode later)."""
+        tokens = tokenize_es1("with")
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_keyword_vs_identifier(self) -> None:
+        """A keyword embedded in a longer name should be a NAME, not KEYWORD."""
+        tokens = tokenize_es1("variable")
+        assert tokens[0].type == TokenType.NAME
+        assert tokens[0].value == "variable"
+
+    def test_keyword_prefix(self) -> None:
+        """``forEach`` starts with ``for`` but is a NAME, not a keyword."""
+        tokens = tokenize_es1("forEach")
+        assert tokens[0].type == TokenType.NAME
+
+
+# ============================================================================
+# Test: Operators
+# ============================================================================
+
+
+class TestES1Operators:
+    """ES1 has 46 operators but NO ``===`` or ``!==``."""
+
+    def test_arithmetic_operators(self) -> None:
+        """Basic arithmetic: + - * / %"""
+        tokens = tokenize_es1("a + b - c * d / e % f")
+        ops = [t.value for t in tokens if t.type != TokenType.NAME and t.type != TokenType.EOF]
+        assert ops == ["+", "-", "*", "/", "%"]
+
+    def test_comparison_operators(self) -> None:
+        """ES1 comparison: == != < > <= >="""
+        tokens = tokenize_es1("a == b")
+        assert tokens[1].value == "=="
+        assert tokens[1].type.name == "EQUALS_EQUALS"
+
+    def test_no_strict_equality(self) -> None:
+        """ES1 does NOT have ===. The lexer should tokenize ``===`` as
+        ``==`` followed by ``=`` (since === is not defined in ES1)."""
+        tokens = tokenize_es1("a === b")
+        # Without === defined, the lexer should match == then =
+        values = token_values(tokens)
+        assert "===" not in values
+
+    def test_assignment_operators(self) -> None:
+        """Compound assignment: += -= *= /= %="""
+        tokens = tokenize_es1("x += 1")
+        assert tokens[1].value == "+="
+
+    def test_bitwise_operators(self) -> None:
+        """Bitwise: & | ^ ~ << >> >>>"""
+        tokens = tokenize_es1("a & b | c ^ d")
+        ops = [t.value for t in tokens if token_type_name(t) in ("AMPERSAND", "PIPE", "CARET")]
+        assert ops == ["&", "|", "^"]
+
+    def test_unsigned_right_shift(self) -> None:
+        """>>> is unique to JavaScript — unsigned right shift."""
+        tokens = tokenize_es1("a >>> b")
+        assert tokens[1].value == ">>>"
+
+    def test_logical_operators(self) -> None:
+        """Logical: && || !"""
+        tokens = tokenize_es1("a && b || !c")
+        ops = [t.value for t in tokens if token_type_name(t) in ("AND_AND", "OR_OR", "BANG")]
+        assert ops == ["&&", "||", "!"]
+
+    def test_increment_decrement(self) -> None:
+        """Prefix and postfix: ++ --"""
+        tokens = tokenize_es1("x++ + --y")
+        assert tokens[1].value == "++"
+        assert tokens[3].value == "--"
+
+    def test_ternary(self) -> None:
+        """Ternary conditional: ? :"""
+        tokens = tokenize_es1("a ? b : c")
+        assert tokens[1].value == "?"
+        assert tokens[3].value == ":"
+
+
+# ============================================================================
+# Test: Literals
+# ============================================================================
+
+
+class TestES1Literals:
+    """ES1 has numbers (decimal/hex/float) and strings (single/double quoted)."""
+
+    def test_integer(self) -> None:
+        tokens = tokenize_es1("42")
+        assert token_type_name(tokens[0]) == "NUMBER"
+        assert tokens[0].value == "42"
+
+    def test_hex_number(self) -> None:
+        """Hex literals start with 0x or 0X."""
+        tokens = tokenize_es1("0xFF")
+        assert token_type_name(tokens[0]) == "NUMBER"
+        assert tokens[0].value == "0xFF"
+
+    def test_float(self) -> None:
+        tokens = tokenize_es1("3.14")
+        assert token_type_name(tokens[0]) == "NUMBER"
+
+    def test_leading_dot_float(self) -> None:
+        """Leading-dot floats like .5 are valid."""
+        tokens = tokenize_es1(".5")
+        assert token_type_name(tokens[0]) == "NUMBER"
+
+    def test_scientific_notation(self) -> None:
+        tokens = tokenize_es1("1e10")
+        assert token_type_name(tokens[0]) == "NUMBER"
+
+    def test_double_quoted_string(self) -> None:
+        tokens = tokenize_es1('"hello"')
+        assert token_type_name(tokens[0]) == "STRING"
+        # The GrammarLexer may or may not strip quotes — check either form
+        assert "hello" in tokens[0].value
+
+    def test_single_quoted_string(self) -> None:
+        tokens = tokenize_es1("'hello'")
+        assert token_type_name(tokens[0]) == "STRING"
+
+    def test_string_with_escapes(self) -> None:
+        tokens = tokenize_es1(r'"hello\nworld"')
+        assert token_type_name(tokens[0]) == "STRING"
+
+
+# ============================================================================
+# Test: Identifiers
+# ============================================================================
+
+
+class TestES1Identifiers:
+    """ES1 identifiers can contain letters, digits, _, and $."""
+
+    def test_simple_name(self) -> None:
+        tokens = tokenize_es1("foo")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_dollar_sign(self) -> None:
+        """The $ character is valid in identifiers (jQuery convention)."""
+        tokens = tokenize_es1("$element")
+        assert tokens[0].type == TokenType.NAME
+        assert tokens[0].value == "$element"
+
+    def test_underscore_prefix(self) -> None:
+        tokens = tokenize_es1("_private")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_dollar_only(self) -> None:
+        """A single $ is a valid identifier (used by jQuery)."""
+        tokens = tokenize_es1("$")
+        assert tokens[0].type == TokenType.NAME
+        assert tokens[0].value == "$"
+
+
+# ============================================================================
+# Test: Delimiters
+# ============================================================================
+
+
+class TestES1Delimiters:
+    """Test all delimiter tokens."""
+
+    def test_braces(self) -> None:
+        tokens = tokenize_es1("{ }")
+        assert token_types(tokens) == ["LBRACE", "RBRACE", "EOF"]
+
+    def test_brackets(self) -> None:
+        tokens = tokenize_es1("[ ]")
+        assert token_types(tokens) == ["LBRACKET", "RBRACKET", "EOF"]
+
+    def test_parens(self) -> None:
+        tokens = tokenize_es1("( )")
+        assert token_types(tokens) == ["LPAREN", "RPAREN", "EOF"]
+
+    def test_semicolon(self) -> None:
+        tokens = tokenize_es1(";")
+        assert token_type_name(tokens[0]) == "SEMICOLON"
+
+    def test_dot(self) -> None:
+        tokens = tokenize_es1("a.b")
+        assert token_type_name(tokens[1]) == "DOT"
+
+
+# ============================================================================
+# Test: Comments (skipped)
+# ============================================================================
+
+
+class TestES1Comments:
+    """Comments are skipped by the lexer — they don't produce tokens."""
+
+    def test_line_comment(self) -> None:
+        tokens = tokenize_es1("x // this is a comment")
+        assert token_types(tokens) == ["NAME", "EOF"]
+
+    def test_block_comment(self) -> None:
+        tokens = tokenize_es1("x /* comment */ y")
+        assert token_types(tokens) == ["NAME", "NAME", "EOF"]
+
+
+# ============================================================================
+# Test: Position Tracking
+# ============================================================================
+
+
+class TestES1Positions:
+    """Verify that line and column numbers are tracked correctly."""
+
+    def test_single_line_positions(self) -> None:
+        tokens = tokenize_es1("var x = 1;")
+        assert tokens[0].line == 1
+        assert tokens[0].column == 1  # var starts at column 1
+
+    def test_multiline_positions(self) -> None:
+        tokens = tokenize_es1("var x;\nvar y;")
+        # Second `var` should be on line 2
+        second_var = [t for t in tokens if t.value == "var"][1]
+        assert second_var.line == 2
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES1Lexer:
+    """Test the ``create_es1_lexer()`` factory function."""
+
+    def test_creates_lexer(self) -> None:
+        lexer = create_es1_lexer("var x = 1;")
+        assert hasattr(lexer, "tokenize")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "var x = 1 + 2;"
+        tokens_direct = tokenize_es1(source)
+        tokens_factory = create_es1_lexer(source).tokenize()
+        assert tokens_direct == tokens_factory
+
+
+# ============================================================================
+# Test: Real-world ES1 Patterns
+# ============================================================================
+
+
+class TestES1RealWorldPatterns:
+    """Test realistic ES1-era code patterns."""
+
+    def test_function_declaration(self) -> None:
+        source = "function add(a, b) { return a + b; }"
+        tokens = tokenize_es1(source)
+        assert tokens[0].value == "function"
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_for_loop(self) -> None:
+        source = "for (var i = 0; i < 10; i++) { }"
+        tokens = tokenize_es1(source)
+        types = token_types(tokens)
+        assert "KEYWORD" in types  # for, var
+        assert "LESS_THAN" in types
+        assert "PLUS_PLUS" in types
+
+    def test_object_literal(self) -> None:
+        source = '{ name: "hello", value: 42 }'
+        tokens = tokenize_es1(source)
+        assert token_type_name(tokens[0]) == "LBRACE"
+        assert token_type_name(tokens[-2]) == "RBRACE"
+
+    def test_array_literal(self) -> None:
+        source = "[1, 2, 3]"
+        tokens = tokenize_es1(source)
+        assert token_type_name(tokens[0]) == "LBRACKET"
+        assert token_type_name(tokens[-2]) == "RBRACKET"

--- a/code/packages/python/ecmascript-es1-parser/BUILD
+++ b/code/packages/python/ecmascript-es1-parser/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es1-lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es1-parser/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es1-lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es1-lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es1-parser/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es1-lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es1-parser/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es1-parser/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 1 (1997) Parser
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 1 (1997) parser
+- Thin wrapper around `GrammarParser` loading `es1.grammar`
+- Public API: `create_es1_parser(source)`, `parse_es1(source)`
+- Comprehensive test suite verifying AST structure

--- a/code/packages/python/ecmascript-es1-parser/README.md
+++ b/code/packages/python/ecmascript-es1-parser/README.md
@@ -1,0 +1,24 @@
+# ECMAScript 1 (1997) Parser
+
+Parses ECMAScript 1 (1997) JavaScript source code into Abstract Syntax Trees (ASTs).
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarParser`. It loads
+the `es1.grammar` file from `code/grammars/ecmascript/` and produces
+`ASTNode` trees from tokenized source code.
+
+## Usage
+
+```python
+from ecmascript_es1_parser import parse_es1
+
+ast = parse_es1('var x = 1 + 2;')
+print(ast.rule_name)  # "program"
+```
+
+## Dependencies
+
+- `coding-adventures-ecmascript-es1-lexer` — Tokenizes source code
+- `coding-adventures-grammar-tools` — Parses `.grammar` files
+- `coding-adventures-parser` — Provides `GrammarParser` engine

--- a/code/packages/python/ecmascript-es1-parser/pyproject.toml
+++ b/code/packages/python/ecmascript-es1-parser/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es1-parser"
+version = "0.1.0"
+description = "Parses ECMAScript 1 (1997) JavaScript source code into ASTs using the grammar-driven parser — loads es1.grammar"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es1", "parser", "ast", "grammar-driven", "computer-science", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-ecmascript-es1-lexer",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es1_parser"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es1_parser --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es1_parser"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es1-parser/required_capabilities.json
+++ b/code/packages/python/ecmascript-es1-parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es1-parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es1.grammar",
+      "justification": "Reads parser grammar definition file to build the parser rules at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es1-parser/src/ecmascript_es1_parser/__init__.py
+++ b/code/packages/python/ecmascript-es1-parser/src/ecmascript_es1_parser/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 1 (1997) Parser — parses ES1 JavaScript into ASTs.
+
+Public API:
+
+- ``create_es1_parser(source)`` — creates a ``GrammarParser`` for ES1.
+- ``parse_es1(source)`` — parses source, returns an ``ASTNode`` tree.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es1_parser.parser import create_es1_parser, parse_es1
+
+__all__ = [
+    "create_es1_parser",
+    "parse_es1",
+]

--- a/code/packages/python/ecmascript-es1-parser/src/ecmascript_es1_parser/parser.py
+++ b/code/packages/python/ecmascript-es1-parser/src/ecmascript_es1_parser/parser.py
@@ -1,0 +1,69 @@
+"""ECMAScript 1 (1997) Parser — parses ES1 JavaScript into ASTs using grammar-driven approach.
+
+This module is a thin wrapper around the generic ``GrammarParser``. It loads
+the ``es1.grammar`` file and uses the ES1 lexer to tokenize source code before
+parsing.
+
+The pipeline is:
+
+1. Read ``es1.tokens`` -> ``GrammarLexer`` -> tokens (via ecmascript-es1-lexer)
+2. Read ``es1.grammar`` -> ``GrammarParser`` -> AST
+
+Locating the Grammar File
+--------------------------
+
+::
+
+    parser.py → ecmascript_es1_parser/ → src/ → ecmascript-es1-parser/
+    → python/ → packages/ → code/ → grammars/ecmascript/es1.grammar
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+from ecmascript_es1_lexer import tokenize_es1
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES1_GRAMMAR_PATH = GRAMMAR_DIR / "es1.grammar"
+
+
+def create_es1_parser(source: str) -> GrammarParser:
+    """Create a ``GrammarParser`` configured for ECMAScript 1 (1997).
+
+    Args:
+        source: The ES1 JavaScript source code to parse.
+
+    Returns:
+        A ``GrammarParser`` instance ready to produce an AST.
+
+    Example::
+
+        parser = create_es1_parser('var x = 1 + 2;')
+        ast = parser.parse()
+    """
+    tokens = tokenize_es1(source)
+    grammar = parse_parser_grammar(ES1_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_es1(source: str) -> ASTNode:
+    """Parse ECMAScript 1 source code and return an AST.
+
+    Args:
+        source: The ES1 JavaScript source code to parse.
+
+    Returns:
+        An ``ASTNode`` representing the parse tree.
+
+    Example::
+
+        ast = parse_es1('var x = 1 + 2;')
+        # ASTNode(rule_name="program", children=[...])
+    """
+    parser = create_es1_parser(source)
+    return parser.parse()

--- a/code/packages/python/ecmascript-es1-parser/tests/test_ecmascript_es1_parser.py
+++ b/code/packages/python/ecmascript-es1-parser/tests/test_ecmascript_es1_parser.py
@@ -1,0 +1,237 @@
+"""Tests for the ECMAScript 1 (1997) Parser.
+
+These tests verify that the grammar-driven parser, loaded with ``es1.grammar``,
+correctly parses ES1-era JavaScript into ASTs.
+"""
+
+from __future__ import annotations
+
+from lang_parser import ASTNode
+from lexer import Token, TokenType
+
+from ecmascript_es1_parser import create_es1_parser, parse_es1
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def find_nodes(node: ASTNode, rule_name: str) -> list[ASTNode]:
+    """Recursively find all descendant nodes with the given rule name."""
+    results: list[ASTNode] = []
+    if node.rule_name == rule_name:
+        results.append(node)
+    for child in node.children:
+        if isinstance(child, ASTNode):
+            results.extend(find_nodes(child, rule_name))
+    return results
+
+
+def find_tokens(node: ASTNode) -> list[Token]:
+    """Recursively collect all Token leaves from an AST."""
+    tokens: list[Token] = []
+    for child in node.children:
+        if isinstance(child, Token):
+            tokens.append(child)
+        elif isinstance(child, ASTNode):
+            tokens.extend(find_tokens(child))
+    return tokens
+
+
+# ============================================================================
+# Test: Program Structure
+# ============================================================================
+
+
+class TestProgramStructure:
+    """The root AST node should be a ``program``."""
+
+    def test_empty_program(self) -> None:
+        ast = parse_es1("")
+        assert ast.rule_name == "program"
+        assert len(ast.children) == 0
+
+    def test_single_statement(self) -> None:
+        ast = parse_es1("var x = 1;")
+        assert ast.rule_name == "program"
+        assert len(ast.children) >= 1
+
+
+# ============================================================================
+# Test: Variable Declarations
+# ============================================================================
+
+
+class TestVarDeclarations:
+    """ES1 only has ``var`` — no ``let`` or ``const``."""
+
+    def test_var_with_initializer(self) -> None:
+        ast = parse_es1("var x = 1;")
+        var_decls = find_nodes(ast, "variable_declaration")
+        assert len(var_decls) >= 1
+
+    def test_var_without_initializer(self) -> None:
+        ast = parse_es1("var x;")
+        var_stmts = find_nodes(ast, "variable_statement")
+        assert len(var_stmts) == 1
+
+    def test_multiple_var_declarations(self) -> None:
+        ast = parse_es1("var x = 1, y = 2;")
+        var_decls = find_nodes(ast, "variable_declaration")
+        assert len(var_decls) == 2
+
+
+# ============================================================================
+# Test: Function Declarations
+# ============================================================================
+
+
+class TestFunctionDeclarations:
+
+    def test_simple_function(self) -> None:
+        ast = parse_es1("function foo() { }")
+        func_decls = find_nodes(ast, "function_declaration")
+        assert len(func_decls) == 1
+
+    def test_function_with_params(self) -> None:
+        ast = parse_es1("function add(a, b) { return a + b; }")
+        func_decls = find_nodes(ast, "function_declaration")
+        assert len(func_decls) == 1
+
+    def test_function_with_body(self) -> None:
+        ast = parse_es1("function greet() { var msg = 1; }")
+        func_decls = find_nodes(ast, "function_declaration")
+        assert len(func_decls) == 1
+        # Should have a function_body with statements
+        func_bodies = find_nodes(ast, "function_body")
+        assert len(func_bodies) >= 1
+
+
+# ============================================================================
+# Test: Control Flow Statements
+# ============================================================================
+
+
+class TestControlFlow:
+
+    def test_if_statement(self) -> None:
+        ast = parse_es1("if (x) { y; }")
+        if_stmts = find_nodes(ast, "if_statement")
+        assert len(if_stmts) == 1
+
+    def test_if_else(self) -> None:
+        ast = parse_es1("if (x) { y; } else { z; }")
+        if_stmts = find_nodes(ast, "if_statement")
+        assert len(if_stmts) == 1
+
+    def test_while_loop(self) -> None:
+        ast = parse_es1("while (x) { y; }")
+        while_stmts = find_nodes(ast, "while_statement")
+        assert len(while_stmts) == 1
+
+    def test_do_while(self) -> None:
+        ast = parse_es1("do { x; } while (y);")
+        do_stmts = find_nodes(ast, "do_while_statement")
+        assert len(do_stmts) == 1
+
+    def test_for_loop(self) -> None:
+        ast = parse_es1("for (var i = 0; i; i) { x; }")
+        for_stmts = find_nodes(ast, "for_statement")
+        assert len(for_stmts) == 1
+
+    def test_switch(self) -> None:
+        ast = parse_es1("switch (x) { case 1: y; default: z; }")
+        switch_stmts = find_nodes(ast, "switch_statement")
+        assert len(switch_stmts) == 1
+
+
+# ============================================================================
+# Test: Expressions
+# ============================================================================
+
+
+class TestExpressions:
+
+    def test_expression_statement(self) -> None:
+        ast = parse_es1("1 + 2;")
+        expr_stmts = find_nodes(ast, "expression_statement")
+        assert len(expr_stmts) == 1
+
+    def test_operator_precedence(self) -> None:
+        """Multiplication should bind tighter than addition."""
+        ast = parse_es1("1 + 2 * 3;")
+        # The AST should have an additive_expression containing
+        # a multiplicative_expression
+        add_nodes = find_nodes(ast, "additive_expression")
+        mult_nodes = find_nodes(ast, "multiplicative_expression")
+        assert len(add_nodes) >= 1
+        assert len(mult_nodes) >= 1
+
+    def test_assignment(self) -> None:
+        """Bare assignments like ``x = 5;`` parse as expression statements
+        containing an assignment_expression (the grammar routes through the
+        full expression precedence chain)."""
+        ast = parse_es1("var x = 5;")
+        var_stmts = find_nodes(ast, "variable_statement")
+        assert len(var_stmts) == 1
+
+    def test_ternary(self) -> None:
+        ast = parse_es1("x ? y : z;")
+        cond_nodes = find_nodes(ast, "conditional_expression")
+        assert len(cond_nodes) >= 1
+
+    def test_function_call(self) -> None:
+        ast = parse_es1("foo(1, 2);")
+        call_nodes = find_nodes(ast, "call_expression")
+        assert len(call_nodes) >= 1
+
+
+# ============================================================================
+# Test: Literals
+# ============================================================================
+
+
+class TestLiterals:
+
+    def test_object_literal(self) -> None:
+        ast = parse_es1('var x = { a: 1, b: 2 };')
+        obj_nodes = find_nodes(ast, "object_literal")
+        assert len(obj_nodes) == 1
+
+    def test_array_literal(self) -> None:
+        ast = parse_es1("var x = [1, 2, 3];")
+        arr_nodes = find_nodes(ast, "array_literal")
+        assert len(arr_nodes) == 1
+
+
+# ============================================================================
+# Test: Multiple Statements
+# ============================================================================
+
+
+class TestMultipleStatements:
+
+    def test_two_statements(self) -> None:
+        ast = parse_es1("var x = 1; var y = 2;")
+        var_stmts = find_nodes(ast, "variable_statement")
+        assert len(var_stmts) == 2
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES1Parser:
+
+    def test_creates_parser(self) -> None:
+        parser = create_es1_parser("var x = 1;")
+        assert hasattr(parser, "parse")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "var x = 1 + 2;"
+        ast_direct = parse_es1(source)
+        ast_factory = create_es1_parser(source).parse()
+        assert ast_direct.rule_name == ast_factory.rule_name
+        assert len(ast_direct.children) == len(ast_factory.children)

--- a/code/packages/python/ecmascript-es3-lexer/BUILD
+++ b/code/packages/python/ecmascript-es3-lexer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es3-lexer/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es3-lexer/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-lexer/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es3-lexer/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 3 (1999) Lexer
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 3 (1999) lexer
+- Thin wrapper around `GrammarLexer` loading `es3.tokens`
+- Public API: `create_es3_lexer(source)`, `tokenize_es3(source)`
+- Comprehensive test suite covering keywords, operators, identifiers, literals

--- a/code/packages/python/ecmascript-es3-lexer/README.md
+++ b/code/packages/python/ecmascript-es3-lexer/README.md
@@ -1,0 +1,29 @@
+# ECMAScript 3 (1999) Lexer
+
+Tokenizes ECMAScript 3 (1999) JavaScript source code using the grammar-driven lexer.
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarLexer`. It loads
+the `es3.tokens` grammar file from `code/grammars/ecmascript/` and
+produces a stream of `Token` objects.
+
+## Usage
+
+```python
+from ecmascript_es3_lexer import tokenize_es3
+
+tokens = tokenize_es3('var x = 1 + 2;')
+for token in tokens:
+    print(f"{token.type.name}: {token.value!r}")
+```
+
+## API
+
+- `tokenize_es3(source: str) -> list[Token]` — Tokenize source code, returns list of tokens ending with EOF.
+- `create_es3_lexer(source: str) -> GrammarLexer` — Create a lexer instance for advanced usage.
+
+## Dependencies
+
+- `coding-adventures-grammar-tools` — Parses `.tokens` files
+- `coding-adventures-lexer` — Provides `GrammarLexer` engine

--- a/code/packages/python/ecmascript-es3-lexer/pyproject.toml
+++ b/code/packages/python/ecmascript-es3-lexer/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es3-lexer"
+version = "0.1.0"
+description = "Tokenizes ECMAScript 3 (1999) JavaScript source code using the grammar-driven lexer — loads es3.tokens"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es3", "lexer", "tokenizer", "grammar-driven", "computer-science", "education"]
+dependencies = ["coding-adventures-directed-graph", "coding-adventures-grammar-tools", "coding-adventures-lexer", "coding-adventures-state-machine"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es3_lexer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es3_lexer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es3_lexer"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es3-lexer/required_capabilities.json
+++ b/code/packages/python/ecmascript-es3-lexer/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es3-lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es3.tokens",
+      "justification": "Reads token grammar definition file to build the lexer DFA at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es3-lexer/src/ecmascript_es3_lexer/__init__.py
+++ b/code/packages/python/ecmascript-es3-lexer/src/ecmascript_es3_lexer/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 3 (1999) Lexer — tokenizes ES3 JavaScript source code.
+
+Public API:
+
+- ``create_es3_lexer(source)`` — creates a ``GrammarLexer`` for ES3.
+- ``tokenize_es3(source)`` — tokenizes source, returns list of ``Token`` objects.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es3_lexer.tokenizer import create_es3_lexer, tokenize_es3
+
+__all__ = [
+    "create_es3_lexer",
+    "tokenize_es3",
+]

--- a/code/packages/python/ecmascript-es3-lexer/src/ecmascript_es3_lexer/tokenizer.py
+++ b/code/packages/python/ecmascript-es3-lexer/src/ecmascript_es3_lexer/tokenizer.py
@@ -1,0 +1,77 @@
+"""ECMAScript 3 (1999) Lexer — tokenizes ES3 JavaScript using grammar-driven approach.
+
+ES3 (ECMA-262 3rd Edition, December 1999) was the version that made JavaScript
+a real, complete language. It adds several critical features over ES1:
+
+- ``===`` and ``!==`` (strict equality — no type coercion)
+- ``try``/``catch``/``finally``/``throw`` (structured error handling)
+- Regular expression literals (``/pattern/flags``)
+- ``instanceof`` operator (prototype chain check)
+- 5 new keywords: ``catch``, ``finally``, ``instanceof``, ``throw``, ``try``
+
+Regex vs Division Disambiguation
+---------------------------------
+
+The ``/`` character is ambiguous: it could start a regex or be division.
+The ``GrammarLexer`` resolves this using context from the previous token.
+After expression-ending tokens (``)`, ``]``, ``NAME``, ``NUMBER``, etc.),
+``/`` is division. After operators and statement-starting tokens, ``/``
+starts a regex.
+
+Locating the Grammar File
+--------------------------
+
+::
+
+    tokenizer.py → ecmascript_es3_lexer/ → src/ → ecmascript-es3-lexer/
+    → python/ → packages/ → code/ → grammars/ecmascript/es3.tokens
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES3_TOKENS_PATH = GRAMMAR_DIR / "es3.tokens"
+
+
+def create_es3_lexer(source: str) -> GrammarLexer:
+    """Create a ``GrammarLexer`` configured for ECMAScript 3 (1999).
+
+    Args:
+        source: The ES3 JavaScript source code to tokenize.
+
+    Returns:
+        A ``GrammarLexer`` instance configured with ES3 token definitions.
+
+    Example::
+
+        lexer = create_es3_lexer('try { x === 1; } catch (e) { }')
+        tokens = lexer.tokenize()
+    """
+    grammar = parse_token_grammar(ES3_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_es3(source: str) -> list[Token]:
+    """Tokenize ECMAScript 3 source code and return a list of tokens.
+
+    Args:
+        source: The ES3 JavaScript source code to tokenize.
+
+    Returns:
+        A list of ``Token`` objects, always ending with ``EOF``.
+
+    Example::
+
+        tokens = tokenize_es3('x === 1')
+        # [Token(NAME, 'x', 1:1), Token(STRICT_EQUALS, '===', 1:3),
+        #  Token(NUMBER, '1', 1:7), Token(EOF, '', 1:8)]
+    """
+    lexer = create_es3_lexer(source)
+    return lexer.tokenize()

--- a/code/packages/python/ecmascript-es3-lexer/tests/test_ecmascript_es3_lexer.py
+++ b/code/packages/python/ecmascript-es3-lexer/tests/test_ecmascript_es3_lexer.py
@@ -1,0 +1,234 @@
+"""Tests for the ECMAScript 3 (1999) Lexer.
+
+ES3 adds strict equality (===, !==), try/catch/finally/throw, regex literals,
+and the instanceof operator over ES1. These tests focus on the ES3-specific
+features while also verifying that all ES1 features still work.
+"""
+
+from __future__ import annotations
+
+from lexer import Token, TokenType
+
+from ecmascript_es3_lexer import create_es3_lexer, tokenize_es3
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def token_types(tokens: list[Token]) -> list[str]:
+    """Extract just the type names from a token list.
+
+    Token types can be ``TokenType`` enum members or plain strings (for
+    grammar-defined types). We handle both.
+    """
+    return [t.type.name if hasattr(t.type, "name") else t.type for t in tokens]
+
+
+def token_type_name(token: Token) -> str:
+    """Get the type name of a single token."""
+    return token.type.name if hasattr(token.type, "name") else token.type
+
+
+def token_values(tokens: list[Token]) -> list[str]:
+    """Extract just the values from a token list."""
+    return [t.value for t in tokens]
+
+
+# ============================================================================
+# Test: ES3 Strict Equality (NEW in ES3)
+# ============================================================================
+
+
+class TestStrictEquality:
+    """ES3 adds === and !== for strict equality (no type coercion)."""
+
+    def test_strict_equals(self) -> None:
+        """``===`` tests strict equality — no type coercion."""
+        tokens = tokenize_es3("x === 1")
+        assert tokens[1].value == "==="
+        assert token_type_name(tokens[1]) == "STRICT_EQUALS"
+
+    def test_strict_not_equals(self) -> None:
+        """``!==`` tests strict inequality."""
+        tokens = tokenize_es3("x !== 1")
+        assert tokens[1].value == "!=="
+        assert token_type_name(tokens[1]) == "STRICT_NOT_EQUALS"
+
+    def test_abstract_equality_still_works(self) -> None:
+        """``==`` still works alongside ``===``."""
+        tokens = tokenize_es3("x == 1")
+        assert tokens[1].value == "=="
+        assert token_type_name(tokens[1]) == "EQUALS_EQUALS"
+
+    def test_strict_before_abstract_ordering(self) -> None:
+        """``===`` must match before ``==`` (first-match-wins)."""
+        tokens = tokenize_es3("a === b == c")
+        assert tokens[1].value == "==="
+        assert tokens[3].value == "=="
+
+
+# ============================================================================
+# Test: ES3 Error Handling Keywords (NEW in ES3)
+# ============================================================================
+
+
+class TestErrorHandlingKeywords:
+    """ES3 adds try, catch, finally, throw as keywords."""
+
+    def test_try_keyword(self) -> None:
+        tokens = tokenize_es3("try")
+        assert tokens[0].type == TokenType.KEYWORD
+        assert tokens[0].value == "try"
+
+    def test_catch_keyword(self) -> None:
+        tokens = tokenize_es3("catch")
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_finally_keyword(self) -> None:
+        tokens = tokenize_es3("finally")
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_throw_keyword(self) -> None:
+        tokens = tokenize_es3("throw")
+        assert tokens[0].type == TokenType.KEYWORD
+
+    def test_instanceof_keyword(self) -> None:
+        """``instanceof`` checks prototype chain membership."""
+        tokens = tokenize_es3("x instanceof Array")
+        assert tokens[1].type == TokenType.KEYWORD
+        assert tokens[1].value == "instanceof"
+
+
+# ============================================================================
+# Test: ES3 Regex Literals (NEW in ES3)
+# ============================================================================
+
+
+class TestRegexLiterals:
+    """ES3 formalizes regex literals: /pattern/flags."""
+
+    def test_simple_regex(self) -> None:
+        """A basic regex literal."""
+        tokens = tokenize_es3("/hello/")
+        assert token_type_name(tokens[0]) == "REGEX"
+        assert tokens[0].value == "/hello/"
+
+    def test_regex_with_flags(self) -> None:
+        """Regex with global and case-insensitive flags."""
+        tokens = tokenize_es3("/pattern/gi")
+        assert token_type_name(tokens[0]) == "REGEX"
+        assert tokens[0].value == "/pattern/gi"
+
+    def test_regex_with_escapes(self) -> None:
+        """Regex containing escaped characters."""
+        tokens = tokenize_es3(r"/hello\/world/")
+        assert token_type_name(tokens[0]) == "REGEX"
+
+    def test_regex_with_character_class(self) -> None:
+        """Regex with character class brackets."""
+        tokens = tokenize_es3("/[a-z]+/")
+        assert token_type_name(tokens[0]) == "REGEX"
+
+
+# ============================================================================
+# Test: ES1 Features Still Work in ES3
+# ============================================================================
+
+
+class TestES1Compatibility:
+    """All ES1 features should work in the ES3 lexer."""
+
+    def test_var_declaration(self) -> None:
+        tokens = tokenize_es3("var x = 1;")
+        assert token_types(tokens) == [
+            "KEYWORD", "NAME", "EQUALS", "NUMBER", "SEMICOLON", "EOF",
+        ]
+
+    def test_all_es1_keywords(self) -> None:
+        """All 26 ES1 keywords are still valid in ES3."""
+        es1_keywords = [
+            "break", "case", "continue", "default", "delete", "do", "else",
+            "for", "function", "if", "in", "new", "return", "switch", "this",
+            "typeof", "var", "void", "while", "with", "true", "false", "null",
+        ]
+        for kw in es1_keywords:
+            tokens = tokenize_es3(kw)
+            assert tokens[0].type == TokenType.KEYWORD, f"{kw} should be KEYWORD in ES3"
+
+    def test_dollar_identifier(self) -> None:
+        tokens = tokenize_es3("$el")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_arithmetic(self) -> None:
+        tokens = tokenize_es3("1 + 2 * 3")
+        assert token_types(tokens) == [
+            "NUMBER", "PLUS", "NUMBER", "STAR", "NUMBER", "EOF",
+        ]
+
+    def test_strings(self) -> None:
+        tokens = tokenize_es3('"hello"')
+        assert token_type_name(tokens[0]) == "STRING"
+
+
+# ============================================================================
+# Test: Try/Catch Pattern
+# ============================================================================
+
+
+class TestTryCatchPattern:
+    """Test tokenization of try/catch/finally blocks."""
+
+    def test_try_catch(self) -> None:
+        source = "try { x; } catch (e) { y; }"
+        tokens = tokenize_es3(source)
+        values = token_values(tokens)
+        assert "try" in values
+        assert "catch" in values
+
+    def test_try_catch_finally(self) -> None:
+        source = "try { } catch (e) { } finally { }"
+        tokens = tokenize_es3(source)
+        values = token_values(tokens)
+        assert "finally" in values
+
+    def test_throw_expression(self) -> None:
+        source = 'throw "error";'
+        tokens = tokenize_es3(source)
+        assert tokens[0].value == "throw"
+        assert tokens[0].type == TokenType.KEYWORD
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES3Lexer:
+    """Test the ``create_es3_lexer()`` factory function."""
+
+    def test_creates_lexer(self) -> None:
+        lexer = create_es3_lexer("var x = 1;")
+        assert hasattr(lexer, "tokenize")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "try { x === 1; } catch (e) { }"
+        tokens_direct = tokenize_es3(source)
+        tokens_factory = create_es3_lexer(source).tokenize()
+        assert tokens_direct == tokens_factory
+
+
+# ============================================================================
+# Test: Comments
+# ============================================================================
+
+
+class TestES3Comments:
+    def test_line_comment_skipped(self) -> None:
+        tokens = tokenize_es3("x // comment")
+        assert token_types(tokens) == ["NAME", "EOF"]
+
+    def test_block_comment_skipped(self) -> None:
+        tokens = tokenize_es3("x /* block */ y")
+        assert token_types(tokens) == ["NAME", "NAME", "EOF"]

--- a/code/packages/python/ecmascript-es3-parser/BUILD
+++ b/code/packages/python/ecmascript-es3-parser/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es3-lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es3-parser/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es3-lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es3-parser/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es3-lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es3-lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es3-parser/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es3-parser/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 3 (1999) Parser
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 3 (1999) parser
+- Thin wrapper around `GrammarParser` loading `es3.grammar`
+- Public API: `create_es3_parser(source)`, `parse_es3(source)`
+- Comprehensive test suite verifying AST structure

--- a/code/packages/python/ecmascript-es3-parser/README.md
+++ b/code/packages/python/ecmascript-es3-parser/README.md
@@ -1,0 +1,24 @@
+# ECMAScript 3 (1999) Parser
+
+Parses ECMAScript 3 (1999) JavaScript source code into Abstract Syntax Trees (ASTs).
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarParser`. It loads
+the `es3.grammar` file from `code/grammars/ecmascript/` and produces
+`ASTNode` trees from tokenized source code.
+
+## Usage
+
+```python
+from ecmascript_es3_parser import parse_es3
+
+ast = parse_es3('var x = 1 + 2;')
+print(ast.rule_name)  # "program"
+```
+
+## Dependencies
+
+- `coding-adventures-ecmascript-es3-lexer` — Tokenizes source code
+- `coding-adventures-grammar-tools` — Parses `.grammar` files
+- `coding-adventures-parser` — Provides `GrammarParser` engine

--- a/code/packages/python/ecmascript-es3-parser/pyproject.toml
+++ b/code/packages/python/ecmascript-es3-parser/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es3-parser"
+version = "0.1.0"
+description = "Parses ECMAScript 3 (1999) JavaScript source code into ASTs using the grammar-driven parser — loads es3.grammar"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es3", "parser", "ast", "grammar-driven", "computer-science", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-ecmascript-es3-lexer",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es3_parser"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es3_parser --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es3_parser"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es3-parser/required_capabilities.json
+++ b/code/packages/python/ecmascript-es3-parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es3-parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es3.grammar",
+      "justification": "Reads parser grammar definition file to build the parser rules at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es3-parser/src/ecmascript_es3_parser/__init__.py
+++ b/code/packages/python/ecmascript-es3-parser/src/ecmascript_es3_parser/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 3 (1999) Parser — parses ES3 JavaScript into ASTs.
+
+Public API:
+
+- ``create_es3_parser(source)`` — creates a ``GrammarParser`` for ES3.
+- ``parse_es3(source)`` — parses source, returns an ``ASTNode`` tree.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es3_parser.parser import create_es3_parser, parse_es3
+
+__all__ = [
+    "create_es3_parser",
+    "parse_es3",
+]

--- a/code/packages/python/ecmascript-es3-parser/src/ecmascript_es3_parser/parser.py
+++ b/code/packages/python/ecmascript-es3-parser/src/ecmascript_es3_parser/parser.py
@@ -1,0 +1,31 @@
+"""ECMAScript 3 (1999) Parser — parses ES3 JavaScript into ASTs.
+
+ES3 adds try/catch/finally/throw statements, strict equality (=== !==),
+instanceof, and regex literals to the ES1 grammar.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+from ecmascript_es3_lexer import tokenize_es3
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES3_GRAMMAR_PATH = GRAMMAR_DIR / "es3.grammar"
+
+
+def create_es3_parser(source: str) -> GrammarParser:
+    """Create a ``GrammarParser`` configured for ECMAScript 3 (1999)."""
+    tokens = tokenize_es3(source)
+    grammar = parse_parser_grammar(ES3_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_es3(source: str) -> ASTNode:
+    """Parse ECMAScript 3 source code and return an AST."""
+    parser = create_es3_parser(source)
+    return parser.parse()

--- a/code/packages/python/ecmascript-es3-parser/tests/test_ecmascript_es3_parser.py
+++ b/code/packages/python/ecmascript-es3-parser/tests/test_ecmascript_es3_parser.py
@@ -1,0 +1,133 @@
+"""Tests for the ECMAScript 3 (1999) Parser.
+
+ES3 adds try/catch/finally/throw, strict equality, instanceof, and regex
+to the ES1 grammar.
+"""
+
+from __future__ import annotations
+
+from lang_parser import ASTNode
+from lexer import Token
+
+from ecmascript_es3_parser import create_es3_parser, parse_es3
+
+
+def find_nodes(node: ASTNode, rule_name: str) -> list[ASTNode]:
+    results: list[ASTNode] = []
+    if node.rule_name == rule_name:
+        results.append(node)
+    for child in node.children:
+        if isinstance(child, ASTNode):
+            results.extend(find_nodes(child, rule_name))
+    return results
+
+
+def find_tokens(node: ASTNode) -> list[Token]:
+    tokens: list[Token] = []
+    for child in node.children:
+        if isinstance(child, Token):
+            tokens.append(child)
+        elif isinstance(child, ASTNode):
+            tokens.extend(find_tokens(child))
+    return tokens
+
+
+# ============================================================================
+# Test: ES3 try/catch/finally (NEW)
+# ============================================================================
+
+
+class TestTryCatchFinally:
+
+    def test_try_catch(self) -> None:
+        ast = parse_es3("try { var x = 1; } catch (e) { var y = 2; }")
+        try_stmts = find_nodes(ast, "try_statement")
+        assert len(try_stmts) == 1
+
+    def test_try_finally(self) -> None:
+        ast = parse_es3("try { var x = 1; } finally { var y = 2; }")
+        try_stmts = find_nodes(ast, "try_statement")
+        assert len(try_stmts) == 1
+
+    def test_try_catch_finally(self) -> None:
+        ast = parse_es3("try { } catch (e) { } finally { }")
+        try_stmts = find_nodes(ast, "try_statement")
+        assert len(try_stmts) == 1
+
+    def test_throw(self) -> None:
+        ast = parse_es3('throw 1;')
+        throw_stmts = find_nodes(ast, "throw_statement")
+        assert len(throw_stmts) == 1
+
+
+# ============================================================================
+# Test: ES3 Strict Equality in Expressions
+# ============================================================================
+
+
+class TestStrictEqualityParsing:
+
+    def test_strict_equals_expression(self) -> None:
+        ast = parse_es3("var x = 1 === 2;")
+        eq_nodes = find_nodes(ast, "equality_expression")
+        assert len(eq_nodes) >= 1
+
+
+# ============================================================================
+# Test: ES1 Features Still Parse in ES3
+# ============================================================================
+
+
+class TestES1Compatibility:
+
+    def test_var_declaration(self) -> None:
+        ast = parse_es3("var x = 1;")
+        assert ast.rule_name == "program"
+
+    def test_function_declaration(self) -> None:
+        ast = parse_es3("function foo() { }")
+        func_decls = find_nodes(ast, "function_declaration")
+        assert len(func_decls) == 1
+
+    def test_if_else(self) -> None:
+        ast = parse_es3("if (x) { } else { }")
+        if_stmts = find_nodes(ast, "if_statement")
+        assert len(if_stmts) == 1
+
+    def test_while_loop(self) -> None:
+        ast = parse_es3("while (x) { }")
+        while_stmts = find_nodes(ast, "while_statement")
+        assert len(while_stmts) == 1
+
+    def test_for_loop(self) -> None:
+        ast = parse_es3("for (var i = 0; i; i) { }")
+        for_stmts = find_nodes(ast, "for_statement")
+        assert len(for_stmts) == 1
+
+    def test_switch(self) -> None:
+        ast = parse_es3("switch (x) { case 1: var y = 2; }")
+        switch_stmts = find_nodes(ast, "switch_statement")
+        assert len(switch_stmts) == 1
+
+    def test_object_literal(self) -> None:
+        ast = parse_es3("var x = { a: 1 };")
+        obj_nodes = find_nodes(ast, "object_literal")
+        assert len(obj_nodes) == 1
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES3Parser:
+
+    def test_creates_parser(self) -> None:
+        parser = create_es3_parser("var x = 1;")
+        assert hasattr(parser, "parse")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "try { } catch (e) { }"
+        ast_direct = parse_es3(source)
+        ast_factory = create_es3_parser(source).parse()
+        assert ast_direct.rule_name == ast_factory.rule_name

--- a/code/packages/python/ecmascript-es5-lexer/BUILD
+++ b/code/packages/python/ecmascript-es5-lexer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es5-lexer/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-lexer/BUILD_windows
+++ b/code/packages/python/ecmascript-es5-lexer/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-lexer/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es5-lexer/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 5 (2009) Lexer
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 5 (2009) lexer
+- Thin wrapper around `GrammarLexer` loading `es5.tokens`
+- Public API: `create_es5_lexer(source)`, `tokenize_es5(source)`
+- Comprehensive test suite covering keywords, operators, identifiers, literals

--- a/code/packages/python/ecmascript-es5-lexer/README.md
+++ b/code/packages/python/ecmascript-es5-lexer/README.md
@@ -1,0 +1,29 @@
+# ECMAScript 5 (2009) Lexer
+
+Tokenizes ECMAScript 5 (2009) JavaScript source code using the grammar-driven lexer.
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarLexer`. It loads
+the `es5.tokens` grammar file from `code/grammars/ecmascript/` and
+produces a stream of `Token` objects.
+
+## Usage
+
+```python
+from ecmascript_es5_lexer import tokenize_es5
+
+tokens = tokenize_es5('var x = 1 + 2;')
+for token in tokens:
+    print(f"{token.type.name}: {token.value!r}")
+```
+
+## API
+
+- `tokenize_es5(source: str) -> list[Token]` — Tokenize source code, returns list of tokens ending with EOF.
+- `create_es5_lexer(source: str) -> GrammarLexer` — Create a lexer instance for advanced usage.
+
+## Dependencies
+
+- `coding-adventures-grammar-tools` — Parses `.tokens` files
+- `coding-adventures-lexer` — Provides `GrammarLexer` engine

--- a/code/packages/python/ecmascript-es5-lexer/pyproject.toml
+++ b/code/packages/python/ecmascript-es5-lexer/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es5-lexer"
+version = "0.1.0"
+description = "Tokenizes ECMAScript 5 (2009) JavaScript source code using the grammar-driven lexer — loads es5.tokens"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es5", "lexer", "tokenizer", "grammar-driven", "computer-science", "education"]
+dependencies = ["coding-adventures-directed-graph", "coding-adventures-grammar-tools", "coding-adventures-lexer", "coding-adventures-state-machine"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es5_lexer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es5_lexer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es5_lexer"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es5-lexer/required_capabilities.json
+++ b/code/packages/python/ecmascript-es5-lexer/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es5-lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es5.tokens",
+      "justification": "Reads token grammar definition file to build the lexer DFA at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es5-lexer/src/ecmascript_es5_lexer/__init__.py
+++ b/code/packages/python/ecmascript-es5-lexer/src/ecmascript_es5_lexer/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 5 (2009) Lexer — tokenizes ES5 JavaScript source code.
+
+Public API:
+
+- ``create_es5_lexer(source)`` — creates a ``GrammarLexer`` for ES5.
+- ``tokenize_es5(source)`` — tokenizes source, returns list of ``Token`` objects.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es5_lexer.tokenizer import create_es5_lexer, tokenize_es5
+
+__all__ = [
+    "create_es5_lexer",
+    "tokenize_es5",
+]

--- a/code/packages/python/ecmascript-es5-lexer/src/ecmascript_es5_lexer/tokenizer.py
+++ b/code/packages/python/ecmascript-es5-lexer/src/ecmascript_es5_lexer/tokenizer.py
@@ -1,0 +1,73 @@
+"""ECMAScript 5 (2009) Lexer — tokenizes ES5 JavaScript using grammar-driven approach.
+
+ES5 (ECMA-262 5th Edition, December 2009) landed a decade after ES3. ES4 was
+abandoned after years of committee disagreement. The syntactic changes in ES5
+are modest — the big innovations were strict mode and property descriptors.
+
+What ES5 adds over ES3:
+
+- ``debugger`` keyword (promoted from future-reserved)
+- Getter/setter syntax in object literals (parsed by the grammar, not the lexer)
+- String line continuation (backslash before newline)
+
+The token set is nearly identical to ES3. The real difference is in the keyword
+list (``debugger`` is now a keyword) and the future-reserved list (significantly
+reduced from ES3's large set).
+
+Locating the Grammar File
+--------------------------
+
+::
+
+    tokenizer.py → ecmascript_es5_lexer/ → src/ → ecmascript-es5-lexer/
+    → python/ → packages/ → code/ → grammars/ecmascript/es5.tokens
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES5_TOKENS_PATH = GRAMMAR_DIR / "es5.tokens"
+
+
+def create_es5_lexer(source: str) -> GrammarLexer:
+    """Create a ``GrammarLexer`` configured for ECMAScript 5 (2009).
+
+    Args:
+        source: The ES5 JavaScript source code to tokenize.
+
+    Returns:
+        A ``GrammarLexer`` instance configured with ES5 token definitions.
+
+    Example::
+
+        lexer = create_es5_lexer('debugger; var x = 1;')
+        tokens = lexer.tokenize()
+    """
+    grammar = parse_token_grammar(ES5_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_es5(source: str) -> list[Token]:
+    """Tokenize ECMAScript 5 source code and return a list of tokens.
+
+    Args:
+        source: The ES5 JavaScript source code to tokenize.
+
+    Returns:
+        A list of ``Token`` objects, always ending with ``EOF``.
+
+    Example::
+
+        tokens = tokenize_es5('debugger;')
+        # [Token(KEYWORD, 'debugger', 1:1), Token(SEMICOLON, ';', 1:9),
+        #  Token(EOF, '', 1:10)]
+    """
+    lexer = create_es5_lexer(source)
+    return lexer.tokenize()

--- a/code/packages/python/ecmascript-es5-lexer/tests/test_ecmascript_es5_lexer.py
+++ b/code/packages/python/ecmascript-es5-lexer/tests/test_ecmascript_es5_lexer.py
@@ -1,0 +1,223 @@
+"""Tests for the ECMAScript 5 (2009) Lexer.
+
+ES5 adds the ``debugger`` keyword (promoted from future-reserved in ES3).
+The token set is otherwise nearly identical to ES3. The real ES5 innovations
+(strict mode, property descriptors, JSON) are semantic, not lexical.
+"""
+
+from __future__ import annotations
+
+from lexer import Token, TokenType
+
+from ecmascript_es5_lexer import create_es5_lexer, tokenize_es5
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def token_types(tokens: list[Token]) -> list[str]:
+    return [t.type.name if hasattr(t.type, "name") else t.type for t in tokens]
+
+
+def token_type_name(token: Token) -> str:
+    return token.type.name if hasattr(token.type, "name") else token.type
+
+
+def token_values(tokens: list[Token]) -> list[str]:
+    return [t.value for t in tokens]
+
+
+# ============================================================================
+# Test: ES5 Debugger Keyword (NEW in ES5)
+# ============================================================================
+
+
+class TestDebuggerKeyword:
+    """ES5 promotes ``debugger`` from future-reserved to a real keyword."""
+
+    def test_debugger_is_keyword(self) -> None:
+        tokens = tokenize_es5("debugger")
+        assert tokens[0].type == TokenType.KEYWORD
+        assert tokens[0].value == "debugger"
+
+    def test_debugger_statement(self) -> None:
+        """``debugger;`` is a complete statement in ES5."""
+        tokens = tokenize_es5("debugger;")
+        assert token_types(tokens) == ["KEYWORD", "SEMICOLON", "EOF"]
+
+
+# ============================================================================
+# Test: All ES3 Features Still Work
+# ============================================================================
+
+
+class TestES3Compatibility:
+    """All ES3 features should work in the ES5 lexer."""
+
+    def test_strict_equality(self) -> None:
+        tokens = tokenize_es5("x === y")
+        assert tokens[1].value == "==="
+
+    def test_strict_inequality(self) -> None:
+        tokens = tokenize_es5("x !== y")
+        assert tokens[1].value == "!=="
+
+    def test_try_catch_keywords(self) -> None:
+        for kw in ["try", "catch", "finally", "throw"]:
+            tokens = tokenize_es5(kw)
+            assert tokens[0].type == TokenType.KEYWORD
+
+    def test_instanceof(self) -> None:
+        tokens = tokenize_es5("x instanceof Array")
+        assert tokens[1].type == TokenType.KEYWORD
+        assert tokens[1].value == "instanceof"
+
+    def test_regex_literal(self) -> None:
+        tokens = tokenize_es5("/pattern/gi")
+        assert token_type_name(tokens[0]) == "REGEX"
+
+
+# ============================================================================
+# Test: All ES1 Features Still Work
+# ============================================================================
+
+
+class TestES1Compatibility:
+    def test_var_declaration(self) -> None:
+        tokens = tokenize_es5("var x = 1;")
+        assert token_types(tokens) == [
+            "KEYWORD", "NAME", "EQUALS", "NUMBER", "SEMICOLON", "EOF",
+        ]
+
+    def test_all_es1_keywords(self) -> None:
+        es1_keywords = [
+            "break", "case", "continue", "default", "delete", "do", "else",
+            "for", "function", "if", "in", "new", "return", "switch", "this",
+            "typeof", "var", "void", "while", "with", "true", "false", "null",
+        ]
+        for kw in es1_keywords:
+            tokens = tokenize_es5(kw)
+            assert tokens[0].type == TokenType.KEYWORD
+
+    def test_arithmetic(self) -> None:
+        tokens = tokenize_es5("1 + 2 * 3")
+        assert token_types(tokens) == [
+            "NUMBER", "PLUS", "NUMBER", "STAR", "NUMBER", "EOF",
+        ]
+
+    def test_dollar_identifier(self) -> None:
+        tokens = tokenize_es5("$")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_hex_number(self) -> None:
+        tokens = tokenize_es5("0xFF")
+        assert token_type_name(tokens[0]) == "NUMBER"
+
+    def test_strings(self) -> None:
+        tokens = tokenize_es5("'hello'")
+        assert token_type_name(tokens[0]) == "STRING"
+
+
+# ============================================================================
+# Test: Full Keyword Set (ES5 = ES3 keywords + debugger)
+# ============================================================================
+
+
+class TestES5FullKeywordSet:
+    """ES5 has all ES3 keywords plus ``debugger``."""
+
+    def test_complete_keyword_list(self) -> None:
+        es5_keywords = [
+            "break", "case", "catch", "continue", "debugger", "default",
+            "delete", "do", "else", "finally", "for", "function", "if",
+            "in", "instanceof", "new", "return", "switch", "this", "throw",
+            "try", "typeof", "var", "void", "while", "with",
+            "true", "false", "null",
+        ]
+        for kw in es5_keywords:
+            tokens = tokenize_es5(kw)
+            assert tokens[0].type == TokenType.KEYWORD, f"{kw} not keyword in ES5"
+
+
+# ============================================================================
+# Test: Getter/Setter Pattern (lexer sees NAME tokens, grammar handles context)
+# ============================================================================
+
+
+class TestGetterSetterTokenization:
+    """In ES5, ``get`` and ``set`` are NOT keywords — they are NAMEs.
+    The grammar handles the contextual interpretation."""
+
+    def test_get_is_name(self) -> None:
+        tokens = tokenize_es5("get")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_set_is_name(self) -> None:
+        tokens = tokenize_es5("set")
+        assert tokens[0].type == TokenType.NAME
+
+    def test_getter_pattern_tokens(self) -> None:
+        """``get name() {}`` tokenizes as NAME NAME LPAREN RPAREN LBRACE RBRACE."""
+        tokens = tokenize_es5("get name() {}")
+        assert token_types(tokens) == [
+            "NAME", "NAME", "LPAREN", "RPAREN", "LBRACE", "RBRACE", "EOF",
+        ]
+
+
+# ============================================================================
+# Test: Real-world ES5 Patterns
+# ============================================================================
+
+
+class TestES5RealWorldPatterns:
+    def test_strict_mode_directive(self) -> None:
+        """The "use strict" directive is just a string literal to the lexer."""
+        tokens = tokenize_es5('"use strict";')
+        assert token_type_name(tokens[0]) == "STRING"
+        assert "use strict" in tokens[0].value
+
+    def test_property_access_chain(self) -> None:
+        tokens = tokenize_es5("a.b.c")
+        assert token_types(tokens) == [
+            "NAME", "DOT", "NAME", "DOT", "NAME", "EOF",
+        ]
+
+    def test_function_call(self) -> None:
+        tokens = tokenize_es5("foo(1, 2)")
+        assert token_types(tokens) == [
+            "NAME", "LPAREN", "NUMBER", "COMMA", "NUMBER", "RPAREN", "EOF",
+        ]
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES5Lexer:
+    def test_creates_lexer(self) -> None:
+        lexer = create_es5_lexer("debugger;")
+        assert hasattr(lexer, "tokenize")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "debugger; var x = 1;"
+        tokens_direct = tokenize_es5(source)
+        tokens_factory = create_es5_lexer(source).tokenize()
+        assert tokens_direct == tokens_factory
+
+
+# ============================================================================
+# Test: Comments
+# ============================================================================
+
+
+class TestES5Comments:
+    def test_line_comment_skipped(self) -> None:
+        tokens = tokenize_es5("x // comment")
+        assert token_types(tokens) == ["NAME", "EOF"]
+
+    def test_block_comment_skipped(self) -> None:
+        tokens = tokenize_es5("x /* block */ y")
+        assert token_types(tokens) == ["NAME", "NAME", "EOF"]

--- a/code/packages/python/ecmascript-es5-parser/BUILD
+++ b/code/packages/python/ecmascript-es5-parser/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es5-lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es5-parser/BUILD_windows
@@ -1,3 +1,5 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es5-lexer -e ".[dev]" --quiet
-.venv\Scripts\python -m pytest tests/ -v
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es5-lexer --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-parser/BUILD_windows
+++ b/code/packages/python/ecmascript-es5-parser/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../ecmascript-es5-lexer -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ecmascript-es5-parser/CHANGELOG.md
+++ b/code/packages/python/ecmascript-es5-parser/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — ECMAScript 5 (2009) Parser
+
+## 0.1.0 (2026-04-04)
+
+### Added
+
+- Initial implementation of the ECMAScript 5 (2009) parser
+- Thin wrapper around `GrammarParser` loading `es5.grammar`
+- Public API: `create_es5_parser(source)`, `parse_es5(source)`
+- Comprehensive test suite verifying AST structure

--- a/code/packages/python/ecmascript-es5-parser/README.md
+++ b/code/packages/python/ecmascript-es5-parser/README.md
@@ -1,0 +1,24 @@
+# ECMAScript 5 (2009) Parser
+
+Parses ECMAScript 5 (2009) JavaScript source code into Abstract Syntax Trees (ASTs).
+
+## Overview
+
+This package is a thin wrapper around the generic `GrammarParser`. It loads
+the `es5.grammar` file from `code/grammars/ecmascript/` and produces
+`ASTNode` trees from tokenized source code.
+
+## Usage
+
+```python
+from ecmascript_es5_parser import parse_es5
+
+ast = parse_es5('var x = 1 + 2;')
+print(ast.rule_name)  # "program"
+```
+
+## Dependencies
+
+- `coding-adventures-ecmascript-es5-lexer` — Tokenizes source code
+- `coding-adventures-grammar-tools` — Parses `.grammar` files
+- `coding-adventures-parser` — Provides `GrammarParser` engine

--- a/code/packages/python/ecmascript-es5-parser/pyproject.toml
+++ b/code/packages/python/ecmascript-es5-parser/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ecmascript-es5-parser"
+version = "0.1.0"
+description = "Parses ECMAScript 5 (2009) JavaScript source code into ASTs using the grammar-driven parser — loads es5.grammar"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ecmascript", "es5", "parser", "ast", "grammar-driven", "computer-science", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-ecmascript-es5-lexer",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ecmascript_es5_parser"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ecmascript_es5_parser --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+omit = ["src/**/_grammar.py"]
+source = ["src/ecmascript_es5_parser"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ecmascript-es5-parser/required_capabilities.json
+++ b/code/packages/python/ecmascript-es5-parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/ecmascript-es5-parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/ecmascript/es5.grammar",
+      "justification": "Reads parser grammar definition file to build the parser rules at initialization time."
+    }
+  ],
+  "justification": "Reads grammar definition files. No write, network, or process access needed."
+}

--- a/code/packages/python/ecmascript-es5-parser/src/ecmascript_es5_parser/__init__.py
+++ b/code/packages/python/ecmascript-es5-parser/src/ecmascript_es5_parser/__init__.py
@@ -1,0 +1,16 @@
+"""ECMAScript 5 (2009) Parser — parses ES5 JavaScript into ASTs.
+
+Public API:
+
+- ``create_es5_parser(source)`` — creates a ``GrammarParser`` for ES5.
+- ``parse_es5(source)`` — parses source, returns an ``ASTNode`` tree.
+"""
+
+from __future__ import annotations
+
+from ecmascript_es5_parser.parser import create_es5_parser, parse_es5
+
+__all__ = [
+    "create_es5_parser",
+    "parse_es5",
+]

--- a/code/packages/python/ecmascript-es5-parser/src/ecmascript_es5_parser/parser.py
+++ b/code/packages/python/ecmascript-es5-parser/src/ecmascript_es5_parser/parser.py
@@ -1,0 +1,31 @@
+"""ECMAScript 5 (2009) Parser — parses ES5 JavaScript into ASTs.
+
+ES5 adds the debugger statement and getter/setter property syntax in
+object literals on top of the ES3 grammar.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+from ecmascript_es5_lexer import tokenize_es5
+
+GRAMMAR_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent.parent / "grammars" / "ecmascript"
+)
+ES5_GRAMMAR_PATH = GRAMMAR_DIR / "es5.grammar"
+
+
+def create_es5_parser(source: str) -> GrammarParser:
+    """Create a ``GrammarParser`` configured for ECMAScript 5 (2009)."""
+    tokens = tokenize_es5(source)
+    grammar = parse_parser_grammar(ES5_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_es5(source: str) -> ASTNode:
+    """Parse ECMAScript 5 source code and return an AST."""
+    parser = create_es5_parser(source)
+    return parser.parse()

--- a/code/packages/python/ecmascript-es5-parser/tests/test_ecmascript_es5_parser.py
+++ b/code/packages/python/ecmascript-es5-parser/tests/test_ecmascript_es5_parser.py
@@ -1,0 +1,117 @@
+"""Tests for the ECMAScript 5 (2009) Parser.
+
+ES5 adds the debugger statement and getter/setter properties on top of ES3.
+"""
+
+from __future__ import annotations
+
+from lang_parser import ASTNode
+from lexer import Token
+
+from ecmascript_es5_parser import create_es5_parser, parse_es5
+
+
+def find_nodes(node: ASTNode, rule_name: str) -> list[ASTNode]:
+    results: list[ASTNode] = []
+    if node.rule_name == rule_name:
+        results.append(node)
+    for child in node.children:
+        if isinstance(child, ASTNode):
+            results.extend(find_nodes(child, rule_name))
+    return results
+
+
+# ============================================================================
+# Test: ES5 Debugger Statement (NEW)
+# ============================================================================
+
+
+class TestDebuggerStatement:
+
+    def test_debugger(self) -> None:
+        ast = parse_es5("debugger;")
+        dbg_stmts = find_nodes(ast, "debugger_statement")
+        assert len(dbg_stmts) == 1
+
+    def test_debugger_in_function(self) -> None:
+        ast = parse_es5("function foo() { debugger; }")
+        dbg_stmts = find_nodes(ast, "debugger_statement")
+        assert len(dbg_stmts) == 1
+
+
+# ============================================================================
+# Test: ES3 Features Still Parse in ES5
+# ============================================================================
+
+
+class TestES3Compatibility:
+
+    def test_try_catch(self) -> None:
+        ast = parse_es5("try { } catch (e) { }")
+        try_stmts = find_nodes(ast, "try_statement")
+        assert len(try_stmts) == 1
+
+    def test_throw(self) -> None:
+        ast = parse_es5("throw 1;")
+        throw_stmts = find_nodes(ast, "throw_statement")
+        assert len(throw_stmts) == 1
+
+
+# ============================================================================
+# Test: ES1 Features Still Parse in ES5
+# ============================================================================
+
+
+class TestES1Compatibility:
+
+    def test_var_declaration(self) -> None:
+        ast = parse_es5("var x = 1;")
+        assert ast.rule_name == "program"
+
+    def test_function_declaration(self) -> None:
+        ast = parse_es5("function foo() { }")
+        func_decls = find_nodes(ast, "function_declaration")
+        assert len(func_decls) == 1
+
+    def test_if_else(self) -> None:
+        ast = parse_es5("if (x) { } else { }")
+        if_stmts = find_nodes(ast, "if_statement")
+        assert len(if_stmts) == 1
+
+    def test_object_literal(self) -> None:
+        ast = parse_es5("var x = { a: 1 };")
+        obj_nodes = find_nodes(ast, "object_literal")
+        assert len(obj_nodes) == 1
+
+
+# ============================================================================
+# Test: Multiple Statements
+# ============================================================================
+
+
+class TestMultipleStatements:
+
+    def test_debugger_and_var(self) -> None:
+        ast = parse_es5("debugger; var x = 1;")
+        dbg_stmts = find_nodes(ast, "debugger_statement")
+        var_stmts = find_nodes(ast, "variable_statement")
+        assert len(dbg_stmts) == 1
+        assert len(var_stmts) == 1
+
+
+# ============================================================================
+# Test: Factory Function
+# ============================================================================
+
+
+class TestCreateES5Parser:
+
+    def test_creates_parser(self) -> None:
+        parser = create_es5_parser("debugger;")
+        assert hasattr(parser, "parse")
+
+    def test_factory_produces_same_result(self) -> None:
+        source = "debugger; var x = 1;"
+        ast_direct = parse_es5(source)
+        ast_factory = create_es5_parser(source).parse()
+        assert ast_direct.rule_name == ast_factory.rule_name

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -17,7 +17,7 @@ func TestAllLanguagesConstant(t *testing.T) {
 	expected := map[string]bool{
 		"python": true, "ruby": true, "go": true,
 		"typescript": true, "rust": true, "elixir": true, "lua": true, "perl": true,
-		"swift": true,
+		"swift": true, "java": true, "kotlin": true,
 	}
 	if len(allLanguages) != len(expected) {
 		t.Errorf("allLanguages has %d entries, want %d", len(allLanguages), len(expected))

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -460,7 +460,7 @@ func run() int {
 
 // allLanguages is the canonical list of supported languages in the monorepo.
 // The order is stable and matches the order used in CI toolchain setup.
-var allLanguages = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift"}
+var allLanguages = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "java", "kotlin"}
 
 // sharedPrefixes are repo paths that, when changed, mean ALL languages
 // need rebuilding. Keep this list intentionally narrow: only changes to


### PR DESCRIPTION
## Summary
- Add ECMAScript ES1, ES3, and ES5 self-contained token grammar and grammar files under `code/specs/`
- Add Python `ecmascript-es1-lexer`, `ecmascript-es3-lexer`, `ecmascript-es5-lexer`, `ecmascript-es1-parser`, `ecmascript-es3-parser`, and `ecmascript-es5-parser` packages with full test coverage
- Add Java and Kotlin foundational `lexer`, `parser`, `grammar-tools`, and `document-ast` packages
- Fix CI: add Java/Kotlin language detection, JDK 21 setup, and JVM target alignment in the Go build-tool
- Fix `BUILD_windows` files for Python ECMAScript packages (168 files, ~9900 lines)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/code)