### PR TITLE
Add ALGOL no-argument procedure formals

### DIFF
--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -41,8 +41,11 @@ until Phase 5 grows full store-helper coverage. The supported integer by-name
 surface is covered by the WASM acceptance suite, including typed whole-array
 formals passed as descriptor pointers, label formals passed as pending-goto
 targets, and switch formals passed as descriptor closures that re-evaluate in
-the caller's declaring scope. Full ALGOL forms such as procedure-valued
-formals and escaping thunk descriptors remain future work.
+the caller's declaring scope. No-argument statement procedure formals pass
+descriptor closures containing the callee procedure id and static link; formal
+calls dispatch through a generated helper so forwarded procedure formals keep
+the original environment. Full ALGOL forms such as typed or argument-taking
+procedure formals and escaping thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -84,6 +84,7 @@ _THUNK_STORE_LABEL = "_fn_algol_store_thunk"
 _THUNK_EVAL_REAL_LABEL = "_fn_algol_eval_real_thunk"
 _THUNK_STORE_REAL_LABEL = "_fn_algol_store_real_thunk"
 _SWITCH_EVAL_LABEL = "_fn_algol_eval_switch"
+_PROCEDURE_CALL_LABEL = "_fn_algol_call_procedure"
 _THUNK_DESCRIPTOR_SIZE = 12
 _THUNK_CODE_ID_OFFSET = 0
 _THUNK_CALLER_FRAME_OFFSET = 4
@@ -93,6 +94,9 @@ _THUNK_FLAG_STORE = 1
 _SWITCH_DESCRIPTOR_SIZE = 8
 _SWITCH_DESCRIPTOR_ID_OFFSET = 0
 _SWITCH_DESCRIPTOR_CALLER_FRAME_OFFSET = 4
+_PROCEDURE_DESCRIPTOR_SIZE = 8
+_PROCEDURE_DESCRIPTOR_ID_OFFSET = 0
+_PROCEDURE_DESCRIPTOR_STATIC_LINK_OFFSET = 4
 _MAX_EVAL_THUNKS = 256
 _INTEGER_TYPE = "integer"
 _BOOLEAN_TYPE = "boolean"
@@ -237,6 +241,7 @@ class AlgolIrCompiler:
         self.eval_thunks: list[_EvalThunk] = []
         self.has_by_name_parameters = False
         self.has_switch_parameters = False
+        self.has_procedure_parameters = False
         self.string_literal_offsets: dict[str, int] = {}
 
     def compile(self, typed: TypeCheckResult | ASTNode) -> CompileResult:
@@ -266,6 +271,7 @@ class AlgolIrCompiler:
         self.eval_thunks = []
         self.has_by_name_parameters = False
         self.has_switch_parameters = False
+        self.has_procedure_parameters = False
         self.string_literal_offsets = {}
         self.semantic_blocks = list(type_result.semantic.blocks)
         self.semantic_blocks_by_ast = {
@@ -336,6 +342,11 @@ class AlgolIrCompiler:
             for procedure in type_result.semantic.procedures
             for parameter in procedure.parameters
         )
+        self.has_procedure_parameters = any(
+            parameter.kind == "procedure"
+            for procedure in type_result.semantic.procedures
+            for parameter in procedure.parameters
+        )
         self.arrays = {
             array.array_id: array for array in type_result.semantic.arrays
         }
@@ -354,7 +365,12 @@ class AlgolIrCompiler:
                     *(
                         _INTEGER_TYPE
                         if parameter.mode == _NAME_MODE
-                        or parameter.kind in {"array", "label", "switch"}
+                        or parameter.kind in {
+                            "array",
+                            "label",
+                            "switch",
+                            "procedure",
+                        }
                         else parameter.type_name
                         for parameter in procedure.parameters
                     ),
@@ -387,6 +403,11 @@ class AlgolIrCompiler:
         if self.has_switch_parameters:
             self.procedure_signatures[_SWITCH_EVAL_LABEL] = ProcedureSignaturePlan(
                 param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
+                return_type=_INTEGER_TYPE,
+            )
+        if self.has_procedure_parameters:
+            self.procedure_signatures[_PROCEDURE_CALL_LABEL] = ProcedureSignaturePlan(
+                param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
                 return_type=_INTEGER_TYPE,
             )
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
@@ -498,6 +519,8 @@ class AlgolIrCompiler:
             )
         if self.has_switch_parameters:
             self._compile_switch_eval_dispatcher()
