### PR TITLE
[codex] Add graph property bag contract

### DIFF
--- a/code/packages/python/graph/CHANGELOG.md
+++ b/code/packages/python/graph/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0 — 2026-04-08
 
 ### Added

--- a/code/packages/python/graph/README.md
+++ b/code/packages/python/graph/README.md
@@ -14,11 +14,15 @@ from graph import Graph, GraphRepr, bfs, shortest_path, minimum_spanning_tree
 
 # Build a city graph
 g: Graph[str] = Graph()
-g.add_edge("London", "Paris", weight=300)
+g.add_node("London", {"kind": "city"})
+g.add_edge("London", "Paris", weight=300, properties={"route": "train"})
 g.add_edge("London", "Amsterdam", weight=520)
 g.add_edge("Paris", "Berlin", weight=878)
 g.add_edge("Amsterdam", "Berlin", weight=655)
 g.add_edge("Amsterdam", "Brussels", weight=180)
+
+print(g.edge_properties("Paris", "London"))
+# → {"route": "train", "weight": 300}
 
 # Breadth-first traversal from London
 print(bfs(g, "London"))
@@ -45,6 +49,21 @@ g_matrix = Graph(repr=GraphRepr.ADJACENCY_MATRIX)  # O(V²) space; O(1) edge loo
 ```
 
 Both expose exactly the same public API — every algorithm works on either.
+
+## Properties
+
+Graphs, nodes, and edges can carry portable property bags:
+
+```python
+g.set_graph_property("name", "city-map")
+g.add_node("Amsterdam", {"kind": "city"})
+g.add_edge("Amsterdam", "Berlin", weight=655, properties={"route": "rail"})
+
+assert g.edge_properties("Berlin", "Amsterdam")["weight"] == 655
+```
+
+Property bags are copied on read. Edge weights are also exposed through the
+canonical `weight` edge property.
 
 ## Where it fits
 

--- a/code/packages/python/graph/src/graph/__init__.py
+++ b/code/packages/python/graph/src/graph/__init__.py
@@ -11,7 +11,7 @@ Public API::
     from graph import has_cycle, shortest_path, minimum_spanning_tree
 """
 
-from graph.graph import Graph, GraphRepr
+from graph.graph import Graph, GraphRepr, PropertyBag, PropertyValue
 from graph.algorithms import (
     bfs,
     connected_components,
@@ -27,6 +27,8 @@ __version__ = "0.1.0"
 __all__ = [
     "Graph",
     "GraphRepr",
+    "PropertyBag",
+    "PropertyValue",
     "bfs",
     "connected_components",
     "dfs",

--- a/code/packages/python/graph/src/graph/graph.py
+++ b/code/packages/python/graph/src/graph/graph.py
@@ -51,9 +51,15 @@ This is the key invariant that makes Graph undirected.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Generic, TypeAlias, TypeVar
 
 T = TypeVar("T")  # Node type — must be hashable
+PropertyValue: TypeAlias = str | int | float | bool | None
+PropertyBag: TypeAlias = dict[str, PropertyValue]
+
+
+def _edge_key(u: T, v: T) -> tuple[T, T]:
+    return (u, v) if repr(u) <= repr(v) else (v, u)
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +99,9 @@ class Graph(Generic[T]):
 
     def __init__(self, repr: GraphRepr = GraphRepr.ADJACENCY_LIST) -> None:
         self._repr = repr
+        self._graph_properties: PropertyBag = {}
+        self._node_properties: dict[T, PropertyBag] = {}
+        self._edge_properties: dict[tuple[T, T], PropertyBag] = {}
 
         if repr is GraphRepr.ADJACENCY_LIST:
             # adj[u][v] = weight for every edge {u, v}.
@@ -111,20 +120,24 @@ class Graph(Generic[T]):
     # Node operations
     # ------------------------------------------------------------------
 
-    def add_node(self, node: T) -> None:
+    def add_node(self, node: T, properties: PropertyBag | None = None) -> None:
         """Add a node to the graph.  No-op if the node already exists."""
         if self._repr is GraphRepr.ADJACENCY_LIST:
             if node not in self._adj:
                 self._adj[node] = {}
+                self._node_properties[node] = {}
         else:
             if node not in self._node_idx:
                 idx = len(self._node_list)
                 self._node_list.append(node)
                 self._node_idx[node] = idx
+                self._node_properties[node] = {}
                 # Add a new row and column of zeros.
                 for row in self._matrix:
                     row.append(0.0)
                 self._matrix.append([0.0] * (idx + 1))
+        if properties is not None:
+            self._node_properties[node].update(properties)
 
     def remove_node(self, node: T) -> None:
         """Remove a node and all edges incident to it.
@@ -137,12 +150,17 @@ class Graph(Generic[T]):
             # Remove all edges that touch this node.
             for neighbour in list(self._adj[node]):
                 del self._adj[neighbour][node]
+                self._edge_properties.pop(_edge_key(node, neighbour), None)
             del self._adj[node]
+            del self._node_properties[node]
         else:
             if node not in self._node_idx:
                 raise KeyError(node)
+            for other in list(self._node_list):
+                self._edge_properties.pop(_edge_key(node, other), None)
             idx = self._node_idx.pop(node)
             self._node_list.pop(idx)
+            del self._node_properties[node]
             # Update indices for nodes that shifted down.
             for n in self._node_list[idx:]:
                 self._node_idx[n] -= 1
@@ -168,7 +186,13 @@ class Graph(Generic[T]):
     # Edge operations
     # ------------------------------------------------------------------
 
-    def add_edge(self, u: T, v: T, weight: float = 1.0) -> None:
+    def add_edge(
+        self,
+        u: T,
+        v: T,
+        weight: float = 1.0,
+        properties: PropertyBag | None = None,
+    ) -> None:
         """Add an undirected edge between u and v with the given weight.
 
         Both nodes are added automatically if they do not already exist.
@@ -176,6 +200,7 @@ class Graph(Generic[T]):
         """
         self.add_node(u)
         self.add_node(v)
+        self._validate_weight(weight)
 
         if self._repr is GraphRepr.ADJACENCY_LIST:
             self._adj[u][v] = weight
@@ -184,6 +209,9 @@ class Graph(Generic[T]):
             i, j = self._node_idx[u], self._node_idx[v]
             self._matrix[i][j] = weight
             self._matrix[j][i] = weight
+        merged = dict(properties or {})
+        merged["weight"] = weight
+        self._edge_properties.setdefault(_edge_key(u, v), {}).update(merged)
 
     def remove_edge(self, u: T, v: T) -> None:
         """Remove the edge between u and v.
@@ -195,6 +223,7 @@ class Graph(Generic[T]):
                 raise KeyError((u, v))
             del self._adj[u][v]
             del self._adj[v][u]
+            self._edge_properties.pop(_edge_key(u, v), None)
         else:
             if u not in self._node_idx or v not in self._node_idx:
                 raise KeyError((u, v))
@@ -203,6 +232,7 @@ class Graph(Generic[T]):
                 raise KeyError((u, v))
             self._matrix[i][j] = 0.0
             self._matrix[j][i] = 0.0
+            self._edge_properties.pop(_edge_key(u, v), None)
 
     def has_edge(self, u: T, v: T) -> bool:
         """Return True if an edge exists between u and v."""
@@ -256,6 +286,74 @@ class Graph(Generic[T]):
         return w
 
     # ------------------------------------------------------------------
+    # Property bags
+    # ------------------------------------------------------------------
+
+    def graph_properties(self) -> PropertyBag:
+        """Return a copy of graph-level properties."""
+        return dict(self._graph_properties)
+
+    def set_graph_property(self, key: str, value: PropertyValue) -> None:
+        """Set one graph-level property."""
+        self._graph_properties[key] = value
+
+    def remove_graph_property(self, key: str) -> None:
+        """Remove one graph-level property if present."""
+        self._graph_properties.pop(key, None)
+
+    def node_properties(self, node: T) -> PropertyBag:
+        """Return a copy of properties attached to ``node``."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        return dict(self._node_properties[node])
+
+    def set_node_property(self, node: T, key: str, value: PropertyValue) -> None:
+        """Set one property on ``node``."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        self._node_properties[node][key] = value
+
+    def remove_node_property(self, node: T, key: str) -> None:
+        """Remove one property from ``node`` if present."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        self._node_properties[node].pop(key, None)
+
+    def edge_properties(self, u: T, v: T) -> PropertyBag:
+        """Return a copy of properties attached to edge {u, v}."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        properties = dict(self._edge_properties.get(_edge_key(u, v), {}))
+        properties["weight"] = self.edge_weight(u, v)
+        return properties
+
+    def set_edge_property(
+        self,
+        u: T,
+        v: T,
+        key: str,
+        value: PropertyValue,
+    ) -> None:
+        """Set one property on edge {u, v}."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        if key == "weight":
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError("edge property 'weight' must be numeric")
+            self._set_edge_weight(u, v, float(value))
+        self._edge_properties.setdefault(_edge_key(u, v), {})[key] = value
+
+    def remove_edge_property(self, u: T, v: T, key: str) -> None:
+        """Remove one property from edge {u, v} if present."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        if key == "weight":
+            self._set_edge_weight(u, v, 1.0)
+            self._edge_properties.setdefault(_edge_key(u, v), {})["weight"] = 1.0
+            return
+        self._edge_properties.setdefault(_edge_key(u, v), {}).pop(key, None)
+
+    # ------------------------------------------------------------------
     # Neighbourhood queries
     # ------------------------------------------------------------------
 
@@ -301,6 +399,20 @@ class Graph(Generic[T]):
         Raises KeyError if the node does not exist.
         """
         return len(self.neighbors(node))
+
+    def _validate_weight(self, weight: float) -> None:
+        if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+            raise ValueError("edge weight must be numeric")
+
+    def _set_edge_weight(self, u: T, v: T, weight: float) -> None:
+        self._validate_weight(weight)
+        if self._repr is GraphRepr.ADJACENCY_LIST:
+            self._adj[u][v] = weight
+            self._adj[v][u] = weight
+            return
+        i, j = self._node_idx[u], self._node_idx[v]
+        self._matrix[i][j] = weight
+        self._matrix[j][i] = weight
 
     # ------------------------------------------------------------------
     # Python dunder methods

--- a/code/packages/python/graph/tests/test_graph.py
+++ b/code/packages/python/graph/tests/test_graph.py
@@ -249,6 +249,89 @@ class TestEdgeOperations:
 
 
 # ---------------------------------------------------------------------------
+# TestPropertyBags
+# ---------------------------------------------------------------------------
+
+
+class TestPropertyBags:
+    """Graph, node, and edge property bags."""
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_graph_properties(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.set_graph_property("name", "city-map")
+        g.set_graph_property("version", 1)
+        assert g.graph_properties() == {"name": "city-map", "version": 1}
+
+        g.remove_graph_property("version")
+        assert g.graph_properties() == {"name": "city-map"}
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_node_properties_merge_and_copy(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_node("A", {"kind": "input"})
+        g.add_node("A", {"trainable": False})
+        g.set_node_property("A", "slot", 0)
+        assert g.node_properties("A") == {
+            "kind": "input",
+            "trainable": False,
+            "slot": 0,
+        }
+
+        copy = g.node_properties("A")
+        copy["kind"] = "mutated"
+        assert g.node_properties("A")["kind"] == "input"
+
+        g.remove_node_property("A", "slot")
+        assert g.node_properties("A") == {
+            "kind": "input",
+            "trainable": False,
+        }
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_edge_properties_include_canonical_weight(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_edge("A", "B", weight=2.5, properties={"role": "distance"})
+
+        assert g.edge_properties("A", "B") == {
+            "role": "distance",
+            "weight": 2.5,
+        }
+        assert g.edge_properties("B", "A") == {
+            "role": "distance",
+            "weight": 2.5,
+        }
+
+        g.set_edge_property("B", "A", "weight", 7)
+        assert g.edge_weight("A", "B") == 7.0
+        assert g.edge_properties("A", "B")["weight"] == 7
+
+        g.set_edge_property("A", "B", "trainable", True)
+        g.remove_edge_property("A", "B", "role")
+        assert g.edge_properties("A", "B") == {
+            "trainable": True,
+            "weight": 7.0,
+        }
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_removing_structure_removes_properties(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_node("A", {"kind": "input"})
+        g.add_edge("A", "B", weight=3, properties={"role": "data"})
+
+        g.remove_edge("A", "B")
+        with pytest.raises(KeyError):
+            g.edge_properties("A", "B")
+
+        g.add_edge("A", "B", weight=3, properties={"role": "data"})
+        g.remove_node("A")
+        with pytest.raises(KeyError):
+            g.node_properties("A")
+        with pytest.raises(KeyError):
+            g.edge_properties("A", "B")
+
+
+# ---------------------------------------------------------------------------
 # TestNeighborhood
 # ---------------------------------------------------------------------------
 

--- a/code/packages/typescript/graph/CHANGELOG.md
+++ b/code/packages/typescript/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0
 
 - Initial TypeScript port of the DT00 undirected graph package

--- a/code/packages/typescript/graph/README.md
+++ b/code/packages/typescript/graph/README.md
@@ -16,6 +16,11 @@ The package exposes one generic `Graph<T>` class plus pure algorithm helpers:
 - `shortestPath`
 - `minimumSpanningTree`
 
+Graphs also support portable graph, node, and edge property bags. Edge weights are
+available as the canonical `weight` edge property, so higher-level packages can treat
+weighted graphs, labeled graphs, visualizers, and neural graph builders as the same
+topology-plus-metadata model.
+
 ## Example
 
 ```ts
