### PR TITLE
fix(algol): parse procedure calls as arithmetic primaries

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -223,7 +223,7 @@ for_elem     = arith_expr "step" arith_expr "until" arith_expr
 #     addition / subtraction
 #     multiplication / division / div / mod
 #     exponentiation (left-associative per ALGOL 60 report)
-#     primary (literal, variable, call, parenthesised expression)
+#     primary (literal, call, variable, parenthesised expression)
 #
 # Only the `expression` rule (used in assignments and actual parameters)
 # needs the full unified hierarchy.  Rules used in type-specific contexts
@@ -273,8 +273,8 @@ factor       = primary { ( CARET | POWER ) primary } ;
 primary      = INTEGER_LIT
              | REAL_LIT
              | STRING_LIT
-             | variable
              | proc_call
+             | variable
              | LPAREN arith_expr RPAREN ;
 
 # Boolean expression.

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -625,6 +625,32 @@ class TestProcedureCall:
         )
         assert ast.rule_name == "program"
 
+    def test_procedure_call_in_relation_left_operand(self) -> None:
+        """Procedure calls remain calls inside arithmetic relation operands."""
+        ast = parse(
+            "begin integer result; "
+            "integer procedure twice(x); value x; integer x; begin twice := x * 2 end; "
+            "if twice(2) = 4 then result := 1 else result := 0 "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "relation")
+        assert find_nodes(ast, "proc_call")
+
+    def test_procedure_call_in_array_subscript(self) -> None:
+        """Subscripts use arith_expr, so calls must parse there too."""
+        ast = parse(
+            "begin integer result; integer array a[1:4]; "
+            "integer procedure idx(x); value x; integer x; begin idx := x end; "
+            "a[idx(2)] := 7; result := a[idx(2)] "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "subscripts")
+        assert find_nodes(ast, "proc_call")
+
 
 # ---------------------------------------------------------------------------
 # Compound statement tests

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -683,6 +683,24 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
 
+    def test_procedure_call_can_be_relation_operand(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure twice(x); value x; integer x; begin twice := x * 2 end; "
+            "if twice(2) = 4 then result := 1 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_procedure_call_can_be_array_subscript(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:4]; "
+            "integer procedure idx(x); value x; integer x; begin idx := x end; "
+            "a[idx(2)] := 7; result := a[idx(2)] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_repeated_switch_designational_gotos_use_distinct_dispatch(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- parse `proc_call` before `variable` in ALGOL arithmetic primaries, matching the unified expression grammar ordering
- allow procedure calls directly inside relation operands, e.g. `if twice(2) = 4 then ...`
- allow procedure calls inside arithmetic-only contexts such as array subscripts
- add parser and WASM runtime regressions for relation operands and subscripts

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `ruff check code/packages/python/algol-parser/tests/test_algol_parser.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Security review
- grammar/test-only change; no dependency, CI, subprocess, network, deserialization, or filesystem access changes
- local grep review found only an existing test name containing `eval`