### PR TITLE
chore(phase13): version alignment — symbolic-ir 0.7.0, symbolic-vm 0.32.0, macsyma-compiler 0.7.0

### DIFF
--- a/code/packages/python/macsyma-compiler/CHANGELOG.md
+++ b/code/packages/python/macsyma-compiler/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.0 — 2026-04-27
+
+**Phase 13 — Hyperbolic function compiler mappings.**
+
+No new compiler logic was needed — `"sinh": SINH`, `"cosh": COSH`,
+`"tanh": TANH`, `"asinh": ASINH`, `"acosh": ACOSH`, and `"atanh": ATANH`
+were already added to `_STANDARD_FUNCTIONS` in 0.5.0. This release bumps the
+version to align with Phase 13 of the symbolic VM (0.32.0), and updates the
+`symbolic-ir` dependency to `>=0.7.0`.
+
 ## 0.6.0 — 2026-04-27
 
 **Phase G — Control-flow AST → IR compilation.**

--- a/code/packages/python/macsyma-compiler/pyproject.toml
+++ b/code/packages/python/macsyma-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-macsyma-compiler"
-version = "0.6.0"
+version = "0.7.0"
 description = "Lowers parsed MACSYMA ASTs to the universal symbolic IR."
 requires-python = ">=3.12"
 license = "MIT"
@@ -19,7 +19,7 @@ dependencies = [
     "coding-adventures-macsyma-parser",
     "coding-adventures-parser",
     "coding-adventures-state-machine",
-    "coding-adventures-symbolic-ir>=0.6.0",
+    "coding-adventures-symbolic-ir>=0.7.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/symbolic-ir/CHANGELOG.md
+++ b/code/packages/python/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.0 — 2026-04-27
+
+**Phase 13 — Hyperbolic function head symbols.**
+
+No new nodes were needed — `SINH`, `COSH`, `TANH`, `ASINH`, `ACOSH`, and
+`ATANH` were already added in 0.5.0. This release bumps the version to align
+with Phase 13 of the symbolic VM (0.32.0) and macsyma-compiler (0.7.0), which
+fully implement hyperbolic function evaluation, differentiation, and
+integration. Consumers that declare `symbolic-ir>=0.7.0` are guaranteed all
+six hyperbolic head symbols are present and exported.
+
 ## 0.6.0 — 2026-04-27
 
 **Phase G — Control-flow head symbols.**

--- a/code/packages/python/symbolic-ir/pyproject.toml
+++ b/code/packages/python/symbolic-ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-ir"
-version = "0.6.0"
+version = "0.7.0"
 description = "Universal symbolic expression IR — the shared tree representation that every CAS frontend compiles to and every CAS backend consumes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.32.0 — 2026-04-27
+
+**Phase 13 — Hyperbolic function evaluation, differentiation, and integration.**
+
+New evaluation handlers (six `_elementary`-based handlers in `handlers.py`,
+registered in `build_handler_table`):
+
+- `sinh(simplify)` — `Sinh(u)`, exact identity `Sinh(0) = 0`.
+- `cosh(simplify)` — `Cosh(u)`, exact identity `Cosh(0) = 1`.
+- `tanh(simplify)` — `Tanh(u)`, exact identity `Tanh(0) = 0`.
+- `asinh(simplify)` — `Asinh(u)`, exact identity `Asinh(0) = 0`.
+- `acosh(simplify)` — `Acosh(u)`, exact identity `Acosh(1) = 0`.
+- `atanh(simplify)` — `Atanh(u)`, exact identity `Atanh(0) = 0`.
+
+New integration modules:
+
+- `sinh_poly_integral.py` — tabular IBP for `∫ P(x)·sinh(ax+b) dx` and
+  `∫ P(x)·cosh(ax+b) dx`. Sign alternation `(−1)^k` (period 2, vs trig's
+  period 4). Public API: `sinh_poly_integral`, `cosh_poly_integral`.
+- `asinh_poly_integral.py` — reduction IBP for `∫ P(x)·asinh(ax+b) dx` and
+  `∫ P(x)·acosh(ax+b) dx`. Uses the reduction formula
+  `Iₙ = (1/n)·tⁿ⁻¹·√(t²±1) ∓ (n−1)/n · Iₙ₋₂`. Public API:
+  `asinh_poly_integral`, `acosh_poly_integral`.
+
+Changes to `integrate.py` (9 change sites):
+
+1. Imports: added `SINH`, `COSH`, `TANH`, `ASINH`, `ACOSH`, `ATANH` and
+   the two new module imports.
+2. Phase 1 head set: added all six hyperbolic heads.
+3. Phase 3 head set: added all six.
+4. Bare dispatch: `SINH`/`COSH` → tabular IBP; `TANH` → `log(cosh(ax+b))/a`;
+   `ASINH`/`ACOSH` → reduction IBP; `ATANH` → inline IBP formula.
+5. Dispatcher functions: `_try_sinh_product`, `_try_cosh_product`,
+   `_try_asinh_product`, `_try_acosh_product`.
+6. Phase 13 MUL hooks wired in after Phase 12 block.
+7. Diff rules in `_diff_ir`: all six hyperbolic functions.
+8. Helper functions: `_tanh_integral`, `_atanh_integral`.
+
+New test file `tests/test_phase13.py` with 55 tests across 9 classes:
+`TestPhase13_SinhCanonical` (8), `TestPhase13_CoshCanonical` (7),
+`TestPhase13_LinearHyp` (8), `TestPhase13_AsinhCanonical` (8),
+`TestPhase13_AcoshCanonical` (5), `TestPhase13_BareAtanhTanh` (4),
+`TestPhase13_Fallthrough` (4), `TestPhase13_Regressions` (6),
+`TestPhase13_Macsyma` (5).
+
+Bumped `symbolic-ir` dependency to `>=0.7.0`.
+
+New spec: `code/specs/phase13-hyperbolic.md`.
+
 ## 0.31.0 — 2026-04-27
 
 **Phase G — Control-flow VM handlers.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.31.0"
+version = "0.32.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,7 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["symbolic", "vm", "interpreter", "cas", "term-rewriting", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.6.0",
+    "coding-adventures-symbolic-ir>=0.7.0",
     "coding-adventures-polynomial",
     "coding-adventures-macsyma-parser",
     "coding-adventures-macsyma-compiler",


### PR DESCRIPTION
## Summary

- Bumps `symbolic-ir` from 0.6.0 → **0.7.0** (post-Phase-G alignment bump)
- Bumps `symbolic-vm` from 0.31.0 → **0.32.0** (Phase 13 officially documented)
- Bumps `macsyma-compiler` from 0.6.0 → **0.7.0** (Phase 13 alignment)
- Updates `symbolic-ir` dependency pin to `>=0.7.0` in both `symbolic-vm` and `macsyma-compiler`
- Adds CHANGELOG entries for all three packages documenting Phase 13 (hyperbolic functions: sinh, cosh, tanh, asinh, acosh, atanh)

The Phase 13 *implementation* (handlers, integration modules `sinh_poly_integral.py` / `asinh_poly_integral.py`, diff rules, 55 tests, spec) was already merged via PR #1095. Phase G (PR #1585) subsequently bumped the minor versions, leaving Phase 13 undocumented at the new version numbers. This PR closes that gap.

## Test plan

- [ ] `build (ubuntu-latest)` passes (941 tests, 86% coverage — no code changes, only metadata)
- [ ] `build (macos-latest)` and `build (windows-latest)` pass
- [ ] No ruff issues introduced (diff is pure CHANGELOG + pyproject.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)