+        if self.has_procedure_parameters:
+            self._compile_procedure_call_dispatcher()
 
         return CompileResult(
             program=self.program,
@@ -2398,6 +2421,8 @@ class AlgolIrCompiler:
         call = self._require_procedure_call(name, role)
         if call.label in {_BUILTIN_PRINT_LABEL, _BUILTIN_OUTPUT_LABEL}:
             return self._compile_builtin_output(node, scope)
+        if call.parameter_symbol_id is not None:
+            return self._compile_procedure_parameter_call(node, call, scope)
         procedure = self.procedures[call.procedure_id]
         static_link = self._emit_static_link_for_call(call, scope)
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
@@ -2411,7 +2436,7 @@ class AlgolIrCompiler:
             for index, (argument, parameter) in enumerate(
                 zip(actuals, procedure.parameters, strict=True)
             )
-            if parameter.kind not in {"array", "label", "switch"}
+            if parameter.kind not in {"array", "label", "switch", "procedure"}
             and parameter.mode == _NAME_MODE
             and self._requires_by_name_thunk_descriptor(argument)
         ]
@@ -2421,6 +2446,13 @@ class AlgolIrCompiler:
                 zip(actuals, procedure.parameters, strict=True)
             )
             if parameter.kind == "switch"
+        ]
+        procedure_actuals = [
+            (index, argument, parameter)
+            for index, (argument, parameter) in enumerate(
+                zip(actuals, procedure.parameters, strict=True)
+            )
+            if parameter.kind == "procedure"
         ]
         for _, argument, parameter in thunk_actuals:
             variable = _single_variable_expr(argument)
@@ -2447,6 +2479,8 @@ class AlgolIrCompiler:
                 continue
             if parameter.kind == "switch":
                 continue
+            if parameter.kind == "procedure":
+                continue
             if parameter.mode == _VALUE_MODE:
                 value = self._compile_expr(argument, scope)
                 arguments[index] = self._coerce_reg_to_type(
@@ -2458,6 +2492,7 @@ class AlgolIrCompiler:
         temp_descriptor_bytes = (
             len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
             + len(switch_actuals) * _SWITCH_DESCRIPTOR_SIZE
+            + len(procedure_actuals) * _PROCEDURE_DESCRIPTOR_SIZE
         )
         descriptor_heap_mark = (
             self._emit_reserve_temp_descriptor_space(temp_descriptor_bytes, scope)
@@ -2488,6 +2523,16 @@ class AlgolIrCompiler:
                 switch_actuals
             )
         }
+        procedure_descriptor_offsets = {
+            argument_index: (
+                len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+                + len(switch_actuals) * _SWITCH_DESCRIPTOR_SIZE
+                + descriptor_index * _PROCEDURE_DESCRIPTOR_SIZE
+            )
+            for descriptor_index, (argument_index, _, _) in enumerate(
+                procedure_actuals
+            )
+        }
         for index, (argument, parameter) in enumerate(
             zip(actuals, procedure.parameters, strict=True)
         ):
@@ -2499,12 +2544,31 @@ class AlgolIrCompiler:
                 continue
             if parameter.kind == "switch":
                 descriptor = None
-                if descriptor_heap_mark is not None and index in switch_descriptor_offsets:
+                if (
+                    descriptor_heap_mark is not None
+                    and index in switch_descriptor_offsets
+                ):
                     descriptor = self._emit_descriptor_at(
                         descriptor_heap_mark,
                         switch_descriptor_offsets[index],
                     )
                 arguments[index] = self._compile_switch_actual_pointer(
+                    argument,
+                    scope,
+                    descriptor,
+                )
+                continue
+            if parameter.kind == "procedure":
+                descriptor = None
+                if (
+                    descriptor_heap_mark is not None
+                    and index in procedure_descriptor_offsets
+                ):
+                    descriptor = self._emit_descriptor_at(
+                        descriptor_heap_mark,
+                        procedure_descriptor_offsets[index],
+                    )
+                arguments[index] = self._compile_procedure_actual_pointer(
                     argument,
                     scope,
                     descriptor,
@@ -2550,6 +2614,43 @@ class AlgolIrCompiler:
             dst=result,
             src=_REAL_RESULT_REG if call.return_type == _REAL_TYPE else _RESULT_REG,
         )
