### PR TITLE
feat(algol): support typed procedure formal expressions

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -236,7 +236,10 @@ class AlgolIrCompiler:
         self.variable_slots: dict[str, int] = {}
         self.legacy_variable_slots: dict[str, int] = {}
         self.procedure_signatures: dict[str, ProcedureSignaturePlan] = {}
-        self.procedure_parameter_dispatchers: dict[tuple[str, ...], str] = {}
+        self.procedure_parameter_dispatchers: dict[
+            tuple[str | None, tuple[str, ...]],
+            str,
+        ] = {}
         self.expression_types: dict[int, str] = {}
         self.current_function_return_type: str | None = _INTEGER_TYPE
         self.eval_thunks: list[_EvalThunk] = []
@@ -525,16 +528,17 @@ class AlgolIrCompiler:
             self._compile_procedure_call_dispatcher(
                 argument_types=tuple(),
                 label=_PROCEDURE_CALL_LABEL,
+                return_type=None,
             )
-            for argument_types, label in sorted(
+            for (return_type, argument_types), label in sorted(
                 self.procedure_parameter_dispatchers.items(),
-                key=lambda item: (len(item[0]), item[0]),
+                key=lambda item: (item[0][0] or "", len(item[0][1]), item[0][1]),
             ):
-                if argument_types:
-                    self._compile_procedure_call_dispatcher(
-                        argument_types=argument_types,
-                        label=label,
-                    )
+                self._compile_procedure_call_dispatcher(
+                    argument_types=argument_types,
+                    label=label,
+                    return_type=return_type,
+                )
 
         return CompileResult(
             program=self.program,
@@ -2890,7 +2894,10 @@ class AlgolIrCompiler:
             if scope.active_thunk_heap_mark_reg is not None
             else self._const_reg(0)
         )
-        dispatch_label = self._procedure_parameter_dispatch_label(argument_types)
+        dispatch_label = self._procedure_parameter_dispatch_label(
+            argument_types,
+            return_type=call.return_type,
+        )
         self._emit(
             IrOp.CALL,
             IrLabel(dispatch_label),
@@ -2902,14 +2909,20 @@ class AlgolIrCompiler:
             self._emit_helper_return_on_thunk_failure(scope)
         self._emit_handle_pending_goto_after_call(scope)
         result = self._fresh_reg()
-        self._copy_reg(dst=result, src=_RESULT_REG)
+        self._copy_scalar_reg(
+            type_name=call.return_type or _INTEGER_TYPE,
+            dst=result,
+            src=_REAL_RESULT_REG if call.return_type == _REAL_TYPE else _RESULT_REG,
+        )
         return result
 
     def _procedure_parameter_dispatch_label(
         self,
         argument_types: tuple[str, ...],
+        *,
+        return_type: str | None,
     ) -> str:
-        if not argument_types:
+        if not argument_types and return_type is None:
             self.procedure_signatures.setdefault(
                 _PROCEDURE_CALL_LABEL,
                 ProcedureSignaturePlan(
@@ -2918,21 +2931,28 @@ class AlgolIrCompiler:
                 ),
             )
             return _PROCEDURE_CALL_LABEL
-        label = self.procedure_parameter_dispatchers.get(argument_types)
+        key = (return_type, argument_types)
+        label = self.procedure_parameter_dispatchers.get(key)
         if label is None:
             suffix = "_".join(
                 _procedure_parameter_dispatch_type_tag(type_name)
                 for type_name in argument_types
             )
-            label = f"{_PROCEDURE_CALL_LABEL}_{suffix}"
-            self.procedure_parameter_dispatchers[argument_types] = label
+            if return_type is None:
+                label = f"{_PROCEDURE_CALL_LABEL}_{suffix}"
+            else:
+                return_tag = _procedure_parameter_dispatch_type_tag(return_type)
+                label = f"{_PROCEDURE_CALL_LABEL}_{return_tag}_result"
+                if suffix:
+                    label = f"{label}_{suffix}"
+            self.procedure_parameter_dispatchers[key] = label
             self.procedure_signatures[label] = ProcedureSignaturePlan(
                 param_types=(
                     _INTEGER_TYPE,
                     _INTEGER_TYPE,
                     *argument_types,
                 ),
-                return_type=_INTEGER_TYPE,
+                return_type=return_type or _INTEGER_TYPE,
             )
         return label
 
@@ -3550,11 +3570,6 @@ class AlgolIrCompiler:
         procedure = self.procedures.get(symbol.procedure_id)
         if procedure is None:
             raise CompileError(f"procedure actual {name.value!r} has no descriptor")
-        if procedure.return_type is not None:
-            raise CompileError(
-                f"procedure parameter actual {name.value!r} must be a statement "
-                "procedure"
-            )
         if descriptor is None:
             raise CompileError(
                 f"missing reserved descriptor for procedure actual {name.value!r}"
@@ -4068,9 +4083,10 @@ class AlgolIrCompiler:
         *,
         argument_types: tuple[str, ...],
         label: str,
+        return_type: str | None,
     ) -> None:
         previous_return_type = self.current_function_return_type
-        self.current_function_return_type = _INTEGER_TYPE
+        self.current_function_return_type = return_type or _INTEGER_TYPE
         self._label(label)
         descriptor = _STATIC_LINK_PARAM_REG
         active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
@@ -4092,6 +4108,7 @@ class AlgolIrCompiler:
             if not self._procedure_matches_dispatch_shape(
                 procedure,
                 argument_types,
+                return_type=return_type,
             ):
                 continue
             index = self.if_count
@@ -4123,6 +4140,22 @@ class AlgolIrCompiler:
                 IrRegister(active_thunk_heap_mark),
                 *(IrRegister(argument) for argument in call_arguments),
             )
+            if return_type is not None:
+                result_source = (
+                    _REAL_RESULT_REG
+                    if procedure.return_type == _REAL_TYPE
+                    else _RESULT_REG
+                )
+                result_value = self._coerce_reg_to_type(
+                    result_source,
+                    procedure.return_type or _INTEGER_TYPE,
+                    expected_type=return_type,
+                )
+                self._copy_scalar_reg(
+                    type_name=return_type,
+                    dst=_RESULT_REG,
+                    src=result_value,
+                )
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
@@ -4135,8 +4168,16 @@ class AlgolIrCompiler:
         self,
         procedure: ProcedureDescriptor,
         argument_types: tuple[str, ...],
+        *,
+        return_type: str | None,
     ) -> bool:
-        if procedure.return_type is not None:
+        if return_type is None:
+            if procedure.return_type is not None:
+                return False
+        elif not _procedure_return_type_satisfies(
+            expected_type=return_type,
+            actual_type=procedure.return_type,
+        ):
             return False
         if len(procedure.parameters) != len(argument_types):
             return False
@@ -5628,3 +5669,13 @@ def _procedure_parameter_dispatch_type_tag(type_name: str) -> str:
         raise CompileError(
             f"unsupported procedure parameter dispatch type {type_name!r}"
         ) from exc
+
+
+def _procedure_return_type_satisfies(
+    *,
+    expected_type: str,
+    actual_type: str | None,
+) -> bool:
+    if actual_type is None:
+        return False
+    return expected_type == actual_type

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -823,6 +823,24 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_typed_procedure_parameter_expression_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "procedure invoke(f); real f; procedure f; "
+                "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+                "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+                "invoke(twice) "
+                "end"
+            )
+        )
+        signature = result.procedure_signatures[
+            "_fn_algol_call_procedure_f64_result_i32"
+        ]
+
+        assert signature.param_types == ("integer", "integer", "integer")
+        assert signature.return_type == "real"
+
     def test_compiles_dynamic_multidimensional_array_bounds(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -914,7 +914,10 @@ class AlgolTypeChecker:
                 parameter_type = LABEL
             elif parameter_kind == SWITCH:
                 parameter_type = SWITCH
-            elif parameter_kind == "procedure":
+            elif (
+                parameter_kind == "procedure"
+                and parameter_type not in {INTEGER, BOOLEAN, REAL, STRING}
+            ):
                 parameter_type = "procedure"
             param_symbol = Symbol(
                 name=formal.value,
@@ -1983,11 +1986,11 @@ class AlgolTypeChecker:
                     f"procedure parameter {name_token.value!r} argument must be "
                     f"integer, boolean, real, or string, got {actual_type}",
                 )
-        if role == "expression":
+        return_type = descriptor.return_type
+        if role == "expression" and return_type is None:
             self._error(
                 name_token,
-                f"procedure parameter {name_token.value!r} cannot be called as an "
-                "expression in this phase",
+                f"procedure parameter {name_token.value!r} does not return a value",
             )
         elif ERROR not in argument_types and descriptor.parameter_symbol_id is not None:
             self._record_procedure_parameter_call_shape(
@@ -1995,7 +1998,7 @@ class AlgolTypeChecker:
                 ProcedureFormalCallShape(
                     role=role,
                     argument_types=tuple(argument_types),
-                    return_type=None,
+                    return_type=return_type if role == "expression" else None,
                 ),
             )
         call = ResolvedProcedureCall(
@@ -2008,7 +2011,7 @@ class AlgolTypeChecker:
             declaration_block_id=declaring_scope.block_id,
             lexical_depth_delta=lexical_depth_delta,
             argument_count=len(arguments),
-            return_type=None,
+            return_type=return_type,
             line=name_token.line,
             column=name_token.column,
             parameter_symbol_id=descriptor.parameter_symbol_id,
@@ -2196,19 +2199,46 @@ class AlgolTypeChecker:
         descriptor: ProcedureDescriptor,
         parameter: ProcedureParameter,
     ) -> bool:
-        if descriptor.return_type is not None:
-            self._error(
-                token,
-                f"procedure parameter {parameter.name!r} expects a statement "
-                "procedure actual in this phase",
-            )
-            return False
         for shape in parameter.procedure_call_shapes:
-            if shape.role != "statement":
+            if shape.role == "expression":
+                if shape.return_type is None:
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} has no typed "
+                        "expression result",
+                    )
+                    return False
+                if descriptor.return_type is None:
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} expects a "
+                        f"{shape.return_type} procedure actual",
+                    )
+                    return False
+                if not self._procedure_return_type_satisfies(
+                    expected_type=shape.return_type,
+                    actual_type=descriptor.return_type,
+                ):
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} expects a "
+                        f"{shape.return_type} procedure actual, got "
+                        f"{descriptor.return_type}",
+                    )
+                    return False
+            elif shape.role == "statement":
+                if descriptor.return_type is not None:
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} expects a "
+                        "statement procedure actual",
+                    )
+                    return False
+            else:
                 self._error(
                     token,
-                    f"procedure parameter {parameter.name!r} cannot accept "
-                    "expression procedure actuals in this phase",
+                    f"procedure parameter {parameter.name!r} has unsupported "
+                    f"{shape.role} call shape",
                 )
                 return False
             if len(descriptor.parameters) != len(shape.argument_types):
