### PR TITLE
Guard ALGOL integer division by zero

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this package will be documented in this file.
   exponents.
 - Lowered bare no-argument typed procedure names as expression calls, including
   use inside read-only by-name eval thunks.
+- Lowered integer `div` and `mod` zero-divisor checks through the existing
+  runtime-failure guard so WASM execution returns `0` instead of trapping.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -79,7 +79,8 @@ one 64 KiB WASM page, and keeps array descriptors plus element storage inside a
 separate 64 KiB heap segment. Larger semantic frame plans raise `CompileError`
 before the WASM data encoder can materialize the memory image, dynamic
 procedure recursion stops at the bounded frame stack, and invalid array bounds,
-out-of-bounds subscripts, oversized arrays, or heap exhaustion return `0`.
+out-of-bounds subscripts, integer `div`/`mod` by zero, oversized arrays, or
+heap exhaustion return `0`.
 
 ```python
 from algol_ir_compiler import compile_algol

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1609,6 +1609,7 @@ class AlgolIrCompiler:
                 loop_reference.type_name,
                 step_value,
                 step_type,
+                scope,
             )
             next_type = self._result_type_for_numeric_operator(
                 "+",
@@ -1725,6 +1726,7 @@ class AlgolIrCompiler:
             loop_reference.type_name,
             step_value,
             step_type,
+            scope,
         )
         next_type = self._result_type_for_numeric_operator(
             "+",
@@ -2258,6 +2260,7 @@ class AlgolIrCompiler:
                 current_type,
                 right,
                 right_type,
+                scope,
             )
             current_type = self._result_type_for_numeric_operator(
                 operator.value,
@@ -2455,6 +2458,7 @@ class AlgolIrCompiler:
         left_type: str,
         right: int,
         right_type: str,
+        scope: _FrameScope,
     ) -> int:
         dst = self._fresh_reg()
         result_type = self._result_type_for_numeric_operator(
@@ -2511,10 +2515,12 @@ class AlgolIrCompiler:
         elif operator == "*":
             self._emit(IrOp.MUL, IrRegister(dst), IrRegister(left), IrRegister(right))
         elif operator == "div":
+            self._emit_integer_zero_divisor_guard(right, scope)
             self._emit(IrOp.DIV, IrRegister(dst), IrRegister(left), IrRegister(right))
         elif operator == "mod":
             quotient = self._fresh_reg()
             product = self._fresh_reg()
+            self._emit_integer_zero_divisor_guard(right, scope)
             self._emit(
                 IrOp.DIV, IrRegister(quotient), IrRegister(left), IrRegister(right)
             )
@@ -2525,6 +2531,18 @@ class AlgolIrCompiler:
         else:
             raise CompileError(f"numeric operator {operator!r} is not supported")
         return dst
+
+    def _emit_integer_zero_divisor_guard(
+        self, divisor: int, scope: _FrameScope
+    ) -> None:
+        failed = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(failed),
+            IrRegister(divisor),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit_runtime_failure_guard(failed, scope)
 
     def _emit_power(self, base: int, base_type: str, exponent: int) -> int:
         if base_type == _REAL_TYPE:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -514,6 +514,16 @@ class TestAlgolIrCompiler:
         assert IrOp.MUL in opcodes
         assert opcodes.count(IrOp.SUB) >= 2
 
+    def test_integer_division_emits_zero_divisor_guard(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result, divisor; result := 10 div divisor end")
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.CMP_EQ in opcodes
+        assert IrOp.BRANCH_Z in opcodes
+        assert opcodes.index(IrOp.CMP_EQ) < opcodes.index(IrOp.DIV)
+
     def test_compiles_boolean_not_or_and_comparison_forms(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this package will be documented in this file.
   including by-name actuals that re-evaluate through eval thunks.
 - Accepted trailing and repeated semicolons in ALGOL block and compound
   statement lists.
+- Returned `0` for integer `div` or `mod` by zero through the ALGOL runtime
+  failure path instead of leaking a host WASM trap.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,8 @@ already supports a substantial ALGOL 60 surface:
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
 - chained assignment, conditional expressions, tolerant trailing/repeated
-  semicolons, and ALGOL-left-associative exponentiation for integer exponents
+  semicolons, integer `div`/`mod` runtime failure guards, and
+  ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks and
   typed whole-array, label, switch, and no-argument statement procedure formals
 - bare no-argument typed procedure names as expression calls, matching ALGOL's

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1226,6 +1226,18 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
 
+    def test_integer_division_by_zero_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result, divisor; divisor := 0; result := 10 div divisor end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_integer_modulo_by_zero_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result, divisor; divisor := 0; result := 10 mod divisor end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
     def test_array_failure_in_procedure_unwinds_before_caller_continues(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- route integer `div`/`mod` zero-divisor checks through the ALGOL runtime-failure guard
- add IR-shape coverage plus end-to-end WASM tests for zero-divisor behavior
- document the runtime-failure behavior in ALGOL IR/WASM package docs and changelogs

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m ruff check code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- New code only emits existing IR comparison/branch/return instructions and adds tests/docs.
- No new file I/O, shell execution, subprocess use, network access, deserialization, or unsafe dynamic execution paths.