### PR TITLE
Converge ALGOL expression semantics for WASM

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -50,7 +50,8 @@ program      = block ;
 # The grammar enforces declaration-before-use at the block level.
 # Blocks can nest: any statement position can hold another block.
 # The statement list is optional — `begin end` is a valid empty block.
-block        = "begin" { declaration SEMICOLON } [ statement { SEMICOLON statement } ] "end" ;
+block        = "begin" { declaration SEMICOLON } { SEMICOLON }
+               [ statement { SEMICOLON [ statement ] } ] "end" ;
 
 # ---------------------------------------------------------------------------
 # Declarations
@@ -166,7 +167,8 @@ cond_stmt    = "if" bool_expr "then" unlabeled_stmt [ "else" statement ] ;
 
 # A compound statement is begin...end with only statements, no declarations.
 # Use a full block when declarations are needed.
-compound_stmt = "begin" statement { SEMICOLON statement } "end" ;
+compound_stmt = "begin" { SEMICOLON }
+                [ statement { SEMICOLON [ statement ] } ] "end" ;
 
 # Assignment. Multiple left-hand sides assign the same value right-to-left.
 #   x := 0          simple assignment
@@ -227,7 +229,8 @@ for_elem     = arith_expr "step" arith_expr "until" arith_expr
 # needs the full unified hierarchy.  Rules used in type-specific contexts
 # (arith_expr for bounds/subscripts, bool_expr for conditionals) are
 # kept as-is.
-expression   = expr_eqv ;
+expression   = "if" bool_expr "then" expression "else" expression
+             | expr_eqv ;
 
 expr_eqv     = expr_impl { "eqv" expr_impl } ;
 expr_impl    = expr_or { "impl" expr_or } ;

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable changes to this package will be documented in this file.
   runtime failure for out-of-range switch indexes.
 - Lowered Phase 7b direct nonlocal block `goto` statements by unwinding exited
   block frames before jumping to the outer ALGOL label.
+- Lowered chained assignments, branch-selected conditional expressions, and
+  ALGOL-left-associative exponentiation for numeric bases with integer
+  exponents.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -22,6 +22,13 @@ checked element loads/stores through the descriptor. Block and procedure exits
 restore the heap pointer to the activation's entry mark, so dynamic arrays keep
 ALGOL block lifetime instead of leaking through loops or recursive calls.
 
+Expression lowering includes mixed integer/real arithmetic, boolean operators,
+comparisons, chained assignment targets, branch-selected conditional
+expressions, and ALGOL-left-associative exponentiation when the exponent is an
+integer. Real bases with negative integer exponents are lowered through a
+reciprocal path; arbitrary real exponents remain outside this phase until the
+runtime has a real `pow` implementation instead of an approximation shortcut.
+
 Scalar by-name parameters lower through a one-word cell in the callee frame.
 Passing a scalar variable as a by-name actual gives the callee a storage pointer,
 so assignments to the formal write back to the caller slot while value

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -999,7 +999,11 @@ class AlgolIrCompiler:
         simple = _first_direct_node(node, "simple_desig")
         if simple is None:
             raise CompileError("unsupported designational expression")
-        self._compile_simple_designational(simple, scope, execution_scope=execution_scope)
+        self._compile_simple_designational(
+            simple,
+            scope,
+            execution_scope=execution_scope,
+        )
 
     def _compile_simple_designational(
         self,
@@ -1172,7 +1176,10 @@ class AlgolIrCompiler:
         descriptor = self.switches.get(selection.switch_id)
         if descriptor is None:
             raise CompileError(f"switch {selection.name!r} has no descriptor")
-        entry_scope = self._active_scope_for_block(selection.declaration_block_id, scope)
+        entry_scope = self._active_scope_for_block(
+            selection.declaration_block_id,
+            scope,
+        )
         dispatch_index = self.switch_count
         self.switch_count += 1
         for entry_index, entry_node_id in enumerate(descriptor.entry_node_ids, start=1):
@@ -1349,34 +1356,52 @@ class AlgolIrCompiler:
         )
 
     def _compile_assignment(self, assign: ASTNode, scope: _FrameScope) -> None:
-        left_part = _first_direct_node(assign, "left_part")
+        left_parts = _direct_nodes(assign, "left_part")
         expr = _first_direct_node(assign, "expression")
-        variable = _first_node(left_part, "variable") if left_part is not None else None
-        if variable is None or expr is None:
+        if not left_parts or expr is None:
             raise CompileError("assignment needs a variable target and expression")
         value = self._compile_expr(expr, scope)
+        expr_type = self._expr_type(expr)
+        for left_part in reversed(left_parts):
+            variable = _first_node(left_part, "variable")
+            if variable is None:
+                raise CompileError("assignment target must be a variable")
+            self._compile_assignment_target(
+                variable,
+                value,
+                expr_type,
+                scope,
+            )
+
+    def _compile_assignment_target(
+        self,
+        variable: ASTNode,
+        value: int,
+        value_type: str,
+        scope: _FrameScope,
+    ) -> None:
         if _variable_subscripts(variable):
             name = _variable_head_name(variable)
             if name is None:
                 raise CompileError("array assignment target is missing a name")
             access = self._require_array_access(name, "write")
