### PR TITLE
[codex] Add hidden-layer example suite

### DIFF
--- a/code/learning/ml-hidden-layer-example-suite.md
+++ b/code/learning/ml-hidden-layer-example-suite.md
@@ -1,0 +1,39 @@
+# Hidden Layer Example Suite
+
+This suite expands the XOR hidden-layer lesson into six small problems that a
+single straight line cannot handle comfortably.
+
+Sine approximation is intentionally left out of this pass so it can get its own
+focused treatment later.
+
+## Examples
+
+| Example | Shape | What the Hidden Layer Learns |
+| --- | --- | --- |
+| XNOR gate | 2 inputs -> 1 output | Two separated "same input" regions. |
+| Absolute value | 1 input -> 1 output | A bend at zero, forming a V shape. |
+| Piecewise pricing | 1 input -> 1 output | Soft thresholds that combine into steps. |
+| Circle classifier | 2 inputs -> 1 output | Several boundaries that approximate an inside/outside region. |
+| Two moons | 2 inputs -> 1 output | A curved decision boundary that cannot be drawn as one line. |
+| Interaction features | 3 inputs -> 1 output | Feature combinations such as garage plus enough rooms. |
+
+## Shared Contract
+
+Every example uses the same two-layer primitive:
+
+```text
+inputs -> input-to-hidden weights + hidden bias -> sigmoid hidden neurons
+hidden outputs -> hidden-to-output weights + output bias -> sigmoid prediction
+prediction + target -> mean squared error -> backpropagation gradients
+```
+
+The language packages all exercise these examples through one training step.
+That keeps the examples portable while stressing the matrix shapes that matter:
+
+- 1 input, many hidden neurons, 1 output
+- 2 inputs, many hidden neurons, 1 output
+- 3 inputs, many hidden neurons, 1 output
+
+The TypeScript visualizer goes further by letting you step and run the browser
+training loop, inspect loss history, and trace one selected row through each
+hidden neuron.

--- a/code/packages/csharp/two-layer-network/tests/CodingAdventures.TwoLayerNetwork.Tests/TwoLayerNetworkTests.cs
+++ b/code/packages/csharp/two-layer-network/tests/CodingAdventures.TwoLayerNetwork.Tests/TwoLayerNetworkTests.cs
@@ -35,4 +35,50 @@ public sealed class TwoLayerNetworkTests
         Assert.Equal(2, step.HiddenToOutputWeightGradients.Length);
         Assert.Single(step.HiddenToOutputWeightGradients[0]);
     }