@@ -26,10 +31,14 @@ import {
 } from "@coding-adventures/graph";
 
 const graph = new Graph<string>(GraphRepr.ADJACENCY_LIST);
-graph.addEdge("London", "Paris", 300);
+graph.addNode("London", { kind: "city" });
+graph.addEdge("London", "Paris", 300, { route: "train" });
 graph.addEdge("Paris", "Berlin", 878);
 graph.addEdge("London", "Amsterdam", 520);
 graph.addEdge("Amsterdam", "Berlin", 655);
+
+console.log(graph.edgeProperties("Paris", "London"));
+// { route: "train", weight: 300 }
 
 console.log(shortestPath(graph, "London", "Berlin"));
 // ["London", "Amsterdam", "Berlin"]
@@ -40,3 +49,4 @@ console.log(shortestPath(graph, "London", "Berlin"));
 - Edges are undirected, so adding `A`-`B` also creates `B`-`A`.
 - Nodes are generic and may be strings, numbers, tuples, or object references.
 - The graph stores isolated nodes as well as connected ones.
+- Property bags are copied on read so callers cannot accidentally mutate the graph.

--- a/code/packages/typescript/graph/src/graph.ts
+++ b/code/packages/typescript/graph/src/graph.ts
@@ -12,6 +12,8 @@ export enum GraphRepr {
   ADJACENCY_MATRIX = "adjacency_matrix",
 }
 
