### PR TITLE
feat(csharp): add native qr-code package

### DIFF
--- a/code/packages/csharp/qr-code/BUILD
+++ b/code/packages/csharp/qr-code/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.QRCode.Tests/CodingAdventures.QRCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.QRCode]*"

--- a/code/packages/csharp/qr-code/BUILD_windows
+++ b/code/packages/csharp/qr-code/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.QRCode.Tests/CodingAdventures.QRCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.QRCode]*"

--- a/code/packages/csharp/qr-code/CHANGELOG.md
+++ b/code/packages/csharp/qr-code/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog - CodingAdventures.QRCode.CSharp
+
+## [0.1.0] - 2026-04-27
+
+### Added
+
+- Initial native C# QR Code encoder.
+- Numeric, alphanumeric, and byte mode encoding.
+- Automatic version selection for versions 1 through 40.
+- GF(256) Reed-Solomon block ECC and interleaving.
+- Finder, separator, timing, alignment, dark module, format, and version
+  pattern placement.
+- Eight mask patterns with ISO penalty scoring.
+- Unit tests covering structure, sizing, ECC levels, format bits, modes,
+  overflow behavior, and determinism.

--- a/code/packages/csharp/qr-code/CodingAdventures.QRCode.csproj
+++ b/code/packages/csharp/qr-code/CodingAdventures.QRCode.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.QRCode.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ISO/IEC 18004 QR Code encoder for C# that emits CodingAdventures.Barcode2D ModuleGrid values</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../gf256/CodingAdventures.Gf256.csproj" />
+    <ProjectReference Include="../barcode-2d/CodingAdventures.Barcode2D.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/qr-code/QRCode.cs
+++ b/code/packages/csharp/qr-code/QRCode.cs
@@ -1,0 +1,971 @@
+using System.Text;
+using CodingAdventures.Barcode2D;
+using Gf256Math = CodingAdventures.Gf256.Gf256;
+
+namespace CodingAdventures.QRCode;
+
+/// <summary>Error-correction level for a QR Code symbol.</summary>
+public enum EccLevel
+{
+    /// <summary>Low error correction, highest capacity.</summary>
+    L,
+    /// <summary>Medium error correction.</summary>
+    M,
+    /// <summary>Quartile error correction.</summary>
+    Q,
+    /// <summary>High error correction, lowest capacity.</summary>
+    H,
+}
+
+/// <summary>Base class for QR Code encoding errors.</summary>
+public class QRCodeException : Exception
+{
+    /// <summary>Create a QR Code exception with a message.</summary>
+    public QRCodeException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>The input cannot fit in a version-40 QR Code at the requested ECC level.</summary>
+public sealed class InputTooLongException : QRCodeException
+{
+    /// <summary>Create an input-too-long error.</summary>
+    public InputTooLongException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>ISO/IEC 18004 QR Code encoder.</summary>
+public static class QRCodeEncoder
+{
+    /// <summary>Package version.</summary>
+    public const string Version = "0.1.0";
+
+    private const string AlphanumChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+    private static readonly int[,] EccCodewordsPerBlock =
+    {
+        { -1, 7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },
+        { -1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28 },
+        { -1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },
+        { -1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },
+    };
+
+    private static readonly int[,] NumBlocks =
+    {
+        { -1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 6, 6, 6, 6, 7, 8, 8, 9, 9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25 },
+        { -1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5, 5, 8, 9, 9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49 },
+        { -1, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8, 8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68 },
+        { -1, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 80 },
+    };
+
+    private static readonly byte[][] AlignmentPositions =
+    [
+        [],
+        [6, 18],
+        [6, 22],
+        [6, 26],
+        [6, 30],
+        [6, 34],
+        [6, 22, 38],
+        [6, 24, 42],
+        [6, 26, 46],
+        [6, 28, 50],
+        [6, 30, 54],
+        [6, 32, 58],
+        [6, 34, 62],
+        [6, 26, 46, 66],
+        [6, 26, 48, 70],
+        [6, 26, 50, 74],
+        [6, 30, 54, 78],
+        [6, 30, 56, 82],
+        [6, 30, 58, 86],
+        [6, 34, 62, 90],
+        [6, 28, 50, 72, 94],
+        [6, 26, 50, 74, 98],
+        [6, 30, 54, 78, 102],
+        [6, 28, 54, 80, 106],
+        [6, 32, 58, 84, 110],
+        [6, 30, 58, 86, 114],
+        [6, 34, 62, 90, 118],
+        [6, 26, 50, 74, 98, 122],
+        [6, 30, 54, 78, 102, 126],
+        [6, 26, 52, 78, 104, 130],
+        [6, 30, 56, 82, 108, 134],
+        [6, 34, 60, 86, 112, 138],
+        [6, 30, 58, 86, 114, 142],
+        [6, 34, 62, 90, 118, 146],
+        [6, 30, 54, 78, 102, 126, 150],
+        [6, 24, 50, 76, 102, 128, 154],
+        [6, 28, 54, 80, 106, 132, 158],
+        [6, 32, 58, 84, 110, 136, 162],
+        [6, 26, 54, 82, 110, 138, 166],
+        [6, 30, 58, 86, 114, 142, 170],
+    ];
+
+    /// <summary>Encode using ECC M.</summary>
+    public static ModuleGrid Encode(string input) => Encode(input, EccLevel.M);
+
+    /// <summary>Encode a UTF-8 string into a square QR Code module grid.</summary>
+    public static ModuleGrid Encode(string input, EccLevel ecc)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (input.Length > 7089)
+        {
+            throw new InputTooLongException($"Input length {input.Length} exceeds 7089.");
+        }
+
+        var version = SelectVersion(input, ecc);
+        var size = SymbolSize(version);
+        var dataCodewords = BuildDataCodewords(input, version, ecc);
+        var blocks = ComputeBlocks(dataCodewords, version, ecc);
+        var interleaved = InterleaveBlocks(blocks);
+        var grid = BuildGrid(version);
+
+        PlaceBits(grid, interleaved, version);
+
+        var bestMask = 0;
+        var bestPenalty = uint.MaxValue;
+        for (var mask = 0; mask < 8; mask++)
+        {
+            var masked = ApplyMask(grid.Modules, grid.Reserved, size, mask);
+            var temp = new WorkGrid(size);
+            CopyGrid(masked, grid.Reserved, temp);
+            WriteFormatInfo(temp, ComputeFormatBits(ecc, mask));
+            var penalty = ComputePenalty(temp.Modules, size);
+            if (penalty < bestPenalty)
+            {
+                bestPenalty = penalty;
+                bestMask = mask;
+            }
+        }
+
+        var finalModules = ApplyMask(grid.Modules, grid.Reserved, size, bestMask);
+        var finalGrid = new WorkGrid(size);
+        CopyGrid(finalModules, grid.Reserved, finalGrid);
+        WriteFormatInfo(finalGrid, ComputeFormatBits(ecc, bestMask));
+        WriteVersionInfo(finalGrid, version);
+        return ToModuleGrid(finalGrid.Modules);
+    }
+
+    private enum EncodingMode
+    {
+        Numeric,
+        Alphanumeric,
+        Byte,
+    }
+
+    private sealed record Block(byte[] Data, byte[] Ecc);
+
+    private sealed class BitWriter
+    {
+        private readonly List<bool> _bits = [];
+
+        public int BitLength => _bits.Count;
+
+        public void Write(uint value, int count)
+        {
+            for (var i = count - 1; i >= 0; i--)
+            {
+                _bits.Add(((value >> i) & 1u) == 1u);
+            }
+        }
+
+        public byte[] ToBytes()
+        {
+            var result = new byte[(_bits.Count + 7) / 8];
+            for (var i = 0; i < _bits.Count; i++)
+            {
+                if (_bits[i])
+                {
+                    result[i / 8] |= (byte)(1 << (7 - i % 8));
+                }
+            }
+
+            return result;
+        }
+    }
+
+    private sealed class WorkGrid(int size)
+    {
+        public int Size { get; } = size;
+
+        public bool[,] Modules { get; } = new bool[size, size];
+
+        public bool[,] Reserved { get; } = new bool[size, size];
+
+        public void Set(int row, int col, bool dark, bool reserve)
+        {
+            Modules[row, col] = dark;
+            if (reserve)
+            {
+                Reserved[row, col] = true;
+            }
+        }
+
+        public void Reserve(int row, int col) => Reserved[row, col] = true;
+    }
+
+    private static int Indicator(EccLevel ecc) =>
+        ecc switch
+        {
+            EccLevel.L => 0b01,
+            EccLevel.M => 0b00,
+            EccLevel.Q => 0b11,
+            EccLevel.H => 0b10,
+            _ => 0b00,
+        };
+
+    private static int RowIndex(EccLevel ecc) =>
+        ecc switch
+        {
+            EccLevel.L => 0,
+            EccLevel.M => 1,
+            EccLevel.Q => 2,
+            EccLevel.H => 3,
+            _ => 1,
+        };
+
+    private static int SymbolSize(int version) => 4 * version + 17;
+
+    private static int NumRawDataModules(int version)
+    {
+        var v = (long)version;
+        var result = (16 * v + 128) * v + 64;
+        if (version >= 2)
+        {
+            var numAlign = v / 7 + 2;
+            result -= (25 * numAlign - 10) * numAlign - 55;
+            if (version >= 7)
+            {
+                result -= 36;
+            }
+        }
+
+        return (int)result;
+    }
+
+    private static int NumDataCodewords(int version, EccLevel ecc)
+    {
+        var row = RowIndex(ecc);
+        var rawCodewords = NumRawDataModules(version) / 8;
+        var eccCodewords = NumBlocks[row, version] * EccCodewordsPerBlock[row, version];
+        return rawCodewords - eccCodewords;
+    }
+
+    private static int NumRemainderBits(int version) => NumRawDataModules(version) % 8;
+
+    private static byte[] BuildGenerator(int count)
+    {
+        var generator = new byte[] { 1 };
+        for (var i = 0; i < count; i++)
+        {
+            var alpha = Gf256Math.Power(2, i);
+            var next = new byte[generator.Length + 1];
+            for (var j = 0; j < generator.Length; j++)
+            {
+                next[j] ^= generator[j];
+                next[j + 1] ^= Gf256Math.Multiply(generator[j], alpha);
+            }
+
+            generator = next;
+        }
+
+        return generator;
+    }
+
+    private static byte[] RsEncode(byte[] data, byte[] generator)
+    {
+        var count = generator.Length - 1;
+        var rem = new byte[count];
+        foreach (var value in data)
+        {
+            var feedback = (byte)(value ^ rem[0]);
+            Array.Copy(rem, 1, rem, 0, count - 1);
+            rem[count - 1] = 0;
+            if (feedback == 0)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < count; i++)
+            {
+                rem[i] ^= Gf256Math.Multiply(generator[i + 1], feedback);
+            }
+        }
+
+        return rem;
+    }
+
+    private static EncodingMode SelectMode(string input)
+    {
+        if (input.All(char.IsDigit))
+        {
+            return EncodingMode.Numeric;
+        }
+
+        return input.All(c => AlphanumChars.Contains(c, StringComparison.Ordinal))
+            ? EncodingMode.Alphanumeric
+            : EncodingMode.Byte;
+    }
+
+    private static uint ModeIndicator(EncodingMode mode) =>
+        mode switch
+        {
+            EncodingMode.Numeric => 0b0001u,
+            EncodingMode.Alphanumeric => 0b0010u,
+            EncodingMode.Byte => 0b0100u,
+            _ => 0u,
+        };
+
+    private static int CharCountBits(EncodingMode mode, int version) =>
+        mode switch
+        {
+            EncodingMode.Numeric => version <= 9 ? 10 : version <= 26 ? 12 : 14,
+            EncodingMode.Alphanumeric => version <= 9 ? 9 : version <= 26 ? 11 : 13,
+            EncodingMode.Byte => version <= 9 ? 8 : 16,
+            _ => 0,
+        };
+
+    private static void EncodeNumeric(string input, BitWriter writer)
+    {
+        var i = 0;
+        while (i + 2 < input.Length)
+        {
+            var value = (uint)((input[i] - '0') * 100 + (input[i + 1] - '0') * 10 + input[i + 2] - '0');
+            writer.Write(value, 10);
+            i += 3;
+        }
+
+        if (i + 1 < input.Length)
+        {
+            writer.Write((uint)((input[i] - '0') * 10 + input[i + 1] - '0'), 7);
+            i += 2;
+        }
+
+        if (i < input.Length)
+        {
+            writer.Write((uint)(input[i] - '0'), 4);
+        }
+    }
+
+    private static void EncodeAlphanumeric(string input, BitWriter writer)
+    {
+        var i = 0;
+        while (i + 1 < input.Length)
+        {
+            var value = (uint)(AlphanumChars.IndexOf(input[i], StringComparison.Ordinal) * 45 +
+                               AlphanumChars.IndexOf(input[i + 1], StringComparison.Ordinal));
+            writer.Write(value, 11);
+            i += 2;
+        }
+
+        if (i < input.Length)
+        {
+            writer.Write((uint)AlphanumChars.IndexOf(input[i], StringComparison.Ordinal), 6);
+        }
+    }
+
+    private static void EncodeByteMode(string input, BitWriter writer)
+    {
+        foreach (var value in Encoding.UTF8.GetBytes(input))
+        {
+            writer.Write(value, 8);
+        }
+    }
+
+    private static byte[] BuildDataCodewords(string input, int version, EccLevel ecc)
+    {
+        var mode = SelectMode(input);
+        var capacity = NumDataCodewords(version, ecc);
+        var writer = new BitWriter();
+
+        writer.Write(ModeIndicator(mode), 4);
+        var charCount = mode == EncodingMode.Byte
+            ? Encoding.UTF8.GetByteCount(input)
+            : input.Length;
+        writer.Write((uint)charCount, CharCountBits(mode, version));
+
+        switch (mode)
+        {
+            case EncodingMode.Numeric:
+                EncodeNumeric(input, writer);
+                break;
+            case EncodingMode.Alphanumeric:
+                EncodeAlphanumeric(input, writer);
+                break;
+            case EncodingMode.Byte:
+                EncodeByteMode(input, writer);
+                break;
+        }
+
+        var available = capacity * 8;
+        var terminatorLength = Math.Min(4, available - writer.BitLength);
+        if (terminatorLength > 0)
+        {
+            writer.Write(0, terminatorLength);
+        }
+
+        var remainder = writer.BitLength % 8;
+        if (remainder != 0)
+        {
+            writer.Write(0, 8 - remainder);
+        }
+
+        var bytes = writer.ToBytes().ToList();
+        var pad = (byte)0xEC;
+        while (bytes.Count < capacity)
+        {
+            bytes.Add(pad);
+            pad = pad == 0xEC ? (byte)0x11 : (byte)0xEC;
+        }
+
+        return bytes.ToArray();
+    }
+
+    private static Block[] ComputeBlocks(byte[] data, int version, EccLevel ecc)
+    {
+        var row = RowIndex(ecc);
+        var totalBlocks = NumBlocks[row, version];
+        var eccLength = EccCodewordsPerBlock[row, version];
+        var totalData = NumDataCodewords(version, ecc);
+        var shortLength = totalData / totalBlocks;
+        var longBlockCount = totalData % totalBlocks;
+        var generator = BuildGenerator(eccLength);
+        var blocks = new Block[totalBlocks];
+        var offset = 0;
+
+        for (var i = 0; i < totalBlocks; i++)
+        {
+            var length = i < totalBlocks - longBlockCount ? shortLength : shortLength + 1;
+            var blockData = new byte[length];
+            Array.Copy(data, offset, blockData, 0, length);
+            blocks[i] = new Block(blockData, RsEncode(blockData, generator));
+            offset += length;
+        }
+
+        return blocks;
+    }
+
+    private static byte[] InterleaveBlocks(Block[] blocks)
+    {
+        var output = new List<byte>();
+        var maxDataLength = blocks.Max(block => block.Data.Length);
+        for (var i = 0; i < maxDataLength; i++)
+        {
+            foreach (var block in blocks)
+            {
+                if (i < block.Data.Length)
+                {
+                    output.Add(block.Data[i]);
+                }
+            }
+        }
+
+        var eccLength = blocks[0].Ecc.Length;
+        for (var i = 0; i < eccLength; i++)
+        {
+            foreach (var block in blocks)
+            {
+                output.Add(block.Ecc[i]);
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    private static void PlaceFinder(WorkGrid grid, int top, int left)
+    {
+        for (var dr = 0; dr <= 6; dr++)
+        {
+            for (var dc = 0; dc <= 6; dc++)
+            {
+                var onBorder = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+                var inCore = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+                grid.Set(top + dr, left + dc, onBorder || inCore, reserve: true);
+            }
+        }
+    }
+
+    private static void PlaceAlignment(WorkGrid grid, int row, int col)
+    {
+        for (var dr = -2; dr <= 2; dr++)
+        {
+            for (var dc = -2; dc <= 2; dc++)
+            {
+                var onBorder = Math.Abs(dr) == 2 || Math.Abs(dc) == 2;
+                var isCenter = dr == 0 && dc == 0;
+                grid.Set(row + dr, col + dc, onBorder || isCenter, reserve: true);
+            }
+        }
+    }
+
+    private static void PlaceAllAlignments(WorkGrid grid, int version)
+    {
+        foreach (var rowByte in AlignmentPositions[version - 1])
+        {
+            foreach (var colByte in AlignmentPositions[version - 1])
+            {
+                var row = (int)rowByte;
+                var col = (int)colByte;
+                if (!grid.Reserved[row, col])
+                {
+                    PlaceAlignment(grid, row, col);
+                }
+            }
+        }
+    }
+
+    private static void PlaceTiming(WorkGrid grid)
+    {
+        var size = grid.Size;
+        for (var col = 8; col <= size - 9; col++)
+        {
+            grid.Set(6, col, col % 2 == 0, reserve: true);
+        }
+
+        for (var row = 8; row <= size - 9; row++)
+        {
+            grid.Set(row, 6, row % 2 == 0, reserve: true);
+        }
+    }
+
+    private static void ReserveFormatInfo(WorkGrid grid)
+    {
+        var size = grid.Size;
+        for (var col = 0; col <= 8; col++)
+        {
+            if (col != 6)
+            {
+                grid.Reserve(8, col);
+            }
+        }
+
+        for (var row = 0; row <= 8; row++)
+        {
+            if (row != 6)
+            {
+                grid.Reserve(row, 8);
+            }
+        }
+
+        for (var row = size - 7; row <= size - 1; row++)
+        {
+            grid.Reserve(row, 8);
+        }
+
+        for (var col = size - 8; col <= size - 1; col++)
+        {
+            grid.Reserve(8, col);
+        }
+    }
+
+    private static void PlaceDarkModule(WorkGrid grid, int version) =>
+        grid.Set(4 * version + 9, 8, true, reserve: true);
+
+    private static uint ComputeFormatBits(EccLevel ecc, int mask)
+    {
+        var data = (uint)((Indicator(ecc) << 3) | mask);
+        var rem = data << 10;
+        for (var i = 14; i >= 10; i--)
+        {
+            if (((rem >> i) & 1u) == 1u)
+            {
+                rem ^= 0x537u << (i - 10);
+            }
+        }
+
+        return ((data << 10) | (rem & 0x3FFu)) ^ 0x5412u;
+    }
+
+    private static void WriteFormatInfo(WorkGrid grid, uint format)
+    {
+        var size = grid.Size;
+        for (var i = 0; i <= 5; i++)
+        {
+            grid.Modules[8, i] = ((format >> (14 - i)) & 1u) == 1u;
+        }
+
+        grid.Modules[8, 7] = ((format >> 8) & 1u) == 1u;
+        grid.Modules[8, 8] = ((format >> 7) & 1u) == 1u;
+        grid.Modules[7, 8] = ((format >> 6) & 1u) == 1u;
+
+        for (var i = 0; i <= 5; i++)
+        {
+            grid.Modules[i, 8] = ((format >> i) & 1u) == 1u;
+        }
+
+        for (var i = 0; i <= 7; i++)
+        {
+            grid.Modules[8, size - 1 - i] = ((format >> i) & 1u) == 1u;
+        }
+
+        for (var i = 8; i <= 14; i++)
+        {
+            grid.Modules[size - 15 + i, 8] = ((format >> i) & 1u) == 1u;
+        }
+    }
+
+    private static void ReserveVersionInfo(WorkGrid grid, int version)
+    {
+        if (version < 7)
+        {
+            return;
+        }
+
+        var size = grid.Size;
+        for (var row = 0; row <= 5; row++)
+        {
+            for (var dc = 0; dc <= 2; dc++)
+            {
+                grid.Reserve(row, size - 11 + dc);
+            }
+        }
+
+        for (var dr = 0; dr <= 2; dr++)
+        {
+            for (var col = 0; col <= 5; col++)
+            {
+                grid.Reserve(size - 11 + dr, col);
+            }
+        }
+    }
+
+    private static uint ComputeVersionBits(int version)
+    {
+        var rem = (uint)version << 12;
+        for (var i = 17; i >= 12; i--)
+        {
+            if (((rem >> i) & 1u) == 1u)
+            {
+                rem ^= 0x1F25u << (i - 12);
+            }
+        }
+
+        return ((uint)version << 12) | (rem & 0xFFFu);
+    }
+
+    private static void WriteVersionInfo(WorkGrid grid, int version)
+    {
+        if (version < 7)
+        {
+            return;
+        }
+
+        var size = grid.Size;
+        var bits = ComputeVersionBits(version);
+        for (var i = 0; i <= 17; i++)
+        {
+            var dark = ((bits >> i) & 1u) == 1u;
+            var a = 5 - i / 3;
+            var b = size - 9 - i % 3;
+            grid.Modules[a, b] = dark;
+            grid.Modules[b, a] = dark;
+        }
+    }
+
+    private static WorkGrid BuildGrid(int version)
+    {
+        var size = SymbolSize(version);
+        var grid = new WorkGrid(size);
+
+        PlaceFinder(grid, 0, 0);
+        PlaceFinder(grid, 0, size - 7);
+        PlaceFinder(grid, size - 7, 0);
+
+        for (var i = 0; i <= 7; i++)
+        {
+            grid.Set(7, i, false, reserve: true);
+            grid.Set(i, 7, false, reserve: true);
+            grid.Set(7, size - 1 - i, false, reserve: true);
+            grid.Set(i, size - 8, false, reserve: true);
+            grid.Set(size - 8, i, false, reserve: true);
+            grid.Set(size - 1 - i, 7, false, reserve: true);
+        }
+
+        PlaceTiming(grid);
+        PlaceAllAlignments(grid, version);
+        ReserveFormatInfo(grid);
+        ReserveVersionInfo(grid, version);
+        PlaceDarkModule(grid, version);
+        return grid;
+    }
+
+    private static void PlaceBits(WorkGrid grid, byte[] codewords, int version)
+    {
+        var size = grid.Size;
+        var bits = new List<bool>();
+        foreach (var codeword in codewords)
+        {
+            for (var bit = 7; bit >= 0; bit--)
+            {
+                bits.Add(((codeword >> bit) & 1) == 1);
+            }
+        }
+
+        for (var i = 0; i < NumRemainderBits(version); i++)
+        {
+            bits.Add(false);
+        }
+
+        var bitIndex = 0;
+        var goUp = true;
+        var col = size - 1;
+        var running = true;
+
+        while (running)
+        {
+            for (var vi = 0; vi < size; vi++)
+            {
+                var row = goUp ? size - 1 - vi : vi;
+                for (var dc = 0; dc <= 1; dc++)
+                {
+                    var c = col - dc;
+                    if (c >= 0 && c != 6 && !grid.Reserved[row, c])
+                    {
+                        if (bitIndex < bits.Count)
+                        {
+                            grid.Modules[row, c] = bits[bitIndex];
+                        }
+
+                        bitIndex++;
+                    }
+                }
+            }
+
+            goUp = !goUp;
+            if (col < 2)
+            {
+                running = false;
+            }
+            else
+            {
+                col -= 2;
+                if (col == 6)
+                {
+                    col = 5;
+                }
+            }
+        }
+    }
+
+    private static bool MaskCondition(int mask, int row, int col) =>
+        mask switch
+        {
+            0 => (row + col) % 2 == 0,
+            1 => row % 2 == 0,
+            2 => col % 3 == 0,
+            3 => (row + col) % 3 == 0,
+            4 => (row / 2 + col / 3) % 2 == 0,
+            5 => (row * col) % 2 + (row * col) % 3 == 0,
+            6 => ((row * col) % 2 + (row * col) % 3) % 2 == 0,
+            7 => ((row + col) % 2 + (row * col) % 3) % 2 == 0,
+            _ => false,
+        };
+
+    private static bool[,] ApplyMask(bool[,] modules, bool[,] reserved, int size, int mask)
+    {
+        var result = (bool[,])modules.Clone();
+        for (var row = 0; row < size; row++)
+        {
+            for (var col = 0; col < size; col++)
+            {
+                if (!reserved[row, col])
+                {
+                    result[row, col] = modules[row, col] != MaskCondition(mask, row, col);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static uint ComputePenalty(bool[,] modules, int size)
+    {
+        var penalty = 0u;
+
+        for (var axis = 0; axis < size; axis++)
+        {
+            for (var horizontal = 0; horizontal < 2; horizontal++)
+            {
+                var run = 1u;
+                var previous = horizontal == 1 ? modules[axis, 0] : modules[0, axis];
+                for (var i = 1; i < size; i++)
+                {
+                    var current = horizontal == 1 ? modules[axis, i] : modules[i, axis];
+                    if (current == previous)
+                    {
+                        run++;
+                    }
+                    else
+                    {
+                        if (run >= 5)
+                        {
+                            penalty += run - 2;
+                        }
+
+                        run = 1;
+                        previous = current;
+                    }
+                }
+
+                if (run >= 5)
+                {
+                    penalty += run - 2;
+                }
+            }
+        }
+
+        for (var row = 0; row < size - 1; row++)
+        {
+            for (var col = 0; col < size - 1; col++)
+            {
+                var dark = modules[row, col];
+                if (dark == modules[row, col + 1] &&
+                    dark == modules[row + 1, col] &&
+                    dark == modules[row + 1, col + 1])
+                {
+                    penalty += 3;
+                }
+            }
+        }
+
+        int[] pattern1 = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
+        int[] pattern2 = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+        for (var axis = 0; axis < size; axis++)
+        {
+            for (var offset = 0; offset < size - 11; offset++)
+            {
+                var rowPattern1 = true;
+                var rowPattern2 = true;
+                var colPattern1 = true;
+                var colPattern2 = true;
+                for (var k = 0; k <= 10; k++)
+                {
+                    var rowBit = modules[axis, offset + k] ? 1 : 0;
+                    var colBit = modules[offset + k, axis] ? 1 : 0;
+                    if (rowBit != pattern1[k])
+                    {
+                        rowPattern1 = false;
+                    }
+
+                    if (rowBit != pattern2[k])
+                    {
+                        rowPattern2 = false;
+                    }
+
+                    if (colBit != pattern1[k])
+                    {
+                        colPattern1 = false;
+                    }
+
+                    if (colBit != pattern2[k])
+                    {
+                        colPattern2 = false;
+                    }
+                }
+
+                if (rowPattern1)
+                {
+                    penalty += 40;
+                }
+
+                if (rowPattern2)
+                {
+                    penalty += 40;
+                }
+
+                if (colPattern1)
+                {
+                    penalty += 40;
+                }
+
+                if (colPattern2)
+                {
+                    penalty += 40;
+                }
+            }
+        }
+
+        var darkCount = 0u;
+        for (var row = 0; row < size; row++)
+        {
+            for (var col = 0; col < size; col++)
+            {
+                if (modules[row, col])
+                {
+                    darkCount++;
+                }
+            }
+        }
+
+        var ratio = darkCount / (double)(size * size) * 100.0;
+        var previousFive = (uint)Math.Floor(ratio / 5.0) * 5;
+        var below = previousFive > 50 ? previousFive - 50 : 50 - previousFive;
+        var aboveBase = previousFive + 5;
+        var above = aboveBase > 50 ? aboveBase - 50 : 50 - aboveBase;
+        penalty += Math.Min(below, above) / 5 * 10;
+
+        return penalty;
+    }
+
+    private static int SelectVersion(string input, EccLevel ecc)
+    {
+        var mode = SelectMode(input);
+        var byteLength = (uint)Encoding.UTF8.GetByteCount(input);
+
+        for (var version = 1; version <= 40; version++)
+        {
+            var capacity = NumDataCodewords(version, ecc);
+            uint dataBits = mode switch
+            {
+                EncodingMode.Byte => byteLength * 8,
+                EncodingMode.Numeric => ((uint)input.Length * 10 + 2) / 3,
+                EncodingMode.Alphanumeric => ((uint)input.Length * 11 + 1) / 2,
+                _ => 0,
+            };
+
+            var bitsNeeded = (uint)(4 + CharCountBits(mode, version)) + dataBits;
+            var codewordsNeeded = (bitsNeeded + 7) / 8;
+            if (codewordsNeeded <= capacity)
+            {
+                return version;
+            }
+        }
+
+        throw new InputTooLongException($"Input ({input.Length} chars, ECC={ecc}) exceeds version-40 capacity.");
+    }
+
+    private static void CopyGrid(bool[,] modules, bool[,] reserved, WorkGrid target)
+    {
+        var size = target.Size;
+        for (var row = 0; row < size; row++)
+        {
+            for (var col = 0; col < size; col++)
+            {
+                target.Modules[row, col] = modules[row, col];
+                target.Reserved[row, col] = reserved[row, col];
+            }
+        }
+    }
+
+    private static ModuleGrid ToModuleGrid(bool[,] modules)
+    {
+        var size = modules.GetLength(0);
+        var grid = ModuleGrid.Create(size, size, ModuleShape.Square);
+        for (var row = 0; row < size; row++)
+        {
+            for (var col = 0; col < size; col++)
+            {
+                if (modules[row, col])
+                {
+                    grid = grid.SetModule(row, col, true);
+                }
+            }
+        }
+
+        return grid;
+    }
+}

--- a/code/packages/csharp/qr-code/README.md
+++ b/code/packages/csharp/qr-code/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.QRCode.CSharp
+
+Native C# QR Code encoder for .NET. It encodes UTF-8 strings into a square
+`ModuleGrid` from `CodingAdventures.Barcode2D`.
+
+```csharp
+using CodingAdventures.QRCode;
+
+var grid = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+```
+
+The encoder implements the same v0.1.0 surface as the F# QR package: numeric,
+alphanumeric, and byte modes; automatic version selection; GF(256)
+Reed-Solomon error correction; finder, separator, timing, alignment, format,
+and version patterns; data zigzag placement; and all eight mask patterns with
+ISO penalty scoring.
+
+Kanji mode and manual mask/version selection are deferred.

--- a/code/packages/csharp/qr-code/required_capabilities.json
+++ b/code/packages/csharp/qr-code/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/qr-code",
+  "capabilities": [],
+  "justification": "Pure in-memory QR Code encoder. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/qr-code/tests/CodingAdventures.QRCode.Tests/CodingAdventures.QRCode.Tests.csproj
+++ b/code/packages/csharp/qr-code/tests/CodingAdventures.QRCode.Tests/CodingAdventures.QRCode.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.QRCode.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/qr-code/tests/CodingAdventures.QRCode.Tests/QRCodeTests.cs
+++ b/code/packages/csharp/qr-code/tests/CodingAdventures.QRCode.Tests/QRCodeTests.cs
@@ -1,0 +1,352 @@
+using CodingAdventures.Barcode2D;
+
+namespace CodingAdventures.QRCode.Tests;
+
+public sealed class QRCodeTests
+{
+    [Fact]
+    public void VersionIsCurrent()
+    {
+        Assert.Equal("0.1.0", QRCodeEncoder.Version);
+    }
+
+    [Fact]
+    public void VersionOneGridIsTwentyOneByTwentyOne()
+    {
+        var grid = QRCodeEncoder.Encode("1", EccLevel.L);
+
+        Assert.Equal(21, grid.Rows);
+        Assert.Equal(21, grid.Cols);
+        Assert.Equal(ModuleShape.Square, grid.ModuleShape);
+    }
+
+    [Fact]
+    public void VersionTwoGridIsTwentyFiveByTwentyFive()
+    {
+        var grid = QRCodeEncoder.Encode(new string('1', 42), EccLevel.L);
+
+        Assert.Equal(25, grid.Rows);
+        Assert.Equal(25, grid.Cols);
+    }
+
+    [Fact]
+    public void VersionFiveGridIsThirtySevenByThirtySeven()
+    {
+        var grid = QRCodeEncoder.Encode(new string('1', 188), EccLevel.L);
+
+        Assert.Equal(37, grid.Rows);
+        Assert.Equal(37, grid.Cols);
+    }
+
+    [Fact]
+    public void LargeNumericInputRequiresVersionTenOrHigher()
+    {
+        var grid = QRCodeEncoder.Encode(new string('1', 600), EccLevel.L);
+
+        Assert.True(grid.Rows >= 57);
+    }
+
+    [Fact]
+    public void FinderPatternsArePresent()
+    {
+        var grid = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+        var size = grid.Rows;
+
+        Assert.True(HasFinder(grid, 0, 0));
+        Assert.True(HasFinder(grid, 0, size - 7));
+        Assert.True(HasFinder(grid, size - 7, 0));
+    }
+
+    [Fact]
+    public void VersionFiveFinderPatternsArePresent()
+    {
+        var grid = QRCodeEncoder.Encode(new string('1', 188), EccLevel.L);
+        var size = grid.Rows;
+
+        Assert.True(HasFinder(grid, 0, 0));
+        Assert.True(HasFinder(grid, 0, size - 7));
+        Assert.True(HasFinder(grid, size - 7, 0));
+    }
+
+    [Theory]
+    [InlineData("HELLO WORLD", EccLevel.M, 0b00u)]
+    [InlineData("12345", EccLevel.L, 0b01u)]
+    [InlineData("TEST", EccLevel.Q, 0b11u)]
+    [InlineData("ABC", EccLevel.H, 0b10u)]
+    public void FormatInfoBchIsValidAndEccMatches(string input, EccLevel ecc, uint expectedIndicator)
+    {
+        var grid = QRCodeEncoder.Encode(input, ecc);
+        var format = ReadFormatInfo(grid);
+
+        Assert.NotNull(format);
+        Assert.Equal(expectedIndicator, format.Value.Indicator);
+    }
+
+    [Fact]
+    public void DarkModuleIsPresentForVersionOneAndFive()
+    {
+        var versionOne = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+        var versionFive = QRCodeEncoder.Encode(new string('1', 188), EccLevel.L);
+
+        Assert.True(versionOne.Modules[13][8]);
+        Assert.True(versionFive.Modules[29][8]);
+    }
+
+    [Fact]
+    public void NumericAndAlphanumericInputsStayInVersionOneAtEccM()
+    {
+        Assert.Equal(21, QRCodeEncoder.Encode("01234567", EccLevel.M).Rows);
+        Assert.Equal(21, QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M).Rows);
+    }
+
+    [Fact]
+    public void LowercaseInputUsesByteModeAndStillEncodes()
+    {
+        var grid = QRCodeEncoder.Encode("hello", EccLevel.M);
+
+        Assert.Equal(21, grid.Rows);
+    }
+
+    [Fact]
+    public void MediumInputSelectsHigherVersion()
+    {
+        var grid = QRCodeEncoder.Encode(new string('3', 300), EccLevel.L);
+
+        Assert.True(grid.Rows > 21);
+    }
+
+    [Fact]
+    public void AllEccLevelsEncode()
+    {
+        foreach (var ecc in new[] { EccLevel.L, EccLevel.M, EccLevel.Q, EccLevel.H })
+        {
+            var grid = QRCodeEncoder.Encode("HELLO", ecc);
+
+            Assert.True(grid.Rows >= 21);
+        }
+    }
+
+    [Fact]
+    public void EmptyStringEncodes()
+    {
+        var grid = QRCodeEncoder.Encode(string.Empty, EccLevel.M);
+
+        Assert.Equal(21, grid.Rows);
+    }
+
+    [Fact]
+    public void OverlyLongInputThrows()
+    {
+        Assert.Throws<InputTooLongException>(() => QRCodeEncoder.Encode(new string('A', 8000), EccLevel.H));
+    }
+
+    [Fact]
+    public void ExactByteModeOverflowThrows()
+    {
+        Assert.Throws<InputTooLongException>(() => QRCodeEncoder.Encode(new string('a', 7089), EccLevel.L));
+    }
+
+    [Fact]
+    public void NullInputThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => QRCodeEncoder.Encode(null!, EccLevel.M));
+    }
+
+    [Fact]
+    public void ModuleGridDimensionsMatchRowsAndCols()
+    {
+        var grid = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+
+        Assert.Equal(grid.Rows, grid.Modules.Count);
+        foreach (var row in grid.Modules)
+        {
+            Assert.Equal(grid.Cols, row.Count);
+        }
+    }
+
+    [Fact]
+    public void TimingPatternsAlternate()
+    {
+        var grid = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+        var size = grid.Rows;
+
+        for (var col = 8; col <= size - 9; col++)
+        {
+            Assert.Equal(col % 2 == 0, grid.Modules[6][col]);
+        }
+
+        for (var row = 8; row <= size - 9; row++)
+        {
+            Assert.Equal(row % 2 == 0, grid.Modules[row][6]);
+        }
+    }
+
+    [Fact]
+    public void VersionSevenOrHigherEncodes()
+    {
+        var grid = QRCodeEncoder.Encode(new string('a', 155), EccLevel.L);
+
+        Assert.True(grid.Rows >= 45);
+    }
+
+    [Fact]
+    public void HighVersionFormatInfoIsValid()
+    {
+        var grid = QRCodeEncoder.Encode(new string('1', 280), EccLevel.L);
+
+        Assert.NotNull(ReadFormatInfo(grid));
+    }
+
+    [Fact]
+    public void FullAlphanumericCharsetEncodes()
+    {
+        var grid = QRCodeEncoder.Encode("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:", EccLevel.L);
+
+        Assert.True(grid.Rows >= 21);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("42")]
+    [InlineData("123")]
+    [InlineData("000")]
+    public void NumericEdgeCasesEncode(string input)
+    {
+        Assert.Equal(21, QRCodeEncoder.Encode(input, EccLevel.L).Rows);
+    }
+
+    [Fact]
+    public void UrlAndMixedCaseInputsEncode()
+    {
+        Assert.True(QRCodeEncoder.Encode("https://example.com", EccLevel.M).Rows >= 21);
+        Assert.True(QRCodeEncoder.Encode("Hello World", EccLevel.M).Rows >= 21);
+    }
+
+    [Fact]
+    public void Utf8ByteInputEncodes()
+    {
+        var grid = QRCodeEncoder.Encode("caf\u00e9", EccLevel.M);
+
+        Assert.True(grid.Rows >= 21);
+    }
+
+    [Fact]
+    public void SeparatorRowsAreLightAroundTopLeftFinder()
+    {
+        var grid = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+
+        for (var col = 0; col <= 7; col++)
+        {
+            Assert.False(grid.Modules[7][col]);
+        }
+
+        for (var row = 0; row <= 7; row++)
+        {
+            Assert.False(grid.Modules[row][7]);
+        }
+    }
+
+    [Fact]
+    public void GridContainsBothDarkAndLightModules()
+    {
+        var grid = QRCodeEncoder.Encode("TEST", EccLevel.H);
+        var dark = 0;
+        var light = 0;
+
+        for (var row = 0; row < grid.Rows; row++)
+        {
+            for (var col = 0; col < grid.Cols; col++)
+            {
+                if (grid.Modules[row][col])
+                {
+                    dark++;
+                }
+                else
+                {
+                    light++;
+                }
+            }
+        }
+
+        Assert.True(dark > 0);
+        Assert.True(light > 0);
+    }
+
+    [Fact]
+    public void EccIndicatorsAreValid()
+    {
+        Assert.Equal(0b11u, ReadFormatInfo(QRCodeEncoder.Encode("HELLO WORLD", EccLevel.Q))!.Value.Indicator);
+        Assert.Equal(0b10u, ReadFormatInfo(QRCodeEncoder.Encode("HELLO WORLD", EccLevel.H))!.Value.Indicator);
+        Assert.Equal(0b01u, ReadFormatInfo(QRCodeEncoder.Encode("HELLO WORLD", EccLevel.L))!.Value.Indicator);
+    }
+
+    [Fact]
+    public void EncodingIsDeterministic()
+    {
+        var first = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+        var second = QRCodeEncoder.Encode("HELLO WORLD", EccLevel.M);
+
+        Assert.Equal(first.Rows, second.Rows);
+        for (var row = 0; row < first.Rows; row++)
+        {
+            for (var col = 0; col < first.Cols; col++)
+            {
+                Assert.Equal(first.Modules[row][col], second.Modules[row][col]);
+            }
+        }
+    }
+
+    private static bool HasFinder(ModuleGrid grid, int top, int left)
+    {
+        for (var dr = 0; dr <= 6; dr++)
+        {
+            for (var dc = 0; dc <= 6; dc++)
+            {
+                var onBorder = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+                var inCore = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+                if (grid.Modules[top + dr][left + dc] != (onBorder || inCore))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static (uint Indicator, uint Mask)? ReadFormatInfo(ModuleGrid grid)
+    {
+        (int Row, int Col)[] positions =
+        [
+            (8, 0), (8, 1), (8, 2), (8, 3), (8, 4), (8, 5), (8, 7), (8, 8),
+            (7, 8), (5, 8), (4, 8), (3, 8), (2, 8), (1, 8), (0, 8),
+        ];
+
+        var raw = 0u;
+        for (var i = 0; i < positions.Length; i++)
+        {
+            var (row, col) = positions[i];
+            if (grid.Modules[row][col])
+            {
+                raw |= 1u << (14 - i);
+            }
+        }
+
+        var format = raw ^ 0x5412u;
+        var rem = (format >> 10) << 10;
+        for (var i = 14; i >= 10; i--)
+        {
+            if (((rem >> i) & 1u) == 1u)
+            {
+                rem ^= 0x537u << (i - 10);
+            }
+        }
+
+        if ((rem & 0x3FFu) != (format & 0x3FFu))
+        {
+            return null;
+        }
+
+        return ((format >> 13) & 0x3u, (format >> 10) & 0x7u);
+    }
+}


### PR DESCRIPTION
## Summary
- add a native C# `qr-code` package to match the existing F# package coverage
- implement QR v0.1.0 directly in C#: numeric/alphanumeric/byte modes, version selection, GF(256) Reed-Solomon ECC, block interleaving, QR function patterns, masking, format bits, and version bits
- include docs, capability metadata, build scripts, and focused xUnit coverage

## Verification
- `dotnet test tests/CodingAdventures.QRCode.Tests/CodingAdventures.QRCode.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line /p:Include=[CodingAdventures.QRCode]*`
- `git diff --check`
- wrapper/platform crypto scan over `code/packages/csharp/qr-code`