### PR TITLE
Recover missing semicolons in numeric HTML references

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -49,3 +49,5 @@ documented in this file.
 - Decimal and hexadecimal numeric character references in data, RCDATA, and
   attribute values, including replacement-character fallback for null or
   invalid scalar values.
+- Missing-semicolon recovery for decimal and hexadecimal numeric character
+  references in data, RCDATA, and attribute values.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -721,14 +721,23 @@ from = "text_numeric_hex_character_reference"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["append_temporary_buffer_to_text", "flush_text", "emit(EOF)"]
+actions = [
+  "append_numeric_character_reference_to_text",
+  "parse_error(missing-semicolon-after-character-reference)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "text_numeric_hex_character_reference"
 matcher = { anything = true }
 to = "data"
 consume = false
-actions = ["append_temporary_buffer_to_text", "switch_to_return_state"]
+actions = [
+  "append_numeric_character_reference_to_text",
+  "parse_error(missing-semicolon-after-character-reference)",
+  "switch_to_return_state",
+]
 
 [[transitions]]
 from = "text_numeric_decimal_character_reference"
@@ -750,14 +759,23 @@ from = "text_numeric_decimal_character_reference"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["append_temporary_buffer_to_text", "flush_text", "emit(EOF)"]
+actions = [
+  "append_numeric_character_reference_to_text",
+  "parse_error(missing-semicolon-after-character-reference)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "text_numeric_decimal_character_reference"
 matcher = { anything = true }
 to = "data"
 consume = false
-actions = ["append_temporary_buffer_to_text", "switch_to_return_state"]
+actions = [
+  "append_numeric_character_reference_to_text",
+  "parse_error(missing-semicolon-after-character-reference)",
+  "switch_to_return_state",
+]
 
 [[transitions]]
 from = "text_named_character_reference_a"
@@ -1840,7 +1858,8 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
-  "append_temporary_buffer_to_attribute_value",
+  "append_numeric_character_reference_to_attribute_value",
+  "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
   "commit_attribute",
   "emit_current_token",
@@ -1853,7 +1872,8 @@ matcher = { anything = true }
 to = "attribute_value_unquoted"
 consume = false
 actions = [
-  "append_temporary_buffer_to_attribute_value",
+  "append_numeric_character_reference_to_attribute_value",
+  "parse_error(missing-semicolon-after-character-reference)",
   "switch_to_return_state",
 ]
 
@@ -1878,7 +1898,8 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
-  "append_temporary_buffer_to_attribute_value",
+  "append_numeric_character_reference_to_attribute_value",
+  "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
   "commit_attribute",
   "emit_current_token",
@@ -1891,7 +1912,8 @@ matcher = { anything = true }
 to = "attribute_value_unquoted"
 consume = false
 actions = [
-  "append_temporary_buffer_to_attribute_value",
+  "append_numeric_character_reference_to_attribute_value",
+  "parse_error(missing-semicolon-after-character-reference)",
   "switch_to_return_state",
 ]
 
@@ -3083,3 +3105,8 @@ tokens = ["Text(data=Fish & <b> \"quote\" 'ok')", "EOF"]
 name = "html-numeric-character-references"
 input = "Letters: &#65; &#x42; &#X43; &#0;"
 tokens = ["Text(data=Letters: A B C \uFFFD)", "EOF"]
+
+[[fixtures]]
+name = "html-missing-semicolon-numeric-character-references"
+input = "Letters: &#65 &#x42Z"
+tokens = ["Text(data=Letters: A BZ)", "EOF"]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -184,6 +184,14 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "EOF".to_string(),
             ],
         },
+        FixtureDefinition {
+            name: "html-missing-semicolon-numeric-character-references".to_string(),
+            input: "Letters: &#65 &#x42Z".to_string(),
+            tokens: vec![
+                "Text(data=Letters: A BZ)".to_string(),
+                "EOF".to_string(),
+            ],
+        },
     ];
     definition.states = vec![
         StateDefinition {
@@ -1431,7 +1439,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_text".to_string(),
+                "append_numeric_character_reference_to_text".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -1446,7 +1455,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_text".to_string(),
+                "append_numeric_character_reference_to_text".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -1488,7 +1498,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_text".to_string(),
+                "append_numeric_character_reference_to_text".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -1503,7 +1514,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_text".to_string(),
+                "append_numeric_character_reference_to_text".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -3529,7 +3541,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_attribute_value".to_string(),
+                "append_numeric_character_reference_to_attribute_value".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
                 "commit_attribute".to_string(),
                 "emit_current_token".to_string(),
@@ -3546,7 +3559,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_attribute_value".to_string(),
+                "append_numeric_character_reference_to_attribute_value".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -3588,7 +3602,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_attribute_value".to_string(),
+                "append_numeric_character_reference_to_attribute_value".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
                 "commit_attribute".to_string(),
                 "emit_current_token".to_string(),
@@ -3605,7 +3620,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_temporary_buffer_to_attribute_value".to_string(),
+                "append_numeric_character_reference_to_attribute_value".to_string(),
+                "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 14);
+    assert_eq!(html1.cases.len(), 17);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 15);
+    assert_eq!(file.tests.len(), 18);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -139,7 +139,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "RCDATA state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 15);
+    assert_eq!(normalized.cases.len(), 18);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[6].initial_state.as_deref(),
@@ -197,7 +197,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 15);
+    assert_eq!(suite.cases.len(), 18);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -76,6 +76,8 @@ currently supports:
   current shared entity subset
 - semicolon-terminated decimal and hexadecimal numeric character references in
   data, RCDATA, and attribute values
