### PR TITLE
feat(algol): support bare no-arg procedure expressions

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this package will be documented in this file.
 - Lowered chained assignments, branch-selected conditional expressions, and
   ALGOL-left-associative exponentiation for numeric bases with integer
   exponents.
+- Lowered bare no-argument typed procedure names as expression calls, including
+  use inside read-only by-name eval thunks.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -14,6 +14,10 @@ Value-only integer procedures lower to generated `_fn_algol_...` functions.
 Calls pass an explicit static link followed by value arguments, procedure frames
 are allocated from the module frame stack, and typed procedures return through
 their procedure-name result slot.
+Parameterless typed procedures can also be used by bare name in expression
+positions, following ALGOL's omitted-parentheses call syntax; read-only by-name
+actuals of that form lower through eval thunks so each formal read re-runs the
+procedure.
 
 Integer arrays lower to frame-stored descriptors backed by a separate bounded
 ALGOL heap segment. The compiler evaluates integer lower/upper bounds once at

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2086,6 +2086,8 @@ class AlgolIrCompiler:
             name = _variable_name(expr)
             if name is None:
                 raise CompileError("variable is missing a name")
+            if self.procedure_calls.get((id(name), "expression")) is not None:
+                return self._compile_procedure_call(expr, scope)
             reference = self._require_reference(name, "read")
             return self._emit_load_reference(reference, scope)
 
@@ -3432,7 +3434,13 @@ class AlgolIrCompiler:
 
     def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
         variable = _single_variable_expr(argument)
-        return variable is None or bool(_variable_subscripts(variable))
+        if variable is None or _variable_subscripts(variable):
+            return True
+        name = _variable_name(variable)
+        return (
+            name is not None
+            and self.procedure_calls.get((id(name), "expression")) is not None
+        )
 
     def _compile_by_name_actual_pointer(
         self,
@@ -3467,6 +3475,18 @@ class AlgolIrCompiler:
         name = _variable_name(variable)
         if name is None:
             raise CompileError("by-name scalar actual is missing a name")
+        if self.procedure_calls.get((id(name), "expression")) is not None:
+            if descriptor is None:
+                raise CompileError(
+                    "missing reserved eval thunk descriptor for by-name procedure "
+                    "expression"
+                )
+            return self._compile_eval_thunk_actual(
+                argument,
+                parameter,
+                scope,
+                descriptor,
+            )
         reference = self._require_reference(name, "read")
         return self._emit_reference_pointer(reference, scope)
 

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -882,6 +882,24 @@ class TestAlgolIrCompiler:
         assert any(label.startswith("_fn_algol_") for label in labels)
         assert result.procedure_signatures[calls[0].operands[0].name].param_count == 3
 
+    def test_compiles_bare_no_argument_typed_procedure_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure seven; begin seven := 7 end; "
+                "result := seven "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert calls[0].operands[0].name.startswith("_fn_algol_")
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 2
+
     def test_compiles_boolean_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -1313,6 +1331,25 @@ class TestAlgolIrCompiler:
 
         assert "_fn_algol_eval_thunk" in calls
         assert any(label.startswith("_fn_algol_") for label in calls)
+
+    def test_compiles_bare_procedure_expression_inside_eval_thunk(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, calls; "
+                "integer procedure next; begin calls := calls + 1; next := calls end; "
+                "integer procedure pair(x); integer x; begin pair := x * 10 + x end; "
+                "result := pair(next) "
+                "end"
+            )
+        )
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_eval_thunk" in calls
+        assert sum(label.startswith("_fn_algol_") for label in calls) >= 2
 
     def test_compiles_builtin_print_string_literal_to_syscalls(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this package will be documented in this file.
   designational branches guarded.
 - Added semantic checking for chained assignments, ALGOL conditional
   expressions, and numeric exponentiation with integer exponents.
+- Added semantic resolution for bare no-argument typed procedure names used as
+  expressions, while keeping written by-name actuals from treating those calls
+  as assignable scalar storage.
 - Accepted parser-tolerated repeated/trailing semicolons through existing
   statement-list traversal.
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -28,6 +28,9 @@ Procedure declarations receive semantic descriptors with generated function
 labels, parameter slots, value-vs-name parameter modes, conservative by-name
 write metadata, result slots for typed procedures, and resolved call sites
 carrying the static-link delta needed by code generation.
+Bare no-argument typed procedure names used in expressions are resolved as
+procedure calls, matching ALGOL's omitted-parentheses call syntax, while
+procedure result variables inside their own bodies still resolve as storage.
 Integer array declarations receive descriptor slots in their declaring frame,
 dimension metadata for lower/upper bound expressions, and resolved read/write
 accesses that preserve the static-link delta and subscript count needed by the

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1600,6 +1600,11 @@ class AlgolTypeChecker:
                     inferred = ERROR
                     self.expression_types[id(expr)] = inferred
                     return inferred
+                call = self._check_bare_procedure_expression(name, scope)
+                if call is not None:
+                    inferred = call.return_type or ERROR
+                    self.expression_types[id(expr)] = inferred
+                    return inferred
                 symbol = self._resolve_name(name, scope, role="read")
                 if symbol is not None and symbol.kind == ARRAY:
                     self._error(name, f"array {name.value!r} requires subscripts")
@@ -1862,6 +1867,51 @@ class AlgolTypeChecker:
             _first_direct_node(node, "actual_params"),
             "expression",
         )
