### PR TITLE
docs(specs): add MACSYMA completion roadmap and CAS package specs

### DIFF
--- a/code/specs/cas-complex.md
+++ b/code/specs/cas-complex.md
@@ -1,0 +1,290 @@
+# cas-complex — Complex Number Arithmetic and Normalization
+
+> **Status**: New spec. Implements complex-number IR support: the
+> `ImaginaryUnit` constant, arithmetic normalization, and `Re`, `Im`,
+> `Conjugate`, `Abs`, `Arg`, `RectForm`, `PolarForm` heads.
+> Parent: `symbolic-computation.md`. Depends on `cas-simplify`.
+
+## Why this package exists
+
+Complex numbers appear naturally the moment you solve `x² + 1 = 0`.
+`cas-solve` already lists `{i, -i}` as outputs but defers the
+representation question here. The implementation strategy is:
+
+- Represent the imaginary unit as a pre-bound symbol `ImaginaryUnit`
+  that satisfies `ImaginaryUnit² = -1`.
+- Extend the existing arithmetic handlers (Add, Mul, Pow) with
+  simplification rules that automatically normalize expressions
+  containing `ImaginaryUnit` into rectangular form `a + b·i`.
+- Add utility heads (`Re`, `Im`, `Conjugate`, `Abs`, `Arg`,
+  `RectForm`, `PolarForm`) to decompose and transform complex expressions.
+
+No new IR node type is needed — complex numbers are represented entirely
+as IR trees using existing node types plus the `ImaginaryUnit` symbol.
+
+## Reuse story
+
+| MACSYMA              | Mathematica          | Maple              | IR head / constant       |
+|----------------------|----------------------|--------------------|--------------------------|
+| `%i`                 | `I`                  | `I`                | `IRSymbol("ImaginaryUnit")` |
+| `realpart(z)`        | `Re[z]`              | `Re(z)`            | `Re`                     |
+| `imagpart(z)`        | `Im[z]`              | `Im(z)`            | `Im`                     |
+| `conjugate(z)`       | `Conjugate[z]`       | `conjugate(z)`     | `Conjugate`              |
+| `cabs(z)`            | `Abs[z]`             | `abs(z)`           | `Abs` (extended)         |
+| `carg(z)`            | `Arg[z]`             | `argument(z)`      | `Arg`                    |
+| `rectform(z)`        | `ComplexExpand[z]`   | `convert(z, rect)` | `RectForm`               |
+| `polarform(z)`       | `ToPolarCoordinates` | `convert(z, polar)`| `PolarForm`              |
+
+## Scope
+
+In:
+
+- Pre-binding `ImaginaryUnit` in every backend that includes this package
+  so `%i`, `I`, or `i` (depending on the frontend's name table) resolves
+  immediately.
+- Simplification rules for `ImaginaryUnit` powers:
+  - `ImaginaryUnit^0 = 1`
+  - `ImaginaryUnit^1 = ImaginaryUnit`
+  - `ImaginaryUnit^2 = -1`
+  - `ImaginaryUnit^3 = -ImaginaryUnit`
+  - `ImaginaryUnit^4 = 1` (and modular reduction for higher powers)
+- Arithmetic normalization: automatically collect real and imaginary parts
+  when `ImaginaryUnit` is present in an `Add` or `Mul` expression.
+- `Re(z)`, `Im(z)` — extract real and imaginary parts when `z` is in
+  rectangular form `a + b·ImaginaryUnit`.
+- `Conjugate(z)` — negate the imaginary part.
+- `Abs(z)` extended to complex inputs — returns `Sqrt(Re(z)^2 + Im(z)^2)`.
+  (The existing `Abs` handler already covers reals; this extends it.)
+- `Arg(z)` — the principal argument `arctan(Im(z)/Re(z))`.
+- `RectForm(z)` — rewrite `z` as `a + b·ImaginaryUnit` with real `a`, `b`.
+- `PolarForm(z)` — rewrite `z` as `r·exp(ImaginaryUnit·θ)`.
+
+Out:
+
+- Arbitrary-precision complex arithmetic (that's the job of floats + IR).
+- Full complex analysis (branch cuts, Riemann surfaces) — research territory.
+- Gaussian integers (Z[i] factoring) — deferred to a future
+  `cas-number-theory` extension.
+
+## Public interface
+
+```python
+from cas_complex import (
+    IMAGINARY_UNIT,          # IRSymbol("ImaginaryUnit")
+    normalize_complex,       # IRNode → IRNode  (collect real+imag parts)
+    re_part,                 # IRNode → IRNode
+    im_part,                 # IRNode → IRNode
+    conjugate,               # IRNode → IRNode
+    build_complex_handler_table,  # () → dict[str, Handler]
+    COMPLEX_SIMPLIFY_RULES,  # list[Rule]  — ImaginaryUnit power rules
+)
+```
+
+`COMPLEX_SIMPLIFY_RULES` is a list of `cas-pattern-matching` rules
+installed on `SymbolicBackend` at startup. They fire inside the normal
+simplification loop so `i^2` folds to `-1` automatically without any
+explicit `TrigSimplify`/`ComplexSimplify` call.
+
+## The ImaginaryUnit representation
+
+`ImaginaryUnit = IRSymbol("ImaginaryUnit")`.
+
+Frontend name tables map surface syntax to this symbol:
+
+```python
+# macsyma_runtime/name_table.py
+{"%i": IRSymbol("ImaginaryUnit")}
+
+# future mathematica_runtime/name_table.py
+{"I": IRSymbol("ImaginaryUnit")}
+```
+
+The symbol is pre-bound in the backend's environment as a self-referential
+binding: `env["ImaginaryUnit"] = IRSymbol("ImaginaryUnit")`. This prevents
+the VM from treating it as a free user variable while still allowing it to
+appear in IR trees exactly as written. (The same pattern is used for `True`
+and `False` in `SymbolicBackend`.)
+
+## Arithmetic simplification rules
+
+These rules are loaded into `SymbolicBackend`'s rule set:
+
+```
+Pow(ImaginaryUnit, 0)  →  1
+Pow(ImaginaryUnit, 1)  →  ImaginaryUnit
+Pow(ImaginaryUnit, 2)  →  -1
+Pow(ImaginaryUnit, 3)  →  Neg(ImaginaryUnit)
+Pow(ImaginaryUnit, n)  →  Pow(ImaginaryUnit, Mod(n, 4))   for integer n ≥ 4
+Mul(ImaginaryUnit, ImaginaryUnit)  →  -1
+Mul(a_, ImaginaryUnit, Mul(b_, ImaginaryUnit))  →  Neg(Mul(a_, b_))
+```
+
+The modular-reduction rule for general integer exponents (`n ≥ 4`) is
+applied by a small Python function in the handler (not a pure pattern
+rule) since `n mod 4` requires arithmetic on `n`.
+
+### Rectangular normalization
+
+After every `Add` or `Mul` containing `ImaginaryUnit`, a normalization
+pass collects the expression into `a + b·ImaginaryUnit` form:
+
+- Walk the tree looking for sub-expressions that are multiples of
+  `ImaginaryUnit` (`Mul(c, ImaginaryUnit)`).
+- Separate real and imaginary parts.
+- Return `Add(real_part, Mul(imag_part, ImaginaryUnit))` or just
+  `real_part` if `imag_part = 0`.
+
+This is `normalize_complex` and is called by the `Mul`/`Add` handlers
+when `ImaginaryUnit` is detected in the argument list.
+
+## Heads added
+
+| Head              | Arity | Meaning                                         |
+|-------------------|-------|-------------------------------------------------|
+| `Re`              | 1     | Real part of `a + b·i`: returns `a`.            |
+| `Im`              | 1     | Imaginary part: returns `b`.                    |
+| `Conjugate`       | 1     | Complex conjugate: `a + b·i → a - b·i`.         |
+| `Abs`             | 1     | Extended: `|z| = sqrt(a² + b²)` for complex `z`.|
+| `Arg`             | 1     | Principal argument `arctan2(b, a)`.             |
+| `RectForm`        | 1     | Rewrite as `a + b·ImaginaryUnit`.               |
+| `PolarForm`       | 1     | Rewrite as `r·Exp(Mul(ImaginaryUnit, theta))`.  |
+
+`Abs` already exists as a VM handler (in `cas_handlers.py`) for real
+inputs. `cas-complex` extends it: if the input is known to be complex
+(i.e., contains `ImaginaryUnit`), compute `Sqrt(Add(Pow(a,2), Pow(b,2)))`.
+Otherwise fall through to the existing real handler.
+
+## Algorithm
+
+### Re / Im
+
+Extract parts from normalized form `a + b·ImaginaryUnit`:
+
+```python
+def re_part(expr: IRNode) -> IRNode:
+    expr = normalize_complex(expr)
+    # Case: Add(a, Mul(b, ImaginaryUnit)) → a
+    if is_rect_form(expr):
+        return real_component(expr)
+    # Case: pure real (no ImaginaryUnit) → expr itself
+    if not contains(expr, IMAGINARY_UNIT):
+        return expr
+    # Otherwise unevaluated
+    return IRApply(RE, (expr,))
+```
+
+### Conjugate
+
+```python
+def conjugate(expr: IRNode) -> IRNode:
+    expr = normalize_complex(expr)
+    a, b = split_rect(expr)   # a + b*i
+    return IRApply(ADD, (a, IRApply(MUL, (IRApply(NEG, (b,)), IMAGINARY_UNIT))))
+```
+
+### RectForm
+
+Recursively distribute `ImaginaryUnit` through the expression, apply
+arithmetic rules, and collect with `normalize_complex`. Handles
+nested complex sub-expressions by recursion.
+
+### PolarForm
+
+1. `a, b = split_rect(RectForm(expr))`
+2. `r = Abs(expr)` → `Sqrt(Add(Pow(a, 2), Pow(b, 2)))`
+3. `theta = Arg(expr)` → `Atan2(b, a)` (uses `Atan` which exists already)
+4. Return `Mul(r, Exp(Mul(IMAGINARY_UNIT, theta)))`
+
+## Effect on cas-solve
+
+Once `cas-complex` is present, `cas-solve` can return complex roots for
+`x² + 1 = 0` as `[ImaginaryUnit, Neg(ImaginaryUnit)]` instead of
+falling through unevaluated.
+
+## MACSYMA name table entries
+
+```python
+# macsyma_runtime/name_table.py additions
+COMPLEX_NAME_TABLE = {
+    "%i":        IRSymbol("ImaginaryUnit"),
+    "realpart":  IRSymbol("Re"),
+    "imagpart":  IRSymbol("Im"),
+    "conjugate": IRSymbol("Conjugate"),
+    "cabs":      IRSymbol("Abs"),
+    "carg":      IRSymbol("Arg"),
+    "rectform":  IRSymbol("RectForm"),
+    "polarform": IRSymbol("PolarForm"),
+}
+```
+
+## Backend integration
+
+`cas-complex` ships `build_complex_handler_table()` and
+`COMPLEX_SIMPLIFY_RULES`. These are wired in `SymbolicBackend.__init__`
+the same way as `build_cas_handler_table()`:
+
+```python
+# in symbolic_vm/backends.py  SymbolicBackend.__init__
+from cas_complex import build_complex_handler_table, COMPLEX_SIMPLIFY_RULES
+handlers.update(build_complex_handler_table())
+self._rules = list(COMPLEX_SIMPLIFY_RULES) + existing_rules
+self._env["ImaginaryUnit"] = IMAGINARY_UNIT
+```
+
+## Test strategy
+
+- `Pow(ImaginaryUnit, 2) = -1`.
+- `Pow(ImaginaryUnit, 4) = 1`.
+- `Pow(ImaginaryUnit, 7) = Neg(ImaginaryUnit)`.
+- `Mul(ImaginaryUnit, ImaginaryUnit) = -1`.
+- `Add(3, Mul(4, ImaginaryUnit))` stays in rect form.
+- `Mul(Add(1, ImaginaryUnit), Add(1, Neg(ImaginaryUnit))) = 2`.
+  (i.e., `(1+i)(1-i) = 2`)
+- `Mul(Add(1, ImaginaryUnit), Add(1, ImaginaryUnit)) = Add(Mul(2, ImaginaryUnit), 0)`
+  ... actually `2i`. Verify rect form.
+- `Re(Add(3, Mul(4, ImaginaryUnit))) = 3`.
+- `Im(Add(3, Mul(4, ImaginaryUnit))) = 4`.
+- `Conjugate(Add(3, Mul(4, ImaginaryUnit))) = Sub(3, Mul(4, ImaginaryUnit))`.
+- `Abs(Add(3, Mul(4, ImaginaryUnit))) = 5` (after numeric fold).
+- `RectForm(Mul(Exp(Mul(ImaginaryUnit, Div(Pi, 2))))) = ImaginaryUnit`
+  (Euler's formula, requires TrigSimplify co-operation).
+- `%i` in MACSYMA session resolves to `ImaginaryUnit` IR node.
+- `solve(x^2 + 1, x)` returns `[ImaginaryUnit, Neg(ImaginaryUnit)]` once
+  `cas-complex` is present.
+- Coverage: ≥85%.
+
+## Package layout
+
+```
+code/packages/python/cas-complex/
+  src/cas_complex/
+    __init__.py
+    constants.py      # IMAGINARY_UNIT sentinel, pre-bind logic
+    rules.py          # ImaginaryUnit power rules for SymbolicBackend
+    normalize.py      # normalize_complex, split_rect, is_rect_form
+    parts.py          # re_part, im_part, conjugate
+    polar.py          # RectForm, PolarForm, Arg handlers
+    handlers.py       # build_complex_handler_table()
+    py.typed
+  tests/
+    test_powers.py
+    test_arithmetic.py
+    test_parts.py
+    test_polar.py
+    test_macsyma_pipeline.py   # end-to-end: "%i^2;" → -1
+```
+
+## Dependencies
+
+`coding-adventures-symbolic-ir`,
+`coding-adventures-cas-simplify`,
+`coding-adventures-cas-pattern-matching`.
+
+## Future extensions
+
+- Gaussian integer factoring: `FactorGaussian(a + b·i)` in the
+  `cas-number-theory` package.
+- Full `Exponentialize` head: rewrite `sin(x)` / `cos(x)` as
+  complex exponentials `(e^{ix} ± e^{-ix})/2`. Enables `cas-trig`'s
+  Phase 2 `TrigReduce` for `sinⁿ` for arbitrary `n`.
+- Hypercomplex numbers (quaternions) — a separate package if needed.

--- a/code/specs/cas-number-theory.md
+++ b/code/specs/cas-number-theory.md
@@ -1,0 +1,259 @@
+# cas-number-theory — Integer Number Theory
+
+> **Status**: New spec. Implements number-theoretic operations as
+> generic IR heads: `IsPrime`, `NextPrime`, `PrevPrime`, `FactorInteger`,
+> `Divisors`, `Totient`, `MoebiusMu`, `JacobiSymbol`, `ChineseRemainder`.
+> Parent: `symbolic-computation.md`. No CAS dependencies beyond
+> `symbolic-ir`.
+
+## Why this package exists
+
+Number theory operations appear in every CAS:
+`ifactor(n)`, `isprime(n)`, `next_prime(n)`, `totient(n)`, etc.
+These are purely integer algorithms — no symbolic IR rewriting is
+required, only exact arithmetic on `IRInteger` nodes. They are kept
+separate from `cas-simplify` and `cas-factor` (which handle *polynomial*
+factoring) to respect the separation between polynomial algebra and
+integer number theory.
+
+Note: `Gcd`, `Lcm`, `Mod` are already implemented in `symbolic_vm/cas_handlers.py`
+as they are needed for polynomial arithmetic. This package adds the
+higher-level number-theoretic operations that build on them.
+
+## Reuse story
+
+| MACSYMA              | Mathematica            | Maple                  | IR head           |
+|----------------------|------------------------|------------------------|-------------------|
+| `primep(n)`          | `PrimeQ[n]`            | `isprime(n)`           | `IsPrime`         |
+| `next_prime(n)`      | `NextPrime[n]`         | `nextprime(n)`         | `NextPrime`       |
+| `prev_prime(n)`      | `NextPrime[n, -1]`     | —                      | `PrevPrime`       |
+| `ifactor(n)`         | `FactorInteger[n]`     | `ifactor(n)`           | `FactorInteger`   |
+| `divisors(n)`        | `Divisors[n]`          | `numtheory[divisors]`  | `Divisors`        |
+| `totient(n)`         | `EulerPhi[n]`          | `numtheory[phi]`       | `Totient`         |
+| `moebius(n)`         | `MoebiusMu[n]`         | `numtheory[mobius]`    | `MoebiusMu`       |
+| `jacobi(a, n)`       | `JacobiSymbol[a, n]`   | `numtheory[jacobi]`    | `JacobiSymbol`    |
+| `chinese(r, m)`      | `ChineseRemainder[r,m]`| `mods(r, m)` (CRT)     | `ChineseRemainder`|
+| `numdigits(n, b)`    | `IntegerLength[n, b]`  | `length(n, b)`         | `IntegerLength`   |
+
+## Scope
+
+In:
+
+- `IsPrime(n)` — primality test for arbitrary-precision integers.
+  Returns `IRSymbol("True")` or `IRSymbol("False")`.
+- `NextPrime(n)` — smallest prime strictly greater than `n`.
+- `PrevPrime(n)` — largest prime strictly less than `n`.
+  Returns unevaluated for `n ≤ 2` (no prime exists below 2).
+- `FactorInteger(n)` — prime factorization as a list of `[prime, exponent]`
+  pairs: `FactorInteger(12) → [[2, 2], [3, 1]]`.
+  In IR: `IRApply(LIST, (IRApply(LIST, (IRInteger(2), IRInteger(2))),
+                         IRApply(LIST, (IRInteger(3), IRInteger(1)))))`.
+- `Divisors(n)` — sorted list of all positive divisors.
+- `Totient(n)` — Euler's phi function: count of integers in `[1, n]`
+  coprime to `n`.
+- `MoebiusMu(n)` — Möbius function: `0` if `n` has a squared prime
+  factor, `(-1)^k` if `n` is a product of `k` distinct primes.
+- `JacobiSymbol(a, n)` — generalized Legendre/Jacobi symbol.
+- `ChineseRemainder(remainders, moduli)` — CRT reconstruction.
+  Both args are `List` IR nodes of equal length.
+- `IntegerLength(n)` or `IntegerLength(n, b)` — number of digits of `n`
+  in base `b` (default 10).
+
+Out:
+
+- Symbolic/polynomial factoring — that is `cas-factor`.
+- Gaussian integer factoring — deferred to `cas-complex` future work.
+- Diophantine equations (e.g. Pell's equation) — future package.
+- Modular arithmetic beyond CRT (e.g. `PowerMod`, `DiscreteLog`) —
+  Phase 2 of this package.
+
+## Public interface
+
+```python
+from cas_number_theory import (
+    is_prime,                 # int → bool
+    next_prime,               # int → int
+    prev_prime,               # int → int | None
+    factor_integer,           # int → list[tuple[int, int]]
+    divisors,                 # int → list[int]
+    totient,                  # int → int
+    moebius_mu,               # int → int  (-1, 0, 1)
+    jacobi_symbol,            # (int, int) → int
+    chinese_remainder,        # (list[int], list[int]) → int
+    integer_length,           # (int, int=10) → int
+    build_number_theory_handler_table,  # () → dict[str, Handler]
+)
+```
+
+All Python-level functions operate on Python `int`s and are
+completely independent of IR. The VM handlers wrap them: extract
+`IRInteger.value`, call the function, wrap the result back in
+`IRInteger` (or `IRApply(LIST, ...)` for `Divisors`/`FactorInteger`).
+
+## Algorithms
+
+### IsPrime — Miller-Rabin
+
+For `n < 3_215_031_751` (fits in 32 bits): deterministic Miller-Rabin
+with witnesses `{2, 3, 5, 7}` — guaranteed correct, no false positives.
+
+For larger `n`: use the first 20 prime witnesses
+`{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71}`.
+This is a BPSW-equivalent test and has no known counterexamples.
+
+Python implementation uses the built-in `pow(a, d, n)` for fast
+modular exponentiation — no external libraries needed.
+
+### NextPrime / PrevPrime
+
+Sieve a small window above/below `n` using `IsPrime`. Start with an
+initial candidate (next odd, skip multiples of 3), advance by 2,
+re-test. For `n < 10^6`, use a pre-built sieve (the Sieve of
+Eratosthenes up to 10^6 is 125 KB and eliminates most candidates
+instantly). Above 10^6, Miller-Rabin per candidate.
+
+### FactorInteger — Trial Division + Pollard's Rho
+
+Phase 1 (small primes): trial-divide by all primes up to min(1000, √n).
+Covers the vast majority of inputs a user will type interactively.
+
+Phase 2 (Pollard's Rho): for any remaining cofactor > 1 that is not
+prime (tested with Miller-Rabin), apply Floyd's cycle-finding variant of
+Pollard's ρ with polynomial `f(x) = x² + c` for a few random `c`. Recursively
+factor both pieces.
+
+This gives correct factorizations for all 64-bit integers and
+handles 128-bit integers within a reasonable time for interactive use.
+
+### Totient
+
+Given the prime factorization `n = p1^a1 · p2^a2 · ...`:
+`φ(n) = n · ∏(1 - 1/pᵢ) = ∏(pᵢ^(aᵢ-1) · (pᵢ-1))`.
+
+Obtain factorization from `factor_integer(n)`, apply the formula
+using Python integer arithmetic.
+
+### ChineseRemainder
+
+Iterative CRT using the standard two-moduli formula:
+`x ≡ r₁ (mod m₁)`, `x ≡ r₂ (mod m₂)` →
+`x = r₁ + m₁ · ((r₂ - r₁) · m₁⁻¹ mod m₂)`.
+
+Extended to `k` moduli by repeated application left-to-right.
+Uses Python's `pow(a, -1, m)` (Python ≥ 3.8) for modular inverse.
+
+Returns `None` if moduli are not pairwise coprime.
+
+## Heads added
+
+| Head                 | Arity | Returns                                        |
+|----------------------|-------|------------------------------------------------|
+| `IsPrime`            | 1     | `True` or `False` (IR symbols)                 |
+| `NextPrime`          | 1     | `IRInteger`                                    |
+| `PrevPrime`          | 1     | `IRInteger` or unevaluated if `n ≤ 2`          |
+| `FactorInteger`      | 1     | `List` of `[prime, exponent]` lists            |
+| `Divisors`           | 1     | `List` of `IRInteger`s                         |
+| `Totient`            | 1     | `IRInteger`                                    |
+| `MoebiusMu`          | 1     | `IRInteger` in `{-1, 0, 1}`                    |
+| `JacobiSymbol`       | 2     | `IRInteger` in `{-1, 0, 1}`                    |
+| `ChineseRemainder`   | 2     | `IRInteger` or unevaluated (incongruent moduli)|
+| `IntegerLength`      | 1–2   | `IRInteger`                                    |
+
+All handlers gracefully return `expr` unevaluated when given non-integer
+or negative arguments (where the operation is undefined).
+
+## MACSYMA name table entries
+
+```python
+# macsyma_runtime/name_table.py additions
+NUMBER_THEORY_NAME_TABLE = {
+    "primep":          IRSymbol("IsPrime"),
+    "next_prime":      IRSymbol("NextPrime"),
+    "prev_prime":      IRSymbol("PrevPrime"),
+    "ifactor":         IRSymbol("FactorInteger"),
+    "divisors":        IRSymbol("Divisors"),
+    "totient":         IRSymbol("Totient"),
+    "moebius":         IRSymbol("MoebiusMu"),
+    "jacobi":          IRSymbol("JacobiSymbol"),
+    "chinese":         IRSymbol("ChineseRemainder"),
+    "numdigits":       IRSymbol("IntegerLength"),
+}
+```
+
+## Test strategy
+
+### IsPrime
+- `IsPrime(2) = True`, `IsPrime(3) = True`, `IsPrime(4) = False`.
+- `IsPrime(97) = True`, `IsPrime(100) = False`.
+- Carmichael number `IsPrime(561) = False` (Miller-Rabin handles this).
+- Large prime: `IsPrime(2^31 - 1) = True` (Mersenne prime).
+- `IsPrime(0) = False`, `IsPrime(1) = False`.
+- Non-integer input → unevaluated.
+
+### NextPrime / PrevPrime
+- `NextPrime(10) = 11`.
+- `NextPrime(13) = 17`.
+- `PrevPrime(10) = 7`.
+- `PrevPrime(2)` → unevaluated.
+
+### FactorInteger
+- `FactorInteger(1) = []` (empty list).
+- `FactorInteger(12) = [[2, 2], [3, 1]]`.
+- `FactorInteger(360) = [[2, 3], [3, 2], [5, 1]]`.
+- `FactorInteger(p)` for prime `p` = `[[p, 1]]`.
+- Large semiprime `FactorInteger(2^32 + 1)` = correct factorization.
+- Negative input → unevaluated.
+
+### Divisors
+- `Divisors(1) = [1]`.
+- `Divisors(12) = [1, 2, 3, 4, 6, 12]`.
+- Result is sorted ascending.
+
+### Totient
+- `Totient(1) = 1`.
+- `Totient(p) = p - 1` for prime `p`.
+- `Totient(12) = 4`.
+
+### ChineseRemainder
+- `ChineseRemainder([2, 3], [3, 5]) = 8`.
+- Non-coprime moduli → unevaluated.
+
+### Stress
+- `FactorInteger(n)` for 1000 random `n` in `[1, 10^9]` verified
+  against `math.prod(p^e for p,e in factorization) == n`.
+
+Coverage: ≥85%.
+
+## Package layout
+
+```
+code/packages/python/cas-number-theory/
+  src/cas_number_theory/
+    __init__.py
+    primality.py          # Miller-Rabin, next/prev prime, sieve
+    factorize.py          # trial division + Pollard's rho
+    arithmetic.py         # totient, moebius_mu, jacobi_symbol
+    crt.py                # ChineseRemainder
+    handlers.py           # build_number_theory_handler_table()
+    py.typed
+  tests/
+    test_primality.py
+    test_factorize.py
+    test_arithmetic.py
+    test_crt.py
+    test_handlers.py
+```
+
+## Dependencies
+
+`coding-adventures-symbolic-ir` only. No other CAS packages needed —
+all operations are pure integer arithmetic.
+
+## Future extensions (Phase 2)
+
+- `PowerMod(a, n, m)` — `a^n mod m`.
+- `DiscreteLog(a, g, p)` — baby-step giant-step.
+- `NthRoot(a, n, m)` — modular nth root (for RSA textbook examples).
+- `LegendreSymbol(a, p)` — already implied by `JacobiSymbol` for prime `p`.
+- Gaussian integer factoring (joint with `cas-complex`):
+  `FactorGaussian(a + b·i)`.

--- a/code/specs/cas-trig.md
+++ b/code/specs/cas-trig.md
@@ -1,0 +1,225 @@
+# cas-trig — Trigonometric Simplification and Expansion
+
+> **Status**: New spec. Implements `TrigSimplify`, `TrigExpand`, and
+> `TrigReduce` heads. Parent: `symbolic-computation.md`. Depends on
+> `cas-simplify` and `cas-pattern-matching`.
+
+## Why this package exists
+
+`cas-simplify` deliberately excludes trig-specific rewriting (see its
+"Future extensions" note) because the rule set is large and qualitatively
+different from algebraic identities. Trig simplification is its own
+mathematical discipline — Pythagorean identities, angle-addition formulas,
+power-reduction formulas, co-function identities — and deserves a dedicated
+home so the rule database can be extended, tested, and reasoned about in
+isolation.
+
+## Reuse story
+
+All CAS frontends map to the same three heads:
+
+| MACSYMA              | Mathematica           | Maple                   | IR head        |
+|----------------------|-----------------------|-------------------------|----------------|
+| `trigsimp(expr)`     | `TrigSimplify[expr]`  | `simplify(expr, trig)`  | `TrigSimplify` |
+| `trigexpand(expr)`   | `TrigExpand[expr]`    | `expand(expr, trig)`    | `TrigExpand`   |
+| `trigreduce(expr)`   | `TrigReduce[expr]`    | `combine(expr, trig)`   | `TrigReduce`   |
+
+MACSYMA also has `trigfactor`, `half_angle`, `exponentialize`. These map
+to the same heads with option flags, deferred to Phase 2.
+
+## Scope
+
+In:
+
+- `TrigSimplify(expr)` — rewrite using Pythagorean identities until no
+  further simplification is possible. Includes:
+  - `sin²x + cos²x → 1` (and variants: `1 - sin²x → cos²x`, etc.)
+  - `tan(x) → sin(x)/cos(x)` and its inverse when beneficial.
+  - `sin(-x) → -sin(x)`, `cos(-x) → cos(x)`.
+  - `sin(n·π) → 0`, `cos(n·π) → (-1)^n` for integer `n`.
+  - Special values: `sin(π/6) → 1/2`, `cos(π/4) → √2/2`, etc.
+- `TrigExpand(expr)` — expand compound angles and products to sums:
+  - `sin(a + b) → sin(a)cos(b) + cos(a)sin(b)`
+  - `cos(a + b) → cos(a)cos(b) - sin(a)sin(b)`
+  - `sin(2x)   → 2·sin(x)·cos(x)`
+  - `cos(2x)   → cos²(x) - sin²(x)`
+  - `sin(n·x)` / `cos(n·x)` via Chebyshev recurrence for integer `n`.
+- `TrigReduce(expr)` — reduce powers of trig functions to multiple
+  angles (the inverse of `TrigExpand`):
+  - `sin²(x) → (1 - cos(2x))/2`
+  - `cos²(x) → (1 + cos(2x))/2`
+  - `sin³(x) → (3·sin(x) - sin(3x))/4`
+  - General `sinⁿ`, `cosⁿ` via the Chebyshev expansion.
+  - `sin(x)·cos(x) → sin(2x)/2`
+
+Out:
+
+- `exponentialize` — write trig functions as complex exponentials
+  (`e^{ix}`). Deferred; requires `cas-complex`.
+- `half_angle` — half-angle formula substitution. Phase 2.
+- `trigfactor` — product-to-sum rewriting. Phase 2.
+- Hyperbolic trig (`sinh`, `cosh`, `tanh`) identities — separate phase
+  (integration Phase 13 already adds hyperbolic IR heads; simplification
+  rules follow the same pattern but are deferred here to keep scope clear).
+
+## Public interface
+
+```python
+from cas_trig import (
+    trig_simplify,    # IRNode → IRNode
+    trig_expand,      # IRNode → IRNode
+    trig_reduce,      # IRNode → IRNode
+    build_trig_handler_table,  # () → dict[str, Handler]
+)
+```
+
+These are pure functions that take and return IR nodes. They never modify
+state. `build_trig_handler_table()` is called by `SymbolicBackend.__init__`
+alongside `build_cas_handler_table()` so every frontend inherits the heads.
+
+## Heads added
+
+| Head            | Arity | Meaning                                      |
+|-----------------|-------|----------------------------------------------|
+| `TrigSimplify`  | 1     | Apply Pythagorean and special-value rules.   |
+| `TrigExpand`    | 1     | Expand sums/multiples to products of singles.|
+| `TrigReduce`    | 1     | Reduce powers to multiple-angle form.        |
+
+`Sin`, `Cos`, `Tan`, `Csc`, `Sec`, `Cot` and their inverses already
+exist as standard IR heads (used by the integration package since
+Phase 4). This package adds only the three transformation heads above.
+
+## Algorithm
+
+### TrigSimplify
+
+Fixed-point loop identical in structure to `cas_simplify.simplify`:
+
+```python
+def trig_simplify(expr: IRNode) -> IRNode:
+    last = None
+    while last != expr:
+        last = expr
+        expr = cas_simplify.canonical(expr)
+        expr = _apply_trig_rules(expr)
+        expr = cas_simplify.numeric_fold(expr)
+    return expr
+```
+
+`_apply_trig_rules` runs the rule database through `cas-pattern-matching`.
+The rule database (`rules.py`) is a list of `(pattern, replacement)`
+pairs. Rules are tried in priority order: specific rules (sin²+cos²=1)
+before general rules (sin(-x)=-sin(x)).
+
+Key Pythagorean pattern:
+
+```
+Add(Pow(Sin(x_), 2), Pow(Cos(x_), 2))  →  1
+Add(Pow(Sin(x_), 2), z_)  when z_ contains Pow(Cos(x_), 2)  →  ...
+```
+
+Special-value lookup table maps `(function, argument_mod_2pi)` pairs to
+exact IR values using `IRRational` and `IRApply(SQRT, ...)` for irrational
+values like `√2/2`. The table covers `π/6, π/4, π/3, π/2` and their
+multiples.
+
+### TrigExpand
+
+Recursive tree walk. On each `IRApply`:
+
+- `Sin(Add(a, b))` → expand via angle-addition formula, recurse.
+- `Cos(Add(a, b))` → expand via angle-addition formula, recurse.
+- `Sin(Mul(n, x))` for integer `n` → Chebyshev recurrence:
+  `sin(nx) = 2cos(x)sin((n-1)x) - sin((n-2)x)`.
+- `Cos(Mul(n, x))` for integer `n` → analogous Chebyshev.
+- All other nodes: recurse into args, return.
+
+Result is simplified by a pass of `cas_simplify.canonical` to flatten
+the resulting expression.
+
+### TrigReduce
+
+Recursive tree walk. On `Pow(Sin(x), n)` or `Pow(Cos(x), n)` for positive
+integer `n`, use the binomial theorem on the complex exponential form
+to derive the multiple-angle expansion, then convert back to real form.
+
+For `n = 2, 3, 4` the formulas are hard-coded (fastest and clearest).
+For `n ≥ 5` the general formula is computed symbolically using the
+identity `sinⁿ(x) = (e^{ix} - e^{-ix})^n / (2i)^n` evaluated with the
+binomial theorem, then simplified to real form. This requires `cas-complex`
+at runtime if complex intermediate values appear; Phase 1 hard-codes up
+to `n = 6` to avoid that dependency initially.
+
+## MACSYMA name table entries
+
+```python
+# These go in macsyma_runtime/name_table.py
+TRIG_NAME_TABLE = {
+    "trigsimp":   IRSymbol("TrigSimplify"),
+    "trigexpand": IRSymbol("TrigExpand"),
+    "trigreduce": IRSymbol("TrigReduce"),
+}
+```
+
+## Test strategy
+
+### TrigSimplify
+- `TrigSimplify(Add(Pow(Sin(x), 2), Pow(Cos(x), 2))) = 1`.
+- `TrigSimplify(Sub(1, Pow(Sin(x), 2))) = Pow(Cos(x), 2)`.
+- `TrigSimplify(Sin(Neg(x))) = Neg(Sin(x))`.
+- `TrigSimplify(Sin(Pi)) = 0`.
+- `TrigSimplify(Cos(Mul(Pi, 2))) = 1`.
+- Special values: `Sin(Div(Pi, 6)) = Rational(1, 2)`.
+- Idempotent: applying twice gives the same result.
+- Non-trig expressions pass through unchanged.
+
+### TrigExpand
+- `TrigExpand(Sin(Add(a, b))) = Add(Mul(Sin(a),Cos(b)), Mul(Cos(a),Sin(b)))`.
+- `TrigExpand(Cos(Add(a, b))) = Sub(Mul(Cos(a),Cos(b)), Mul(Sin(a),Sin(b)))`.
+- `TrigExpand(Sin(Mul(2, x))) = Mul(2, Sin(x), Cos(x))`.
+- `TrigExpand(Cos(Mul(3, x)))` matches the triple-angle formula.
+- Nested: `TrigExpand(Sin(Add(Mul(2,x), y)))` fully expands.
+
+### TrigReduce
+- `TrigReduce(Pow(Sin(x), 2)) = Mul(Rational(1,2), Sub(1, Cos(Mul(2,x))))`.
+- `TrigReduce(Pow(Cos(x), 2)) = Mul(Rational(1,2), Add(1, Cos(Mul(2,x))))`.
+- `TrigReduce(Mul(Sin(x), Cos(x))) = Mul(Rational(1,2), Sin(Mul(2,x)))`.
+- `TrigReduce(Pow(Sin(x), 3))` matches the triple-angle formula.
+- Round-trip: `TrigSimplify(TrigExpand(TrigReduce(expr)))` equals the
+  original on polynomial-trig expressions.
+
+Coverage: ≥85%.
+
+## Package layout
+
+```
+code/packages/python/cas-trig/
+  src/cas_trig/
+    __init__.py
+    rules.py              # Pythagorean + special-value rule database
+    simplify.py           # TrigSimplify fixed-point loop
+    expand.py             # TrigExpand recursive rewriter
+    reduce.py             # TrigReduce power-to-multiple-angle
+    special_values.py     # sin/cos/tan at rational multiples of pi
+    handlers.py           # build_trig_handler_table()
+    py.typed
+  tests/
+    test_trig_simplify.py
+    test_trig_expand.py
+    test_trig_reduce.py
+    test_special_values.py
+```
+
+## Dependencies
+
+`coding-adventures-symbolic-ir`,
+`coding-adventures-cas-pattern-matching`,
+`coding-adventures-cas-simplify`.
+
+## Future extensions
+
+- Phase 2: `TrigFactor` (product-to-sum), `HalfAngle`, `Exponentialize`
+  (writes trig as complex exponentials; depends on `cas-complex`).
+- Hyperbolic analogs: `HypSimplify`, `HypExpand` using `cosh²-sinh²=1`.
+- Integration into `cas-simplify`'s `Simplify` head as an optional
+  sub-pass gated by a `trig=True` option.

--- a/code/specs/macsyma-completion.md
+++ b/code/specs/macsyma-completion.md
@@ -1,0 +1,371 @@
+# MACSYMA Completion Roadmap
+
+> **Status**: Living document. Tracks what is implemented, what is
+> specified but not built, and what needs a new spec. Updated as
+> work lands.
+
+## Guiding principle
+
+Every operation must live at the IR layer — in a `cas-*` package
+wired into `SymbolicBackend` — before it appears in any language
+frontend. MACSYMA's `factor(x^2-1)` maps to `Factor(x^2-1)` IR;
+a future Maple `factor(x^2-1)` maps to the same `Factor(x^2-1)` IR;
+both share the same handler without touching each other's code.
+
+The "Russian nesting dolls" stack:
+
+```
+SymbolicBackend          ← universal algebraic substrate
+  └── MacsymaBackend     ← MACSYMA surface: Display/Suppress/Kill/Ev
+  └── (future) MapleBackend
+  └── (future) MathematicaBackend
+```
+
+New CAS operations always go in `SymbolicBackend`. Language-specific
+syntax differences go in the frontend name table and backend subclass.
+
+---
+
+## Current status (as of symbolic-vm 0.19.0 / macsyma-runtime 0.2.0)
+
+### Fully working end-to-end
+
+| Area                | IR heads                                         | Package              |
+|---------------------|--------------------------------------------------|----------------------|
+| Arithmetic          | `Add Mul Pow Neg Sub Div Inv`                    | `symbolic-vm` (built-in) |
+| Variables / functions | `Assign Define`                                | `symbolic-vm` (built-in) |
+| Simplification      | `Simplify Expand`                                | `cas-simplify` |
+| Substitution        | `Subst`                                          | `cas-substitution` |
+| Factoring           | `Factor` (Phase 1–2: rational-root test)         | `cas-factor` |
+| Solving             | `Solve` (linear + quadratic over Q)              | `cas-solve` |
+| List operations     | `Length First Rest Last Append Reverse Range Map Apply Select Sort Part Flatten Join` | `cas-list-operations` |
+| Matrix operations   | `Matrix Transpose Determinant Inverse`           | `cas-matrix` |
+| Limits              | `Limit` (direct substitution)                    | `cas-limit-series` |
+| Taylor series       | `Taylor` (polynomial expressions)                | `cas-limit-series` |
+| Differentiation     | `D`                                              | `symbolic-vm` |
+| Integration         | `Integrate` (Risch Phases 1–13)                  | `symbolic-vm` |
+| Numeric ops         | `Abs Floor Ceiling Mod Gcd Lcm`                  | `cas-handlers` (in `symbolic-vm`) |
+| Constants           | `%pi %e`                                         | `macsyma-runtime` |
+| REPL mechanics      | `;` / `$` terminators, history `%/%iN/%oN`, `kill`, `ev(numer)` | `macsyma-runtime` |
+
+---
+
+## Group A — Extend existing packages (specs exist, Phase N not yet built)
+
+These are specified in their respective `.md` files; the listed phases
+are confirmed unimplemented.
+
+### A1 · `cas-factor` Phases 3–4
+
+**Spec**: `cas-factor.md` → "Phase 3: Kronecker" and "Phase 4: Berlekamp-Zassenhaus-Hensel".
+
+**Gap**: The current implementation (Phase 2, rational-root test) correctly
+factors polynomials whose irreducible factors are all linear over Q.
+It leaves `x^4 + 1`, `x^4 + x^2 + 1`, and similar non-linear irreducibles
+unevaluated even though they can be factored over Q (`x^4+1` is irreducible,
+so that case is correct, but `x^4-4 = (x^2-2)(x^2+2)` should factor and does
+not today).
+
+**What to implement**:
+- `Phase 3 (Kronecker)`: evaluate `p(x)` at `deg+1` integer points, enumerate
+  candidate divisor coefficients, verify by polynomial division. Handles all
+  polynomials up to degree 6 reliably.
+- `Phase 4 (Berlekamp + Zassenhaus + Hensel)`: factor `p mod small_prime`
+  in GF(p)[x], Hensel-lift to Z[x], combinatorially reconstruct. Production
+  algorithm for arbitrary degree.
+
+**New IR heads**: none (still `Factor`).
+
+**Test cases to add**:
+- `Factor(x^4 - 4)` → `Mul(Sub(Pow(x,2), 2), Add(Pow(x,2), 2))`.
+- `Factor(x^6 - 1)` → `(x-1)(x+1)(x^2+x+1)(x^2-x+1)`.
+- `Factor(x^4 + 1)` → unevaluated (irreducible over Q).
+
+---
+
+### A2 · `cas-solve` Phases 3–5
+
+**Spec**: `cas-solve.md` → "Cubic and quartic", "Degree ≥ 5", "Linear systems".
+
+**Gap**: Current implementation handles degree 1 and 2 only.
+
+**What to implement**:
+
+| Phase | Algorithm | New IR heads |
+|-------|-----------|--------------|
+| A2a — Cubic | Cardano's formula. Returns 3 roots (real + complex conjugate pair when discriminant < 0). Requires `cas-complex` for the complex case. | `Cbrt` (cube root, for Cardano's formula output) |
+| A2b — Quartic | Ferrari's method (reduce to cubic resolvent). Returns 4 roots. | none beyond A2a |
+| A2c — Degree ≥ 5 | `NSolve`: Durand–Kerner (Weierstrass) iteration, returns `IRFloat` roots. | `NSolve` |
+| A2d — Linear systems | `Solve([eq1, eq2, ...], [x, y, ...])`: Gaussian elimination with `Fraction` coefficients. Returns `List(Rule(x, val), ...)`. | `Rule` (already in symbolic-ir standard heads), `RuleDelayed` |
+
+**Dependency note**: A2a and A2b should be implemented after `cas-complex`
+(spec: `cas-complex.md`) so that complex roots can be returned as
+`ImaginaryUnit`-containing IR expressions rather than floats.
+
+**Test cases to add** (see `cas-solve.md` test strategy):
+- `Solve(x^3 - 6*x^2 + 11*x - 6, x)` → `[1, 2, 3]` (all real roots).
+- `Solve(x^3 + 1, x)` → `[-1, complex roots using %i]`.
+- `Solve([x + y = 3, x - y = 1], [x, y])` → `[Rule(x, 2), Rule(y, 1)]`.
+- `NSolve(x^5 + x + 1, x)` → 5 `IRFloat` roots.
+
+---
+
+### A3 · `cas-simplify` — `Collect`, `Together`, `Apart`, polynomial `Expand`
+
+**Spec**: `cas-simplify.md` → `Collect`, `Together`, `Apart`, and the
+polynomial-distribution pass of `Expand`.
+
+**Gap**: Current `Expand` only calls `canonical()` (normalizes sort order /
+flattens); it does not distribute `Mul` over `Add` (e.g.,
+`(x+1)*(x+2)` stays unexpanded).
+
+**What to implement**:
+
+| Head      | Algorithm |
+|-----------|-----------|
+| `Expand` (full) | Convert sub-expressions to polynomial via `polynomial-bridge`, multiply out, convert back. |
+| `Collect` | `Collect(expr, x)`: group terms by powers of `x`, return `IRApply(Add, [Mul(coeff, Pow(x,n)), ...])`. |
+| `Together` | Combine fractions over common denominator: GCD of denominators, multiply out. |
+| `Apart`   | Partial-fraction decomposition via `polynomial-bridge` (already implemented in hermite/Rothstein-Trager; surface it here). |
+| `RatSimplify` | `ratsimp` in MACSYMA: cancel common polynomial factors in numerator and denominator. |
+
+**New IR heads**: `Collect`, `Together`, `Apart`, `RatSimplify`.
+
+**MACSYMA name table additions**:
+```python
+{"collect":   IRSymbol("Collect"),
+ "together":  IRSymbol("Together"),
+ "partfrac":  IRSymbol("Apart"),
+ "ratsimp":   IRSymbol("RatSimplify")}
+```
+
+---
+
+## Group B — New packages (no implementation exists yet)
+
+These need both the package and the spec to be implemented.
+Specs are written; implementation is pending.
+
+### B1 · `cas-trig` — Trigonometric simplification
+
+**Spec**: `cas-trig.md` ← written.
+
+**Priority**: High. `trigsimp` and `trigexpand` come up constantly in
+a real MACSYMA session.
+
+**New IR heads**: `TrigSimplify`, `TrigExpand`, `TrigReduce`.
+
+**MACSYMA name table**:
+```python
+{"trigsimp":   IRSymbol("TrigSimplify"),
+ "trigexpand": IRSymbol("TrigExpand"),
+ "trigreduce": IRSymbol("TrigReduce")}
+```
+
+**Integration into `SymbolicBackend`**: call `build_trig_handler_table()`
+in `SymbolicBackend.__init__` alongside `build_cas_handler_table()`.
+Add the trig special-value rules to the rules list so `Sin(Pi)` → `0`
+fires automatically inside `Simplify`.
+
+---
+
+### B2 · `cas-complex` — Complex number support
+
+**Spec**: `cas-complex.md` ← written.
+
+**Priority**: High. Needed by `cas-solve` for cubic/quartic roots.
+
+**New IR heads**: `Re`, `Im`, `Conjugate`, `Arg`, `RectForm`, `PolarForm`.
+
+**New constant**: `ImaginaryUnit` pre-bound in every backend.
+
+**Backend wiring**: `COMPLEX_SIMPLIFY_RULES` added to `SymbolicBackend`
+rule list so `ImaginaryUnit^2 → -1` fires automatically.
+
+---
+
+### B3 · `cas-number-theory` — Integer number theory
+
+**Spec**: `cas-number-theory.md` ← written.
+
+**Priority**: Medium. Needed for `ifactor`, `primep`, `totient`.
+
+**New IR heads**: `IsPrime`, `NextPrime`, `PrevPrime`, `FactorInteger`,
+`Divisors`, `Totient`, `MoebiusMu`, `JacobiSymbol`, `ChineseRemainder`,
+`IntegerLength`.
+
+---
+
+## Group C — MACSYMA wiring (language-layer, no new IR needed)
+
+These items require changes to `macsyma-runtime` or `macsyma-compiler`
+but no new CAS packages.
+
+### C1 · `%i` constant pre-binding
+
+**What**: Once `cas-complex` exists, add to `MacsymaBackend.__init__`:
+
+```python
+from cas_complex import IMAGINARY_UNIT
+self._env["%i"] = IMAGINARY_UNIT
+```
+
+Add to `MACSYMA_NAME_TABLE`:
+```python
+{"%i": IRSymbol("ImaginaryUnit")}
+```
+
+---
+
+### C2 · `makelist` → `MakeList` head
+
+**What**: MACSYMA's `makelist(expr, var, n)` generates a list by
+evaluating `expr` for `var = 1, 2, ..., n`. Equivalent forms:
+`makelist(expr, var, from, to)` and `makelist(expr, var, from, to, step)`.
+
+**IR head**: `MakeList(expr, var, from, to, step)`.
+
+**Implementation**: Add to `cas-list-operations`:
+
+```python
+def make_list(
+    expr: IRNode, var: IRSymbol,
+    start: int, stop: int, step: int = 1
+) -> IRNode:
+    from cas_substitution import subst
+    results = [
+        subst(IRInteger(i), var, expr)
+        for i in range(start, stop + 1, step)
+    ]
+    return IRApply(LIST, tuple(results))
+```
+
+The VM handler evaluates each substituted expression through `vm.eval()`.
+
+**MACSYMA name table**:
+```python
+{"makelist": IRSymbol("MakeList")}
+```
+
+---
+
+### C3 · `ev` flag improvements
+
+**What**: `Ev(expr, flag1, flag2, ...)` in MACSYMA re-evaluates `expr`
+with specified flags. Current implementation only honors `numer`.
+
+**Flags to add**:
+
+| Flag       | Meaning                                         | Implementation |
+|------------|-------------------------------------------------|----------------|
+| `expand`   | Apply `Expand` to result before returning.      | `vm.eval(IRApply(EXPAND, (result,)))` |
+| `factor`   | Apply `Factor` to result.                       | `vm.eval(IRApply(FACTOR, (result,)))` |
+| `ratsimp`  | Apply `RatSimplify` to result.                  | Requires A3 above |
+| `trigsimp` | Apply `TrigSimplify` to result.                 | Requires B1 above |
+| `float`    | Force float evaluation (same as `numer`).       | Already works |
+
+**File**: `macsyma_runtime/handlers.py` in the `ev_handler` function.
+
+---
+
+### C4 · `at` / point evaluation
+
+**What**: MACSYMA's `at(expr, x = a)` evaluates `expr` at `x = a`.
+This is syntactic sugar over `Subst(a, x, expr)`.
+
+**IR mapping**: The MACSYMA compiler already compiles `x = a` to
+`Equal(x, a)`. The `at` handler needs to recognize
+`At(expr, Equal(x, a))` and rewrite to `Subst(a, x, expr)`.
+
+**New IR head**: `At(expr, rule_or_list_of_rules)`.
+
+**MACSYMA name table**:
+```python
+{"at": IRSymbol("At")}
+```
+
+Implementation lives in `macsyma-runtime` (not `SymbolicBackend`) since
+the `Equal`-as-substitution-rule convention is MACSYMA-specific.
+(In Mathematica the same operation uses `Rule`: `expr /. x -> a`.)
+
+---
+
+### C5 · `lhs` / `rhs` — equation sides
+
+**What**: `lhs(a = b)` → `a`, `rhs(a = b)` → `b`.
+
+**IR**: `Equal(a, b)` is the IR for equations. Add `Lhs` and `Rhs` handlers:
+
+```python
+def lhs_handler(_vm, expr):
+    if len(expr.args) != 1: return expr
+    eq = expr.args[0]
+    if isinstance(eq, IRApply) and eq.head.name == "Equal" and len(eq.args) == 2:
+        return eq.args[0]
+    return expr
+```
+
+These are one-liners added to `build_cas_handler_table()` in `symbolic-vm`.
+
+**New IR heads**: `Lhs`, `Rhs`.
+
+**MACSYMA name table**:
+```python
+{"lhs": IRSymbol("Lhs"), "rhs": IRSymbol("Rhs")}
+```
+
+---
+
+## Group D — Deferred (out of scope for now)
+
+| Feature | Reason deferred |
+|---------|-----------------|
+| `ode2` — ODE solving | Complex algorithms (variation of parameters, integrating factors, Lie symmetries); warrants its own `cas-ode` spec |
+| `laplace` / `ilt` | Laplace transform and inverse; needs `cas-complex` + a residue-theorem-based partial-fraction algorithm |
+| 2D pretty printing | `display2d` mode with fraction bars and superscript exponents; UI concern, not CAS algebra |
+| `fourier` / `ifourier` | Symbolic Fourier transform; requires distribution theory |
+| `mnewton` — Newton's method | Numeric; easier to implement than ODE but not blocking any current gap |
+| Multivariate `factor`/`solve` | Gröbner bases (Buchberger's algorithm); large scope, future `cas-multivariate` package |
+| Algebraic number extensions | Factoring over `Q[√2]`, `Q[ζ_n]` etc.; depends on Berlekamp-Zassenhaus lift |
+
+---
+
+## Suggested implementation order
+
+Based on user impact and dependency ordering:
+
+```
+1. C2 (makelist)          ← 1 day, pure list-operations extension, no deps
+2. C5 (lhs/rhs)           ← 1 hour, trivial handler addition
+3. B2 (cas-complex)       ← 3 days, unlocks complex roots in cas-solve
+4. A3 (Expand/Collect/Together/Apart/RatSimplify)  ← 3 days, high user demand
+5. B1 (cas-trig)          ← 3 days, high user demand
+6. A2a/A2b (cubic/quartic in cas-solve)  ← 3 days, depends on B2
+7. B3 (cas-number-theory) ← 2 days, self-contained
+8. C1 (%i binding)        ← 1 hour, depends on B2
+9. C3 (ev flags)          ← 1 day, depends on A3 and B1
+10. C4 (at head)          ← 0.5 day
+11. A1 (factor Phase 3–4) ← 1 week, mathematically dense
+12. A2c/A2d (NSolve, linear systems) ← 3 days
+```
+
+Total estimate to "feature-complete MACSYMA Phase 1": ~4 weeks of focused
+implementation effort.
+
+---
+
+## How to wire a new package into the VM
+
+Every new `cas-*` package follows the same four-step integration:
+
+```
+1. Implement pure Python functions operating on IRNode.
+2. Write a build_<name>_handler_table() → dict[str, Handler].
+3. In symbolic_vm/backends.py SymbolicBackend.__init__:
+       handlers.update(build_<name>_handler_table())
+4. In macsyma_runtime/name_table.py:
+       NAME_TABLE.update({macsyma_name: IRSymbol(HeadName), ...})
+```
+
+No changes to the VM core, no changes to MacsymaBackend, no changes to
+the parser or compiler. The head just starts working everywhere.


### PR DESCRIPTION
## Summary

- Adds `cas-trig.md`: spec for `TrigSimplify`, `TrigExpand`, `TrigReduce` — Pythagorean identity rules, angle-addition formulas, Chebyshev recurrence for power reduction
- Adds `cas-complex.md`: spec for complex number IR support — `ImaginaryUnit` constant, `i^n` power rules, `Re`/`Im`/`Conjugate`/`Abs`/`Arg`/`RectForm`/`PolarForm` heads
- Adds `cas-number-theory.md`: spec for integer number theory — `IsPrime` (Miller-Rabin), `FactorInteger` (trial division + Pollard ρ), `NextPrime`/`PrevPrime`, `Divisors`, `Totient`, `MoebiusMu`, `JacobiSymbol`, `ChineseRemainder`
- Adds `macsyma-completion.md`: master roadmap dividing remaining work into Groups A/B/C/D with dependency ordering and ~4-week estimate to feature-complete MACSYMA Phase 1

All specs follow the IR-first design: every operation is a generic `SymbolicBackend` IR head, inheritable by any future CAS frontend (Maple, Mathematica, etc.).

## Test plan
- [ ] Spec-only PR — no code changes, no tests needed
- [ ] Review spec content for correctness and completeness
- [ ] Verify MACSYMA name table entries are consistent with existing `macsyma-runtime/name_table.py` naming conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)