+        return result
+
+    def _compile_procedure_parameter_call(
+        self,
+        node: ASTNode,
+        call: ResolvedProcedureCall,
+        scope: _FrameScope,
+    ) -> int:
+        actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
+        if actuals:
+            raise CompileError(
+                f"procedure parameter {call.name!r} expects no arguments in this phase"
+            )
+        descriptor_pointer = self._compile_procedure_parameter_pointer(
+            call.name,
+            scope,
+        )
+        if descriptor_pointer is None:
+            raise CompileError(
+                f"procedure parameter {call.name!r} was not resolved"
+            )
+        active_thunk_heap_mark = (
+            scope.active_thunk_heap_mark_reg
+            if scope.active_thunk_heap_mark_reg is not None
+            else self._const_reg(0)
+        )
+        self._emit(
+            IrOp.CALL,
+            IrLabel(_PROCEDURE_CALL_LABEL),
+            IrRegister(descriptor_pointer),
+            IrRegister(active_thunk_heap_mark),
+        )
+        if scope.helper_failure:
+            self._emit_helper_return_on_thunk_failure(scope)
+        self._emit_handle_pending_goto_after_call(scope)
+        result = self._fresh_reg()
+        self._copy_reg(dst=result, src=_RESULT_REG)
         return result
 
     def _compile_builtin_output(self, node: ASTNode, scope: _FrameScope) -> int:
@@ -3128,6 +3229,61 @@ class AlgolIrCompiler:
         )
         return descriptor
 