-            value = self._coerce_reg_to_type(
+            coerced = self._coerce_reg_to_type(
                 value,
-                self._expr_type(expr),
+                value_type,
                 expected_type=self.arrays[access.array_id].element_type,
             )
-            self._compile_array_store(variable, scope, value)
+            self._compile_array_store(variable, scope, coerced)
             return
         name = _variable_name(variable)
         if name is None:
             raise CompileError("only scalar assignments are supported")
         target = self._require_reference(name, "write")
-        value = self._coerce_reg_to_type(
+        coerced = self._coerce_reg_to_type(
             value,
-            self._expr_type(expr),
+            value_type,
             expected_type=target.type_name,
         )
-        self._emit_store_reference(target, scope, value)
+        self._emit_store_reference(target, scope, coerced)
 
     def _compile_if(self, cond: ASTNode, scope: _FrameScope) -> None:
         index = self.if_count
@@ -2049,6 +2074,18 @@ class AlgolIrCompiler:
         meaningful = _meaningful_children(expr)
         if not meaningful:
             raise CompileError(f"empty expression node {expr.rule_name}")
+
+        conditional = _conditional_expression_parts(meaningful)
+        if conditional is not None:
+            condition, then_expr, else_expr = conditional
+            return self._compile_conditional_expression(
+                expr,
+                condition,
+                then_expr,
+                else_expr,
+                scope,
+            )
+
         if len(meaningful) == 1:
             return self._compile_expr(meaningful[0], scope)
 
@@ -2117,17 +2154,57 @@ class AlgolIrCompiler:
             "expression",
             "arith_expr",
             "bool_expr",
-            "expr_pow",
-            "factor",
         }:
+            return self._compile_expr(meaningful[0], scope)
+
+        if expr.rule_name in {"expr_pow", "factor"}:
             if any(
                 isinstance(child, Token) and child.value in {"**", "^"}
                 for child in meaningful
             ):
-                raise CompileError("exponentiation is not supported yet")
+                return self._compile_power_chain(meaningful, scope)
             return self._compile_expr(meaningful[0], scope)
 
         return self._compile_expr(meaningful[0], scope)
+
+    def _compile_conditional_expression(
+        self,
+        node: ASTNode,
+        condition: ASTNode,
+        then_expr: ASTNode,
+        else_expr: ASTNode,
+        scope: _FrameScope,
+    ) -> int:
+        index = self.if_count
+        self.if_count += 1
+        else_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        result_type = self._expr_type(node)
+        result = self._fresh_reg()
+
+        condition_reg = self._compile_expr(condition, scope)
+        self._emit(IrOp.BRANCH_Z, IrRegister(condition_reg), IrLabel(else_label))
+
+        then_value = self._compile_expr(then_expr, scope)
+        then_value = self._coerce_reg_to_type(
+            then_value,
+            self._expr_type(then_expr),
+            expected_type=result_type,
+        )
+        self._copy_scalar_reg(type_name=result_type, dst=result, src=then_value)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+
+        self._label(else_label)
+        else_value = self._compile_expr(else_expr, scope)
+        else_value = self._coerce_reg_to_type(
+            else_value,
+            self._expr_type(else_expr),
+            expected_type=result_type,
+        )
+        self._copy_scalar_reg(type_name=result_type, dst=result, src=else_value)
+
+        self._label(end_label)
+        return result
 
     def _compile_token(self, token: Token, scope: _FrameScope) -> int:
         if token.type_name == "INTEGER_LIT":
@@ -2166,6 +2243,31 @@ class AlgolIrCompiler:
                 operator.value,
                 current_type,
                 right_type,
+            )
+            index += 2
+        return current
+
+    def _compile_power_chain(
+        self, children: list[ASTNode | Token], scope: _FrameScope
+    ) -> int:
+        current = self._compile_expr(children[0], scope)
+        current_type = self._expr_type(children[0])
+        index = 1
+        while index < len(children):
+            operator = children[index]
+            exponent = self._compile_expr(children[index + 1], scope)
+            if not isinstance(operator, Token):
+                raise CompileError("expected exponentiation operator")
+            if operator.value not in {"**", "^"}:
+                raise CompileError(
+                    f"numeric operator {operator.value!r} is not supported"
+                )
+            exponent_type = self._expr_type(children[index + 1])
+            if exponent_type != _INTEGER_TYPE:
+                raise CompileError("exponentiation exponent must be integer")
+            current = self._emit_power(current, current_type, exponent)
+            current_type = (
+                _REAL_TYPE if current_type == _REAL_TYPE else _INTEGER_TYPE
             )
             index += 2
         return current
@@ -2403,6 +2505,130 @@ class AlgolIrCompiler:
         else:
             raise CompileError(f"numeric operator {operator!r} is not supported")
         return dst
