### PR TITLE
docs: refresh README and GitHub Pages landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ The learning side of the repo is a first-class part of the structure, not an aft
 Start here:
 
 - [Learning Index](./code/learning/README.md)
-- [Algorithms](./code/learning/algorithms/README.md)
-- [Computer Architecture](./code/learning/computer-architecture/README.md)
+- [Algorithms](./code/learning/algorithms/README.md) — graph algorithms, hashing, Kahn's algorithm
+- [Computer Architecture](./code/learning/computer-architecture/README.md) — logic gates, arithmetic circuits, CPU architecture, floating-point, ISA simulators, bytecode compilation, parsing, lexical analysis, virtual machines, and the computing-stack overview
 - [Language Tooling](./code/learning/language-tooling/README.md)
-- [Python Ecosystem](./code/learning/python/ecosystem.md)
+- [Programming Languages](./code/learning/programming-languages/) — language-by-language pattern guides for Go, Python, Ruby, Rust, TypeScript, plus the Python ecosystem deep-dive
 
 The intended relationship is:
 
@@ -154,10 +154,35 @@ If you want to explore the repo by theme, start here:
 
 - [00-architecture.md](./code/specs/00-architecture.md) for the big picture
 - [D00-deep-cpu-architecture.md](./code/specs/D00-deep-cpu-architecture.md) for the architecture track