@@ -2258,6 +2288,14 @@ class AlgolTypeChecker:
                     )
                     return False
         return True
+
+    def _procedure_return_type_satisfies(
+        self,
+        *,
+        expected_type: str,
+        actual_type: str,
+    ) -> bool:
+        return expected_type == actual_type
 
     def _resolve_builtin_procedure(
         self,
@@ -2319,6 +2357,11 @@ class AlgolTypeChecker:
                     return None
                 return descriptor, current, lexical_depth_delta
             if symbol is not None and symbol.kind == "procedure_parameter":
+                return_type = (
+                    symbol.type_name
+                    if symbol.type_name in {INTEGER, BOOLEAN, REAL, STRING}
+                    else None
+                )
                 return (
                     ProcedureDescriptor(
                         procedure_id=-2,
@@ -2327,7 +2370,7 @@ class AlgolTypeChecker:
                         declaring_block_id=current.block_id,
                         body_block_id=current.block_id,
                         body_node_id=-1,
-                        return_type=None,
+                        return_type=return_type,
                         parameters=tuple(),
                         line=token.line,
                         column=token.column,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -809,6 +809,23 @@ class TestAlgolTypeChecker:
         parameter = result.semantic.procedures[0].parameters[0]
         assert parameter.procedure_call_shapes[0].argument_types == ("integer",)
 
+    def test_accepts_typed_procedure_parameter_expression_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+            "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.type_name == "real"
+        assert parameter.procedure_call_shapes[0].return_type == "real"
+
     def test_rejects_procedure_parameter_actual_with_mismatched_arity(
         self,
     ) -> None:
@@ -844,6 +861,19 @@ class TestAlgolTypeChecker:
             "expects a procedure actual with scalar value parameters"
             in result.diagnostics[0].message
         )
+
+    def test_rejects_typed_procedure_parameter_void_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "procedure invoke(f); real f; procedure f; begin y := f(2) end; "
+            "procedure set(x); value x; integer x; begin result := x end; "
+            "invoke(set) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "expects a real procedure actual" in result.diagnostics[0].message
 
     def test_rejects_value_procedure_parameter_in_this_phase(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -657,6 +657,32 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_typed_procedure_parameter_expression_call_returns_real(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+            "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_forwarded_typed_procedure_parameter_expression_uses_static_link(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result, base; real y; "
+            "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 7 then result := 1 else result := 0 end; "
+            "procedure relay(f); real f; procedure f; begin invoke(f) end; "
+            "real procedure addbase(x); value x; real x; "
+            "begin addbase := base + x end; "
+            "base := 5; relay(addbase) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
     def test_repeated_switch_designational_gotos_use_distinct_dispatch(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- preserve scalar result types on formal procedure parameters declared with both a type specifier and `procedure`
- allow typed formal procedure parameters to be called as expressions and record their return-type call shapes
- validate direct/forwarded procedure actuals against typed expression call shapes
- generate return-type-aware dynamic procedure dispatch helpers for WASM lowering
- add type checker, IR, and WASM runtime coverage for direct/forwarded real-return formal procedures

## Notes
- procedure result type matching remains exact for dynamic formal procedure expressions; argument promotion such as integer actual argument to real value parameter remains supported
- this avoids changing the current WASM scratch/result-register ABI in this batch

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `ruff check code/packages/python/algol-type-checker/src/algol_type_checker code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Security review
- no dependency, CI, subprocess, network, deserialization, or filesystem access changes
- local grep review found only pre-existing symbol names such as `_emit_call_switch_eval`