+
+    def _emit_power(self, base: int, base_type: str, exponent: int) -> int:
+        if base_type == _REAL_TYPE:
+            return self._emit_real_integer_power(base, exponent)
+        return self._emit_integer_power(base, exponent)
+
+    def _emit_integer_power(self, base: int, exponent: int) -> int:
+        index = self.if_count
+        self.if_count += 1
+        negative_label = f"pow_{index}_negative"
+        loop_label = f"pow_{index}_loop"
+        end_label = f"pow_{index}_end"
+        result = self._const_reg(1)
+        remaining = self._fresh_reg()
+        self._copy_reg(dst=remaining, src=exponent)
+        is_negative = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(is_negative),
+            IrRegister(remaining),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(is_negative), IrLabel(negative_label))
+        self._label(loop_label)
+        done = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(done),
+            IrRegister(remaining),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(done), IrLabel(end_label))
+        next_result = self._fresh_reg()
+        self._emit(
+            IrOp.MUL,
+            IrRegister(next_result),
+            IrRegister(result),
+            IrRegister(base),
+        )
+        self._copy_reg(dst=result, src=next_result)
+        next_remaining = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_remaining),
+            IrRegister(remaining),
+            IrImmediate(-1),
+        )
+        self._copy_reg(dst=remaining, src=next_remaining)
+        self._emit(IrOp.JUMP, IrLabel(loop_label))
+        self._label(negative_label)
+        self._copy_reg(dst=result, src=_ZERO_REG)
+        self._label(end_label)
+        return result
+
+    def _emit_real_integer_power(self, base: int, exponent: int) -> int:
+        index = self.if_count
+        self.if_count += 1
+        negative_label = f"pow_{index}_negative"
+        prepare_loop_label = f"pow_{index}_prepare_loop"
+        loop_label = f"pow_{index}_loop"
+        reciprocal_label = f"pow_{index}_reciprocal"
+        end_label = f"pow_{index}_end"
+        result = self._const_f64_reg(1.0)
+        remaining = self._fresh_reg()
+        self._copy_reg(dst=remaining, src=exponent)
+        negative = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(negative),
+            IrRegister(remaining),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(negative), IrLabel(negative_label))
+        self._emit(IrOp.JUMP, IrLabel(prepare_loop_label))
+        self._label(negative_label)
+        zero = self._const_reg(0)
+        absolute = self._fresh_reg()
+        self._emit(
+            IrOp.SUB,
+            IrRegister(absolute),
+            IrRegister(zero),
+            IrRegister(remaining),
+        )
+        self._copy_reg(dst=remaining, src=absolute)
+        self._label(prepare_loop_label)
+        self._label(loop_label)
+        done = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(done),
+            IrRegister(remaining),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(done), IrLabel(reciprocal_label))
+        next_result = self._fresh_reg()
+        self._emit(
+            IrOp.F64_MUL,
+            IrRegister(next_result),
+            IrRegister(result),
+            IrRegister(base),
+        )
+        self._copy_scalar_reg(type_name=_REAL_TYPE, dst=result, src=next_result)
+        next_remaining = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_remaining),
+            IrRegister(remaining),
+            IrImmediate(-1),
+        )
+        self._copy_reg(dst=remaining, src=next_remaining)
+        self._emit(IrOp.JUMP, IrLabel(loop_label))
+        self._label(reciprocal_label)
+        self._emit(IrOp.BRANCH_Z, IrRegister(negative), IrLabel(end_label))
+        one = self._const_f64_reg(1.0)
+        reciprocal = self._fresh_reg()
+        self._emit(
+            IrOp.F64_DIV,
+            IrRegister(reciprocal),
+            IrRegister(one),
+            IrRegister(result),
+        )
+        self._copy_scalar_reg(type_name=_REAL_TYPE, dst=result, src=reciprocal)
+        self._label(end_label)
+        return result
 
     def _invert_bool(self, source: int) -> int:
         dst = self._fresh_reg()
@@ -4413,7 +4639,12 @@ class AlgolIrCompiler:
                 IrRegister(base_reg),
                 IrLabel(_STATIC_MEMORY_LABEL),
             )
-            self._emit_load_scalar(symbol.type_name, dst_reg, base_reg, symbol.slot_offset)
+            self._emit_load_scalar(
+                symbol.type_name,
+                dst_reg,
+                base_reg,
+                symbol.slot_offset,
+            )
             return
         if symbol.declaring_block_id != scope.block_id:
             raise CompileError(f"symbol {symbol.name!r} does not belong to root block")
@@ -5141,6 +5372,45 @@ def _meaningful_children(node: ASTNode) -> list[ASTNode | Token]:
         for child in node.children
         if not (isinstance(child, Token) and child.value in {"(", ")"})
     ]
+
+
+def _conditional_expression_parts(
+    children: list[ASTNode | Token],
+) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    first = children[0] if children else None
+    if not isinstance(first, Token) or first.value != "if":
+        return None
+    then_index = _keyword_child_index(children, "then")
+    else_index = _keyword_child_index(children, "else")
+    if then_index is None or else_index is None or then_index >= else_index:
+        return None
+    condition = _first_ast_child_between(children, 1, then_index)
+    then_expr = _first_ast_child_between(children, then_index + 1, else_index)
+    else_expr = _first_ast_child_between(children, else_index + 1, len(children))
+    if condition is None or then_expr is None or else_expr is None:
+        return None
+    return condition, then_expr, else_expr
+
+
+def _keyword_child_index(
+    children: list[ASTNode | Token],
+    keyword: str,
+) -> int | None:
+    for index, child in enumerate(children):
+        if isinstance(child, Token) and child.value == keyword:
+            return index
+    return None
+
+
+def _first_ast_child_between(
+    children: list[ASTNode | Token],
+    start: int,
+    end: int,
+) -> ASTNode | None:
+    return next(
+        (child for child in children[start:end] if isinstance(child, ASTNode)),
+        None,
+    )
 
 
 def _first_node(node: ASTNode, rule_name: str) -> ASTNode | None:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -2,12 +2,12 @@
 
 import pytest
 from algol_parser import parse_algol
-from algol_ir_compiler.compiler import _MAX_STRING_OUTPUT_BYTES, _MAX_TOTAL_OUTPUT_BYTES
 from algol_type_checker import FRAME_WORD_SIZE, FrameSlot, check_algol
 from compiler_ir import IrOp
 from lang_parser import ASTNode
 
 from algol_ir_compiler import CompileError, __version__, compile_algol
+from algol_ir_compiler.compiler import _MAX_STRING_OUTPUT_BYTES, _MAX_TOTAL_OUTPUT_BYTES
 
 
 class TestVersion:
@@ -40,6 +40,15 @@ class TestAlgolIrCompiler:
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
         assert opcodes.index(IrOp.MUL) < opcodes.index(IrOp.ADD)
