### PR TITLE
feat(dotnet): port core compiler pipeline packages (lexer, parser, grammar-tools, directed-graph, state-machine) to C# and F#

### DIFF
--- a/code/packages/csharp/directed-graph/BUILD
+++ b/code/packages/csharp/directed-graph/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/directed-graph/BUILD
+++ b/code/packages/csharp/directed-graph/BUILD
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/directed-graph/BUILD_windows
+++ b/code/packages/csharp/directed-graph/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/directed-graph/BUILD_windows
+++ b/code/packages/csharp/directed-graph/BUILD_windows
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/directed-graph/CHANGELOG.md
+++ b/code/packages/csharp/directed-graph/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial C# directed-graph port

--- a/code/packages/csharp/directed-graph/CodingAdventures.DirectedGraph.csproj
+++ b/code/packages/csharp/directed-graph/CodingAdventures.DirectedGraph.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.DirectedGraph.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>A directed graph with traversal and topological sorting algorithms</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/directed-graph/DirectedGraph.cs
+++ b/code/packages/csharp/directed-graph/DirectedGraph.cs
@@ -1,0 +1,334 @@
+namespace CodingAdventures.DirectedGraph;
+
+public sealed class CycleError : Exception
+{
+    public CycleError(string message, IReadOnlyList<string> cycle) : base(message)
+    {
+        Cycle = cycle;
+    }
+
+    public IReadOnlyList<string> Cycle { get; }
+}
+
+public sealed class NodeNotFoundError : Exception
+{
+    public NodeNotFoundError(string node) : base($"Node not found: \"{node}\"")
+    {
+        Node = node;
+    }
+
+    public string Node { get; }
+}
+
+public sealed class EdgeNotFoundError : Exception
+{
+    public EdgeNotFoundError(string fromNode, string toNode) : base($"Edge not found: \"{fromNode}\" -> \"{toNode}\"")
+    {
+        FromNode = fromNode;
+        ToNode = toNode;
+    }
+
+    public string FromNode { get; }
+    public string ToNode { get; }
+}
+
+public sealed class Graph
+{
+    private readonly Dictionary<string, HashSet<string>> _forward = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HashSet<string>> _reverse = new(StringComparer.Ordinal);
+
+    public Graph(bool allowSelfLoops = false)
+    {
+        AllowSelfLoops = allowSelfLoops;
+    }
+
+    public bool AllowSelfLoops { get; }
+    public int Size => _forward.Count;
+
+    public void AddNode(string node)
+    {
+        _forward.TryAdd(node, new HashSet<string>(StringComparer.Ordinal));
+        _reverse.TryAdd(node, new HashSet<string>(StringComparer.Ordinal));
+    }
+
+    public void RemoveNode(string node)
+    {
+        if (!_forward.ContainsKey(node))
+        {
+            throw new NodeNotFoundError(node);
+        }
+
+        foreach (var successor in _forward[node].ToArray())
+        {
+            _reverse[successor].Remove(node);
+        }
+
+        foreach (var predecessor in _reverse[node].ToArray())
+        {
+            _forward[predecessor].Remove(node);
+        }
+
+        _forward.Remove(node);
+        _reverse.Remove(node);
+    }
+
+    public bool HasNode(string node) => _forward.ContainsKey(node);
+    public IReadOnlyList<string> Nodes() => _forward.Keys.ToList();
+
+    public void AddEdge(string fromNode, string toNode)
+    {
+        if (fromNode == toNode && !AllowSelfLoops)
+        {
+            throw new ArgumentException($"Self-loops are not allowed: \"{fromNode}\" -> \"{toNode}\"");
+        }
+
+        AddNode(fromNode);
+        AddNode(toNode);
+        _forward[fromNode].Add(toNode);
+        _reverse[toNode].Add(fromNode);
+    }
+
+    public void RemoveEdge(string fromNode, string toNode)
+    {
+        if (!HasNode(fromNode))
+        {
+            throw new NodeNotFoundError(fromNode);
+        }
+
+        if (!HasNode(toNode) || !_forward[fromNode].Contains(toNode))
+        {
+            throw new EdgeNotFoundError(fromNode, toNode);
+        }
+
+        _forward[fromNode].Remove(toNode);
+        _reverse[toNode].Remove(fromNode);
+    }
+
+    public bool HasEdge(string fromNode, string toNode) => HasNode(fromNode) && _forward[fromNode].Contains(toNode);
+
+    public IReadOnlyList<string> Successors(string node)
+    {
+        if (!HasNode(node))
+        {
+            throw new NodeNotFoundError(node);
+        }
+
+        return _forward[node].ToList();
+    }
+
+    public IReadOnlyList<string> Predecessors(string node)
+    {
+        if (!HasNode(node))
+        {
+            throw new NodeNotFoundError(node);
+        }
+
+        return _reverse[node].ToList();
+    }
+
+    public IReadOnlyList<(string From, string To)> Edges() =>
+        _forward.SelectMany(pair => pair.Value.Select(target => (pair.Key, target))).ToList();
+
+    public ISet<string> TransitiveClosure(string startNode) => Reach(startNode, Successors);
+    public ISet<string> TransitiveDependents(string startNode) => Reach(startNode, Predecessors);
+
+    public IReadOnlyList<string> TopologicalSort()
+    {
+        var indegree = _forward.Keys.ToDictionary(node => node, node => _reverse[node].Count, StringComparer.Ordinal);
+        var queue = new Queue<string>(indegree.Where(pair => pair.Value == 0).Select(pair => pair.Key));
+        var order = new List<string>();
+
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            order.Add(node);
+            foreach (var successor in _forward[node])
+            {
+                indegree[successor]--;
+                if (indegree[successor] == 0)
+                {
+                    queue.Enqueue(successor);
+                }
+            }
+        }
+
+        if (order.Count != _forward.Count)
+        {
+            throw new CycleError("Graph contains a cycle", FindCycle());
+        }
+
+        return order;
+    }
+
+    public IReadOnlyList<IReadOnlyList<string>> IndependentGroups()
+    {
+        var indegree = _forward.Keys.ToDictionary(node => node, node => _reverse[node].Count, StringComparer.Ordinal);
+        var remaining = new HashSet<string>(_forward.Keys, StringComparer.Ordinal);
+        var result = new List<IReadOnlyList<string>>();
+
+        while (remaining.Count > 0)
+        {
+            var layer = remaining.Where(node => indegree[node] == 0).OrderBy(node => node, StringComparer.Ordinal).ToList();
+            if (layer.Count == 0)
+            {
+                throw new CycleError("Graph contains a cycle", FindCycle());
+            }
+
+            result.Add(layer);
+            foreach (var node in layer)
+            {
+                remaining.Remove(node);
+                foreach (var successor in _forward[node])
+                {
+                    indegree[successor]--;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public IReadOnlyList<string> AffectedNodes(IEnumerable<string> changedNodes)
+    {
+        var affected = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var node in changedNodes)
+        {
+            if (!HasNode(node))
+            {
+                continue;
+            }
+
+            affected.Add(node);
+            affected.UnionWith(TransitiveClosure(node));
+        }
+
+        return TopologicalSort().Where(affected.Contains).ToList();
+    }
+
+    private HashSet<string> Reach(string startNode, Func<string, IReadOnlyList<string>> next)
+    {
+        if (!HasNode(startNode))
+        {
+            throw new NodeNotFoundError(startNode);
+        }
+
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+        stack.Push(startNode);
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            foreach (var neighbor in next(node))
+            {
+                if (visited.Add(neighbor))
+                {
+                    stack.Push(neighbor);
+                }
+            }
+        }
+
+        return visited;
+    }
+
+    private List<string> FindCycle()
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var onStack = new HashSet<string>(StringComparer.Ordinal);
+        var parent = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        foreach (var node in _forward.Keys)
+        {
+            var cycle = FindCycleFrom(node, visited, onStack, parent);
+            if (cycle.Count > 0)
+            {
+                return cycle;
+            }
+        }
+
+        return [];
+    }
+
+    private List<string> FindCycleFrom(
+        string node,
+        HashSet<string> visited,
+        HashSet<string> onStack,
+        Dictionary<string, string?> parent)
+    {
+        if (onStack.Contains(node))
+        {
+            var cycle = new List<string> { node };
+            var current = parent.GetValueOrDefault(node);
+            while (current is not null && current != node)
+            {
+                cycle.Insert(0, current);
+                current = parent.GetValueOrDefault(current);
+            }
+
+            cycle.Add(node);
+            return cycle;
+        }
+
+        if (!visited.Add(node))
+        {
+            return [];
+        }
+
+        onStack.Add(node);
+        foreach (var successor in _forward[node])
+        {
+            parent[successor] = node;
+            var cycle = FindCycleFrom(successor, visited, onStack, parent);
+            if (cycle.Count > 0)
+            {
+                return cycle;
+            }
+        }
+
+        onStack.Remove(node);
+        return [];
+    }
+}
+
+public sealed class LabeledDirectedGraph
+{
+    private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _labels = new(StringComparer.Ordinal);
+    private readonly Graph _graph;
+
+    public LabeledDirectedGraph(bool allowSelfLoops = false)
+    {
+        _graph = new Graph(allowSelfLoops);
+    }
+
+    public void AddNode(string node)
+    {
+        _graph.AddNode(node);
+        _labels.TryAdd(node, new Dictionary<string, HashSet<string>>(StringComparer.Ordinal));
+    }
+
+    public void AddEdge(string fromNode, string toNode, string label)
+    {
+        AddNode(fromNode);
+        AddNode(toNode);
+        _graph.AddEdge(fromNode, toNode);
+        if (!_labels[fromNode].TryGetValue(toNode, out var labels))
+        {
+            labels = new HashSet<string>(StringComparer.Ordinal);
+            _labels[fromNode][toNode] = labels;
+        }
+
+        labels.Add(label);
+    }
+
+    public IReadOnlyList<string> Labels(string fromNode, string toNode)
+    {
+        if (_labels.TryGetValue(fromNode, out var targets) && targets.TryGetValue(toNode, out var labels))
+        {
+            return labels.ToList();
+        }
+
+        return [];
+    }
+
+    public IReadOnlyList<string> TopologicalSort() => _graph.TopologicalSort();
+    public ISet<string> TransitiveClosure(string startNode) => _graph.TransitiveClosure(startNode);
+}

--- a/code/packages/csharp/directed-graph/README.md
+++ b/code/packages/csharp/directed-graph/README.md
@@ -1,0 +1,3 @@
+# Directed Graph
+
+C# support for dependency graphs, topological sorting, and labeled directed edges.

--- a/code/packages/csharp/directed-graph/required_capabilities.json
+++ b/code/packages/csharp/directed-graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/directed-graph",
+  "capabilities": [],
+  "justification": "Pure in-memory graph library and tests."
+}

--- a/code/packages/csharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.csproj
+++ b/code/packages/csharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.DirectedGraph.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.cs
+++ b/code/packages/csharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.cs
@@ -1,0 +1,31 @@
+using CodingAdventures.DirectedGraph;
+
+namespace CodingAdventures.DirectedGraph.Tests;
+
+public class DirectedGraphTests
+{
+    [Fact]
+    public void TopologicalSort_OrdersDependencies()
+    {
+        var graph = new Graph();
+        graph.AddEdge("A", "B");
+        graph.AddEdge("B", "C");
+
+        Assert.Equal(["A", "B", "C"], graph.TopologicalSort());
+    }
+
+    [Fact]
+    public void IndependentGroups_LayersDiamond()
+    {
+        var graph = new Graph();
+        graph.AddEdge("A", "B");
+        graph.AddEdge("A", "C");
+        graph.AddEdge("B", "D");
+        graph.AddEdge("C", "D");
+
+        var groups = graph.IndependentGroups();
+        Assert.Equal(["A"], groups[0]);
+        Assert.Equal(["B", "C"], groups[1]);
+        Assert.Equal(["D"], groups[2]);
+    }
+}

--- a/code/packages/csharp/grammar-tools/BUILD
+++ b/code/packages/csharp/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/grammar-tools/BUILD
+++ b/code/packages/csharp/grammar-tools/BUILD
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/grammar-tools/BUILD_windows
+++ b/code/packages/csharp/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/grammar-tools/BUILD_windows
+++ b/code/packages/csharp/grammar-tools/BUILD_windows
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/grammar-tools/CHANGELOG.md
+++ b/code/packages/csharp/grammar-tools/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial C# grammar-tools port