+    def _compile_procedure_actual_pointer(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+        descriptor: int | None,
+    ) -> int:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            raise CompileError("procedure parameter actual must be a direct procedure")
+        name = _variable_name(variable)
+        if name is None:
+            raise CompileError("procedure parameter actual is missing a name")
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            raise CompileError(f"procedure actual {name.value!r} was not resolved")
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind == "procedure_parameter":
+            if symbol.slot_offset is None:
+                raise CompileError(
+                    f"procedure parameter actual {name.value!r} has no planned "
+                    "frame slot"
+                )
+            frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+            pointer = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(pointer),
+                IrRegister(frame_reg),
+                IrRegister(self._const_reg(symbol.slot_offset)),
+            )
+            return pointer
+        if symbol.kind != "procedure" or symbol.procedure_id is None:
+            raise CompileError(
+                f"procedure parameter actual {name.value!r} is not a procedure"
+            )
+        procedure = self.procedures.get(symbol.procedure_id)
+        if procedure is None:
+            raise CompileError(f"procedure actual {name.value!r} has no descriptor")
+        if procedure.return_type is not None or procedure.parameters:
+            raise CompileError(
+                f"procedure parameter actual {name.value!r} must be a no-argument "
+                "statement procedure"
+            )
+        if descriptor is None:
+            raise CompileError(
+                f"missing reserved descriptor for procedure actual {name.value!r}"
+            )
+        static_link = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+        self._emit_write_procedure_descriptor(
+            descriptor,
+            procedure.procedure_id,
+            static_link,
+        )
+        return descriptor
+
     def _compile_label_actual_value(
         self,
         argument: ASTNode,
@@ -3165,6 +3321,31 @@ class AlgolIrCompiler:
         if label is None:
             raise CompileError(f"label actual {name.value!r} has no descriptor")
         return self._const_reg(label.label_id)
+
+    def _compile_procedure_parameter_pointer(
+        self,
+        name: str,
+        scope: _FrameScope,
+    ) -> int | None:
+        resolved = self._resolve_symbol_in_scope_chain(name, scope)
+        if resolved is None:
+            return None
+        symbol, lexical_depth_delta = resolved
+        if symbol.kind != "procedure_parameter":
+            return None
+        if symbol.slot_offset is None:
+            raise CompileError(
+                f"procedure parameter {name!r} has no planned frame slot"
+            )
+        frame_reg = self._emit_frame_for_lexical_depth(scope, lexical_depth_delta)
+        descriptor_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(descriptor_pointer),
+            IrRegister(frame_reg),
+            IrRegister(self._const_reg(symbol.slot_offset)),
+        )
+        return descriptor_pointer
 
     def _emit_call_switch_eval(
         self,
@@ -3354,6 +3535,23 @@ class AlgolIrCompiler:
             value_reg=caller_frame_reg,
             base_reg=descriptor,
             offset=_SWITCH_DESCRIPTOR_CALLER_FRAME_OFFSET,
+        )
+
+    def _emit_write_procedure_descriptor(
+        self,
+        descriptor: int,
+        procedure_id: int,
+        static_link_reg: int,
+    ) -> None:
+        self._store_word_const(
+            descriptor,
+            _PROCEDURE_DESCRIPTOR_ID_OFFSET,
+            procedure_id,
+        )
+        self._store_word_reg(
+            value_reg=static_link_reg,
+            base_reg=descriptor,
+            offset=_PROCEDURE_DESCRIPTOR_STATIC_LINK_OFFSET,
         )
 
     def _compile_procedures(
@@ -3578,6 +3776,55 @@ class AlgolIrCompiler:
             self._label(else_label)
             self._label(end_label)
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
+        self._emit_zero_result_reg()
+        self._emit(IrOp.RET)
+        self.current_function_return_type = previous_return_type
+
+    def _compile_procedure_call_dispatcher(self) -> None:
+        previous_return_type = self.current_function_return_type
+        self.current_function_return_type = _INTEGER_TYPE
+        self._label(_PROCEDURE_CALL_LABEL)
+        descriptor = _STATIC_LINK_PARAM_REG
+        active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
+        procedure_id = self._fresh_reg()
+        static_link = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(procedure_id),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_PROCEDURE_DESCRIPTOR_ID_OFFSET)),
+        )
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(static_link),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_PROCEDURE_DESCRIPTOR_STATIC_LINK_OFFSET)),
+        )
+        for procedure in self.procedures.values():
+            if procedure.return_type is not None or procedure.parameters:
+                continue
+            index = self.if_count
+            self.if_count += 1
+            else_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(procedure_id),
+                IrRegister(self._const_reg(procedure.procedure_id)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            self._emit(
+                IrOp.CALL,
+                IrLabel(procedure.label),
+                IrRegister(static_link),
+                IrRegister(active_thunk_heap_mark),
+            )
+            self._emit(IrOp.RET)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            self._label(end_label)
         self._emit_zero_result_reg()
         self._emit(IrOp.RET)
         self.current_function_return_type = previous_return_type

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -753,6 +753,34 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_procedure_parameter_call_and_dispatcher(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure twice(p); procedure p; begin p; p end; "
+                "procedure bump; begin result := result + 1 end; "
+                "result := 0; twice(bump) "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert result.procedure_signatures["_fn_algol_call_procedure"].param_count == 2
+        assert "_fn_algol_call_procedure" in labels
+        assert any(
+            instruction.operands[0].name == "_fn_algol_call_procedure"
+            for instruction in calls
+        )
+
     def test_compiles_dynamic_multidimensional_array_bounds(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -36,14 +36,14 @@ switch selections and nonlocal conditional/switch designational branches remain
 guarded with targeted diagnostics. Switch entries that recursively select
 another switch are also guarded until the later dispatch-lowering phase.
 
-Unsupported ALGOL 60 features, including switch- and procedure-valued
-parameters, are reported as diagnostics instead of being silently accepted by
-the compiled pipeline. By-name parameters are accepted in the semantic model,
-while later lowering packages now implement scalar call-by-name, typed
-whole-array formals, label formals, and switch formals. The checker keeps
-guarding the remaining full-ALGOL gaps, including non-assignable actuals
-passed to written by-name formals, non-integer by-name types, value
-array/label/switch parameters, and procedure-valued parameters.
+Unsupported ALGOL 60 features are reported as diagnostics instead of being
+silently accepted by the compiled pipeline. By-name parameters are accepted in
+the semantic model, while later lowering packages now implement scalar
+call-by-name, typed whole-array formals, label formals, switch formals, and
+no-argument statement procedure formals. The checker keeps guarding the
+remaining full-ALGOL gaps, including non-assignable actuals passed to written
+by-name formals, value array/label/switch/procedure parameters, and richer
+procedure-valued parameters with arguments or return values.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -220,6 +220,7 @@ class ProcedureDescriptor:
     parameters: tuple[ProcedureParameter, ...]
     line: int
     column: int
+    parameter_symbol_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -238,6 +239,7 @@ class ResolvedProcedureCall:
     return_type: str | None
     line: int
     column: int
+    parameter_symbol_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -804,10 +806,13 @@ class AlgolTypeChecker:
                     )
                 parameter_type = SWITCH
             elif parameter_kind == "procedure":
-                self._error(
-                    formal,
-                    f"{parameter_kind} parameter {formal.value!r} is not supported yet",
-                )
+                if mode == VALUE:
+                    self._error(
+                        formal,
+                        f"value parameter {formal.value!r} cannot be a procedure in "
+                        "this phase",
+                    )
+                parameter_type = "procedure"
             elif mode == NAME and parameter_type not in {
                 INTEGER,
                 BOOLEAN,
@@ -895,13 +900,13 @@ class AlgolTypeChecker:
             elif parameter_kind == SWITCH:
                 parameter_type = SWITCH
             elif parameter_kind == "procedure":
-                parameter_kind = "scalar"
+                parameter_type = "procedure"
             param_symbol = Symbol(
                 name=formal.value,
                 type_name=(
                     parameter_type
                     if parameter_type
-                    in {INTEGER, BOOLEAN, REAL, STRING, LABEL, SWITCH}
+                    in {INTEGER, BOOLEAN, REAL, STRING, LABEL, SWITCH, "procedure"}
                     else INTEGER
                 ),
                 line=formal.line,
@@ -910,6 +915,8 @@ class AlgolTypeChecker:
                 kind=(
                     parameter_kind
                     if parameter_kind in {ARRAY, LABEL, SWITCH}
+                    else "procedure_parameter"
+                    if parameter_kind == "procedure"
                     else "parameter"
                 ),
                 storage_class=(
@@ -1763,6 +1770,9 @@ class AlgolTypeChecker:
             if parameter.kind == SWITCH:
                 self._check_switch_parameter_actual(argument, scope, parameter)
                 continue
+            if parameter.kind == "procedure":
+                self._check_procedure_parameter_actual(argument, scope, parameter)
+                continue
             actual_type = self._infer_expr(argument, scope)
             if descriptor.procedure_id == -1:
                 if actual_type != ERROR and actual_type not in {
@@ -1827,6 +1837,7 @@ class AlgolTypeChecker:
             return_type=descriptor.return_type,
             line=name_token.line,
             column=name_token.column,
+            parameter_symbol_id=descriptor.parameter_symbol_id,
         )
         self.resolved_procedure_calls.append(call)
         return call
@@ -1940,6 +1951,61 @@ class AlgolTypeChecker:
             return None
         return symbol
 
+    def _check_procedure_parameter_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        parameter: ProcedureParameter,
+    ) -> Symbol | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            self._error(
+                argument,
+                f"procedure parameter {parameter.name!r} expects a direct "
+                "procedure actual",
+            )
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            self._error(argument, "procedure actual is missing a name")
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            self._error(
+                name,
+                f"{name.value!r} is not declared in block {scope.block_id} "
+                "or its lexical parents",
+            )
+            return None
+        symbol, _, _ = resolved
+        if symbol.kind == "procedure_parameter":
+            return symbol
+        if symbol.kind != "procedure" or symbol.procedure_id is None:
+            self._error(
+                name,
+                f"procedure parameter {parameter.name!r} expects a procedure actual",
+            )
+            return None
+        descriptor = next(
+            (
+                procedure
+                for procedure in self.semantic_procedures
+                if procedure.procedure_id == symbol.procedure_id
+            ),
+            None,
+        )
+        if descriptor is None:
+            self._error(name, f"procedure {name.value!r} has no descriptor")
+            return None
+        if descriptor.return_type is not None or descriptor.parameters:
+            self._error(
+                name,
+                f"procedure parameter {parameter.name!r} expects a no-argument "
+                "statement procedure actual in this phase",
+            )
+            return None
+        return symbol
+
     def _resolve_builtin_procedure(
         self,
         token: Token,
@@ -1999,6 +2065,24 @@ class AlgolTypeChecker:
                 if descriptor is None:
                     return None
                 return descriptor, current, lexical_depth_delta
+            if symbol is not None and symbol.kind == "procedure_parameter":
+                return (
+                    ProcedureDescriptor(
+                        procedure_id=-2,
+                        name=token.value,
+                        label="__algol_dynamic_procedure_parameter",
+                        declaring_block_id=current.block_id,
+                        body_block_id=current.block_id,
+                        body_node_id=-1,
+                        return_type=None,
+                        parameters=tuple(),
+                        line=token.line,
+                        column=token.column,
+                        parameter_symbol_id=symbol.symbol_id,
+                    ),
+                    current,
+                    lexical_depth_delta,
+                )
             current = current.parent
             lexical_depth_delta += 1
         return None

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -739,6 +739,58 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "cannot be a switch in this phase" in result.diagnostics[0].message
 
+    def test_accepts_procedure_parameter_and_direct_procedure_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure twice(p); procedure p; begin p; p end; "
+            "procedure bump; begin result := result + 1 end; "
+            "result := 0; twice(bump) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "procedure"
+        assert parameter.type_name == "procedure"
+        formal_call = next(
+            call
+            for call in result.semantic.procedure_calls
+            if call.name == "p"
+        )
+        assert formal_call.parameter_symbol_id == parameter.symbol_id
+
+    def test_rejects_procedure_parameter_with_argument_actual_in_this_phase(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p end; "
+            "procedure set(x); value x; integer x; begin result := x end; "
+            "invoke(set) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "expects a no-argument statement procedure actual in this phase"
+            in result.diagnostics[0].message
+        )
+
+    def test_rejects_value_procedure_parameter_in_this_phase(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure invoke(p); value p; procedure p; begin end; "
+            "result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "cannot be a procedure in this phase" in result.diagnostics[0].message
+
     def test_accepts_integer_array_descriptor_and_accesses(self) -> None:
         ast = parse_algol(
             "begin integer result, lo, hi; "

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,7 @@ already supports a substantial ALGOL 60 surface:
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
 - value and by-name parameters, including Jensen-style expression thunks and
-  typed whole-array, label, and switch formals
+  typed whole-array, label, switch, and no-argument statement procedure formals
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   non-recursive switch entries
@@ -70,7 +70,7 @@ local WASM runtime. Those fixtures cover:
 
 - mixed scalar and array computation with output
 - Jensen-style by-name procedure calls
-- switch dispatch and procedure-crossing `goto`
+- switch dispatch, procedure-formal dispatch, and procedure-crossing `goto`
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -546,6 +546,29 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_procedure_parameter_statement_call_dispatches_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure twice(p); procedure p; begin p; p end; "
+            "procedure bump; begin result := result + 1 end; "
+            "result := 0; twice(bump) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_forwarded_procedure_parameter_propagates_descriptor_through_calls(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p end; "
+            "procedure relay(p); procedure p; begin invoke(p) end; "
+            "procedure bump; begin result := result + 3 end; "
+            "result := 2; relay(bump) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
     def test_repeated_switch_designational_gotos_use_distinct_dispatch(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- Add type-checker support for no-argument statement procedure formals and direct/forwarded procedure actual validation.
- Lower procedure formals through descriptor closures and an IR dispatcher helper for dynamic formal calls.
- Add IR and WASM coverage for direct procedure actual dispatch and forwarded procedure parameters, plus README updates for the new support boundary.

## Validation
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k "not array_failure_in_procedure_unwinds_before_caller_continues" -q`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -k "procedure_parameter" -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m ruff check --select F,E9 code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Security Review
- No new host filesystem, network, subprocess, deserialization, or secrets handling.
- New behavior is limited to guest-language semantic validation and IR/WASM descriptor dispatch for already-compiled ALGOL procedures.
- Explicit scan only matched existing compiler token identifiers/test names; no new risky host APIs were introduced.