+
+    [Fact]
+    public void HiddenLayerTeachingExamplesRunOneTrainingStep()
+    {
+        var cases = new (string Name, double[][] Inputs, double[][] Targets, int HiddenCount)[]
+        {
+            ("XNOR", Inputs, [[1.0], [0.0], [0.0], [1.0]], 3),
+            ("absolute value", [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4),
+            ("piecewise pricing", [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4),
+            ("circle classifier", [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5),
+            ("two moons", [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5),
+            ("interaction features", [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5),
+        };
+
+        foreach (var item in cases)
+        {
+            var step = TwoLayerNetwork.TrainOneEpoch(item.Inputs, item.Targets, SampleParameters(item.Inputs[0].Length, item.HiddenCount), 0.4);
+
+            Assert.True(step.Loss >= 0.0, item.Name);
+            Assert.Equal(item.Inputs[0].Length, step.InputToHiddenWeightGradients.Length);
+            Assert.Equal(item.HiddenCount, step.HiddenToOutputWeightGradients.Length);
+        }
+    }
+
+    private static Parameters SampleParameters(int inputCount, int hiddenCount)
+    {
+        var inputToHidden = new double[inputCount][];
+        for (var feature = 0; feature < inputCount; feature++)
+        {
+            inputToHidden[feature] = new double[hiddenCount];
+            for (var hidden = 0; hidden < hiddenCount; hidden++)
+            {
+                inputToHidden[feature][hidden] = 0.17 * (feature + 1) - 0.11 * (hidden + 1);
+            }
+        }
+
+        var hiddenBiases = new double[hiddenCount];
+        var hiddenToOutput = new double[hiddenCount][];
+        for (var hidden = 0; hidden < hiddenCount; hidden++)
+        {
+            hiddenBiases[hidden] = 0.05 * (hidden - 1);
+            hiddenToOutput[hidden] = [0.13 * (hidden + 1) - 0.25];
+        }
+
+        return new Parameters(inputToHidden, hiddenBiases, hiddenToOutput, [0.02]);
+    }
 }

--- a/code/packages/dart/two-layer-network/test/two_layer_network_test.dart
+++ b/code/packages/dart/two-layer-network/test/two_layer_network_test.dart
@@ -32,4 +32,151 @@ void main() {
     expect(step.hiddenToOutputWeightGradients.length, 2);
     expect(step.hiddenToOutputWeightGradients.first.length, 1);
   });
+
+  test('hidden layer teaching examples run one training step', () {
+    final cases = [
+      _ExampleCase('XNOR', inputs, [
+        [1.0],
+        [0.0],
+        [0.0],
+        [1.0],
+      ], 3),
+      _ExampleCase(
+        'absolute value',
+        [
+          [-1.0],
+          [-0.5],
+          [0.0],
+          [0.5],
+          [1.0],
+        ],
+        [
+          [1.0],
+          [0.5],
+          [0.0],
+          [0.5],
+          [1.0],
+        ],
+        4,
+      ),
+      _ExampleCase(
+        'piecewise pricing',
+        [
+          [0.1],
+          [0.3],
+          [0.5],
+          [0.7],
+          [0.9],
+        ],
+        [
+          [0.12],
+          [0.25],
+          [0.55],
+          [0.88],
+          [0.88],
+        ],
+        4,
+      ),
+      _ExampleCase(
+        'circle classifier',
+        [
+          [0.0, 0.0],
+          [0.5, 0.0],
+          [1.0, 1.0],
+          [-0.5, 0.5],
+          [-1.0, 0.0],
+        ],
+        [
+          [1.0],
+          [1.0],
+          [0.0],
+          [1.0],
+          [0.0],
+        ],
+        5,
+      ),
+      _ExampleCase(
+        'two moons',
+        [
+          [1.0, 0.0],
+          [0.0, 0.5],
+          [0.5, 0.85],
+          [0.5, -0.35],
+          [-1.0, 0.0],
+          [2.0, 0.5],
+        ],
+        [
+          [0.0],
+          [1.0],
+          [0.0],
+          [1.0],
+          [0.0],
+          [1.0],
+        ],
+        5,
+      ),
+      _ExampleCase(
+        'interaction features',
+        [
+          [0.2, 0.25, 0.0],
+          [0.6, 0.5, 1.0],
+          [1.0, 0.75, 1.0],
+          [1.0, 1.0, 0.0],
+        ],
+        [
+          [0.08],
+          [0.72],
+          [0.96],
+          [0.76],
+        ],
+        5,
+      ),
+    ];
+
+    for (final example in cases) {
+      final step = trainOneEpoch(
+        example.inputs,
+        example.targets,
+        _sampleParameters(example.inputs.first.length, example.hiddenCount),
+        0.4,
+      );
+
+      expect(step.loss, greaterThanOrEqualTo(0.0), reason: example.name);
+      expect(
+        step.inputToHiddenWeightGradients.length,
+        example.inputs.first.length,
+        reason: example.name,
+      );
+      expect(
+        step.hiddenToOutputWeightGradients.length,
+        example.hiddenCount,
+        reason: example.name,
+      );
+    }
+  });
+}
+
+Parameters _sampleParameters(int inputCount, int hiddenCount) => Parameters(
+  inputToHiddenWeights: List.generate(
+    inputCount,
+    (feature) => List.generate(
+      hiddenCount,
+      (hidden) => 0.17 * (feature + 1) - 0.11 * (hidden + 1),
+    ),
+  ),
+  hiddenBiases: List.generate(hiddenCount, (hidden) => 0.05 * (hidden - 1)),
+  hiddenToOutputWeights: List.generate(
+    hiddenCount,
+    (hidden) => [0.13 * (hidden + 1) - 0.25],
+  ),
+  outputBiases: [0.02],
+);
+
+class _ExampleCase {
+  _ExampleCase(this.name, this.inputs, this.targets, this.hiddenCount);
+
+  final String name;
+  final Matrix inputs;
+  final Matrix targets;
+  final int hiddenCount;
 }

--- a/code/packages/elixir/two_layer_network/test/two_layer_network_test.exs
+++ b/code/packages/elixir/two_layer_network/test/two_layer_network_test.exs
@@ -23,4 +23,35 @@ defmodule CodingAdventures.TwoLayerNetworkTest do
     assert length(step.hidden_to_output_weight_gradients) == 2
     assert length(hd(step.hidden_to_output_weight_gradients)) == 1
   end
+
+  test "hidden layer teaching examples run one training step" do
+    cases = [
+      {"XNOR", @inputs, [[1.0], [0.0], [0.0], [1.0]], 3},
+      {"absolute value", [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4},
+      {"piecewise pricing", [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4},
+      {"circle classifier", [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5},
+      {"two moons", [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5},
+      {"interaction features", [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5}
+    ]
+
+    for {name, inputs, targets, hidden_count} <- cases do
+      step = TwoLayerNetwork.train_one_epoch(inputs, targets, sample_parameters(length(hd(inputs)), hidden_count), 0.4)
+
+      assert step.loss >= 0.0, name
+      assert length(step.input_to_hidden_weight_gradients) == length(hd(inputs))
+      assert length(step.hidden_to_output_weight_gradients) == hidden_count
+    end
+  end
+
+  defp sample_parameters(input_count, hidden_count) do
+    %{
+      input_to_hidden_weights:
+        for feature <- 0..(input_count - 1) do
+          for hidden <- 0..(hidden_count - 1), do: 0.17 * (feature + 1) - 0.11 * (hidden + 1)
+        end,
+      hidden_biases: for(hidden <- 0..(hidden_count - 1), do: 0.05 * (hidden - 1)),
+      hidden_to_output_weights: for(hidden <- 0..(hidden_count - 1), do: [0.13 * (hidden + 1) - 0.25]),
+      output_biases: [0.02]
+    }
+  end
 end

--- a/code/packages/fsharp/two-layer-network/tests/CodingAdventures.TwoLayerNetwork.Tests/TwoLayerNetworkTests.fs
+++ b/code/packages/fsharp/two-layer-network/tests/CodingAdventures.TwoLayerNetwork.Tests/TwoLayerNetworkTests.fs
@@ -7,6 +7,14 @@ module TwoLayerNetworkTests =
     let inputs = [| [| 0.0; 0.0 |]; [| 0.0; 1.0 |]; [| 1.0; 0.0 |]; [| 1.0; 1.0 |] |]
     let targets = [| [| 0.0 |]; [| 1.0 |]; [| 1.0 |]; [| 0.0 |] |]
 
+    let sampleParameters inputCount hiddenCount =
+        { InputToHiddenWeights =
+            Array.init inputCount (fun feature ->
+                Array.init hiddenCount (fun hidden -> 0.17 * float (feature + 1) - 0.11 * float (hidden + 1)))
+          HiddenBiases = Array.init hiddenCount (fun hidden -> 0.05 * float (hidden - 1))
+          HiddenToOutputWeights = Array.init hiddenCount (fun hidden -> [| 0.13 * float (hidden + 1) - 0.25 |])
+          OutputBiases = [| 0.02 |] }
+
     [<Fact>]
     let ``forward pass exposes hidden activations`` () =
         let passed = TwoLayerNetwork.forward inputs (TwoLayerNetwork.xorWarmStartParameters()) Sigmoid Sigmoid
@@ -22,3 +30,19 @@ module TwoLayerNetworkTests =
         Assert.Equal(2, step.InputToHiddenWeightGradients[0].Length)
         Assert.Equal(2, step.HiddenToOutputWeightGradients.Length)
         Assert.Equal(1, step.HiddenToOutputWeightGradients[0].Length)
+
+    [<Fact>]
+    let ``hidden layer teaching examples run one training step`` () =
+        let cases =
+            [| ("XNOR", inputs, [| [| 1.0 |]; [| 0.0 |]; [| 0.0 |]; [| 1.0 |] |], 3)
+               ("absolute value", [| [| -1.0 |]; [| -0.5 |]; [| 0.0 |]; [| 0.5 |]; [| 1.0 |] |], [| [| 1.0 |]; [| 0.5 |]; [| 0.0 |]; [| 0.5 |]; [| 1.0 |] |], 4)
+               ("piecewise pricing", [| [| 0.1 |]; [| 0.3 |]; [| 0.5 |]; [| 0.7 |]; [| 0.9 |] |], [| [| 0.12 |]; [| 0.25 |]; [| 0.55 |]; [| 0.88 |]; [| 0.88 |] |], 4)
+               ("circle classifier", [| [| 0.0; 0.0 |]; [| 0.5; 0.0 |]; [| 1.0; 1.0 |]; [| -0.5; 0.5 |]; [| -1.0; 0.0 |] |], [| [| 1.0 |]; [| 1.0 |]; [| 0.0 |]; [| 1.0 |]; [| 0.0 |] |], 5)
+               ("two moons", [| [| 1.0; 0.0 |]; [| 0.0; 0.5 |]; [| 0.5; 0.85 |]; [| 0.5; -0.35 |]; [| -1.0; 0.0 |]; [| 2.0; 0.5 |] |], [| [| 0.0 |]; [| 1.0 |]; [| 0.0 |]; [| 1.0 |]; [| 0.0 |]; [| 1.0 |] |], 5)
+               ("interaction features", [| [| 0.2; 0.25; 0.0 |]; [| 0.6; 0.5; 1.0 |]; [| 1.0; 0.75; 1.0 |]; [| 1.0; 1.0; 0.0 |] |], [| [| 0.08 |]; [| 0.72 |]; [| 0.96 |]; [| 0.76 |] |], 5) |]
+
+        for name, exampleInputs, exampleTargets, hiddenCount in cases do
+            let step = TwoLayerNetwork.trainOneEpoch exampleInputs exampleTargets (sampleParameters exampleInputs[0].Length hiddenCount) 0.4 Sigmoid Sigmoid
+            Assert.True(step.Loss >= 0.0, name)
+            Assert.Equal(exampleInputs[0].Length, step.InputToHiddenWeightGradients.Length)
+            Assert.Equal(hiddenCount, step.HiddenToOutputWeightGradients.Length)

--- a/code/packages/go/two-layer-network/two_layer_network_test.go
+++ b/code/packages/go/two-layer-network/two_layer_network_test.go
@@ -44,3 +44,57 @@ func TestWarmStartSolvesXor(t *testing.T) {
 		t.Fatalf("warm start did not solve XOR: %#v", predictions)
 	}
 }
+
+func sampleParameters(inputCount int, hiddenCount int) Parameters {
+	weights := make(Matrix, inputCount)
+	for feature := 0; feature < inputCount; feature++ {
+		weights[feature] = make([]float64, hiddenCount)
+		for hidden := 0; hidden < hiddenCount; hidden++ {
+			weights[feature][hidden] = 0.17*float64(feature+1) - 0.11*float64(hidden+1)
+		}
+	}
+	hiddenBiases := make([]float64, hiddenCount)
+	hiddenToOutput := make(Matrix, hiddenCount)
+	for hidden := 0; hidden < hiddenCount; hidden++ {
+		hiddenBiases[hidden] = 0.05 * float64(hidden-1)
+		hiddenToOutput[hidden] = []float64{0.13*float64(hidden+1) - 0.25}
+	}
+	return Parameters{
+		InputToHiddenWeights:  weights,
+		HiddenBiases:          hiddenBiases,
+		HiddenToOutputWeights: hiddenToOutput,
+		OutputBiases:          []float64{0.02},
+	}
+}
+
+func TestHiddenLayerTeachingExamplesRunOneTrainingStep(t *testing.T) {
+	cases := []struct {
+		name        string
+		inputs      Matrix
+		targets     Matrix
+		hiddenCount int
+	}{
+		{"XNOR", xorInputs, Matrix{{1}, {0}, {0}, {1}}, 3},
+		{"absolute value", Matrix{{-1}, {-0.5}, {0}, {0.5}, {1}}, Matrix{{1}, {0.5}, {0}, {0.5}, {1}}, 4},
+		{"piecewise pricing", Matrix{{0.1}, {0.3}, {0.5}, {0.7}, {0.9}}, Matrix{{0.12}, {0.25}, {0.55}, {0.88}, {0.88}}, 4},
+		{"circle classifier", Matrix{{0, 0}, {0.5, 0}, {1, 1}, {-0.5, 0.5}, {-1, 0}}, Matrix{{1}, {1}, {0}, {1}, {0}}, 5},
+		{"two moons", Matrix{{1, 0}, {0, 0.5}, {0.5, 0.85}, {0.5, -0.35}, {-1, 0}, {2, 0.5}}, Matrix{{0}, {1}, {0}, {1}, {0}, {1}}, 5},
+		{"interaction features", Matrix{{0.2, 0.25, 0}, {0.6, 0.5, 1}, {1, 0.75, 1}, {1, 1, 0}}, Matrix{{0.08}, {0.72}, {0.96}, {0.76}}, 5},
+	}
+
+	for _, tc := range cases {
+		step, err := TrainOneEpoch(tc.inputs, tc.targets, sampleParameters(len(tc.inputs[0]), tc.hiddenCount), 0.4, Sigmoid, Sigmoid)
+		if err != nil {
+			t.Fatalf("%s failed: %v", tc.name, err)
+		}
+		if step.Loss < 0 {
+			t.Fatalf("%s returned a negative loss", tc.name)
+		}
+		if len(step.InputToHiddenWeightGradients) != len(tc.inputs[0]) {
+			t.Fatalf("%s returned unexpected input-to-hidden gradient shape", tc.name)
+		}
+		if len(step.HiddenToOutputWeightGradients) != tc.hiddenCount {
+			t.Fatalf("%s returned unexpected hidden-to-output gradient shape", tc.name)
+		}
+	}
+}

--- a/code/packages/haskell/two-layer-network/test/TwoLayerNetworkSpec.hs
+++ b/code/packages/haskell/two-layer-network/test/TwoLayerNetworkSpec.hs
@@ -9,6 +9,18 @@ xorInputs = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
 xorTargets :: Matrix
 xorTargets = [[0.0], [1.0], [1.0], [0.0]]
 
+sampleParameters :: Int -> Int -> Parameters
+sampleParameters inputCount hiddenCount =
+    Parameters
+        { inputToHiddenWeights =
+            [ [0.17 * fromIntegral (feature + 1) - 0.11 * fromIntegral (hidden + 1) | hidden <- [0 .. hiddenCount - 1]]
+            | feature <- [0 .. inputCount - 1]
+            ]
+        , hiddenBiases = [0.05 * fromIntegral (hidden - 1) | hidden <- [0 .. hiddenCount - 1]]
+        , hiddenToOutputWeights = [[0.13 * fromIntegral (hidden + 1) - 0.25] | hidden <- [0 .. hiddenCount - 1]]
+        , outputBiases = [0.02]
+        }
+
 spec :: Spec
 spec = do
     it "forward pass exposes hidden activations" $ do
@@ -24,3 +36,21 @@ spec = do
         length (head (inputToHiddenWeightGradients step)) `shouldBe` 2
         length (hiddenToOutputWeightGradients step) `shouldBe` 2
         length (head (hiddenToOutputWeightGradients step)) `shouldBe` 1
+
+    it "runs hidden-layer teaching examples through one training step" $ do
+        let cases =
+                [ ("XNOR", xorInputs, [[1.0], [0.0], [0.0], [1.0]], 3)
+                , ("absolute value", [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4)
+                , ("piecewise pricing", [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4)
+                , ("circle classifier", [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5)
+                , ("two moons", [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5)
+                , ("interaction features", [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5)
+                ]
+        mapM_
+            ( \(name, exampleInputs, exampleTargets, hiddenCount) -> do
+                let step = trainOneEpoch exampleInputs exampleTargets (sampleParameters (length (head exampleInputs)) hiddenCount) 0.4 Sigmoid Sigmoid
+                loss step >= 0.0 `shouldBe` True
+                length (inputToHiddenWeightGradients step) `shouldBe` length (head exampleInputs)
+                length (hiddenToOutputWeightGradients step) `shouldBe` hiddenCount
+            )
+            cases

--- a/code/packages/java/two-layer-network/src/test/java/com/codingadventures/twolayernetwork/TwoLayerNetworkTest.java
+++ b/code/packages/java/two-layer-network/src/test/java/com/codingadventures/twolayernetwork/TwoLayerNetworkTest.java
@@ -32,4 +32,49 @@ class TwoLayerNetworkTest {
         assertEquals(2, step.hiddenToOutputWeightGradients().length);
         assertEquals(1, step.hiddenToOutputWeightGradients()[0].length);
     }
+
+    @Test
+    void hiddenLayerTeachingExamplesRunOneTrainingStep() {
+        var cases = new ExampleCase[] {
+            new ExampleCase("XNOR", INPUTS, new double[][]{{1.0}, {0.0}, {0.0}, {1.0}}, 3),
+            new ExampleCase("absolute value", new double[][]{{-1.0}, {-0.5}, {0.0}, {0.5}, {1.0}}, new double[][]{{1.0}, {0.5}, {0.0}, {0.5}, {1.0}}, 4),
+            new ExampleCase("piecewise pricing", new double[][]{{0.1}, {0.3}, {0.5}, {0.7}, {0.9}}, new double[][]{{0.12}, {0.25}, {0.55}, {0.88}, {0.88}}, 4),
+            new ExampleCase("circle classifier", new double[][]{{0.0, 0.0}, {0.5, 0.0}, {1.0, 1.0}, {-0.5, 0.5}, {-1.0, 0.0}}, new double[][]{{1.0}, {1.0}, {0.0}, {1.0}, {0.0}}, 5),
+            new ExampleCase("two moons", new double[][]{{1.0, 0.0}, {0.0, 0.5}, {0.5, 0.85}, {0.5, -0.35}, {-1.0, 0.0}, {2.0, 0.5}}, new double[][]{{0.0}, {1.0}, {0.0}, {1.0}, {0.0}, {1.0}}, 5),
+            new ExampleCase("interaction features", new double[][]{{0.2, 0.25, 0.0}, {0.6, 0.5, 1.0}, {1.0, 0.75, 1.0}, {1.0, 1.0, 0.0}}, new double[][]{{0.08}, {0.72}, {0.96}, {0.76}}, 5),
+        };
+
+        for (var example : cases) {
+            var step = TwoLayerNetwork.trainOneEpoch(
+                example.inputs,
+                example.targets,
+                sampleParameters(example.inputs[0].length, example.hiddenCount),
+                0.4
+            );
+
+            assertTrue(step.loss() >= 0.0, example.name);
+            assertEquals(example.inputs[0].length, step.inputToHiddenWeightGradients().length, example.name);
+            assertEquals(example.hiddenCount, step.hiddenToOutputWeightGradients().length, example.name);
+        }
+    }
+
+    private static TwoLayerNetwork.Parameters sampleParameters(int inputCount, int hiddenCount) {
+        var inputToHidden = new double[inputCount][hiddenCount];
+        for (var feature = 0; feature < inputCount; feature++) {
+            for (var hidden = 0; hidden < hiddenCount; hidden++) {
+                inputToHidden[feature][hidden] = 0.17 * (feature + 1) - 0.11 * (hidden + 1);
+            }
+        }
+
+        var hiddenBiases = new double[hiddenCount];
+        var hiddenToOutput = new double[hiddenCount][1];
+        for (var hidden = 0; hidden < hiddenCount; hidden++) {
+            hiddenBiases[hidden] = 0.05 * (hidden - 1);
+            hiddenToOutput[hidden][0] = 0.13 * (hidden + 1) - 0.25;
+        }
+
+        return new TwoLayerNetwork.Parameters(inputToHidden, hiddenBiases, hiddenToOutput, new double[]{0.02});
+    }
+
+    private record ExampleCase(String name, double[][] inputs, double[][] targets, int hiddenCount) {}
 }

--- a/code/packages/kotlin/two-layer-network/src/test/kotlin/com/codingadventures/twolayernetwork/TwoLayerNetworkTest.kt
+++ b/code/packages/kotlin/two-layer-network/src/test/kotlin/com/codingadventures/twolayernetwork/TwoLayerNetworkTest.kt
@@ -30,4 +30,40 @@ class TwoLayerNetworkTest {
         assertEquals(2, step.hiddenToOutputWeightGradients.size)
         assertEquals(1, step.hiddenToOutputWeightGradients[0].size)
     }
+
+    @Test fun `hidden layer teaching examples run one training step`() {
+        val cases = listOf(
+            ExampleCase("XNOR", inputs, arrayOf(doubleArrayOf(1.0), doubleArrayOf(0.0), doubleArrayOf(0.0), doubleArrayOf(1.0)), 3),
+            ExampleCase("absolute value", arrayOf(doubleArrayOf(-1.0), doubleArrayOf(-0.5), doubleArrayOf(0.0), doubleArrayOf(0.5), doubleArrayOf(1.0)), arrayOf(doubleArrayOf(1.0), doubleArrayOf(0.5), doubleArrayOf(0.0), doubleArrayOf(0.5), doubleArrayOf(1.0)), 4),
+            ExampleCase("piecewise pricing", arrayOf(doubleArrayOf(0.1), doubleArrayOf(0.3), doubleArrayOf(0.5), doubleArrayOf(0.7), doubleArrayOf(0.9)), arrayOf(doubleArrayOf(0.12), doubleArrayOf(0.25), doubleArrayOf(0.55), doubleArrayOf(0.88), doubleArrayOf(0.88)), 4),
+            ExampleCase("circle classifier", arrayOf(doubleArrayOf(0.0, 0.0), doubleArrayOf(0.5, 0.0), doubleArrayOf(1.0, 1.0), doubleArrayOf(-0.5, 0.5), doubleArrayOf(-1.0, 0.0)), arrayOf(doubleArrayOf(1.0), doubleArrayOf(1.0), doubleArrayOf(0.0), doubleArrayOf(1.0), doubleArrayOf(0.0)), 5),
+            ExampleCase("two moons", arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(0.0, 0.5), doubleArrayOf(0.5, 0.85), doubleArrayOf(0.5, -0.35), doubleArrayOf(-1.0, 0.0), doubleArrayOf(2.0, 0.5)), arrayOf(doubleArrayOf(0.0), doubleArrayOf(1.0), doubleArrayOf(0.0), doubleArrayOf(1.0), doubleArrayOf(0.0), doubleArrayOf(1.0)), 5),
+            ExampleCase("interaction features", arrayOf(doubleArrayOf(0.2, 0.25, 0.0), doubleArrayOf(0.6, 0.5, 1.0), doubleArrayOf(1.0, 0.75, 1.0), doubleArrayOf(1.0, 1.0, 0.0)), arrayOf(doubleArrayOf(0.08), doubleArrayOf(0.72), doubleArrayOf(0.96), doubleArrayOf(0.76)), 5),
+        )
+
+        for (example in cases) {
+            val step = trainOneEpoch(example.inputs, example.targets, sampleParameters(example.inputs[0].size, example.hiddenCount), 0.4)
+
+            assertTrue(step.loss >= 0.0, example.name)
+            assertEquals(example.inputs[0].size, step.inputToHiddenWeightGradients.size, example.name)
+            assertEquals(example.hiddenCount, step.hiddenToOutputWeightGradients.size, example.name)
+        }
+    }
+
+    private fun sampleParameters(inputCount: Int, hiddenCount: Int): Parameters =
+        Parameters(
+            inputToHiddenWeights = Array(inputCount) { feature ->
+                DoubleArray(hiddenCount) { hidden -> 0.17 * (feature + 1) - 0.11 * (hidden + 1) }
+            },
+            hiddenBiases = DoubleArray(hiddenCount) { hidden -> 0.05 * (hidden - 1) },
+            hiddenToOutputWeights = Array(hiddenCount) { hidden -> doubleArrayOf(0.13 * (hidden + 1) - 0.25) },
+            outputBiases = doubleArrayOf(0.02),
+        )
+
+    private data class ExampleCase(
+        val name: String,
+        val inputs: Array<DoubleArray>,
+        val targets: Array<DoubleArray>,
+        val hiddenCount: Int,
+    )
 }

--- a/code/packages/lua/two_layer_network/tests/test_two_layer_network.lua
+++ b/code/packages/lua/two_layer_network/tests/test_two_layer_network.lua
@@ -16,3 +16,47 @@ assert(#step.input_to_hidden_weight_gradients == 2)
 assert(#step.input_to_hidden_weight_gradients[1] == 2)
 assert(#step.hidden_to_output_weight_gradients == 2)
 assert(#step.hidden_to_output_weight_gradients[1] == 1)
+
+local function sample_parameters(input_count, hidden_count)
+    local input_to_hidden = {}
+    for feature = 1, input_count do
+        input_to_hidden[feature] = {}
+        for hidden = 1, hidden_count do
+            input_to_hidden[feature][hidden] = 0.17 * feature - 0.11 * hidden
+        end
+    end
+    local hidden_biases = {}
+    local hidden_to_output = {}
+    for hidden = 1, hidden_count do
+        hidden_biases[hidden] = 0.05 * (hidden - 2)
+        hidden_to_output[hidden] = {0.13 * hidden - 0.25}
+    end
+    return {
+        input_to_hidden_weights = input_to_hidden,
+        hidden_biases = hidden_biases,
+        hidden_to_output_weights = hidden_to_output,
+        output_biases = {0.02},
+    }
+end
+
+local cases = {
+    {"XNOR", inputs, {{1.0}, {0.0}, {0.0}, {1.0}}, 3},
+    {"absolute value", {{-1.0}, {-0.5}, {0.0}, {0.5}, {1.0}}, {{1.0}, {0.5}, {0.0}, {0.5}, {1.0}}, 4},
+    {"piecewise pricing", {{0.1}, {0.3}, {0.5}, {0.7}, {0.9}}, {{0.12}, {0.25}, {0.55}, {0.88}, {0.88}}, 4},
+    {"circle classifier", {{0.0, 0.0}, {0.5, 0.0}, {1.0, 1.0}, {-0.5, 0.5}, {-1.0, 0.0}}, {{1.0}, {1.0}, {0.0}, {1.0}, {0.0}}, 5},
+    {"two moons", {{1.0, 0.0}, {0.0, 0.5}, {0.5, 0.85}, {0.5, -0.35}, {-1.0, 0.0}, {2.0, 0.5}}, {{0.0}, {1.0}, {0.0}, {1.0}, {0.0}, {1.0}}, 5},
+    {"interaction features", {{0.2, 0.25, 0.0}, {0.6, 0.5, 1.0}, {1.0, 0.75, 1.0}, {1.0, 1.0, 0.0}}, {{0.08}, {0.72}, {0.96}, {0.76}}, 5},
+}
+
+for _, case in ipairs(cases) do
+    local name, example_inputs, example_targets, hidden_count = case[1], case[2], case[3], case[4]
+    local example_step = tln.train_one_epoch(
+        example_inputs,
+        example_targets,
+        sample_parameters(#example_inputs[1], hidden_count),
+        0.4
+    )
+    assert(example_step.loss >= 0.0, name)
+    assert(#example_step.input_to_hidden_weight_gradients == #example_inputs[1], name)
+    assert(#example_step.hidden_to_output_weight_gradients == hidden_count, name)
+end

--- a/code/packages/perl/two-layer-network/t/01-basic.t
+++ b/code/packages/perl/two-layer-network/t/01-basic.t
@@ -23,4 +23,48 @@ my $step = CodingAdventures::TwoLayerNetwork::train_one_epoch(
 is(scalar @{ $step->{input_to_hidden_weight_gradients} }, 2, 'input-to-hidden gradient rows');
 is(scalar @{ $step->{hidden_to_output_weight_gradients}[0] }, 1, 'hidden-to-output gradient width');
 
+my @cases = (
+    ['XNOR', $inputs, [[1.0], [0.0], [0.0], [1.0]], 3],
+    ['absolute value', [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4],
+    ['piecewise pricing', [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4],
+    ['circle classifier', [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5],
+    ['two moons', [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5],
+    ['interaction features', [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5],
+);
+
+for my $case (@cases) {
+    my ($name, $example_inputs, $example_targets, $hidden_count) = @$case;
+    my $example_step = CodingAdventures::TwoLayerNetwork::train_one_epoch(
+        $example_inputs,
+        $example_targets,
+        sample_parameters(scalar @{ $example_inputs->[0] }, $hidden_count),
+        0.4,
+    );
+
+    ok($example_step->{loss} >= 0.0, "$name loss is finite");
+    is(scalar @{ $example_step->{input_to_hidden_weight_gradients} }, scalar @{ $example_inputs->[0] }, "$name input gradient shape");
+    is(scalar @{ $example_step->{hidden_to_output_weight_gradients} }, $hidden_count, "$name hidden gradient shape");
+}
+
 done_testing;
+
+sub sample_parameters {
+    my ($input_count, $hidden_count) = @_;
+    my @input_to_hidden;
+    for my $feature (0 .. $input_count - 1) {
+        my @row;
+        for my $hidden (0 .. $hidden_count - 1) {
+            push @row, 0.17 * ($feature + 1) - 0.11 * ($hidden + 1);
+        }
+        push @input_to_hidden, \@row;
+    }
+    my @hidden_biases = map { 0.05 * ($_ - 1) } 0 .. $hidden_count - 1;
+    my @hidden_to_output = map { [0.13 * ($_ + 1) - 0.25] } 0 .. $hidden_count - 1;
+
+    return {
+        input_to_hidden_weights => \@input_to_hidden,
+        hidden_biases => \@hidden_biases,
+        hidden_to_output_weights => \@hidden_to_output,
+        output_biases => [0.02],
+    };
+}

--- a/code/packages/python/two-layer-network/tests/test_two_layer_network.py
+++ b/code/packages/python/two-layer-network/tests/test_two_layer_network.py
@@ -1,5 +1,6 @@
 from two_layer_network import (
     TwoLayerNetwork,
+    TwoLayerParameters,
     create_xor_warm_start_parameters,
     forward_two_layer,
     train_one_epoch_two_layer,
@@ -40,3 +41,33 @@ def test_warm_start_solves_xor():
     assert predictions[1] > 0.7
     assert predictions[2] > 0.7
     assert predictions[3] < 0.2
+
+
+def _sample_parameters(input_count: int, hidden_count: int) -> TwoLayerParameters:
+    return TwoLayerParameters(
+        input_to_hidden_weights=[
+            [0.17 * (feature + 1) - 0.11 * (hidden + 1) for hidden in range(hidden_count)]
+            for feature in range(input_count)
+        ],
+        hidden_biases=[0.05 * (hidden - 1) for hidden in range(hidden_count)],
+        hidden_to_output_weights=[[0.13 * (hidden + 1) - 0.25] for hidden in range(hidden_count)],
+        output_biases=[0.02],
+    )
+
+
+def test_hidden_layer_teaching_examples_run_one_training_step():
+    cases = [
+        ("XNOR", XOR_INPUTS, [[1.0], [0.0], [0.0], [1.0]], 3),
+        ("absolute value", [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4),
+        ("piecewise pricing", [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4),
+        ("circle classifier", [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5),
+        ("two moons", [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5),
+        ("interaction features", [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5),
+    ]
+
+    for name, inputs, targets, hidden_count in cases:
+        step = train_one_epoch_two_layer(inputs, targets, _sample_parameters(len(inputs[0]), hidden_count), 0.4)
+
+        assert step.loss >= 0.0, name
+        assert len(step.input_to_hidden_weight_gradients) == len(inputs[0]), name
+        assert len(step.hidden_to_output_weight_gradients) == hidden_count, name

--- a/code/packages/ruby/two-layer-network/test/test_two_layer_network.rb
+++ b/code/packages/ruby/two-layer-network/test/test_two_layer_network.rb
@@ -27,4 +27,36 @@ class TwoLayerNetworkTest < Minitest::Test
     assert_equal 2, step.hidden_to_output_weight_gradients.length
     assert_equal 1, step.hidden_to_output_weight_gradients.first.length
   end
+
+  def test_hidden_layer_teaching_examples_run_one_training_step
+    cases = [
+      ["XNOR", XOR_INPUTS, [[1.0], [0.0], [0.0], [1.0]], 3],
+      ["absolute value", [[-1.0], [-0.5], [0.0], [0.5], [1.0]], [[1.0], [0.5], [0.0], [0.5], [1.0]], 4],
+      ["piecewise pricing", [[0.1], [0.3], [0.5], [0.7], [0.9]], [[0.12], [0.25], [0.55], [0.88], [0.88]], 4],
+      ["circle classifier", [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], [[1.0], [1.0], [0.0], [1.0], [0.0]], 5],
+      ["two moons", [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], 5],
+      ["interaction features", [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], [[0.08], [0.72], [0.96], [0.76]], 5]
+    ]
+
+    cases.each do |name, inputs, targets, hidden_count|
+      step = TwoLayerNetwork.train_one_epoch(inputs, targets, sample_parameters(inputs.first.length, hidden_count), 0.4)
+
+      assert_operator step.loss, :>=, 0.0, name
+      assert_equal inputs.first.length, step.input_to_hidden_weight_gradients.length, name
+      assert_equal hidden_count, step.hidden_to_output_weight_gradients.length, name
+    end
+  end
+
+  private
+
+  def sample_parameters(input_count, hidden_count)
+    TwoLayerNetwork::Parameters.new(
+      input_to_hidden_weights: Array.new(input_count) do |feature|
+        Array.new(hidden_count) { |hidden| 0.17 * (feature + 1) - 0.11 * (hidden + 1) }
+      end,
+      hidden_biases: Array.new(hidden_count) { |hidden| 0.05 * (hidden - 1) },
+      hidden_to_output_weights: Array.new(hidden_count) { |hidden| [0.13 * (hidden + 1) - 0.25] },
+      output_biases: [0.02]
+    )
+  end
 end

--- a/code/packages/rust/two-layer-network/src/lib.rs
+++ b/code/packages/rust/two-layer-network/src/lib.rs
@@ -277,6 +277,25 @@ mod tests {
         vec![vec![0.0], vec![1.0], vec![1.0], vec![0.0]]
     }
 
+    fn sample_parameters(input_count: usize, hidden_count: usize) -> Parameters {
+        Parameters {
+            input_to_hidden_weights: (0..input_count)
+                .map(|feature| {
+                    (0..hidden_count)
+                        .map(|hidden| 0.17 * (feature + 1) as f64 - 0.11 * (hidden + 1) as f64)
+                        .collect()
+                })
+                .collect(),
+            hidden_biases: (0..hidden_count)
+                .map(|hidden| 0.05 * (hidden as f64 - 1.0))
+                .collect(),
+            hidden_to_output_weights: (0..hidden_count)
+                .map(|hidden| vec![0.13 * (hidden + 1) as f64 - 0.25])
+                .collect(),
+            output_biases: vec![0.02],
+        }
+    }
+
     #[test]
     fn forward_pass_exposes_hidden_activations() {
         let passed = forward(
@@ -307,5 +326,95 @@ mod tests {
         assert_eq!(step.input_to_hidden_weight_gradients[0].len(), 2);
         assert_eq!(step.hidden_to_output_weight_gradients.len(), 2);
         assert_eq!(step.hidden_to_output_weight_gradients[0].len(), 1);
+    }
+
+    #[test]
+    fn hidden_layer_teaching_examples_run_one_training_step() {
+        let cases = vec![
+            (
+                "XNOR",
+                xor_inputs(),
+                vec![vec![1.0], vec![0.0], vec![0.0], vec![1.0]],
+                3,
+            ),
+            (
+                "absolute value",
+                vec![vec![-1.0], vec![-0.5], vec![0.0], vec![0.5], vec![1.0]],
+                vec![vec![1.0], vec![0.5], vec![0.0], vec![0.5], vec![1.0]],
+                4,
+            ),
+            (
+                "piecewise pricing",
+                vec![vec![0.1], vec![0.3], vec![0.5], vec![0.7], vec![0.9]],
+                vec![vec![0.12], vec![0.25], vec![0.55], vec![0.88], vec![0.88]],
+                4,
+            ),
+            (
+                "circle classifier",
+                vec![
+                    vec![0.0, 0.0],
+                    vec![0.5, 0.0],
+                    vec![1.0, 1.0],
+                    vec![-0.5, 0.5],
+                    vec![-1.0, 0.0],
+                ],
+                vec![vec![1.0], vec![1.0], vec![0.0], vec![1.0], vec![0.0]],
+                5,
+            ),
+            (
+                "two moons",
+                vec![
+                    vec![1.0, 0.0],
+                    vec![0.0, 0.5],
+                    vec![0.5, 0.85],
+                    vec![0.5, -0.35],
+                    vec![-1.0, 0.0],
+                    vec![2.0, 0.5],
+                ],
+                vec![
+                    vec![0.0],
+                    vec![1.0],
+                    vec![0.0],
+                    vec![1.0],
+                    vec![0.0],
+                    vec![1.0],
+                ],
+                5,
+            ),
+            (
+                "interaction features",
+                vec![
+                    vec![0.2, 0.25, 0.0],
+                    vec![0.6, 0.5, 1.0],
+                    vec![1.0, 0.75, 1.0],
+                    vec![1.0, 1.0, 0.0],
+                ],
+                vec![vec![0.08], vec![0.72], vec![0.96], vec![0.76]],
+                5,
+            ),
+        ];
+
+        for (name, inputs, targets, hidden_count) in cases {
+            let step = train_one_epoch(
+                &inputs,
+                &targets,
+                &sample_parameters(inputs[0].len(), hidden_count),
+                0.4,
+                ActivationName::Sigmoid,
+                ActivationName::Sigmoid,
+            )
+            .expect(name);
+            assert!(step.loss >= 0.0, "{name}");
+            assert_eq!(
+                step.input_to_hidden_weight_gradients.len(),
+                inputs[0].len(),
+                "{name}"
+            );
+            assert_eq!(
+                step.hidden_to_output_weight_gradients.len(),
+                hidden_count,
+                "{name}"
+            );
+        }
     }
 }

--- a/code/packages/swift/two-layer-network/Tests/TwoLayerNetworkTests/TwoLayerNetworkTests.swift
+++ b/code/packages/swift/two-layer-network/Tests/TwoLayerNetworkTests/TwoLayerNetworkTests.swift
@@ -22,4 +22,58 @@ final class TwoLayerNetworkTests: XCTestCase {
         XCTAssertEqual(step.hiddenToOutputWeightGradients.count, 2)
         XCTAssertEqual(step.hiddenToOutputWeightGradients[0].count, 1)
     }
+
+    func testHiddenLayerTeachingExamplesRunOneTrainingStep() throws {
+        let cases = [
+            ExampleCase(name: "XNOR", inputs: inputs, targets: [[1.0], [0.0], [0.0], [1.0]], hiddenCount: 3),
+            ExampleCase(name: "absolute value", inputs: [[-1.0], [-0.5], [0.0], [0.5], [1.0]], targets: [[1.0], [0.5], [0.0], [0.5], [1.0]], hiddenCount: 4),
+            ExampleCase(name: "piecewise pricing", inputs: [[0.1], [0.3], [0.5], [0.7], [0.9]], targets: [[0.12], [0.25], [0.55], [0.88], [0.88]], hiddenCount: 4),
+            ExampleCase(name: "circle classifier", inputs: [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [-0.5, 0.5], [-1.0, 0.0]], targets: [[1.0], [1.0], [0.0], [1.0], [0.0]], hiddenCount: 5),
+            ExampleCase(name: "two moons", inputs: [[1.0, 0.0], [0.0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1.0, 0.0], [2.0, 0.5]], targets: [[0.0], [1.0], [0.0], [1.0], [0.0], [1.0]], hiddenCount: 5),
+            ExampleCase(name: "interaction features", inputs: [[0.2, 0.25, 0.0], [0.6, 0.5, 1.0], [1.0, 0.75, 1.0], [1.0, 1.0, 0.0]], targets: [[0.08], [0.72], [0.96], [0.76]], hiddenCount: 5),
+        ]
+
+        for example in cases {
+            let step = try trainOneEpoch(
+                inputs: example.inputs,
+                targets: example.targets,
+                parameters: sampleParameters(inputCount: example.inputs[0].count, hiddenCount: example.hiddenCount),
+                learningRate: 0.4
+            )
+
+            XCTAssertGreaterThanOrEqual(step.loss, 0.0, example.name)
+            XCTAssertEqual(step.inputToHiddenWeightGradients.count, example.inputs[0].count, example.name)
+            XCTAssertEqual(step.hiddenToOutputWeightGradients.count, example.hiddenCount, example.name)
+        }
+    }
+
+    private func sampleParameters(inputCount: Int, hiddenCount: Int) -> Parameters {
+        var inputToHiddenWeights = Array(repeating: Array(repeating: 0.0, count: hiddenCount), count: inputCount)
+        for feature in 0..<inputCount {
+            for hidden in 0..<hiddenCount {
+                inputToHiddenWeights[feature][hidden] = 0.17 * Double(feature + 1) - 0.11 * Double(hidden + 1)
+            }
+        }
+
+        var hiddenBiases = Array(repeating: 0.0, count: hiddenCount)
+        var hiddenToOutputWeights = Array(repeating: [0.0], count: hiddenCount)
+        for hidden in 0..<hiddenCount {
+            hiddenBiases[hidden] = 0.05 * Double(hidden - 1)
+            hiddenToOutputWeights[hidden][0] = 0.13 * Double(hidden + 1) - 0.25
+        }
+
+        return Parameters(
+            inputToHiddenWeights: inputToHiddenWeights,
+            hiddenBiases: hiddenBiases,
+            hiddenToOutputWeights: hiddenToOutputWeights,
+            outputBiases: [0.02]
+        )
+    }
+
+    private struct ExampleCase {
+        let name: String
+        let inputs: [[Double]]
+        let targets: [[Double]]
+        let hiddenCount: Int
+    }
 }

--- a/code/packages/typescript/two-layer-network/tests/two-layer-network.test.ts
+++ b/code/packages/typescript/two-layer-network/tests/two-layer-network.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   TwoLayerNetwork,
+  createSeededParameters,
   createXorWarmStartParameters,
   forwardTwoLayer,
   trainOneEpochTwoLayer,
   traceExampleTwoLayer,
+  type MatrixData,
 } from "../src/index.js";
 
 const XOR_INPUTS = [
@@ -118,5 +120,29 @@ describe("two-layer network", () => {
 
     expect(history.length).toBeGreaterThan(0);
     expect(history[history.length - 1]!.epoch).toBe(10);
+  });
+
+  it("runs the hidden-layer teaching examples through one training step", () => {
+    const cases: Array<{ name: string; inputs: MatrixData; targets: MatrixData; hiddenCount: number }> = [
+      { name: "XNOR", inputs: XOR_INPUTS, targets: [[1], [0], [0], [1]], hiddenCount: 3 },
+      { name: "absolute value", inputs: [[-1], [-0.5], [0], [0.5], [1]], targets: [[1], [0.5], [0], [0.5], [1]], hiddenCount: 4 },
+      { name: "piecewise pricing", inputs: [[0.1], [0.3], [0.5], [0.7], [0.9]], targets: [[0.12], [0.25], [0.55], [0.88], [0.88]], hiddenCount: 4 },
+      { name: "circle classifier", inputs: [[0, 0], [0.5, 0], [1, 1], [-0.5, 0.5], [-1, 0]], targets: [[1], [1], [0], [1], [0]], hiddenCount: 5 },
+      { name: "two moons", inputs: [[1, 0], [0, 0.5], [0.5, 0.85], [0.5, -0.35], [-1, 0], [2, 0.5]], targets: [[0], [1], [0], [1], [0], [1]], hiddenCount: 5 },
+      { name: "interaction features", inputs: [[0.2, 0.25, 0], [0.6, 0.5, 1], [1, 0.75, 1], [1, 1, 0]], targets: [[0.08], [0.72], [0.96], [0.76]], hiddenCount: 5 },
+    ];
+
+    for (const item of cases) {
+      const step = trainOneEpochTwoLayer(
+        item.inputs,
+        item.targets,
+        createSeededParameters(item.inputs[0]!.length, item.hiddenCount, 1, item.hiddenCount, 0.8),
+        0.4,
+      );
+
+      expect(step.loss, item.name).toBeGreaterThanOrEqual(0);
+      expect(step.inputToHiddenWeightGradients, item.name).toHaveLength(item.inputs[0]!.length);
+      expect(step.hiddenToOutputWeightGradients, item.name).toHaveLength(item.hiddenCount);
+    }
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/BUILD
+++ b/code/programs/typescript/ml-learning-visualizer/BUILD
@@ -1,6 +1,8 @@
 set -eu
 
 (cd ../../../packages/typescript/directed-graph && npm install)
+(cd ../../../packages/typescript/matrix && npm install)
+(cd ../../../packages/typescript/two-layer-network && npm install)
 (cd ../../../packages/typescript/state-machine && npm install)
 (cd ../../../packages/typescript/grammar-tools && npm install)
 (cd ../../../packages/typescript/lexer && npm install)

--- a/code/programs/typescript/ml-learning-visualizer/package-lock.json
+++ b/code/programs/typescript/ml-learning-visualizer/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/lattice-transpiler": "file:../../../packages/typescript/lattice-transpiler",
+        "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
+        "matrix": "file:../../../packages/typescript/matrix",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -39,6 +41,28 @@
         "@coding-adventures/lexer": "file:../lexer",
         "@coding-adventures/parser": "file:../parser",
         "@coding-adventures/state-machine": "file:../state-machine"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/matrix": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "../../../packages/typescript/two-layer-network": {
+      "name": "coding-adventures-two-layer-network",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "matrix": "file:../matrix"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
@@ -1963,6 +1987,10 @@
         "node": ">= 16"
       }
     },
+    "node_modules/coding-adventures-two-layer-network": {
+      "resolved": "../../../packages/typescript/two-layer-network",
+      "link": true
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2880,6 +2908,10 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/matrix": {
+      "resolved": "../../../packages/typescript/matrix",
+      "link": true
     },
     "node_modules/mime-db": {
       "version": "1.52.0",

--- a/code/programs/typescript/ml-learning-visualizer/package.json
+++ b/code/programs/typescript/ml-learning-visualizer/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@coding-adventures/lattice-transpiler": "file:../../../packages/typescript/lattice-transpiler",
+    "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
+    "matrix": "file:../../../packages/typescript/matrix",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
+import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import {
   loss,
@@ -163,6 +164,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 }
 
 export function App() {
+  const [workbench, setWorkbench] = useState<"linear" | "hidden">("linear");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
   const [activationKind, setActivationKind] = useState<ActivationKind>("linear");
@@ -263,14 +265,37 @@ export function App() {
     <div className="app">
       <header className="app-header">
         <div>
-          <p className="eyebrow">100-lab foundation</p>
+          <p className="eyebrow">{workbench === "linear" ? "100-lab foundation" : "Hidden-layer playground"}</p>
           <h1>ML Learning Lab</h1>
         </div>
-        <div className="formula">
-          y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong>
+        <div className="header-actions">
+          <div className="mode-toggle" aria-label="Workbench mode">
+            <button
+              className={workbench === "linear" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("linear")}
+            >
+              Linear
+            </button>
+            <button
+              className={workbench === "hidden" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("hidden")}
+            >
+              Hidden Layer
+            </button>
+          </div>
+          <div className="formula">
+            {workbench === "linear" ? (
+              <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
+            ) : (
+              <>inputs {"->"} <strong>hidden</strong> {"->"} prediction</>
+            )}
+          </div>
         </div>
       </header>
 
+      {workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">
           <div className="rail-summary">
@@ -472,6 +497,7 @@ export function App() {
           </div>
         </aside>
       </main>
+      )}
     </div>
   );
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -1,0 +1,485 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  HIDDEN_LAYER_EXAMPLES,
+  createInitialHiddenState,
+  hiddenHistoryPoint,
+  hiddenLoss,
+  hiddenMeanAbsoluteError,
+  predictHidden,
+  traceHiddenExample,
+  trainHiddenSteps,
+  type HiddenLayerExample,
+  type HiddenLayerHistoryPoint,
+  type HiddenLayerModelState,
+  type HiddenLayerStepResult,
+} from "./hidden-layer-examples.js";
+import { forwardTwoLayer } from "coding-adventures-two-layer-network/src/index";
+
+interface HiddenChartFrame {
+  width: number;
+  height: number;
+  padLeft: number;
+  padRight: number;
+  padTop: number;
+  padBottom: number;
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+const CURVE_CHART: HiddenChartFrame = {
+  width: 720,
+  height: 410,
+  padLeft: 58,
+  padRight: 24,
+  padTop: 24,
+  padBottom: 48,
+  xMin: -1,
+  xMax: 1,
+  yMin: -0.08,
+  yMax: 1.08,
+};
+
+const SURFACE_SIZE = 460;
+
+function formatNumber(value: number, digits = 3): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  if (Math.abs(value) < 0.01 && value !== 0) {
+    return value.toExponential(2);
+  }
+  return value.toFixed(digits);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function xScale(value: number, chart: HiddenChartFrame): number {
+  const width = chart.width - chart.padLeft - chart.padRight;
+  return chart.padLeft + ((value - chart.xMin) / (chart.xMax - chart.xMin)) * width;
+}
+
+function yScale(value: number, chart: HiddenChartFrame): number {
+  const height = chart.height - chart.padTop - chart.padBottom;
+  return chart.padTop + (1 - (value - chart.yMin) / (chart.yMax - chart.yMin)) * height;
+}
+
+function hiddenHistoryPath(history: HiddenLayerHistoryPoint[]): string {
+  if (history.length === 0) {
+    return "";
+  }
+  const width = 250;
+  const height = 74;
+  const maxLoss = Math.max(...history.map((point) => point.loss), 1e-6);
+  const startEpoch = history[0]!.epoch;
+  const span = Math.max(history[history.length - 1]!.epoch - startEpoch, 1);
+
+  return history
+    .map((point, index) => {
+      const x = ((point.epoch - startEpoch) / span) * width;
+      const y = height - clamp(point.loss / maxLoss, 0, 1) * height;
+      return `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+function makeCurvePath(state: HiddenLayerModelState): string {
+  const samples = Array.from({ length: 121 }, (_, index) => {
+    const x = CURVE_CHART.xMin + (index / 120) * (CURVE_CHART.xMax - CURVE_CHART.xMin);
+    const prediction = forwardTwoLayer([[x]], state.parameters).predictions[0]![0]!;
+    return [x, prediction] as const;
+  });
+
+  return samples
+    .map(([x, y], index) => {
+      const command = index === 0 ? "M" : "L";
+      return `${command} ${xScale(x, CURVE_CHART).toFixed(2)} ${yScale(y, CURVE_CHART).toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelState): Array<{ x: number; y: number; value: number }> {
+  const cells: Array<{ x: number; y: number; value: number }> = [];
+  const divisions = 26;
+  const xValues = example.rows.map((row) => row.input[0]!);
+  const yValues = example.rows.map((row) => row.input[1]!);
+  const xMin = Math.min(...xValues, -1);
+  const xMax = Math.max(...xValues, 1);
+  const yMin = Math.min(...yValues, -1);
+  const yMax = Math.max(...yValues, 1);
+  const xPad = Math.max((xMax - xMin) * 0.08, 0.15);
+  const yPad = Math.max((yMax - yMin) * 0.08, 0.15);
+
+  for (let y = 0; y < divisions; y += 1) {
+    for (let x = 0; x < divisions; x += 1) {
+      const inputX = xMin - xPad + (x / (divisions - 1)) * (xMax - xMin + xPad * 2);
+      const inputY = yMin - yPad + (y / (divisions - 1)) * (yMax - yMin + yPad * 2);
+      const value = forwardTwoLayer([[inputX, inputY]], state.parameters).predictions[0]![0]!;
+      cells.push({ x, y, value });
+    }
+  }
+
+  return cells;
+}
+
+function CurveChart({ example, state, predictions }: { example: HiddenLayerExample; state: HiddenLayerModelState; predictions: number[] }) {
+  return (
+    <svg viewBox={`0 0 ${CURVE_CHART.width} ${CURVE_CHART.height}`} role="img" aria-label={`${example.title} hidden-layer curve`}>
+      <rect
+        className="plot-bg"
+        x={CURVE_CHART.padLeft}
+        y={CURVE_CHART.padTop}
+        width={CURVE_CHART.width - CURVE_CHART.padLeft - CURVE_CHART.padRight}
+        height={CURVE_CHART.height - CURVE_CHART.padTop - CURVE_CHART.padBottom}
+      />
+      {[0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+        const x = CURVE_CHART.xMin + (CURVE_CHART.xMax - CURVE_CHART.xMin) * ratio;
+        const y = CURVE_CHART.yMin + (CURVE_CHART.yMax - CURVE_CHART.yMin) * ratio;
+        return (
+          <g key={ratio}>
+            <line className="grid-line" x1={xScale(x, CURVE_CHART)} x2={xScale(x, CURVE_CHART)} y1={CURVE_CHART.padTop} y2={CURVE_CHART.height - CURVE_CHART.padBottom} />
+            <text className="axis-label" x={xScale(x, CURVE_CHART)} y={CURVE_CHART.height - 18}>{formatNumber(x, 1)}</text>
+            <line className="grid-line" x1={CURVE_CHART.padLeft} x2={CURVE_CHART.width - CURVE_CHART.padRight} y1={yScale(y, CURVE_CHART)} y2={yScale(y, CURVE_CHART)} />
+            <text className="axis-label axis-label--y" x={CURVE_CHART.padLeft - 10} y={yScale(y, CURVE_CHART) + 4}>{formatNumber(y, 1)}</text>
+          </g>
+        );
+      })}
+      <path className="hidden-curve" d={makeCurvePath(state)} />
+      {example.rows.map((row, index) => {
+        const px = xScale(row.input[0]!, CURVE_CHART);
+        const targetY = yScale(row.target, CURVE_CHART);
+        const predY = yScale(predictions[index]!, CURVE_CHART);
+        return (
+          <g key={row.label}>
+            <line className="error-line" x1={px} x2={px} y1={targetY} y2={predY} />
+            <circle className="truth-point" cx={px} cy={targetY} r="6" />
+            <circle className="prediction-point" cx={px} cy={predY} r="5" />
+          </g>
+        );
+      })}
+      <text className="axis-title" x={CURVE_CHART.width / 2} y={CURVE_CHART.height - 5}>{example.inputLabels[0]}</text>
+      <text className="axis-title axis-title--y" x="20" y={CURVE_CHART.height / 2}>{example.outputLabel}</text>
+    </svg>
+  );
+}
+
+function SurfaceChart({ example, state, predictions, selectedIndex, onSelect }: {
+  example: HiddenLayerExample;
+  state: HiddenLayerModelState;
+  predictions: number[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  const cells = makeSurfaceCells(example, state);
+  const divisions = Math.sqrt(cells.length);
+  const cellSize = SURFACE_SIZE / divisions;
+  const xValues = example.rows.map((row) => row.input[0]!);
+  const yValues = example.rows.map((row) => row.input[1]!);
+  const xMin = Math.min(...xValues, -1);
+  const xMax = Math.max(...xValues, 1);
+  const yMin = Math.min(...yValues, -1);
+  const yMax = Math.max(...yValues, 1);
+  const xPad = Math.max((xMax - xMin) * 0.08, 0.15);
+  const yPad = Math.max((yMax - yMin) * 0.08, 0.15);
+  const sx = (value: number) => ((value - (xMin - xPad)) / (xMax - xMin + xPad * 2)) * SURFACE_SIZE;
+  const sy = (value: number) => SURFACE_SIZE - ((value - (yMin - yPad)) / (yMax - yMin + yPad * 2)) * SURFACE_SIZE;
+
+  return (
+    <svg className="surface-chart" viewBox={`0 0 ${SURFACE_SIZE} ${SURFACE_SIZE}`} role="img" aria-label={`${example.title} decision surface`}>
+      {cells.map((cell) => (
+        <rect
+          key={`${cell.x}-${cell.y}`}
+          x={cell.x * cellSize}
+          y={cell.y * cellSize}
+          width={cellSize + 0.5}
+          height={cellSize + 0.5}
+          style={{
+            fill: `rgba(${Math.round(194 - cell.value * 150)}, ${Math.round(65 + cell.value * 90)}, ${Math.round(59 + cell.value * 120)}, 0.72)`,
+          }}
+        />
+      ))}
+      {example.rows.map((row, index) => (
+        <g
+          aria-label={`Select ${row.label}`}
+          className="svg-button"
+          key={row.label}
+          role="button"
+          tabIndex={0}
+          onClick={() => onSelect(index)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              onSelect(index);
+            }
+          }}
+        >
+          <circle
+            className={index === selectedIndex ? "surface-point surface-point--selected" : "surface-point"}
+            cx={sx(row.input[0]!)}
+            cy={sy(row.input[1]!)}
+            r={index === selectedIndex ? 9 : 7}
+            style={{ fill: row.target >= 0.5 ? "#237a57" : "#f7f8f3" }}
+          />
+          <text className="surface-label" x={sx(row.input[0]!) + 10} y={sy(row.input[1]!) - 8}>
+            {formatNumber(predictions[index]!, 2)}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+function TableChart({ example, predictions, selectedIndex, onSelect }: {
+  example: HiddenLayerExample;
+  predictions: number[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  return (
+    <div className="hidden-table-chart">
+      {example.rows.map((row, index) => {
+        const error = predictions[index]! - row.target;
+        return (
+          <button
+            className={index === selectedIndex ? "table-row table-row--selected" : "table-row"}
+            key={row.label}
+            type="button"
+            onClick={() => onSelect(index)}
+          >
+            <span>{row.label}</span>
+            <span className="bar-pair">
+              <i className="bar-target" style={{ width: `${row.target * 100}%` }} />
+              <i className="bar-prediction" style={{ width: `${predictions[index]! * 100}%` }} />
+            </span>
+            <code>{formatNumber(error, 3)}</code>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function HiddenLayerWorkbench() {
+  const [selectedId, setSelectedId] = useState(HIDDEN_LAYER_EXAMPLES[0]!.id);
+  const example = HIDDEN_LAYER_EXAMPLES.find((item) => item.id === selectedId) ?? HIDDEN_LAYER_EXAMPLES[0]!;
+  const [learningRate, setLearningRate] = useState(example.defaultLearningRate);
+  const [state, setState] = useState<HiddenLayerModelState>(() => createInitialHiddenState(example));
+  const [history, setHistory] = useState<HiddenLayerHistoryPoint[]>(() => [hiddenHistoryPoint(example, createInitialHiddenState(example))]);
+  const [lastStep, setLastStep] = useState<HiddenLayerStepResult | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+
+  useEffect(() => {
+    const initial = createInitialHiddenState(example);
+    setLearningRate(example.defaultLearningRate);
+    setState(initial);
+    setHistory([hiddenHistoryPoint(example, initial)]);
+    setLastStep(null);
+    setSelectedIndex(0);
+    setIsRunning(false);
+  }, [example]);
+
+  const predictions = useMemo(() => predictHidden(example, state), [example, state]);
+  const loss = useMemo(() => hiddenLoss(example, state), [example, state]);
+  const mae = useMemo(() => hiddenMeanAbsoluteError(example, state), [example, state]);
+  const trace = useMemo(() => traceHiddenExample(example, state, selectedIndex), [example, selectedIndex, state]);
+
+  function record(result: HiddenLayerStepResult): void {
+    setState(result.state);
+    setLastStep(result);
+    setHistory((items) => [...items.slice(-159), {
+      epoch: result.state.epoch,
+      loss: result.loss,
+      mae: result.mae,
+    }]);
+  }
+
+  function step(count: number): void {
+    const results = trainHiddenSteps(example, state, learningRate, count);
+    const result = results[results.length - 1];
+    if (result !== undefined) {
+      record(result);
+    }
+  }
+
+  function reset(): void {
+    const initial = createInitialHiddenState(example);
+    setState(initial);
+    setHistory([hiddenHistoryPoint(example, initial)]);
+    setLastStep(null);
+    setIsRunning(false);
+  }
+
+  useEffect(() => {
+    if (!isRunning) {
+      return undefined;
+    }
+
+    const id = window.setInterval(() => {
+      setState((current) => {
+        const results = trainHiddenSteps(example, current, learningRate, 5);
+        const result = results[results.length - 1]!;
+        setLastStep(result);
+        setHistory((items) => [...items.slice(-159), {
+          epoch: result.state.epoch,
+          loss: result.loss,
+          mae: result.mae,
+        }]);
+        return result.state;
+      });
+    }, 160);
+
+    return () => window.clearInterval(id);
+  }, [example, isRunning, learningRate]);
+
+  return (
+    <main className="workspace workspace--hidden">
+      <nav className="lab-rail" aria-label="Hidden-layer examples">
+        <div className="rail-summary">
+          <strong>{HIDDEN_LAYER_EXAMPLES.length}</strong>
+          <span>hidden examples</span>
+        </div>
+        <div className="lab-list">
+          {HIDDEN_LAYER_EXAMPLES.map((item) => (
+            <button
+              className={item.id === example.id ? "lab-button lab-button--active" : "lab-button"}
+              key={item.id}
+              type="button"
+              onClick={() => setSelectedId(item.id)}
+            >
+              <span>{item.title}</span>
+              <small>{item.category}</small>
+            </button>
+          ))}
+        </div>
+      </nav>
+
+      <section className="lab-stage" aria-label="Hidden-layer training stage">
+        <div className="lab-intro">
+          <div>
+            <p className="eyebrow">{example.category}</p>
+            <h2>{example.title}</h2>
+            <p>{example.summary}</p>
+          </div>
+          <div className="lab-chip">{example.hiddenCount} hidden</div>
+        </div>
+
+        <section className="chart-panel chart-panel--hidden" aria-label="Hidden-layer chart">
+          {example.chartKind === "curve" && <CurveChart example={example} state={state} predictions={predictions} />}
+          {example.chartKind === "surface" && (
+            <SurfaceChart
+              example={example}
+              state={state}
+              predictions={predictions}
+              selectedIndex={selectedIndex}
+              onSelect={setSelectedIndex}
+            />
+          )}
+          {example.chartKind === "table" && (
+            <TableChart example={example} predictions={predictions} selectedIndex={selectedIndex} onSelect={setSelectedIndex} />
+          )}
+
+          <div className="legend" aria-label="Hidden chart legend">
+            <span><i className="legend-dot legend-dot--truth" />Target</span>
+            <span><i className="legend-dot legend-dot--prediction" />Prediction</span>
+            <span><i className="legend-line legend-line--model" />Current model</span>
+          </div>
+        </section>
+
+        <section className="trace-panel" aria-label="Neuron trace">
+          <div className="history__topline">
+            <span>{example.rows[selectedIndex]!.label}</span>
+            <strong>{formatNumber(predictions[selectedIndex]!, 3)} / {formatNumber(example.rows[selectedIndex]!.target, 3)}</strong>
+          </div>
+          <div className="hidden-neuron-grid">
+            {trace.layers[0]!.neurons.map((neuron, index) => (
+              <div className="neuron-tile" key={neuron.neuron}>
+                <span>h{index + 1}</span>
+                <strong>{formatNumber(neuron.output, 3)}</strong>
+                <i style={{ width: `${clamp(neuron.output, 0, 1) * 100}%` }} />
+              </div>
+            ))}
+          </div>
+          <div className="trace-equation">
+            <code>{example.inputLabels.join(", ")} {"->"} hidden[{example.hiddenCount}] {"->"} {example.outputLabel}</code>
+          </div>
+        </section>
+      </section>
+
+      <aside className="controls metrics" aria-label="Hidden-layer controls">
+        <label className="field">
+          <span>Learning rate</span>
+          <input
+            type="range"
+            min={example.learningRateMin}
+            max={example.learningRateMax}
+            step={example.learningRateStep}
+            value={learningRate}
+            onChange={(event) => setLearningRate(Number(event.target.value))}
+          />
+          <input
+            type="number"
+            min={example.learningRateMin}
+            max={example.learningRateMax}
+            step={example.learningRateStep}
+            value={learningRate}
+            onChange={(event) => setLearningRate(Number(event.target.value))}
+          />
+        </label>
+
+        <div className="button-grid">
+          <button type="button" onClick={() => step(1)}>Step</button>
+          <button type="button" onClick={() => step(25)}>Step 25</button>
+          <button type="button" onClick={() => setIsRunning((value) => !value)}>{isRunning ? "Pause" : "Run"}</button>
+          <button type="button" onClick={reset}>Reset</button>
+        </div>
+
+        <div className="metric">
+          <span>Epoch</span>
+          <strong>{state.epoch}</strong>
+        </div>
+        <div className="metric">
+          <span>Loss</span>
+          <strong>{formatNumber(loss, 4)}</strong>
+        </div>
+        <div className="metric">
+          <span>Average error</span>
+          <strong>{formatNumber(mae, 3)}</strong>
+        </div>
+
+        <div className="history">
+          <div className="history__topline">
+            <span>Loss history</span>
+            <strong>{history.length} points</strong>
+          </div>
+          <svg viewBox="0 0 250 74" role="img" aria-label="Hidden-layer loss history">
+            <path className="history-grid" d="M 0 37 L 250 37" />
+            <path className="history-line" d={hiddenHistoryPath(history)} />
+          </svg>
+        </div>
+
+        <label className="field">
+          <span>Trace row</span>
+          <select value={selectedIndex} onChange={(event) => setSelectedIndex(Number(event.target.value))}>
+            {example.rows.map((row, index) => (
+              <option key={row.label} value={index}>{row.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <div className="gradients">
+          <span>Last gradient shape</span>
+          <code>input-hidden {lastStep === null ? "0x0" : `${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]!.length}`}</code>
+          <code>hidden-output {lastStep === null ? "0x0" : `${lastStep.step.hiddenToOutputWeightGradients.length}x${lastStep.step.hiddenToOutputWeightGradients[0]!.length}`}</code>
+        </div>
+
+        <div className="lesson">
+          <span>Learning note</span>
+          <p>{example.lesson}</p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
@@ -1,0 +1,329 @@
+import {
+  createSeededParameters,
+  forwardTwoLayer,
+  trainOneEpochTwoLayer,
+  traceExampleTwoLayer,
+  type ExampleTrace,
+  type MatrixData,
+  type TwoLayerParameters,
+  type TwoLayerTrainingStep,
+} from "coding-adventures-two-layer-network/src/index";
+
+export type HiddenLayerChartKind = "curve" | "surface" | "table";
+
+export interface HiddenLayerExampleRow {
+  input: number[];
+  target: number;
+  label: string;
+  group?: string;
+}
+
+export interface HiddenLayerExample {
+  id: string;
+  title: string;
+  category: string;
+  summary: string;
+  lesson: string;
+  inputLabels: string[];
+  outputLabel: string;
+  rows: HiddenLayerExampleRow[];
+  hiddenCount: number;
+  initialScale: number;
+  seed: number;
+  defaultLearningRate: number;
+  learningRateMin: number;
+  learningRateMax: number;
+  learningRateStep: number;
+  chartKind: HiddenLayerChartKind;
+}
+
+export interface HiddenLayerModelState {
+  parameters: TwoLayerParameters;
+  epoch: number;
+}
+
+export interface HiddenLayerStepResult {
+  state: HiddenLayerModelState;
+  step: TwoLayerTrainingStep;
+  loss: number;
+  mae: number;
+}
+
+export interface HiddenLayerHistoryPoint {
+  epoch: number;
+  loss: number;
+  mae: number;
+}
+
+function makeExample(args: Omit<HiddenLayerExample, "learningRateMin" | "learningRateMax" | "learningRateStep">): HiddenLayerExample {
+  return {
+    ...args,
+    learningRateMin: args.defaultLearningRate / 20,
+    learningRateMax: args.defaultLearningRate * 8,
+    learningRateStep: args.defaultLearningRate / 20,
+  };
+}
+
+function targetRows(example: HiddenLayerExample): MatrixData {
+  return example.rows.map((row) => [row.target]);
+}
+
+export function exampleInputs(example: HiddenLayerExample): MatrixData {
+  return example.rows.map((row) => row.input);
+}
+
+export function exampleTargets(example: HiddenLayerExample): MatrixData {
+  return targetRows(example);
+}
+
+export function createInitialHiddenState(example: HiddenLayerExample): HiddenLayerModelState {
+  return {
+    epoch: 0,
+    parameters: createSeededParameters(
+      example.inputLabels.length,
+      example.hiddenCount,
+      1,
+      example.seed,
+      example.initialScale,
+    ),
+  };
+}
+
+export function predictHidden(example: HiddenLayerExample, state: HiddenLayerModelState): number[] {
+  return forwardTwoLayer(exampleInputs(example), state.parameters).predictions.map((row) => row[0]!);
+}
+
+export function hiddenLoss(example: HiddenLayerExample, state: HiddenLayerModelState): number {
+  const predictions = predictHidden(example, state);
+  return predictions.reduce((sum, prediction, index) => {
+    const error = prediction - example.rows[index]!.target;
+    return sum + error * error;
+  }, 0) / predictions.length;
+}
+
+export function hiddenMeanAbsoluteError(example: HiddenLayerExample, state: HiddenLayerModelState): number {
+  const predictions = predictHidden(example, state);
+  return predictions.reduce((sum, prediction, index) => {
+    return sum + Math.abs(prediction - example.rows[index]!.target);
+  }, 0) / predictions.length;
+}
+
+export function hiddenHistoryPoint(example: HiddenLayerExample, state: HiddenLayerModelState): HiddenLayerHistoryPoint {
+  return {
+    epoch: state.epoch,
+    loss: hiddenLoss(example, state),
+    mae: hiddenMeanAbsoluteError(example, state),
+  };
+}
+
+export function trainHiddenStep(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+  learningRate: number,
+): HiddenLayerStepResult {
+  const step = trainOneEpochTwoLayer(
+    exampleInputs(example),
+    targetRows(example),
+    state.parameters,
+    learningRate,
+  );
+  const nextState = {
+    epoch: state.epoch + 1,
+    parameters: step.nextParameters,
+  };
+
+  return {
+    state: nextState,
+    step,
+    loss: hiddenLoss(example, nextState),
+    mae: hiddenMeanAbsoluteError(example, nextState),
+  };
+}
+
+export function trainHiddenSteps(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+  learningRate: number,
+  count: number,
+): HiddenLayerStepResult[] {
+  const results: HiddenLayerStepResult[] = [];
+  let current = state;
+  for (let index = 0; index < count; index += 1) {
+    const result = trainHiddenStep(example, current, learningRate);
+    results.push(result);
+    current = result.state;
+  }
+  return results;
+}
+
+export function traceHiddenExample(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+  rowIndex: number,
+): ExampleTrace {
+  return {
+    ...traceExampleTwoLayer(
+      [example.rows[rowIndex]!.input],
+      state.parameters,
+      0,
+      [example.rows[rowIndex]!.target],
+    ),
+    exampleIndex: rowIndex,
+  };
+}
+
+const circleRows: HiddenLayerExampleRow[] = [];
+for (const x of [-1, -0.5, 0, 0.5, 1]) {
+  for (const y of [-1, -0.5, 0, 0.5, 1]) {
+    circleRows.push({
+      input: [x, y],
+      target: x * x + y * y <= 0.55 ? 1 : 0,
+      label: `(${x}, ${y})`,
+      group: x * x + y * y <= 0.55 ? "inside" : "outside",
+    });
+  }
+}
+
+const moonRows: HiddenLayerExampleRow[] = [];
+for (let index = 0; index < 12; index += 1) {
+  const angle = (Math.PI * index) / 11;
+  moonRows.push({
+    input: [Math.cos(angle), Math.sin(angle)],
+    target: 0,
+    label: `upper ${index + 1}`,
+    group: "upper",
+  });
+  moonRows.push({
+    input: [1 - Math.cos(angle), 0.5 - Math.sin(angle)],
+    target: 1,
+    label: `lower ${index + 1}`,
+    group: "lower",
+  });
+}
+
+export const HIDDEN_LAYER_EXAMPLES: HiddenLayerExample[] = [
+  makeExample({
+    id: "xnor",
+    title: "XNOR Gate",
+    category: "Logic",
+    summary: "Outputs 1 when the two inputs match and 0 when they differ.",
+    lesson: "The hidden layer learns two useful regions: both inputs off and both inputs on. The output neuron combines those regions into one decision.",
+    inputLabels: ["A", "B"],
+    outputLabel: "same?",
+    rows: [
+      { input: [0, 0], target: 1, label: "A=0, B=0", group: "same" },
+      { input: [0, 1], target: 0, label: "A=0, B=1", group: "different" },
+      { input: [1, 0], target: 0, label: "A=1, B=0", group: "different" },
+      { input: [1, 1], target: 1, label: "A=1, B=1", group: "same" },
+    ],
+    hiddenCount: 3,
+    initialScale: 2,
+    seed: 31,
+    defaultLearningRate: 1.4,
+    chartKind: "surface",
+  }),
+  makeExample({
+    id: "absolute-value",
+    title: "Absolute Value",
+    category: "Regression",
+    summary: "Learns the V-shaped relationship y = |x| on normalized inputs.",
+    lesson: "A single line cannot bend at zero. Hidden neurons can split the input range into left and right regions, then recombine them into a V.",
+    inputLabels: ["x"],
+    outputLabel: "|x|",
+    rows: [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1].map((x) => ({
+      input: [x],
+      target: Math.abs(x),
+      label: `x=${x}`,
+    })),
+    hiddenCount: 6,
+    initialScale: 3,
+    seed: 12,
+    defaultLearningRate: 1.8,
+    chartKind: "curve",
+  }),
+  makeExample({
+    id: "piecewise-pricing",
+    title: "Piecewise Pricing",
+    category: "Regression",
+    summary: "Approximates a stepped shipping-price schedule from package weight.",
+    lesson: "Hidden neurons can behave like soft thresholds. Several thresholds together make a stair-step curve.",
+    inputLabels: ["weight"],
+    outputLabel: "price tier",
+    rows: [
+      [0.05, 0.12],
+      [0.15, 0.12],
+      [0.25, 0.25],
+      [0.35, 0.25],
+      [0.45, 0.55],
+      [0.55, 0.55],
+      [0.7, 0.88],
+      [0.85, 0.88],
+      [1, 0.88],
+    ].map(([x, y]) => ({
+      input: [x],
+      target: y,
+      label: `${Math.round(x * 40)} lb`,
+    })),
+    hiddenCount: 6,
+    initialScale: 3,
+    seed: 19,
+    defaultLearningRate: 2,
+    chartKind: "curve",
+  }),
+  makeExample({
+    id: "circle-classifier",
+    title: "Circle Classifier",
+    category: "Classification",
+    summary: "Classifies whether a point is inside a circle.",
+    lesson: "The hidden layer combines several soft boundaries. Together they can carve out a round-ish region even though each neuron is simple.",
+    inputLabels: ["x", "y"],
+    outputLabel: "inside?",
+    rows: circleRows,
+    hiddenCount: 8,
+    initialScale: 3,
+    seed: 37,
+    defaultLearningRate: 2.2,
+    chartKind: "surface",
+  }),
+  makeExample({
+    id: "two-moons",
+    title: "Two Moons",
+    category: "Classification",
+    summary: "Separates two curved bands that no single straight boundary can split.",
+    lesson: "The hidden layer remaps curved geometry into features the output neuron can combine into a useful decision.",
+    inputLabels: ["x", "y"],
+    outputLabel: "moon",
+    rows: moonRows,
+    hiddenCount: 10,
+    initialScale: 3,
+    seed: 43,
+    defaultLearningRate: 1.8,
+    chartKind: "surface",
+  }),
+  makeExample({
+    id: "interaction-features",
+    title: "Interaction Features",
+    category: "Tabular",
+    summary: "Predicts a normalized house-value score from bedrooms, bathrooms, and garage.",
+    lesson: "The hidden layer can learn combinations, like garage plus enough rooms, instead of treating each input as a separate straight-line effect.",
+    inputLabels: ["bedrooms", "bathrooms", "garage"],
+    outputLabel: "value score",
+    rows: [
+      { input: [0.2, 0.25, 0], target: 0.08, label: "1 bed, 1 bath, no garage" },
+      { input: [0.4, 0.25, 0], target: 0.18, label: "2 bed, 1 bath, no garage" },
+      { input: [0.4, 0.5, 0], target: 0.32, label: "2 bed, 2 bath, no garage" },
+      { input: [0.6, 0.5, 0], target: 0.45, label: "3 bed, 2 bath, no garage" },
+      { input: [0.6, 0.5, 1], target: 0.72, label: "3 bed, 2 bath, garage" },
+      { input: [0.8, 0.5, 0], target: 0.58, label: "4 bed, 2 bath, no garage" },
+      { input: [0.8, 0.75, 1], target: 0.9, label: "4 bed, 3 bath, garage" },
+      { input: [1, 0.75, 1], target: 0.96, label: "5 bed, 3 bath, garage" },
+      { input: [1, 1, 0], target: 0.76, label: "5 bed, 4 bath, no garage" },
+      { input: [0.2, 0.5, 1], target: 0.35, label: "1 bed, 2 bath, garage" },
+    ],
+    hiddenCount: 7,
+    initialScale: 3,
+    seed: 51,
+    defaultLearningRate: 1.8,
+    chartKind: "table",
+  }),
+];

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -128,6 +128,35 @@ h2 {
   text-align: right;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mode-toggle {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.mode-button {
+  min-height: 34px;
+  padding: 0 12px;
+  border-color: transparent;
+  white-space: nowrap;
+}
+
+.mode-button--active {
+  border-color: rgba(37, 99, 235, 0.38);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
 .workspace--lab {
   display: grid;
   grid-template-columns: 310px minmax(500px, 1fr) 300px;
@@ -135,10 +164,18 @@ h2 {
   align-items: start;
 }
 
+.workspace--hidden {
+  display: grid;
+  grid-template-columns: 260px minmax(520px, 1fr) 310px;
+  gap: 14px;
+  align-items: start;
+}
+
 .lab-rail,
 .chart-panel,
 .metrics,
-.lab-intro {
+.lab-intro,
+.trace-panel {
   @include surface;
 }
 
@@ -286,6 +323,14 @@ h2 {
   aspect-ratio: 720 / 460;
 }
 
+.chart-panel--hidden {
+  min-height: 520px;
+}
+
+.chart-panel--hidden svg {
+  max-height: 520px;
+}
+
 .plot-bg {
   fill: #ffffff;
 }
@@ -328,6 +373,12 @@ h2 {
   stroke-width: 4;
 }
 
+.hidden-curve {
+  fill: none;
+  stroke: $blue;
+  stroke-width: 4;
+}
+
 .error-line {
   stroke: rgba(194, 65, 59, 0.42);
   stroke-width: 2;
@@ -341,6 +392,93 @@ h2 {
 
 .prediction-point {
   fill: $red;
+}
+
+.surface-chart {
+  display: block;
+  width: min(100%, 560px);
+  aspect-ratio: 1;
+  margin: 0 auto;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.svg-button {
+  cursor: pointer;
+  outline: none;
+}
+
+.svg-button:focus .surface-point {
+  stroke: $blue;
+  stroke-width: 4;
+}
+
+.surface-point {
+  stroke: #17201c;
+  stroke-width: 2;
+}
+
+.surface-point--selected {
+  stroke: $blue;
+  stroke-width: 4;
+}
+
+.surface-label {
+  fill: #17201c;
+  font-size: 13px;
+  font-weight: 850;
+  paint-order: stroke;
+  stroke: rgba(255, 255, 255, 0.78);
+  stroke-width: 4px;
+}
+
+.hidden-table-chart {
+  display: grid;
+  gap: 8px;
+  padding: 4px;
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(140px, 220px) 72px;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 8px 10px;
+  border-color: $line;
+  text-align: left;
+}
+
+.table-row--selected {
+  border-color: rgba(37, 99, 235, 0.5);
+  background: #edf4ff;
+}
+
+.bar-pair {
+  position: relative;
+  display: block;
+  height: 22px;
+  border-radius: 6px;
+  background: #eef4f0;
+  overflow: hidden;
+}
+
+.bar-target,
+.bar-prediction {
+  position: absolute;
+  left: 0;
+  display: block;
+  height: 10px;
+}
+
+.bar-target {
+  top: 2px;
+  background: rgba(35, 122, 87, 0.78);
+}
+
+.bar-prediction {
+  bottom: 2px;
+  background: rgba(194, 65, 59, 0.78);
 }
 
 .legend {
@@ -436,9 +574,14 @@ h2 {
 .gradients,
 .lesson,
 .activation-panel,
-.source-panel {
+.source-panel,
+.trace-panel {
   display: grid;
   gap: 6px;
+}
+
+.trace-panel {
+  padding: 14px;
 }
 
 .lesson p,
@@ -472,8 +615,47 @@ code {
   font-size: 0.8rem;
 }
 
+.hidden-neuron-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  gap: 8px;
+}
+
+.neuron-tile {
+  display: grid;
+  gap: 4px;
+  min-height: 76px;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.neuron-tile span {
+  color: $muted;
+  font-size: 0.74rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.neuron-tile strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.neuron-tile i {
+  display: block;
+  height: 8px;
+  border-radius: 999px;
+  background: $green;
+}
+
+.trace-equation code {
+  margin-top: 4px;
+}
+
 @media (max-width: 1180px) {
-  .workspace--lab {
+  .workspace--lab,
+  .workspace--hidden {
     grid-template-columns: 270px minmax(420px, 1fr);
   }
 
@@ -489,7 +671,8 @@ code {
   }
 
   .app-header,
-  .lab-intro {
+  .lab-intro,
+  .header-actions {
     display: grid;
   }
 
@@ -498,7 +681,8 @@ code {
     text-align: left;
   }
 
-  .workspace--lab {
+  .workspace--lab,
+  .workspace--hidden {
     grid-template-columns: 1fr;
   }
 
@@ -507,6 +691,10 @@ code {
   }
 
   .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .table-row {
     grid-template-columns: 1fr;
   }
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -9,6 +9,13 @@ import {
   type ModelState,
 } from "./training.js";
 import { LABS } from "./labs.js";
+import {
+  HIDDEN_LAYER_EXAMPLES,
+  createInitialHiddenState,
+  hiddenLoss,
+  trainHiddenStep,
+  trainHiddenSteps,
+} from "./hidden-layer-examples.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -54,5 +61,40 @@ describe("training helpers", () => {
     expect(activate(-2, "leakyRelu")).toBeCloseTo(-0.2);
     expect(activate(0, "sigmoid")).toBeCloseTo(0.5);
     expect(activate(0, "tanh")).toBeCloseTo(0);
+  });
+
+  it("registers the hidden-layer teaching examples without sine yet", () => {
+    expect(HIDDEN_LAYER_EXAMPLES.map((example) => example.id)).toEqual([
+      "xnor",
+      "absolute-value",
+      "piecewise-pricing",
+      "circle-classifier",
+      "two-moons",
+      "interaction-features",
+    ]);
+    expect(HIDDEN_LAYER_EXAMPLES.every((example) => example.rows.length > 0)).toBe(true);
+  });
+
+  it("runs a hidden-layer training step for every teaching example", () => {
+    for (const example of HIDDEN_LAYER_EXAMPLES) {
+      const initial = createInitialHiddenState(example);
+      const step = trainHiddenStep(example, initial, example.defaultLearningRate);
+
+      expect(Number.isFinite(step.loss)).toBe(true);
+      expect(step.state.epoch).toBe(1);
+      expect(step.step.inputToHiddenWeightGradients).toHaveLength(example.inputLabels.length);
+      expect(step.step.hiddenToOutputWeightGradients).toHaveLength(example.hiddenCount);
+    }
+  });
+
+  it("moves downhill on XNOR and absolute value with batch updates", () => {
+    for (const example of HIDDEN_LAYER_EXAMPLES.slice(0, 2)) {
+      const initial = createInitialHiddenState(example);
+      const before = hiddenLoss(example, initial);
+      const steps = trainHiddenSteps(example, initial, example.defaultLearningRate, 40);
+      const after = hiddenLoss(example, steps[steps.length - 1]!.state);
+
+      expect(after).toBeLessThan(before);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- add six hidden-layer teaching examples to the TypeScript ML visualizer: XNOR, absolute value, piecewise pricing, circle classifier, two moons, and interaction features
- add a hidden-layer workbench with curve/surface/table visualizations, learning-rate controls, loss history, and per-neuron tracing
- add a shared learning note for the example suite and explicitly leave sine approximation for a later focused pass
- expand two-layer-network executable coverage across the supported language packages so every language runs the same hidden-layer example shapes through a training step

## Validation

- `bash BUILD` in `code/programs/typescript/ml-learning-visualizer`
- `npm run build && npm test` in `code/packages/typescript/two-layer-network`
- `go test ./...` in `code/packages/go/two-layer-network`
- `/usr/bin/python3 -m pytest tests` in `code/packages/python/two-layer-network`
- `cargo fmt -p two-layer-network && cargo test -p two-layer-network` in `code/packages/rust`
- `ruby -Ilib test/test_two_layer_network.rb` in `code/packages/ruby/two-layer-network`
- `perl -Ilib t/00-load.t && perl -Ilib t/01-basic.t` in `code/packages/perl/two-layer-network`
- `lua tests/test_two_layer_network.lua` in `code/packages/lua/two_layer_network`
- `mix test` in `code/packages/elixir/two_layer_network`
- `gradle test --quiet` in `code/packages/java/two-layer-network`
- `gradle test --quiet` in `code/packages/kotlin/two-layer-network`
- `dart test` in `code/packages/dart/two-layer-network`
- `swift test` in `code/packages/swift/two-layer-network`
- `dotnet test tests/CodingAdventures.TwoLayerNetwork.Tests/CodingAdventures.TwoLayerNetwork.Tests.csproj` in `code/packages/csharp/two-layer-network`
- `dotnet test tests/CodingAdventures.TwoLayerNetwork.Tests/CodingAdventures.TwoLayerNetwork.Tests.fsproj` in `code/packages/fsharp/two-layer-network`
- `cabal test` in `code/packages/haskell/two-layer-network`
- `git diff --check`