+
+    def test_compiles_conditional_expression_value(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; result := if true then 1 else 2 end")
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert IrOp.BRANCH_Z in opcodes
+        assert IrOp.JUMP in opcodes
+        assert opcodes.count(IrOp.STORE_WORD) >= 1
 
     def test_compiles_structured_if_labels(self) -> None:
         result = compile_algol(
@@ -117,7 +126,9 @@ class TestAlgolIrCompiler:
 
     def test_compiles_own_scalar_to_static_storage(self) -> None:
         result = compile_algol(
-            parse_algol("begin own integer counter; integer result; result := counter end")
+            parse_algol(
+                "begin own integer counter; integer result; result := counter end"
+            )
         )
         data_labels = [decl.label for decl in result.program.data]
         load_addr_labels = [
@@ -184,9 +195,13 @@ class TestAlgolIrCompiler:
         assert "loop_0_start" in labels
         assert "loop_0_end" in labels
 
-    def test_compiles_string_variable_assignment_to_static_literal_descriptor(self) -> None:
+    def test_compiles_string_variable_assignment_to_static_literal_descriptor(
+        self,
+    ) -> None:
         result = compile_algol(
-            parse_algol("begin string msg; integer result; msg := 'Hi'; result := 1 end")
+            parse_algol(
+                "begin string msg; integer result; msg := 'Hi'; result := 1 end"
+            )
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
         data_labels = [decl.label for decl in result.program.data]
@@ -204,7 +219,8 @@ class TestAlgolIrCompiler:
     def test_compiles_string_variable_output_to_descriptor_loop(self) -> None:
         result = compile_algol(
             parse_algol(
-                "begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end"
+                "begin string msg; integer result; msg := 'Hi'; "
+                "print(msg); result := 1 end"
             )
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
@@ -221,7 +237,8 @@ class TestAlgolIrCompiler:
     def test_compiles_string_output_guards_for_length_and_total_bytes(self) -> None:
         result = compile_algol(
             parse_algol(
-                "begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end"
+                "begin string msg; integer result; msg := 'Hi'; "
+                "print(msg); result := 1 end"
             )
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
@@ -995,9 +1012,27 @@ class TestAlgolIrCompiler:
         with pytest.raises(CompileError, match="result"):
             compile_algol(parse_algol("begin integer x; x := 1 end"))
 
-    def test_raises_for_unsupported_exponentiation(self) -> None:
-        with pytest.raises(CompileError):
-            compile_algol(parse_algol("begin integer result; result := 2 ** 3 end"))
+    def test_compiles_integer_exponentiation_loop(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; result := 2 ** 3 end")
+        )
+
+        assert any(
+            instruction.opcode == IrOp.MUL
+            for instruction in result.program.instructions
+        )
+
+    def test_compiles_chained_assignment_right_to_left(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result, other; result := other := 1 end")
+        )
+
+        stores = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.STORE_WORD
+        ]
+        assert len(stores) >= 2
 
     def test_compiles_scalar_by_name_parameter_as_storage_pointer(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Unified `expression` parsing now accepts ALGOL conditional expressions such
+  as `if b then x else y` in assignment values and actual parameters.
+- Block and compound statement lists now tolerate repeated and trailing
+  semicolons, matching common ALGOL dummy-statement style.
+
 ## [0.1.0] — 2026-04-06
 
 ### Added

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -32,11 +32,10 @@ The ALGOL 60 grammar differs from JSON in several important ways:
 from __future__ import annotations
 
 import pytest
-
-from algol_parser import create_algol_parser, parse_algol
-from lang_parser import ASTNode, GrammarParser, GrammarParseError
+from lang_parser import ASTNode, GrammarParseError, GrammarParser
 from lexer import Token
 
+from algol_parser import create_algol_parser, parse_algol
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -136,9 +135,9 @@ class TestMinimalProgram:
                 else:
                     collect_tokens(child)
         collect_tokens(ast)
-        type_names = [get_type_name(t) for t in all_tokens]
-        assert "BEGIN" in type_names
-        assert "END" in type_names
+        token_values = [token.value for token in all_tokens]
+        assert "begin" in token_values
+        assert "end" in token_values
 
 
 # ---------------------------------------------------------------------------
@@ -210,10 +209,10 @@ class TestArithmeticExpression:
         ast = parse("begin integer x; x := 1 + 2 * 3 end")
         # The tree should contain a term node (for multiplication)
         # nested inside a simple_arith node (for addition).
-        term_nodes = find_nodes(ast, "term")
-        simple_arith_nodes = find_nodes(ast, "simple_arith")
-        assert len(term_nodes) >= 1
-        assert len(simple_arith_nodes) >= 1
+        product_nodes = find_nodes(ast, "expr_mul") + find_nodes(ast, "term")
+        sum_nodes = find_nodes(ast, "expr_add") + find_nodes(ast, "simple_arith")
+        assert len(product_nodes) >= 1
+        assert len(sum_nodes) >= 1
 
     def test_parenthesized_expression(self) -> None:
         """``(1 + 2) * 3`` parses correctly."""
@@ -239,6 +238,12 @@ class TestArithmeticExpression:
         """Exponentiation with ``^``."""
         ast = parse("begin real x; x := 2 ^ 10 end")
         assert ast.rule_name == "program"
+
+    def test_conditional_expression_assignment(self) -> None:
+        """ALGOL conditional expressions can appear as assignment values."""
+        ast = parse("begin integer x; x := if true then 1 else 2 end")
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "expression")
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +566,11 @@ class TestDeclarations:
         )
         type_decl_nodes = find_nodes(ast, "type_decl")
         assert len(type_decl_nodes) >= 3
+
+    def test_statement_list_allows_extra_semicolons(self) -> None:
+        """Statement lists tolerate dummy separators and trailing semicolons."""
+        ast = parse("begin integer x; ; x := 1;; x := 2; end")
+        assert ast.rule_name == "program"
 
     def test_own_scalar_declaration(self) -> None:
         """Own scalar declaration produces an own_decl node."""

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to this package will be documented in this file.
 - Added Phase 7b direct nonlocal block `goto` resolution within one
   procedure/function, while keeping procedure-crossing jumps and nonlocal
   designational branches guarded.
+- Added semantic checking for chained assignments, ALGOL conditional
+  expressions, and numeric exponentiation with integer exponents.
+- Accepted parser-tolerated repeated/trailing semicolons through existing
+  statement-list traversal.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -13,6 +13,12 @@ are direct nonlocal block `goto` statements that stay inside the same lowered
 function. Local switch declarations, switch selections, and conditional
 designational `goto` forms are also supported.
 
+The expression checker also accepts chained assignments, ALGOL conditional
+expressions, tolerant trailing/repeated semicolons from the parser, and
+left-associative exponentiation for numeric bases with integer exponents.
+Mixed integer/real conditional branches resolve to `real`; incompatible branch
+types are still rejected before IR lowering.
+
 The checker also builds the first ALGOL 60 full-runtime semantic model. Each
 source block receives a stable block id, lexical depth, static-parent id, and a
 planned frame layout. Scalar declarations are assigned explicit frame slots,

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1344,56 +1344,60 @@ class AlgolTypeChecker:
 
     def _check_assignment(self, assign: ASTNode, scope: Scope) -> None:
         left_parts = _direct_nodes(assign, "left_part")
-        if len(left_parts) != 1:
-            self._error(assign, "chained assignment is not supported yet")
+        if not left_parts:
+            self._error(assign, "assignment needs at least one target")
             return
-
-        variable = _first_node(left_parts[0], "variable")
-        if variable is None:
-            self._error(left_parts[0], "assignment target must be a variable")
-            return
-
-        name = _variable_head_name(variable)
-        if name is None:
-            self._error(left_parts[0], "assignment target is missing a name")
-            return
-
-        if _variable_subscripts(variable):
-            access = self._check_array_access(variable, scope, role="write")
-            if access is None:
-                target_type = ERROR
-            else:
-                descriptor = next(
-                    (
-                        array
-                        for array in self.semantic_arrays
-                        if array.array_id == access.array_id
-                    ),
-                    None,
-                )
-                target_type = ERROR if descriptor is None else descriptor.element_type
-        else:
-            symbol = self._resolve_name(name, scope, role="write")
-            if symbol is not None and symbol.kind == ARRAY:
-                self._error(name, f"array {name.value!r} requires subscripts")
-                target_type = ERROR
-            elif symbol is not None and symbol.kind == LABEL:
-                self._error(name, f"label {name.value!r} is not assignable")
-                target_type = ERROR
-            else:
-                target_type = ERROR if symbol is None else symbol.type_name
 
         expr = _first_direct_node(assign, "expression")
         value_type = self._infer_expr(expr, scope) if expr is not None else ERROR
-        if (
-            target_type != ERROR
-            and value_type != ERROR
-            and not self._can_assign(target_type, value_type)
-        ):
-            self._error(
-                name,
-                f"cannot assign {value_type} to {target_type} variable {name.value!r}",
-            )
+        for left_part in left_parts:
+            variable = _first_node(left_part, "variable")
+            if variable is None:
+                self._error(left_part, "assignment target must be a variable")
+                continue
+
+            name = _variable_head_name(variable)
+            if name is None:
+                self._error(left_part, "assignment target is missing a name")
+                continue
+
+            if _variable_subscripts(variable):
+                access = self._check_array_access(variable, scope, role="write")
+                if access is None:
+                    target_type = ERROR
+                else:
+                    descriptor = next(
+                        (
+                            array
+                            for array in self.semantic_arrays
+                            if array.array_id == access.array_id
+                        ),
+                        None,
+                    )
+                    target_type = (
+                        ERROR if descriptor is None else descriptor.element_type
+                    )
+            else:
+                symbol = self._resolve_name(name, scope, role="write")
+                if symbol is not None and symbol.kind == ARRAY:
+                    self._error(name, f"array {name.value!r} requires subscripts")
+                    target_type = ERROR
+                elif symbol is not None and symbol.kind == LABEL:
+                    self._error(name, f"label {name.value!r} is not assignable")
+                    target_type = ERROR
+                else:
+                    target_type = ERROR if symbol is None else symbol.type_name
+
+            if (
+                target_type != ERROR
+                and value_type != ERROR
+                and not self._can_assign(target_type, value_type)
+            ):
+                self._error(
+                    name,
+                    f"cannot assign {value_type} to {target_type} variable "
+                    f"{name.value!r}",
+                )
 
     def _check_cond(self, cond: ASTNode, scope: Scope) -> None:
         bool_expr = _first_direct_node(cond, "bool_expr")
@@ -1433,7 +1437,10 @@ class AlgolTypeChecker:
             bool_node = _first_direct_node(elem, "bool_expr")
             if bool_node is not None:
                 if len(arith_nodes) != 1:
-                    self._error(elem, "for while-element must have one value expression")
+                    self._error(
+                        elem,
+                        "for while-element must have one value expression",
+                    )
                     continue
                 start_type = self._infer_expr(arith_nodes[0], scope)
                 if (
@@ -1448,7 +1455,10 @@ class AlgolTypeChecker:
                     )
                 condition_type = self._infer_expr(bool_node, scope)
                 if condition_type != ERROR and condition_type != BOOLEAN:
-                    self._error(bool_node, "for while-element condition must be boolean")
+                    self._error(
+                        bool_node,
+                        "for while-element condition must be boolean",
+                    )
                 continue
             if len(arith_nodes) == 1:
                 value_type = self._infer_expr(arith_nodes[0], scope)
@@ -1555,6 +1565,17 @@ class AlgolTypeChecker:
         if not meaningful:
             return ERROR
 
+        conditional = _conditional_expression_parts(meaningful)
+        if conditional is not None:
+            condition, then_expr, else_expr = conditional
+            return self._infer_conditional_expression(
+                expr,
+                condition,
+                then_expr,
+                else_expr,
+                scope,
+            )
+
         if len(meaningful) == 1:
             return self._infer_expr(meaningful[0], scope)
 
@@ -1599,8 +1620,7 @@ class AlgolTypeChecker:
                 isinstance(child, Token) and child.value in {"**", "^"}
                 for child in meaningful
             ):
-                self._error(expr, "exponentiation is not supported yet")
-                return ERROR
+                return self._infer_power_chain(expr, meaningful, scope)
             return self._infer_expr(meaningful[0], scope)
 
         if expr.rule_name in {"expr_atom", "primary", "bool_primary"}:
@@ -1622,6 +1642,35 @@ class AlgolTypeChecker:
             return self._infer_expr(meaningful[0], scope)
 
         return self._infer_expr(meaningful[0], scope)
+
+    def _infer_conditional_expression(
+        self,
+        node: ASTNode,
+        condition: ASTNode,
+        then_expr: ASTNode,
+        else_expr: ASTNode,
+        scope: Scope,
+    ) -> str:
+        condition_type = self._infer_expr(condition, scope)
+        then_type = self._infer_expr(then_expr, scope)
+        else_type = self._infer_expr(else_expr, scope)
+        if condition_type != ERROR and condition_type != BOOLEAN:
+            self._error(
+                node,
+                "conditional expression requires boolean condition, got "
+                f"{condition_type}",
+            )
+            return ERROR
+        if then_type == ERROR or else_type == ERROR:
+            return ERROR
+        result_type = _conditional_branch_type(then_type, else_type)
+        if result_type is None:
+            self._error(
+                node,
+                "conditional expression branches must have compatible types",
+            )
+            return ERROR
+        return result_type
 
     def _infer_token(self, token: Token, scope: Scope) -> str:
         if token.type_name == "INTEGER_LIT":
@@ -2208,6 +2257,42 @@ class AlgolTypeChecker:
             index += 2
         return current_type if saw_operator else self._infer_expr(children[0], scope)
 
+    def _infer_power_chain(
+        self,
+        node: ASTNode,
+        children: list[ASTNode | Token],
+        scope: Scope,
+    ) -> str:
+        current_type = self._infer_expr(children[0], scope)
+        if current_type == ERROR:
+            return ERROR
+        if not _is_numeric_type(current_type):
+            self._error(node, f"operator requires numeric operand, got {current_type}")
+            return ERROR
+
+        index = 1
+        while index < len(children):
+            operator = children[index]
+            exponent = children[index + 1]
+            exponent_type = self._infer_expr(exponent, scope)
+            if exponent_type == ERROR:
+                return ERROR
+            if not isinstance(operator, Token):
+                self._error(node, "expected exponentiation operator")
+                return ERROR
+            if operator.value not in {"**", "^"}:
+                self._error(
+                    node,
+                    f"numeric operator {operator.value!r} is not supported",
+                )
+                return ERROR
+            if exponent_type != INTEGER:
+                self._error(node, "exponentiation exponent must be integer")
+                return ERROR
+            current_type = REAL if current_type == REAL else INTEGER
+            index += 2
+        return current_type
+
     def _infer_numeric_comparison(
         self,
         node: ASTNode,
@@ -2270,6 +2355,14 @@ def check_algol(ast: ASTNode) -> TypeCheckResult:
 
 def _is_numeric_type(type_name: str) -> bool:
     return type_name in {INTEGER, REAL}
+
+
+def _conditional_branch_type(then_type: str, else_type: str) -> str | None:
+    if then_type == else_type:
+        return then_type
+    if _is_numeric_type(then_type) and _is_numeric_type(else_type):
+        return REAL if REAL in {then_type, else_type} else INTEGER
+    return None
 
 
 def check(ast: ASTNode) -> TypeCheckResult:
@@ -2346,6 +2439,45 @@ def _meaningful_children(node: ASTNode) -> list[ASTNode | Token]:
         for child in node.children
         if not (isinstance(child, Token) and child.value in {"(", ")"})
     ]
+
+
+def _conditional_expression_parts(
+    children: list[ASTNode | Token],
+) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    first = children[0] if children else None
+    if not isinstance(first, Token) or first.value != "if":
+        return None
+    then_index = _keyword_child_index(children, "then")
+    else_index = _keyword_child_index(children, "else")
+    if then_index is None or else_index is None or then_index >= else_index:
+        return None
+    condition = _first_ast_child_between(children, 1, then_index)
+    then_expr = _first_ast_child_between(children, then_index + 1, else_index)
+    else_expr = _first_ast_child_between(children, else_index + 1, len(children))
+    if condition is None or then_expr is None or else_expr is None:
+        return None
+    return condition, then_expr, else_expr
+
+
+def _keyword_child_index(
+    children: list[ASTNode | Token],
+    keyword: str,
+) -> int | None:
+    for index, child in enumerate(children):
+        if isinstance(child, Token) and child.value == keyword:
+            return index
+    return None
+
+
+def _first_ast_child_between(
+    children: list[ASTNode | Token],
+    start: int,
+    end: int,
+) -> ASTNode | None:
+    return next(
+        (child for child in children[start:end] if isinstance(child, ASTNode)),
+        None,
+    )
 
 
 def _first_node(node: ASTNode, rule_name: str) -> ASTNode | None:
@@ -2489,13 +2621,13 @@ def _by_name_formal_write_reasons(
             active_names = active_names - hidden
 
         if node.rule_name == "assign_stmt":
-            left_part = _first_direct_node(node, "left_part")
-            variable = _first_node(left_part, "variable") if left_part else None
-            record(
-                _variable_head_name_value(variable),
-                "local assignment",
-                active_names,
-            )
+            for left_part in _direct_nodes(node, "left_part"):
+                variable = _first_node(left_part, "variable")
+                record(
+                    _variable_head_name_value(variable),
+                    "local assignment",
+                    active_names,
+                )
         elif node.rule_name == "for_stmt":
             loop_token = next(
                 (token for token in _direct_tokens(node) if token.type_name == "NAME"),

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -318,11 +318,10 @@ class TestAlgolTypeChecker:
         )
         assert check_algol(ast).ok
 
-    def test_reports_chained_assignment(self) -> None:
+    def test_accepts_chained_assignment(self) -> None:
         ast = parse_algol("begin integer result, other; result := other := 1 end")
         result = check_algol(ast)
-        assert not result.ok
-        assert "chained assignment" in result.diagnostics[0].message
+        assert result.ok
 
     def test_accepts_real_division_and_integer_to_real_assignment(self) -> None:
         ast = parse_algol(
@@ -333,11 +332,45 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
         assert result.ok
 
-    def test_reports_unsupported_exponentiation(self) -> None:
+    def test_accepts_integer_exponentiation(self) -> None:
         ast = parse_algol("begin integer result; result := 2 ** 3 end")
         result = check_algol(ast)
+        assert result.ok
+
+    def test_rejects_real_exponent_for_exponentiation(self) -> None:
+        ast = parse_algol("begin real result; result := 2.0 ** 3.5 end")
+        result = check_algol(ast)
         assert not result.ok
-        assert "exponentiation is not supported" in result.diagnostics[0].message
+        assert (
+            "exponentiation exponent must be integer"
+            in result.diagnostics[0].message
+        )
+
+    def test_accepts_conditional_expression_assignment(self) -> None:
+        ast = parse_algol("begin integer result; result := if true then 1 else 2 end")
+        result = check_algol(ast)
+        assert result.ok
+
+    def test_accepts_mixed_numeric_conditional_expression_as_real(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; "
+            "x := if false then 1 else 2.5; "
+            "if x > 2.0 then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+        assert result.ok
+
+    def test_rejects_incompatible_conditional_expression_branches(self) -> None:
+        ast = parse_algol(
+            "begin integer result; result := if true then 1 else false end"
+        )
+        result = check_algol(ast)
+        assert not result.ok
+        assert (
+            "conditional expression branches must have compatible types"
+            in result.diagnostics[0].message
+        )
 
     def test_accepts_simple_for_element(self) -> None:
         ast = parse_algol("begin integer result, i; for i := 1 do result := i end")
@@ -1298,7 +1331,10 @@ class TestAlgolTypeChecker:
         assert result.root_scope.children[0].symbols["msg"].type_name == "string"
 
     def test_accepts_builtin_print_with_string_variable(self) -> None:
-        ast = parse_algol("begin string msg; integer result; msg := 'Hi'; print(msg); result := 1 end")
+        ast = parse_algol(
+            "begin string msg; integer result; msg := 'Hi'; "
+            "print(msg); result := 1 end"
+        )
         result = check_algol(ast)
 
         assert result.ok

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -37,6 +37,14 @@ All notable changes to this package will be documented in this file.
   `goto` forms through the WASM path, including conditional switch entries.
 - Executed Phase 7b direct nonlocal block `goto` statements through the WASM
   path with frame restoration before later block entry.
+- Executed chained assignments, ALGOL-left-associative exponentiation with
+  integer exponents, and branch-selected conditional expressions through the
+  full WASM path.
+- Accepted trailing and repeated semicolons in ALGOL block and compound
+  statement lists.
+- Added a convergence golden fixture that combines conditional expressions,
+  exponentiation, chained assignment, by-name array summation, real arithmetic,
+  and output in one end-to-end program.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -17,6 +17,8 @@ already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
+- chained assignment, conditional expressions, tolerant trailing/repeated
+  semicolons, and ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks and
   typed whole-array, label, switch, and no-argument statement procedure formals
 - labels, local and nonlocal `goto`, switch designators, and conditional
@@ -71,6 +73,8 @@ local WASM runtime. Those fixtures cover:
 - mixed scalar and array computation with output
 - Jensen-style by-name procedure calls
 - switch dispatch, procedure-formal dispatch, and procedure-crossing `goto`
+- conditional expressions, chained assignment, and exponentiation in the same
+  end-to-end program
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/compiler.py
@@ -149,22 +149,25 @@ def write_wasm_file(source: str, output_path: str | Path) -> AlgolWasmResult:
 
 def _wasm_lowering_strategy(program: IrProgram) -> str:
     for instruction in program.instructions:
-        if instruction.opcode != IrOp.LABEL:
+        if instruction.opcode not in (IrOp.BRANCH_NZ, IrOp.BRANCH_Z, IrOp.JUMP):
             continue
         if (
             instruction.operands
-            and isinstance(instruction.operands[0], IrLabel)
+            and isinstance(instruction.operands[-1], IrLabel)
+            and not _structured_lowerer_target(instruction.operands[-1].name)
         ):
-            label_name = instruction.operands[0].name
-            if label_name.startswith("algol_label_"):
-                return "dispatch_loop"
-            if label_name.startswith("loop_") and "_dispatch" in label_name:
-                return "dispatch_loop"
-            if label_name.startswith("loop_") and (
-                "_positive" in label_name or "_negative" in label_name
-            ):
-                return "dispatch_loop"
+            return "dispatch_loop"
     return "structured"
+
+
+def _structured_lowerer_target(label_name: str) -> bool:
+    parts = label_name.split("_")
+    if len(parts) != 3 or not parts[1].isdigit():
+        return False
+    prefix, _index, suffix = parts
+    return (prefix == "if" and suffix in {"else", "end"}) or (
+        prefix == "loop" and suffix in {"start", "end"}
+    )
 
 
 def _wasm_value_type(type_name: str | None) -> ValueType:

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/convergence.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/convergence.alg
@@ -1,0 +1,32 @@
+begin
+  integer result, x, y, i, total;
+  real scale;
+  integer array a[1:3];
+  string msg;
+
+  integer procedure choose(flag, left, right);
+    value flag, left, right;
+    boolean flag;
+    integer left, right;
+    begin
+      choose := if flag then left else right
+    end;
+
+  integer procedure sum(k, lo, hi, term);
+    value lo, hi;
+    integer k, lo, hi, term;
+    begin
+      sum := 0;
+      for k := lo step 1 until hi do sum := sum + term
+    end;
+
+  ; msg := 'CONVERGE';
+  x := y := 2;
+  a[1] := x ** 3;
+  a[2] := if y = 2 then 5 else 99;
+  scale := 2.0 ^ (0 - 1);
+  a[3] := choose(scale < 1.0, 7, 0);
+  total := sum(i, 1, 3, a[i] * i);
+  print(msg); output(' '); print(total);
+  result := total;
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -67,6 +67,53 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
 
+    def test_chained_assignment_stores_right_to_left(self) -> None:
+        result = compile_source(
+            "begin integer result, other; result := other := 7; "
+            "result := result + other end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [14]
+
+    def test_integer_exponentiation_is_left_associative(self) -> None:
+        result = compile_source("begin integer result; result := 2 ** 3 ** 2 end")
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [64]
+
+    def test_real_base_integer_exponentiation_runs_in_wasm(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; x := 2.0 ^ (0 - 3); "
+            "if x < 0.126 then result := 8 else result := 0 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_conditional_expression_assigns_selected_branch(self) -> None:
+        result = compile_source(
+            "begin integer result; result := if false then 1 else 7 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_conditional_expression_only_evaluates_selected_branch(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:1]; "
+            "result := if true then 7 else a[2] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_conditional_expression_promotes_integer_branch_to_real(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := if false then 1 else 2.5; "
+            "if x > 2.0 then result := 9 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
+    def test_statement_lists_allow_trailing_and_repeated_semicolons(self) -> None:
+        result = compile_source(
+            "begin integer result; ; result := 1;; result := 2; end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_simple_for_element_executes_once(self) -> None:
         result = compile_source(
             "begin integer result, i; "
@@ -219,7 +266,8 @@ class TestAlgolWasmCompiler:
     def test_own_integer_array_persists_across_procedure_calls(self) -> None:
         result = compile_source(
             "begin own integer array counts[1:1]; integer result; "
-            "procedure bump; begin counts[1] := counts[1] + 1; result := counts[1] end; "
+            "procedure bump; "
+            "begin counts[1] := counts[1] + 1; result := counts[1] end; "
             "counts[1] := 4; bump; bump "
             "end"
         )
@@ -451,7 +499,9 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
-    def test_nested_switch_selection_entry_dispatches_through_inner_switch(self) -> None:
+    def test_nested_switch_selection_entry_dispatches_through_inner_switch(
+        self,
+    ) -> None:
         result = compile_source(
             "begin integer result, i; "
             "switch inner := first, second; "
@@ -715,7 +765,9 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
-    def test_array_parameter_runtime_dimension_mismatch_returns_from_callee(self) -> None:
+    def test_array_parameter_runtime_dimension_mismatch_returns_from_callee(
+        self,
+    ) -> None:
         result = compile_source(
             "begin integer array xs[1:2]; integer result; "
             "procedure probe(a); integer a; array a; begin result := a[1, 1] end; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -25,6 +25,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="showcase", result=[12], stdout="ALGOL 2 7.000"),
     GoldenFixture(name="jensens-device", result=[30], stdout=""),
     GoldenFixture(name="control-flow", result=[7], stdout="FLOW 7"),
+    GoldenFixture(name="convergence", result=[39], stdout="CONVERGE 39"),
 )
 
 


### PR DESCRIPTION
## Summary
- Accept conditional expressions in the unified ALGOL expression grammar and lower them through parser, type checker, IR, and WASM with branch-selected evaluation.
- Support chained assignment and ALGOL-left-associative exponentiation for numeric bases with integer exponents, including real bases with negative integer exponents.
- Tolerate repeated/trailing semicolons in block and compound statement lists.
- Make ALGOL WASM lowering select the dispatch-loop path for IR with non-structured jump targets instead of enumerating feature-specific label names.
- Add a convergence golden fixture combining conditional expressions, chained assignment, exponentiation, by-name array summation, real arithmetic, output, and semicolon tolerance.

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check ...`
- `git diff --check`