+        return self._check_resolved_procedure_call(
+            name_token,
+            descriptor,
+            declaring_scope,
+            lexical_depth_delta,
+            arguments,
+            scope,
+            role=role,
+        )
+
+    def _check_bare_procedure_expression(
+        self,
+        name_token: Token,
+        scope: Scope,
+    ) -> ResolvedProcedureCall | None:
+        nearest = scope.resolve_with_scope(name_token.value)
+        if nearest is not None and nearest[0].kind == "procedure_result":
+            return None
+
+        resolved = self._resolve_procedure(name_token, scope)
+        if resolved is None:
+            return None
+
+        descriptor, declaring_scope, lexical_depth_delta = resolved
+        return self._check_resolved_procedure_call(
+            name_token,
+            descriptor,
+            declaring_scope,
+            lexical_depth_delta,
+            [],
+            scope,
+            role="expression",
+        )
+
+    def _check_resolved_procedure_call(
+        self,
+        name_token: Token,
+        descriptor: ProcedureDescriptor,
+        declaring_scope: Scope,
+        lexical_depth_delta: int,
+        arguments: list[ASTNode],
+        scope: Scope,
+        *,
+        role: str,
+    ) -> ResolvedProcedureCall | None:
         if descriptor.parameter_symbol_id is not None:
             return self._check_formal_procedure_call(
                 name_token,
@@ -1926,7 +1976,10 @@ class AlgolTypeChecker:
             if (
                 parameter.mode == NAME
                 and parameter.may_write
-                and not _is_assignable_actual(argument)
+                and (
+                    not _is_assignable_actual(argument)
+                    or self._resolved_bare_procedure_expression(argument) is not None
+                )
             ):
                 self._error(
                     argument,
@@ -1959,6 +2012,25 @@ class AlgolTypeChecker:
         )
         self.resolved_procedure_calls.append(call)
         return call
+
+    def _resolved_bare_procedure_expression(
+        self,
+        argument: ASTNode,
+    ) -> ResolvedProcedureCall | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            return None
+        return next(
+            (
+                call
+                for call in self.resolved_procedure_calls
+                if call.token_id == id(name) and call.role == "expression"
+            ),
+            None,
+        )
 
     def _check_formal_procedure_call(
         self,
@@ -2344,41 +2416,47 @@ class AlgolTypeChecker:
         lexical_depth_delta = 0
         while current is not None:
             symbol = current.symbols.get(token.value)
-            if symbol is not None and symbol.kind == "procedure":
-                descriptor = next(
-                    (
-                        procedure
-                        for procedure in self.semantic_procedures
-                        if procedure.procedure_id == symbol.procedure_id
-                    ),
-                    None,
-                )
-                if descriptor is None:
-                    return None
-                return descriptor, current, lexical_depth_delta
-            if symbol is not None and symbol.kind == "procedure_parameter":
-                return_type = (
-                    symbol.type_name
-                    if symbol.type_name in {INTEGER, BOOLEAN, REAL, STRING}
-                    else None
-                )
-                return (
-                    ProcedureDescriptor(
-                        procedure_id=-2,
-                        name=token.value,
-                        label="__algol_dynamic_procedure_parameter",
-                        declaring_block_id=current.block_id,
-                        body_block_id=current.block_id,
-                        body_node_id=-1,
-                        return_type=return_type,
-                        parameters=tuple(),
-                        line=token.line,
-                        column=token.column,
-                        parameter_symbol_id=symbol.symbol_id,
-                    ),
-                    current,
-                    lexical_depth_delta,
-                )
+            if symbol is not None:
+                if symbol.kind == "procedure":
+                    descriptor = next(
+                        (
+                            procedure
+                            for procedure in self.semantic_procedures
+                            if procedure.procedure_id == symbol.procedure_id
+                        ),
+                        None,
+                    )
+                    if descriptor is None:
+                        return None
+                    return descriptor, current, lexical_depth_delta
+                if symbol.kind == "procedure_parameter":
+                    return_type = (
+                        symbol.type_name
+                        if symbol.type_name in {INTEGER, BOOLEAN, REAL, STRING}
+                        else None
+                    )
+                    return (
+                        ProcedureDescriptor(
+                            procedure_id=-2,
+                            name=token.value,
+                            label="__algol_dynamic_procedure_parameter",
+                            declaring_block_id=current.block_id,
+                            body_block_id=current.block_id,
+                            body_node_id=-1,
+                            return_type=return_type,
+                            parameters=tuple(),
+                            line=token.line,
+                            column=token.column,
+                            parameter_symbol_id=symbol.symbol_id,
+                        ),
+                        current,
+                        lexical_depth_delta,
+                    )
+                if symbol.kind == "procedure_result":
+                    current = current.parent
+                    lexical_depth_delta += 1
+                    continue
+                return None
             current = current.parent
             lexical_depth_delta += 1
         return None

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -587,6 +587,45 @@ class TestAlgolTypeChecker:
         assert body_block.scope.symbols["inc"].kind == "procedure_result"
         assert body_block.scope.symbols["x"].kind == "parameter"
 
+    def test_accepts_bare_no_argument_typed_procedure_expression(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure seven; begin seven := 7 end; "
+            "result := seven "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        call = next(
+            call
+            for call in result.semantic.procedure_calls
+            if call.name == "seven" and call.role == "expression"
+        )
+        assert call.argument_count == 0
+        assert call.return_type == "integer"
+        assert not any(
+            reference.name == "seven" and reference.role == "read"
+            for reference in result.semantic.references
+        )
+
+    def test_rejects_bare_typed_procedure_expression_with_required_argument(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(x); value x; integer x; begin inc := x + 1 end; "
+            "result := inc "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "procedure 'inc' expects 1 argument(s), got 0" in result.diagnostics[
+            0
+        ].message
+
     def test_records_procedure_call_static_link_delta(self) -> None:
         ast = parse_algol(
             "begin integer result; "
@@ -1060,6 +1099,19 @@ class TestAlgolTypeChecker:
             "integer procedure inc(n); value n; integer n; begin inc := n + 1 end; "
             "procedure put(x); integer x; begin x := 7 end; "
             "put(inc(1)) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "actual expression is not assignable" in result.diagnostics[0].message
+
+    def test_rejects_bare_procedure_actual_for_written_by_name_parameter(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure seven; begin seven := 7 end; "
+            "procedure put(x); integer x; begin x := 9 end; "
+            "put(seven) "
             "end"
         )
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this package will be documented in this file.
 - Executed chained assignments, ALGOL-left-associative exponentiation with
   integer exponents, and branch-selected conditional expressions through the
   full WASM path.
+- Executed bare no-argument typed procedure names as expression calls,
+  including by-name actuals that re-evaluate through eval thunks.
 - Accepted trailing and repeated semicolons in ALGOL block and compound
   statement lists.
 - Added a convergence golden fixture that combines conditional expressions,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,6 +21,8 @@ already supports a substantial ALGOL 60 surface:
   semicolons, and ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks and
   typed whole-array, label, switch, and no-argument statement procedure formals
+- bare no-argument typed procedure names as expression calls, matching ALGOL's
+  omitted-parentheses call syntax for parameterless procedures
 - labels, local and nonlocal `goto`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   non-recursive switch entries

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -740,6 +740,25 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
+    def test_bare_no_argument_typed_procedure_expression_runs(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure seven; begin seven := 7 end; "
+            "result := seven "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_bare_procedure_expression_by_name_re_evaluates_each_read(self) -> None:
+        result = compile_source(
+            "begin integer result, calls; "
+            "integer procedure next; begin calls := calls + 1; next := calls end; "
+            "integer procedure pair(x); integer x; begin pair := x * 10 + x end; "
+            "result := pair(next) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
+
     def test_boolean_value_procedure_returns_boolean_result(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- resolve bare parameterless typed procedure names in expression positions as zero-argument procedure calls
- keep procedure result variables inside their own procedure bodies resolving as storage, while preserving recursive `p(...)` calls
- route bare procedure by-name actuals through eval thunks so each formal read re-runs the actual procedure
- reject bare procedure actuals for written by-name formals as non-assignable
- document and add changelog entries for the newly supported ALGOL omitted-parentheses procedure expression form

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `ruff check code/packages/python/algol-type-checker/src/algol_type_checker/checker.py code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py code/packages/python/algol-type-checker/tests/test_algol_type_checker.py code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py`
- `git diff --check`

## Security review
- no dependency, CI, subprocess, shell, network, deserialization, or filesystem access changes
- compiler changes only add semantic resolution/lowering for an existing grammar form and tests/docs
- grep review for risky APIs only found existing `eval` terminology in thunk/test names