--- a/code/packages/csharp/grammar-tools/CodingAdventures.GrammarTools.csproj
+++ b/code/packages/csharp/grammar-tools/CodingAdventures.GrammarTools.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.GrammarTools.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Parsers and data models for .tokens and .grammar files</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/grammar-tools/GrammarTools.cs
+++ b/code/packages/csharp/grammar-tools/GrammarTools.cs
@@ -1,0 +1,679 @@
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace CodingAdventures.GrammarTools;
+
+public sealed class TokenGrammarError : Exception
+{
+    public TokenGrammarError(string message, int lineNumber) : base($"Line {lineNumber}: {message}")
+    {
+        LineNumber = lineNumber;
+    }
+
+    public int LineNumber { get; }
+}
+
+public sealed record TokenDefinition(string Name, string Pattern, bool IsRegex, int LineNumber, string? Alias = null);
+public sealed record PatternGroup(string Name, IReadOnlyList<TokenDefinition> Definitions);
+
+public sealed record TokenGrammar(
+    IReadOnlyList<TokenDefinition> Definitions,
+    IReadOnlyList<string> Keywords,
+    string? Mode = null,
+    string? EscapeMode = null,
+    IReadOnlyList<TokenDefinition>? SkipDefinitions = null,
+    IReadOnlyList<string>? ReservedKeywords = null,
+    IReadOnlyDictionary<string, PatternGroup>? Groups = null,
+    bool CaseSensitive = true,
+    int Version = 0,
+    bool CaseInsensitive = false,
+    IReadOnlyList<string>? ContextKeywords = null,
+    IReadOnlyList<string>? SoftKeywords = null,
+    IReadOnlyList<TokenDefinition>? ErrorDefinitions = null);
+
+public abstract record GrammarElement;
+public sealed record RuleReference(string Name, bool IsToken) : GrammarElement;
+public sealed record Literal(string Value) : GrammarElement;
+public sealed record Group(GrammarElement Element) : GrammarElement;
+public sealed record Optional(GrammarElement Element) : GrammarElement;
+public sealed record Repetition(GrammarElement Element) : GrammarElement;
+public sealed record Alternation(IReadOnlyList<GrammarElement> Choices) : GrammarElement;
+public sealed record Sequence(IReadOnlyList<GrammarElement> Elements) : GrammarElement;
+public sealed record PositiveLookahead(GrammarElement Element) : GrammarElement;
+public sealed record NegativeLookahead(GrammarElement Element) : GrammarElement;
+public sealed record OneOrMoreRepetition(GrammarElement Element) : GrammarElement;
+public sealed record SeparatedRepetition(GrammarElement Element, GrammarElement Separator, bool AtLeastOne) : GrammarElement;
+public sealed record GrammarRule(string Name, GrammarElement Body);
+
+public sealed class ParserGrammar
+{
+    public ParserGrammar()
+    {
+        Rules = new List<GrammarRule>();
+    }
+
+    public ParserGrammar(IReadOnlyList<GrammarRule> rules)
+    {
+        Rules = rules;
+    }
+
+    public IReadOnlyList<GrammarRule> Rules { get; init; }
+}
+
+public sealed class ParserGrammarError : Exception
+{
+    public ParserGrammarError(string message, int lineNumber) : base($"Line {lineNumber}: {message}")
+    {
+        LineNumber = lineNumber;
+    }
+
+    public int LineNumber { get; }
+}
+
+public static class TokenGrammarParser
+{
+    public static TokenGrammar Parse(string source)
+    {
+        var definitions = new List<TokenDefinition>();
+        var skipDefinitions = new List<TokenDefinition>();
+        var errorDefinitions = new List<TokenDefinition>();
+        var keywords = new List<string>();
+        var reserved = new List<string>();
+        var contextKeywords = new List<string>();
+        var softKeywords = new List<string>();
+        var groups = new Dictionary<string, PatternGroup>(StringComparer.Ordinal);
+        var groupDefinitions = new Dictionary<string, List<TokenDefinition>>(StringComparer.Ordinal);
+        string? mode = null;
+        string? escapeMode = null;
+        var version = 0;
+        var caseInsensitive = false;
+
+        var section = "definitions";
+        string? currentGroup = null;
+
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var lineNumber = index + 1;
+            var rawLine = lines[index];
+            var trimmed = rawLine.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (trimmed.StartsWith("#", StringComparison.Ordinal))
+            {
+                if (TryParseMagicComment(trimmed, out var key, out var value))
+                {
+                    if (key == "version" && int.TryParse(value, out var parsedVersion))
+                    {
+                        version = parsedVersion;
+                    }
+                    else if (key == "case_insensitive" && bool.TryParse(value, out var parsedBool))
+                    {
+                        caseInsensitive = parsedBool;
+                    }
+                }
+
+                continue;
+            }
+
+            if (trimmed.StartsWith("mode:", StringComparison.Ordinal))
+            {
+                mode = trimmed["mode:".Length..].Trim();
+                continue;
+            }
+
+            if (trimmed.StartsWith("escape_mode:", StringComparison.Ordinal))
+            {
+                escapeMode = trimmed["escape_mode:".Length..].Trim();
+                continue;
+            }
+
+            if (trimmed == "keywords:" || trimmed == "reserved:" || trimmed == "context_keywords:" || trimmed == "soft_keywords:" || trimmed == "skip:" || trimmed == "errors:")
+            {
+                section = trimmed[..^1];
+                currentGroup = null;
+                continue;
+            }
+
+            if (trimmed.StartsWith("group ", StringComparison.Ordinal) && trimmed.EndsWith(':'))
+            {
+                currentGroup = trimmed[6..^1].Trim();
+                if (currentGroup.Length == 0)
+                {
+                    throw new TokenGrammarError("Group name cannot be empty", lineNumber);
+                }
+
+                section = "group";
+                groupDefinitions[currentGroup] = new List<TokenDefinition>();
+                continue;
+            }
+
+            switch (section)
+            {
+                case "keywords":
+                    keywords.Add(trimmed);
+                    break;
+                case "reserved":
+                    reserved.Add(trimmed);
+                    break;
+                case "context_keywords":
+                    contextKeywords.Add(trimmed);
+                    break;
+                case "soft_keywords":
+                    softKeywords.Add(trimmed);
+                    break;
+                case "definitions":
+                case "skip":
+                case "errors":
+                case "group":
+                    var definition = ParseDefinition(trimmed, lineNumber);
+                    if (section == "skip")
+                    {
+                        skipDefinitions.Add(definition);
+                    }
+                    else if (section == "errors")
+                    {
+                        errorDefinitions.Add(definition);
+                    }
+                    else if (section == "group")
+                    {
+                        groupDefinitions[currentGroup!].Add(definition);
+                    }
+                    else
+                    {
+                        definitions.Add(definition);
+                    }
+                    break;
+                default:
+                    throw new TokenGrammarError($"Unsupported section '{section}'", lineNumber);
+            }
+        }
+
+        foreach (var (name, defs) in groupDefinitions)
+        {
+            groups[name] = new PatternGroup(name, defs);
+        }
+
+        return new TokenGrammar(
+            definitions,
+            keywords,
+            mode,
+            escapeMode,
+            skipDefinitions,
+            reserved,
+            new ReadOnlyDictionary<string, PatternGroup>(groups),
+            !caseInsensitive,
+            version,
+            caseInsensitive,
+            contextKeywords,
+            softKeywords,
+            errorDefinitions);
+    }
+
+    private static bool TryParseMagicComment(string line, out string key, out string value)
+    {
+        key = string.Empty;
+        value = string.Empty;
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith("# @", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rest = trimmed[3..].Trim();
+        var split = rest.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        if (split.Length == 0)
+        {
+            return false;
+        }
+
+        key = split[0];
+        value = split.Length == 2 ? split[1].Trim() : string.Empty;
+        return true;
+    }
+
+    private static TokenDefinition ParseDefinition(string line, int lineNumber)
+    {
+        var equalsIndex = line.IndexOf('=');
+        if (equalsIndex < 1)
+        {
+            throw new TokenGrammarError("Expected TOKEN_NAME = PATTERN", lineNumber);
+        }
+
+        var name = line[..equalsIndex].Trim();
+        var rhs = line[(equalsIndex + 1)..].Trim();
+        string? alias = null;
+
+        var aliasIndex = rhs.IndexOf("->", StringComparison.Ordinal);
+        if (aliasIndex >= 0)
+        {
+            alias = rhs[(aliasIndex + 2)..].Trim();
+            rhs = rhs[..aliasIndex].Trim();
+        }
+
+        if (rhs.StartsWith('/') && rhs.EndsWith('/'))
+        {
+            return new TokenDefinition(name, rhs[1..^1], true, lineNumber, alias);
+        }
+
+        if (rhs.StartsWith('"') && rhs.EndsWith('"'))
+        {
+            return new TokenDefinition(name, UnescapeQuoted(rhs[1..^1]), false, lineNumber, alias);
+        }
+
+        throw new TokenGrammarError("Pattern must be /regex/ or \"literal\"", lineNumber);
+    }
+
+    private static string UnescapeQuoted(string text)
+    {
+        var result = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\\' && i + 1 < text.Length)
+            {
+                i++;
+                result.Append(text[i] switch
+                {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    '"' => '"',
+                    '\\' => '\\',
+                    _ => text[i],
+                });
+            }
+            else
+            {
+                result.Append(text[i]);
+            }
+        }
+
+        return result.ToString();
+    }
+}
+
+public static class TokenGrammarValidator
+{
+    public static void Validate(TokenGrammar grammar)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var definition in grammar.Definitions)
+        {
+            if (!seen.Add(definition.Name))
+            {
+                throw new InvalidOperationException($"Duplicate token definition: {definition.Name}");
+            }
+        }
+    }
+}
+
+public static class ParserGrammarParser
+{
+    private enum Kind
+    {
+        Identifier,
+        String,
+        Equals,
+        Pipe,
+        LBrace,
+        RBrace,
+        LBracket,
+        RBracket,
+        LParen,
+        RParen,
+        Semicolon,
+        Ampersand,
+        Bang,
+        DoubleSlash,
+        Plus,
+        End,
+    }
+
+    private sealed record MetaToken(Kind Kind, string Text, int Line);
+
+    private sealed class Parser
+    {
+        private readonly List<MetaToken> _tokens;
+        private int _pos;
+
+        public Parser(List<MetaToken> tokens)
+        {
+            _tokens = tokens;
+        }
+
+        public ParserGrammar Parse()
+        {
+            var rules = new List<GrammarRule>();
+            while (Peek().Kind != Kind.End)
+            {
+                var name = Expect(Kind.Identifier).Text;
+                Expect(Kind.Equals);
+                var body = ParseAlternation([Kind.Semicolon]);
+                Expect(Kind.Semicolon);
+                rules.Add(new GrammarRule(name, body));
+            }
+
+            return new ParserGrammar(rules);
+        }
+
+        private GrammarElement ParseAlternation(HashSet<Kind> terminators)
+        {
+            var choices = new List<GrammarElement> { ParseSequence(new HashSet<Kind>(terminators) { Kind.Pipe }) };
+            while (Match(Kind.Pipe))
+            {
+                choices.Add(ParseSequence(new HashSet<Kind>(terminators) { Kind.Pipe }));
+            }
+
+            return choices.Count == 1 ? choices[0] : new Alternation(choices);
+        }
+
+        private GrammarElement ParseSequence(HashSet<Kind> terminators)
+        {
+            var elements = new List<GrammarElement>();
+            while (!terminators.Contains(Peek().Kind) && Peek().Kind != Kind.End)
+            {
+                elements.Add(ParseElement());
+            }
+
+            return elements.Count switch
+            {
+                0 => new Sequence(Array.Empty<GrammarElement>()),
+                1 => elements[0],
+                _ => new Sequence(elements),
+            };
+        }
+
+        private GrammarElement ParseElement()
+        {
+            if (Match(Kind.Ampersand))
+            {
+                return new PositiveLookahead(ParseElement());
+            }
+
+            if (Match(Kind.Bang))
+            {
+                return new NegativeLookahead(ParseElement());
+            }
+
+            if (Match(Kind.Identifier, out var identifier))
+            {
+                var isToken = identifier!.Text.All(static ch => char.IsUpper(ch) || ch == '_');
+                return new RuleReference(identifier.Text, isToken);
+            }
+
+            if (Match(Kind.String, out var literal))
+            {
+                return new Literal(literal!.Text);
+            }
+
+            if (Match(Kind.LParen))
+            {
+                var inner = ParseAlternation([Kind.RParen]);
+                Expect(Kind.RParen);
+                return new Group(inner);
+            }
+
+            if (Match(Kind.LBracket))
+            {
+                var inner = ParseAlternation([Kind.RBracket]);
+                Expect(Kind.RBracket);
+                return new Optional(inner);
+            }
+
+            if (Match(Kind.LBrace))
+            {
+                var inner = ParseAlternation([Kind.RBrace, Kind.DoubleSlash]);
+                GrammarElement repetition;
+                if (Match(Kind.DoubleSlash))
+                {
+                    var separator = ParseAlternation([Kind.RBrace]);
+                    Expect(Kind.RBrace);
+                    repetition = new SeparatedRepetition(inner, separator, false);
+                }
+                else
+                {
+                    Expect(Kind.RBrace);
+                    repetition = new Repetition(inner);
+                }
+
+                if (Match(Kind.Plus))
+                {
+                    return repetition switch
+                    {
+                        SeparatedRepetition separated => separated with { AtLeastOne = true },
+                        Repetition repeated => new OneOrMoreRepetition(repeated.Element),
+                        _ => repetition,
+                    };
+                }
+
+                return repetition;
+            }
+
+            throw new ParserGrammarError($"Unexpected token '{Peek().Text}'", Peek().Line);
+        }
+
+        private MetaToken Peek() => _tokens[_pos];
+
+        private bool Match(Kind kind) => Match(kind, out _);
+
+        private bool Match(Kind kind, out MetaToken? token)
+        {
+            if (Peek().Kind == kind)
+            {
+                token = _tokens[_pos++];
+                return true;
+            }
+
+            token = null;
+            return false;
+        }
+
+        private MetaToken Expect(Kind kind)
+        {
+            if (!Match(kind, out var token))
+            {
+                throw new ParserGrammarError($"Expected {kind} but found '{Peek().Text}'", Peek().Line);
+            }
+
+            return token!;
+        }
+    }
+
+    public static ParserGrammar Parse(string source)
+    {
+        return new Parser(Tokenize(source)).Parse();
+    }
+
+    private static List<MetaToken> Tokenize(string source)
+    {
+        var tokens = new List<MetaToken>();
+        var line = 1;
+        for (var i = 0; i < source.Length;)
+        {
+            var ch = source[i];
+            if (ch == '\r')
+            {
+                i++;
+                continue;
+            }
+
+            if (ch == '\n')
+            {
+                line++;
+                i++;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(ch))
+            {
+                i++;
+                continue;
+            }
+
+            if (ch == '#')
+            {
+                while (i < source.Length && source[i] != '\n')
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (char.IsLetter(ch) || ch == '_')
+            {
+                var start = i;
+                while (i < source.Length && (char.IsLetterOrDigit(source[i]) || source[i] == '_' || source[i] == '-'))
+                {
+                    i++;
+                }
+
+                tokens.Add(new MetaToken(Kind.Identifier, source[start..i], line));
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                var builder = new StringBuilder();
+                i++;
+                while (i < source.Length)
+                {
+                    if (source[i] == '"' && source[i - 1] != '\\')
+                    {
+                        i++;
+                        break;
+                    }
+
+                    if (source[i] == '\\' && i + 1 < source.Length)
+                    {
+                        i++;
+                        builder.Append(source[i] switch
+                        {
+                            'n' => '\n',
+                            't' => '\t',
+                            'r' => '\r',
+                            '"' => '"',
+                            '\\' => '\\',
+                            _ => source[i],
+                        });
+                    }
+                    else
+                    {
+                        builder.Append(source[i]);
+                    }
+
+                    i++;
+                }
+
+                tokens.Add(new MetaToken(Kind.String, builder.ToString(), line));
+                continue;
+            }
+
+            if (ch == '/' && i + 1 < source.Length && source[i + 1] == '/')
+            {
+                tokens.Add(new MetaToken(Kind.DoubleSlash, "//", line));
+                i += 2;
+                continue;
+            }
+
+            tokens.Add(ch switch
+            {
+                '=' => new MetaToken(Kind.Equals, "=", line),
+                '|' => new MetaToken(Kind.Pipe, "|", line),
+                '{' => new MetaToken(Kind.LBrace, "{", line),
+                '}' => new MetaToken(Kind.RBrace, "}", line),
+                '[' => new MetaToken(Kind.LBracket, "[", line),
+                ']' => new MetaToken(Kind.RBracket, "]", line),
+                '(' => new MetaToken(Kind.LParen, "(", line),
+                ')' => new MetaToken(Kind.RParen, ")", line),
+                ';' => new MetaToken(Kind.Semicolon, ";", line),
+                '&' => new MetaToken(Kind.Ampersand, "&", line),
+                '!' => new MetaToken(Kind.Bang, "!", line),
+                '+' => new MetaToken(Kind.Plus, "+", line),
+                _ => throw new ParserGrammarError($"Unexpected character '{ch}'", line),
+            });
+            i++;
+        }
+
+        tokens.Add(new MetaToken(Kind.End, string.Empty, line));
+        return tokens;
+    }
+}
+
+public static class ParserGrammarValidator
+{
+    public static void Validate(ParserGrammar grammar)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var rule in grammar.Rules)
+        {
+            if (!names.Add(rule.Name))
+            {
+                throw new InvalidOperationException($"Duplicate grammar rule: {rule.Name}");
+            }
+        }
+    }
+}
+
+public static class CrossValidator
+{
+    public static void Validate(TokenGrammar tokenGrammar, ParserGrammar parserGrammar)
+    {
+        var tokenNames = tokenGrammar.Definitions.Select(def => def.Alias ?? def.Name).ToHashSet(StringComparer.Ordinal);
+        if (tokenGrammar.Keywords.Count > 0)
+        {
+            tokenNames.Add("KEYWORD");
+        }
+
+        foreach (var rule in parserGrammar.Rules)
+        {
+            Visit(rule.Body);
+        }
+
+        void Visit(GrammarElement element)
+        {
+            switch (element)
+            {
+                case RuleReference reference when reference.IsToken && !tokenNames.Contains(reference.Name):
+                    throw new InvalidOperationException($"Unknown token reference: {reference.Name}");
+                case Group group:
+                    Visit(group.Element);
+                    break;
+                case Optional optional:
+                    Visit(optional.Element);
+                    break;
+                case Repetition repetition:
+                    Visit(repetition.Element);
+                    break;
+                case OneOrMoreRepetition repetition:
+                    Visit(repetition.Element);
+                    break;
+                case PositiveLookahead lookahead:
+                    Visit(lookahead.Element);
+                    break;
+                case NegativeLookahead lookahead:
+                    Visit(lookahead.Element);
+                    break;
+                case SeparatedRepetition separated:
+                    Visit(separated.Element);
+                    Visit(separated.Separator);
+                    break;
+                case Alternation alternation:
+                    foreach (var choice in alternation.Choices)
+                    {
+                        Visit(choice);
+                    }
+                    break;
+                case Sequence sequence:
+                    foreach (var child in sequence.Elements)
+                    {
+                        Visit(child);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/code/packages/csharp/grammar-tools/README.md
+++ b/code/packages/csharp/grammar-tools/README.md
@@ -1,0 +1,3 @@
+# Grammar Tools
+
+C# support for parsing `.tokens` and `.grammar` files into structured in-memory models.

--- a/code/packages/csharp/grammar-tools/required_capabilities.json
+++ b/code/packages/csharp/grammar-tools/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/grammar-tools",
+  "capabilities": [],
+  "justification": "Pure in-memory grammar parsing and validation."
+}

--- a/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.csproj
+++ b/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.GrammarTools.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.cs
+++ b/code/packages/csharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.cs
@@ -1,0 +1,42 @@
+using CodingAdventures.GrammarTools;
+
+namespace CodingAdventures.GrammarTools.Tests;
+
+public class GrammarToolsTests
+{
+    [Fact]
+    public void TokenGrammarParser_ParsesSections()
+    {
+        var grammar = TokenGrammarParser.Parse("""
+            NUMBER = /[0-9]+/
+            PLUS = "+"
+            skip:
+              WS = /[ \t]+/
+            keywords:
+              if
+            reserved:
+              class
+            errors:
+              BAD = /.+/
+            """);
+
+        Assert.Equal(2, grammar.Definitions.Count);
+        Assert.Single(grammar.SkipDefinitions!);
+        Assert.Single(grammar.Keywords);
+        Assert.Single(grammar.ReservedKeywords!);
+        Assert.Single(grammar.ErrorDefinitions!);
+    }
+
+    [Fact]
+    public void ParserGrammarParser_ParsesCoreForms()
+    {
+        var grammar = ParserGrammarParser.Parse("""
+            program = { statement } ;
+            statement = NAME | NUMBER | [ STRING ] | &NAME NAME | !PLUS NUMBER | { NUMBER // COMMA } ;
+            """);
+
+        Assert.Equal(2, grammar.Rules.Count);
+        Assert.Equal("program", grammar.Rules[0].Name);
+        Assert.Equal("statement", grammar.Rules[1].Name);
+    }
+}

--- a/code/packages/csharp/lexer/BUILD
+++ b/code/packages/csharp/lexer/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle test

--- a/code/packages/csharp/lexer/BUILD
+++ b/code/packages/csharp/lexer/BUILD
@@ -1,1 +1,1 @@
-cd ../grammar-tools && gradle jar && cd ../lexer && gradle test
+dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lexer/BUILD_windows
+++ b/code/packages/csharp/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/lexer/BUILD_windows
+++ b/code/packages/csharp/lexer/BUILD_windows
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lexer/CHANGELOG.md
+++ b/code/packages/csharp/lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial C# lexer port

--- a/code/packages/csharp/lexer/CodingAdventures.Lexer.csproj
+++ b/code/packages/csharp/lexer/CodingAdventures.Lexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Lexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven lexer for .tokens grammars</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\grammar-tools\CodingAdventures.GrammarTools.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lexer/Lexer.cs
+++ b/code/packages/csharp/lexer/Lexer.cs
@@ -1,0 +1,206 @@
+using System.Text.RegularExpressions;
+using CodingAdventures.GrammarTools;
+
+namespace CodingAdventures.Lexer;
+
+public enum TokenType
+{
+    Name,
+    Number,
+    String,
+    Keyword,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Equals,
+    EqualsEquals,
+    LParen,
+    RParen,
+    Comma,
+    Colon,
+    Semicolon,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Dot,
+    Bang,
+    Newline,
+    EOF,
+    Grammar,
+}
+
+public sealed record Token(TokenType Type, string Value, int Line, int Column, string? TypeName = null, int Flags = 0)
+{
+    public const int FlagPrecededByNewline = 1;
+    public const int FlagContextKeyword = 2;
+
+    public string EffectiveTypeName => TypeName ?? Type.ToString().ToUpperInvariant();
+    public bool HasFlag(int flag) => (Flags & flag) != 0;
+    public override string ToString() => $"Token({EffectiveTypeName}, \"{Value}\", {Line}:{Column})";
+}
+
+public sealed class LexerError : Exception
+{
+    public LexerError(string message, int line, int column) : base($"Lexer error at {line}:{column}: {message}")
+    {
+        Line = line;
+        Column = column;
+    }
+
+    public int Line { get; }
+    public int Column { get; }
+}
+
+public sealed class GrammarLexer
+{
+    private sealed record CompiledPattern(string Name, Regex Regex, string? Alias);
+    private sealed record MatcherNode(string Stage, CompiledPattern Pattern);
+
+    private readonly TokenGrammar _grammar;
+    private readonly List<MatcherNode> _matcherPipeline;
+    private readonly HashSet<string> _keywords;
+    private readonly HashSet<string> _reserved;
+    private readonly HashSet<string> _contextKeywords;
+
+    public GrammarLexer(TokenGrammar grammar)
+    {
+        _grammar = grammar;
+        _matcherPipeline = BuildMatcherPipeline(grammar);
+        _keywords = new HashSet<string>(grammar.Keywords, StringComparer.Ordinal);
+        _reserved = new HashSet<string>(grammar.ReservedKeywords ?? [], StringComparer.Ordinal);
+        _contextKeywords = new HashSet<string>(grammar.ContextKeywords ?? [], StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<Token> Tokenize(string source)
+    {
+        var workingSource = _grammar.CaseSensitive ? source : source.ToLowerInvariant();
+        var tokens = new List<Token>();
+        var pos = 0;
+        var line = 1;
+        var column = 1;
+        var precededByNewline = false;
+
+        while (pos < workingSource.Length)
+        {
+            var matched = false;
+            foreach (var node in _matcherPipeline)
+            {
+                var match = node.Pattern.Regex.Match(workingSource, pos);
+                if (!match.Success || match.Index != pos)
+                {
+                    continue;
+                }
+
+                var value = source.Substring(pos, match.Length);
+                switch (node.Stage)
+                {
+                    case "skip":
+                        Advance(value, ref line, ref column, ref precededByNewline);
+                        pos += value.Length;
+                        break;
+                    case "token":
+                    case "error":
+                        var typeName = node.Pattern.Alias ?? node.Pattern.Name;
+                        if (typeName == "NAME" && _reserved.Contains(value))
+                        {
+                            throw new LexerError($"Reserved keyword '{value}'", line, column);
+                        }
+
+                        var flags = 0;
+                        if (precededByNewline)
+                        {
+                            flags |= Token.FlagPrecededByNewline;
+                        }
+
+                        if (typeName == "NAME" && _contextKeywords.Contains(_grammar.CaseSensitive ? value : value.ToLowerInvariant()))
+                        {
+                            flags |= Token.FlagContextKeyword;
+                        }
+
+                        tokens.Add(new Token(TokenType.Grammar, value, line, column, typeName, flags));
+                        var localPrecededByNewline = false;
+                        Advance(value, ref line, ref column, ref localPrecededByNewline);
+                        precededByNewline = false;
+                        pos += value.Length;
+                        break;
+                }
+
+                matched = true;
+                break;
+            }
+
+            if (!matched)
+            {
+                throw new LexerError($"Unexpected character '{source[pos]}'", line, column);
+            }
+        }
+
+        PromoteKeywords(tokens);
+        tokens.Add(new Token(TokenType.EOF, string.Empty, line, column, "EOF"));
+        return tokens;
+    }
+
+    private void PromoteKeywords(List<Token> tokens)
+    {
+        if (_keywords.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.TypeName == "NAME")
+            {
+                var check = _grammar.CaseSensitive ? token.Value : token.Value.ToLowerInvariant();
+                if (_keywords.Contains(check))
+                {
+                    tokens[i] = token with { Type = TokenType.Keyword, TypeName = "KEYWORD" };
+                }
+            }
+        }
+    }
+
+    private static void Advance(string value, ref int line, ref int column, ref bool precededByNewline)
+    {
+        foreach (var ch in value)
+        {
+            if (ch == '\n')
+            {
+                line++;
+                column = 1;
+                precededByNewline = true;
+            }
+            else
+            {
+                column++;
+            }
+        }
+    }
+
+    private static List<CompiledPattern> CompileDefinitions(IEnumerable<TokenDefinition> definitions, bool caseSensitive)
+    {
+        var options = RegexOptions.Compiled | RegexOptions.CultureInvariant;
+        if (!caseSensitive)
+        {
+            options |= RegexOptions.IgnoreCase;
+        }
+
+        return definitions.Select(definition =>
+        {
+            var pattern = definition.IsRegex ? $@"\G(?:{definition.Pattern})" : $@"\G{Regex.Escape(definition.Pattern)}";
+            return new CompiledPattern(definition.Name, new Regex(pattern, options), definition.Alias);
+        }).ToList();
+    }
+
+    private static List<MatcherNode> BuildMatcherPipeline(TokenGrammar grammar)
+    {
+        var pipeline = new List<MatcherNode>();
+        pipeline.AddRange(CompileDefinitions(grammar.SkipDefinitions ?? [], grammar.CaseSensitive).Select(pattern => new MatcherNode("skip", pattern)));
+        pipeline.AddRange(CompileDefinitions(grammar.Definitions, grammar.CaseSensitive).Select(pattern => new MatcherNode("token", pattern)));
+        pipeline.AddRange(CompileDefinitions(grammar.ErrorDefinitions ?? [], grammar.CaseSensitive).Select(pattern => new MatcherNode("error", pattern)));
+        return pipeline;
+    }
+}

--- a/code/packages/csharp/lexer/README.md
+++ b/code/packages/csharp/lexer/README.md
@@ -1,0 +1,3 @@
+# Lexer
+
+C# grammar-driven lexer built on `.tokens` grammars.

--- a/code/packages/csharp/lexer/required_capabilities.json
+++ b/code/packages/csharp/lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory lexer and tests."
+}

--- a/code/packages/csharp/lexer/tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.csproj
+++ b/code/packages/csharp/lexer/tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../../../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.cs
+++ b/code/packages/csharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.cs
@@ -1,0 +1,26 @@
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.Lexer.Tests;
+
+public class LexerTests
+{
+    [Fact]
+    public void GrammarLexer_TokenizesSimpleExpression()
+    {
+        var grammar = TokenGrammarParser.Parse("""
+            NUMBER = /[0-9]+/
+            PLUS = "+"
+            skip:
+              WS = /[ \t]+/
+            """);
+
+        var lexer = new GrammarLexer(grammar);
+        var tokens = lexer.Tokenize("42 + 7");
+
+        Assert.Equal("NUMBER", tokens[0].TypeName);
+        Assert.Equal("PLUS", tokens[1].TypeName);
+        Assert.Equal("NUMBER", tokens[2].TypeName);
+        Assert.Equal("EOF", tokens[^1].TypeName);
+    }
+}

--- a/code/packages/csharp/parser/BUILD
+++ b/code/packages/csharp/parser/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test

--- a/code/packages/csharp/parser/BUILD
+++ b/code/packages/csharp/parser/BUILD
@@ -1,1 +1,1 @@
-cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test
+dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/parser/BUILD_windows
+++ b/code/packages/csharp/parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/csharp/parser/BUILD_windows
+++ b/code/packages/csharp/parser/BUILD_windows
@@ -1,1 +1,1 @@
-gradle test
+dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/parser/CHANGELOG.md
+++ b/code/packages/csharp/parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial C# parser port

--- a/code/packages/csharp/parser/CodingAdventures.Parser.csproj
+++ b/code/packages/csharp/parser/CodingAdventures.Parser.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Parser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven parser for token streams and .grammar grammars</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\grammar-tools\CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="..\lexer\CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/parser/Parser.cs
+++ b/code/packages/csharp/parser/Parser.cs
@@ -1,0 +1,313 @@
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.Parser;
+
+public sealed class GrammarParseError : Exception
+{
+    public GrammarParseError(string message, Token? token = null) : base(token is null
+        ? $"Parse error: {message}"
+        : $"Parse error at {token.Line}:{token.Column}: {message}")
+    {
+        Token = token;
+    }
+
+    public Token? Token { get; }
+}
+
+public sealed class ASTNode
+{
+    public ASTNode(string ruleName)
+        : this(ruleName, [], 0, 0, 0, 0)
+    {
+    }
+
+    public ASTNode(string ruleName, IReadOnlyList<object> children, int startLine = 0, int startColumn = 0, int endLine = 0, int endColumn = 0)
+    {
+        RuleName = ruleName;
+        Children = children;
+        StartLine = startLine;
+        StartColumn = startColumn;
+        EndLine = endLine;
+        EndColumn = endColumn;
+    }
+
+    public string RuleName { get; }
+    public IReadOnlyList<object> Children { get; }
+    public int StartLine { get; }
+    public int StartColumn { get; }
+    public int EndLine { get; }
+    public int EndColumn { get; }
+    public bool IsLeaf => Children.Count == 1 && Children[0] is Token;
+    public Token? Token => IsLeaf ? (Token)Children[0] : null;
+    public int DescendantCount() => Children.Sum(child => child is ASTNode node ? 1 + node.DescendantCount() : 1);
+}
+
+public sealed class GrammarParser
+{
+    private sealed record MemoEntry(IReadOnlyList<object>? Children, int EndPos, bool Ok);
+    private sealed record MatchResult(IReadOnlyList<object> Children, int EndPos);
+
+    private readonly ParserGrammar _grammar;
+    private readonly Dictionary<string, GrammarRule> _ruleMap;
+
+    public GrammarParser(ParserGrammar grammar)
+    {
+        _grammar = grammar;
+        _ruleMap = grammar.Rules.ToDictionary(rule => rule.Name, StringComparer.Ordinal);
+    }
+
+    public ASTNode Parse(IReadOnlyList<Token> tokens)
+    {
+        if (_grammar.Rules.Count == 0)
+        {
+            throw new GrammarParseError("No rules in grammar", tokens.Count > 0 ? tokens[^1] : null);
+        }
+
+        var startRule = _grammar.Rules[0].Name;
+        var memo = new Dictionary<(string Rule, int Pos), MemoEntry>();
+        var recursion = new HashSet<(string Rule, int Pos)>();
+        var result = MatchRule(startRule, tokens, 0, memo, recursion);
+        if (result is null)
+        {
+            throw new GrammarParseError($"Failed to parse starting rule '{startRule}'", tokens.Count > 0 ? tokens[0] : null);
+        }
+
+        if (result.Children.Count == 1 && result.Children[0] is ASTNode node && node.RuleName == startRule)
+        {
+            return node;
+        }
+
+        return BuildNode(startRule, result.Children);
+    }
+
+    private MatchResult? MatchRule(
+        string ruleName,
+        IReadOnlyList<Token> tokens,
+        int pos,
+        Dictionary<(string Rule, int Pos), MemoEntry> memo,
+        HashSet<(string Rule, int Pos)> recursion)
+    {
+        if (memo.TryGetValue((ruleName, pos), out var cached))
+        {
+            return cached.Ok ? new MatchResult(cached.Children!, cached.EndPos) : null;
+        }
+
+        if (!recursion.Add((ruleName, pos)))
+        {
+            memo[(ruleName, pos)] = new MemoEntry(null, pos, false);
+            return null;
+        }
+
+        try
+        {
+            if (!_ruleMap.TryGetValue(ruleName, out var rule))
+            {
+                memo[(ruleName, pos)] = new MemoEntry(null, pos, false);
+                return null;
+            }
+
+            var result = MatchElement(rule.Body, tokens, pos, memo, recursion);
+            if (result is null)
+            {
+                memo[(ruleName, pos)] = new MemoEntry(null, pos, false);
+                return null;
+            }
+
+            var wrapped = (IReadOnlyList<object>)[BuildNode(ruleName, result.Children)];
+            memo[(ruleName, pos)] = new MemoEntry(wrapped, result.EndPos, true);
+            return new MatchResult(wrapped, result.EndPos);
+        }
+        finally
+        {
+            recursion.Remove((ruleName, pos));
+        }
+    }
+
+    private MatchResult? MatchElement(
+        GrammarElement element,
+        IReadOnlyList<Token> tokens,
+        int pos,
+        Dictionary<(string Rule, int Pos), MemoEntry> memo,
+        HashSet<(string Rule, int Pos)> recursion)
+    {
+        switch (element)
+        {
+            case RuleReference reference:
+                if (reference.IsToken)
+                {
+                    return pos < tokens.Count && tokens[pos].EffectiveTypeName == reference.Name
+                        ? new MatchResult([tokens[pos]], pos + 1)
+                        : null;
+                }
+
+                return MatchRule(reference.Name, tokens, pos, memo, recursion);
+            case Literal literal:
+                return pos < tokens.Count && tokens[pos].Value == literal.Value
+                    ? new MatchResult([tokens[pos]], pos + 1)
+                    : null;
+            case Sequence sequence:
+            {
+                var children = new List<object>();
+                var currentPos = pos;
+                foreach (var child in sequence.Elements)
+                {
+                    var result = MatchElement(child, tokens, currentPos, memo, recursion);
+                    if (result is null)
+                    {
+                        return null;
+                    }
+
+                    children.AddRange(result.Children);
+                    currentPos = result.EndPos;
+                }
+
+                return new MatchResult(children, currentPos);
+            }
+            case Alternation alternation:
+                foreach (var choice in alternation.Choices)
+                {
+                    var result = MatchElement(choice, tokens, pos, memo, recursion);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+
+                return null;
+            case Repetition repetition:
+                return MatchRepeated(repetition.Element, tokens, pos, memo, recursion, false);
+            case OneOrMoreRepetition repetition:
+                return MatchRepeated(repetition.Element, tokens, pos, memo, recursion, true);
+            case Optional optional:
+            {
+                var result = MatchElement(optional.Element, tokens, pos, memo, recursion);
+                return result ?? new MatchResult([], pos);
+            }
+            case Group group:
+                return MatchElement(group.Element, tokens, pos, memo, recursion);
+            case PositiveLookahead lookahead:
+                return MatchElement(lookahead.Element, tokens, pos, memo, recursion) is not null ? new MatchResult([], pos) : null;
+            case NegativeLookahead lookahead:
+                return MatchElement(lookahead.Element, tokens, pos, memo, recursion) is null ? new MatchResult([], pos) : null;
+            case SeparatedRepetition separated:
+            {
+                var first = MatchElement(separated.Element, tokens, pos, memo, recursion);
+                if (first is null)
+                {
+                    return separated.AtLeastOne ? null : new MatchResult([], pos);
+                }
+
+                var children = new List<object>(first.Children);
+                var currentPos = first.EndPos;
+                while (true)
+                {
+                    var separator = MatchElement(separated.Separator, tokens, currentPos, memo, recursion);
+                    if (separator is null)
+                    {
+                        break;
+                    }
+
+                    var elementResult = MatchElement(separated.Element, tokens, separator.EndPos, memo, recursion);
+                    if (elementResult is null)
+                    {
+                        break;
+                    }
+
+                    children.AddRange(separator.Children);
+                    children.AddRange(elementResult.Children);
+                    currentPos = elementResult.EndPos;
+                }
+
+                return new MatchResult(children, currentPos);
+            }
+            default:
+                throw new InvalidOperationException($"Unsupported grammar element: {element.GetType().Name}");
+        }
+    }
+
+    private MatchResult? MatchRepeated(
+        GrammarElement element,
+        IReadOnlyList<Token> tokens,
+        int pos,
+        Dictionary<(string Rule, int Pos), MemoEntry> memo,
+        HashSet<(string Rule, int Pos)> recursion,
+        bool requireOne)
+    {
+        var children = new List<object>();
+        var currentPos = pos;
+        var matchedOne = false;
+
+        while (true)
+        {
+            var result = MatchElement(element, tokens, currentPos, memo, recursion);
+            if (result is null || result.EndPos == currentPos)
+            {
+                break;
+            }
+
+            matchedOne = true;
+            children.AddRange(result.Children);
+            currentPos = result.EndPos;
+        }
+
+        return requireOne && !matchedOne ? null : new MatchResult(children, currentPos);
+    }
+
+    private static ASTNode BuildNode(string ruleName, IReadOnlyList<object> children)
+    {
+        var first = FindFirstToken(children);
+        var last = FindLastToken(children);
+        return new ASTNode(
+            ruleName,
+            children,
+            first?.Line ?? 0,
+            first?.Column ?? 0,
+            last?.Line ?? 0,
+            last?.Column ?? 0);
+    }
+
+    private static Token? FindFirstToken(IEnumerable<object> children)
+    {
+        foreach (var child in children)
+        {
+            if (child is Token token)
+            {
+                return token;
+            }
+
+            if (child is ASTNode node)
+            {
+                var nested = FindFirstToken(node.Children);
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static Token? FindLastToken(IEnumerable<object> children)
+    {
+        foreach (var child in children.Reverse())
+        {
+            if (child is Token token)
+            {
+                return token;
+            }
+
+            if (child is ASTNode node)
+            {
+                var nested = FindLastToken(node.Children);
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/code/packages/csharp/parser/README.md
+++ b/code/packages/csharp/parser/README.md
@@ -1,0 +1,3 @@
+# Parser
+
+C# grammar-driven parser that builds generic AST nodes from token streams.

--- a/code/packages/csharp/parser/required_capabilities.json
+++ b/code/packages/csharp/parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/parser",
+  "capabilities": [],
+  "justification": "Pure in-memory parser and tests."
+}

--- a/code/packages/csharp/parser/tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.csproj
+++ b/code/packages/csharp/parser/tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../../../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../../../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.cs
+++ b/code/packages/csharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.cs
@@ -1,0 +1,26 @@
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+using CodingAdventures.Parser;
+
+namespace CodingAdventures.Parser.Tests;
+
+public class ParserTests
+{
+    [Fact]
+    public void GrammarParser_ParsesSequence()
+    {
+        var grammar = ParserGrammarParser.Parse("assign = NAME EQUALS NUMBER ;");
+        var parser = new GrammarParser(grammar);
+        var tokens = new List<Token>
+        {
+            new(TokenType.Grammar, "x", 1, 1, "NAME"),
+            new(TokenType.Grammar, "=", 1, 2, "EQUALS"),
+            new(TokenType.Grammar, "42", 1, 3, "NUMBER"),
+            new(TokenType.EOF, string.Empty, 1, 5, "EOF"),
+        };
+
+        var ast = parser.Parse(tokens);
+        Assert.Equal("assign", ast.RuleName);
+        Assert.Equal(3, ast.Children.Count);
+    }
+}

--- a/code/packages/csharp/state-machine/BUILD
+++ b/code/packages/csharp/state-machine/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/csharp/state-machine/BUILD
+++ b/code/packages/csharp/state-machine/BUILD
@@ -1,1 +1,1 @@
-go test ./... -v -cover
+dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/state-machine/BUILD_windows
+++ b/code/packages/csharp/state-machine/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/csharp/state-machine/BUILD_windows
+++ b/code/packages/csharp/state-machine/BUILD_windows
@@ -1,1 +1,1 @@
-go test ./... -v -cover
+dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/state-machine/CHANGELOG.md
+++ b/code/packages/csharp/state-machine/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial C# state-machine port

--- a/code/packages/csharp/state-machine/CodingAdventures.StateMachine.csproj
+++ b/code/packages/csharp/state-machine/CodingAdventures.StateMachine.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.StateMachine.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Finite automata from DFA and NFA through PDA and modal machines</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/state-machine/README.md
+++ b/code/packages/csharp/state-machine/README.md
@@ -1,0 +1,3 @@
+# State Machine
+
+C# finite-automata package with DFA, NFA, modal machines, minimization, and pushdown automata.

--- a/code/packages/csharp/state-machine/StateMachine.cs
+++ b/code/packages/csharp/state-machine/StateMachine.cs
@@ -1,0 +1,449 @@
+namespace CodingAdventures.StateMachine;
+
+public delegate void TransitionAction(string source, string @event, string target);
+
+public sealed record TransitionRecord(string Source, string Event, string Target, string ActionName);
+public sealed record ModeTransitionRecord(string FromMode, string Trigger, string ToMode);
+public sealed record PDATransition(string Source, string? Event, string StackRead, string Target, IReadOnlyList<string> StackPush);
+public sealed record PDATraceEntry(string Source, string? Event, string StackRead, string Target, IReadOnlyList<string> StackPush, IReadOnlyList<string> StackAfter);
+
+public sealed class DFA
+{
+    private readonly Dictionary<(string State, string Event), string> _transitions;
+    private readonly Dictionary<(string State, string Event), TransitionAction> _actions;
+    private readonly List<TransitionRecord> _trace = [];
+
+    public DFA(
+        IEnumerable<string> states,
+        IEnumerable<string> alphabet,
+        IDictionary<(string State, string Event), string> transitions,
+        string initial,
+        IEnumerable<string> accepting,
+        IDictionary<(string State, string Event), TransitionAction>? actions = null)
+    {
+        States = states.ToHashSet(StringComparer.Ordinal);
+        Alphabet = alphabet.ToHashSet(StringComparer.Ordinal);
+        Accepting = accepting.ToHashSet(StringComparer.Ordinal);
+        if (States.Count == 0)
+        {
+            throw new ArgumentException("states set must be non-empty");
+        }
+
+        if (!States.Contains(initial))
+        {
+            throw new ArgumentException($"Initial state '{initial}' is not in the states set");
+        }
+
+        if (!Accepting.IsSubsetOf(States))
+        {
+            throw new ArgumentException("Accepting states must be a subset of states");
+        }
+
+        _transitions = new Dictionary<(string State, string Event), string>(transitions);
+        foreach (var (key, target) in _transitions)
+        {
+            if (!States.Contains(key.State) || !States.Contains(target))
+            {
+                throw new ArgumentException("Transition source and target must be in states");
+            }
+
+            if (!Alphabet.Contains(key.Event))
+            {
+                throw new ArgumentException("Transition events must be in alphabet");
+            }
+        }
+
+        _actions = actions is null ? [] : new Dictionary<(string State, string Event), TransitionAction>(actions);
+        Initial = initial;
+        CurrentState = initial;
+    }
+
+    public IReadOnlySet<string> States { get; }
+    public IReadOnlySet<string> Alphabet { get; }
+    public IReadOnlySet<string> Accepting { get; }
+    public string Initial { get; }
+    public string CurrentState { get; private set; }
+    public IReadOnlyDictionary<(string State, string Event), string> Transitions => new Dictionary<(string State, string Event), string>(_transitions);
+    public IReadOnlyList<TransitionRecord> Trace => _trace.ToList();
+
+    public string Process(string @event)
+    {
+        if (!_transitions.TryGetValue((CurrentState, @event), out var target))
+        {
+            throw new InvalidOperationException($"No transition defined for ({CurrentState}, {@event})");
+        }
+
+        _actions.TryGetValue((CurrentState, @event), out var action);
+        action?.Invoke(CurrentState, @event, target);
+        _trace.Add(new TransitionRecord(CurrentState, @event, target, action?.Method.Name ?? string.Empty));
+        CurrentState = target;
+        return target;
+    }
+
+    public string Process(IEnumerable<string> events)
+    {
+        var state = CurrentState;
+        foreach (var @event in events)
+        {
+            state = Process(@event);
+        }
+
+        return state;
+    }
+
+    public void Reset()
+    {
+        CurrentState = Initial;
+        _trace.Clear();
+    }
+
+    public bool IsAccepting() => Accepting.Contains(CurrentState);
+
+    public bool Accepts(IEnumerable<string> events)
+    {
+        Reset();
+        Process(events);
+        return IsAccepting();
+    }
+
+    public IDictionary<(string State, string Event), string> MissingTransitions()
+    {
+        var missing = new Dictionary<(string State, string Event), string>();
+        foreach (var state in States)
+        {
+            foreach (var @event in Alphabet)
+            {
+                if (!_transitions.ContainsKey((state, @event)))
+                {
+                    missing[(state, @event)] = string.Empty;
+                }
+            }
+        }
+
+        return missing;
+    }
+
+    public bool IsComplete() => MissingTransitions().Count == 0;
+
+    public ISet<string> ReachableStates()
+    {
+        var reachable = new HashSet<string>(StringComparer.Ordinal) { Initial };
+        var queue = new Queue<string>();
+        queue.Enqueue(Initial);
+        while (queue.Count > 0)
+        {
+            var state = queue.Dequeue();
+            foreach (var @event in Alphabet)
+            {
+                if (_transitions.TryGetValue((state, @event), out var target) && reachable.Add(target))
+                {
+                    queue.Enqueue(target);
+                }
+            }
+        }
+
+        return reachable;
+    }
+}
+
+public sealed class NFA
+{
+    public const string EPSILON = "";
+    private readonly Dictionary<(string State, string Event), HashSet<string>> _transitions;
+    private HashSet<string> _currentStates = [];
+
+    public NFA(
+        IEnumerable<string> states,
+        IEnumerable<string> alphabet,
+        IDictionary<(string State, string Event), IEnumerable<string>> transitions,
+        string initial,
+        IEnumerable<string> accepting)
+    {
+        States = states.ToHashSet(StringComparer.Ordinal);
+        Alphabet = alphabet.ToHashSet(StringComparer.Ordinal);
+        Accepting = accepting.ToHashSet(StringComparer.Ordinal);
+        Initial = initial;
+        _transitions = transitions.ToDictionary(pair => pair.Key, pair => pair.Value.ToHashSet(StringComparer.Ordinal));
+        Reset();
+    }
+
+    public IReadOnlySet<string> States { get; }
+    public IReadOnlySet<string> Alphabet { get; }
+    public IReadOnlySet<string> Accepting { get; }
+    public string Initial { get; }
+    public IReadOnlySet<string> CurrentStates => _currentStates;
+
+    public void Reset()
+    {
+        _currentStates = EpsilonClosure([Initial]);
+    }
+
+    public HashSet<string> EpsilonClosure(IEnumerable<string> states)
+    {
+        var closure = states.ToHashSet(StringComparer.Ordinal);
+        var stack = new Stack<string>(closure);
+        while (stack.Count > 0)
+        {
+            var state = stack.Pop();
+            if (_transitions.TryGetValue((state, EPSILON), out var targets))
+            {
+                foreach (var target in targets)
+                {
+                    if (closure.Add(target))
+                    {
+                        stack.Push(target);
+                    }
+                }
+            }
+        }
+
+        return closure;
+    }
+
+    public IReadOnlySet<string> Process(string @event)
+    {
+        var next = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var state in _currentStates)
+        {
+            if (_transitions.TryGetValue((state, @event), out var targets))
+            {
+                next.UnionWith(targets);
+            }
+        }
+
+        _currentStates = EpsilonClosure(next);
+        return _currentStates;
+    }
+
+    public bool Accepts(IEnumerable<string> events)
+    {
+        Reset();
+        foreach (var @event in events)
+        {
+            Process(@event);
+        }
+
+        return _currentStates.Overlaps(Accepting);
+    }
+}
+
+public static class Minimize
+{
+    public static DFA Run(DFA dfa)
+    {
+        var reachable = dfa.ReachableStates();
+        var accepting = reachable.Intersect(dfa.Accepting).ToHashSet(StringComparer.Ordinal);
+        var nonAccepting = reachable.Except(accepting).ToHashSet(StringComparer.Ordinal);
+        var partitions = new List<HashSet<string>>();
+        if (accepting.Count > 0)
+        {
+            partitions.Add(accepting);
+        }
+
+        if (nonAccepting.Count > 0)
+        {
+            partitions.Add(nonAccepting);
+        }
+
+        while (true)
+        {
+            var changed = false;
+            var nextPartitions = new List<HashSet<string>>();
+            foreach (var group in partitions)
+            {
+                var splits = SplitGroup(group, dfa, partitions);
+                nextPartitions.AddRange(splits);
+                changed |= splits.Count > 1;
+            }
+
+            partitions = nextPartitions;
+            if (!changed)
+            {
+                break;
+            }
+        }
+
+        string Name(HashSet<string> group) => group.Count == 1 ? group.First() : "{" + string.Join(",", group.OrderBy(static s => s, StringComparer.Ordinal)) + "}";
+        var stateToPartition = partitions.SelectMany((group, index) => group.Select(state => (state, index))).ToDictionary(pair => pair.state, pair => pair.index, StringComparer.Ordinal);
+        var transitions = new Dictionary<(string State, string Event), string>();
+        foreach (var group in partitions)
+        {
+            var representative = group.First();
+            foreach (var @event in dfa.Alphabet)
+            {
+                if (dfa.Transitions.TryGetValue((representative, @event), out var target))
+                {
+                    transitions[(Name(group), @event)] = Name(partitions[stateToPartition[target]]);
+                }
+            }
+        }
+
+        var minimizedAccepting = partitions.Where(group => group.Overlaps(dfa.Accepting)).Select(Name);
+        return new DFA(partitions.Select(Name), dfa.Alphabet, transitions, Name(partitions[stateToPartition[dfa.Initial]]), minimizedAccepting);
+    }
+
+    private static List<HashSet<string>> SplitGroup(HashSet<string> group, DFA dfa, IReadOnlyList<HashSet<string>> partitions)
+    {
+        if (group.Count <= 1)
+        {
+            return [group];
+        }
+
+        var stateToPartition = partitions.SelectMany((partition, index) => partition.Select(state => (state, index))).ToDictionary(pair => pair.state, pair => pair.index, StringComparer.Ordinal);
+        return group.GroupBy(state =>
+            string.Join("|", dfa.Alphabet.OrderBy(static e => e, StringComparer.Ordinal).Select(@event =>
+                dfa.Transitions.TryGetValue((state, @event), out var target) ? stateToPartition[target].ToString() : "-1")))
+            .Select(states => states.ToHashSet(StringComparer.Ordinal))
+            .ToList();
+    }
+}
+
+public sealed class ModalStateMachine
+{
+    private readonly Dictionary<string, DFA> _modes;
+    private readonly Dictionary<(string Mode, string Trigger), string> _modeTransitions;
+    private readonly List<ModeTransitionRecord> _modeTrace = [];
+
+    public ModalStateMachine(IDictionary<string, DFA> modes, IDictionary<(string Mode, string Trigger), string> modeTransitions, string initialMode)
+    {
+        _modes = new Dictionary<string, DFA>(modes, StringComparer.Ordinal);
+        _modeTransitions = new Dictionary<(string Mode, string Trigger), string>(modeTransitions);
+        InitialMode = initialMode;
+        CurrentMode = initialMode;
+    }
+
+    public string InitialMode { get; }
+    public string CurrentMode { get; private set; }
+    public DFA ActiveMachine => _modes[CurrentMode];
+    public IReadOnlyList<ModeTransitionRecord> ModeTrace => _modeTrace.ToList();
+    public string Process(string @event) => ActiveMachine.Process(@event);
+
+    public string TriggerMode(string trigger)
+    {
+        if (!_modeTransitions.TryGetValue((CurrentMode, trigger), out var target))
+        {
+            throw new InvalidOperationException($"No mode transition defined for ({CurrentMode}, {trigger})");
+        }
+
+        var from = CurrentMode;
+        CurrentMode = target;
+        ActiveMachine.Reset();
+        _modeTrace.Add(new ModeTransitionRecord(from, trigger, target));
+        return target;
+    }
+
+    public void Reset()
+    {
+        CurrentMode = InitialMode;
+        _modeTrace.Clear();
+        foreach (var mode in _modes.Values)
+        {
+            mode.Reset();
+        }
+    }
+}
+
+public sealed class PushdownAutomaton
+{
+    private readonly Dictionary<(string State, string? Event, string StackTop), PDATransition> _index;
+    private readonly HashSet<string> _accepting;
+    private readonly List<string> _stack = [];
+    private readonly List<PDATraceEntry> _trace = [];
+
+    public PushdownAutomaton(
+        IEnumerable<string> states,
+        IEnumerable<string> inputAlphabet,
+        IEnumerable<string> stackAlphabet,
+        IEnumerable<PDATransition> transitions,
+        string initial,
+        string initialStackSymbol,
+        IEnumerable<string> accepting)
+    {
+        Initial = initial;
+        InitialStackSymbol = initialStackSymbol;
+        _accepting = accepting.ToHashSet(StringComparer.Ordinal);
+        _index = transitions.ToDictionary(transition => (transition.Source, transition.Event, transition.StackRead), transition => transition);
+        Reset();
+    }
+
+    public string Initial { get; }
+    public string InitialStackSymbol { get; }
+    public string CurrentState { get; private set; } = string.Empty;
+    public IReadOnlyList<string> Stack => _stack.ToList();
+    public IReadOnlyList<PDATraceEntry> Trace => _trace.ToList();
+
+    public void Reset()
+    {
+        CurrentState = Initial;
+        _stack.Clear();
+        _stack.Add(InitialStackSymbol);
+        _trace.Clear();
+    }
+
+    public void Process(string @event)
+    {
+        Step(@event);
+        while (TryStepEpsilon())
+        {
+        }
+    }
+
+    public void Process(IEnumerable<string> events)
+    {
+        foreach (var @event in events)
+        {
+            Process(@event);
+        }
+
+        while (TryStepEpsilon())
+        {
+        }
+    }
+
+    public bool Accepts(IEnumerable<string> events)
+    {
+        Reset();
+        Process(events);
+        return _accepting.Contains(CurrentState);
+    }
+
+    private void Step(string? @event)
+    {
+        var top = _stack.Count > 0 ? _stack[^1] : string.Empty;
+        if (!_index.TryGetValue((CurrentState, @event, top), out var transition))
+        {
+            throw new InvalidOperationException($"No PDA transition defined for ({CurrentState}, {@event}, {top})");
+        }
+
+        ApplyTransition(transition);
+    }
+
+    private bool TryStepEpsilon()
+    {
+        var top = _stack.Count > 0 ? _stack[^1] : string.Empty;
+        if (!_index.TryGetValue((CurrentState, null, top), out var transition))
+        {
+            return false;
+        }
+
+        ApplyTransition(transition);
+        return true;
+    }
+
+    private void ApplyTransition(PDATransition transition)
+    {
+        if (_stack.Count == 0 || _stack[^1] != transition.StackRead)
+        {
+            throw new InvalidOperationException("PDA stack top does not match transition");
+        }
+
+        _stack.RemoveAt(_stack.Count - 1);
+        foreach (var symbol in transition.StackPush)
+        {
+            _stack.Add(symbol);
+        }
+
+        CurrentState = transition.Target;
+        _trace.Add(new PDATraceEntry(transition.Source, transition.Event, transition.StackRead, transition.Target, transition.StackPush, _stack.ToList()));
+    }
+}

--- a/code/packages/csharp/state-machine/required_capabilities.json
+++ b/code/packages/csharp/state-machine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/state-machine",
+  "capabilities": [],
+  "justification": "Pure in-memory automata library and tests."
+}

--- a/code/packages/csharp/state-machine/tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.csproj
+++ b/code/packages/csharp/state-machine/tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.StateMachine.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.cs
+++ b/code/packages/csharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.cs
@@ -1,0 +1,26 @@
+using CodingAdventures.StateMachine;
+
+namespace CodingAdventures.StateMachine.Tests;
+
+public class StateMachineTests
+{
+    [Fact]
+    public void Dfa_ProcessesTurnstile()
+    {
+        var dfa = new DFA(
+            ["locked", "unlocked"],
+            ["coin", "push"],
+            new Dictionary<(string State, string Event), string>
+            {
+                [("locked", "coin")] = "unlocked",
+                [("locked", "push")] = "locked",
+                [("unlocked", "coin")] = "unlocked",
+                [("unlocked", "push")] = "locked",
+            },
+            "locked",
+            ["unlocked"]);
+
+        Assert.Equal("unlocked", dfa.Process("coin"));
+        Assert.True(dfa.IsAccepting());
+    }
+}

--- a/code/packages/fsharp/directed-graph/BUILD
+++ b/code/packages/fsharp/directed-graph/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/directed-graph/BUILD
+++ b/code/packages/fsharp/directed-graph/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/directed-graph/BUILD_windows
+++ b/code/packages/fsharp/directed-graph/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/directed-graph/BUILD_windows
+++ b/code/packages/fsharp/directed-graph/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/directed-graph/CHANGELOG.md
+++ b/code/packages/fsharp/directed-graph/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial F# directed-graph wrapper

--- a/code/packages/fsharp/directed-graph/CHANGELOG.md
+++ b/code/packages/fsharp/directed-graph/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# directed-graph wrapper
+- replace the initial C# wrapper with a native F# directed graph implementation

--- a/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
+++ b/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.DirectedGraph.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.DirectedGraph.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# wrappers for the directed-graph package</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/directed-graph/CodingAdventures.DirectedGraph.csproj" />
+    <Compile Include="DirectedGraph.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
+++ b/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.DirectedGraph.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the directed-graph package</Description>
+    <Description>Pure F# directed graph with cycle detection, topological sorting, and dependency queries</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/directed-graph/CodingAdventures.DirectedGraph.csproj" />
     <Compile Include="DirectedGraph.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/directed-graph/DirectedGraph.fs
+++ b/code/packages/fsharp/directed-graph/DirectedGraph.fs
@@ -1,0 +1,17 @@
+namespace CodingAdventures.DirectedGraph.FSharp
+
+open CodingAdventures.DirectedGraph
+
+module DirectedGraph =
+    let create allowSelfLoops =
+        Graph(allowSelfLoops)
+
+    let createDefault () =
+        Graph()
+
+    let addEdge fromNode toNode (graph: Graph) =
+        graph.AddEdge(fromNode, toNode)
+        graph
+
+    let topologicalSort (graph: Graph) =
+        graph.TopologicalSort() |> Seq.toList

--- a/code/packages/fsharp/directed-graph/DirectedGraph.fs
+++ b/code/packages/fsharp/directed-graph/DirectedGraph.fs
@@ -1,17 +1,270 @@
 namespace CodingAdventures.DirectedGraph.FSharp
 
-open CodingAdventures.DirectedGraph
+open System
+open System.Collections.Generic
+
+type CycleError(message: string, cycle: IReadOnlyList<string>) =
+    inherit Exception(message)
+
+    member _.Cycle = cycle
+
+type NodeNotFoundError(node: string) =
+    inherit Exception(sprintf "Node not found: \"%s\"" node)
+
+    member _.Node = node
+
+type EdgeNotFoundError(fromNode: string, toNode: string) =
+    inherit Exception(sprintf "Edge not found: \"%s\" -> \"%s\"" fromNode toNode)
+
+    member _.FromNode = fromNode
+    member _.ToNode = toNode
+
+type Graph(?allowSelfLoops: bool) =
+    let allowSelfLoops = defaultArg allowSelfLoops false
+    let forward = Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+    let reverse = Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+
+    let ensureNode (node: string) =
+        if not (forward.ContainsKey(node)) then
+            raise (NodeNotFoundError(node))
+
+    let orderedStrings (values: seq<string>) =
+        values |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> Seq.toList
+
+    member _.AllowSelfLoops = allowSelfLoops
+    member _.Size = forward.Count
+
+    member _.AddNode(node: string) =
+        if not (forward.ContainsKey(node)) then
+            forward.[node] <- HashSet<string>(StringComparer.Ordinal)
+
+        if not (reverse.ContainsKey(node)) then
+            reverse.[node] <- HashSet<string>(StringComparer.Ordinal)
+
+    member this.RemoveNode(node: string) =
+        ensureNode node
+
+        for successor in forward.[node] |> Seq.toArray do
+            reverse.[successor].Remove(node) |> ignore
+
+        for predecessor in reverse.[node] |> Seq.toArray do
+            forward.[predecessor].Remove(node) |> ignore
+
+        forward.Remove(node) |> ignore
+        reverse.Remove(node) |> ignore
+
+    member _.HasNode(node: string) = forward.ContainsKey(node)
+
+    member _.Nodes() = orderedStrings forward.Keys
+
+    member this.AddEdge(fromNode: string, toNode: string) =
+        if fromNode = toNode && not allowSelfLoops then
+            invalidArg "toNode" (sprintf "Self-loops are not allowed: \"%s\" -> \"%s\"" fromNode toNode)
+
+        this.AddNode(fromNode)
+        this.AddNode(toNode)
+        forward.[fromNode].Add(toNode) |> ignore
+        reverse.[toNode].Add(fromNode) |> ignore
+
+    member _.RemoveEdge(fromNode: string, toNode: string) =
+        ensureNode fromNode
+
+        if not (forward.ContainsKey(toNode)) || not (forward.[fromNode].Contains(toNode)) then
+            raise (EdgeNotFoundError(fromNode, toNode))
+
+        forward.[fromNode].Remove(toNode) |> ignore
+        reverse.[toNode].Remove(fromNode) |> ignore
+
+    member _.HasEdge(fromNode: string, toNode: string) =
+        forward.ContainsKey(fromNode) && forward.[fromNode].Contains(toNode)
+
+    member _.Successors(node: string) =
+        ensureNode node
+        orderedStrings forward.[node]
+
+    member _.Predecessors(node: string) =
+        ensureNode node
+        orderedStrings reverse.[node]
+
+    member _.Edges() =
+        [
+            for KeyValue(source, targets) in forward do
+                for target in targets do
+                    yield source, target
+        ]
+        |> List.sortWith (fun (leftSource, leftTarget) (rightSource, rightTarget) ->
+            let bySource = StringComparer.Ordinal.Compare(leftSource, rightSource)
+            if bySource <> 0 then bySource else StringComparer.Ordinal.Compare(leftTarget, rightTarget))
+
+    member this.TransitiveClosure(startNode: string) =
+        this.Reach(startNode, this.Successors)
+
+    member this.TransitiveDependents(startNode: string) =
+        this.Reach(startNode, this.Predecessors)
+
+    member this.TopologicalSort() =
+        let indegree = Dictionary<string, int>(StringComparer.Ordinal)
+        for node in forward.Keys do
+            indegree.[node] <- reverse.[node].Count
+
+        let available =
+            ResizeArray(
+                indegree
+                |> Seq.choose (fun (KeyValue(node, count)) -> if count = 0 then Some node else None)
+                |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)))
+        let order = ResizeArray<string>()
+
+        let popSmallest () =
+            let smallest =
+                available
+                |> Seq.minBy id
+
+            available.Remove(smallest) |> ignore
+            smallest
+
+        while available.Count > 0 do
+            let node = popSmallest ()
+            order.Add(node)
+
+            for successor in this.Successors(node) do
+                indegree.[successor] <- indegree.[successor] - 1
+                if indegree.[successor] = 0 then
+                    available.Add(successor)
+
+        if order.Count <> forward.Count then
+            raise (CycleError("Graph contains a cycle", this.FindCycle()))
+
+        order |> Seq.toList
+
+    member this.IndependentGroups() =
+        let indegree = Dictionary<string, int>(StringComparer.Ordinal)
+        for node in forward.Keys do
+            indegree.[node] <- reverse.[node].Count
+
+        let remaining = HashSet<string>(forward.Keys, StringComparer.Ordinal)
+        let groups = ResizeArray<IReadOnlyList<string>>()
+
+        while remaining.Count > 0 do
+            let layer =
+                remaining
+                |> Seq.filter (fun node -> indegree.[node] = 0)
+                |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right))
+                |> Seq.toList
+
+            if List.isEmpty layer then
+                raise (CycleError("Graph contains a cycle", this.FindCycle()))
+
+            groups.Add(layer)
+            for node in layer do
+                remaining.Remove(node) |> ignore
+                for successor in this.Successors(node) do
+                    indegree.[successor] <- indegree.[successor] - 1
+
+        groups |> Seq.toList
+
+    member this.AffectedNodes(changedNodes: seq<string>) =
+        let affected = HashSet<string>(StringComparer.Ordinal)
+        for node in changedNodes do
+            if this.HasNode(node) then
+                affected.Add(node) |> ignore
+                affected.UnionWith(this.TransitiveClosure(node))
+
+        this.TopologicalSort() |> List.filter affected.Contains
+
+    member private _.Reach(startNode: string, next: string -> string list) =
+        ensureNode startNode
+
+        let visited = HashSet<string>(StringComparer.Ordinal)
+        let stack = Stack<string>()
+        stack.Push(startNode)
+
+        while stack.Count > 0 do
+            let node = stack.Pop()
+            for neighbor in next(node) do
+                if visited.Add(neighbor) then
+                    stack.Push(neighbor)
+
+        visited :> ISet<string>
+
+    member private this.FindCycle() =
+        let visited = HashSet<string>(StringComparer.Ordinal)
+        let onStack = HashSet<string>(StringComparer.Ordinal)
+        let parent = Dictionary<string, string option>(StringComparer.Ordinal)
+
+        let rec findCycleFrom node =
+            if onStack.Contains(node) then
+                let mutable cycle = [ node ]
+                let mutable current =
+                    match parent.TryGetValue(node) with
+                    | true, value -> value
+                    | _ -> None
+
+                while current.IsSome && current.Value <> node do
+                    cycle <- current.Value :: cycle
+                    current <-
+                        match parent.TryGetValue(current.Value) with
+                        | true, value -> value
+                        | _ -> None
+
+                cycle @ [ node ]
+
+            elif not (visited.Add(node)) then
+                []
+
+            else
+                onStack.Add(node) |> ignore
+                let mutable found = []
+                for successor in this.Successors(node) do
+                    if List.isEmpty found then
+                        parent.[successor] <- Some node
+                        let cycle = findCycleFrom successor
+                        if not (List.isEmpty cycle) then
+                            found <- cycle
+
+                onStack.Remove(node) |> ignore
+                found
+
+        forward.Keys
+        |> Seq.tryPick (fun node ->
+            let cycle = findCycleFrom node
+            if List.isEmpty cycle then None else Some cycle)
+        |> Option.defaultValue []
+
+type LabeledDirectedGraph(?allowSelfLoops: bool) =
+    let graph = Graph(defaultArg allowSelfLoops false)
+    let labels = Dictionary<string, Dictionary<string, HashSet<string>>>(StringComparer.Ordinal)
+
+    member _.AddNode(node: string) =
+        graph.AddNode(node)
+        if not (labels.ContainsKey(node)) then
+            labels.[node] <- Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+
+    member this.AddEdge(fromNode: string, toNode: string, label: string) =
+        this.AddNode(fromNode)
+        this.AddNode(toNode)
+        graph.AddEdge(fromNode, toNode)
+
+        if not (labels.[fromNode].ContainsKey(toNode)) then
+            labels.[fromNode].[toNode] <- HashSet<string>(StringComparer.Ordinal)
+
+        labels.[fromNode].[toNode].Add(label) |> ignore
+
+    member _.Labels(fromNode: string, toNode: string) =
+        match labels.TryGetValue(fromNode) with
+        | true, targets when targets.ContainsKey(toNode) ->
+            targets.[toNode] |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> Seq.toList
+        | _ ->
+            []
+
+    member _.TopologicalSort() = graph.TopologicalSort()
+    member _.TransitiveClosure(startNode: string) = graph.TransitiveClosure(startNode)
 
 module DirectedGraph =
-    let create allowSelfLoops =
-        Graph(allowSelfLoops)
-
-    let createDefault () =
-        Graph()
+    let create allowSelfLoops = Graph(allowSelfLoops)
+    let createDefault () = Graph()
 
     let addEdge fromNode toNode (graph: Graph) =
         graph.AddEdge(fromNode, toNode)
         graph
 
-    let topologicalSort (graph: Graph) =
-        graph.TopologicalSort() |> Seq.toList
+    let topologicalSort (graph: Graph) = graph.TopologicalSort()

--- a/code/packages/fsharp/directed-graph/README.md
+++ b/code/packages/fsharp/directed-graph/README.md
@@ -1,3 +1,3 @@
 # Directed Graph
 
-F# wrapper helpers for the C# directed-graph implementation.
+Pure F# directed graph operations with topological sorting, dependency grouping, transitive queries, and labeled edges.

--- a/code/packages/fsharp/directed-graph/README.md
+++ b/code/packages/fsharp/directed-graph/README.md
@@ -1,0 +1,3 @@
+# Directed Graph
+
+F# wrapper helpers for the C# directed-graph implementation.

--- a/code/packages/fsharp/directed-graph/required_capabilities.json
+++ b/code/packages/fsharp/directed-graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/directed-graph",
+  "capabilities": [],
+  "justification": "Thin F# wrapper over the C# directed-graph implementation."
+}

--- a/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj
+++ b/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.DirectedGraph.fsproj" />
+    <Compile Include="DirectedGraphTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
+++ b/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
@@ -12,3 +12,24 @@ module DirectedGraphTests =
             |> DirectedGraph.addEdge "B" "C"
 
         Assert.Equal<string list>(["A"; "B"; "C"], DirectedGraph.topologicalSort graph)
+
+    [<Fact>]
+    let ``graph exposes successors predecessors and affected nodes`` () =
+        let graph = Graph()
+        graph.AddEdge("logic-gates", "arithmetic")
+        graph.AddEdge("arithmetic", "cpu")
+        graph.AddEdge("logic-gates", "alu")
+
+        Assert.Equal<string list>(["alu"; "arithmetic"], graph.Successors("logic-gates"))
+        Assert.Equal<string list>(["logic-gates"], graph.Predecessors("arithmetic"))
+        Assert.Equal<string list>(["logic-gates"; "alu"; "arithmetic"; "cpu"], graph.AffectedNodes([ "logic-gates" ]))
+
+    [<Fact>]
+    let ``cycles surface a helpful error`` () =
+        let graph = Graph()
+        graph.AddEdge("A", "B")
+        graph.AddEdge("B", "C")
+        graph.AddEdge("C", "A")
+
+        let error = Assert.Throws<CycleError>(fun () -> graph.TopologicalSort() |> ignore)
+        Assert.Contains("A", error.Cycle)

--- a/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
+++ b/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
@@ -1,0 +1,14 @@
+namespace CodingAdventures.DirectedGraph.FSharp.Tests
+
+open CodingAdventures.DirectedGraph.FSharp
+open Xunit
+
+module DirectedGraphTests =
+    [<Fact>]
+    let ``topological sort works`` () =
+        let graph =
+            DirectedGraph.createDefault()
+            |> DirectedGraph.addEdge "A" "B"
+            |> DirectedGraph.addEdge "B" "C"
+
+        Assert.Equal<string list>(["A"; "B"; "C"], DirectedGraph.topologicalSort graph)

--- a/code/packages/fsharp/lexer/BUILD
+++ b/code/packages/fsharp/lexer/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lexer/BUILD
+++ b/code/packages/fsharp/lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lexer/BUILD_windows
+++ b/code/packages/fsharp/lexer/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lexer/BUILD_windows
+++ b/code/packages/fsharp/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lexer/CHANGELOG.md
+++ b/code/packages/fsharp/lexer/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# lexer wrapper
+- replace the initial C# wrapper with a native F# lexer implementation

--- a/code/packages/fsharp/lexer/CHANGELOG.md
+++ b/code/packages/fsharp/lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial F# lexer wrapper

--- a/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
+++ b/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.Lexer.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the lexer package</Description>
+    <Description>Pure F# grammar-driven lexer built on the shared grammar model</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
     <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
     <Compile Include="Lexer.fs" />
   </ItemGroup>

--- a/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
+++ b/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Lexer.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# wrappers for the lexer package</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <Compile Include="Lexer.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lexer/Lexer.fs
+++ b/code/packages/fsharp/lexer/Lexer.fs
@@ -1,11 +1,224 @@
 namespace CodingAdventures.Lexer.FSharp
 
+open System
+open System.Collections.Generic
+open System.Text.RegularExpressions
 open CodingAdventures.GrammarTools
-open CodingAdventures.Lexer
+
+type TokenType =
+    | Name = 0
+    | Number = 1
+    | String = 2
+    | Keyword = 3
+    | Plus = 4
+    | Minus = 5
+    | Star = 6
+    | Slash = 7
+    | Equals = 8
+    | EqualsEquals = 9
+    | LParen = 10
+    | RParen = 11
+    | Comma = 12
+    | Colon = 13
+    | Semicolon = 14
+    | LBrace = 15
+    | RBrace = 16
+    | LBracket = 17
+    | RBracket = 18
+    | Dot = 19
+    | Bang = 20
+    | Newline = 21
+    | EOF = 22
+    | Grammar = 23
+
+type Token(tokenType: TokenType, value: string, line: int, column: int, ?typeName: string, ?flags: int) =
+    let typeName = defaultArg typeName null
+    let flags = defaultArg flags 0
+
+    static member FlagPrecededByNewline = 1
+    static member FlagContextKeyword = 2
+
+    member _.Type = tokenType
+    member _.Value = value
+    member _.Line = line
+    member _.Column = column
+    member _.TypeName = typeName
+    member _.Flags = flags
+    member this.EffectiveTypeName = if String.IsNullOrEmpty(typeName) then tokenType.ToString().ToUpperInvariant() else typeName
+    member _.HasFlag(flag: int) = (flags &&& flag) <> 0
+
+    override this.ToString() = sprintf "Token(%s, \"%s\", %d:%d)" this.EffectiveTypeName value line column
+
+    override this.Equals(other: obj) =
+        match other with
+        | :? Token as token ->
+            token.Type = tokenType
+            && token.Value = value
+            && token.Line = line
+            && token.Column = column
+            && token.TypeName = typeName
+            && token.Flags = flags
+        | _ ->
+            false
+
+    override _.GetHashCode() =
+        HashCode.Combine(tokenType, value, line, column, typeName, flags)
+
+type LexerError(message: string, line: int, column: int) =
+    inherit Exception(sprintf "Lexer error at %d:%d: %s" line column message)
+
+    member _.Line = line
+    member _.Column = column
+
+type private CompiledPattern =
+    {
+        Name: string
+        Regex: Regex
+        Alias: string
+    }
+
+type private MatcherNode =
+    {
+        Stage: string
+        Pattern: CompiledPattern
+    }
+
+type GrammarLexer(grammar: TokenGrammar) =
+    let definitionsOrEmpty (definitions: IReadOnlyList<TokenDefinition>) =
+        if isNull definitions then Seq.empty else definitions :> seq<TokenDefinition>
+
+    let compileDefinitions definitions =
+        let mutable options = RegexOptions.Compiled ||| RegexOptions.CultureInvariant
+        if not grammar.CaseSensitive then
+            options <- options ||| RegexOptions.IgnoreCase
+
+        definitions
+        |> Seq.map (fun (definition: TokenDefinition) ->
+            let pattern =
+                if definition.IsRegex then
+                    sprintf @"\G(?:%s)" definition.Pattern
+                else
+                    sprintf @"\G%s" (Regex.Escape(definition.Pattern))
+
+            {
+                Name = definition.Name
+                Regex = Regex(pattern, options)
+                Alias =
+                    if String.IsNullOrEmpty(definition.Alias) then
+                        null
+                    else
+                        definition.Alias
+            })
+        |> Seq.toList
+
+    let matcherPipeline =
+        [
+            yield!
+                compileDefinitions (definitionsOrEmpty grammar.SkipDefinitions)
+                |> List.map (fun pattern -> { Stage = "skip"; Pattern = pattern })
+            yield!
+                compileDefinitions grammar.Definitions
+                |> List.map (fun pattern -> { Stage = "token"; Pattern = pattern })
+            yield!
+                compileDefinitions (definitionsOrEmpty grammar.ErrorDefinitions)
+                |> List.map (fun pattern -> { Stage = "error"; Pattern = pattern })
+        ]
+
+    let keywords = HashSet<string>(grammar.Keywords, StringComparer.Ordinal)
+    let reserved =
+        let values =
+            if isNull grammar.ReservedKeywords then
+                Seq.empty
+            else
+                grammar.ReservedKeywords :> seq<string>
+
+        HashSet<string>(
+            values,
+            StringComparer.Ordinal)
+
+    let contextKeywords =
+        let values =
+            if isNull grammar.ContextKeywords then
+                Seq.empty
+            else
+                grammar.ContextKeywords :> seq<string>
+
+        HashSet<string>(
+            values,
+            StringComparer.Ordinal)
+
+    let normalizeCase (value: string) =
+        if grammar.CaseSensitive then value else value.ToLowerInvariant()
+
+    let advance (text: string) (line: byref<int>) (column: byref<int>) (precededByNewline: byref<bool>) =
+        for ch in text do
+            if ch = '\n' then
+                line <- line + 1
+                column <- 1
+                precededByNewline <- true
+            else
+                column <- column + 1
+
+    let promoteKeywords (tokens: ResizeArray<Token>) =
+        if keywords.Count > 0 then
+            for index in 0 .. tokens.Count - 1 do
+                let token = tokens.[index]
+                if token.TypeName = "NAME" && keywords.Contains(normalizeCase token.Value) then
+                    tokens.[index] <- Token(TokenType.Keyword, token.Value, token.Line, token.Column, "KEYWORD", token.Flags)
+
+    member _.Tokenize(source: string) =
+        let workingSource = if grammar.CaseSensitive then source else source.ToLowerInvariant()
+        let tokens = ResizeArray<Token>()
+        let mutable pos = 0
+        let mutable line = 1
+        let mutable column = 1
+        let mutable precededByNewline = false
+
+        while pos < workingSource.Length do
+            let mutable matched = false
+
+            for node in matcherPipeline do
+                if not matched then
+                    let ``match`` = node.Pattern.Regex.Match(workingSource, pos)
+                    if ``match``.Success && ``match``.Index = pos then
+                        let value = source.Substring(pos, ``match``.Length)
+                        match node.Stage with
+                        | "skip" ->
+                            advance value &line &column &precededByNewline
+                            pos <- pos + value.Length
+                        | _ ->
+                            let typeName =
+                                if String.IsNullOrEmpty(node.Pattern.Alias) then
+                                    node.Pattern.Name
+                                else
+                                    node.Pattern.Alias
+
+                            if typeName = "NAME" && reserved.Contains(value) then
+                                raise (LexerError(sprintf "Reserved keyword '%s'" value, line, column))
+
+                            let mutable tokenFlags = 0
+                            if precededByNewline then
+                                tokenFlags <- tokenFlags ||| Token.FlagPrecededByNewline
+
+                            if typeName = "NAME" && contextKeywords.Contains(normalizeCase value) then
+                                tokenFlags <- tokenFlags ||| Token.FlagContextKeyword
+
+                            tokens.Add(Token(TokenType.Grammar, value, line, column, typeName, tokenFlags))
+
+                            let mutable ignoredPrecededByNewline = false
+                            advance value &line &column &ignoredPrecededByNewline
+                            precededByNewline <- false
+                            pos <- pos + value.Length
+
+                        matched <- true
+
+            if not matched then
+                raise (LexerError(sprintf "Unexpected character '%c'" source.[pos], line, column))
+
+        promoteKeywords tokens
+        tokens.Add(Token(TokenType.EOF, String.Empty, line, column, "EOF"))
+        tokens |> Seq.toList
 
 module Lexer =
-    let parseGrammar source =
-        TokenGrammarParser.Parse(source)
-
-    let tokenize source grammar =
-        GrammarLexer(grammar).Tokenize(source) |> Seq.toList
+    let parseGrammar source = TokenGrammarParser.Parse(source)
+    let tokenize source grammar = GrammarLexer(grammar).Tokenize(source)

--- a/code/packages/fsharp/lexer/Lexer.fs
+++ b/code/packages/fsharp/lexer/Lexer.fs
@@ -1,0 +1,11 @@
+namespace CodingAdventures.Lexer.FSharp
+
+open CodingAdventures.GrammarTools
+open CodingAdventures.Lexer
+
+module Lexer =
+    let parseGrammar source =
+        TokenGrammarParser.Parse(source)
+
+    let tokenize source grammar =
+        GrammarLexer(grammar).Tokenize(source) |> Seq.toList

--- a/code/packages/fsharp/lexer/README.md
+++ b/code/packages/fsharp/lexer/README.md
@@ -1,3 +1,3 @@
 # Lexer
 
-F# wrapper helpers for the C# lexer implementation.
+Pure F# grammar-driven lexer using the shared grammar-tools grammar model.

--- a/code/packages/fsharp/lexer/README.md
+++ b/code/packages/fsharp/lexer/README.md
@@ -1,0 +1,3 @@
+# Lexer
+
+F# wrapper helpers for the C# lexer implementation.

--- a/code/packages/fsharp/lexer/required_capabilities.json
+++ b/code/packages/fsharp/lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lexer",
+  "capabilities": [],
+  "justification": "Thin F# wrapper over the C# lexer implementation."
+}

--- a/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj
+++ b/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Lexer.fsproj" />
+    <Compile Include="LexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
+++ b/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
@@ -5,7 +5,7 @@ open Xunit
 
 module LexerTests =
     [<Fact>]
-    let ``lexer wrapper tokenizes`` () =
+    let ``lexer tokenizes grammar driven input`` () =
         let grammar =
             Lexer.parseGrammar """
                 NUMBER = /[0-9]+/
@@ -16,3 +16,21 @@ module LexerTests =
 
         let tokens = Lexer.tokenize "42 + 7" grammar
         Assert.Equal("NUMBER", tokens[0].TypeName)
+        Assert.Equal("PLUS", tokens[1].TypeName)
+        Assert.Equal("NUMBER", tokens[2].TypeName)
+
+    [<Fact>]
+    let ``lexer promotes keywords and preserves newline flags`` () =
+        let grammar =
+            Lexer.parseGrammar """
+                NAME = /[a-z]+/
+                skip:
+                  WS = /[ \t]+/
+                  NL = /\n/
+                keywords:
+                  if
+                """
+
+        let tokens = Lexer.tokenize "if\nname" grammar
+        Assert.Equal(TokenType.Keyword, tokens[0].Type)
+        Assert.True(tokens[1].HasFlag(Token.FlagPrecededByNewline))

--- a/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
+++ b/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
@@ -1,0 +1,18 @@
+namespace CodingAdventures.Lexer.FSharp.Tests
+
+open CodingAdventures.Lexer.FSharp
+open Xunit
+
+module LexerTests =
+    [<Fact>]
+    let ``lexer wrapper tokenizes`` () =
+        let grammar =
+            Lexer.parseGrammar """
+                NUMBER = /[0-9]+/
+                PLUS = "+"
+                skip:
+                  WS = /[ \t]+/
+                """
+
+        let tokens = Lexer.tokenize "42 + 7" grammar
+        Assert.Equal("NUMBER", tokens[0].TypeName)

--- a/code/packages/fsharp/parser/BUILD
+++ b/code/packages/fsharp/parser/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/parser/BUILD
+++ b/code/packages/fsharp/parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/parser/BUILD_windows
+++ b/code/packages/fsharp/parser/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/parser/BUILD_windows
+++ b/code/packages/fsharp/parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/parser/CHANGELOG.md
+++ b/code/packages/fsharp/parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial F# parser wrapper

--- a/code/packages/fsharp/parser/CHANGELOG.md
+++ b/code/packages/fsharp/parser/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# parser wrapper
+- replace the initial C# wrapper with a native F# parser implementation

--- a/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
+++ b/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
@@ -6,14 +6,13 @@
     <PackageId>CodingAdventures.Parser.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the parser package</Description>
+    <Description>Pure F# grammar-driven parser built on the shared grammar model</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/parser/CodingAdventures.Parser.csproj" />
     <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
-    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../../fsharp/lexer/CodingAdventures.Lexer.fsproj" />
     <Compile Include="Parser.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
+++ b/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Parser.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Parser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# wrappers for the parser package</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
+    <Compile Include="Parser.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/parser/Parser.fs
+++ b/code/packages/fsharp/parser/Parser.fs
@@ -1,12 +1,238 @@
 namespace CodingAdventures.Parser.FSharp
 
+open System
+open System.Collections.Generic
 open CodingAdventures.GrammarTools
-open CodingAdventures.Lexer
-open CodingAdventures.Parser
+open CodingAdventures.Lexer.FSharp
+
+type GrammarParseError(message: string, ?token: Token) =
+    inherit
+        Exception(
+            match token with
+            | Some value -> sprintf "Parse error at %d:%d: %s" value.Line value.Column message
+            | None -> sprintf "Parse error: %s" message)
+
+    member _.Token = defaultArg token Unchecked.defaultof<Token>
+
+type ASTNode(ruleName: string, children: IReadOnlyList<obj>, ?startLine: int, ?startColumn: int, ?endLine: int, ?endColumn: int) =
+    let startLine = defaultArg startLine 0
+    let startColumn = defaultArg startColumn 0
+    let endLine = defaultArg endLine 0
+    let endColumn = defaultArg endColumn 0
+
+    new (ruleName: string) = ASTNode(ruleName, ResizeArray<obj>() :> IReadOnlyList<obj>)
+
+    member _.RuleName = ruleName
+    member _.Children = children
+    member _.StartLine = startLine
+    member _.StartColumn = startColumn
+    member _.EndLine = endLine
+    member _.EndColumn = endColumn
+    member _.IsLeaf = children.Count = 1 && children.[0] :? Token
+    member this.Token = if this.IsLeaf then children.[0] :?> Token else Unchecked.defaultof<Token>
+
+    member this.DescendantCount() =
+        children
+        |> Seq.sumBy (fun child ->
+            match child with
+            | :? ASTNode as node -> 1 + node.DescendantCount()
+            | _ -> 1)
+
+type private MemoEntry =
+    {
+        Children: IReadOnlyList<obj> option
+        EndPos: int
+        Ok: bool
+    }
+
+type private MatchResult =
+    {
+        Children: IReadOnlyList<obj>
+        EndPos: int
+    }
+
+type GrammarParser(grammar: ParserGrammar) =
+    let ruleMap =
+        let result = Dictionary<string, GrammarRule>(StringComparer.Ordinal)
+        for rule in grammar.Rules do
+            result.[rule.Name] <- rule
+        result
+
+    static member private AsReadOnly(items: seq<obj>) =
+        ResizeArray<obj>(items) :> IReadOnlyList<obj>
+
+    static member private FindFirstToken(children: IReadOnlyList<obj>) =
+        children
+        |> Seq.tryPick (fun child ->
+            match child with
+            | :? Token as token -> Some token
+            | :? ASTNode as node -> GrammarParser.FindFirstToken(node.Children)
+            | _ -> None)
+
+    static member private FindLastToken(children: IReadOnlyList<obj>) =
+        children
+        |> Seq.toArray
+        |> Array.rev
+        |> Array.tryPick (fun child ->
+            match child with
+            | :? Token as token -> Some token
+            | :? ASTNode as node -> GrammarParser.FindLastToken(node.Children)
+            | _ -> None)
+
+    static member private BuildNode(ruleName: string, children: IReadOnlyList<obj>) =
+        let first = GrammarParser.FindFirstToken(children)
+        let last = GrammarParser.FindLastToken(children)
+        ASTNode(
+            ruleName,
+            children,
+            first |> Option.map (fun token -> token.Line) |> Option.defaultValue 0,
+            first |> Option.map (fun token -> token.Column) |> Option.defaultValue 0,
+            last |> Option.map (fun token -> token.Line) |> Option.defaultValue 0,
+            last |> Option.map (fun token -> token.Column) |> Option.defaultValue 0)
+
+    member this.Parse(tokens: IReadOnlyList<Token>) =
+        if grammar.Rules.Count = 0 then
+            raise (GrammarParseError("No rules in grammar", if tokens.Count > 0 then tokens.[tokens.Count - 1] else Unchecked.defaultof<Token>))
+
+        let startRule = grammar.Rules.[0].Name
+        let memo = Dictionary<struct (string * int), MemoEntry>()
+        let recursion = HashSet<struct (string * int)>()
+
+        match this.MatchRule(startRule, tokens, 0, memo, recursion) with
+        | None ->
+            raise (GrammarParseError(sprintf "Failed to parse starting rule '%s'" startRule, if tokens.Count > 0 then tokens.[0] else Unchecked.defaultof<Token>))
+        | Some result ->
+            if result.Children.Count = 1 && result.Children.[0] :? ASTNode then
+                let node = result.Children.[0] :?> ASTNode
+                if node.RuleName = startRule then node else GrammarParser.BuildNode(startRule, result.Children)
+            else
+                GrammarParser.BuildNode(startRule, result.Children)
+
+    member private this.MatchRule(ruleName: string, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>) =
+        match memo.TryGetValue(struct (ruleName, pos)) with
+        | true, cached ->
+            if cached.Ok then
+                Some { Children = cached.Children.Value; EndPos = cached.EndPos }
+            else
+                None
+        | _ when not (recursion.Add(struct (ruleName, pos))) ->
+            memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+            None
+        | _ ->
+            try
+                match ruleMap.TryGetValue(ruleName) with
+                | false, _ ->
+                    memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+                    None
+                | true, rule ->
+                    match this.MatchElement(rule.Body, tokens, pos, memo, recursion) with
+                    | None ->
+                        memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+                        None
+                    | Some result ->
+                        let wrapped = GrammarParser.AsReadOnly [ box (GrammarParser.BuildNode(ruleName, result.Children)) ]
+                        memo.[struct (ruleName, pos)] <- { Children = Some wrapped; EndPos = result.EndPos; Ok = true }
+                        Some { Children = wrapped; EndPos = result.EndPos }
+            finally
+                recursion.Remove(struct (ruleName, pos)) |> ignore
+
+    member private this.MatchRepeated(element: GrammarElement, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>, requireOne: bool) =
+        let children = ResizeArray<obj>()
+        let mutable currentPos = pos
+        let mutable matchedOne = false
+        let mutable keepGoing = true
+
+        while keepGoing do
+            match this.MatchElement(element, tokens, currentPos, memo, recursion) with
+            | Some result when result.EndPos <> currentPos ->
+                matchedOne <- true
+                children.AddRange(result.Children)
+                currentPos <- result.EndPos
+            | _ ->
+                keepGoing <- false
+
+        if requireOne && not matchedOne then
+            None
+        else
+            Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+
+    member private this.MatchElement(element: GrammarElement, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>) =
+        match element with
+        | :? RuleReference as reference ->
+            if reference.IsToken then
+                if pos < tokens.Count && tokens.[pos].EffectiveTypeName = reference.Name then
+                    Some { Children = GrammarParser.AsReadOnly [ box tokens.[pos] ]; EndPos = pos + 1 }
+                else
+                    None
+            else
+                this.MatchRule(reference.Name, tokens, pos, memo, recursion)
+        | :? Literal as literal ->
+            if pos < tokens.Count && tokens.[pos].Value = literal.Value then
+                Some { Children = GrammarParser.AsReadOnly [ box tokens.[pos] ]; EndPos = pos + 1 }
+            else
+                None
+        | :? Sequence as sequence ->
+            let children = ResizeArray<obj>()
+            let mutable currentPos = pos
+            let mutable failed = false
+            for child in sequence.Elements do
+                if not failed then
+                    match this.MatchElement(child, tokens, currentPos, memo, recursion) with
+                    | Some result ->
+                        children.AddRange(result.Children)
+                        currentPos <- result.EndPos
+                    | None ->
+                        failed <- true
+
+            if failed then None else Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+        | :? Alternation as alternation ->
+            alternation.Choices |> Seq.tryPick (fun choice -> this.MatchElement(choice, tokens, pos, memo, recursion))
+        | :? Repetition as repetition ->
+            this.MatchRepeated(repetition.Element, tokens, pos, memo, recursion, false)
+        | :? OneOrMoreRepetition as repetition ->
+            this.MatchRepeated(repetition.Element, tokens, pos, memo, recursion, true)
+        | :? Optional as optional ->
+            match this.MatchElement(optional.Element, tokens, pos, memo, recursion) with
+            | Some result -> Some result
+            | None -> Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+        | :? Group as group ->
+            this.MatchElement(group.Element, tokens, pos, memo, recursion)
+        | :? PositiveLookahead as lookahead ->
+            if this.MatchElement(lookahead.Element, tokens, pos, memo, recursion) |> Option.isSome then
+                Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            else
+                None
+        | :? NegativeLookahead as lookahead ->
+            if this.MatchElement(lookahead.Element, tokens, pos, memo, recursion) |> Option.isNone then
+                Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            else
+                None
+        | :? SeparatedRepetition as separated ->
+            match this.MatchElement(separated.Element, tokens, pos, memo, recursion) with
+            | None when separated.AtLeastOne -> None
+            | None -> Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            | Some first ->
+                let children = ResizeArray<obj>(first.Children)
+                let mutable currentPos = first.EndPos
+                let mutable keepGoing = true
+
+                while keepGoing do
+                    match this.MatchElement(separated.Separator, tokens, currentPos, memo, recursion) with
+                    | None ->
+                        keepGoing <- false
+                    | Some separatorResult ->
+                        match this.MatchElement(separated.Element, tokens, separatorResult.EndPos, memo, recursion) with
+                        | None ->
+                            keepGoing <- false
+                        | Some elementResult ->
+                            children.AddRange(separatorResult.Children)
+                            children.AddRange(elementResult.Children)
+                            currentPos <- elementResult.EndPos
+
+                Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+        | _ ->
+            invalidOp (sprintf "Unsupported grammar element: %s" (element.GetType().Name))
 
 module Parser =
-    let parseGrammar source =
-        ParserGrammarParser.Parse(source)
-
-    let parse tokens grammar =
-        GrammarParser(grammar).Parse(tokens)
+    let parseGrammar source = ParserGrammarParser.Parse(source)
+    let parse (tokens: IReadOnlyList<Token>) grammar = GrammarParser(grammar).Parse(tokens)

--- a/code/packages/fsharp/parser/Parser.fs
+++ b/code/packages/fsharp/parser/Parser.fs
@@ -1,0 +1,12 @@
+namespace CodingAdventures.Parser.FSharp
+
+open CodingAdventures.GrammarTools
+open CodingAdventures.Lexer
+open CodingAdventures.Parser
+
+module Parser =
+    let parseGrammar source =
+        ParserGrammarParser.Parse(source)
+
+    let parse tokens grammar =
+        GrammarParser(grammar).Parse(tokens)

--- a/code/packages/fsharp/parser/README.md
+++ b/code/packages/fsharp/parser/README.md
@@ -1,0 +1,3 @@
+# Parser
+
+F# wrapper helpers for the C# parser implementation.

--- a/code/packages/fsharp/parser/README.md
+++ b/code/packages/fsharp/parser/README.md
@@ -1,3 +1,3 @@
 # Parser
 
-F# wrapper helpers for the C# parser implementation.
+Pure F# grammar-driven parser using the shared grammar-tools grammar model.

--- a/code/packages/fsharp/parser/required_capabilities.json
+++ b/code/packages/fsharp/parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/parser",
+  "capabilities": [],
+  "justification": "Thin F# wrapper over the C# parser implementation."
+}

--- a/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj
+++ b/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Parser.fsproj" />
+    <Compile Include="ParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
+++ b/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
@@ -1,13 +1,13 @@
 namespace CodingAdventures.Parser.FSharp.Tests
 
 open System.Collections.Generic
-open CodingAdventures.Lexer
+open CodingAdventures.Lexer.FSharp
 open CodingAdventures.Parser.FSharp
 open Xunit
 
 module ParserTests =
     [<Fact>]
-    let ``parser wrapper parses`` () =
+    let ``parser builds an AST from tokens`` () =
         let grammar = Parser.parseGrammar "assign = NAME EQUALS NUMBER ;"
         let tokens =
             [|
@@ -19,3 +19,20 @@ module ParserTests =
 
         let ast = Parser.parse tokens grammar
         Assert.Equal("assign", ast.RuleName)
+        Assert.Equal(1, ast.StartLine)
+        Assert.True(ast.DescendantCount() >= 3)
+
+    [<Fact>]
+    let ``parser handles repetition and optionals`` () =
+        let grammar = Parser.parseGrammar "program = { NAME } [ NUMBER ] ;"
+        let tokens =
+            [|
+                Token(TokenType.Grammar, "alpha", 1, 1, "NAME")
+                Token(TokenType.Grammar, "beta", 1, 7, "NAME")
+                Token(TokenType.Grammar, "7", 1, 12, "NUMBER")
+                Token(TokenType.EOF, "", 1, 13, "EOF")
+            |]
+
+        let ast = Parser.parse tokens grammar
+        Assert.Equal("program", ast.RuleName)
+        Assert.True(ast.DescendantCount() >= 3)

--- a/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
+++ b/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
@@ -1,0 +1,21 @@
+namespace CodingAdventures.Parser.FSharp.Tests
+
+open System.Collections.Generic
+open CodingAdventures.Lexer
+open CodingAdventures.Parser.FSharp
+open Xunit
+
+module ParserTests =
+    [<Fact>]
+    let ``parser wrapper parses`` () =
+        let grammar = Parser.parseGrammar "assign = NAME EQUALS NUMBER ;"
+        let tokens =
+            [|
+                Token(TokenType.Grammar, "x", 1, 1, "NAME")
+                Token(TokenType.Grammar, "=", 1, 2, "EQUALS")
+                Token(TokenType.Grammar, "42", 1, 3, "NUMBER")
+                Token(TokenType.EOF, "", 1, 5, "EOF")
+            |]
+
+        let ast = Parser.parse tokens grammar
+        Assert.Equal("assign", ast.RuleName)

--- a/code/packages/fsharp/state-machine/BUILD
+++ b/code/packages/fsharp/state-machine/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/state-machine/BUILD
+++ b/code/packages/fsharp/state-machine/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/state-machine/BUILD_windows
+++ b/code/packages/fsharp/state-machine/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/state-machine/BUILD_windows
+++ b/code/packages/fsharp/state-machine/BUILD_windows
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Graph.Tests/CodingAdventures.Graph.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/state-machine/CHANGELOG.md
+++ b/code/packages/fsharp/state-machine/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- add initial F# state-machine wrapper

--- a/code/packages/fsharp/state-machine/CHANGELOG.md
+++ b/code/packages/fsharp/state-machine/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# state-machine wrapper
+- replace the initial C# wrapper with native F# automata implementations

--- a/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
+++ b/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.StateMachine.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the state-machine package</Description>
+    <Description>Pure F# deterministic, nondeterministic, modal, and pushdown state machines</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/state-machine/CodingAdventures.StateMachine.csproj" />
     <Compile Include="StateMachine.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
+++ b/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.StateMachine.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.StateMachine.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# wrappers for the state-machine package</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/state-machine/CodingAdventures.StateMachine.csproj" />
+    <Compile Include="StateMachine.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/state-machine/README.md
+++ b/code/packages/fsharp/state-machine/README.md
@@ -1,3 +1,3 @@
 # State Machine
 
-F# wrapper helpers for the C# state-machine implementation.
+Pure F# deterministic, nondeterministic, modal, and pushdown state machines.

--- a/code/packages/fsharp/state-machine/README.md
+++ b/code/packages/fsharp/state-machine/README.md
@@ -1,0 +1,3 @@
+# State Machine
+
+F# wrapper helpers for the C# state-machine implementation.

--- a/code/packages/fsharp/state-machine/StateMachine.fs
+++ b/code/packages/fsharp/state-machine/StateMachine.fs
@@ -1,0 +1,13 @@
+namespace CodingAdventures.StateMachine.FSharp
+
+open System.Collections.Generic
+open CodingAdventures.StateMachine
+
+module StateMachine =
+    let createDfa
+        (states: seq<string>)
+        (alphabet: seq<string>)
+        (transitions: IDictionary<struct (string * string), string>)
+        (initial: string)
+        (accepting: seq<string>) =
+        DFA(states, alphabet, Dictionary<struct (string * string), string>(transitions), initial, accepting)

--- a/code/packages/fsharp/state-machine/StateMachine.fs
+++ b/code/packages/fsharp/state-machine/StateMachine.fs
@@ -1,7 +1,440 @@
 namespace CodingAdventures.StateMachine.FSharp
 
+open System
 open System.Collections.Generic
-open CodingAdventures.StateMachine
+
+type TransitionAction = delegate of source: string * eventName: string * target: string -> unit
+
+[<CLIMutable>]
+type TransitionRecord =
+    {
+        Source: string
+        Event: string
+        Target: string
+        ActionName: string
+    }
+
+[<CLIMutable>]
+type ModeTransitionRecord =
+    {
+        FromMode: string
+        Trigger: string
+        ToMode: string
+    }
+
+[<CLIMutable>]
+type PDATransition =
+    {
+        Source: string
+        Event: string option
+        StackRead: string
+        Target: string
+        StackPush: IReadOnlyList<string>
+    }
+
+[<CLIMutable>]
+type PDATraceEntry =
+    {
+        Source: string
+        Event: string option
+        StackRead: string
+        Target: string
+        StackPush: IReadOnlyList<string>
+        StackAfter: IReadOnlyList<string>
+    }
+
+type DFA
+    (
+        states: seq<string>,
+        alphabet: seq<string>,
+        transitions: IDictionary<struct (string * string), string>,
+        initial: string,
+        accepting: seq<string>,
+        ?actions: IDictionary<struct (string * string), TransitionAction>
+    ) =
+    let states = HashSet<string>(states, StringComparer.Ordinal)
+    let alphabet = HashSet<string>(alphabet, StringComparer.Ordinal)
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let transitions = Dictionary<struct (string * string), string>(transitions)
+    let actions =
+        match actions with
+        | Some value -> Dictionary<struct (string * string), TransitionAction>(value)
+        | None -> Dictionary<struct (string * string), TransitionAction>()
+
+    let trace = ResizeArray<TransitionRecord>()
+    let mutable currentState = initial
+
+    do
+        if states.Count = 0 then
+            invalidArg "states" "states set must be non-empty"
+
+        if not (states.Contains(initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        if not (accepting |> Seq.forall states.Contains) then
+            invalidArg "accepting" "Accepting states must be a subset of states"
+
+        for KeyValue(struct (state, eventName), target) in transitions do
+            if not (states.Contains(state)) || not (states.Contains(target)) then
+                invalidArg "transitions" "Transition source and target must be in states"
+
+            if not (alphabet.Contains(eventName)) then
+                invalidArg "transitions" "Transition events must be in alphabet"
+
+    member _.States = states :> IReadOnlyCollection<string>
+    member _.Alphabet = alphabet :> IReadOnlyCollection<string>
+    member _.Accepting = accepting :> IReadOnlyCollection<string>
+    member _.Initial = initial
+    member _.CurrentState = currentState
+    member _.Transitions = Dictionary<struct (string * string), string>(transitions) :> IReadOnlyDictionary<struct (string * string), string>
+    member _.Trace = trace |> Seq.toList
+
+    member _.Process(eventName: string) =
+        let key = struct (currentState, eventName)
+        match transitions.TryGetValue(key) with
+        | true, target ->
+            let action =
+                match actions.TryGetValue(key) with
+                | true, value -> Some value
+                | _ -> None
+
+            action |> Option.iter (fun callback -> callback.Invoke(currentState, eventName, target))
+            trace.Add(
+                {
+                    Source = currentState
+                    Event = eventName
+                    Target = target
+                    ActionName = action |> Option.map (fun callback -> callback.Method.Name) |> Option.defaultValue String.Empty
+                })
+            currentState <- target
+            target
+        | _ ->
+            invalidOp (sprintf "No transition defined for (%s, %s)" currentState eventName)
+
+    member this.Process(events: seq<string>) =
+        let mutable state = currentState
+        for eventName in events do
+            state <- this.Process(eventName)
+
+        state
+
+    member _.Reset() =
+        currentState <- initial
+        trace.Clear()
+
+    member _.IsAccepting() = accepting.Contains(currentState)
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        this.Process(events) |> ignore
+        this.IsAccepting()
+
+    member _.MissingTransitions() =
+        let missing = Dictionary<struct (string * string), string>()
+        for state in states do
+            for eventName in alphabet do
+                let key = struct (state, eventName)
+                if not (transitions.ContainsKey(key)) then
+                    missing.[key] <- String.Empty
+
+        missing
+
+    member this.IsComplete() = this.MissingTransitions().Count = 0
+
+    member _.ReachableStates() =
+        let reachable = HashSet<string>(StringComparer.Ordinal)
+        reachable.Add(initial) |> ignore
+        let queue = Queue<string>()
+        queue.Enqueue(initial)
+
+        while queue.Count > 0 do
+            let state = queue.Dequeue()
+            for eventName in alphabet do
+                match transitions.TryGetValue(struct (state, eventName)) with
+                | true, target when reachable.Add(target) ->
+                    queue.Enqueue(target)
+                | _ -> ()
+
+        reachable :> ISet<string>
+
+type NFA
+    (
+        states: seq<string>,
+        alphabet: seq<string>,
+        transitions: IDictionary<struct (string * string), seq<string>>,
+        initial: string,
+        accepting: seq<string>
+    ) =
+    let states = HashSet<string>(states, StringComparer.Ordinal)
+    let alphabet = HashSet<string>(alphabet, StringComparer.Ordinal)
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let transitions =
+        Dictionary<struct (string * string), HashSet<string>>(
+            transitions
+            |> Seq.map (fun (KeyValue(key, value)) -> KeyValuePair<_, _>(key, HashSet<string>(value, StringComparer.Ordinal))))
+
+    let mutable currentStates = HashSet<string>(StringComparer.Ordinal)
+
+    do
+        if not (states.Contains(initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        currentStates <-
+            let closure = HashSet<string>(StringComparer.Ordinal)
+            closure.Add(initial) |> ignore
+            closure
+
+    static member EPSILON = ""
+
+    member _.States = states :> IReadOnlyCollection<string>
+    member _.Alphabet = alphabet :> IReadOnlyCollection<string>
+    member _.Accepting = accepting :> IReadOnlyCollection<string>
+    member _.Initial = initial
+    member _.CurrentStates = currentStates :> IReadOnlySet<string>
+
+    member this.Reset() =
+        currentStates <- this.EpsilonClosure([ initial ])
+
+    member _.EpsilonClosure(seedStates: seq<string>) =
+        let closure = HashSet<string>(seedStates, StringComparer.Ordinal)
+        let stack = Stack<string>(closure)
+        while stack.Count > 0 do
+            let state = stack.Pop()
+            match transitions.TryGetValue(struct (state, NFA.EPSILON)) with
+            | true, targets ->
+                for target in targets do
+                    if closure.Add(target) then
+                        stack.Push(target)
+            | _ -> ()
+
+        closure
+
+    member this.Process(eventName: string) =
+        let next = HashSet<string>(StringComparer.Ordinal)
+        for state in currentStates do
+            match transitions.TryGetValue(struct (state, eventName)) with
+            | true, targets -> next.UnionWith(targets)
+            | _ -> ()
+
+        currentStates <- this.EpsilonClosure(next)
+        currentStates :> IReadOnlySet<string>
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        for eventName in events do
+            this.Process(eventName) |> ignore
+
+        currentStates.Overlaps(accepting)
+
+[<AbstractClass; Sealed>]
+type Minimize private () =
+    static member Run(dfa: DFA) =
+        let reachable = dfa.ReachableStates()
+        let accepting = HashSet<string>(reachable |> Seq.filter (fun state -> (dfa.Accepting :> seq<string>) |> Seq.contains state), StringComparer.Ordinal)
+        let nonAccepting = HashSet<string>(reachable |> Seq.filter (fun state -> not (accepting.Contains(state))), StringComparer.Ordinal)
+        let mutable partitions =
+            [
+                if accepting.Count > 0 then accepting
+                if nonAccepting.Count > 0 then nonAccepting
+            ]
+
+        let splitGroup (group: HashSet<string>) (allPartitions: HashSet<string> list) =
+            if group.Count <= 1 then
+                [ group ]
+            else
+                let stateToPartition =
+                    allPartitions
+                    |> List.mapi (fun index partition -> partition |> Seq.map (fun state -> state, index))
+                    |> Seq.concat
+                    |> dict
+
+                group
+                |> Seq.groupBy (fun state ->
+                    dfa.Alphabet
+                    |> Seq.cast<string>
+                    |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right))
+                    |> Seq.map (fun eventName ->
+                        match dfa.Transitions.TryGetValue(struct (state, eventName)) with
+                        | true, target -> string stateToPartition.[target]
+                        | _ -> "-1")
+                    |> String.concat "|")
+                |> Seq.map (fun (_, states) -> HashSet<string>(states, StringComparer.Ordinal))
+                |> Seq.toList
+
+        let mutable changed = true
+        while changed do
+            changed <- false
+            let nextPartitions = ResizeArray<HashSet<string>>()
+            for group in partitions do
+                let splits = splitGroup group partitions
+                nextPartitions.AddRange(splits)
+                if splits.Length > 1 then
+                    changed <- true
+
+            partitions <- nextPartitions |> Seq.toList
+
+        let partitionNames =
+            partitions
+            |> List.map (fun group ->
+                if group.Count = 1 then
+                    Seq.head group
+                else
+                    "{" + (group |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> String.concat ",") + "}")
+
+        let stateToPartition =
+            partitions
+            |> List.mapi (fun index partition -> partition |> Seq.map (fun state -> state, index))
+            |> Seq.concat
+            |> dict
+
+        let minimizedTransitions = Dictionary<struct (string * string), string>()
+        for index, group in partitions |> List.indexed do
+            let representative = Seq.head group
+            let fromName = partitionNames.[index]
+            for eventName in dfa.Alphabet |> Seq.cast<string> do
+                match dfa.Transitions.TryGetValue(struct (representative, eventName)) with
+                | true, target ->
+                    minimizedTransitions.[struct (fromName, eventName)] <- partitionNames.[stateToPartition.[target]]
+                | _ -> ()
+
+        let acceptingStates =
+            partitions
+            |> List.indexed
+            |> List.choose (fun (index, group) ->
+                if group |> Seq.exists (fun state -> (dfa.Accepting :> seq<string>) |> Seq.contains state) then
+                    Some partitionNames.[index]
+                else
+                    None)
+
+        DFA(partitionNames, dfa.Alphabet, minimizedTransitions, partitionNames.[stateToPartition.[dfa.Initial]], acceptingStates)
+
+type ModalStateMachine(modes: IDictionary<string, DFA>, modeTransitions: IDictionary<struct (string * string), string>, initialMode: string) =
+    let modes = Dictionary<string, DFA>(modes, StringComparer.Ordinal)
+    let modeTransitions = Dictionary<struct (string * string), string>(modeTransitions)
+    let modeTrace = ResizeArray<ModeTransitionRecord>()
+    let mutable currentMode = initialMode
+
+    do
+        if not (modes.ContainsKey(initialMode)) then
+            invalidArg "initialMode" (sprintf "Unknown mode '%s'" initialMode)
+
+    member _.InitialMode = initialMode
+    member _.CurrentMode = currentMode
+    member _.ActiveMachine = modes.[currentMode]
+    member _.ModeTrace = modeTrace |> Seq.toList
+
+    member this.Process(eventName: string) =
+        this.ActiveMachine.Process(eventName)
+
+    member this.TriggerMode(trigger: string) =
+        match modeTransitions.TryGetValue(struct (currentMode, trigger)) with
+        | true, target ->
+            let fromMode = currentMode
+            currentMode <- target
+            this.ActiveMachine.Reset()
+            modeTrace.Add({ FromMode = fromMode; Trigger = trigger; ToMode = target })
+            target
+        | _ ->
+            invalidOp (sprintf "No mode transition defined for (%s, %s)" currentMode trigger)
+
+    member _.Reset() =
+        currentMode <- initialMode
+        modeTrace.Clear()
+        for machine in modes.Values do
+            machine.Reset()
+
+type PushdownAutomaton
+    (
+        states: seq<string>,
+        inputAlphabet: seq<string>,
+        stackAlphabet: seq<string>,
+        transitions: seq<PDATransition>,
+        initial: string,
+        initialStackSymbol: string,
+        accepting: seq<string>
+    ) =
+    let index =
+        Dictionary<struct (string * string option * string), PDATransition>(
+            transitions
+            |> Seq.map (fun transition -> KeyValuePair<_, _>(struct (transition.Source, transition.Event, transition.StackRead), transition)))
+
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let stack = ResizeArray<string>()
+    let trace = ResizeArray<PDATraceEntry>()
+    let mutable currentState = initial
+
+    do
+        if not (states |> Seq.exists ((=) initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        if not (accepting |> Seq.forall (fun state -> states |> Seq.exists ((=) state))) then
+            invalidArg "accepting" "Accepting states must be a subset of states"
+
+        ignore inputAlphabet
+        ignore stackAlphabet
+        stack.Add(initialStackSymbol)
+
+    let applyTransition (transition: PDATransition) =
+        if stack.Count = 0 || stack.[stack.Count - 1] <> transition.StackRead then
+            invalidOp "PDA stack top does not match transition"
+
+        stack.RemoveAt(stack.Count - 1)
+        for symbol in transition.StackPush do
+            stack.Add(symbol)
+
+        currentState <- transition.Target
+        trace.Add(
+            {
+                Source = transition.Source
+                Event = transition.Event
+                StackRead = transition.StackRead
+                Target = transition.Target
+                StackPush = transition.StackPush
+                StackAfter = stack |> Seq.toList
+            })
+
+    let step eventName =
+        let top = if stack.Count > 0 then stack.[stack.Count - 1] else String.Empty
+        match index.TryGetValue(struct (currentState, eventName, top)) with
+        | true, transition -> applyTransition transition
+        | _ -> invalidOp (sprintf "No PDA transition defined for (%s, %A, %s)" currentState eventName top)
+
+    let tryStepEpsilon () =
+        let top = if stack.Count > 0 then stack.[stack.Count - 1] else String.Empty
+        match index.TryGetValue(struct (currentState, None, top)) with
+        | true, transition ->
+            applyTransition transition
+            true
+        | _ -> false
+
+    member _.Initial = initial
+    member _.InitialStackSymbol = initialStackSymbol
+    member _.CurrentState = currentState
+    member _.Stack = stack |> Seq.toList
+    member _.Trace = trace |> Seq.toList
+
+    member _.Reset() =
+        currentState <- initial
+        stack.Clear()
+        stack.Add(initialStackSymbol)
+        trace.Clear()
+
+    member _.Process(eventName: string) =
+        step (Some eventName)
+        while tryStepEpsilon () do
+            ()
+
+    member this.Process(events: seq<string>) =
+        for eventName in events do
+            this.Process(eventName)
+
+        while tryStepEpsilon () do
+            ()
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        this.Process(events)
+        accepting.Contains(currentState)
 
 module StateMachine =
     let createDfa
@@ -10,4 +443,4 @@ module StateMachine =
         (transitions: IDictionary<struct (string * string), string>)
         (initial: string)
         (accepting: seq<string>) =
-        DFA(states, alphabet, Dictionary<struct (string * string), string>(transitions), initial, accepting)
+        DFA(states, alphabet, transitions, initial, accepting)

--- a/code/packages/fsharp/state-machine/required_capabilities.json
+++ b/code/packages/fsharp/state-machine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/state-machine",
+  "capabilities": [],
+  "justification": "Thin F# wrapper over the C# state-machine implementation."
+}

--- a/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj
+++ b/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.StateMachine.fsproj" />
+    <Compile Include="StateMachineTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
+++ b/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
@@ -1,0 +1,17 @@
+namespace CodingAdventures.StateMachine.FSharp.Tests
+
+open System.Collections.Generic
+open CodingAdventures.StateMachine.FSharp
+open Xunit
+
+module StateMachineTests =
+    [<Fact>]
+    let ``dfa wrapper works`` () =
+        let transitions = Dictionary<struct (string * string), string>()
+        transitions.Add(struct ("locked", "coin"), "unlocked")
+        transitions.Add(struct ("locked", "push"), "locked")
+        transitions.Add(struct ("unlocked", "coin"), "unlocked")
+        transitions.Add(struct ("unlocked", "push"), "locked")
+
+        let dfa = StateMachine.createDfa [ "locked"; "unlocked" ] [ "coin"; "push" ] transitions "locked" [ "unlocked" ]
+        Assert.Equal("unlocked", dfa.Process("coin"))

--- a/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
+++ b/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
@@ -6,7 +6,7 @@ open Xunit
 
 module StateMachineTests =
     [<Fact>]
-    let ``dfa wrapper works`` () =
+    let ``dfa processes events`` () =
         let transitions = Dictionary<struct (string * string), string>()
         transitions.Add(struct ("locked", "coin"), "unlocked")
         transitions.Add(struct ("locked", "push"), "locked")
@@ -15,3 +15,59 @@ module StateMachineTests =
 
         let dfa = StateMachine.createDfa [ "locked"; "unlocked" ] [ "coin"; "push" ] transitions "locked" [ "unlocked" ]
         Assert.Equal("unlocked", dfa.Process("coin"))
+
+    [<Fact>]
+    let ``minimize collapses equivalent states`` () =
+        let transitions = Dictionary<struct (string * string), string>()
+        transitions.Add(struct ("A", "0"), "B")
+        transitions.Add(struct ("A", "1"), "C")
+        transitions.Add(struct ("B", "0"), "B")
+        transitions.Add(struct ("B", "1"), "C")
+        transitions.Add(struct ("C", "0"), "B")
+        transitions.Add(struct ("C", "1"), "C")
+
+        let dfa = DFA([ "A"; "B"; "C" ], [ "0"; "1" ], transitions, "A", [ "C" ])
+        let minimized = Minimize.Run(dfa)
+        Assert.True((minimized.States :> seq<string>) |> Seq.length <= 3)
+        Assert.True(minimized.Accepts([ "1" ]))
+
+    [<Fact>]
+    let ``pushdown automaton traces stack updates`` () =
+        let transitions =
+            [
+                {
+                    Source = "start"
+                    Event = Some "("
+                    StackRead = "$"
+                    Target = "start"
+                    StackPush = [ "$"; "(" ]
+                }
+                {
+                    Source = "start"
+                    Event = Some "("
+                    StackRead = "("
+                    Target = "start"
+                    StackPush = [ "("; "(" ]
+                }
+                {
+                    Source = "start"
+                    Event = Some ")"
+                    StackRead = "("
+                    Target = "start"
+                    StackPush = []
+                }
+            ]
+
+        let pda =
+            PushdownAutomaton(
+                [ "start" ],
+                [ "("; ")" ],
+                [ "$"; "(" ],
+                transitions,
+                "start",
+                "$",
+                [ "start" ])
+
+        pda.Process([ "("; "("; ")" ])
+        Assert.Equal("start", pda.CurrentState)
+        Assert.True(pda.Stack |> Seq.contains "(")


### PR DESCRIPTION
## Summary
- Add `csharp/lexer`, `csharp/parser`, `csharp/grammar-tools`, `csharp/directed-graph`, and `csharp/state-machine` packages
- Add `fsharp/lexer`, `fsharp/parser`, `fsharp/grammar-tools`, `fsharp/directed-graph`, and `fsharp/state-machine` packages, rewritten in idiomatic pure F# (discriminated unions, computation expressions)
- Each package includes BUILD, BUILD_windows, README.md, CHANGELOG.md, `required_capabilities.json`, and tests
- Fix C# and F# package build scripts to correctly invoke `dotnet test` (81 files, ~4000 lines)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/code)