+export type GraphPropertyValue = string | number | boolean | null;
+export type GraphPropertyBag = Record<string, GraphPropertyValue>;
 export type WeightedEdge<T> = readonly [T, T, number];
 
 function nodeSortKey(node: unknown): string {
@@ -52,6 +54,9 @@ export class Graph<T> {
   private readonly _nodeList: T[];
   private readonly _nodeIndex: Map<T, number>;
   private readonly _matrix: Array<Array<number | null>>;
+  private readonly _graphProperties: GraphPropertyBag;
+  private readonly _nodeProperties: Map<T, GraphPropertyBag>;
+  private readonly _edgeProperties: Map<string, GraphPropertyBag>;
 
   constructor(repr: GraphRepr = GraphRepr.ADJACENCY_LIST) {
     this._repr = repr;
@@ -59,6 +64,9 @@ export class Graph<T> {
     this._nodeList = [];
     this._nodeIndex = new Map();
     this._matrix = [];
+    this._graphProperties = {};
+    this._nodeProperties = new Map();
+    this._edgeProperties = new Map();
   }
 
   get repr(): GraphRepr {
@@ -71,21 +79,26 @@ export class Graph<T> {
       : this._nodeList.length;
   }
 
-  addNode(node: T): void {
+  addNode(node: T, properties: GraphPropertyBag = {}): void {
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       if (!this._adj.has(node)) {
         this._adj.set(node, new Map());
+        this._nodeProperties.set(node, {});
       }
+      this.mergeNodeProperties(node, properties);
       return;
     }
 
     if (this._nodeIndex.has(node)) {
+      this.mergeNodeProperties(node, properties);
       return;
     }
 
     const index = this._nodeList.length;
     this._nodeList.push(node);
     this._nodeIndex.set(node, index);
+    this._nodeProperties.set(node, {});
+    this.mergeNodeProperties(node, properties);
 
     for (const row of this._matrix) {
       row.push(null);
@@ -102,15 +115,21 @@ export class Graph<T> {
 
       for (const neighbor of Array.from(neighbors.keys())) {
         this._adj.get(neighbor)?.delete(node);
+        this._edgeProperties.delete(edgeKey(node, neighbor));
       }
 
       this._adj.delete(node);
+      this._nodeProperties.delete(node);
       return;
     }
 
     const index = this._nodeIndex.get(node);
     if (index === undefined) {
       throw new Error(`Node not found: ${String(node)}`);
+    }
+
+    for (const other of this._nodeList) {
+      this._edgeProperties.delete(edgeKey(node, other));
     }
 
     this._nodeIndex.delete(node);
@@ -123,6 +142,7 @@ export class Graph<T> {
     for (let i = index; i < this._nodeList.length; i++) {
       this._nodeIndex.set(this._nodeList[i], i);
     }
+    this._nodeProperties.delete(node);
   }
 
   hasNode(node: T): boolean {
@@ -137,13 +157,20 @@ export class Graph<T> {
       : new Set(this._nodeList);
   }
 
-  addEdge(left: T, right: T, weight = 1.0): void {
+  addEdge(
+    left: T,
+    right: T,
+    weight = 1.0,
+    properties: GraphPropertyBag = {}
+  ): void {
     this.addNode(left);
     this.addNode(right);
+    this.validateWeight(weight);
 
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       this._adj.get(left)!.set(right, weight);
       this._adj.get(right)!.set(left, weight);
+      this.mergeEdgeProperties(left, right, { ...properties, weight });
       return;
     }
 
@@ -151,6 +178,7 @@ export class Graph<T> {
     const rightIndex = this._nodeIndex.get(right)!;
     this._matrix[leftIndex][rightIndex] = weight;
     this._matrix[rightIndex][leftIndex] = weight;
+    this.mergeEdgeProperties(left, right, { ...properties, weight });
   }
 
   removeEdge(left: T, right: T): void {
@@ -165,6 +193,7 @@ export class Graph<T> {
 
       leftNeighbors.delete(right);
       rightNeighbors.delete(left);
+      this._edgeProperties.delete(edgeKey(left, right));
       return;
     }
 
@@ -179,6 +208,7 @@ export class Graph<T> {
 
     this._matrix[leftIndex][rightIndex] = null;
     this._matrix[rightIndex][leftIndex] = null;
+    this._edgeProperties.delete(edgeKey(left, right));
   }
 
   hasEdge(left: T, right: T): boolean {
@@ -262,6 +292,65 @@ export class Graph<T> {
     return weight;
   }
 
+  graphProperties(): GraphPropertyBag {
+    return { ...this._graphProperties };
+  }
+
+  setGraphProperty(key: string, value: GraphPropertyValue): void {
+    this._graphProperties[key] = value;
+  }
+
+  removeGraphProperty(key: string): void {
+    delete this._graphProperties[key];
+  }
+
+  nodeProperties(node: T): GraphPropertyBag {
+    this.assertNode(node);
+    return { ...(this._nodeProperties.get(node) ?? {}) };
+  }
+
+  setNodeProperty(node: T, key: string, value: GraphPropertyValue): void {
+    this.assertNode(node);
+    this._nodeProperties.get(node)![key] = value;
+  }
+
+  removeNodeProperty(node: T, key: string): void {
+    this.assertNode(node);
+    delete this._nodeProperties.get(node)![key];
+  }
+
+  edgeProperties(left: T, right: T): GraphPropertyBag {
+    this.assertEdge(left, right);
+    const properties = this._edgeProperties.get(edgeKey(left, right)) ?? {};
+    return { ...properties, weight: this.edgeWeight(left, right) };
+  }
+
+  setEdgeProperty(
+    left: T,
+    right: T,
+    key: string,
+    value: GraphPropertyValue
+  ): void {
+    this.assertEdge(left, right);
+    if (key === "weight") {
+      if (typeof value !== "number") {
+        throw new Error("Edge property 'weight' must be a number");
+      }
+      this.setEdgeWeight(left, right, value);
+    }
+    this.mergeEdgeProperties(left, right, { [key]: value });
+  }
+
+  removeEdgeProperty(left: T, right: T, key: string): void {
+    this.assertEdge(left, right);
+    if (key === "weight") {
+      this.setEdgeWeight(left, right, 1.0);
+      this.mergeEdgeProperties(left, right, { weight: 1.0 });
+      return;
+    }
+    delete this._edgeProperties.get(edgeKey(left, right))?.[key];
+  }
+
   neighbors(node: T): ReadonlySet<T> {
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       const neighbors = this._adj.get(node);
@@ -315,5 +404,57 @@ export class Graph<T> {
 
   toString(): string {
     return `Graph(nodes=${this.size}, edges=${this.edges().length}, repr=${this._repr})`;
+  }
+
+  private assertNode(node: T): void {
+    if (!this.hasNode(node)) {
+      throw new Error(`Node not found: ${String(node)}`);
+    }
+  }
+
+  private assertEdge(left: T, right: T): void {
+    if (!this.hasEdge(left, right)) {
+      throw new Error(`Edge not found: ${String(left)} -- ${String(right)}`);
+    }
+  }
+
+  private mergeNodeProperties(node: T, properties: GraphPropertyBag): void {
+    const existing = this._nodeProperties.get(node);
+    if (existing === undefined) {
+      return;
+    }
+    Object.assign(existing, properties);
+  }
+
+  private mergeEdgeProperties(
+    left: T,
+    right: T,
+    properties: GraphPropertyBag
+  ): void {
+    const key = edgeKey(left, right);
+    const existing = this._edgeProperties.get(key) ?? {};
+    Object.assign(existing, properties);
+    this._edgeProperties.set(key, existing);
+  }
+
+  private validateWeight(weight: number): void {
+    if (typeof weight !== "number" || Number.isNaN(weight)) {
+      throw new Error("Edge weight must be a number");
+    }
+  }
+
+  private setEdgeWeight(left: T, right: T, weight: number): void {
+    this.validateWeight(weight);
+
+    if (this._repr === GraphRepr.ADJACENCY_LIST) {
+      this._adj.get(left)!.set(right, weight);
+      this._adj.get(right)!.set(left, weight);
+      return;
+    }
+
+    const leftIndex = this._nodeIndex.get(left)!;
+    const rightIndex = this._nodeIndex.get(right)!;
+    this._matrix[leftIndex][rightIndex] = weight;
+    this._matrix[rightIndex][leftIndex] = weight;
   }
 }

--- a/code/packages/typescript/graph/src/index.ts
+++ b/code/packages/typescript/graph/src/index.ts
@@ -1,4 +1,11 @@
-export { Graph, GraphRepr, compareNodes, type WeightedEdge } from "./graph.js";
+export {
+  Graph,
+  GraphRepr,
+  compareNodes,
+  type GraphPropertyBag,
+  type GraphPropertyValue,
+  type WeightedEdge,
+} from "./graph.js";
 export {
   bfs,
   connectedComponents,

--- a/code/packages/typescript/graph/tests/graph.test.ts
+++ b/code/packages/typescript/graph/tests/graph.test.ts
@@ -113,6 +113,84 @@ describe("edge operations", () => {
   }
 });
 
+describe("property bags", () => {
+  for (const repr of representations) {
+    it(`stores graph properties for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.setGraphProperty("name", "city-map");
+      graph.setGraphProperty("version", 1);
+      expect(graph.graphProperties()).toEqual({
+        name: "city-map",
+        version: 1,
+      });
+
+      graph.removeGraphProperty("version");
+      expect(graph.graphProperties()).toEqual({ name: "city-map" });
+    });
+
+    it(`stores and merges node properties for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addNode("A", { kind: "input" });
+      graph.addNode("A", { trainable: false });
+      graph.setNodeProperty("A", "slot", 0);
+      expect(graph.nodeProperties("A")).toEqual({
+        kind: "input",
+        trainable: false,
+        slot: 0,
+      });
+
+      const copy = graph.nodeProperties("A");
+      copy.kind = "mutated";
+      expect(graph.nodeProperties("A").kind).toBe("input");
+
+      graph.removeNodeProperty("A", "slot");
+      expect(graph.nodeProperties("A")).toEqual({
+        kind: "input",
+        trainable: false,
+      });
+    });
+
+    it(`stores edge properties and treats weight as canonical for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addEdge("A", "B", 2.5, { role: "distance" });
+
+      expect(graph.edgeProperties("A", "B")).toEqual({
+        role: "distance",
+        weight: 2.5,
+      });
+      expect(graph.edgeProperties("B", "A")).toEqual({
+        role: "distance",
+        weight: 2.5,
+      });
+
+      graph.setEdgeProperty("B", "A", "weight", 7);
+      expect(graph.edgeWeight("A", "B")).toBe(7);
+      expect(graph.edgeProperties("A", "B").weight).toBe(7);
+
+      graph.setEdgeProperty("A", "B", "trainable", true);
+      graph.removeEdgeProperty("A", "B", "role");
+      expect(graph.edgeProperties("A", "B")).toEqual({
+        trainable: true,
+        weight: 7,
+      });
+    });
+
+    it(`removes node and edge properties with their structure for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addNode("A", { kind: "input" });
+      graph.addEdge("A", "B", 3, { role: "data" });
+
+      graph.removeEdge("A", "B");
+      expect(() => graph.edgeProperties("A", "B")).toThrow(/Edge not found/);
+
+      graph.addEdge("A", "B", 3, { role: "data" });
+      graph.removeNode("A");
+      expect(() => graph.nodeProperties("A")).toThrow(/Node not found/);
+      expect(() => graph.edgeProperties("A", "B")).toThrow(/Edge not found/);
+    });
+  }
+});
+
 describe("neighborhood queries", () => {
   for (const repr of representations) {
     it(`returns neighbors, weights, and degree for ${repr}`, () => {

--- a/code/specs/DT00-graph.md
+++ b/code/specs/DT00-graph.md
@@ -92,6 +92,61 @@ The weight is stored alongside the edge. Algorithms that care about weights (lik
 shortest path) use them; algorithms that don't (like BFS) ignore them and treat all edges
 as weight 1.
 
+### Node and edge properties
+
+Graphs also need metadata. A compiler graph may need to know that a node is a parser
+stage. A neural graph may need to know that a node is an activation function and that an
+edge is trainable. A build graph may want to tag edges as `runtime`, `test`, or
+`compile`.
+
+The base graph package owns this capability directly:
+
+```
+node_properties[node]       = PropertyBag
+edge_properties[{u, v}]     = PropertyBag
+graph_properties            = PropertyBag
+```
+
+A **PropertyBag** is a string-keyed map whose values are portable JSON-like scalars:
+
+```
+PropertyValue = string | number | boolean | null
+PropertyBag   = Map<string, PropertyValue>
+```
+
+Language implementations should use the closest idiomatic representation while preserving
+the same semantics:
+
+```
+TypeScript: Record<string, string | number | boolean | null>
+Python:     dict[str, str | int | float | bool | None]
+Go:         map[string]any, restricted by tests/documentation to scalar values
+Rust:       enum GraphPropertyValue { String, Number, Bool, Null }
+Ruby/Perl/Lua/Elixir: native map/hash/table values, restricted to scalar values
+Java/Kotlin/C#/F#: Map/Dictionary<string, object?>
+Swift:      enum GraphPropertyValue
+Dart:       Map<String, Object?>
+Haskell:    data GraphPropertyValue = PropertyString | PropertyNumber | PropertyBool | PropertyNull
+```
+
+Properties are not the runtime. They are facts attached to the graph's structure. A future
+runtime can interpret them, trace them, lower them to matrix operations, or ignore them.
+
+#### The `weight` property
+
+`weight` is the canonical edge property for weighted algorithms. Existing `add_edge(...,
+weight)` and `edge_weight(...)` APIs remain valid, but implementations should also expose
+the weight through the edge property bag:
+
+```
+graph.add_edge("London", "Paris", weight: 300)
+graph.edge_properties("London", "Paris")["weight"] == 300
+```
+
+When callers set the `weight` edge property to a number, `edge_weight` and weighted
+algorithms must observe the same value. If `weight` is absent, the default is `1.0`.
+Non-numeric `weight` values are invalid.
+
 ### Two ways to store a graph
 
 This is one of the most important design decisions in graph programming. There are two
@@ -214,6 +269,9 @@ For adjacency list:
 ```
 nodes: Set<T>
 adj:   Map<T, Map<T, float>>   # neighbor → edge_weight (default 1.0)
+node_properties: Map<T, PropertyBag>
+edge_properties: Map<EdgeKey<T>, PropertyBag>
+graph_properties: PropertyBag
 ```
 
 For adjacency matrix:
@@ -221,10 +279,53 @@ For adjacency matrix:
 nodes:   List<T>               # ordered list for index mapping
 index:   Map<T, int>           # node → row/col index
 matrix:  List<List<float>>     # V×V matrix; 0.0 means no edge
+node_properties: Map<T, PropertyBag>
+edge_properties: Map<EdgeKey<T>, PropertyBag>
+graph_properties: PropertyBag
 ```
 
 Both expose the same public API so every algorithm works on either representation
 without modification.
+
+Edge property keys for undirected graphs are canonicalized because `{u, v}` and `{v, u}`
+are the same edge. Implementations may use tuple keys, stable string keys, or internal
+edge IDs, but the public API must treat both endpoint orders identically.
+
+## Public API
+
+Existing graph APIs remain source-compatible. Property support extends the surface with
+the following common operations:
+
+```
+add_node(node, properties = {})
+add_edge(left, right, weight = 1.0, properties = {})
+
+graph_properties() -> PropertyBag
+set_graph_property(key, value)
+remove_graph_property(key)
+
+node_properties(node) -> PropertyBag
+set_node_property(node, key, value)
+remove_node_property(node, key)
+
+edge_properties(left, right) -> PropertyBag
+set_edge_property(left, right, key, value)
+remove_edge_property(left, right, key)
+```
+
+API naming may follow each language's style (`addNode`, `AddNode`, `add_node`,
+`setNodeProperty`), but semantics must match:
+
+- Returned property bags are copies or read-only views unless the language deliberately
+  documents live mutation.
+- Adding an existing node merges new properties into the existing property bag.
+- Adding an existing edge updates its weight and merges new properties into the existing
+  edge property bag.
+- Removing a node removes its node properties and all incident edge properties.
+- Removing an edge removes its edge properties.
+- Algorithms must not mutate graph, node, or edge properties.
+- Property insertion order is not semantically meaningful.
+- Unknown properties are preserved by copy and serialization operations.
 
 ## Algorithms (Pure Functions)
 

--- a/code/specs/DT01-directed-graph.md
+++ b/code/specs/DT01-directed-graph.md
@@ -8,6 +8,11 @@ directed graphs the right model for any relationship that flows one way: depende
 imports, causality, state transitions. DT01 builds on DT00 (Graph) by adding a second
 adjacency map that tracks predecessors, enabling O(1) lookup in both directions.
 
+DT01 inherits the DT00 property model. Nodes, directed edges, and the graph itself can
+carry property bags. This is deliberately part of the graph foundation rather than a
+neural-network-specific layer, so packages such as state machines, build graphs, graph
+visualizers, and future neural graphs all share the same metadata contract.
+
 ## Layer Position
 
 ```
@@ -100,6 +105,54 @@ When you remove edge A→B:
 
 This doubles memory usage but pays off enormously: many graph algorithms need to
 walk edges in reverse (e.g., finding everything that depends on a changed file).
+
+### Directed edge properties
+
+Directed edge properties are attached to the ordered edge `(u, v)`. Unlike DT00,
+the reverse edge `(v, u)` is different and has its own property bag:
+
+```
+graph.add_edge("A", "B", properties: {"role": "forward"})
+graph.add_edge("B", "A", properties: {"role": "reverse"})
+
+graph.edge_properties("A", "B")["role"] == "forward"
+graph.edge_properties("B", "A")["role"] == "reverse"
+```
+
+This distinction matters for neural graphs:
+
+```
+InputA -> Hidden1   weight: 0.42, trainable: true
+Hidden1 -> Output   weight: 1.20, trainable: true
+```
+
+Both edges may connect related concepts, but their direction, weights, gradients, and
+runtime traces are independent.
+
+Directed graph implementations must expose the same property operations as DT00 using
+language-idiomatic names:
+
+```
+add_node(node, properties = {})
+add_edge(from, to, weight = 1.0, properties = {})
+
+graph_properties() -> PropertyBag
+node_properties(node) -> PropertyBag
+edge_properties(from, to) -> PropertyBag
+
+set_graph_property(key, value)
+set_node_property(node, key, value)
+set_edge_property(from, to, key, value)
+
+remove_graph_property(key)
+remove_node_property(node, key)
+remove_edge_property(from, to, key)
+```
+
+If a directed-graph package internally composes or inherits from DT00 graph, it should
+delegate this behavior to DT00 rather than duplicating a second metadata system. If a
+language currently has a standalone directed graph implementation, it must still match
+the DT00 property semantics so higher-level packages can target one graph contract.
 
 ### Directed Acyclic Graph (DAG)
 
@@ -220,6 +273,22 @@ Valid build order: app → server → auth → db-driver → logger
 ```
 
 Time: O(V + E).
+
+### Multi-directed graph extension
+
+DT01 intentionally keeps one edge per ordered `(from, to)` pair. A future
+`multi-directed-graph` package should build on the same concepts but assign each edge a
+stable edge id so multiple parallel edges can exist between the same nodes:
+
+```
+edge1: A -> B, properties: {"channel": "data", "weight": 0.4}
+edge2: A -> B, properties: {"channel": "trace", "weight": 1.0}
+```
+
+That package should relax the "one ordered pair, one edge" constraint without changing
+the node property, edge property, graph property, traversal, or serialization vocabulary.
+In other words: DT01 is the simple directed graph. `multi-directed-graph` is the same
+semantic model with edge identity added.
 
 ### Strongly Connected Components (Kosaraju's algorithm)
 


### PR DESCRIPTION
## Summary

- Adds a shared DT00/DT01 property-bag contract for graph, node, and edge metadata.
- Implements the contract in the TypeScript graph package, including canonical `weight` edge metadata.
- Implements the same contract in the Python graph package; Python directed graph inherits the behavior from DT00.

## Why

This gives future neural graph, graph VM, and multi-directed-graph work a common topology-plus-metadata foundation instead of baking ML-specific fields into a higher-level package.

## Validation

- `bash BUILD` in `code/packages/typescript/graph`
- `npm run build` in `code/packages/typescript/graph`
- `bash BUILD` in `code/packages/python/graph`
- `bash BUILD` in `code/packages/python/directed-graph`
- `git diff --check`