### PR TITLE
fix(ci): bump setup-uv to v5/latest and Elixir/OTP to current stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,9 @@ jobs:
 
       - name: Install uv
         if: needs.detect.outputs.needs_python == 'true'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.x"
+          version: "latest"
 
       # ── Lua must be set up BEFORE Ruby on Windows ──────────────
       #
@@ -308,8 +308,9 @@ jobs:
         if: needs.detect.outputs.needs_elixir == 'true'
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.16'
-          otp-version: '26.0'
+          elixir-version: '1.18.4'
+          otp-version: '27.3.4.11'
+          version-type: strict
 
       - name: Set up Dart
         if: needs.detect.outputs.needs_dart == 'true'


### PR DESCRIPTION
## Summary

- **uv**: `astral-sh/setup-uv@v4` with `version: "0.6.x"` no longer resolves — uv has moved to 0.11.x. Switched to `setup-uv@v5` with `version: "latest"` so CI always installs a working release.
- **Elixir/OTP**: `erlef/setup-beam` loose matching for OTP `26.0` fails because GitHub's releases API `per_page=100` window no longer returns old minor versions. Bumped to Elixir `1.18.4` + OTP `27.3.4.11` with `version-type: strict` so the action resolves the exact release tag.

These two breakages are blocking every PR that touches Python or Elixir packages. This is a minimal, surgical fix with no other changes.

## Test plan

- [ ] CI build job installs uv without "No version found" error
- [ ] CI build job sets up Elixir/OTP without "Requested loose version not found" error
- [ ] All other CI checks unaffected (no package code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)