+- missing-semicolon decimal and hexadecimal numeric character reference
+  recovery in data, RCDATA, and attribute values
 - tokenizer error codes lowered into Venture diagnostics
 
 Unsupported raw cases are skipped into metadata in the generated file rather

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -145,6 +145,47 @@
       ],
       "initial_state": "RCDATA state",
       "last_start_tag": "title"
+    },
+    {
+      "id": "html-missing-semicolon-numeric-character-references-data",
+      "description": "Numeric character references recover when the semicolon is missing in data state",
+      "input": "Letters: &#65 &#x42Z",
+      "tokens": [
+        "Text(data=Letters: A BZ)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html-missing-semicolon-numeric-character-references-attributes",
+      "description": "Numeric character references recover when the semicolon is missing in attributes",
+      "input": "<a title=&#65 data-x=&#x42>",
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A, data-x=B], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html-missing-semicolon-numeric-character-references-rcdata",
+      "description": "Seeded title RCDATA context recovers numeric character references with missing semicolons",
+      "input": "Fish &#38 &#x3C/title>",
+      "tokens": [
+        "Text(data=Fish & </title>)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -183,6 +183,47 @@
       "diagnostics": [],
       "initial_state": "RCDATA state",
       "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-16",
+      "description": "data state numeric character references missing semicolons",
+      "input": "Letters: &#65 &#x42Z",
+      "tokens": [
+        "Text(data=Letters: A BZ)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-17",
+      "description": "attribute numeric character references missing semicolons",
+      "input": "<a title=&#65 data-x=&#x42>",
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A, data-x=B], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-18",
+      "description": "rcdata numeric character references missing semicolons",
+      "input": "Fish &#38 &#x3C/title>",
+      "tokens": [
+        "Text(data=Fish & </title>)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -159,6 +159,49 @@
         ["Character", "<"],
         ["Character", "/title>"]
       ]
+    },
+    {
+      "description": "data state numeric character references missing semicolons",
+      "input": "Letters: &#65 &#x42Z",
+      "output": [
+        ["Character", "Letters: "],
+        ["Character", "A"],
+        ["Character", " "],
+        ["Character", "B"],
+        ["Character", "Z"]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 14},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 20}
+      ]
+    },
+    {
+      "description": "attribute numeric character references missing semicolons",
+      "input": "<a title=&#65 data-x=&#x42>",
+      "output": [
+        ["StartTag", "a", {"title": "A", "data-x": "B"}]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 14},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 27}
+      ]
+    },
+    {
+      "description": "rcdata numeric character references missing semicolons",
+      "initialStates": ["RCDATA state"],
+      "lastStartTag": "title",
+      "input": "Fish &#38 &#x3C/title>",
+      "output": [
+        ["Character", "Fish "],
+        ["Character", "&"],
+        ["Character", " "],
+        ["Character", "<"],
+        ["Character", "/title>"]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 10},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 16}
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
+++ b/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
@@ -10,7 +10,7 @@ fn html1_authoring_artifact_parses_as_mosaic_era_floor() {
 
     assert_eq!(definition.name, "html1-lexer");
     assert_eq!(definition.profile.as_deref(), Some("lexer/v1"));
-    assert_eq!(definition.fixtures.len(), 7);
+    assert_eq!(definition.fixtures.len(), 8);
     assert!(definition.states.iter().any(|state| state.id == "comment"));
     assert!(definition
         .states

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -295,6 +295,48 @@ fn default_html_lexer_supports_seeded_rcdata_numeric_character_references() {
 }
 
 #[test]
+fn default_html_lexer_supports_missing_semicolon_numeric_character_references() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("Letters: &#65 &#x42Z <a title=&#67 data-x=&#x44>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Letters: A BZ ".to_string()),
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "C".to_string(),
+                    },
+                    Attribute {
+                        name: "data-x".to_string(),
+                        value: "D".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "missing-semicolon-after-character-reference"
+            })
+            .count(),
+        4
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_character_references() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();
@@ -338,7 +380,7 @@ fn html1_generated_definition_preserves_lexer_profile_metadata() {
         .registers
         .iter()
         .any(|register| register.id == "temporary_buffer"));
-    assert_eq!(definition.fixtures.len(), 7);
+    assert_eq!(definition.fixtures.len(), 8);
 }
 
 #[test]

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -141,7 +141,7 @@ fn lexer_profile_html1_toml_parses_into_typed_definition() {
         .actions
         .iter()
         .any(|action| action == "emit_rcdata_end_tag_or_text")));
-    assert_eq!(definition.fixtures.len(), 7);
+    assert_eq!(definition.fixtures.len(), 8);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- recover semicolonless decimal and hexadecimal numeric character references in data and RCDATA states
- recover semicolonless numeric character references inside attribute values while reconsuming the delimiter
- emit `missing-semicolon-after-character-reference` diagnostics and update HTML1/html5lib smoke fixtures
- regenerate the checked-in Rust HTML1 lexer source from the authored TOML

## Verification
- cargo fmt -p coding-adventures-html-lexer -p state-machine-markup-deserializer -p state-machine-source-compiler
- cargo test -p coding-adventures-html-lexer --test html_lexer_test -- --nocapture
- cargo test -p coding-adventures-html-lexer --test conformance_test -- --nocapture
- cargo test -p coding-adventures-html-lexer --test html1_authoring_test -- --nocapture
- cargo test -p state-machine-markup-deserializer --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo test -p state-machine-source-compiler --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo check -p coding-adventures-html-lexer --tests
- git diff --check