### PR TITLE
feat(csharp): add native aztec-code package

### DIFF
--- a/code/packages/csharp/aztec-code/AztecCode.cs
+++ b/code/packages/csharp/aztec-code/AztecCode.cs
@@ -1,0 +1,645 @@
+using System.Text;
+using CodingAdventures.Barcode2D;
+
+namespace CodingAdventures.AztecCode;
+
+/// <summary>Options controlling Aztec Code encoding.</summary>
+public sealed record AztecOptions(int MinEccPercent = 23)
+{
+    /// <summary>Default options: 23 percent minimum error correction.</summary>
+    public static readonly AztecOptions Default = new();
+}
+
+/// <summary>Base class for Aztec Code encoding errors.</summary>
+public class AztecCodeException : Exception
+{
+    /// <summary>Create an Aztec Code exception with a message.</summary>
+    public AztecCodeException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>The input is too long for the largest supported Aztec symbol.</summary>
+public sealed class InputTooLongException : AztecCodeException
+{
+    /// <summary>Create an input-too-long error.</summary>
+    public InputTooLongException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>Encoder options are outside the supported range.</summary>
+public sealed class InvalidAztecOptionsException : AztecCodeException
+{
+    /// <summary>Create an invalid-options error.</summary>
+    public InvalidAztecOptionsException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// ISO/IEC 24778 Aztec Code encoder.
+///
+/// <para>
+/// Version 0.1.0 implements the same byte-mode pipeline as the F# package:
+/// binary-shift input bytes, automatic compact/full symbol selection,
+/// GF(256)/0x12D Reed-Solomon ECC, bit stuffing, GF(16) mode-message ECC,
+/// and clockwise layer placement into a <see cref="ModuleGrid"/>.
+/// </para>
+/// </summary>
+public static class AztecCodeEncoder
+{
+    /// <summary>Package version.</summary>
+    public const string Version = "0.1.0";
+
+    private const int MaxInputBytes = 4096;
+    private const int Gf256Poly = 0x12D;
+
+    private static readonly int[] Log16 =
+    [
+        -1, 0, 1, 4, 2, 8, 5, 10, 3, 14, 9, 7, 6, 13, 11, 12,
+    ];
+
+    private static readonly int[] Alog16 =
+    [
+        1, 2, 4, 8, 3, 6, 12, 11, 5, 10, 7, 14, 15, 13, 9, 1,
+    ];
+
+    private static readonly int[] Exp12D = new int[512];
+    private static readonly int[] Log12D = new int[256];
+
+    private static readonly (int TotalBits, int MaxBytes8)[] CompactCapacity =
+    [
+        (0, 0),
+        (72, 9),
+        (200, 25),
+        (392, 49),
+        (648, 81),
+    ];
+
+    private static readonly (int TotalBits, int MaxBytes8)[] FullCapacity =
+    [
+        (0, 0),
+        (88, 11),
+        (216, 27),
+        (360, 45),
+        (520, 65),
+        (696, 87),
+        (888, 111),
+        (1096, 137),
+        (1320, 165),
+        (1560, 195),
+        (1816, 227),
+        (2088, 261),
+        (2376, 297),
+        (2680, 335),
+        (3000, 375),
+        (3336, 417),
+        (3688, 461),
+        (4056, 507),
+        (4440, 555),
+        (4840, 605),
+        (5256, 657),
+        (5688, 711),
+        (6136, 767),
+        (6600, 825),
+        (7080, 885),
+        (7576, 947),
+        (8088, 1011),
+        (8616, 1077),
+        (9160, 1145),
+        (9720, 1215),
+        (10296, 1287),
+        (10888, 1361),
+        (11496, 1437),
+    ];
+
+    static AztecCodeEncoder()
+    {
+        var value = 1;
+        for (var i = 0; i < 255; i++)
+        {
+            Exp12D[i] = value;
+            Exp12D[i + 255] = value;
+            Log12D[value] = i;
+            value <<= 1;
+            if ((value & 0x100) != 0)
+            {
+                value ^= Gf256Poly;
+            }
+
+            value &= 0xFF;
+        }
+
+        Exp12D[255] = 1;
+    }
+
+    /// <summary>Encode a UTF-8 string with default options.</summary>
+    public static ModuleGrid Encode(string input) => Encode(input, AztecOptions.Default);
+
+    /// <summary>Encode a UTF-8 string with caller-supplied options.</summary>
+    public static ModuleGrid Encode(string input, AztecOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return EncodeBytes(Encoding.UTF8.GetBytes(input), options);
+    }
+
+    /// <summary>Encode raw bytes with default options.</summary>
+    public static ModuleGrid EncodeBytes(byte[] input) => EncodeBytes(input, AztecOptions.Default);
+
+    /// <summary>Encode raw bytes with caller-supplied options.</summary>
+    public static ModuleGrid EncodeBytes(byte[] input, AztecOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        options ??= AztecOptions.Default;
+
+        if (options.MinEccPercent < 10 || options.MinEccPercent > 90)
+        {
+            throw new InvalidAztecOptionsException(
+                $"MinEccPercent must be between 10 and 90, got {options.MinEccPercent}.");
+        }
+
+        if (input.Length > MaxInputBytes)
+        {
+            throw new InputTooLongException(
+                $"Input is {input.Length} bytes; maximum supported is {MaxInputBytes}.");
+        }
+
+        var dataBits = EncodeBytesAsBits(input);
+        var spec = SelectSymbol(dataBits.Length, options.MinEccPercent);
+
+        var paddedBits = PadToBytes(dataBits, spec.DataCwCount);
+        var dataBytes = new int[spec.DataCwCount];
+        for (var i = 0; i < spec.DataCwCount; i++)
+        {
+            var codeword = 0;
+            for (var b = 0; b < 8; b++)
+            {
+                codeword = (codeword << 1) | paddedBits[i * 8 + b];
+            }
+
+            dataBytes[i] = codeword == 0 && i == spec.DataCwCount - 1
+                ? 0xFF
+                : codeword;
+        }
+
+        var eccBytes = Gf256RsEncode(dataBytes, spec.EccCwCount);
+        var allBytes = dataBytes.Concat(eccBytes).ToArray();
+        var rawBits = new int[allBytes.Length * 8];
+        for (var i = 0; i < allBytes.Length; i++)
+        {
+            var codeword = allBytes[i];
+            for (var b = 0; b < 8; b++)
+            {
+                rawBits[i * 8 + b] = (codeword >> (7 - b)) & 1;
+            }
+        }
+
+        var stuffedBits = StuffBits(rawBits);
+        var modeMessage = EncodeModeMessage(spec.Compact, spec.Layers, spec.DataCwCount);
+        return BuildGrid(spec, stuffedBits, modeMessage);
+    }
+
+    private sealed record SymbolSpec(
+        bool Compact,
+        int Layers,
+        int DataCwCount,
+        int EccCwCount,
+        int TotalBits);
+
+    private static int Gf16Mul(int a, int b) =>
+        a == 0 || b == 0 ? 0 : Alog16[(Log16[a] + Log16[b]) % 15];
+
+    private static int[] BuildGf16Generator(int n)
+    {
+        var generator = new[] { 1 };
+        for (var i = 1; i <= n; i++)
+        {
+            var alpha = Alog16[i % 15];
+            var next = new int[generator.Length + 1];
+            for (var j = 0; j < generator.Length; j++)
+            {
+                next[j + 1] ^= generator[j];
+                next[j] ^= Gf16Mul(alpha, generator[j]);
+            }
+
+            generator = next;
+        }
+
+        return generator;
+    }
+
+    private static int[] Gf16RsEncode(int[] data, int checkCount)
+    {
+        var generator = BuildGf16Generator(checkCount);
+        var rem = new int[checkCount];
+        foreach (var nibble in data)
+        {
+            var feedback = nibble ^ rem[0];
+            for (var i = 0; i < checkCount - 1; i++)
+            {
+                rem[i] = rem[i + 1] ^ Gf16Mul(generator[i + 1], feedback);
+            }
+
+            rem[checkCount - 1] = Gf16Mul(generator[checkCount], feedback);
+        }
+
+        return rem;
+    }
+
+    private static int Gf256Mul(int a, int b) =>
+        a == 0 || b == 0 ? 0 : Exp12D[Log12D[a] + Log12D[b]];
+
+    private static int[] BuildGf256Generator(int checkCount)
+    {
+        var generator = new[] { 1 };
+        for (var i = 1; i <= checkCount; i++)
+        {
+            var alpha = Exp12D[i];
+            var next = new int[generator.Length + 1];
+            for (var j = 0; j < generator.Length; j++)
+            {
+                next[j] ^= generator[j];
+                next[j + 1] ^= Gf256Mul(generator[j], alpha);
+            }
+
+            generator = next;
+        }
+
+        return generator;
+    }
+
+    private static int[] Gf256RsEncode(int[] data, int checkCount)
+    {
+        var generator = BuildGf256Generator(checkCount);
+        var rem = new int[checkCount];
+        foreach (var codeword in data)
+        {
+            var feedback = codeword ^ rem[0];
+            for (var i = 0; i < checkCount - 1; i++)
+            {
+                rem[i] = rem[i + 1] ^ Gf256Mul(generator[i + 1], feedback);
+            }
+
+            rem[checkCount - 1] = Gf256Mul(generator[checkCount], feedback);
+        }
+
+        return rem;
+    }
+
+    private static int[] EncodeBytesAsBits(byte[] input)
+    {
+        var bits = new List<int>();
+        WriteBits(bits, 31, 5);
+
+        if (input.Length <= 31)
+        {
+            WriteBits(bits, input.Length, 5);
+        }
+        else
+        {
+            WriteBits(bits, 0, 5);
+            WriteBits(bits, input.Length, 11);
+        }
+
+        foreach (var value in input)
+        {
+            WriteBits(bits, value, 8);
+        }
+
+        return bits.ToArray();
+    }
+
+    private static void WriteBits(List<int> bits, int value, int count)
+    {
+        for (var i = count - 1; i >= 0; i--)
+        {
+            bits.Add((value >> i) & 1);
+        }
+    }
+
+    private static SymbolSpec SelectSymbol(int dataBitCount, int minEccPercent)
+    {
+        var stuffedBitCount = (dataBitCount * 12 + 9) / 10;
+        var compact = TryFitFromTable(CompactCapacity, isCompact: true, maxLayers: 4, stuffedBitCount, minEccPercent);
+        if (compact is not null)
+        {
+            return compact;
+        }
+
+        var full = TryFitFromTable(FullCapacity, isCompact: false, maxLayers: 32, stuffedBitCount, minEccPercent);
+        if (full is not null)
+        {
+            return full;
+        }
+
+        throw new InputTooLongException(
+            $"Input is too long to fit in any Aztec Code symbol ({dataBitCount} bits needed).");
+    }
+
+    private static SymbolSpec? TryFitFromTable(
+        (int TotalBits, int MaxBytes8)[] table,
+        bool isCompact,
+        int maxLayers,
+        int stuffedBitCount,
+        int minEccPercent)
+    {
+        for (var layers = 1; layers <= maxLayers; layers++)
+        {
+            var (totalBits, totalBytes) = table[layers];
+            var eccCwCount = (minEccPercent * totalBytes + 99) / 100;
+            var dataCwCount = totalBytes - eccCwCount;
+            var neededBytes = (stuffedBitCount + 7) / 8;
+            if (dataCwCount > 0 && neededBytes <= dataCwCount)
+            {
+                return new SymbolSpec(isCompact, layers, dataCwCount, eccCwCount, totalBits);
+            }
+        }
+
+        return null;
+    }
+
+    private static int[] PadToBytes(int[] bits, int targetBytes)
+    {
+        var target = targetBytes * 8;
+        if (bits.Length >= target)
+        {
+            return bits.Take(target).ToArray();
+        }
+
+        var output = new int[target];
+        Array.Copy(bits, output, bits.Length);
+        return output;
+    }
+
+    private static int[] StuffBits(int[] bits)
+    {
+        var stuffed = new List<int>();
+        var runValue = -1;
+        var runLength = 0;
+
+        foreach (var bit in bits)
+        {
+            if (bit == runValue)
+            {
+                runLength++;
+            }
+            else
+            {
+                runValue = bit;
+                runLength = 1;
+            }
+
+            stuffed.Add(bit);
+
+            if (runLength == 4)
+            {
+                var stuffBit = 1 - bit;
+                stuffed.Add(stuffBit);
+                runValue = stuffBit;
+                runLength = 1;
+            }
+        }
+
+        return stuffed.ToArray();
+    }
+
+    private static int[] EncodeModeMessage(bool compact, int layers, int dataCwCount)
+    {
+        int[] dataNibbles;
+        int numEcc;
+
+        if (compact)
+        {
+            var mode = ((layers - 1) << 6) | (dataCwCount - 1);
+            dataNibbles = [mode & 0xF, (mode >> 4) & 0xF];
+            numEcc = 5;
+        }
+        else
+        {
+            var mode = ((layers - 1) << 11) | (dataCwCount - 1);
+            dataNibbles = [mode & 0xF, (mode >> 4) & 0xF, (mode >> 8) & 0xF, (mode >> 12) & 0xF];
+            numEcc = 6;
+        }
+
+        var allNibbles = dataNibbles.Concat(Gf16RsEncode(dataNibbles, numEcc)).ToArray();
+        var bits = new List<int>(allNibbles.Length * 4);
+        foreach (var nibble in allNibbles)
+        {
+            WriteBits(bits, nibble, 4);
+        }
+
+        return bits.ToArray();
+    }
+
+    private static ModuleGrid BuildGrid(SymbolSpec spec, int[] stuffedBits, int[] modeMessage)
+    {
+        var size = SymbolSize(spec.Compact, spec.Layers);
+        var center = size / 2;
+        var modules = new bool[size, size];
+        var reserved = new bool[size, size];
+
+        if (!spec.Compact)
+        {
+            DrawReferenceGrid(modules, reserved, center, center, size);
+        }
+
+        DrawBullseye(modules, reserved, center, center, spec.Compact);
+        var modeRingRemaining = DrawOrientationAndModeMessage(modules, reserved, center, center, spec.Compact, modeMessage);
+        PlaceDataBits(modules, reserved, stuffedBits, center, center, spec.Compact, spec.Layers, modeRingRemaining);
+        return ToModuleGrid(modules);
+    }
+
+    private static int SymbolSize(bool compact, int layers) =>
+        compact ? 11 + 4 * layers : 15 + 4 * layers;
+
+    private static int BullseyeRadius(bool compact) => compact ? 5 : 7;
+
+    private static void DrawBullseye(bool[,] modules, bool[,] reserved, int cx, int cy, bool compact)
+    {
+        var radius = BullseyeRadius(compact);
+        for (var row = cy - radius; row <= cy + radius; row++)
+        {
+            for (var col = cx - radius; col <= cx + radius; col++)
+            {
+                var distance = Math.Max(Math.Abs(col - cx), Math.Abs(row - cy));
+                var dark = distance <= 1 || distance % 2 == 1;
+                modules[row, col] = dark;
+                reserved[row, col] = true;
+            }
+        }
+    }
+
+    private static void DrawReferenceGrid(bool[,] modules, bool[,] reserved, int cx, int cy, int size)
+    {
+        for (var row = 0; row < size; row++)
+        {
+            for (var col = 0; col < size; col++)
+            {
+                var onHorizontal = (cy - row) % 16 == 0;
+                var onVertical = (cx - col) % 16 == 0;
+                if (!onHorizontal && !onVertical)
+                {
+                    continue;
+                }
+
+                var dark = onHorizontal && onVertical
+                    ? true
+                    : onHorizontal
+                        ? (cx - col) % 2 == 0
+                        : (cy - row) % 2 == 0;
+                modules[row, col] = dark;
+                reserved[row, col] = true;
+            }
+        }
+    }
+
+    private static List<(int Col, int Row)> DrawOrientationAndModeMessage(
+        bool[,] modules,
+        bool[,] reserved,
+        int cx,
+        int cy,
+        bool compact,
+        int[] modeMessageBits)
+    {
+        var ring = BullseyeRadius(compact) + 1;
+        var nonCorner = new List<(int Col, int Row)>();
+
+        for (var col = cx - ring + 1; col <= cx + ring - 1; col++)
+        {
+            nonCorner.Add((col, cy - ring));
+        }
+
+        for (var row = cy - ring + 1; row <= cy + ring - 1; row++)
+        {
+            nonCorner.Add((cx + ring, row));
+        }
+
+        for (var col = cx + ring - 1; col >= cx - ring + 1; col--)
+        {
+            nonCorner.Add((col, cy + ring));
+        }
+
+        for (var row = cy + ring - 1; row >= cy - ring + 1; row--)
+        {
+            nonCorner.Add((cx - ring, row));
+        }
+
+        (int Col, int Row)[] corners =
+        [
+            (cx - ring, cy - ring),
+            (cx + ring, cy - ring),
+            (cx + ring, cy + ring),
+            (cx - ring, cy + ring),
+        ];
+
+        foreach (var (col, row) in corners)
+        {
+            modules[row, col] = true;
+            reserved[row, col] = true;
+        }
+
+        var count = Math.Min(modeMessageBits.Length, nonCorner.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var (col, row) = nonCorner[i];
+            modules[row, col] = modeMessageBits[i] == 1;
+            reserved[row, col] = true;
+        }
+
+        return nonCorner.Skip(modeMessageBits.Length).ToList();
+    }
+
+    private static void PlaceDataBits(
+        bool[,] modules,
+        bool[,] reserved,
+        int[] bits,
+        int cx,
+        int cy,
+        bool compact,
+        int layers,
+        List<(int Col, int Row)> modeRingRemainingPositions)
+    {
+        var size = modules.GetLength(0);
+        var bitIndex = 0;
+
+        void PlaceBit(int col, int row)
+        {
+            if (row < 0 || row >= size || col < 0 || col >= size || reserved[row, col])
+            {
+                return;
+            }
+
+            if (bitIndex < bits.Length)
+            {
+                modules[row, col] = bits[bitIndex] == 1;
+            }
+
+            bitIndex++;
+        }
+
+        foreach (var (col, row) in modeRingRemainingPositions)
+        {
+            if (bitIndex < bits.Length)
+            {
+                modules[row, col] = bits[bitIndex] == 1;
+            }
+
+            bitIndex++;
+        }
+
+        var startRadius = BullseyeRadius(compact) + 2;
+        for (var layer = 0; layer < layers; layer++)
+        {
+            var inner = startRadius + 2 * layer;
+            var outer = inner + 1;
+
+            for (var col = cx - inner + 1; col <= cx + inner; col++)
+            {
+                PlaceBit(col, cy - outer);
+                PlaceBit(col, cy - inner);
+            }
+
+            for (var row = cy - inner + 1; row <= cy + inner; row++)
+            {
+                PlaceBit(cx + outer, row);
+                PlaceBit(cx + inner, row);
+            }
+
+            for (var col = cx + inner; col >= cx - inner + 1; col--)
+            {
+                PlaceBit(col, cy + outer);
+                PlaceBit(col, cy + inner);
+            }
+
+            for (var row = cy + inner; row >= cy - inner + 1; row--)
+            {
+                PlaceBit(cx - outer, row);
+                PlaceBit(cx - inner, row);
+            }
+        }
+    }
+
+    private static ModuleGrid ToModuleGrid(bool[,] modules)
+    {
+        var rows = modules.GetLength(0);
+        var cols = modules.GetLength(1);
+        var grid = ModuleGrid.Create(rows, cols, ModuleShape.Square);
+
+        for (var row = 0; row < rows; row++)
+        {
+            for (var col = 0; col < cols; col++)
+            {
+                if (modules[row, col])
+                {
+                    grid = grid.SetModule(row, col, true);
+                }
+            }
+        }
+
+        return grid;
+    }
+}

--- a/code/packages/csharp/aztec-code/BUILD
+++ b/code/packages/csharp/aztec-code/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AztecCode.Tests/CodingAdventures.AztecCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.AztecCode]*"

--- a/code/packages/csharp/aztec-code/BUILD_windows
+++ b/code/packages/csharp/aztec-code/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AztecCode.Tests/CodingAdventures.AztecCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.AztecCode]*"

--- a/code/packages/csharp/aztec-code/CHANGELOG.md
+++ b/code/packages/csharp/aztec-code/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog - CodingAdventures.AztecCode.CSharp
+
+## [0.1.0] - 2026-04-27
+
+### Added
+
+- Initial native C# Aztec Code encoder.
+- Byte-mode compact/full symbol selection with tunable minimum ECC.
+- GF(256)/0x12D Reed-Solomon data ECC and GF(16) mode-message ECC.
+- Bullseye, orientation marks, full-symbol reference grid, bit stuffing, and
+  clockwise data placement.
+- Unit tests covering symbol sizing, geometry, determinism, byte payloads,
+  UTF-8 input, and option validation.

--- a/code/packages/csharp/aztec-code/CodingAdventures.AztecCode.csproj
+++ b/code/packages/csharp/aztec-code/CodingAdventures.AztecCode.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AztecCode.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ISO/IEC 24778 Aztec Code encoder for C# that emits CodingAdventures.Barcode2D ModuleGrid values</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../barcode-2d/CodingAdventures.Barcode2D.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/aztec-code/README.md
+++ b/code/packages/csharp/aztec-code/README.md
@@ -1,0 +1,21 @@
+# CodingAdventures.AztecCode.CSharp
+
+Native C# Aztec Code encoder for .NET. It encodes UTF-8 strings or raw byte
+payloads into a `ModuleGrid` from `CodingAdventures.Barcode2D`.
+
+```csharp
+using CodingAdventures.AztecCode;
+
+var grid = AztecCodeEncoder.Encode("HELLO");
+var highEcc = AztecCodeEncoder.Encode("MY DATA", new AztecOptions(50));
+var binary = AztecCodeEncoder.EncodeBytes([0x01, 0x02, 0xff]);
+```
+
+The encoder implements the same v0.1.0 byte-mode pipeline as the F# package:
+binary-shift byte encoding, automatic compact/full symbol selection, GF(256)
+Reed-Solomon over primitive polynomial `0x12D`, bit stuffing, GF(16)
+mode-message ECC, bullseye/orientation/reference patterns, and clockwise data
+placement.
+
+Current limitations match the F# package: byte mode only, 8-bit data codewords
+only, default 23 percent ECC, and no force-compact option.

--- a/code/packages/csharp/aztec-code/required_capabilities.json
+++ b/code/packages/csharp/aztec-code/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/aztec-code",
+  "capabilities": [],
+  "justification": "Pure in-memory Aztec Code encoder. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/aztec-code/tests/CodingAdventures.AztecCode.Tests/AztecCodeTests.cs
+++ b/code/packages/csharp/aztec-code/tests/CodingAdventures.AztecCode.Tests/AztecCodeTests.cs
@@ -1,0 +1,308 @@
+using CodingAdventures.Barcode2D;
+
+namespace CodingAdventures.AztecCode.Tests;
+
+public sealed class AztecCodeTests
+{
+    [Fact]
+    public void VersionIsCurrent()
+    {
+        Assert.Equal("0.1.0", AztecCodeEncoder.Version);
+    }
+
+    [Fact]
+    public void DefaultOptionsUseTwentyThreePercentEcc()
+    {
+        Assert.Equal(23, AztecOptions.Default.MinEccPercent);
+    }
+
+    [Fact]
+    public void EmptyStringProducesSmallCompactSymbol()
+    {
+        var grid = AztecCodeEncoder.Encode(string.Empty);
+
+        Assert.Equal(15, grid.Rows);
+        Assert.Equal(15, grid.Cols);
+        Assert.Equal(ModuleShape.Square, grid.ModuleShape);
+    }
+
+    [Fact]
+    public void SmallInputsFitCompactSymbols()
+    {
+        Assert.Equal(15, AztecCodeEncoder.Encode("A").Rows);
+        Assert.True(AztecCodeEncoder.Encode("HELLO").Rows <= 19);
+        Assert.True(AztecCodeEncoder.Encode(new string('A', 20)).Rows <= 27);
+    }
+
+    [Fact]
+    public void LargerInputsUseFullSymbols()
+    {
+        var grid = AztecCodeEncoder.Encode(new string('A', 100));
+
+        Assert.True(grid.Rows >= 19);
+        Assert.Equal(grid.Rows, grid.Cols);
+    }
+
+    [Fact]
+    public void HandlesTwoHundredBytePayload()
+    {
+        var grid = AztecCodeEncoder.Encode(new string('B', 200));
+
+        Assert.True(grid.Rows > 0);
+        Assert.Equal(grid.Rows, grid.Cols);
+    }
+
+    [Fact]
+    public void CompactSymbolSizeMatchesLayerFormula()
+    {
+        var valid = new[] { 15, 19, 23, 27 };
+
+        Assert.Contains(AztecCodeEncoder.Encode("A").Rows, valid);
+    }
+
+    [Fact]
+    public void GridIsAlwaysSquare()
+    {
+        foreach (var input in new[] { "A", "HELLO", "1234567890", new string('X', 50) })
+        {
+            var grid = AztecCodeEncoder.Encode(input);
+
+            Assert.Equal(grid.Rows, grid.Cols);
+        }
+    }
+
+    [Fact]
+    public void CompactBullseyeCenterAndRingsAreCorrect()
+    {
+        var grid = AztecCodeEncoder.Encode("A");
+        var center = grid.Rows / 2;
+
+        Assert.True(ModuleAt(grid, center, center));
+        for (var distance = 0; distance <= 5; distance++)
+        {
+            var expected = distance <= 1 || distance % 2 == 1;
+            Assert.Equal(expected, ModuleAt(grid, center - distance, center));
+        }
+    }
+
+    [Fact]
+    public void FullBullseyeCenterAndRingsAreCorrect()
+    {
+        var grid = AztecCodeEncoder.Encode(new string('A', 100));
+        var center = grid.Rows / 2;
+
+        Assert.True(ModuleAt(grid, center, center));
+        for (var distance = 0; distance <= 7; distance++)
+        {
+            var expected = distance <= 1 || distance % 2 == 1;
+            Assert.Equal(expected, ModuleAt(grid, center - distance, center + distance));
+        }
+    }
+
+    [Fact]
+    public void OrientationCornersAreDarkForCompactAndFullSymbols()
+    {
+        AssertOrientationCorners(AztecCodeEncoder.Encode("HELLO"));
+        AssertOrientationCorners(AztecCodeEncoder.Encode(new string('A', 100)));
+    }
+
+    [Fact]
+    public void FullSymbolHasReferenceGridAtCenter()
+    {
+        var grid = AztecCodeEncoder.Encode(new string('A', 100));
+        var center = grid.Rows / 2;
+
+        Assert.True(ModuleAt(grid, center, center));
+    }
+
+    [Fact]
+    public void EncodingIsDeterministic()
+    {
+        var first = AztecCodeEncoder.Encode("HELLO WORLD");
+        var second = AztecCodeEncoder.Encode("HELLO WORLD");
+
+        AssertEqualModules(first, second);
+    }
+
+    [Fact]
+    public void EncodeBytesMatchesStringEncodingForAscii()
+    {
+        var fromString = AztecCodeEncoder.Encode("HELLO");
+        var fromBytes = AztecCodeEncoder.EncodeBytes("HELLO"u8.ToArray());
+
+        AssertEqualModules(fromString, fromBytes);
+    }
+
+    [Fact]
+    public void EncodeBytesSupportsBinaryPayloads()
+    {
+        var grid = AztecCodeEncoder.EncodeBytes([0x00, 0x01, 0xFF, 0x7F, 0x80]);
+
+        Assert.True(grid.Rows >= 15);
+    }
+
+    [Fact]
+    public void BitStuffingHeavyInputsEncode()
+    {
+        foreach (var input in new[] { new string('A', 30), new string('a', 30), new string('0', 30), new string('F', 30) })
+        {
+            var grid = AztecCodeEncoder.Encode(input);
+
+            Assert.True(grid.Rows > 0);
+            Assert.Equal(grid.Rows, grid.Cols);
+        }
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(95)]
+    public void InvalidEccPercentThrows(int value)
+    {
+        var ex = Assert.Throws<InvalidAztecOptionsException>(
+            () => AztecCodeEncoder.Encode("HELLO", new AztecOptions(value)));
+
+        Assert.Contains(value.ToString(), ex.Message);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(90)]
+    public void EccPercentBoundaryValuesAreAllowed(int value)
+    {
+        var grid = AztecCodeEncoder.Encode("HELLO", new AztecOptions(value));
+
+        Assert.True(grid.Rows > 0);
+    }
+
+    [Fact]
+    public void HigherEccDoesNotShrinkSymbol()
+    {
+        var defaultGrid = AztecCodeEncoder.Encode("HELLO WORLD");
+        var highEccGrid = AztecCodeEncoder.Encode("HELLO WORLD", new AztecOptions(50));
+
+        Assert.True(highEccGrid.Rows >= defaultGrid.Rows);
+    }
+
+    [Fact]
+    public void MassivePayloadThrowsInputTooLong()
+    {
+        var ex = Assert.Throws<InputTooLongException>(() => AztecCodeEncoder.Encode(new string('A', 100_000)));
+
+        Assert.Contains("maximum supported", ex.Message);
+    }
+
+    [Fact]
+    public void NullInputsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => AztecCodeEncoder.Encode(null!));
+        Assert.Throws<ArgumentNullException>(() => AztecCodeEncoder.EncodeBytes(null!));
+    }
+
+    [Fact]
+    public void ModuleGridDimensionsMatchRowsAndCols()
+    {
+        var grid = AztecCodeEncoder.Encode("HELLO");
+
+        Assert.Equal(grid.Rows, grid.Modules.Count);
+        foreach (var row in grid.Modules)
+        {
+            Assert.Equal(grid.Cols, row.Count);
+        }
+    }
+
+    [Fact]
+    public void ModuleGridContainsDarkAndLightModules()
+    {
+        var grid = AztecCodeEncoder.Encode("HELLO WORLD");
+        var darkCount = 0;
+        var lightCount = 0;
+
+        for (var row = 0; row < grid.Rows; row++)
+        {
+            for (var col = 0; col < grid.Cols; col++)
+            {
+                if (ModuleAt(grid, row, col))
+                {
+                    darkCount++;
+                }
+                else
+                {
+                    lightCount++;
+                }
+            }
+        }
+
+        Assert.True(darkCount > 0);
+        Assert.True(lightCount > 0);
+    }
+
+    [Fact]
+    public void Utf8MultiByteCharactersEncode()
+    {
+        var grid = AztecCodeEncoder.Encode("cafe resume");
+
+        Assert.True(grid.Rows > 0);
+    }
+
+    [Theory]
+    [InlineData(31)]
+    [InlineData(32)]
+    public void LengthEncodingBoundaryCasesEncode(int length)
+    {
+        var grid = AztecCodeEncoder.Encode(new string('X', length));
+
+        Assert.True(grid.Rows > 0);
+    }
+
+    [Fact]
+    public void OrientationCornersAreEquidistantFromCenter()
+    {
+        var grid = AztecCodeEncoder.Encode("ABC");
+        var center = grid.Rows / 2;
+        var radius = ExpectedBullseyeRadius(grid.Rows) + 1;
+        var corners = new[]
+        {
+            (Row: center - radius, Col: center - radius),
+            (Row: center - radius, Col: center + radius),
+            (Row: center + radius, Col: center + radius),
+            (Row: center + radius, Col: center - radius),
+        };
+
+        foreach (var (row, col) in corners)
+        {
+            Assert.Equal(radius, Chebyshev((row, col), (center, center)));
+        }
+    }
+
+    private static bool ModuleAt(ModuleGrid grid, int row, int col) => grid.Modules[row][col];
+
+    private static int ExpectedBullseyeRadius(int size) => size <= 27 ? 5 : 7;
+
+    private static int Chebyshev((int Row, int Col) a, (int Row, int Col) b) =>
+        Math.Max(Math.Abs(a.Row - b.Row), Math.Abs(a.Col - b.Col));
+
+    private static void AssertOrientationCorners(ModuleGrid grid)
+    {
+        var center = grid.Rows / 2;
+        var ring = ExpectedBullseyeRadius(grid.Rows) + 1;
+
+        Assert.True(ModuleAt(grid, center - ring, center - ring));
+        Assert.True(ModuleAt(grid, center - ring, center + ring));
+        Assert.True(ModuleAt(grid, center + ring, center + ring));
+        Assert.True(ModuleAt(grid, center + ring, center - ring));
+    }
+
+    private static void AssertEqualModules(ModuleGrid first, ModuleGrid second)
+    {
+        Assert.Equal(first.Rows, second.Rows);
+        Assert.Equal(first.Cols, second.Cols);
+
+        for (var row = 0; row < first.Rows; row++)
+        {
+            for (var col = 0; col < first.Cols; col++)
+            {
+                Assert.Equal(first.Modules[row][col], second.Modules[row][col]);
+            }
+        }
+    }
+}

--- a/code/packages/csharp/aztec-code/tests/CodingAdventures.AztecCode.Tests/CodingAdventures.AztecCode.Tests.csproj
+++ b/code/packages/csharp/aztec-code/tests/CodingAdventures.AztecCode.Tests/CodingAdventures.AztecCode.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AztecCode.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a native C# `aztec-code` package to match the existing F# package coverage
- implement byte-mode Aztec encoding directly in C#: symbol selection, GF(256)/0x12D data ECC, GF(16) mode-message ECC, bit stuffing, structural patterns, and clockwise data placement
- include docs, capability metadata, build scripts, and focused xUnit coverage

## Verification
- `dotnet test tests/CodingAdventures.AztecCode.Tests/CodingAdventures.AztecCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line /p:Include=[CodingAdventures.AztecCode]*`
- `git diff --check`
- wrapper/platform crypto scan over `code/packages/csharp/aztec-code`