+- [LANG00-generic-language-pipeline.md](./code/specs/LANG00-generic-language-pipeline.md) for the language pipeline that all of Tetrad, Nib, MACSYMA, Lattice, and others share
+- [VLT00-vault-master.md](./code/specs/VLT00-vault-master.md) for the password-manager-class vault stack
+- [ST00-r-stats-roadmap.md](./code/specs/ST00-r-stats-roadmap.md) for the R-style statistics + language roadmap
 - [DT25-mini-redis.md](./code/specs/DT25-mini-redis.md) for the single-node data-store baseline
 - [Kahn's algorithm](./code/learning/algorithms/kahns-algorithm.md) for the build-planning story
 - [computing-stack.md](./code/learning/computer-architecture/computing-stack.md) for the hardware-to-language story
 - [code/programs/typescript](./code/programs/typescript/) for the current app and visualizer-heavy program surface
+
+## Live Pages
+
+A subset of the repo is deployed to GitHub Pages so you can run things in
+the browser without cloning. The root landing page is at
+[adhithyan15.github.io/coding-adventures](https://adhithyan15.github.io/coding-adventures/);
+individual apps and visualizers live at sibling paths:
+
+- `arithmetic/` — adders, ALU, two's-complement, multiply, CPU step-through
+- `arm1-web/` — ARM1 processor across registers, pipeline, barrel shifter, memory views
+- `busicom/` — Intel 4004-powered Busicom 141-PF calculator with live ALU and gate-level activity
+- `code39/` — full barcode pipeline from text to SVG via draw instructions
+- `commonmark/` — live Markdown-to-HTML renderer built from scratch in TypeScript
+- `electronics-visualizers/` — circuit-level visualizers backing the architecture track
+- `engram/` and `engram-docs/` — product experiment plus its browser-based docs
+- `eniac/` — decimal vacuum-tube computing alongside binary equivalents
+- `journal/` — journaling app
+- `lattice/` — Lattice CSS-superset docs and live transpiler playground
+- `logic-gates/` — NOT/AND/OR/XOR with truth tables and CMOS layouts
+- `ml-learning/` — browser ML demos (predictors, classifiers)
+- `nib-web/` — Nib source → Intel 4004 assembly/binary/HEX, then run in the simulator
+- `transistors/` — vacuum tube → BJT → MOSFET → CMOS device models
 
 ## Copyright
 

--- a/code/programs/static/landing-page/index.html
+++ b/code/programs/static/landing-page/index.html
@@ -506,6 +506,7 @@
       <nav class="topnav" aria-label="Primary">
         <a class="nav-link" href="#stack">Explore the stack</a>
         <a class="nav-link" href="#languages">Languages and tooling</a>
+        <a class="nav-link" href="#apps">Apps and experiments</a>
         <a
           class="nav-link"
           href="https://github.com/adhithyan15/coding-adventures"
@@ -766,6 +767,106 @@
             <span class="tag">Code39</span>
             <span class="tag">SVG</span>
             <span class="tag">Draw instructions</span>
+          </div>
+        </a>
+
+        <a class="card" href="/coding-adventures/engram-docs/" aria-label="Open Engram Docs">
+          <div class="card-meta">
+            <span class="card-badge">Browser docs</span>
+            <span class="card-arrow" aria-hidden="true">-></span>
+          </div>
+          <div class="card-title">Engram Docs</div>
+          <p class="card-desc">
+            Browser-rendered documentation site for the Engram product experiment, built on the
+            same in-house Markdown and document-AST infrastructure as the rest of the rendering track.
+          </p>
+          <div class="tags">
+            <span class="tag">Docs site</span>
+            <span class="tag">CommonMark</span>
+            <span class="tag">Document AST</span>
+          </div>
+        </a>
+
+        <a class="card" href="/coding-adventures/electronics-visualizers/" aria-label="Open Electronics Visualizers">
+          <div class="card-meta">
+            <span class="card-badge">Circuits</span>
+            <span class="card-arrow" aria-hidden="true">-></span>
+          </div>
+          <div class="card-title">Electronics Visualizers</div>
+          <p class="card-desc">
+            Circuit-level visualizers that back the architecture track — see resistors, capacitors,
+            diodes, and small subcircuits behave under live controls before they aggregate into gates.
+          </p>
+          <div class="tags">
+            <span class="tag">Circuits</span>
+            <span class="tag">Components</span>
+            <span class="tag">Live controls</span>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <section class="section" id="apps">
+      <div class="section-header">
+        <div>
+          <div class="section-label">Apps and Experiments</div>
+          <h2 class="section-title">Product surfaces and ML demos.</h2>
+        </div>
+        <p class="section-copy">
+          The repo is also a product sandbox. These are end-user-facing experiments built on the
+          same package lab — UI sitting on top of the same parsers, runtimes, and ML primitives.
+        </p>
+      </div>
+
+      <div class="cards">
+        <a class="card" href="/coding-adventures/engram/" aria-label="Open Engram App">
+          <div class="card-meta">
+            <span class="card-badge">App</span>
+            <span class="card-arrow" aria-hidden="true">-></span>
+          </div>
+          <div class="card-title">Engram</div>
+          <p class="card-desc">
+            A spaced-repetition product experiment using the repo's own document AST, sanitizer,
+            and storage primitives — a working app that doubles as a stress test for the underlying packages.
+          </p>
+          <div class="tags">
+            <span class="tag">Memory</span>
+            <span class="tag">Document AST</span>
+            <span class="tag">Storage</span>
+          </div>
+        </a>
+
+        <a class="card" href="/coding-adventures/journal/" aria-label="Open Journal App">
+          <div class="card-meta">
+            <span class="card-badge">App</span>
+            <span class="card-arrow" aria-hidden="true">-></span>
+          </div>
+          <div class="card-title">Journal</div>
+          <p class="card-desc">
+            A daily journaling surface with Markdown editing, browser-side persistence, and a UI
+            built on the in-house CommonMark renderer rather than a third-party Markdown component.
+          </p>
+          <div class="tags">
+            <span class="tag">Journaling</span>
+            <span class="tag">Markdown</span>
+            <span class="tag">IndexedDB</span>
+          </div>
+        </a>
+
+        <a class="card" href="/coding-adventures/ml-learning/" aria-label="Open ML Learning Demos">
+          <div class="card-meta">
+            <span class="card-badge">ML demos</span>
+            <span class="card-arrow" aria-hidden="true">-></span>
+          </div>
+          <div class="card-title">ML Learning Lab</div>
+          <p class="card-desc">
+            Browser-runnable ML demonstrations — single-layer perceptrons, hidden-layer XOR
+            learning, feature normalization sweeps — backed by the repo's own gradient-descent and matrix packages.
+          </p>
+          <div class="tags">
+            <span class="tag">Perceptron</span>
+            <span class="tag">Gradient descent</span>
+            <span class="tag">Matrix math</span>
           </div>
         </a>
       </div>


### PR DESCRIPTION
## Summary

Two related documentation updates that were split out of the original (now reduced) PR #1518.

## README

- Expanded **Learning Material** to reflect the new `code/learning/programming-languages/` category (go / python / ruby / rust / typescript patterns + python-ecosystem) and the broader `computer-architecture/` coverage (logic gates, arithmetic circuits, CPU architecture, floating-point, ISA simulators, bytecode compilation, parsing, lexical analysis, virtual machines).
- Updated the python-ecosystem link to its new path under `programming-languages/` (matches the rename in #1518).
- Added `LANG00`, `VLT00`, and `ST00` to **Good Entry Points** so the language-pipeline, vault, and R-stats roadmaps are discoverable from the README.
- Added a new **Live Pages** section listing every GitHub Pages deployment (arithmetic, arm1-web, busicom, code39, commonmark, electronics-visualizers, engram, engram-docs, eniac, journal, lattice, logic-gates, ml-learning, nib-web, transistors).

## GitHub Pages landing page (`code/programs/static/landing-page/index.html`)

- New **Apps and experiments** section (`#apps`) with cards for **Engram**, **Journal**, and **ML Learning Lab** — three apps that were already deployed but not linked from the root.
- Two extra cards added to the **Languages and tooling** section: **Engram Docs** (browser-rendered docs site) and **Electronics Visualizers** (circuit-level visualizers backing the architecture track).
- Added `#apps` link to the top nav.

After merge, every currently-deployed Pages app is reachable in one click from the root landing page.

## Dependency

This PR pairs with #1518 (the new `code/learning/programming-languages/` directory). The README's "Programming Languages" link assumes that PR has merged; if #1518 lands first, this becomes a clean follow-up. If they're reviewed in the other order, the README link will resolve only once #1518 is in.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Landing page renders correctly when deployed to Pages
- [ ] All in-page anchor links (`#stack`, `#languages`, `#apps`) work
- [ ] All app links (`/coding-adventures/<app>/`) point at currently-deployed apps