### PR TITLE
Harden ALGOL numeric runtime failures

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -51,6 +51,9 @@ All notable changes to this package will be documented in this file.
   use inside read-only by-name eval thunks.
 - Lowered integer `div` and `mod` zero-divisor checks through the existing
   runtime-failure guard so WASM execution returns `0` instead of trapping.
+- Lowered integer divide-overflow checks, real division zero-divisor checks,
+  and zero-real-base negative exponent checks through the same runtime-failure
+  guard path.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -79,8 +79,9 @@ one 64 KiB WASM page, and keeps array descriptors plus element storage inside a
 separate 64 KiB heap segment. Larger semantic frame plans raise `CompileError`
 before the WASM data encoder can materialize the memory image, dynamic
 procedure recursion stops at the bounded frame stack, and invalid array bounds,
-out-of-bounds subscripts, integer `div`/`mod` by zero, oversized arrays, or
-heap exhaustion return `0`.
+out-of-bounds subscripts, integer `div`/`mod` by zero or signed divide
+overflow, real division by zero, zero-real-base negative exponentiation,
+oversized arrays, or heap exhaustion return `0`.
 
 ```python
 from algol_ir_compiler import compile_algol

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -102,6 +102,8 @@ _INTEGER_TYPE = "integer"
 _BOOLEAN_TYPE = "boolean"
 _REAL_TYPE = "real"
 _STRING_TYPE = "string"
+_I32_MIN = -(1 << 31)
+_I32_NEG_ONE = -1
 _STRING_DESCRIPTOR_LENGTH_OFFSET = 0
 _STRING_DESCRIPTOR_DATA_POINTER_OFFSET = 4
 _STRING_DESCRIPTOR_SIZE = 8
@@ -2288,7 +2290,7 @@ class AlgolIrCompiler:
             exponent_type = self._expr_type(children[index + 1])
             if exponent_type != _INTEGER_TYPE:
                 raise CompileError("exponentiation exponent must be integer")
-            current = self._emit_power(current, current_type, exponent)
+            current = self._emit_power(current, current_type, exponent, scope)
             current_type = (
                 _REAL_TYPE if current_type == _REAL_TYPE else _INTEGER_TYPE
             )
@@ -2499,6 +2501,7 @@ class AlgolIrCompiler:
                     IrRegister(right),
                 )
             elif operator == "/":
+                self._emit_real_zero_divisor_guard(right, scope)
                 self._emit(
                     IrOp.F64_DIV,
                     IrRegister(dst),
@@ -2515,12 +2518,12 @@ class AlgolIrCompiler:
         elif operator == "*":
             self._emit(IrOp.MUL, IrRegister(dst), IrRegister(left), IrRegister(right))
         elif operator == "div":
-            self._emit_integer_zero_divisor_guard(right, scope)
+            self._emit_integer_division_failure_guard(left, right, scope)
             self._emit(IrOp.DIV, IrRegister(dst), IrRegister(left), IrRegister(right))
         elif operator == "mod":
             quotient = self._fresh_reg()
             product = self._fresh_reg()
-            self._emit_integer_zero_divisor_guard(right, scope)
+            self._emit_integer_division_failure_guard(left, right, scope)
             self._emit(
                 IrOp.DIV, IrRegister(quotient), IrRegister(left), IrRegister(right)
             )
@@ -2532,21 +2535,64 @@ class AlgolIrCompiler:
             raise CompileError(f"numeric operator {operator!r} is not supported")
         return dst
 
-    def _emit_integer_zero_divisor_guard(
-        self, divisor: int, scope: _FrameScope
+    def _emit_integer_division_failure_guard(
+        self, dividend: int, divisor: int, scope: _FrameScope
     ) -> None:
-        failed = self._fresh_reg()
+        zero_divisor = self._fresh_reg()
         self._emit(
             IrOp.CMP_EQ,
-            IrRegister(failed),
+            IrRegister(zero_divisor),
             IrRegister(divisor),
             IrRegister(_ZERO_REG),
         )
+        min_dividend = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(min_dividend),
+            IrRegister(dividend),
+            IrRegister(self._const_reg(_I32_MIN)),
+        )
+        negative_one_divisor = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(negative_one_divisor),
+            IrRegister(divisor),
+            IrRegister(self._const_reg(_I32_NEG_ONE)),
+        )
+        overflowing_division = self._fresh_reg()
+        self._emit(
+            IrOp.AND,
+            IrRegister(overflowing_division),
+            IrRegister(min_dividend),
+            IrRegister(negative_one_divisor),
+        )
+        failed = self._fresh_reg()
+        self._emit(
+            IrOp.OR,
+            IrRegister(failed),
+            IrRegister(zero_divisor),
+            IrRegister(overflowing_division),
+        )
         self._emit_runtime_failure_guard(failed, scope)
 
-    def _emit_power(self, base: int, base_type: str, exponent: int) -> int:
+    def _emit_real_zero_divisor_guard(
+        self, divisor: int, scope: _FrameScope
+    ) -> None:
+        zero = self._const_f64_reg(0.0)
+        failed = self._fresh_reg()
+        self._emit(
+            IrOp.F64_CMP_EQ,
+            IrRegister(failed),
+            IrRegister(divisor),
+            IrRegister(zero),
+        )
+        self._emit_runtime_failure_guard(failed, scope)
+
+    def _emit_power(
+        self, base: int, base_type: str, exponent: int, scope: _FrameScope
+    ) -> int:
         if base_type == _REAL_TYPE:
-            return self._emit_real_integer_power(base, exponent)
+            return self._emit_real_integer_power(base, exponent, scope)
         return self._emit_integer_power(base, exponent)
 
     def _emit_integer_power(self, base: int, exponent: int) -> int:
@@ -2597,7 +2643,9 @@ class AlgolIrCompiler:
         self._label(end_label)
         return result
 
-    def _emit_real_integer_power(self, base: int, exponent: int) -> int:
+    def _emit_real_integer_power(
+        self, base: int, exponent: int, scope: _FrameScope
+    ) -> int:
         index = self.if_count
         self.if_count += 1
         negative_label = f"pow_{index}_negative"
@@ -2618,6 +2666,7 @@ class AlgolIrCompiler:
         self._emit(IrOp.BRANCH_NZ, IrRegister(negative), IrLabel(negative_label))
         self._emit(IrOp.JUMP, IrLabel(prepare_loop_label))
         self._label(negative_label)
+        self._emit_real_zero_divisor_guard(base, scope)
         zero = self._const_reg(0)
         absolute = self._fresh_reg()
         self._emit(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -514,15 +514,26 @@ class TestAlgolIrCompiler:
         assert IrOp.MUL in opcodes
         assert opcodes.count(IrOp.SUB) >= 2
 
-    def test_integer_division_emits_zero_divisor_guard(self) -> None:
+    def test_integer_division_emits_runtime_failure_guard(self) -> None:
         result = compile_algol(
             parse_algol("begin integer result, divisor; result := 10 div divisor end")
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
 
         assert IrOp.CMP_EQ in opcodes
+        assert IrOp.OR in opcodes
         assert IrOp.BRANCH_Z in opcodes
         assert opcodes.index(IrOp.CMP_EQ) < opcodes.index(IrOp.DIV)
+
+    def test_real_division_emits_zero_divisor_guard(self) -> None:
+        result = compile_algol(
+            parse_algol("begin integer result; real x, y; x := 1.0 / y end")
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.F64_CMP_EQ in opcodes
+        assert IrOp.BRANCH_Z in opcodes
+        assert opcodes.index(IrOp.F64_CMP_EQ) < opcodes.index(IrOp.F64_DIV)
 
     def test_compiles_boolean_not_or_and_comparison_forms(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this package will be documented in this file.
   statement lists.
 - Returned `0` for integer `div` or `mod` by zero through the ALGOL runtime
   failure path instead of leaking a host WASM trap.
+- Returned `0` for integer divide overflow, real division by zero, and
+  zero-real-base negative exponentiation through the same ALGOL runtime
+  failure path.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,7 @@ already supports a substantial ALGOL 60 surface:
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
 - chained assignment, conditional expressions, tolerant trailing/repeated
-  semicolons, integer `div`/`mod` runtime failure guards, and
+  semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks and
   typed whole-array, label, switch, and no-argument statement procedure formals

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1238,6 +1238,42 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
 
+    def test_integer_division_overflow_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result, low, divisor; "
+            "low := 0 - 2147483647 - 1; "
+            "divisor := 0 - 1; "
+            "result := low div divisor "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_integer_modulo_overflow_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result, low, divisor; "
+            "low := 0 - 2147483647 - 1; "
+            "divisor := 0 - 1; "
+            "result := low mod divisor "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_real_division_by_zero_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; real x, divisor; "
+            "divisor := 0.0; x := 1.0 / divisor; result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_zero_real_base_negative_exponent_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 0.0 ^ (0 - 1); result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
     def test_array_failure_in_procedure_unwinds_before_caller_continues(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
## Summary
- route signed integer divide overflow through the ALGOL zero-result runtime failure path for `div` and `mod`
- guard real division by zero and zero-real-base negative exponentiation before WASM can produce infinities
- add IR-shape and end-to-end WASM coverage plus package docs/changelog notes

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m ruff check code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- New code only emits existing IR comparison/boolean/branch instructions before arithmetic operations.
- No new file I/O, shell execution, subprocess use, network access, deserialization, or unsafe dynamic execution paths.