### PR TITLE
chore(runtime-repl): Phase G + 13 pins, REPL tests, symbolic-vm 0.32.1 derivative fix

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -11,10 +11,11 @@ capabilities:
 - `coding-adventures-symbolic-ir>=0.7.0` — picks up the Phase 13 IR heads for
   hyperbolic functions (`Sinh`, `Cosh`, `Tanh`, `Asinh`, `Acosh`, `Atanh`) and
   their evaluation, differentiation, and integration rules.
-- `coding-adventures-symbolic-vm>=0.32.0` — picks up Phase G control-flow VM
-  handlers: `while`-loop, `for..thru`/`for..in`, `block` with local scope,
-  `return`, and `if/elseif/else`. These are compiled by the grammar-level
-  Phase G keywords and require no name-table additions here.
+- `coding-adventures-symbolic-vm>=0.32.1` — picks up Phase G control-flow VM
+  handlers (`while`-loop, `for..thru`/`for..in`, `block` with local scope,
+  `return`, `if/elseif/else`) and the 0.32.1 bug fix: missing hyperbolic
+  differentiation rules in `derivative.py` that caused `diff(sinh(x),x)` to
+  raise `RecursionError`.
 
 Test count and coverage unchanged (135 tests, ≥80 %).
 

--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.4.0 — 2026-04-27
+
+**Bump dependency pins to pick up Phase G control flow and Phase 13 hyperbolic functions.**
+
+No source changes to `macsyma-runtime` itself. The two upstream dependencies are
+pinned higher so that installing this package pulls in all recently-landed VM
+capabilities:
+
+- `coding-adventures-symbolic-ir>=0.7.0` — picks up the Phase 13 IR heads for
+  hyperbolic functions (`Sinh`, `Cosh`, `Tanh`, `Asinh`, `Acosh`, `Atanh`) and
+  their evaluation, differentiation, and integration rules.
+- `coding-adventures-symbolic-vm>=0.32.0` — picks up Phase G control-flow VM
+  handlers: `while`-loop, `for..thru`/`for..in`, `block` with local scope,
+  `return`, and `if/elseif/else`. These are compiled by the grammar-level
+  Phase G keywords and require no name-table additions here.
+
+Test count and coverage unchanged (135 tests, ≥80 %).
+
 ## 1.3.0 — 2026-04-27
 
 **Add `is_prime` alias for `primep` in the MACSYMA name table.**

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-macsyma-runtime"
-version = "1.3.0"
+version = "1.4.0"
 description = "MACSYMA-specific runtime layer on top of the symbolic VM — history, $/; terminators, kill, ev, name table."
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,8 +12,8 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.5.0",
-    "coding-adventures-symbolic-vm>=0.27.0",
+    "coding-adventures-symbolic-ir>=0.7.0",
+    "coding-adventures-symbolic-vm>=0.32.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
 dependencies = [
     "coding-adventures-symbolic-ir>=0.7.0",
-    "coding-adventures-symbolic-vm>=0.32.0",
+    "coding-adventures-symbolic-vm>=0.32.1",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.32.1 — 2026-04-27
+
+**Bug fix — hyperbolic differentiation via `derivative.py` pathway.**
+
+Phase 13 added differentiation rules for `sinh/cosh/tanh/asinh/acosh/atanh` to
+`integrate.py`'s `_diff_ir` helper, but the standalone `derivative.py` module
+(used when callers invoke `diff` directly rather than through the integrator) was
+not updated.  Without this fix, `diff(sinh(x), x)` called through `derivative.py`
+entered infinite recursion and raised `RecursionError`.
+
+Added chain-rule branches to `derivative.py` for all six hyperbolic heads:
+
+- `Sinh(u)` → `Cosh(u) · u'`
+- `Cosh(u)` → `Sinh(u) · u'`
+- `Tanh(u)` → `u' / Cosh(u)²`
+- `Asinh(u)` → `u' / √(u²+1)`
+- `Acosh(u)` → `u' / √(u²−1)`
+- `Atanh(u)` → `u' / (1−u²)`
+
+---
+
 ## 0.32.0 — 2026-04-27
 
 **Phase 13 — Hyperbolic function evaluation, differentiation, and integration.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.32.0"
+version = "0.32.1"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/derivative.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/derivative.py
@@ -20,8 +20,12 @@ which raises.
 from __future__ import annotations
 
 from symbolic_ir import (
+    ACOSH,
     ADD,
+    ASINH,
+    ATANH,
     COS,
+    COSH,
     DIV,
     EXP,
     LOG,
@@ -29,9 +33,11 @@ from symbolic_ir import (
     NEG,
     POW,
     SIN,
+    SINH,
     SQRT,
     SUB,
     TAN,
+    TANH,
     D,
     IRApply,
     IRFloat,
@@ -209,6 +215,40 @@ def _diff(f: IRNode, x: IRSymbol) -> IRNode:
                 IRApply(MUL, (IRInteger(2), IRApply(SQRT, (inner,)))),
             ),
         )
+
+    # -- Hyperbolic functions (chain rule) --------------------------------
+    # d/dx sinh(u) = cosh(u) · u'
+    if head == SINH:
+        (inner,) = f.args
+        return IRApply(MUL, (IRApply(COSH, (inner,)), _diff(inner, x)))
+    # d/dx cosh(u) = sinh(u) · u'
+    if head == COSH:
+        (inner,) = f.args
+        return IRApply(MUL, (IRApply(SINH, (inner,)), _diff(inner, x)))
+    # d/dx tanh(u) = sech²(u) · u' = u' / cosh²(u)
+    if head == TANH:
+        (inner,) = f.args
+        return IRApply(
+            DIV,
+            (_diff(inner, x), IRApply(POW, (IRApply(COSH, (inner,)), IRInteger(2)))),
+        )
+    # d/dx asinh(u) = u' / sqrt(u² + 1)
+    if head == ASINH:
+        (inner,) = f.args
+        u2_plus_1 = IRApply(ADD, (IRApply(POW, (inner, IRInteger(2))), ONE))
+        denom = IRApply(SQRT, (u2_plus_1,))
+        return IRApply(DIV, (_diff(inner, x), denom))
+    # d/dx acosh(u) = u' / sqrt(u² - 1)
+    if head == ACOSH:
+        (inner,) = f.args
+        u2_minus_1 = IRApply(SUB, (IRApply(POW, (inner, IRInteger(2))), ONE))
+        denom = IRApply(SQRT, (u2_minus_1,))
+        return IRApply(DIV, (_diff(inner, x), denom))
+    # d/dx atanh(u) = u' / (1 - u²)
+    if head == ATANH:
+        (inner,) = f.args
+        denom = IRApply(SUB, (ONE, IRApply(POW, (inner, IRInteger(2)))))
+        return IRApply(DIV, (_diff(inner, x), denom))
 
     # Unknown function — leave as ``D(f, x)`` unevaluated.
     return IRApply(D, (f, x))

--- a/code/programs/python/macsyma-repl/CHANGELOG.md
+++ b/code/programs/python/macsyma-repl/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.2.0 — 2026-04-27
+
+**Add Phase G control-flow and Phase 13 hyperbolic-function end-to-end REPL tests.**
+
+Two new test classes added to `tests/test_session.py` (14 tests total):
+
+### `TestPhaseGControlFlow` (8 tests)
+
+Exercises grammar-level control-flow keywords compiled by the Phase G grammar
+(`while`, `for..thru`, `for..in`, `block`, `return`, `if/elseif/else`) through
+the full REPL stack end-to-end:
+
+- `test_while_loop_sum` — `while s < 5 do s: s + 1` accumulates to 5.
+- `test_for_range_sum` — `for i thru 5 do s:s+i` inside a `block` sums to 15.
+- `test_for_each_applies_body` — `for x in [1,2,3] do s:s+x` sums to 6.
+- `test_if_then_else_true` — `if 2 > 1 then 99 else 0` → 99.
+- `test_if_then_else_false` — `if 1 > 2 then 99 else 0` → 0.
+- `test_if_then_no_else_miss` — `if false then 99` → false (unmatched branch).
+- `test_block_local_scope` — local `x:99` inside block does not overwrite outer `x:10`.
+- `test_return_from_block` — `return(42)` inside a block short-circuits to 42.
+
+### `TestPhase13Hyperbolic` (6 tests)
+
+Exercises the Phase 13 hyperbolic function suite (`sinh`, `cosh`, `tanh`,
+`asinh`, `acosh`, `atanh`) that was added to `symbolic-vm` 0.32.0:
+
+- `test_sinh_zero` — `sinh(0)` → 0 (exact zero).
+- `test_cosh_zero` — `cosh(0)` → 1 (exact one).
+- `test_tanh_zero` — `tanh(0)` → 0 (exact zero).
+- `test_sinh_numeric` — `ev(sinh(1), numer)` → decimal starting with `1.1` (≈ 1.1752).
+- `test_diff_sinh` — `diff(sinh(x), x)` output contains `cosh`.
+- `test_integrate_sinh` — `integrate(sinh(x), x)` output contains `cosh`.
+
 ## 0.1.0 — 2026-04-25
 
 Initial release — Phase A.

--- a/code/programs/python/macsyma-repl/pyproject.toml
+++ b/code/programs/python/macsyma-repl/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coding-adventures-macsyma-repl-program"
-version = "0.1.0"
+version = "0.2.0"
 description = "Interactive MACSYMA-flavored REPL on top of the symbolic VM."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -251,3 +251,131 @@ def test_diff_product_pretty_output() -> None:
     assert " - " in line, f"Expected subtraction in output, got: {line!r}"
     # Should not contain the ugly 'f*-g' pattern.
     assert "*-" not in line, f"Unexpected raw '*-' in output: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# Phase G — control flow (while / for / block / return / if)
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseGControlFlow:
+    """End-to-end REPL tests for Phase G grammar-level control-flow keywords.
+
+    These constructs are compiled by the Phase G grammar and evaluated by the
+    Phase G VM handlers in ``symbolic-vm`` 0.32.0. No name-table additions are
+    needed; the keywords are handled at the grammar / compiler layer.
+    """
+
+    def test_while_loop_sum(self) -> None:
+        """``while s < 5 do s: s + 1`` increments s from 0 to 5."""
+        out = _run(["s: 0$", "while s < 5 do s: s + 1;", ":quit"])
+        combined = "\n".join(out)
+        assert "5" in combined
+
+    def test_for_range_sum(self) -> None:
+        """``for i thru 5 do s:s+i`` inside a block sums 0+1+2+3+4+5 = 15."""
+        out = _run(["block([s:0], for i thru 5 do s:s+i, s);", ":quit"])
+        combined = "\n".join(out)
+        assert "15" in combined
+
+    def test_for_each_applies_body(self) -> None:
+        """``for x in [1,2,3] do s:s+x`` accumulates to 6."""
+        out = _run(["block([s:0], for x in [1,2,3] do s:s+x, s);", ":quit"])
+        combined = "\n".join(out)
+        assert "6" in combined
+
+    def test_if_then_else_true(self) -> None:
+        """``if 2 > 1 then 99 else 0`` takes the true branch → 99."""
+        out = _run(["if 2 > 1 then 99 else 0;", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "99" in result_lines[0]
+
+    def test_if_then_else_false(self) -> None:
+        """``if 1 > 2 then 99 else 0`` takes the false branch → 0."""
+        out = _run(["if 1 > 2 then 99 else 0;", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "0" in result_lines[0]
+
+    def test_if_then_no_else_miss(self) -> None:
+        """``if false then 99`` with no else clause → false (unmatched branch)."""
+        out = _run(["if false then 99;", ":quit"])
+        combined = "\n".join(out)
+        assert "false" in combined.lower()
+
+    def test_block_local_scope(self) -> None:
+        """Local ``x:99`` inside a block does not overwrite the outer ``x:10``."""
+        out = _run(["x: 10$", "block([x:99], x);", "x;", ":quit"])
+        # (%o2) must be 99 (inside block), (%o3) must be 10 (outer scope restored).
+        assert any("(%o2)" in line and "99" in line for line in out), (
+            f"Expected (%o2) 99 in output; got: {out}"
+        )
+        assert any("(%o3)" in line and "10" in line for line in out), (
+            f"Expected (%o3) 10 in output; got: {out}"
+        )
+
+    def test_return_from_block(self) -> None:
+        """``return(42)`` inside a block short-circuits the block to 42."""
+        out = _run(["block([x:1], x:2, return(42), x);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "42" in result_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Phase 13 — hyperbolic functions (sinh / cosh / tanh and calculus)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase13Hyperbolic:
+    """End-to-end REPL tests for Phase 13 hyperbolic functions.
+
+    ``sinh``, ``cosh``, ``tanh``, ``asinh``, ``acosh``, ``atanh`` were added
+    to the symbolic VM in 0.32.0.  The compiler's ``_STANDARD_FUNCTIONS``
+    already maps these names to canonical IR heads, so no name-table additions
+    are required in ``macsyma-runtime``.
+    """
+
+    def test_sinh_zero(self) -> None:
+        """``sinh(0)`` evaluates to the exact integer 0."""
+        out = _run(["sinh(0);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "0" in result_lines[0]
+
+    def test_cosh_zero(self) -> None:
+        """``cosh(0)`` evaluates to the exact integer 1."""
+        out = _run(["cosh(0);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "1" in result_lines[0]
+
+    def test_tanh_zero(self) -> None:
+        """``tanh(0)`` evaluates to the exact integer 0."""
+        out = _run(["tanh(0);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "0" in result_lines[0]
+
+    def test_sinh_numeric(self) -> None:
+        """``ev(sinh(1), numer)`` → a decimal close to 1.1752."""
+        out = _run(["ev(sinh(1), numer);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        # sinh(1) ≈ 1.1752011936438014 — check the leading digits appear.
+        assert "1.1" in result_lines[0]
+
+    def test_diff_sinh(self) -> None:
+        """``diff(sinh(x), x)`` → cosh(x) (derivative of sinh is cosh)."""
+        out = _run(["diff(sinh(x), x);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "cosh" in result_lines[0].lower()
+
+    def test_integrate_sinh(self) -> None:
+        """``integrate(sinh(x), x)`` → cosh(x) (antiderivative of sinh is cosh)."""
+        out = _run(["integrate(sinh(x), x);", ":quit"])
+        result_lines = [line for line in out if line.startswith("(%o1)")]
+        assert len(result_lines) == 1
+        assert "cosh" in result_lines[0].lower()

--- a/code/specs/macsyma-completion.md
+++ b/code/specs/macsyma-completion.md
@@ -26,7 +26,7 @@ syntax differences go in the frontend name table and backend subclass.
 
 ---
 
-## Current status (as of symbolic-vm 0.30.0 / macsyma-runtime 1.3.0)
+## Current status (as of symbolic-vm 0.32.0 / macsyma-runtime 1.4.0)
 
 ### Fully working end-to-end
 


### PR DESCRIPTION
## Summary

- **`symbolic-vm` 0.32.0 → 0.32.1**: Bug fix — `derivative.py` was missing all six hyperbolic chain-rule cases (`sinh/cosh/tanh/asinh/acosh/atanh`) that Phase 13 added only to `integrate.py`'s `_diff_ir`. Without this, `diff(sinh(x), x)` via the standalone diff pathway raised `RecursionError`.
- **`macsyma-runtime` 1.3.0 → 1.4.0**: Bump dependency pins to `symbolic-ir>=0.7.0` and `symbolic-vm>=0.32.1` (stale since before Phase G and Phase 13 landed).
- **`macsyma-repl` 0.1.0 → 0.2.0**: Add 14 end-to-end REPL session tests (37 total):
  - `TestPhaseGControlFlow` (8): `while`, `for..thru`, `for..in`, `if/else`, `block` scope, `return`
  - `TestPhase13Hyperbolic` (6): `sinh(0)=0`, `cosh(0)=1`, `tanh(0)=0`, numeric `ev`, `diff(sinh)`, `integrate(sinh)`

## Test plan

- [ ] `symbolic-vm` tests pass (≥662 existing + derivative.py hyperbolic diff now covered)
- [ ] `macsyma-runtime` tests pass (135 tests, ≥80% coverage)
- [ ] `macsyma-repl` tests pass (37 tests including 14 new end-to-end tests)
- [ ] No ruff lint errors across all three packages
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)