### PR TITLE
[codex] Port graph property bags across languages

### DIFF
--- a/code/packages/csharp/graph/CHANGELOG.md
+++ b/code/packages/csharp/graph/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Changed
 
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata
 - Expanded `Graph.cs` into the repo's literate-programming style with design
   commentary about representations, traversal order, shortest path selection,
   and Kruskal's MST algorithm

--- a/code/packages/csharp/graph/Graph.cs
+++ b/code/packages/csharp/graph/Graph.cs
@@ -99,6 +99,9 @@ public sealed class Graph<T> where T : notnull
     private readonly List<T> _nodeList = new();
     private readonly Dictionary<T, int> _nodeIndex = new();
     private readonly List<List<double?>> _matrix = new();
+    private readonly Dictionary<string, object?> _graphProperties = new(StringComparer.Ordinal);
+    private readonly Dictionary<T, Dictionary<string, object?>> _nodeProperties = new();
+    private readonly Dictionary<string, Dictionary<string, object?>> _edgeProperties = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Create an empty graph backed by the selected representation.
@@ -121,7 +124,7 @@ public sealed class Graph<T> where T : notnull
     /// <summary>
     /// Add a node if it is not already present.
     /// </summary>
-    public void AddNode(T node)
+    public void AddNode(T node, IReadOnlyDictionary<string, object?>? properties = null)
     {
         // In adjacency-list mode, "adding a node" just means ensuring it has an
         // empty neighbor map.
@@ -132,6 +135,7 @@ public sealed class Graph<T> where T : notnull
                 _adj[node] = new Dictionary<T, double>();
             }
 
+            MergeNodeProperties(node, properties);
             return;
         }
 
@@ -139,6 +143,7 @@ public sealed class Graph<T> where T : notnull
         // every existing row gets a new column, and we append one new row.
         if (_nodeIndex.ContainsKey(node))
         {
+            MergeNodeProperties(node, properties);
             return;
         }
 
@@ -158,6 +163,7 @@ public sealed class Graph<T> where T : notnull
         }
 
         _matrix.Add(newRow);
+        MergeNodeProperties(node, properties);
     }
 
     /// <summary>
@@ -175,9 +181,11 @@ public sealed class Graph<T> where T : notnull
             foreach (var neighbor in neighbors.Keys.ToList())
             {
                 _adj[neighbor].Remove(node);
+                _edgeProperties.Remove(NodeOrdering.EdgeKey(node, neighbor));
             }
 
             _adj.Remove(node);
+            _nodeProperties.Remove(node);
             return;
         }
 
@@ -186,6 +194,12 @@ public sealed class Graph<T> where T : notnull
             throw new KeyNotFoundException($"Node not found: {node}");
         }
 
+        foreach (var other in _nodeList)
+        {
+            _edgeProperties.Remove(NodeOrdering.EdgeKey(node, other));
+        }
+
+        _nodeProperties.Remove(node);
         _nodeIndex.Remove(node);
         _nodeList.RemoveAt(index);
         _matrix.RemoveAt(index);
@@ -218,7 +232,7 @@ public sealed class Graph<T> where T : notnull
     /// Add or overwrite an undirected weighted edge between two nodes.
     /// Missing endpoints are created automatically.
     /// </summary>
-    public void AddEdge(T left, T right, double weight = 1.0)
+    public void AddEdge(T left, T right, double weight = 1.0, IReadOnlyDictionary<string, object?>? properties = null)
     {
         AddNode(left);
         AddNode(right);
@@ -227,6 +241,7 @@ public sealed class Graph<T> where T : notnull
         {
             _adj[left][right] = weight;
             _adj[right][left] = weight;
+            MergeEdgeProperties(left, right, weight, properties);
             return;
         }
 
@@ -234,6 +249,7 @@ public sealed class Graph<T> where T : notnull
         var rightIndex = _nodeIndex[right];
         _matrix[leftIndex][rightIndex] = weight;
         _matrix[rightIndex][leftIndex] = weight;
+        MergeEdgeProperties(left, right, weight, properties);
     }
 
     /// <summary>
@@ -252,6 +268,7 @@ public sealed class Graph<T> where T : notnull
 
             leftNeighbors.Remove(right);
             rightNeighbors.Remove(left);
+            _edgeProperties.Remove(NodeOrdering.EdgeKey(left, right));
             return;
         }
 
@@ -264,6 +281,7 @@ public sealed class Graph<T> where T : notnull
 
         _matrix[leftIndex][rightIndex] = null;
         _matrix[rightIndex][leftIndex] = null;
+        _edgeProperties.Remove(NodeOrdering.EdgeKey(left, right));
     }
 
     /// <summary>
@@ -436,10 +454,251 @@ public sealed class Graph<T> where T : notnull
     public int Degree(T node) => Neighbors(node).Count;
 
     /// <summary>
+    /// Return a copy of the graph-level property bag.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> GraphProperties() =>
+        new Dictionary<string, object?>(_graphProperties, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Add or overwrite one graph-level property.
+    /// </summary>
+    public void SetGraphProperty(string key, object? value) => _graphProperties[key] = value;
+
+    /// <summary>
+    /// Remove one graph-level property if present.
+    /// </summary>
+    public void RemoveGraphProperty(string key) => _graphProperties.Remove(key);
+
+    /// <summary>
+    /// Return a copy of one node's property bag.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> NodeProperties(T node)
+    {
+        if (!HasNode(node))
+        {
+            throw new KeyNotFoundException($"Node not found: {node}");
+        }
+
+        return _nodeProperties.TryGetValue(node, out var properties)
+            ? new Dictionary<string, object?>(properties, StringComparer.Ordinal)
+            : new Dictionary<string, object?>(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Add or overwrite one node property.
+    /// </summary>
+    public void SetNodeProperty(T node, string key, object? value)
+    {
+        if (!HasNode(node))
+        {
+            throw new KeyNotFoundException($"Node not found: {node}");
+        }
+
+        if (!_nodeProperties.TryGetValue(node, out var properties))
+        {
+            properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+            _nodeProperties[node] = properties;
+        }
+
+        properties[key] = value;
+    }
+
+    /// <summary>
+    /// Remove one node property if present.
+    /// </summary>
+    public void RemoveNodeProperty(T node, string key)
+    {
+        if (!HasNode(node))
+        {
+            throw new KeyNotFoundException($"Node not found: {node}");
+        }
+
+        if (_nodeProperties.TryGetValue(node, out var properties))
+        {
+            properties.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Return a copy of one edge's property bag, including the current weight.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> EdgeProperties(T left, T right)
+    {
+        if (!HasEdge(left, right))
+        {
+            throw new KeyNotFoundException($"Edge not found: {left} -- {right}");
+        }
+
+        var key = NodeOrdering.EdgeKey(left, right);
+        var result = _edgeProperties.TryGetValue(key, out var properties)
+            ? new Dictionary<string, object?>(properties, StringComparer.Ordinal)
+            : new Dictionary<string, object?>(StringComparer.Ordinal);
+        result["weight"] = EdgeWeight(left, right);
+        return result;
+    }
+
+    /// <summary>
+    /// Add or overwrite one edge property. Setting <c>weight</c> also updates the edge weight.
+    /// </summary>
+    public void SetEdgeProperty(T left, T right, string key, object? value)
+    {
+        if (!HasEdge(left, right))
+        {
+            throw new KeyNotFoundException($"Edge not found: {left} -- {right}");
+        }
+
+        if (key == "weight")
+        {
+            if (!TryConvertToDouble(value, out var weight))
+            {
+                throw new ArgumentException("Edge property 'weight' must be numeric.", nameof(value));
+            }
+
+            SetEdgeWeight(left, right, weight);
+        }
+
+        var edgeKey = NodeOrdering.EdgeKey(left, right);
+        if (!_edgeProperties.TryGetValue(edgeKey, out var properties))
+        {
+            properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+            _edgeProperties[edgeKey] = properties;
+        }
+
+        properties[key] = value;
+    }
+
+    /// <summary>
+    /// Remove one edge property if present. Removing <c>weight</c> resets the edge weight to 1.0.
+    /// </summary>
+    public void RemoveEdgeProperty(T left, T right, string key)
+    {
+        if (!HasEdge(left, right))
+        {
+            throw new KeyNotFoundException($"Edge not found: {left} -- {right}");
+        }
+
+        if (key == "weight")
+        {
+            SetEdgeWeight(left, right, 1.0);
+            var edgeKey = NodeOrdering.EdgeKey(left, right);
+            if (!_edgeProperties.TryGetValue(edgeKey, out var properties))
+            {
+                properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+                _edgeProperties[edgeKey] = properties;
+            }
+
+            properties["weight"] = 1.0;
+            return;
+        }
+
+        if (_edgeProperties.TryGetValue(NodeOrdering.EdgeKey(left, right), out var bag))
+        {
+            bag.Remove(key);
+        }
+    }
+
+    /// <summary>
     /// Produce a short human-readable graph summary.
     /// </summary>
     public override string ToString() =>
         $"Graph(nodes={Size}, edges={Edges().Count}, repr={Representation})";
+
+    private void MergeNodeProperties(T node, IReadOnlyDictionary<string, object?>? properties)
+    {
+        if (!_nodeProperties.TryGetValue(node, out var target))
+        {
+            target = new Dictionary<string, object?>(StringComparer.Ordinal);
+            _nodeProperties[node] = target;
+        }
+
+        if (properties is null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in properties)
+        {
+            target[key] = value;
+        }
+    }
+
+    private void MergeEdgeProperties(T left, T right, double weight, IReadOnlyDictionary<string, object?>? properties)
+    {
+        var edgeKey = NodeOrdering.EdgeKey(left, right);
+        if (!_edgeProperties.TryGetValue(edgeKey, out var target))
+        {
+            target = new Dictionary<string, object?>(StringComparer.Ordinal);
+            _edgeProperties[edgeKey] = target;
+        }
+
+        if (properties is not null)
+        {
+            foreach (var (key, value) in properties)
+            {
+                target[key] = value;
+            }
+        }
+
+        target["weight"] = weight;
+    }
+
+    private void SetEdgeWeight(T left, T right, double weight)
+    {
+        if (_repr == GraphRepr.AdjacencyList)
+        {
+            _adj[left][right] = weight;
+            _adj[right][left] = weight;
+            return;
+        }
+
+        var leftIndex = _nodeIndex[left];
+        var rightIndex = _nodeIndex[right];
+        _matrix[leftIndex][rightIndex] = weight;
+        _matrix[rightIndex][leftIndex] = weight;
+    }
+
+    private static bool TryConvertToDouble(object? value, out double result)
+    {
+        switch (value)
+        {
+            case byte numeric:
+                result = numeric;
+                return true;
+            case sbyte numeric:
+                result = numeric;
+                return true;
+            case short numeric:
+                result = numeric;
+                return true;
+            case ushort numeric:
+                result = numeric;
+                return true;
+            case int numeric:
+                result = numeric;
+                return true;
+            case uint numeric:
+                result = numeric;
+                return true;
+            case long numeric:
+                result = numeric;
+                return true;
+            case ulong numeric:
+                result = numeric;
+                return true;
+            case float numeric:
+                result = numeric;
+                return true;
+            case double numeric:
+                result = numeric;
+                return true;
+            case decimal numeric:
+                result = (double)numeric;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
 }
 
 /// <summary>

--- a/code/packages/csharp/graph/README.md
+++ b/code/packages/csharp/graph/README.md
@@ -7,6 +7,7 @@ adjacency lists for sparse graphs and adjacency matrices for dense ones.
 
 - `Graph<T>` with `GraphRepr.AdjacencyList` and `GraphRepr.AdjacencyMatrix`
 - weighted undirected edges, including self-loops
+- graph, node, and edge property bags for metadata
 - traversal algorithms: BFS, DFS, connectivity, components, cycle detection
 - path and tree helpers: shortest path and minimum spanning tree
 

--- a/code/packages/csharp/graph/tests/CodingAdventures.Graph.Tests/GraphTests.cs
+++ b/code/packages/csharp/graph/tests/CodingAdventures.Graph.Tests/GraphTests.cs
@@ -214,6 +214,45 @@ public sealed class GraphTests
     }
 
     [Fact]
+    public void PropertyBagsTrackGraphNodeAndEdgeMetadata()
+    {
+        foreach (var repr in Representations())
+        {
+            var graph = new Graph<string>(repr);
+
+            graph.SetGraphProperty("name", "city-map");
+            graph.SetGraphProperty("version", 1);
+            Assert.Equal("city-map", graph.GraphProperties()["name"]);
+            Assert.Equal(1, graph.GraphProperties()["version"]);
+            graph.RemoveGraphProperty("version");
+            Assert.False(graph.GraphProperties().ContainsKey("version"));
+
+            graph.AddNode("A", new Dictionary<string, object?> { ["kind"] = "input" });
+            graph.AddNode("A", new Dictionary<string, object?> { ["trainable"] = false });
+            graph.SetNodeProperty("A", "slot", 0);
+            var nodeProperties = graph.NodeProperties("A");
+            Assert.Equal("input", nodeProperties["kind"]);
+            Assert.Equal(false, nodeProperties["trainable"]);
+            Assert.Equal(0, nodeProperties["slot"]);
+            graph.RemoveNodeProperty("A", "slot");
+            Assert.False(graph.NodeProperties("A").ContainsKey("slot"));
+
+            graph.AddEdge("A", "B", 2.5, new Dictionary<string, object?> { ["role"] = "distance" });
+            Assert.Equal("distance", graph.EdgeProperties("B", "A")["role"]);
+            Assert.Equal(2.5, graph.EdgeProperties("B", "A")["weight"]);
+            graph.SetEdgeProperty("B", "A", "weight", 7.0);
+            Assert.Equal(7.0, graph.EdgeWeight("A", "B"));
+            graph.SetEdgeProperty("A", "B", "trainable", true);
+            graph.RemoveEdgeProperty("A", "B", "role");
+            Assert.Equal(true, graph.EdgeProperties("A", "B")["trainable"]);
+            Assert.False(graph.EdgeProperties("A", "B").ContainsKey("role"));
+
+            graph.RemoveEdge("A", "B");
+            Assert.Throws<KeyNotFoundException>(() => graph.EdgeProperties("A", "B"));
+        }
+    }
+
+    [Fact]
     public void NumericNodesAreSupported()
     {
         foreach (var repr in Representations())

--- a/code/packages/dart/graph/CHANGELOG.md
+++ b/code/packages/dart/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata.
+
 ## 0.1.0
 
 - Added the initial Dart graph package with adjacency-list and adjacency-matrix representations.

--- a/code/packages/dart/graph/README.md
+++ b/code/packages/dart/graph/README.md
@@ -7,6 +7,7 @@ and adjacency-matrix storage.
 
 - `Graph` with `GraphRepr.adjacencyList` and `GraphRepr.adjacencyMatrix`
 - Weighted undirected edges, including self-loops
+- Graph, node, and edge property bags for metadata and future graph runtimes
 - `bfs`, `dfs`, `isConnected`, `connectedComponents`, and `hasCycle`
 - `shortestPath` and `minimumSpanningTree`
 
@@ -20,6 +21,7 @@ void main() {
   graph.addEdge('London', 'Paris', 300);
   graph.addEdge('London', 'Amsterdam', 520);
   graph.addEdge('Amsterdam', 'Berlin', 655);
+  graph.setNodeProperty('London', 'kind', 'city');
 
   print(shortestPath(graph, 'London', 'Berlin'));
   // [London, Amsterdam, Berlin]

--- a/code/packages/dart/graph/lib/src/graph.dart
+++ b/code/packages/dart/graph/lib/src/graph.dart
@@ -3,12 +3,11 @@ import 'dart:convert';
 
 import 'errors.dart';
 
-enum GraphRepr {
-  adjacencyList,
-  adjacencyMatrix,
-}
+enum GraphRepr { adjacencyList, adjacencyMatrix }
 
 typedef WeightedEdge<T> = ({T left, T right, double weight});
+typedef GraphPropertyValue = Object?;
+typedef GraphPropertyBag = Map<String, GraphPropertyValue>;
 
 int compareNodes<T>(T left, T right) {
   if (left is String && right is String) {
@@ -35,19 +34,25 @@ class Graph<T> {
   final List<T> _nodeList = <T>[];
   final Map<T, int> _nodeIndex = <T, int>{};
   final List<List<double?>> _matrix = <List<double?>>[];
+  final GraphPropertyBag _graphProperties = <String, GraphPropertyValue>{};
+  final Map<T, GraphPropertyBag> _nodeProperties = <T, GraphPropertyBag>{};
+  final Map<String, GraphPropertyBag> _edgeProperties =
+      <String, GraphPropertyBag>{};
 
   GraphRepr get repr => _repr;
 
   int get size =>
       _repr == GraphRepr.adjacencyList ? _adj.length : _nodeList.length;
 
-  void addNode(T node) {
+  void addNode(T node, [GraphPropertyBag properties = const {}]) {
     if (_repr == GraphRepr.adjacencyList) {
       _adj.putIfAbsent(node, () => <T, double>{});
+      _mergeNodeProperties(node, properties);
       return;
     }
 
     if (_nodeIndex.containsKey(node)) {
+      _mergeNodeProperties(node, properties);
       return;
     }
 
@@ -59,6 +64,7 @@ class Graph<T> {
       row.add(null);
     }
     _matrix.add(List<double?>.filled(index + 1, null, growable: true));
+    _mergeNodeProperties(node, properties);
   }
 
   void removeNode(T node) {
@@ -70,8 +76,10 @@ class Graph<T> {
 
       for (final neighbor in List<T>.from(neighbors.keys)) {
         _adj[neighbor]?.remove(node);
+        _edgeProperties.remove(_edgeKey(node, neighbor));
       }
       _adj.remove(node);
+      _nodeProperties.remove(node);
       return;
     }
 
@@ -80,6 +88,10 @@ class Graph<T> {
       throw NodeNotFoundError<T>(node);
     }
 
+    for (final other in _nodeList) {
+      _edgeProperties.remove(_edgeKey(node, other));
+    }
+    _nodeProperties.remove(node);
     _nodeList.removeAt(index);
     _matrix.removeAt(index);
     for (final row in _matrix) {
@@ -103,7 +115,12 @@ class Graph<T> {
     return Set<T>.unmodifiable(nodes);
   }
 
-  void addEdge(T left, T right, [num weight = 1]) {
+  void addEdge(
+    T left,
+    T right, [
+    num weight = 1,
+    GraphPropertyBag properties = const {},
+  ]) {
     final normalizedWeight = weight.toDouble();
     addNode(left);
     addNode(right);
@@ -111,6 +128,7 @@ class Graph<T> {
     if (_repr == GraphRepr.adjacencyList) {
       _adj[left]![right] = normalizedWeight;
       _adj[right]![left] = normalizedWeight;
+      _mergeEdgeProperties(left, right, normalizedWeight, properties);
       return;
     }
 
@@ -118,6 +136,7 @@ class Graph<T> {
     final rightIndex = _nodeIndex[right]!;
     _matrix[leftIndex][rightIndex] = normalizedWeight;
     _matrix[rightIndex][leftIndex] = normalizedWeight;
+    _mergeEdgeProperties(left, right, normalizedWeight, properties);
   }
 
   void removeEdge(T left, T right) {
@@ -134,6 +153,7 @@ class Graph<T> {
       if (left != right) {
         rightNeighbors.remove(left);
       }
+      _edgeProperties.remove(_edgeKey(left, right));
       return;
     }
 
@@ -147,6 +167,7 @@ class Graph<T> {
 
     _matrix[leftIndex][rightIndex] = null;
     _matrix[rightIndex][leftIndex] = null;
+    _edgeProperties.remove(_edgeKey(left, right));
   }
 
   bool hasEdge(T left, T right) {
@@ -206,9 +227,7 @@ class Graph<T> {
         for (var col = row; col < _nodeList.length; col++) {
           final weight = _matrix[row][col];
           if (weight != null) {
-            result.add(
-              _canonicalEdge(_nodeList[row], _nodeList[col], weight),
-            );
+            result.add(_canonicalEdge(_nodeList[row], _nodeList[col], weight));
           }
         }
       }
@@ -278,8 +297,126 @@ class Graph<T> {
 
   int degree(T node) => neighbors(node).length;
 
+  GraphPropertyBag graphProperties() =>
+      Map<String, GraphPropertyValue>.unmodifiable(_graphProperties);
+
+  void setGraphProperty(String key, GraphPropertyValue value) {
+    _graphProperties[key] = value;
+  }
+
+  void removeGraphProperty(String key) {
+    _graphProperties.remove(key);
+  }
+
+  GraphPropertyBag nodeProperties(T node) {
+    if (!hasNode(node)) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    return Map<String, GraphPropertyValue>.unmodifiable(
+      _nodeProperties[node] ?? const <String, GraphPropertyValue>{},
+    );
+  }
+
+  void setNodeProperty(T node, String key, GraphPropertyValue value) {
+    if (!hasNode(node)) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    _nodeProperties.putIfAbsent(node, () => <String, GraphPropertyValue>{});
+    _nodeProperties[node]![key] = value;
+  }
+
+  void removeNodeProperty(T node, String key) {
+    if (!hasNode(node)) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    _nodeProperties[node]?.remove(key);
+  }
+
+  GraphPropertyBag edgeProperties(T left, T right) {
+    if (!hasEdge(left, right)) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+
+    final properties = <String, GraphPropertyValue>{
+      ...?_edgeProperties[_edgeKey(left, right)],
+      'weight': edgeWeight(left, right),
+    };
+    return Map<String, GraphPropertyValue>.unmodifiable(properties);
+  }
+
+  void setEdgeProperty(T left, T right, String key, GraphPropertyValue value) {
+    if (!hasEdge(left, right)) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+
+    if (key == 'weight') {
+      if (value is! num) {
+        throw ArgumentError("edge property 'weight' must be numeric");
+      }
+      _setEdgeWeight(left, right, value.toDouble());
+    }
+
+    _edgeProperties.putIfAbsent(
+      _edgeKey(left, right),
+      () => <String, GraphPropertyValue>{},
+    );
+    _edgeProperties[_edgeKey(left, right)]![key] = value;
+  }
+
+  void removeEdgeProperty(T left, T right, String key) {
+    if (!hasEdge(left, right)) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+
+    if (key == 'weight') {
+      _setEdgeWeight(left, right, 1);
+      _edgeProperties.putIfAbsent(
+        _edgeKey(left, right),
+        () => <String, GraphPropertyValue>{},
+      );
+      _edgeProperties[_edgeKey(left, right)]!['weight'] = 1.0;
+      return;
+    }
+
+    _edgeProperties[_edgeKey(left, right)]?.remove(key);
+  }
+
   @override
-  String toString() => 'Graph(nodes=$size, edges=${edges().length}, repr=$_repr)';
+  String toString() =>
+      'Graph(nodes=$size, edges=${edges().length}, repr=$_repr)';
+
+  void _mergeNodeProperties(T node, GraphPropertyBag properties) {
+    _nodeProperties.putIfAbsent(node, () => <String, GraphPropertyValue>{});
+    _nodeProperties[node]!.addAll(properties);
+  }
+
+  void _mergeEdgeProperties(
+    T left,
+    T right,
+    double weight,
+    GraphPropertyBag properties,
+  ) {
+    final key = _edgeKey(left, right);
+    _edgeProperties.putIfAbsent(key, () => <String, GraphPropertyValue>{});
+    _edgeProperties[key]!.addAll(properties);
+    _edgeProperties[key]!['weight'] = weight;
+  }
+
+  void _setEdgeWeight(T left, T right, double weight) {
+    if (_repr == GraphRepr.adjacencyList) {
+      _adj[left]![right] = weight;
+      _adj[right]![left] = weight;
+      return;
+    }
+
+    final leftIndex = _nodeIndex[left]!;
+    final rightIndex = _nodeIndex[right]!;
+    _matrix[leftIndex][rightIndex] = weight;
+    _matrix[rightIndex][leftIndex] = weight;
+  }
 }
 
 String _nodeSortKey(Object? node) {

--- a/code/packages/dart/graph/test/graph_test.dart
+++ b/code/packages/dart/graph/test/graph_test.dart
@@ -114,6 +114,54 @@ void main() {
     }
   });
 
+  group('property bags', () {
+    for (final repr in representations) {
+      test('stores graph, node, and edge properties for $repr', () {
+        final graph = Graph<String>(repr);
+
+        graph.setGraphProperty('name', 'city-map');
+        graph.setGraphProperty('version', 1);
+        expect(graph.graphProperties(), {'name': 'city-map', 'version': 1});
+        graph.removeGraphProperty('version');
+        expect(graph.graphProperties(), {'name': 'city-map'});
+
+        graph.addNode('A', {'kind': 'input'});
+        graph.addNode('A', {'trainable': false});
+        graph.setNodeProperty('A', 'slot', 0);
+        expect(graph.nodeProperties('A'), {
+          'kind': 'input',
+          'trainable': false,
+          'slot': 0,
+        });
+        graph.removeNodeProperty('A', 'slot');
+        expect(graph.nodeProperties('A'), {
+          'kind': 'input',
+          'trainable': false,
+        });
+
+        graph.addEdge('A', 'B', 2.5, {'role': 'distance'});
+        expect(graph.edgeProperties('B', 'A'), {
+          'role': 'distance',
+          'weight': 2.5,
+        });
+        graph.setEdgeProperty('B', 'A', 'weight', 7);
+        expect(graph.edgeWeight('A', 'B'), 7);
+        graph.setEdgeProperty('A', 'B', 'trainable', true);
+        graph.removeEdgeProperty('A', 'B', 'role');
+        expect(graph.edgeProperties('A', 'B'), {
+          'weight': 7,
+          'trainable': true,
+        });
+
+        graph.removeEdge('A', 'B');
+        expect(
+          () => graph.edgeProperties('A', 'B'),
+          throwsA(isA<EdgeNotFoundError<String>>()),
+        );
+      });
+    }
+  });
+
   group('neighborhood queries', () {
     for (final repr in representations) {
       test('returns neighbors, weights, and degree for $repr', () {
@@ -170,8 +218,8 @@ void main() {
         expect(components, hasLength(3));
         expect(
           components.any(
-            (component) => component.length == 3 &&
-                component.containsAll({'A', 'B', 'C'}),
+            (component) =>
+                component.length == 3 && component.containsAll({'A', 'B', 'C'}),
           ),
           isTrue,
         );
@@ -228,10 +276,11 @@ void main() {
       });
 
       test('handles the city example for $repr', () {
-        expect(
-          shortestPath(makeGraph(repr), 'London', 'Berlin'),
-          ['London', 'Amsterdam', 'Berlin'],
-        );
+        expect(shortestPath(makeGraph(repr), 'London', 'Berlin'), [
+          'London',
+          'Amsterdam',
+          'Berlin',
+        ]);
       });
     }
   });
@@ -248,8 +297,9 @@ void main() {
         graph.addEdge('A', 'B', 1);
         graph.addEdge('B', 'C', 2);
         graph.addEdge('C', 'A', 4);
-        final total = minimumSpanningTree(graph)
-            .fold<double>(0, (sum, edge) => sum + edge.weight);
+        final total = minimumSpanningTree(
+          graph,
+        ).fold<double>(0, (sum, edge) => sum + edge.weight);
         expect(total, 3);
       });
 

--- a/code/packages/elixir/graph/lib/graph.ex
+++ b/code/packages/elixir/graph/lib/graph.ex
@@ -9,16 +9,25 @@ defmodule CodingAdventures.Graph do
   alias CodingAdventures.Graph.Graph
 
   defdelegate new(opts \\ []), to: Graph
-  defdelegate add_node(graph, node), to: Graph
+  defdelegate add_node(graph, node, properties \\ %{}), to: Graph
   defdelegate remove_node(graph, node), to: Graph
   defdelegate has_node?(graph, node), to: Graph
   defdelegate nodes(graph), to: Graph
   defdelegate size(graph), to: Graph
-  defdelegate add_edge(graph, left, right, weight \\ 1.0), to: Graph
+  defdelegate add_edge(graph, left, right, weight \\ 1.0, properties \\ %{}), to: Graph
   defdelegate remove_edge(graph, left, right), to: Graph
   defdelegate has_edge?(graph, left, right), to: Graph
   defdelegate edges(graph), to: Graph
   defdelegate edge_weight(graph, left, right), to: Graph
+  defdelegate graph_properties(graph), to: Graph
+  defdelegate set_graph_property(graph, key, value), to: Graph
+  defdelegate remove_graph_property(graph, key), to: Graph
+  defdelegate node_properties(graph, node), to: Graph
+  defdelegate set_node_property(graph, node, key, value), to: Graph
+  defdelegate remove_node_property(graph, node, key), to: Graph
+  defdelegate edge_properties(graph, left, right), to: Graph
+  defdelegate set_edge_property(graph, left, right, key, value), to: Graph
+  defdelegate remove_edge_property(graph, left, right, key), to: Graph
   defdelegate neighbors(graph, node), to: Graph
   defdelegate neighbors_weighted(graph, node), to: Graph
   defdelegate degree(graph, node), to: Graph

--- a/code/packages/elixir/graph/lib/graph/graph.ex
+++ b/code/packages/elixir/graph/lib/graph/graph.ex
@@ -11,15 +11,29 @@ defmodule CodingAdventures.Graph.Graph do
   }
 
   @enforce_keys [:repr, :adj, :node_list, :node_index, :matrix]
-  defstruct [:repr, :adj, :node_list, :node_index, :matrix]
+  defstruct [
+    :repr,
+    :adj,
+    :node_list,
+    :node_index,
+    :matrix,
+    graph_properties: %{},
+    node_properties: %{},
+    edge_properties: %{}
+  ]
 
   @type repr_t :: :adjacency_list | :adjacency_matrix
+  @type property_value :: String.t() | number() | boolean() | nil
+  @type property_bag :: %{optional(String.t()) => property_value()}
   @type t :: %__MODULE__{
           repr: repr_t(),
           adj: %{optional(String.t()) => %{optional(String.t()) => float()}},
           node_list: [String.t()],
           node_index: %{optional(String.t()) => non_neg_integer()},
-          matrix: [[float() | nil]]
+          matrix: [[float() | nil]],
+          graph_properties: property_bag(),
+          node_properties: %{optional(String.t()) => property_bag()},
+          edge_properties: %{optional({String.t(), String.t()}) => property_bag()}
         }
 
   @type weighted_edge :: {String.t(), String.t(), float()}
@@ -40,14 +54,27 @@ defmodule CodingAdventures.Graph.Graph do
     }
   end
 
-  @spec add_node(t(), String.t()) :: {:ok, t()}
-  def add_node(%__MODULE__{repr: :adjacency_list, adj: adj} = graph, node) do
-    {:ok, %{graph | adj: Map.put_new(adj, node, %{})}}
+  @spec add_node(t(), String.t(), property_bag()) :: {:ok, t()}
+  def add_node(graph, node, properties \\ %{})
+
+  def add_node(%__MODULE__{repr: :adjacency_list, adj: adj} = graph, node, properties) do
+    graph = %{
+      graph
+      | adj: Map.put_new(adj, node, %{}),
+        node_properties: merge_property_bag(graph.node_properties, node, properties)
+    }
+
+    {:ok, graph}
   end
 
-  def add_node(%__MODULE__{repr: :adjacency_matrix, node_index: node_index} = graph, node) do
+  def add_node(
+        %__MODULE__{repr: :adjacency_matrix, node_index: node_index} = graph,
+        node,
+        properties
+      ) do
     if Map.has_key?(node_index, node) do
-      {:ok, graph}
+      {:ok,
+       %{graph | node_properties: merge_property_bag(graph.node_properties, node, properties)}}
     else
       index = length(graph.node_list)
       matrix = Enum.map(graph.matrix, &(&1 ++ [nil])) ++ [List.duplicate(nil, index + 1)]
@@ -57,7 +84,8 @@ defmodule CodingAdventures.Graph.Graph do
          graph
          | node_list: graph.node_list ++ [node],
            node_index: Map.put(node_index, node, index),
-           matrix: matrix
+           matrix: matrix,
+           node_properties: merge_property_bag(graph.node_properties, node, properties)
        }}
     end
   end
@@ -77,7 +105,20 @@ defmodule CodingAdventures.Graph.Graph do
           end)
           |> Map.delete(node)
 
-        {:ok, %{graph | adj: next_adj}}
+        edge_properties =
+          neighbors
+          |> Map.keys()
+          |> Enum.reduce(graph.edge_properties, fn neighbor, acc ->
+            Map.delete(acc, edge_key(node, neighbor))
+          end)
+
+        {:ok,
+         %{
+           graph
+           | adj: next_adj,
+             node_properties: Map.delete(graph.node_properties, node),
+             edge_properties: edge_properties
+         }}
     end
   end
 
@@ -90,13 +131,29 @@ defmodule CodingAdventures.Graph.Graph do
         node_list = List.delete_at(graph.node_list, index)
         matrix = graph.matrix |> List.delete_at(index) |> Enum.map(&List.delete_at(&1, index))
         node_index = rebuild_index(node_list)
-        {:ok, %{graph | node_list: node_list, node_index: node_index, matrix: matrix}}
+
+        edge_properties =
+          Enum.reduce(graph.node_list, graph.edge_properties, fn other, acc ->
+            Map.delete(acc, edge_key(node, other))
+          end)
+
+        {:ok,
+         %{
+           graph
+           | node_list: node_list,
+             node_index: node_index,
+             matrix: matrix,
+             node_properties: Map.delete(graph.node_properties, node),
+             edge_properties: edge_properties
+         }}
     end
   end
 
   @spec has_node?(t(), String.t()) :: boolean()
   def has_node?(%__MODULE__{repr: :adjacency_list, adj: adj}, node), do: Map.has_key?(adj, node)
-  def has_node?(%__MODULE__{repr: :adjacency_matrix, node_index: idx}, node), do: Map.has_key?(idx, node)
+
+  def has_node?(%__MODULE__{repr: :adjacency_matrix, node_index: idx}, node),
+    do: Map.has_key?(idx, node)
 
   @spec nodes(t()) :: [String.t()]
   def nodes(%__MODULE__{repr: :adjacency_list, adj: adj}), do: sort_nodes(Map.keys(adj))
@@ -106,10 +163,11 @@ defmodule CodingAdventures.Graph.Graph do
   def size(%__MODULE__{repr: :adjacency_list, adj: adj}), do: map_size(adj)
   def size(%__MODULE__{repr: :adjacency_matrix, node_list: node_list}), do: length(node_list)
 
-  @spec add_edge(t(), String.t(), String.t(), float()) :: {:ok, t()}
-  def add_edge(graph, left, right, weight \\ 1.0) do
+  @spec add_edge(t(), String.t(), String.t(), float(), property_bag()) :: {:ok, t()}
+  def add_edge(graph, left, right, weight \\ 1.0, properties \\ %{}) do
     {:ok, graph} = add_node(graph, left)
     {:ok, graph} = add_node(graph, right)
+    edge_properties = put_edge_properties(graph.edge_properties, left, right, weight, properties)
 
     case graph.repr do
       :adjacency_list ->
@@ -118,7 +176,7 @@ defmodule CodingAdventures.Graph.Graph do
           |> put_in([left, right], weight)
           |> put_in([right, left], weight)
 
-        {:ok, %{graph | adj: adj}}
+        {:ok, %{graph | adj: adj, edge_properties: edge_properties}}
 
       :adjacency_matrix ->
         left_index = Map.fetch!(graph.node_index, left)
@@ -129,7 +187,7 @@ defmodule CodingAdventures.Graph.Graph do
           |> replace_cell(left_index, right_index, weight)
           |> replace_cell(right_index, left_index, weight)
 
-        {:ok, %{graph | matrix: matrix}}
+        {:ok, %{graph | matrix: matrix, edge_properties: edge_properties}}
     end
   end
 
@@ -143,7 +201,12 @@ defmodule CodingAdventures.Graph.Graph do
             |> update_in([left], &Map.delete(&1, right))
             |> update_in([right], &Map.delete(&1, left))
 
-          {:ok, %{graph | adj: adj}}
+          {:ok,
+           %{
+             graph
+             | adj: adj,
+               edge_properties: Map.delete(graph.edge_properties, edge_key(left, right))
+           }}
 
         :adjacency_matrix ->
           left_index = Map.fetch!(graph.node_index, left)
@@ -154,7 +217,12 @@ defmodule CodingAdventures.Graph.Graph do
             |> replace_cell(left_index, right_index, nil)
             |> replace_cell(right_index, left_index, nil)
 
-          {:ok, %{graph | matrix: matrix}}
+          {:ok,
+           %{
+             graph
+             | matrix: matrix,
+               edge_properties: Map.delete(graph.edge_properties, edge_key(left, right))
+           }}
       end
     else
       {:error,
@@ -171,7 +239,11 @@ defmodule CodingAdventures.Graph.Graph do
     adj |> Map.get(left, %{}) |> Map.has_key?(right)
   end
 
-  def has_edge?(%__MODULE__{repr: :adjacency_matrix, node_index: idx, matrix: matrix}, left, right) do
+  def has_edge?(
+        %__MODULE__{repr: :adjacency_matrix, node_index: idx, matrix: matrix},
+        left,
+        right
+      ) do
     with {:ok, left_index} <- Map.fetch(idx, left),
          {:ok, right_index} <- Map.fetch(idx, right) do
       get_in(matrix, [Access.at(left_index), Access.at(right_index)]) != nil
@@ -203,21 +275,22 @@ defmodule CodingAdventures.Graph.Graph do
     if node_list == [] do
       []
     else
-    0..(length(node_list) - 1)
-    |> Enum.flat_map(fn row ->
-      row..(length(node_list) - 1)
-      |> Enum.reduce([], fn col, acc ->
-        case get_in(matrix, [Access.at(row), Access.at(col)]) do
-          nil -> acc
-          weight -> [{Enum.at(node_list, row), Enum.at(node_list, col), weight} | acc]
-        end
+      0..(length(node_list) - 1)
+      |> Enum.flat_map(fn row ->
+        row..(length(node_list) - 1)
+        |> Enum.reduce([], fn col, acc ->
+          case get_in(matrix, [Access.at(row), Access.at(col)]) do
+            nil -> acc
+            weight -> [{Enum.at(node_list, row), Enum.at(node_list, col), weight} | acc]
+          end
+        end)
       end)
-    end)
-    |> Enum.sort_by(fn {left, right, weight} -> {weight, sort_key(left), sort_key(right)} end)
+      |> Enum.sort_by(fn {left, right, weight} -> {weight, sort_key(left), sort_key(right)} end)
     end
   end
 
-  @spec edge_weight(t(), String.t(), String.t()) :: {:ok, float()} | {:error, EdgeNotFoundError.t()}
+  @spec edge_weight(t(), String.t(), String.t()) ::
+          {:ok, float()} | {:error, EdgeNotFoundError.t()}
   def edge_weight(%__MODULE__{repr: :adjacency_list, adj: adj}, left, right) do
     case adj |> Map.get(left, %{}) |> Map.fetch(right) do
       {:ok, weight} -> {:ok, weight}
@@ -225,13 +298,146 @@ defmodule CodingAdventures.Graph.Graph do
     end
   end
 
-  def edge_weight(%__MODULE__{repr: :adjacency_matrix, node_index: idx, matrix: matrix}, left, right) do
+  def edge_weight(
+        %__MODULE__{repr: :adjacency_matrix, node_index: idx, matrix: matrix},
+        left,
+        right
+      ) do
     with {:ok, left_index} <- Map.fetch(idx, left),
          {:ok, right_index} <- Map.fetch(idx, right),
-         weight when not is_nil(weight) <- get_in(matrix, [Access.at(left_index), Access.at(right_index)]) do
+         weight when not is_nil(weight) <-
+           get_in(matrix, [Access.at(left_index), Access.at(right_index)]) do
       {:ok, weight}
     else
       _ -> edge_not_found(left, right)
+    end
+  end
+
+  @spec graph_properties(t()) :: property_bag()
+  def graph_properties(%__MODULE__{graph_properties: properties}), do: Map.new(properties)
+
+  @spec set_graph_property(t(), String.t(), property_value()) :: {:ok, t()}
+  def set_graph_property(%__MODULE__{} = graph, key, value) do
+    {:ok, %{graph | graph_properties: Map.put(graph.graph_properties, key, value)}}
+  end
+
+  @spec remove_graph_property(t(), String.t()) :: {:ok, t()}
+  def remove_graph_property(%__MODULE__{} = graph, key) do
+    {:ok, %{graph | graph_properties: Map.delete(graph.graph_properties, key)}}
+  end
+
+  @spec node_properties(t(), String.t()) ::
+          {:ok, property_bag()} | {:error, NodeNotFoundError.t()}
+  def node_properties(graph, node) do
+    if has_node?(graph, node) do
+      {:ok, Map.new(Map.get(graph.node_properties, node, %{}))}
+    else
+      node_not_found(node)
+    end
+  end
+
+  @spec set_node_property(t(), String.t(), String.t(), property_value()) ::
+          {:ok, t()} | {:error, NodeNotFoundError.t()}
+  def set_node_property(graph, node, key, value) do
+    if has_node?(graph, node) do
+      {:ok,
+       %{
+         graph
+         | node_properties: merge_property_bag(graph.node_properties, node, %{key => value})
+       }}
+    else
+      node_not_found(node)
+    end
+  end
+
+  @spec remove_node_property(t(), String.t(), String.t()) ::
+          {:ok, t()} | {:error, NodeNotFoundError.t()}
+  def remove_node_property(graph, node, key) do
+    if has_node?(graph, node) do
+      node_properties =
+        Map.update(graph.node_properties, node, %{}, fn properties ->
+          Map.delete(properties, key)
+        end)
+
+      {:ok, %{graph | node_properties: node_properties}}
+    else
+      node_not_found(node)
+    end
+  end
+
+  @spec edge_properties(t(), String.t(), String.t()) ::
+          {:ok, property_bag()} | {:error, EdgeNotFoundError.t()}
+  def edge_properties(graph, left, right) do
+    case edge_weight(graph, left, right) do
+      {:ok, weight} ->
+        properties =
+          graph.edge_properties
+          |> Map.get(edge_key(left, right), %{})
+          |> Map.put("weight", weight)
+
+        {:ok, properties}
+
+      error ->
+        error
+    end
+  end
+
+  @spec set_edge_property(t(), String.t(), String.t(), String.t(), property_value()) ::
+          {:ok, t()} | {:error, EdgeNotFoundError.t()}
+  def set_edge_property(graph, left, right, "weight", value) when is_number(value) do
+    with {:ok, graph} <- set_edge_weight(graph, left, right, value) do
+      {:ok,
+       %{
+         graph
+         | edge_properties:
+             put_edge_properties(graph.edge_properties, left, right, value, %{"weight" => value})
+       }}
+    end
+  end
+
+  def set_edge_property(_graph, _left, _right, "weight", _value) do
+    raise ArgumentError, "edge property \"weight\" must be numeric"
+  end
+
+  def set_edge_property(graph, left, right, key, value) do
+    if has_edge?(graph, left, right) do
+      edge_properties =
+        Map.update(
+          graph.edge_properties,
+          edge_key(left, right),
+          %{key => value},
+          &Map.put(&1, key, value)
+        )
+
+      {:ok, %{graph | edge_properties: edge_properties}}
+    else
+      edge_not_found(left, right)
+    end
+  end
+
+  @spec remove_edge_property(t(), String.t(), String.t(), String.t()) ::
+          {:ok, t()} | {:error, EdgeNotFoundError.t()}
+  def remove_edge_property(graph, left, right, "weight") do
+    with {:ok, graph} <- set_edge_weight(graph, left, right, 1.0) do
+      {:ok,
+       %{
+         graph
+         | edge_properties:
+             put_edge_properties(graph.edge_properties, left, right, 1.0, %{"weight" => 1.0})
+       }}
+    end
+  end
+
+  def remove_edge_property(graph, left, right, key) do
+    if has_edge?(graph, left, right) do
+      edge_properties =
+        Map.update(graph.edge_properties, edge_key(left, right), %{}, fn properties ->
+          Map.delete(properties, key)
+        end)
+
+      {:ok, %{graph | edge_properties: edge_properties}}
+    else
+      edge_not_found(left, right)
     end
   end
 
@@ -243,7 +449,15 @@ defmodule CodingAdventures.Graph.Graph do
     end
   end
 
-  def neighbors(%__MODULE__{repr: :adjacency_matrix, node_index: idx, node_list: node_list, matrix: matrix}, node) do
+  def neighbors(
+        %__MODULE__{
+          repr: :adjacency_matrix,
+          node_index: idx,
+          node_list: node_list,
+          matrix: matrix
+        },
+        node
+      ) do
     case Map.fetch(idx, node) do
       {:ok, index} ->
         result =
@@ -271,7 +485,15 @@ defmodule CodingAdventures.Graph.Graph do
     end
   end
 
-  def neighbors_weighted(%__MODULE__{repr: :adjacency_matrix, node_index: idx, node_list: node_list, matrix: matrix}, node) do
+  def neighbors_weighted(
+        %__MODULE__{
+          repr: :adjacency_matrix,
+          node_index: idx,
+          node_list: node_list,
+          matrix: matrix
+        },
+        node
+      ) do
     case Map.fetch(idx, node) do
       {:ok, index} ->
         weights =
@@ -319,7 +541,9 @@ defmodule CodingAdventures.Graph.Graph do
   @spec is_connected?(t()) :: boolean()
   def is_connected?(graph) do
     case nodes(graph) do
-      [] -> true
+      [] ->
+        true
+
       [first | _] ->
         case bfs(graph, first) do
           {:ok, visited} -> length(visited) == size(graph)
@@ -355,10 +579,17 @@ defmodule CodingAdventures.Graph.Graph do
   @spec shortest_path(t(), String.t(), String.t()) :: [String.t()]
   def shortest_path(graph, start, finish) do
     cond do
-      not has_node?(graph, start) or not has_node?(graph, finish) -> []
-      start == finish -> [start]
-      Enum.all?(edges(graph), fn {_l, _r, weight} -> weight == 1.0 end) -> bfs_shortest_path(graph, start, finish)
-      true -> dijkstra_shortest_path(graph, start, finish)
+      not has_node?(graph, start) or not has_node?(graph, finish) ->
+        []
+
+      start == finish ->
+        [start]
+
+      Enum.all?(edges(graph), fn {_l, _r, weight} -> weight == 1.0 end) ->
+        bfs_shortest_path(graph, start, finish)
+
+      true ->
+        dijkstra_shortest_path(graph, start, finish)
     end
   end
 
@@ -373,7 +604,9 @@ defmodule CodingAdventures.Graph.Graph do
 
       true ->
         result =
-          Enum.reduce(edges(graph), {new_union_find(nodes(graph)), []}, fn {left, right, _weight} = edge, {uf, acc} ->
+          Enum.reduce(edges(graph), {new_union_find(nodes(graph)), []}, fn {left, right, _weight} =
+                                                                             edge,
+                                                                           {uf, acc} ->
             if find(uf, left) == find(uf, right) do
               {uf, acc}
             else
@@ -498,7 +731,8 @@ defmodule CodingAdventures.Graph.Graph do
 
         {next_queue, next_distances, next_parents} =
           Enum.reduce(weighted, {rest, distances, parents}, fn {neighbor, weight},
-                                                                {queue_acc, distances_acc, parents_acc} ->
+                                                               {queue_acc, distances_acc,
+                                                                parents_acc} ->
             new_distance = distance + weight
             current_distance = Map.get(distances_acc, neighbor, :infinity)
 
@@ -589,6 +823,50 @@ defmodule CodingAdventures.Graph.Graph do
     if sort_key(left) <= sort_key(right), do: {left, right}, else: {right, left}
   end
 
+  defp edge_key(left, right), do: canonical_endpoints(left, right)
+
+  defp merge_property_bag(property_map, owner, properties) do
+    Map.update(property_map, owner, Map.new(properties), &Map.merge(&1, properties))
+  end
+
+  defp put_edge_properties(edge_properties, left, right, weight, properties) do
+    key = edge_key(left, right)
+
+    Map.update(
+      edge_properties,
+      key,
+      Map.put(Map.new(properties), "weight", weight),
+      fn existing -> existing |> Map.merge(properties) |> Map.put("weight", weight) end
+    )
+  end
+
+  defp set_edge_weight(graph, left, right, weight) do
+    if has_edge?(graph, left, right) do
+      case graph.repr do
+        :adjacency_list ->
+          adj =
+            graph.adj
+            |> put_in([left, right], weight)
+            |> put_in([right, left], weight)
+
+          {:ok, %{graph | adj: adj}}
+
+        :adjacency_matrix ->
+          left_index = Map.fetch!(graph.node_index, left)
+          right_index = Map.fetch!(graph.node_index, right)
+
+          matrix =
+            graph.matrix
+            |> replace_cell(left_index, right_index, weight)
+            |> replace_cell(right_index, left_index, weight)
+
+          {:ok, %{graph | matrix: matrix}}
+      end
+    else
+      edge_not_found(left, right)
+    end
+  end
+
   defp sort_nodes(nodes), do: Enum.sort_by(nodes, &sort_key/1)
   defp sort_key(node), do: "#{node}"
 
@@ -598,7 +876,11 @@ defmodule CodingAdventures.Graph.Graph do
   defp normalize_repr!("adjacency_matrix"), do: :adjacency_matrix
 
   defp normalize_repr!(other),
-    do: raise(ArgumentError, "repr must be :adjacency_list or :adjacency_matrix, got: #{inspect(other)}")
+    do:
+      raise(
+        ArgumentError,
+        "repr must be :adjacency_list or :adjacency_matrix, got: #{inspect(other)}"
+      )
 
   defp node_not_found(node),
     do: {:error, %NodeNotFoundError{message: "Node not found: #{inspect(node)}", node: node}}

--- a/code/packages/elixir/graph/test/graph_test.exs
+++ b/code/packages/elixir/graph/test/graph_test.exs
@@ -49,8 +49,13 @@ defmodule CodingAdventures.Graph.GraphTest do
   test "bfs dfs connectivity and cycle detection match the spec" do
     for repr <- reprs() do
       graph = make_graph(repr)
-      assert {:ok, ["London", "Amsterdam", "Paris", "Berlin", "Brussels"]} = Graph.bfs(graph, "London")
-      assert {:ok, ["London", "Amsterdam", "Berlin", "Paris", "Brussels"]} = Graph.dfs(graph, "London")
+
+      assert {:ok, ["London", "Amsterdam", "Paris", "Berlin", "Brussels"]} =
+               Graph.bfs(graph, "London")
+
+      assert {:ok, ["London", "Amsterdam", "Berlin", "Paris", "Brussels"]} =
+               Graph.dfs(graph, "London")
+
       assert Graph.is_connected?(graph)
       assert Graph.has_cycle?(graph)
       refute Graph.has_cycle?(make_path(repr))
@@ -97,6 +102,44 @@ defmodule CodingAdventures.Graph.GraphTest do
       {:ok, graph} = Graph.remove_node(graph, "B")
       refute Graph.has_node?(graph, "B")
       assert Graph.nodes(graph) == ["A", "C"]
+    end
+  end
+
+  test "property bags track graph node and edge metadata" do
+    for repr <- reprs() do
+      graph = Graph.new(repr: repr)
+
+      {:ok, graph} = Graph.set_graph_property(graph, "name", "city-map")
+      {:ok, graph} = Graph.set_graph_property(graph, "version", 1)
+      assert Graph.graph_properties(graph) == %{"name" => "city-map", "version" => 1}
+      {:ok, graph} = Graph.remove_graph_property(graph, "version")
+      assert Graph.graph_properties(graph) == %{"name" => "city-map"}
+
+      {:ok, graph} = Graph.add_node(graph, "A", %{"kind" => "input"})
+      {:ok, graph} = Graph.add_node(graph, "A", %{"trainable" => false})
+      {:ok, graph} = Graph.set_node_property(graph, "A", "slot", 0)
+
+      assert {:ok, %{"kind" => "input", "trainable" => false, "slot" => 0}} =
+               Graph.node_properties(graph, "A")
+
+      {:ok, graph} = Graph.remove_node_property(graph, "A", "slot")
+      assert {:ok, %{"kind" => "input", "trainable" => false}} = Graph.node_properties(graph, "A")
+
+      {:ok, graph} = Graph.add_edge(graph, "A", "B", 2.5, %{"role" => "distance"})
+
+      assert {:ok, %{"role" => "distance", "weight" => 2.5}} =
+               Graph.edge_properties(graph, "B", "A")
+
+      {:ok, graph} = Graph.set_edge_property(graph, "B", "A", "weight", 7.0)
+      assert {:ok, 7.0} = Graph.edge_weight(graph, "A", "B")
+      {:ok, graph} = Graph.set_edge_property(graph, "A", "B", "trainable", true)
+      {:ok, graph} = Graph.remove_edge_property(graph, "A", "B", "role")
+
+      assert {:ok, %{"weight" => 7.0, "trainable" => true}} =
+               Graph.edge_properties(graph, "A", "B")
+
+      {:ok, graph} = Graph.remove_edge(graph, "A", "B")
+      assert {:error, %EdgeNotFoundError{}} = Graph.edge_properties(graph, "A", "B")
     end
   end
 end

--- a/code/packages/fsharp/graph/CHANGELOG.md
+++ b/code/packages/fsharp/graph/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Changed
 
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata
 - Expanded `Graph.fs` into the repo's literate-programming style with design
   commentary about representations, traversal order, shortest path selection,
   and Kruskal's MST algorithm

--- a/code/packages/fsharp/graph/Graph.fs
+++ b/code/packages/fsharp/graph/Graph.fs
@@ -31,6 +31,9 @@ type WeightedEdge<'T when 'T : equality> =
         Weight: float
     }
 
+type GraphPropertyValue = obj
+type GraphPropertyBag = Dictionary<string, GraphPropertyValue>
+
 module internal NodeOrdering =
     // Hash-based containers do not preserve insertion order. We sort by a
     // canonical textual key so examples and tests stay deterministic.
@@ -73,6 +76,64 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
     let nodeList = ResizeArray<'T>()
     let nodeIndex = Dictionary<'T, int>()
     let matrix = ResizeArray<ResizeArray<float option>>()
+    let graphProperties = Dictionary<string, GraphPropertyValue>(StringComparer.Ordinal)
+    let nodeProperties = Dictionary<'T, GraphPropertyBag>()
+    let edgeProperties = Dictionary<string, GraphPropertyBag>(StringComparer.Ordinal)
+
+    let copyPropertyBag (properties: GraphPropertyBag) =
+        let result = GraphPropertyBag(StringComparer.Ordinal)
+        for KeyValue(key, value) in properties do
+            result.[key] <- value
+        result
+
+    let mergePropertyBag (target: GraphPropertyBag) (properties: IDictionary<string, GraphPropertyValue> option) =
+        match properties with
+        | Some values ->
+            for KeyValue(key, value) in values do
+                target.[key] <- value
+        | None -> ()
+
+    let nodePropertyBag node =
+        match nodeProperties.TryGetValue(node) with
+        | true, properties -> properties
+        | _ ->
+            let properties = GraphPropertyBag(StringComparer.Ordinal)
+            nodeProperties.[node] <- properties
+            properties
+
+    let edgePropertyBag left right =
+        let key = NodeOrdering.edgeKey left right
+        match edgeProperties.TryGetValue(key) with
+        | true, properties -> properties
+        | _ ->
+            let properties = GraphPropertyBag(StringComparer.Ordinal)
+            edgeProperties.[key] <- properties
+            properties
+
+    let setEdgeWeight left right weight =
+        if representation = GraphRepr.AdjacencyList then
+            adjacency.[left].[right] <- weight
+            adjacency.[right].[left] <- weight
+        else
+            let leftIndex = nodeIndex.[left]
+            let rightIndex = nodeIndex.[right]
+            matrix.[leftIndex].[rightIndex] <- Some weight
+            matrix.[rightIndex].[leftIndex] <- Some weight
+
+    let tryNumeric (value: obj) =
+        match value with
+        | :? byte as value -> Some(float value)
+        | :? sbyte as value -> Some(float value)
+        | :? int16 as value -> Some(float value)
+        | :? uint16 as value -> Some(float value)
+        | :? int as value -> Some(float value)
+        | :? uint32 as value -> Some(float value)
+        | :? int64 as value -> Some(float value)
+        | :? uint64 as value -> Some(float value)
+        | :? single as value -> Some(float value)
+        | :? double as value -> Some(value)
+        | :? decimal as value -> Some(float value)
+        | _ -> None
 
     member _.Representation = representation
 
@@ -82,11 +143,12 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
         else
             nodeList.Count
 
-    member _.AddNode(node: 'T) =
+    member _.AddNode(node: 'T, ?properties: IDictionary<string, GraphPropertyValue>) =
         if representation = GraphRepr.AdjacencyList then
             // In list mode, a node exists once it has an empty neighbor map.
             if not (adjacency.ContainsKey(node)) then
                 adjacency.[node] <- Dictionary<'T, float>()
+            mergePropertyBag (nodePropertyBag node) properties
         else if not (nodeIndex.ContainsKey(node)) then
             // In matrix mode we must grow the matrix in both dimensions.
             let index = nodeList.Count
@@ -100,6 +162,9 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
             for _ in 0 .. index do
                 newRow.Add(None)
             matrix.Add(newRow)
+            mergePropertyBag (nodePropertyBag node) properties
+        else
+            mergePropertyBag (nodePropertyBag node) properties
 
     member _.RemoveNode(node: 'T) =
         if representation = GraphRepr.AdjacencyList then
@@ -107,12 +172,17 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
             | true, neighbors ->
                 for KeyValue(neighbor, _) in neighbors do
                     adjacency.[neighbor].Remove(node) |> ignore
+                    edgeProperties.Remove(NodeOrdering.edgeKey node neighbor) |> ignore
                 adjacency.Remove(node) |> ignore
+                nodeProperties.Remove(node) |> ignore
             | _ ->
                 raise (KeyNotFoundException(sprintf "Node not found: %A" node))
         else
             match nodeIndex.TryGetValue(node) with
             | true, index ->
+                for other in nodeList do
+                    edgeProperties.Remove(NodeOrdering.edgeKey node other) |> ignore
+                nodeProperties.Remove(node) |> ignore
                 nodeIndex.Remove(node) |> ignore
                 nodeList.RemoveAt(index)
                 matrix.RemoveAt(index)
@@ -135,7 +205,7 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
         else
             nodeList |> Seq.toList |> NodeOrdering.orderNodes
 
-    member this.AddEdge(left: 'T, right: 'T, ?weight: float) =
+    member this.AddEdge(left: 'T, right: 'T, ?weight: float, ?properties: IDictionary<string, GraphPropertyValue>) =
         let edgeWeight = defaultArg weight 1.0
         this.AddNode(left)
         this.AddNode(right)
@@ -149,12 +219,17 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
             matrix.[leftIndex].[rightIndex] <- Some edgeWeight
             matrix.[rightIndex].[leftIndex] <- Some edgeWeight
 
+        let edgeBag = edgePropertyBag left right
+        mergePropertyBag edgeBag properties
+        edgeBag.["weight"] <- box edgeWeight
+
     member _.RemoveEdge(left: 'T, right: 'T) =
         if representation = GraphRepr.AdjacencyList then
             match adjacency.TryGetValue(left), adjacency.TryGetValue(right) with
             | (true, leftNeighbors), (true, rightNeighbors) when leftNeighbors.ContainsKey(right) ->
                 leftNeighbors.Remove(right) |> ignore
                 rightNeighbors.Remove(left) |> ignore
+                edgeProperties.Remove(NodeOrdering.edgeKey left right) |> ignore
             | _ ->
                 raise (KeyNotFoundException(sprintf "Edge not found: %A -- %A" left right))
         else
@@ -162,6 +237,7 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
             | (true, leftIndex), (true, rightIndex) when matrix.[leftIndex].[rightIndex].IsSome ->
                 matrix.[leftIndex].[rightIndex] <- None
                 matrix.[rightIndex].[leftIndex] <- None
+                edgeProperties.Remove(NodeOrdering.edgeKey left right) |> ignore
             | _ ->
                 raise (KeyNotFoundException(sprintf "Edge not found: %A -- %A" left right))
 
@@ -262,6 +338,58 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
         result
 
     member this.Degree(node: 'T) = this.Neighbors(node).Length
+
+    member _.GraphProperties() = copyPropertyBag graphProperties
+
+    member _.SetGraphProperty(key: string, value: GraphPropertyValue) =
+        graphProperties.[key] <- value
+
+    member _.RemoveGraphProperty(key: string) =
+        graphProperties.Remove(key) |> ignore
+
+    member this.NodeProperties(node: 'T) =
+        if not (this.HasNode(node)) then
+            raise (KeyNotFoundException(sprintf "Node not found: %A" node))
+        nodePropertyBag node |> copyPropertyBag
+
+    member this.SetNodeProperty(node: 'T, key: string, value: GraphPropertyValue) =
+        if not (this.HasNode(node)) then
+            raise (KeyNotFoundException(sprintf "Node not found: %A" node))
+        (nodePropertyBag node).[key] <- value
+
+    member this.RemoveNodeProperty(node: 'T, key: string) =
+        if not (this.HasNode(node)) then
+            raise (KeyNotFoundException(sprintf "Node not found: %A" node))
+        (nodePropertyBag node).Remove(key) |> ignore
+
+    member this.EdgeProperties(left: 'T, right: 'T) =
+        if not (this.HasEdge(left, right)) then
+            raise (KeyNotFoundException(sprintf "Edge not found: %A -- %A" left right))
+        let key = NodeOrdering.edgeKey left right
+        let properties =
+            match edgeProperties.TryGetValue(key) with
+            | true, values -> copyPropertyBag values
+            | _ -> GraphPropertyBag(StringComparer.Ordinal)
+        properties.["weight"] <- box (this.EdgeWeight(left, right))
+        properties
+
+    member this.SetEdgeProperty(left: 'T, right: 'T, key: string, value: GraphPropertyValue) =
+        if not (this.HasEdge(left, right)) then
+            raise (KeyNotFoundException(sprintf "Edge not found: %A -- %A" left right))
+        if key = "weight" then
+            match tryNumeric value with
+            | Some weight -> setEdgeWeight left right weight
+            | None -> raise (ArgumentException("Edge property 'weight' must be numeric.", nameof value))
+        (edgePropertyBag left right).[key] <- value
+
+    member this.RemoveEdgeProperty(left: 'T, right: 'T, key: string) =
+        if not (this.HasEdge(left, right)) then
+            raise (KeyNotFoundException(sprintf "Edge not found: %A -- %A" left right))
+        if key = "weight" then
+            setEdgeWeight left right 1.0
+            (edgePropertyBag left right).["weight"] <- box 1.0
+        else
+            (edgePropertyBag left right).Remove(key) |> ignore
 
     override this.ToString() =
         sprintf "Graph(nodes=%d, edges=%d, repr=%O)" this.Size (this.Edges().Length) this.Representation

--- a/code/packages/fsharp/graph/README.md
+++ b/code/packages/fsharp/graph/README.md
@@ -7,6 +7,7 @@ adjacency lists for sparse graphs and adjacency matrices for dense ones.
 
 - `Graph<'T>` with `GraphRepr.AdjacencyList` and `GraphRepr.AdjacencyMatrix`
 - weighted undirected edges, including self-loops
+- graph, node, and edge property bags for metadata
 - traversal algorithms: BFS, DFS, connectivity, components, cycle detection
 - path and tree helpers: shortest path and minimum spanning tree
 

--- a/code/packages/fsharp/graph/tests/CodingAdventures.Graph.Tests/GraphTests.fs
+++ b/code/packages/fsharp/graph/tests/CodingAdventures.Graph.Tests/GraphTests.fs
@@ -177,6 +177,48 @@ type GraphTests() =
             Assert.Throws<InvalidOperationException>(fun () -> GraphAlgorithms.minimumSpanningTree disconnected |> ignore) |> ignore
 
     [<Fact>]
+    member _.``Property bags track graph node and edge metadata``() =
+        for repr in GraphTests.Representations do
+            let graph = Graph<string>(repr)
+
+            graph.SetGraphProperty("name", box "city-map")
+            graph.SetGraphProperty("version", box 1)
+            Assert.Equal(box "city-map", graph.GraphProperties().["name"])
+            Assert.Equal(box 1, graph.GraphProperties().["version"])
+            graph.RemoveGraphProperty("version")
+            Assert.False(graph.GraphProperties().ContainsKey("version"))
+
+            let nodeProperties = Dictionary<string, obj>(StringComparer.Ordinal)
+            nodeProperties.["kind"] <- box "input"
+            graph.AddNode("A", nodeProperties)
+
+            let nextNodeProperties = Dictionary<string, obj>(StringComparer.Ordinal)
+            nextNodeProperties.["trainable"] <- box false
+            graph.AddNode("A", nextNodeProperties)
+
+            graph.SetNodeProperty("A", "slot", box 0)
+            Assert.Equal(box "input", graph.NodeProperties("A").["kind"])
+            Assert.Equal(box false, graph.NodeProperties("A").["trainable"])
+            Assert.Equal(box 0, graph.NodeProperties("A").["slot"])
+            graph.RemoveNodeProperty("A", "slot")
+            Assert.False(graph.NodeProperties("A").ContainsKey("slot"))
+
+            let edgeProperties = Dictionary<string, obj>(StringComparer.Ordinal)
+            edgeProperties.["role"] <- box "distance"
+            graph.AddEdge("A", "B", 2.5, edgeProperties)
+            Assert.Equal(box "distance", graph.EdgeProperties("B", "A").["role"])
+            Assert.Equal(box 2.5, graph.EdgeProperties("B", "A").["weight"])
+            graph.SetEdgeProperty("B", "A", "weight", box 7.0)
+            Assert.Equal(7.0, graph.EdgeWeight("A", "B"))
+            graph.SetEdgeProperty("A", "B", "trainable", box true)
+            graph.RemoveEdgeProperty("A", "B", "role")
+            Assert.Equal(box true, graph.EdgeProperties("A", "B").["trainable"])
+            Assert.False(graph.EdgeProperties("A", "B").ContainsKey("role"))
+
+            graph.RemoveEdge("A", "B")
+            Assert.Throws<KeyNotFoundException>(fun () -> graph.EdgeProperties("A", "B") |> ignore) |> ignore
+
+    [<Fact>]
     member _.``Numeric nodes are supported``() =
         for repr in GraphTests.Representations do
             let graph = Graph<int>(repr)

--- a/code/packages/go/graph/CHANGELOG.md
+++ b/code/packages/go/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0
 
 - Added the initial undirected weighted graph package with adjacency-list and adjacency-matrix representations.

--- a/code/packages/go/graph/README.md
+++ b/code/packages/go/graph/README.md
@@ -5,9 +5,16 @@ storage, plus the core DT00 algorithms.
 
 ```go
 g := graph.New(graph.AdjacencyList)
-g.AddEdge("London", "Paris", 300)
+g.AddNode("London", graph.PropertyBag{"kind": "city"})
+g.AddEdge("London", "Paris", 300, graph.PropertyBag{"route": "train"})
 g.AddEdge("London", "Amsterdam", 520)
+
+properties, _ := g.EdgeProperties("Paris", "London")
+fmt.Println(properties["weight"]) // 300
 
 path, _ := graph.ShortestPath(g, "London", "Paris")
 mst, _ := graph.MinimumSpanningTree(g)
 ```
+
+Graph, node, and edge property bags are copied on read. The canonical edge
+property `weight` is kept in sync with `EdgeWeight` and weighted algorithms.

--- a/code/packages/go/graph/graph.go
+++ b/code/packages/go/graph/graph.go
@@ -18,12 +18,18 @@ type WeightedEdge struct {
 	Weight float64
 }
 
+type PropertyValue any
+type PropertyBag map[string]PropertyValue
+
 type Graph struct {
-	repr      GraphRepr
-	adj       map[string]map[string]float64
-	nodeList  []string
-	nodeIndex map[string]int
-	matrix    [][]float64
+	repr            GraphRepr
+	adj             map[string]map[string]float64
+	nodeList        []string
+	nodeIndex       map[string]int
+	matrix          [][]float64
+	graphProperties PropertyBag
+	nodeProperties  map[string]PropertyBag
+	edgeProperties  map[string]PropertyBag
 }
 
 func New(repr GraphRepr) *Graph {
@@ -31,11 +37,14 @@ func New(repr GraphRepr) *Graph {
 		repr = AdjacencyList
 	}
 	return &Graph{
-		repr:      repr,
-		adj:       make(map[string]map[string]float64),
-		nodeList:  []string{},
-		nodeIndex: make(map[string]int),
-		matrix:    [][]float64{},
+		repr:            repr,
+		adj:             make(map[string]map[string]float64),
+		nodeList:        []string{},
+		nodeIndex:       make(map[string]int),
+		matrix:          [][]float64{},
+		graphProperties: make(PropertyBag),
+		nodeProperties:  make(map[string]PropertyBag),
+		edgeProperties:  make(map[string]PropertyBag),
 	}
 }
 
@@ -43,21 +52,26 @@ func (g *Graph) Repr() GraphRepr {
 	return g.repr
 }
 
-func (g *Graph) AddNode(node string) {
+func (g *Graph) AddNode(node string, properties ...PropertyBag) {
 	if g.repr == AdjacencyList {
 		if _, ok := g.adj[node]; !ok {
 			g.adj[node] = make(map[string]float64)
+			g.nodeProperties[node] = make(PropertyBag)
 		}
+		g.mergeNodeProperties(node, properties...)
 		return
 	}
 
 	if _, ok := g.nodeIndex[node]; ok {
+		g.mergeNodeProperties(node, properties...)
 		return
 	}
 
 	index := len(g.nodeList)
 	g.nodeList = append(g.nodeList, node)
 	g.nodeIndex[node] = index
+	g.nodeProperties[node] = make(PropertyBag)
+	g.mergeNodeProperties(node, properties...)
 	for i := range g.matrix {
 		g.matrix[i] = append(g.matrix[i], 0)
 	}
@@ -72,8 +86,10 @@ func (g *Graph) RemoveNode(node string) error {
 		}
 		for neighbor := range neighbors {
 			delete(g.adj[neighbor], node)
+			delete(g.edgeProperties, edgeKey(node, neighbor))
 		}
 		delete(g.adj, node)
+		delete(g.nodeProperties, node)
 		return nil
 	}
 
@@ -81,8 +97,12 @@ func (g *Graph) RemoveNode(node string) error {
 	if !ok {
 		return &NodeNotFoundError{Node: node}
 	}
+	for _, other := range g.nodeList {
+		delete(g.edgeProperties, edgeKey(node, other))
+	}
 
 	delete(g.nodeIndex, node)
+	delete(g.nodeProperties, node)
 	g.nodeList = append(g.nodeList[:index], g.nodeList[index+1:]...)
 	g.matrix = append(g.matrix[:index], g.matrix[index+1:]...)
 	for i := range g.matrix {
@@ -115,7 +135,7 @@ func (g *Graph) Nodes() []string {
 	return append([]string(nil), g.nodeList...)
 }
 
-func (g *Graph) AddEdge(left, right string, weight float64) {
+func (g *Graph) AddEdge(left, right string, weight float64, properties ...PropertyBag) {
 	if weight == 0 {
 		weight = 1
 	}
@@ -125,6 +145,7 @@ func (g *Graph) AddEdge(left, right string, weight float64) {
 	if g.repr == AdjacencyList {
 		g.adj[left][right] = weight
 		g.adj[right][left] = weight
+		g.mergeEdgeProperties(left, right, weight, properties...)
 		return
 	}
 
@@ -132,6 +153,7 @@ func (g *Graph) AddEdge(left, right string, weight float64) {
 	rightIndex := g.nodeIndex[right]
 	g.matrix[leftIndex][rightIndex] = weight
 	g.matrix[rightIndex][leftIndex] = weight
+	g.mergeEdgeProperties(left, right, weight, properties...)
 }
 
 func (g *Graph) RemoveEdge(left, right string) error {
@@ -145,6 +167,7 @@ func (g *Graph) RemoveEdge(left, right string) error {
 		}
 		delete(g.adj[left], right)
 		delete(g.adj[right], left)
+		delete(g.edgeProperties, edgeKey(left, right))
 		return nil
 	}
 
@@ -155,6 +178,7 @@ func (g *Graph) RemoveEdge(left, right string) error {
 	}
 	g.matrix[leftIndex][rightIndex] = 0
 	g.matrix[rightIndex][leftIndex] = 0
+	delete(g.edgeProperties, edgeKey(left, right))
 	return nil
 }
 
@@ -297,6 +321,90 @@ func (g *Graph) Degree(node string) (int, error) {
 	return len(neighbors), nil
 }
 
+func (g *Graph) GraphProperties() PropertyBag {
+	return copyPropertyBag(g.graphProperties)
+}
+
+func (g *Graph) SetGraphProperty(key string, value PropertyValue) {
+	g.graphProperties[key] = value
+}
+
+func (g *Graph) RemoveGraphProperty(key string) {
+	delete(g.graphProperties, key)
+}
+
+func (g *Graph) NodeProperties(node string) (PropertyBag, error) {
+	if !g.HasNode(node) {
+		return nil, &NodeNotFoundError{Node: node}
+	}
+	return copyPropertyBag(g.nodeProperties[node]), nil
+}
+
+func (g *Graph) SetNodeProperty(node, key string, value PropertyValue) error {
+	if !g.HasNode(node) {
+		return &NodeNotFoundError{Node: node}
+	}
+	g.nodeProperties[node][key] = value
+	return nil
+}
+
+func (g *Graph) RemoveNodeProperty(node, key string) error {
+	if !g.HasNode(node) {
+		return &NodeNotFoundError{Node: node}
+	}
+	delete(g.nodeProperties[node], key)
+	return nil
+}
+
+func (g *Graph) EdgeProperties(left, right string) (PropertyBag, error) {
+	if !g.HasEdge(left, right) {
+		return nil, &EdgeNotFoundError{Left: left, Right: right}
+	}
+	properties := copyPropertyBag(g.edgeProperties[edgeKey(left, right)])
+	weight, err := g.EdgeWeight(left, right)
+	if err != nil {
+		return nil, err
+	}
+	properties["weight"] = weight
+	return properties, nil
+}
+
+func (g *Graph) SetEdgeProperty(left, right, propertyKey string, value PropertyValue) error {
+	if !g.HasEdge(left, right) {
+		return &EdgeNotFoundError{Left: left, Right: right}
+	}
+	if propertyKey == "weight" {
+		weight, ok := numericValue(value)
+		if !ok {
+			return fmt.Errorf("edge property %q must be numeric", propertyKey)
+		}
+		g.setEdgeWeight(left, right, weight)
+	}
+	edgeID := edgeKey(left, right)
+	if _, ok := g.edgeProperties[edgeID]; !ok {
+		g.edgeProperties[edgeID] = make(PropertyBag)
+	}
+	g.edgeProperties[edgeID][propertyKey] = value
+	return nil
+}
+
+func (g *Graph) RemoveEdgeProperty(left, right, key string) error {
+	if !g.HasEdge(left, right) {
+		return &EdgeNotFoundError{Left: left, Right: right}
+	}
+	if key == "weight" {
+		g.setEdgeWeight(left, right, 1)
+		edgeID := edgeKey(left, right)
+		if _, ok := g.edgeProperties[edgeID]; !ok {
+			g.edgeProperties[edgeID] = make(PropertyBag)
+		}
+		g.edgeProperties[edgeID]["weight"] = float64(1)
+		return nil
+	}
+	delete(g.edgeProperties[edgeKey(left, right)], key)
+	return nil
+}
+
 func (g *Graph) Size() int {
 	if g.repr == AdjacencyList {
 		return len(g.adj)
@@ -313,4 +421,84 @@ func canonicalEndpoints(left, right string) (string, string) {
 		return left, right
 	}
 	return right, left
+}
+
+func edgeKey(left, right string) string {
+	keyLeft, keyRight := canonicalEndpoints(left, right)
+	return keyLeft + "\x00" + keyRight
+}
+
+func copyPropertyBag(properties PropertyBag) PropertyBag {
+	result := make(PropertyBag, len(properties))
+	for key, value := range properties {
+		result[key] = value
+	}
+	return result
+}
+
+func (g *Graph) mergeNodeProperties(node string, properties ...PropertyBag) {
+	for _, propertyBag := range properties {
+		for key, value := range propertyBag {
+			g.nodeProperties[node][key] = value
+		}
+	}
+}
+
+func (g *Graph) mergeEdgeProperties(left, right string, weight float64, properties ...PropertyBag) {
+	edgeID := edgeKey(left, right)
+	if _, ok := g.edgeProperties[edgeID]; !ok {
+		g.edgeProperties[edgeID] = make(PropertyBag)
+	}
+	for _, propertyBag := range properties {
+		for propertyKey, value := range propertyBag {
+			g.edgeProperties[edgeID][propertyKey] = value
+		}
+	}
+	g.edgeProperties[edgeID]["weight"] = weight
+}
+
+func (g *Graph) setEdgeWeight(left, right string, weight float64) {
+	if weight == 0 {
+		weight = 1
+	}
+	if g.repr == AdjacencyList {
+		g.adj[left][right] = weight
+		g.adj[right][left] = weight
+		return
+	}
+	leftIndex := g.nodeIndex[left]
+	rightIndex := g.nodeIndex[right]
+	g.matrix[leftIndex][rightIndex] = weight
+	g.matrix[rightIndex][leftIndex] = weight
+}
+
+func numericValue(value PropertyValue) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int8:
+		return float64(typed), true
+	case int16:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case uint:
+		return float64(typed), true
+	case uint8:
+		return float64(typed), true
+	case uint16:
+		return float64(typed), true
+	case uint32:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case float32:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	default:
+		return 0, false
+	}
 }

--- a/code/packages/go/graph/graph_test.go
+++ b/code/packages/go/graph/graph_test.go
@@ -72,6 +72,84 @@ func TestEdgesAndNeighbors(t *testing.T) {
 	}
 }
 
+func TestPropertyBags(t *testing.T) {
+	for _, repr := range representations() {
+		g := New(repr)
+
+		g.SetGraphProperty("name", "city-map")
+		g.SetGraphProperty("version", 1)
+		graphProps := g.GraphProperties()
+		if graphProps["name"] != "city-map" || graphProps["version"] != 1 {
+			t.Fatalf("GraphProperties() = %#v", graphProps)
+		}
+		graphProps["name"] = "mutated"
+		if g.GraphProperties()["name"] != "city-map" {
+			t.Fatalf("GraphProperties should return a copy for repr=%s", repr)
+		}
+		g.RemoveGraphProperty("version")
+		if _, ok := g.GraphProperties()["version"]; ok {
+			t.Fatalf("RemoveGraphProperty failed for repr=%s", repr)
+		}
+
+		g.AddNode("A", PropertyBag{"kind": "input"})
+		g.AddNode("A", PropertyBag{"trainable": false})
+		if err := g.SetNodeProperty("A", "slot", 0); err != nil {
+			t.Fatalf("SetNodeProperty failed: %v", err)
+		}
+		nodeProps, err := g.NodeProperties("A")
+		if err != nil {
+			t.Fatalf("NodeProperties failed: %v", err)
+		}
+		wantNodeProps := PropertyBag{"kind": "input", "trainable": false, "slot": 0}
+		if !reflect.DeepEqual(nodeProps, wantNodeProps) {
+			t.Fatalf("NodeProperties = %#v, want %#v", nodeProps, wantNodeProps)
+		}
+		nodeProps["kind"] = "mutated"
+		nodeProps, _ = g.NodeProperties("A")
+		if nodeProps["kind"] != "input" {
+			t.Fatalf("NodeProperties should return a copy for repr=%s", repr)
+		}
+		if err := g.RemoveNodeProperty("A", "slot"); err != nil {
+			t.Fatalf("RemoveNodeProperty failed: %v", err)
+		}
+
+		g.AddEdge("A", "B", 2.5, PropertyBag{"role": "distance"})
+		edgeProps, err := g.EdgeProperties("B", "A")
+		if err != nil {
+			t.Fatalf("EdgeProperties failed: %v", err)
+		}
+		wantEdgeProps := PropertyBag{"role": "distance", "weight": 2.5}
+		if !reflect.DeepEqual(edgeProps, wantEdgeProps) {
+			t.Fatalf("EdgeProperties = %#v, want %#v", edgeProps, wantEdgeProps)
+		}
+		if err := g.SetEdgeProperty("B", "A", "weight", 7); err != nil {
+			t.Fatalf("SetEdgeProperty weight failed: %v", err)
+		}
+		weight, _ := g.EdgeWeight("A", "B")
+		if weight != 7 {
+			t.Fatalf("EdgeWeight after weight property = %v, want 7", weight)
+		}
+		if err := g.SetEdgeProperty("A", "B", "trainable", true); err != nil {
+			t.Fatalf("SetEdgeProperty failed: %v", err)
+		}
+		if err := g.RemoveEdgeProperty("A", "B", "role"); err != nil {
+			t.Fatalf("RemoveEdgeProperty failed: %v", err)
+		}
+		edgeProps, _ = g.EdgeProperties("A", "B")
+		wantEdgeProps = PropertyBag{"trainable": true, "weight": float64(7)}
+		if !reflect.DeepEqual(edgeProps, wantEdgeProps) {
+			t.Fatalf("EdgeProperties after updates = %#v, want %#v", edgeProps, wantEdgeProps)
+		}
+
+		if err := g.RemoveEdge("A", "B"); err != nil {
+			t.Fatalf("RemoveEdge failed: %v", err)
+		}
+		if _, err := g.EdgeProperties("A", "B"); err == nil {
+			t.Fatalf("EdgeProperties should fail after RemoveEdge for repr=%s", repr)
+		}
+	}
+}
+
 func TestTraversalsAndConnectivity(t *testing.T) {
 	for _, repr := range representations() {
 		bfsResult, _ := BFS(makePath(repr), "A")

--- a/code/packages/haskell/graph/CHANGELOG.md
+++ b/code/packages/haskell/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata.
+
 ## 0.1.0
 
 - Added the first Haskell graph package.

--- a/code/packages/haskell/graph/README.md
+++ b/code/packages/haskell/graph/README.md
@@ -1,6 +1,7 @@
 # graph
 
-Undirected weighted graph package for Haskell.
+Undirected weighted graph package for Haskell with graph, node, and edge
+property bags for metadata.
 
 ## Development
 

--- a/code/packages/haskell/graph/graph.cabal
+++ b/code/packages/haskell/graph/graph.cabal
@@ -19,6 +19,7 @@ test-suite spec
     main-is:          Spec.hs
     other-modules:    GraphSpec
     build-depends:    base >=4.14
+                    , containers
                     , graph
                     , hspec == 2.*
     hs-source-dirs:   test

--- a/code/packages/haskell/graph/src/Graph.hs
+++ b/code/packages/haskell/graph/src/Graph.hs
@@ -1,17 +1,30 @@
 module Graph
     ( Graph
+    , GraphPropertyBag
+    , GraphPropertyValue(..)
     , WeightedEdge(..)
     , addEdge
+    , addEdgeWithProperties
     , addNode
+    , addNodeWithProperties
     , edgeWeight
+    , edgeProperties
     , edges
     , empty
+    , graphProperties
     , hasEdge
     , hasNode
     , neighbors
+    , nodeProperties
     , nodes
     , removeEdge
+    , removeEdgeProperty
+    , removeGraphProperty
     , removeNode
+    , removeNodeProperty
+    , setEdgeProperty
+    , setGraphProperty
+    , setNodeProperty
     , size
     ) where
 
@@ -26,20 +39,39 @@ data WeightedEdge = WeightedEdge
     }
     deriving (Eq, Ord, Show)
 
-newtype Graph = Graph
+data GraphPropertyValue
+    = GraphString String
+    | GraphNumber Double
+    | GraphBool Bool
+    | GraphNull
+    deriving (Eq, Ord, Show)
+
+type GraphPropertyBag = Map String GraphPropertyValue
+
+data Graph = Graph
     { adjacency :: Map String (Map String Double)
+    , graphPropertiesMap :: GraphPropertyBag
+    , nodePropertiesMap :: Map String GraphPropertyBag
+    , edgePropertiesMap :: Map (String, String) GraphPropertyBag
     }
     deriving (Eq, Show)
 
 empty :: Graph
-empty = Graph Map.empty
+empty = Graph Map.empty Map.empty Map.empty Map.empty
 
 addNode :: String -> Graph -> Graph
-addNode node (Graph adjacencyMap) =
-    Graph (Map.insertWith (\_ old -> old) node Map.empty adjacencyMap)
+addNode node = addNodeWithProperties node Map.empty
+
+addNodeWithProperties :: String -> GraphPropertyBag -> Graph -> Graph
+addNodeWithProperties node properties graph =
+    graph
+        { adjacency = Map.insertWith (\_ old -> old) node Map.empty (adjacency graph)
+        , nodePropertiesMap =
+            Map.insertWith Map.union node properties (nodePropertiesMap graph)
+        }
 
 removeNode :: String -> Graph -> Either String Graph
-removeNode node (Graph adjacencyMap) =
+removeNode node graph =
     case Map.lookup node adjacencyMap of
         Nothing -> Left ("node not found: " ++ node)
         Just neighborsMap ->
@@ -50,56 +82,171 @@ removeNode node (Graph adjacencyMap) =
                         )
                         adjacencyMap
                         (Map.keys neighborsMap)
-             in Right (Graph (Map.delete node cleaned))
+                cleanedEdges =
+                    foldl
+                        (\acc neighbor -> Map.delete (edgeKey node neighbor) acc)
+                        (edgePropertiesMap graph)
+                        (Map.keys neighborsMap)
+             in Right
+                    graph
+                        { adjacency = Map.delete node cleaned
+                        , nodePropertiesMap = Map.delete node (nodePropertiesMap graph)
+                        , edgePropertiesMap = cleanedEdges
+                        }
+  where
+    adjacencyMap = adjacency graph
 
 hasNode :: String -> Graph -> Bool
-hasNode node (Graph adjacencyMap) = Map.member node adjacencyMap
+hasNode node graph = Map.member node (adjacency graph)
 
 nodes :: Graph -> [String]
-nodes (Graph adjacencyMap) = Map.keys adjacencyMap
+nodes graph = Map.keys (adjacency graph)
 
 size :: Graph -> Int
-size (Graph adjacencyMap) = Map.size adjacencyMap
+size graph = Map.size (adjacency graph)
 
 addEdge :: String -> String -> Double -> Graph -> Graph
-addEdge left right weight graph =
+addEdge left right weight = addEdgeWithProperties left right weight Map.empty
+
+addEdgeWithProperties :: String -> String -> Double -> GraphPropertyBag -> Graph -> Graph
+addEdgeWithProperties left right weight properties graph =
     let normalizedWeight = if weight == 0 then 1 else weight
-        Graph adjacencyMap = addNode right (addNode left graph)
+        prepared = addNode right (addNode left graph)
+        adjacencyMap = adjacency prepared
         withLeft = Map.adjust (Map.insert right normalizedWeight) left adjacencyMap
         withRight = Map.adjust (Map.insert left normalizedWeight) right withLeft
-     in Graph withRight
+        edgePropertyBag =
+            Map.insert
+                "weight"
+                (GraphNumber normalizedWeight)
+                properties
+     in prepared
+            { adjacency = withRight
+            , edgePropertiesMap =
+                Map.insertWith Map.union (edgeKey left right) edgePropertyBag (edgePropertiesMap prepared)
+            }
 
 removeEdge :: String -> String -> Graph -> Either String Graph
-removeEdge left right (Graph adjacencyMap) =
+removeEdge left right graph =
     case Map.lookup left adjacencyMap >>= Map.lookup right of
         Nothing -> Left ("edge not found: " ++ left ++ " -- " ++ right)
         Just _ ->
             let withoutLeft = Map.adjust (Map.delete right) left adjacencyMap
                 withoutRight = Map.adjust (Map.delete left) right withoutLeft
-             in Right (Graph withoutRight)
+             in Right
+                    graph
+                        { adjacency = withoutRight
+                        , edgePropertiesMap = Map.delete (edgeKey left right) (edgePropertiesMap graph)
+                        }
+  where
+    adjacencyMap = adjacency graph
 
 hasEdge :: String -> String -> Graph -> Bool
-hasEdge left right (Graph adjacencyMap) =
-    maybe False (Map.member right) (Map.lookup left adjacencyMap)
+hasEdge left right graph =
+    maybe False (Map.member right) (Map.lookup left (adjacency graph))
 
 edgeWeight :: String -> String -> Graph -> Either String Double
-edgeWeight left right (Graph adjacencyMap) =
-    case Map.lookup left adjacencyMap >>= Map.lookup right of
+edgeWeight left right graph =
+    case Map.lookup left (adjacency graph) >>= Map.lookup right of
         Just weight -> Right weight
         Nothing -> Left ("edge not found: " ++ left ++ " -- " ++ right)
 
+graphProperties :: Graph -> GraphPropertyBag
+graphProperties = graphPropertiesMap
+
+setGraphProperty :: String -> GraphPropertyValue -> Graph -> Graph
+setGraphProperty key value graph =
+    graph {graphPropertiesMap = Map.insert key value (graphPropertiesMap graph)}
+
+removeGraphProperty :: String -> Graph -> Graph
+removeGraphProperty key graph =
+    graph {graphPropertiesMap = Map.delete key (graphPropertiesMap graph)}
+
+nodeProperties :: String -> Graph -> Either String GraphPropertyBag
+nodeProperties node graph
+    | hasNode node graph = Right (Map.findWithDefault Map.empty node (nodePropertiesMap graph))
+    | otherwise = Left ("node not found: " ++ node)
+
+setNodeProperty :: String -> String -> GraphPropertyValue -> Graph -> Either String Graph
+setNodeProperty node key value graph
+    | hasNode node graph =
+        Right
+            graph
+                { nodePropertiesMap =
+                    Map.insertWith
+                        Map.union
+                        node
+                        (Map.singleton key value)
+                        (nodePropertiesMap graph)
+                }
+    | otherwise = Left ("node not found: " ++ node)
+
+removeNodeProperty :: String -> String -> Graph -> Either String Graph
+removeNodeProperty node key graph
+    | hasNode node graph =
+        Right
+            graph
+                { nodePropertiesMap =
+                    Map.adjust (Map.delete key) node (nodePropertiesMap graph)
+                }
+    | otherwise = Left ("node not found: " ++ node)
+
+edgeProperties :: String -> String -> Graph -> Either String GraphPropertyBag
+edgeProperties left right graph =
+    case edgeWeight left right graph of
+        Left err -> Left err
+        Right weight ->
+            Right
+                ( Map.insert
+                    "weight"
+                    (GraphNumber weight)
+                    (Map.findWithDefault Map.empty (edgeKey left right) (edgePropertiesMap graph))
+                )
+
+setEdgeProperty :: String -> String -> String -> GraphPropertyValue -> Graph -> Either String Graph
+setEdgeProperty left right key value graph
+    | not (hasEdge left right graph) = Left ("edge not found: " ++ left ++ " -- " ++ right)
+    | key == "weight" =
+        case value of
+            GraphNumber weight ->
+                Right
+                    (setEdgePropertyBagValue left right key value (setEdgeWeight left right weight graph))
+            _ -> Left "edge property 'weight' must be numeric"
+    | otherwise = Right (setEdgePropertyBagValue left right key value graph)
+
+removeEdgeProperty :: String -> String -> String -> Graph -> Either String Graph
+removeEdgeProperty left right key graph
+    | not (hasEdge left right graph) = Left ("edge not found: " ++ left ++ " -- " ++ right)
+    | key == "weight" =
+        Right
+            ( setEdgePropertyBagValue
+                left
+                right
+                "weight"
+                (GraphNumber 1)
+                (setEdgeWeight left right 1 graph)
+            )
+    | otherwise =
+        Right
+            graph
+                { edgePropertiesMap =
+                    Map.adjust (Map.delete key) (edgeKey left right) (edgePropertiesMap graph)
+                }
+
 edges :: Graph -> [WeightedEdge]
-edges (Graph adjacencyMap) =
+edges graph =
     nub
         [ WeightedEdge first second weight
         | (left, neighborsMap) <- Map.toList adjacencyMap
         , (right, weight) <- Map.toList neighborsMap
         , let (first, second) = canonicalEndpoints left right
         ]
+  where
+    adjacencyMap = adjacency graph
 
 neighbors :: String -> Graph -> Either String [String]
-neighbors node (Graph adjacencyMap) =
-    case Map.lookup node adjacencyMap of
+neighbors node graph =
+    case Map.lookup node (adjacency graph) of
         Nothing -> Left ("node not found: " ++ node)
         Just neighborsMap -> Right (Map.keys neighborsMap)
 
@@ -107,3 +254,25 @@ canonicalEndpoints :: String -> String -> (String, String)
 canonicalEndpoints left right
     | left <= right = (left, right)
     | otherwise = (right, left)
+
+edgeKey :: String -> String -> (String, String)
+edgeKey = canonicalEndpoints
+
+setEdgeWeight :: String -> String -> Double -> Graph -> Graph
+setEdgeWeight left right weight graph =
+    graph
+        { adjacency =
+            Map.adjust (Map.insert right weight) left $
+                Map.adjust (Map.insert left weight) right (adjacency graph)
+        }
+
+setEdgePropertyBagValue :: String -> String -> String -> GraphPropertyValue -> Graph -> Graph
+setEdgePropertyBagValue left right key value graph =
+    graph
+        { edgePropertiesMap =
+            Map.insertWith
+                Map.union
+                (edgeKey left right)
+                (Map.singleton key value)
+                (edgePropertiesMap graph)
+        }

--- a/code/packages/haskell/graph/test/GraphSpec.hs
+++ b/code/packages/haskell/graph/test/GraphSpec.hs
@@ -3,6 +3,7 @@ module GraphSpec (spec) where
 import Test.Hspec
 
 import Graph
+import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec = do
@@ -22,3 +23,50 @@ spec = do
             let graph = addEdge "A" "B" 1 (addEdge "B" "C" 1 empty)
             fmap (hasEdge "A" "B") (removeEdge "A" "B" graph) `shouldBe` Right False
             fmap (hasNode "B") (removeNode "B" graph) `shouldBe` Right False
+
+        it "tracks graph node and edge property bags" $ do
+            let graph0 =
+                    setGraphProperty "name" (GraphString "city-map") $
+                        setGraphProperty "version" (GraphNumber 1) empty
+            graphProperties graph0 `shouldBe` Map.fromList [("name", GraphString "city-map"), ("version", GraphNumber 1)]
+
+            let graph1 = removeGraphProperty "version" graph0
+            graphProperties graph1 `shouldBe` Map.fromList [("name", GraphString "city-map")]
+
+            let graph2 =
+                    addNodeWithProperties "A" (Map.fromList [("kind", GraphString "input")]) graph1
+            let graph3 =
+                    addNodeWithProperties "A" (Map.fromList [("trainable", GraphBool False)]) graph2
+            let Right graph4 = setNodeProperty "A" "slot" (GraphNumber 0) graph3
+            nodeProperties "A" graph4
+                `shouldBe` Right
+                    ( Map.fromList
+                        [ ("kind", GraphString "input")
+                        , ("trainable", GraphBool False)
+                        , ("slot", GraphNumber 0)
+                        ]
+                    )
+
+            let Right graph5 = removeNodeProperty "A" "slot" graph4
+            nodeProperties "A" graph5
+                `shouldBe` Right
+                    (Map.fromList [("kind", GraphString "input"), ("trainable", GraphBool False)])
+
+            let graph6 =
+                    addEdgeWithProperties
+                        "A"
+                        "B"
+                        2.5
+                        (Map.fromList [("role", GraphString "distance")])
+                        graph5
+            edgeProperties "B" "A" graph6
+                `shouldBe` Right
+                    (Map.fromList [("role", GraphString "distance"), ("weight", GraphNumber 2.5)])
+
+            let Right graph7 = setEdgeProperty "B" "A" "weight" (GraphNumber 7) graph6
+            edgeWeight "A" "B" graph7 `shouldBe` Right 7
+            let Right graph8 = setEdgeProperty "A" "B" "trainable" (GraphBool True) graph7
+            let Right graph9 = removeEdgeProperty "A" "B" "role" graph8
+            edgeProperties "A" "B" graph9
+                `shouldBe` Right
+                    (Map.fromList [("weight", GraphNumber 7), ("trainable", GraphBool True)])

--- a/code/packages/java/graph/CHANGELOG.md
+++ b/code/packages/java/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # graph
 
+## Unreleased
+
+- Add graph, node, and edge property bags with synchronized `weight` edge metadata
+
 ## 0.1.0
 
 - Add initial Java `graph` package

--- a/code/packages/java/graph/README.md
+++ b/code/packages/java/graph/README.md
@@ -5,5 +5,6 @@ Native Java implementation of the graph package.
 This package provides:
 
 - `Graph` for undirected weighted graphs
+- graph, node, and edge property bags for metadata
 - `Traversals` for reusable BFS/DFS helpers
 - graph-specific error types

--- a/code/packages/java/graph/src/main/java/com/codingadventures/graph/Graph.java
+++ b/code/packages/java/graph/src/main/java/com/codingadventures/graph/Graph.java
@@ -2,6 +2,7 @@ package com.codingadventures.graph;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -12,6 +13,9 @@ public final class Graph implements TraversalGraph {
     public record WeightedEdge(String leftNode, String rightNode, double weight) {}
 
     private final Map<String, Map<String, Double>> adjacency = new LinkedHashMap<>();
+    private final Map<String, Object> graphProperties = new LinkedHashMap<>();
+    private final Map<String, Map<String, Object>> nodeProperties = new LinkedHashMap<>();
+    private final Map<String, Map<String, Object>> edgeProperties = new LinkedHashMap<>();
 
     @Override
     public int size() {
@@ -19,7 +23,12 @@ public final class Graph implements TraversalGraph {
     }
 
     public void addNode(String node) {
+        addNode(node, Map.of());
+    }
+
+    public void addNode(String node, Map<String, Object> properties) {
         adjacency.computeIfAbsent(node, ignored -> new LinkedHashMap<>());
+        mergeNodeProperties(node, properties);
     }
 
     public void removeNode(String node) {
@@ -30,8 +39,10 @@ public final class Graph implements TraversalGraph {
 
         for (String neighbor : List.copyOf(neighbors.keySet())) {
             adjacency.get(neighbor).remove(node);
+            edgeProperties.remove(canonicalEdgeKey(node, neighbor));
         }
         adjacency.remove(node);
+        nodeProperties.remove(node);
     }
 
     @Override
@@ -53,6 +64,15 @@ public final class Graph implements TraversalGraph {
         addNode(rightNode);
         adjacency.get(leftNode).put(rightNode, weight);
         adjacency.get(rightNode).put(leftNode, weight);
+        mergeEdgeProperties(leftNode, rightNode, weight, Map.of());
+    }
+
+    public void addEdge(String leftNode, String rightNode, double weight, Map<String, Object> properties) {
+        addNode(leftNode);
+        addNode(rightNode);
+        adjacency.get(leftNode).put(rightNode, weight);
+        adjacency.get(rightNode).put(leftNode, weight);
+        mergeEdgeProperties(leftNode, rightNode, weight, properties);
     }
 
     public void removeEdge(String leftNode, String rightNode) {
@@ -61,6 +81,7 @@ public final class Graph implements TraversalGraph {
         }
         adjacency.get(leftNode).remove(rightNode);
         adjacency.get(rightNode).remove(leftNode);
+        edgeProperties.remove(canonicalEdgeKey(leftNode, rightNode));
     }
 
     public boolean hasEdge(String leftNode, String rightNode) {
@@ -73,6 +94,82 @@ public final class Graph implements TraversalGraph {
             throw new EdgeNotFoundError(leftNode, rightNode);
         }
         return neighbors.get(rightNode);
+    }
+
+    public Map<String, Object> graphProperties() {
+        return immutablePropertyCopy(graphProperties);
+    }
+
+    public void setGraphProperty(String key, Object value) {
+        graphProperties.put(key, value);
+    }
+
+    public void removeGraphProperty(String key) {
+        graphProperties.remove(key);
+    }
+
+    public Map<String, Object> nodeProperties(String node) {
+        if (!hasNode(node)) {
+            throw new NodeNotFoundError(node);
+        }
+        return immutablePropertyCopy(nodeProperties.getOrDefault(node, Map.of()));
+    }
+
+    public void setNodeProperty(String node, String key, Object value) {
+        if (!hasNode(node)) {
+            throw new NodeNotFoundError(node);
+        }
+        nodeProperties.computeIfAbsent(node, ignored -> new LinkedHashMap<>()).put(key, value);
+    }
+
+    public void removeNodeProperty(String node, String key) {
+        if (!hasNode(node)) {
+            throw new NodeNotFoundError(node);
+        }
+        Map<String, Object> properties = nodeProperties.get(node);
+        if (properties != null) {
+            properties.remove(key);
+        }
+    }
+
+    public Map<String, Object> edgeProperties(String leftNode, String rightNode) {
+        if (!hasEdge(leftNode, rightNode)) {
+            throw new EdgeNotFoundError(leftNode, rightNode);
+        }
+        Map<String, Object> copy = new LinkedHashMap<>(edgeProperties.getOrDefault(
+                canonicalEdgeKey(leftNode, rightNode), Map.of()));
+        copy.put("weight", edgeWeight(leftNode, rightNode));
+        return Collections.unmodifiableMap(copy);
+    }
+
+    public void setEdgeProperty(String leftNode, String rightNode, String key, Object value) {
+        if (!hasEdge(leftNode, rightNode)) {
+            throw new EdgeNotFoundError(leftNode, rightNode);
+        }
+        if ("weight".equals(key)) {
+            if (!(value instanceof Number number)) {
+                throw new IllegalArgumentException("Edge property 'weight' must be numeric.");
+            }
+            setEdgeWeight(leftNode, rightNode, number.doubleValue());
+        }
+        edgeProperties.computeIfAbsent(canonicalEdgeKey(leftNode, rightNode), ignored -> new LinkedHashMap<>())
+                .put(key, value);
+    }
+
+    public void removeEdgeProperty(String leftNode, String rightNode, String key) {
+        if (!hasEdge(leftNode, rightNode)) {
+            throw new EdgeNotFoundError(leftNode, rightNode);
+        }
+        if ("weight".equals(key)) {
+            setEdgeWeight(leftNode, rightNode, 1.0);
+            edgeProperties.computeIfAbsent(canonicalEdgeKey(leftNode, rightNode), ignored -> new LinkedHashMap<>())
+                    .put("weight", 1.0);
+            return;
+        }
+        Map<String, Object> properties = edgeProperties.get(canonicalEdgeKey(leftNode, rightNode));
+        if (properties != null) {
+            properties.remove(key);
+        }
     }
 
     public List<WeightedEdge> edges() {
@@ -124,5 +221,30 @@ public final class Graph implements TraversalGraph {
         return leftNode.compareTo(rightNode) <= 0
                 ? leftNode + "\0" + rightNode
                 : rightNode + "\0" + leftNode;
+    }
+
+    private static Map<String, Object> immutablePropertyCopy(Map<String, Object> properties) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+    }
+
+    private void mergeNodeProperties(String node, Map<String, Object> properties) {
+        if (properties == null) {
+            return;
+        }
+        nodeProperties.computeIfAbsent(node, ignored -> new LinkedHashMap<>()).putAll(properties);
+    }
+
+    private void mergeEdgeProperties(String leftNode, String rightNode, double weight, Map<String, Object> properties) {
+        Map<String, Object> target = edgeProperties.computeIfAbsent(canonicalEdgeKey(leftNode, rightNode),
+                ignored -> new LinkedHashMap<>());
+        if (properties != null) {
+            target.putAll(properties);
+        }
+        target.put("weight", weight);
+    }
+
+    private void setEdgeWeight(String leftNode, String rightNode, double weight) {
+        adjacency.get(leftNode).put(rightNode, weight);
+        adjacency.get(rightNode).put(leftNode, weight);
     }
 }

--- a/code/packages/java/graph/src/test/java/com/codingadventures/graph/GraphTest.java
+++ b/code/packages/java/graph/src/test/java/com/codingadventures/graph/GraphTest.java
@@ -3,6 +3,7 @@ package com.codingadventures.graph;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,5 +51,39 @@ class GraphTest {
     void removingMissingNodeThrows() {
         Graph graph = new Graph();
         assertThrows(NodeNotFoundError.class, () -> graph.removeNode("missing"));
+    }
+
+    @Test
+    void propertyBagsTrackGraphNodeAndEdgeMetadata() {
+        Graph graph = new Graph();
+
+        graph.setGraphProperty("name", "city-map");
+        graph.setGraphProperty("version", 1);
+        assertEquals("city-map", graph.graphProperties().get("name"));
+        assertEquals(1, graph.graphProperties().get("version"));
+        graph.removeGraphProperty("version");
+        assertFalse(graph.graphProperties().containsKey("version"));
+
+        graph.addNode("A", Map.of("kind", "input"));
+        graph.addNode("A", Map.of("trainable", false));
+        graph.setNodeProperty("A", "slot", 0);
+        assertEquals("input", graph.nodeProperties("A").get("kind"));
+        assertEquals(false, graph.nodeProperties("A").get("trainable"));
+        assertEquals(0, graph.nodeProperties("A").get("slot"));
+        graph.removeNodeProperty("A", "slot");
+        assertFalse(graph.nodeProperties("A").containsKey("slot"));
+
+        graph.addEdge("A", "B", 2.5, Map.of("role", "distance"));
+        assertEquals("distance", graph.edgeProperties("B", "A").get("role"));
+        assertEquals(2.5, graph.edgeProperties("B", "A").get("weight"));
+        graph.setEdgeProperty("B", "A", "weight", 7.0);
+        assertEquals(7.0, graph.edgeWeight("A", "B"));
+        graph.setEdgeProperty("A", "B", "trainable", true);
+        graph.removeEdgeProperty("A", "B", "role");
+        assertEquals(true, graph.edgeProperties("A", "B").get("trainable"));
+        assertFalse(graph.edgeProperties("A", "B").containsKey("role"));
+
+        graph.removeEdge("A", "B");
+        assertThrows(EdgeNotFoundError.class, () -> graph.edgeProperties("A", "B"));
     }
 }

--- a/code/packages/kotlin/graph/CHANGELOG.md
+++ b/code/packages/kotlin/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # graph
 
+## Unreleased
+
+- Add graph, node, and edge property bags with synchronized `weight` edge metadata
+
 ## 0.1.0
 
 - Add initial Kotlin `graph` package

--- a/code/packages/kotlin/graph/README.md
+++ b/code/packages/kotlin/graph/README.md
@@ -5,5 +5,6 @@ Native Kotlin implementation of the graph package.
 This package provides:
 
 - `Graph` for undirected weighted graphs
+- graph, node, and edge property bags for metadata
 - `Traversals` for reusable BFS/DFS helpers
 - graph-specific error types

--- a/code/packages/kotlin/graph/src/main/kotlin/com/codingadventures/graph/Graph.kt
+++ b/code/packages/kotlin/graph/src/main/kotlin/com/codingadventures/graph/Graph.kt
@@ -85,35 +85,51 @@ data class WeightedEdge(val leftNode: String, val rightNode: String, val weight:
 
 class Graph : TraversalGraph {
     private val adjacency = linkedMapOf<String, LinkedHashMap<String, Double>>()
+    private val graphProperties = linkedMapOf<String, Any?>()
+    private val nodeProperties = linkedMapOf<String, LinkedHashMap<String, Any?>>()
+    private val edgeProperties = linkedMapOf<String, LinkedHashMap<String, Any?>>()
 
     override val size: Int get() = adjacency.size
 
-    fun addNode(node: String) {
+    fun addNode(node: String, properties: Map<String, Any?> = emptyMap()) {
         adjacency.getOrPut(node) { linkedMapOf() }
+        nodeProperties.getOrPut(node) { linkedMapOf() }.putAll(properties)
     }
 
     fun removeNode(node: String) {
         val neighbors = adjacency[node] ?: throw NodeNotFoundError(node)
         neighbors.keys.toList().forEach { neighbor ->
             adjacency.getValue(neighbor).remove(node)
+            edgeProperties.remove(canonicalEdgeKey(node, neighbor))
         }
         adjacency.remove(node)
+        nodeProperties.remove(node)
     }
 
     override fun hasNode(node: String): Boolean = adjacency.containsKey(node)
     override fun nodes(): List<String> = adjacency.keys.toList()
 
-    fun addEdge(leftNode: String, rightNode: String, weight: Double = 1.0) {
+    fun addEdge(
+        leftNode: String,
+        rightNode: String,
+        weight: Double = 1.0,
+        properties: Map<String, Any?> = emptyMap(),
+    ) {
         addNode(leftNode)
         addNode(rightNode)
         adjacency.getValue(leftNode)[rightNode] = weight
         adjacency.getValue(rightNode)[leftNode] = weight
+        edgeProperties.getOrPut(canonicalEdgeKey(leftNode, rightNode)) { linkedMapOf() }.apply {
+            putAll(properties)
+            put("weight", weight)
+        }
     }
 
     fun removeEdge(leftNode: String, rightNode: String) {
         if (!hasEdge(leftNode, rightNode)) throw EdgeNotFoundError(leftNode, rightNode)
         adjacency.getValue(leftNode).remove(rightNode)
         adjacency.getValue(rightNode).remove(leftNode)
+        edgeProperties.remove(canonicalEdgeKey(leftNode, rightNode))
     }
 
     fun hasEdge(leftNode: String, rightNode: String): Boolean =
@@ -121,6 +137,57 @@ class Graph : TraversalGraph {
 
     fun edgeWeight(leftNode: String, rightNode: String): Double =
         adjacency[leftNode]?.get(rightNode) ?: throw EdgeNotFoundError(leftNode, rightNode)
+
+    fun graphProperties(): Map<String, Any?> = graphProperties.toMap()
+
+    fun setGraphProperty(key: String, value: Any?) {
+        graphProperties[key] = value
+    }
+
+    fun removeGraphProperty(key: String) {
+        graphProperties.remove(key)
+    }
+
+    fun nodeProperties(node: String): Map<String, Any?> {
+        if (!hasNode(node)) throw NodeNotFoundError(node)
+        return nodeProperties[node]?.toMap() ?: emptyMap()
+    }
+
+    fun setNodeProperty(node: String, key: String, value: Any?) {
+        if (!hasNode(node)) throw NodeNotFoundError(node)
+        nodeProperties.getOrPut(node) { linkedMapOf() }[key] = value
+    }
+
+    fun removeNodeProperty(node: String, key: String) {
+        if (!hasNode(node)) throw NodeNotFoundError(node)
+        nodeProperties[node]?.remove(key)
+    }
+
+    fun edgeProperties(leftNode: String, rightNode: String): Map<String, Any?> {
+        if (!hasEdge(leftNode, rightNode)) throw EdgeNotFoundError(leftNode, rightNode)
+        val properties = edgeProperties[canonicalEdgeKey(leftNode, rightNode)]?.toMutableMap() ?: linkedMapOf()
+        properties["weight"] = edgeWeight(leftNode, rightNode)
+        return properties.toMap()
+    }
+
+    fun setEdgeProperty(leftNode: String, rightNode: String, key: String, value: Any?) {
+        if (!hasEdge(leftNode, rightNode)) throw EdgeNotFoundError(leftNode, rightNode)
+        if (key == "weight") {
+            require(value is Number) { "Edge property 'weight' must be numeric." }
+            setEdgeWeight(leftNode, rightNode, value.toDouble())
+        }
+        edgeProperties.getOrPut(canonicalEdgeKey(leftNode, rightNode)) { linkedMapOf() }[key] = value
+    }
+
+    fun removeEdgeProperty(leftNode: String, rightNode: String, key: String) {
+        if (!hasEdge(leftNode, rightNode)) throw EdgeNotFoundError(leftNode, rightNode)
+        if (key == "weight") {
+            setEdgeWeight(leftNode, rightNode, 1.0)
+            edgeProperties.getOrPut(canonicalEdgeKey(leftNode, rightNode)) { linkedMapOf() }["weight"] = 1.0
+            return
+        }
+        edgeProperties[canonicalEdgeKey(leftNode, rightNode)]?.remove(key)
+    }
 
     fun edges(): List<WeightedEdge> {
         val seen = linkedSetOf<String>()
@@ -150,4 +217,9 @@ class Graph : TraversalGraph {
 
     private fun canonicalEdgeKey(leftNode: String, rightNode: String): String =
         if (leftNode <= rightNode) "$leftNode\u0000$rightNode" else "$rightNode\u0000$leftNode"
+
+    private fun setEdgeWeight(leftNode: String, rightNode: String, weight: Double) {
+        adjacency.getValue(leftNode)[rightNode] = weight
+        adjacency.getValue(rightNode)[leftNode] = weight
+    }
 }

--- a/code/packages/kotlin/graph/src/test/kotlin/com/codingadventures/graph/GraphTest.kt
+++ b/code/packages/kotlin/graph/src/test/kotlin/com/codingadventures/graph/GraphTest.kt
@@ -50,4 +50,38 @@ class GraphTest {
         val graph = Graph()
         assertFailsWith<NodeNotFoundError> { graph.removeNode("missing") }
     }
+
+    @Test
+    fun propertyBagsTrackGraphNodeAndEdgeMetadata() {
+        val graph = Graph()
+
+        graph.setGraphProperty("name", "city-map")
+        graph.setGraphProperty("version", 1)
+        assertEquals("city-map", graph.graphProperties()["name"])
+        assertEquals(1, graph.graphProperties()["version"])
+        graph.removeGraphProperty("version")
+        assertFalse(graph.graphProperties().containsKey("version"))
+
+        graph.addNode("A", mapOf("kind" to "input"))
+        graph.addNode("A", mapOf("trainable" to false))
+        graph.setNodeProperty("A", "slot", 0)
+        assertEquals("input", graph.nodeProperties("A")["kind"])
+        assertEquals(false, graph.nodeProperties("A")["trainable"])
+        assertEquals(0, graph.nodeProperties("A")["slot"])
+        graph.removeNodeProperty("A", "slot")
+        assertFalse(graph.nodeProperties("A").containsKey("slot"))
+
+        graph.addEdge("A", "B", 2.5, mapOf("role" to "distance"))
+        assertEquals("distance", graph.edgeProperties("B", "A")["role"])
+        assertEquals(2.5, graph.edgeProperties("B", "A")["weight"])
+        graph.setEdgeProperty("B", "A", "weight", 7.0)
+        assertEquals(7.0, graph.edgeWeight("A", "B"))
+        graph.setEdgeProperty("A", "B", "trainable", true)
+        graph.removeEdgeProperty("A", "B", "role")
+        assertEquals(true, graph.edgeProperties("A", "B")["trainable"])
+        assertFalse(graph.edgeProperties("A", "B").containsKey("role"))
+
+        graph.removeEdge("A", "B")
+        assertFailsWith<EdgeNotFoundError> { graph.edgeProperties("A", "B") }
+    }
 }

--- a/code/packages/lua/graph/CHANGELOG.md
+++ b/code/packages/lua/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata.
+
 ## 0.1.0 - 2026-04-12
 
 - Initial DT00 graph package for Lua.

--- a/code/packages/lua/graph/README.md
+++ b/code/packages/lua/graph/README.md
@@ -13,6 +13,7 @@ local GraphRepr = graph.GraphRepr
 local g = Graph.new({ repr = GraphRepr.ADJACENCY_LIST })
 g:add_edge("London", "Paris", 300)
 g:add_edge("London", "Amsterdam", 520)
+g:set_node_property("London", "kind", "city")
 
 local path = graph.shortest_path(g, "London", "Paris")
 local mst = graph.minimum_spanning_tree(g)
@@ -22,6 +23,7 @@ local mst = graph.minimum_spanning_tree(g)
 
 - `Graph`
 - `GraphRepr`
+- graph, node, and edge property bag methods on `Graph`
 - `bfs(graph, start)`
 - `dfs(graph, start)`
 - `is_connected(graph)`

--- a/code/packages/lua/graph/src/coding_adventures/graph/init.lua
+++ b/code/packages/lua/graph/src/coding_adventures/graph/init.lua
@@ -28,6 +28,25 @@ local function canonical_endpoints(left, right)
     return right, left
 end
 
+local function edge_key(left, right)
+    local first, second = canonical_endpoints(left, right)
+    return node_sort_key(first) .. "\0" .. node_sort_key(second)
+end
+
+local function copy_properties(properties)
+    local copy = {}
+    for key, value in pairs(properties or {}) do
+        copy[key] = value
+    end
+    return copy
+end
+
+local function merge_properties(target, properties)
+    for key, value in pairs(properties or {}) do
+        target[key] = value
+    end
+end
+
 local function NodeNotFoundError(node)
     return {
         type = "node_not_found",
@@ -69,6 +88,9 @@ function Graph.new(opts)
     self._node_list = {}
     self._node_index = {}
     self._matrix = {}
+    self._graph_properties = {}
+    self._node_properties = {}
+    self._edge_properties = {}
     return self
 end
 
@@ -76,15 +98,19 @@ function Graph:repr()
     return self._repr
 end
 
-function Graph:add_node(node)
+function Graph:add_node(node, properties)
     if self._repr == GraphRepr.ADJACENCY_LIST then
         if self._adj[node] == nil then
             self._adj[node] = {}
         end
+        self._node_properties[node] = self._node_properties[node] or {}
+        merge_properties(self._node_properties[node], properties)
         return
     end
 
     if self._node_index[node] ~= nil then
+        self._node_properties[node] = self._node_properties[node] or {}
+        merge_properties(self._node_properties[node], properties)
         return
     end
 
@@ -101,6 +127,8 @@ function Graph:add_node(node)
         new_row[i] = nil
     end
     self._matrix[index] = new_row
+    self._node_properties[node] = self._node_properties[node] or {}
+    merge_properties(self._node_properties[node], properties)
 end
 
 function Graph:remove_node(node)
@@ -112,8 +140,10 @@ function Graph:remove_node(node)
 
         for neighbor, _ in pairs(neighbors) do
             self._adj[neighbor][node] = nil
+            self._edge_properties[edge_key(node, neighbor)] = nil
         end
         self._adj[node] = nil
+        self._node_properties[node] = nil
         return true
     end
 
@@ -122,6 +152,10 @@ function Graph:remove_node(node)
         return nil, NodeNotFoundError(node)
     end
 
+    for _, other in ipairs(self._node_list) do
+        self._edge_properties[edge_key(node, other)] = nil
+    end
+    self._node_properties[node] = nil
     table.remove(self._node_list, index)
     table.remove(self._matrix, index)
     for _, row in ipairs(self._matrix) do
@@ -168,7 +202,7 @@ function Graph:size()
     return #self._node_list
 end
 
-function Graph:add_edge(left, right, weight)
+function Graph:add_edge(left, right, weight, properties)
     weight = weight == nil and 1.0 or weight
     self:add_node(left)
     self:add_node(right)
@@ -176,6 +210,9 @@ function Graph:add_edge(left, right, weight)
     if self._repr == GraphRepr.ADJACENCY_LIST then
         self._adj[left][right] = weight
         self._adj[right][left] = weight
+        self._edge_properties[edge_key(left, right)] = self._edge_properties[edge_key(left, right)] or {}
+        merge_properties(self._edge_properties[edge_key(left, right)], properties)
+        self._edge_properties[edge_key(left, right)].weight = weight
         return
     end
 
@@ -183,6 +220,9 @@ function Graph:add_edge(left, right, weight)
     local right_index = self._node_index[right]
     self._matrix[left_index][right_index] = weight
     self._matrix[right_index][left_index] = weight
+    self._edge_properties[edge_key(left, right)] = self._edge_properties[edge_key(left, right)] or {}
+    merge_properties(self._edge_properties[edge_key(left, right)], properties)
+    self._edge_properties[edge_key(left, right)].weight = weight
 end
 
 function Graph:remove_edge(left, right)
@@ -195,6 +235,7 @@ function Graph:remove_edge(left, right)
 
         left_neighbors[right] = nil
         right_neighbors[left] = nil
+        self._edge_properties[edge_key(left, right)] = nil
         return true
     end
 
@@ -206,6 +247,7 @@ function Graph:remove_edge(left, right)
 
     self._matrix[left_index][right_index] = nil
     self._matrix[right_index][left_index] = nil
+    self._edge_properties[edge_key(left, right)] = nil
     return true
 end
 
@@ -235,6 +277,100 @@ function Graph:edge_weight(left, right)
         return nil, EdgeNotFoundError(left, right)
     end
     return self._matrix[left_index][right_index]
+end
+
+function Graph:graph_properties()
+    return copy_properties(self._graph_properties)
+end
+
+function Graph:set_graph_property(key, value)
+    self._graph_properties[key] = value
+    return true
+end
+
+function Graph:remove_graph_property(key)
+    self._graph_properties[key] = nil
+    return true
+end
+
+function Graph:node_properties(node)
+    if not self:has_node(node) then
+        return nil, NodeNotFoundError(node)
+    end
+    return copy_properties(self._node_properties[node])
+end
+
+function Graph:set_node_property(node, key, value)
+    if not self:has_node(node) then
+        return nil, NodeNotFoundError(node)
+    end
+    self._node_properties[node] = self._node_properties[node] or {}
+    self._node_properties[node][key] = value
+    return true
+end
+
+function Graph:remove_node_property(node, key)
+    if not self:has_node(node) then
+        return nil, NodeNotFoundError(node)
+    end
+    if self._node_properties[node] ~= nil then
+        self._node_properties[node][key] = nil
+    end
+    return true
+end
+
+function Graph:edge_properties(left, right)
+    local weight, err = self:edge_weight(left, right)
+    if weight == nil then
+        return nil, err
+    end
+    local properties = copy_properties(self._edge_properties[edge_key(left, right)])
+    properties.weight = weight
+    return properties
+end
+
+function Graph:set_edge_property(left, right, key, value)
+    if not self:has_edge(left, right) then
+        return nil, EdgeNotFoundError(left, right)
+    end
+    if key == "weight" then
+        if type(value) ~= "number" then
+            return nil, { type = "invalid_property", message = "edge property 'weight' must be numeric" }
+        end
+        self:_set_edge_weight(left, right, value)
+    end
+    self._edge_properties[edge_key(left, right)] = self._edge_properties[edge_key(left, right)] or {}
+    self._edge_properties[edge_key(left, right)][key] = value
+    return true
+end
+
+function Graph:remove_edge_property(left, right, key)
+    if not self:has_edge(left, right) then
+        return nil, EdgeNotFoundError(left, right)
+    end
+    if key == "weight" then
+        self:_set_edge_weight(left, right, 1.0)
+        self._edge_properties[edge_key(left, right)] = self._edge_properties[edge_key(left, right)] or {}
+        self._edge_properties[edge_key(left, right)].weight = 1.0
+        return true
+    end
+    if self._edge_properties[edge_key(left, right)] ~= nil then
+        self._edge_properties[edge_key(left, right)][key] = nil
+    end
+    return true
+end
+
+function Graph:_set_edge_weight(left, right, weight)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        self._adj[left][right] = weight
+        self._adj[right][left] = weight
+        return
+    end
+
+    local left_index = self._node_index[left]
+    local right_index = self._node_index[right]
+    self._matrix[left_index][right_index] = weight
+    self._matrix[right_index][left_index] = weight
 end
 
 function Graph:edges()

--- a/code/packages/lua/graph/tests/test_graph.lua
+++ b/code/packages/lua/graph/tests/test_graph.lua
@@ -93,4 +93,38 @@ do
     assert_true(not g:has_node("A"))
 end
 
+do
+    local g = Graph.new()
+    assert_true(g:set_graph_property("name", "city-map"))
+    assert_true(g:set_graph_property("version", 1))
+    assert_equals("city-map", g:graph_properties().name)
+    assert_equals(1, g:graph_properties().version)
+    assert_true(g:remove_graph_property("version"))
+    assert_equals(nil, g:graph_properties().version)
+
+    g:add_node("A", { kind = "input" })
+    g:add_node("A", { trainable = false })
+    assert_true(g:set_node_property("A", "slot", 0))
+    assert_equals("input", g:node_properties("A").kind)
+    assert_equals(false, g:node_properties("A").trainable)
+    assert_equals(0, g:node_properties("A").slot)
+    assert_true(g:remove_node_property("A", "slot"))
+    assert_equals(nil, g:node_properties("A").slot)
+
+    g:add_edge("A", "B", 2.5, { role = "distance" })
+    assert_equals("distance", g:edge_properties("B", "A").role)
+    assert_equals(2.5, g:edge_properties("B", "A").weight)
+    assert_true(g:set_edge_property("B", "A", "weight", 7.0))
+    assert_equals(7.0, assert(g:edge_weight("A", "B")))
+    assert_true(g:set_edge_property("A", "B", "trainable", true))
+    assert_true(g:remove_edge_property("A", "B", "role"))
+    assert_equals(true, g:edge_properties("A", "B").trainable)
+    assert_equals(nil, g:edge_properties("A", "B").role)
+
+    assert_true(g:remove_edge("A", "B"))
+    local properties, err = g:edge_properties("A", "B")
+    assert_equals(nil, properties)
+    assert_equals("edge_not_found", err.type)
+end
+
 print("lua/graph tests passed")

--- a/code/packages/perl/graph/CHANGELOG.md
+++ b/code/packages/perl/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata.
+
 ## 0.01
 
 - Add the DT00 undirected weighted graph package for Perl.

--- a/code/packages/perl/graph/README.md
+++ b/code/packages/perl/graph/README.md
@@ -6,5 +6,6 @@ Features:
 
 - adjacency-list and adjacency-matrix representations
 - weighted undirected edges
+- graph, node, and edge property bags
 - BFS, DFS, connectivity, connected components, cycle detection
 - shortest path and minimum spanning tree

--- a/code/packages/perl/graph/lib/CodingAdventures/Graph.pm
+++ b/code/packages/perl/graph/lib/CodingAdventures/Graph.pm
@@ -3,6 +3,7 @@ package CodingAdventures::Graph;
 use strict;
 use warnings;
 use List::Util qw(sum);
+use Scalar::Util qw(looks_like_number);
 
 our $VERSION = '0.01';
 
@@ -18,6 +19,9 @@ sub new {
         _node_list  => [],
         _node_index => {},
         _matrix     => [],
+        _graph_properties => {},
+        _node_properties  => {},
+        _edge_properties  => {},
     }, $class;
 }
 
@@ -25,19 +29,25 @@ sub repr { $_[0]->{_repr} }
 sub size { $_[0]->{_repr} eq 'adjacency_list' ? scalar(keys %{ $_[0]->{_adj} }) : scalar(@{ $_[0]->{_node_list} }) }
 
 sub add_node {
-    my ($self, $node) = @_;
+    my ($self, $node, $properties) = @_;
+    $properties //= {};
     if ($self->{_repr} eq 'adjacency_list') {
         $self->{_adj}{$node} //= {};
+        _merge_properties($self->{_node_properties}, $node, $properties);
         return 1;
     }
 
-    return 1 if exists $self->{_node_index}{$node};
+    if (exists $self->{_node_index}{$node}) {
+        _merge_properties($self->{_node_properties}, $node, $properties);
+        return 1;
+    }
 
     my $index = scalar @{ $self->{_node_list} };
     push @{ $self->{_node_list} }, $node;
     $self->{_node_index}{$node} = $index;
     push @$_, undef for @{ $self->{_matrix} };
     push @{ $self->{_matrix} }, [ (undef) x ($index + 1) ];
+    _merge_properties($self->{_node_properties}, $node, $properties);
     return 1;
 }
 
@@ -49,12 +59,16 @@ sub remove_node {
         my $neighbors = $self->{_adj}{$node};
         for my $neighbor (keys %$neighbors) {
             delete $self->{_adj}{$neighbor}{$node};
+            delete $self->{_edge_properties}{_edge_key($node, $neighbor)};
         }
         delete $self->{_adj}{$node};
+        delete $self->{_node_properties}{$node};
         return 1;
     }
 
     my $index = delete $self->{_node_index}{$node};
+    delete $self->{_edge_properties}{_edge_key($node, $_)} for @{ $self->{_node_list} };
+    delete $self->{_node_properties}{$node};
     splice @{ $self->{_node_list} }, $index, 1;
     splice @{ $self->{_matrix} }, $index, 1;
     for my $row (@{ $self->{_matrix} }) {
@@ -80,14 +94,16 @@ sub nodes {
 }
 
 sub add_edge {
-    my ($self, $left, $right, $weight) = @_;
+    my ($self, $left, $right, $weight, $properties) = @_;
     $weight = 1 unless defined $weight;
+    $properties //= {};
     $self->add_node($left);
     $self->add_node($right);
 
     if ($self->{_repr} eq 'adjacency_list') {
         $self->{_adj}{$left}{$right} = $weight;
         $self->{_adj}{$right}{$left} = $weight;
+        _merge_edge_properties($self, $left, $right, $weight, $properties);
         return 1;
     }
 
@@ -95,6 +111,7 @@ sub add_edge {
     my $ri = $self->{_node_index}{$right};
     $self->{_matrix}[$li][$ri] = $weight;
     $self->{_matrix}[$ri][$li] = $weight;
+    _merge_edge_properties($self, $left, $right, $weight, $properties);
     return 1;
 }
 
@@ -105,6 +122,7 @@ sub remove_edge {
     if ($self->{_repr} eq 'adjacency_list') {
         delete $self->{_adj}{$left}{$right};
         delete $self->{_adj}{$right}{$left};
+        delete $self->{_edge_properties}{_edge_key($left, $right)};
         return 1;
     }
 
@@ -112,6 +130,7 @@ sub remove_edge {
     my $ri = $self->{_node_index}{$right};
     $self->{_matrix}[$li][$ri] = undef;
     $self->{_matrix}[$ri][$li] = undef;
+    delete $self->{_edge_properties}{_edge_key($left, $right)};
     return 1;
 }
 
@@ -131,6 +150,78 @@ sub edge_weight {
         return $self->{_adj}{$left}{$right};
     }
     return $self->{_matrix}[ $self->{_node_index}{$left} ][ $self->{_node_index}{$right} ];
+}
+
+sub graph_properties {
+    my ($self) = @_;
+    return { %{ $self->{_graph_properties} } };
+}
+
+sub set_graph_property {
+    my ($self, $key, $value) = @_;
+    $self->{_graph_properties}{$key} = $value;
+    return 1;
+}
+
+sub remove_graph_property {
+    my ($self, $key) = @_;
+    delete $self->{_graph_properties}{$key};
+    return 1;
+}
+
+sub node_properties {
+    my ($self, $node) = @_;
+    die "node not found: '$node'" unless $self->has_node($node);
+    return { %{ $self->{_node_properties}{$node} // {} } };
+}
+
+sub set_node_property {
+    my ($self, $node, $key, $value) = @_;
+    die "node not found: '$node'" unless $self->has_node($node);
+    $self->{_node_properties}{$node} //= {};
+    $self->{_node_properties}{$node}{$key} = $value;
+    return 1;
+}
+
+sub remove_node_property {
+    my ($self, $node, $key) = @_;
+    die "node not found: '$node'" unless $self->has_node($node);
+    delete $self->{_node_properties}{$node}{$key};
+    return 1;
+}
+
+sub edge_properties {
+    my ($self, $left, $right) = @_;
+    die "edge not found: '$left' -- '$right'" unless $self->has_edge($left, $right);
+    return {
+        %{ $self->{_edge_properties}{_edge_key($left, $right)} // {} },
+        weight => $self->edge_weight($left, $right),
+    };
+}
+
+sub set_edge_property {
+    my ($self, $left, $right, $key, $value) = @_;
+    die "edge not found: '$left' -- '$right'" unless $self->has_edge($left, $right);
+    if ($key eq 'weight') {
+        die "edge property 'weight' must be numeric" unless looks_like_number($value);
+        _set_edge_weight($self, $left, $right, $value + 0);
+    }
+    $self->{_edge_properties}{_edge_key($left, $right)} //= {};
+    $self->{_edge_properties}{_edge_key($left, $right)}{$key} = $value;
+    return 1;
+}
+
+sub remove_edge_property {
+    my ($self, $left, $right, $key) = @_;
+    die "edge not found: '$left' -- '$right'" unless $self->has_edge($left, $right);
+    if ($key eq 'weight') {
+        _set_edge_weight($self, $left, $right, 1);
+        $self->{_edge_properties}{_edge_key($left, $right)} //= {};
+        $self->{_edge_properties}{_edge_key($left, $right)}{weight} = 1;
+    } else {
+        delete $self->{_edge_properties}{_edge_key($left, $right)}{$key};
+    }
+    return 1;
 }
 
 sub edges {
@@ -392,6 +483,43 @@ sub _union {
 
     $parent->{$right_root} = $left_root;
     $rank->{$left_root}++ if $rank->{$left_root} == $rank->{$right_root};
+}
+
+sub _edge_key {
+    my ($left, $right) = @_;
+    return $left le $right ? "$left\0$right" : "$right\0$left";
+}
+
+sub _merge_properties {
+    my ($property_map, $owner, $properties) = @_;
+    $property_map->{$owner} //= {};
+    for my $key (keys %$properties) {
+        $property_map->{$owner}{$key} = $properties->{$key};
+    }
+}
+
+sub _merge_edge_properties {
+    my ($self, $left, $right, $weight, $properties) = @_;
+    my $key = _edge_key($left, $right);
+    $self->{_edge_properties}{$key} //= {};
+    for my $property_key (keys %$properties) {
+        $self->{_edge_properties}{$key}{$property_key} = $properties->{$property_key};
+    }
+    $self->{_edge_properties}{$key}{weight} = $weight;
+}
+
+sub _set_edge_weight {
+    my ($self, $left, $right, $weight) = @_;
+    if ($self->{_repr} eq 'adjacency_list') {
+        $self->{_adj}{$left}{$right} = $weight;
+        $self->{_adj}{$right}{$left} = $weight;
+        return;
+    }
+
+    my $li = $self->{_node_index}{$left};
+    my $ri = $self->{_node_index}{$right};
+    $self->{_matrix}[$li][$ri] = $weight;
+    $self->{_matrix}[$ri][$li] = $weight;
 }
 
 1;

--- a/code/packages/perl/graph/t/01-basic.t
+++ b/code/packages/perl/graph/t/01-basic.t
@@ -66,4 +66,32 @@ for my $repr (qw(adjacency_list adjacency_matrix)) {
     like(dies { $graph->minimum_spanning_tree }, qr/not connected/, "$repr disconnected mst");
 }
 
+for my $repr (qw(adjacency_list adjacency_matrix)) {
+    my $graph = CodingAdventures::Graph->new(repr => $repr);
+
+    $graph->set_graph_property('name', 'city-map');
+    $graph->set_graph_property('version', 1);
+    is($graph->graph_properties, { name => 'city-map', version => 1 }, "$repr graph properties");
+    $graph->remove_graph_property('version');
+    is($graph->graph_properties, { name => 'city-map' }, "$repr remove graph property");
+
+    $graph->add_node('A', { kind => 'input' });
+    $graph->add_node('A', { trainable => 0 });
+    $graph->set_node_property('A', 'slot', 0);
+    is($graph->node_properties('A'), { kind => 'input', trainable => 0, slot => 0 }, "$repr node properties");
+    $graph->remove_node_property('A', 'slot');
+    is($graph->node_properties('A'), { kind => 'input', trainable => 0 }, "$repr remove node property");
+
+    $graph->add_edge('A', 'B', 2.5, { role => 'distance' });
+    is($graph->edge_properties('B', 'A'), { role => 'distance', weight => 2.5 }, "$repr edge properties");
+    $graph->set_edge_property('B', 'A', 'weight', 7.0);
+    is($graph->edge_weight('A', 'B'), 7.0, "$repr weight property syncs edge weight");
+    $graph->set_edge_property('A', 'B', 'trainable', 1);
+    $graph->remove_edge_property('A', 'B', 'role');
+    is($graph->edge_properties('A', 'B'), { trainable => 1, weight => 7.0 }, "$repr edge property removal");
+
+    $graph->remove_edge('A', 'B');
+    like(dies { $graph->edge_properties('A', 'B') }, qr/edge not found/, "$repr edge props removed with edge");
+}
+
 done_testing;

--- a/code/packages/python/graph/CHANGELOG.md
+++ b/code/packages/python/graph/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0 — 2026-04-08
 
 ### Added

--- a/code/packages/python/graph/README.md
+++ b/code/packages/python/graph/README.md
@@ -14,11 +14,15 @@ from graph import Graph, GraphRepr, bfs, shortest_path, minimum_spanning_tree
 
 # Build a city graph
 g: Graph[str] = Graph()
-g.add_edge("London", "Paris", weight=300)
+g.add_node("London", {"kind": "city"})
+g.add_edge("London", "Paris", weight=300, properties={"route": "train"})
 g.add_edge("London", "Amsterdam", weight=520)
 g.add_edge("Paris", "Berlin", weight=878)
 g.add_edge("Amsterdam", "Berlin", weight=655)
 g.add_edge("Amsterdam", "Brussels", weight=180)
+
+print(g.edge_properties("Paris", "London"))
+# → {"route": "train", "weight": 300}
 
 # Breadth-first traversal from London
 print(bfs(g, "London"))
@@ -45,6 +49,21 @@ g_matrix = Graph(repr=GraphRepr.ADJACENCY_MATRIX)  # O(V²) space; O(1) edge loo
 ```
 
 Both expose exactly the same public API — every algorithm works on either.
+
+## Properties
+
+Graphs, nodes, and edges can carry portable property bags:
+
+```python
+g.set_graph_property("name", "city-map")
+g.add_node("Amsterdam", {"kind": "city"})
+g.add_edge("Amsterdam", "Berlin", weight=655, properties={"route": "rail"})
+
+assert g.edge_properties("Berlin", "Amsterdam")["weight"] == 655
+```
+
+Property bags are copied on read. Edge weights are also exposed through the
+canonical `weight` edge property.
 
 ## Where it fits
 

--- a/code/packages/python/graph/src/graph/__init__.py
+++ b/code/packages/python/graph/src/graph/__init__.py
@@ -11,7 +11,7 @@ Public API::
     from graph import has_cycle, shortest_path, minimum_spanning_tree
 """
 
-from graph.graph import Graph, GraphRepr
+from graph.graph import Graph, GraphRepr, PropertyBag, PropertyValue
 from graph.algorithms import (
     bfs,
     connected_components,
@@ -27,6 +27,8 @@ __version__ = "0.1.0"
 __all__ = [
     "Graph",
     "GraphRepr",
+    "PropertyBag",
+    "PropertyValue",
     "bfs",
     "connected_components",
     "dfs",

--- a/code/packages/python/graph/src/graph/graph.py
+++ b/code/packages/python/graph/src/graph/graph.py
@@ -51,9 +51,15 @@ This is the key invariant that makes Graph undirected.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Generic, TypeAlias, TypeVar
 
 T = TypeVar("T")  # Node type — must be hashable
+PropertyValue: TypeAlias = str | int | float | bool | None
+PropertyBag: TypeAlias = dict[str, PropertyValue]
+
+
+def _edge_key(u: T, v: T) -> tuple[T, T]:
+    return (u, v) if repr(u) <= repr(v) else (v, u)
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +99,9 @@ class Graph(Generic[T]):
 
     def __init__(self, repr: GraphRepr = GraphRepr.ADJACENCY_LIST) -> None:
         self._repr = repr
+        self._graph_properties: PropertyBag = {}
+        self._node_properties: dict[T, PropertyBag] = {}
+        self._edge_properties: dict[tuple[T, T], PropertyBag] = {}
 
         if repr is GraphRepr.ADJACENCY_LIST:
             # adj[u][v] = weight for every edge {u, v}.
@@ -111,20 +120,24 @@ class Graph(Generic[T]):
     # Node operations
     # ------------------------------------------------------------------
 
-    def add_node(self, node: T) -> None:
+    def add_node(self, node: T, properties: PropertyBag | None = None) -> None:
         """Add a node to the graph.  No-op if the node already exists."""
         if self._repr is GraphRepr.ADJACENCY_LIST:
             if node not in self._adj:
                 self._adj[node] = {}
+                self._node_properties[node] = {}
         else:
             if node not in self._node_idx:
                 idx = len(self._node_list)
                 self._node_list.append(node)
                 self._node_idx[node] = idx
+                self._node_properties[node] = {}
                 # Add a new row and column of zeros.
                 for row in self._matrix:
                     row.append(0.0)
                 self._matrix.append([0.0] * (idx + 1))
+        if properties is not None:
+            self._node_properties[node].update(properties)
 
     def remove_node(self, node: T) -> None:
         """Remove a node and all edges incident to it.
@@ -137,12 +150,17 @@ class Graph(Generic[T]):
             # Remove all edges that touch this node.
             for neighbour in list(self._adj[node]):
                 del self._adj[neighbour][node]
+                self._edge_properties.pop(_edge_key(node, neighbour), None)
             del self._adj[node]
+            del self._node_properties[node]
         else:
             if node not in self._node_idx:
                 raise KeyError(node)
+            for other in list(self._node_list):
+                self._edge_properties.pop(_edge_key(node, other), None)
             idx = self._node_idx.pop(node)
             self._node_list.pop(idx)
+            del self._node_properties[node]
             # Update indices for nodes that shifted down.
             for n in self._node_list[idx:]:
                 self._node_idx[n] -= 1
@@ -168,7 +186,13 @@ class Graph(Generic[T]):
     # Edge operations
     # ------------------------------------------------------------------
 
-    def add_edge(self, u: T, v: T, weight: float = 1.0) -> None:
+    def add_edge(
+        self,
+        u: T,
+        v: T,
+        weight: float = 1.0,
+        properties: PropertyBag | None = None,
+    ) -> None:
         """Add an undirected edge between u and v with the given weight.
 
         Both nodes are added automatically if they do not already exist.
@@ -176,6 +200,7 @@ class Graph(Generic[T]):
         """
         self.add_node(u)
         self.add_node(v)
+        self._validate_weight(weight)
 
         if self._repr is GraphRepr.ADJACENCY_LIST:
             self._adj[u][v] = weight
@@ -184,6 +209,9 @@ class Graph(Generic[T]):
             i, j = self._node_idx[u], self._node_idx[v]
             self._matrix[i][j] = weight
             self._matrix[j][i] = weight
+        merged = dict(properties or {})
+        merged["weight"] = weight
+        self._edge_properties.setdefault(_edge_key(u, v), {}).update(merged)
 
     def remove_edge(self, u: T, v: T) -> None:
         """Remove the edge between u and v.
@@ -195,6 +223,7 @@ class Graph(Generic[T]):
                 raise KeyError((u, v))
             del self._adj[u][v]
             del self._adj[v][u]
+            self._edge_properties.pop(_edge_key(u, v), None)
         else:
             if u not in self._node_idx or v not in self._node_idx:
                 raise KeyError((u, v))
@@ -203,6 +232,7 @@ class Graph(Generic[T]):
                 raise KeyError((u, v))
             self._matrix[i][j] = 0.0
             self._matrix[j][i] = 0.0
+            self._edge_properties.pop(_edge_key(u, v), None)
 
     def has_edge(self, u: T, v: T) -> bool:
         """Return True if an edge exists between u and v."""
@@ -256,6 +286,74 @@ class Graph(Generic[T]):
         return w
 
     # ------------------------------------------------------------------
+    # Property bags
+    # ------------------------------------------------------------------
+
+    def graph_properties(self) -> PropertyBag:
+        """Return a copy of graph-level properties."""
+        return dict(self._graph_properties)
+
+    def set_graph_property(self, key: str, value: PropertyValue) -> None:
+        """Set one graph-level property."""
+        self._graph_properties[key] = value
+
+    def remove_graph_property(self, key: str) -> None:
+        """Remove one graph-level property if present."""
+        self._graph_properties.pop(key, None)
+
+    def node_properties(self, node: T) -> PropertyBag:
+        """Return a copy of properties attached to ``node``."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        return dict(self._node_properties[node])
+
+    def set_node_property(self, node: T, key: str, value: PropertyValue) -> None:
+        """Set one property on ``node``."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        self._node_properties[node][key] = value
+
+    def remove_node_property(self, node: T, key: str) -> None:
+        """Remove one property from ``node`` if present."""
+        if not self.has_node(node):
+            raise KeyError(node)
+        self._node_properties[node].pop(key, None)
+
+    def edge_properties(self, u: T, v: T) -> PropertyBag:
+        """Return a copy of properties attached to edge {u, v}."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        properties = dict(self._edge_properties.get(_edge_key(u, v), {}))
+        properties["weight"] = self.edge_weight(u, v)
+        return properties
+
+    def set_edge_property(
+        self,
+        u: T,
+        v: T,
+        key: str,
+        value: PropertyValue,
+    ) -> None:
+        """Set one property on edge {u, v}."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        if key == "weight":
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError("edge property 'weight' must be numeric")
+            self._set_edge_weight(u, v, float(value))
+        self._edge_properties.setdefault(_edge_key(u, v), {})[key] = value
+
+    def remove_edge_property(self, u: T, v: T, key: str) -> None:
+        """Remove one property from edge {u, v} if present."""
+        if not self.has_edge(u, v):
+            raise KeyError((u, v))
+        if key == "weight":
+            self._set_edge_weight(u, v, 1.0)
+            self._edge_properties.setdefault(_edge_key(u, v), {})["weight"] = 1.0
+            return
+        self._edge_properties.setdefault(_edge_key(u, v), {}).pop(key, None)
+
+    # ------------------------------------------------------------------
     # Neighbourhood queries
     # ------------------------------------------------------------------
 
@@ -301,6 +399,20 @@ class Graph(Generic[T]):
         Raises KeyError if the node does not exist.
         """
         return len(self.neighbors(node))
+
+    def _validate_weight(self, weight: float) -> None:
+        if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+            raise ValueError("edge weight must be numeric")
+
+    def _set_edge_weight(self, u: T, v: T, weight: float) -> None:
+        self._validate_weight(weight)
+        if self._repr is GraphRepr.ADJACENCY_LIST:
+            self._adj[u][v] = weight
+            self._adj[v][u] = weight
+            return
+        i, j = self._node_idx[u], self._node_idx[v]
+        self._matrix[i][j] = weight
+        self._matrix[j][i] = weight
 
     # ------------------------------------------------------------------
     # Python dunder methods

--- a/code/packages/python/graph/tests/test_graph.py
+++ b/code/packages/python/graph/tests/test_graph.py
@@ -249,6 +249,89 @@ class TestEdgeOperations:
 
 
 # ---------------------------------------------------------------------------
+# TestPropertyBags
+# ---------------------------------------------------------------------------
+
+
+class TestPropertyBags:
+    """Graph, node, and edge property bags."""
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_graph_properties(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.set_graph_property("name", "city-map")
+        g.set_graph_property("version", 1)
+        assert g.graph_properties() == {"name": "city-map", "version": 1}
+
+        g.remove_graph_property("version")
+        assert g.graph_properties() == {"name": "city-map"}
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_node_properties_merge_and_copy(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_node("A", {"kind": "input"})
+        g.add_node("A", {"trainable": False})
+        g.set_node_property("A", "slot", 0)
+        assert g.node_properties("A") == {
+            "kind": "input",
+            "trainable": False,
+            "slot": 0,
+        }
+
+        copy = g.node_properties("A")
+        copy["kind"] = "mutated"
+        assert g.node_properties("A")["kind"] == "input"
+
+        g.remove_node_property("A", "slot")
+        assert g.node_properties("A") == {
+            "kind": "input",
+            "trainable": False,
+        }
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_edge_properties_include_canonical_weight(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_edge("A", "B", weight=2.5, properties={"role": "distance"})
+
+        assert g.edge_properties("A", "B") == {
+            "role": "distance",
+            "weight": 2.5,
+        }
+        assert g.edge_properties("B", "A") == {
+            "role": "distance",
+            "weight": 2.5,
+        }
+
+        g.set_edge_property("B", "A", "weight", 7)
+        assert g.edge_weight("A", "B") == 7.0
+        assert g.edge_properties("A", "B")["weight"] == 7
+
+        g.set_edge_property("A", "B", "trainable", True)
+        g.remove_edge_property("A", "B", "role")
+        assert g.edge_properties("A", "B") == {
+            "trainable": True,
+            "weight": 7.0,
+        }
+
+    @pytest.mark.parametrize("repr", list(GraphRepr))
+    def test_removing_structure_removes_properties(self, repr: GraphRepr) -> None:
+        g: Graph[str] = Graph(repr=repr)
+        g.add_node("A", {"kind": "input"})
+        g.add_edge("A", "B", weight=3, properties={"role": "data"})
+
+        g.remove_edge("A", "B")
+        with pytest.raises(KeyError):
+            g.edge_properties("A", "B")
+
+        g.add_edge("A", "B", weight=3, properties={"role": "data"})
+        g.remove_node("A")
+        with pytest.raises(KeyError):
+            g.node_properties("A")
+        with pytest.raises(KeyError):
+            g.edge_properties("A", "B")
+
+
+# ---------------------------------------------------------------------------
 # TestNeighborhood
 # ---------------------------------------------------------------------------
 

--- a/code/packages/ruby/graph/CHANGELOG.md
+++ b/code/packages/ruby/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add graph, node, and edge property bags with canonical `"weight"` edge metadata.
+
 ## 0.1.0
 
 - Add the initial DT00 graph package for Ruby.

--- a/code/packages/ruby/graph/README.md
+++ b/code/packages/ruby/graph/README.md
@@ -12,13 +12,20 @@ connected components, cycle detection, and minimum spanning tree.
 require "coding_adventures_graph"
 
 graph = CodingAdventures::Graph::Graph.new
-graph.add_edge("London", "Paris", 300.0)
+graph.add_node("London", { "kind" => "city" })
+graph.add_edge("London", "Paris", 300.0, { "route" => "train" })
 graph.add_edge("London", "Amsterdam", 520.0)
 graph.add_edge("Amsterdam", "Berlin", 655.0)
+
+graph.edge_properties("Paris", "London")
+# => { "route" => "train", "weight" => 300.0 }
 
 CodingAdventures::Graph.bfs(graph, "London")
 CodingAdventures::Graph.shortest_path(graph, "London", "Berlin")
 ```
+
+Graph, node, and edge property bags are copied on read. The canonical edge
+property `"weight"` is kept in sync with `edge_weight` and weighted algorithms.
 
 ## Development
 

--- a/code/packages/ruby/graph/lib/coding_adventures/graph/graph.rb
+++ b/code/packages/ruby/graph/lib/coding_adventures/graph/graph.rb
@@ -23,9 +23,12 @@ module CodingAdventures
         @node_list = []
         @node_index = {}
         @matrix = []
+        @graph_properties = {}
+        @node_properties = {}
+        @edge_properties = {}
       end
 
-      def add_node(node)
+      def add_node(node, properties = {})
         if @repr == GraphRepr::ADJACENCY_LIST
           @adj[node] ||= {}
         elsif !@node_index.key?(node)
@@ -35,6 +38,8 @@ module CodingAdventures
           @matrix.each { |row| row << nil }
           @matrix << Array.new(index + 1)
         end
+        @node_properties[node] ||= {}
+        @node_properties[node].merge!(properties)
         self
       end
 
@@ -44,15 +49,18 @@ module CodingAdventures
         if @repr == GraphRepr::ADJACENCY_LIST
           @adj[node].keys.each do |neighbor|
             @adj[neighbor]&.delete(node)
+            @edge_properties.delete(edge_key(node, neighbor))
           end
           @adj.delete(node)
         else
+          @node_list.each { |other| @edge_properties.delete(edge_key(node, other)) }
           index = @node_index.delete(node)
           @node_list.delete_at(index)
           @matrix.delete_at(index)
           @matrix.each { |row| row.delete_at(index) }
           @node_list.each_with_index { |name, offset| @node_index[name] = offset }
         end
+        @node_properties.delete(node)
 
         self
       end
@@ -69,7 +77,7 @@ module CodingAdventures
         sort_nodes(@repr == GraphRepr::ADJACENCY_LIST ? @adj.keys : @node_list)
       end
 
-      def add_edge(left, right, weight = 1.0)
+      def add_edge(left, right, weight = 1.0, properties = {})
         add_node(left)
         add_node(right)
 
@@ -82,6 +90,9 @@ module CodingAdventures
           @matrix[left_index][right_index] = weight
           @matrix[right_index][left_index] = weight
         end
+        @edge_properties[edge_key(left, right)] ||= {}
+        @edge_properties[edge_key(left, right)].merge!(properties)
+        @edge_properties[edge_key(left, right)]["weight"] = weight
 
         self
       end
@@ -98,6 +109,7 @@ module CodingAdventures
           @matrix[left_index][right_index] = nil
           @matrix[right_index][left_index] = nil
         end
+        @edge_properties.delete(edge_key(left, right))
 
         self
       end
@@ -155,6 +167,73 @@ module CodingAdventures
         end
 
         raise EdgeNotFoundError, "Edge not found: #{left.inspect} -- #{right.inspect}"
+      end
+
+      def graph_properties
+        @graph_properties.dup
+      end
+
+      def set_graph_property(key, value)
+        @graph_properties[key] = value
+        self
+      end
+
+      def remove_graph_property(key)
+        @graph_properties.delete(key)
+        self
+      end
+
+      def node_properties(node)
+        raise NodeNotFoundError, "Node not found: #{node.inspect}" unless has_node?(node)
+
+        @node_properties.fetch(node, {}).dup
+      end
+
+      def set_node_property(node, key, value)
+        raise NodeNotFoundError, "Node not found: #{node.inspect}" unless has_node?(node)
+
+        @node_properties[node] ||= {}
+        @node_properties[node][key] = value
+        self
+      end
+
+      def remove_node_property(node, key)
+        raise NodeNotFoundError, "Node not found: #{node.inspect}" unless has_node?(node)
+
+        @node_properties.fetch(node, {}).delete(key)
+        self
+      end
+
+      def edge_properties(left, right)
+        raise EdgeNotFoundError, "Edge not found: #{left.inspect} -- #{right.inspect}" unless has_edge?(left, right)
+
+        @edge_properties.fetch(edge_key(left, right), {}).merge("weight" => edge_weight(left, right))
+      end
+
+      def set_edge_property(left, right, key, value)
+        raise EdgeNotFoundError, "Edge not found: #{left.inspect} -- #{right.inspect}" unless has_edge?(left, right)
+
+        if key == "weight"
+          raise ArgumentError, "edge property 'weight' must be numeric" unless value.is_a?(Numeric)
+
+          set_edge_weight(left, right, value)
+        end
+        @edge_properties[edge_key(left, right)] ||= {}
+        @edge_properties[edge_key(left, right)][key] = value
+        self
+      end
+
+      def remove_edge_property(left, right, key)
+        raise EdgeNotFoundError, "Edge not found: #{left.inspect} -- #{right.inspect}" unless has_edge?(left, right)
+
+        if key == "weight"
+          set_edge_weight(left, right, 1.0)
+          @edge_properties[edge_key(left, right)] ||= {}
+          @edge_properties[edge_key(left, right)]["weight"] = 1.0
+        else
+          @edge_properties.fetch(edge_key(left, right), {}).delete(key)
+        end
+        self
       end
 
       def neighbors(node)
@@ -215,6 +294,22 @@ module CodingAdventures
 
       def canonical_endpoints(left, right)
         node_key(left) <= node_key(right) ? [left, right] : [right, left]
+      end
+
+      def edge_key(left, right)
+        canonical_endpoints(left, right)
+      end
+
+      def set_edge_weight(left, right, weight)
+        if @repr == GraphRepr::ADJACENCY_LIST
+          @adj[left][right] = weight
+          @adj[right][left] = weight
+        else
+          left_index = @node_index.fetch(left)
+          right_index = @node_index.fetch(right)
+          @matrix[left_index][right_index] = weight
+          @matrix[right_index][left_index] = weight
+        end
       end
     end
 

--- a/code/packages/ruby/graph/test/test_graph.rb
+++ b/code/packages/ruby/graph/test/test_graph.rb
@@ -85,6 +85,40 @@ module CodingAdventures
           assert_raises(NodeNotFoundError) { graph.neighbors("Z") }
         end
       end
+
+      def test_property_bags
+        each_repr do |repr|
+          graph = graph_for(repr)
+
+          graph.set_graph_property("name", "city-map")
+          graph.set_graph_property("version", 1)
+          assert_equal({ "name" => "city-map", "version" => 1 }, graph.graph_properties)
+          graph.graph_properties["name"] = "mutated"
+          assert_equal "city-map", graph.graph_properties["name"]
+          graph.remove_graph_property("version")
+          assert_equal({ "name" => "city-map" }, graph.graph_properties)
+
+          graph.add_node("A", { "kind" => "input" })
+          graph.add_node("A", { "trainable" => false })
+          graph.set_node_property("A", "slot", 0)
+          assert_equal({ "kind" => "input", "trainable" => false, "slot" => 0 }, graph.node_properties("A"))
+          graph.node_properties("A")["kind"] = "mutated"
+          assert_equal "input", graph.node_properties("A")["kind"]
+          graph.remove_node_property("A", "slot")
+          assert_equal({ "kind" => "input", "trainable" => false }, graph.node_properties("A"))
+
+          graph.add_edge("A", "B", 2.5, { "role" => "distance" })
+          assert_equal({ "role" => "distance", "weight" => 2.5 }, graph.edge_properties("B", "A"))
+          graph.set_edge_property("B", "A", "weight", 7.0)
+          assert_equal 7.0, graph.edge_weight("A", "B")
+          graph.set_edge_property("A", "B", "trainable", true)
+          graph.remove_edge_property("A", "B", "role")
+          assert_equal({ "weight" => 7.0, "trainable" => true }, graph.edge_properties("A", "B"))
+
+          graph.remove_edge("A", "B")
+          assert_raises(EdgeNotFoundError) { graph.edge_properties("A", "B") }
+        end
+      end
     end
   end
 end

--- a/code/packages/ruby/sql_execution_engine/CHANGELOG.md
+++ b/code/packages/ruby/sql_execution_engine/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — coding_adventures_sql_execution_engine
 
+## Unreleased
+
+### Fixed
+
+- `IN` and `NOT IN` expression evaluation now locates the parsed
+  `value_list` node directly, so multi-value predicates evaluate every listed
+  value instead of only the first one.
+
 ## [0.1.1] - 2026-03-31
 
 ### Fixed

--- a/code/packages/ruby/sql_execution_engine/CHANGELOG.md
+++ b/code/packages/ruby/sql_execution_engine/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- `IN` and `NOT IN` expression evaluation now locates the parsed
-  `value_list` node directly, so multi-value predicates evaluate every listed
-  value instead of only the first one.
+- `IN` and `NOT IN` expression evaluation now locates the nested parsed
+  `value_list` node, so multi-value predicates evaluate every listed value
+  instead of only the first one.
 
 ## [0.1.1] - 2026-03-31
 

--- a/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.rb
+++ b/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.rb
@@ -195,7 +195,7 @@ module CodingAdventures
 
         # IN (value_list)
         if second_kw == "IN"
-          values = eval_value_list(find_child_rule(children, "value_list") || children[3], row_ctx)
+          values = eval_value_list(find_descendant_rule(children, "value_list") || children[3], row_ctx)
           return nil if left.nil?
           return values.include?(left)
         end
@@ -217,7 +217,7 @@ module CodingAdventures
             return nil if left.nil? || low.nil? || high.nil?
             return !(low <= left && left <= high)
           when "IN"
-            values = eval_value_list(find_child_rule(children, "value_list") || children[4], row_ctx)
+            values = eval_value_list(find_descendant_rule(children, "value_list") || children[4], row_ctx)
             return nil if left.nil?
             return !values.include?(left)
           when "LIKE"
@@ -267,8 +267,16 @@ module CodingAdventures
         end
       end
 
-      def self.find_child_rule(children, rule_name)
-        children.find { |child| child.is_a?(ASTNode) && child.rule_name == rule_name }
+      def self.find_descendant_rule(children, rule_name)
+        children.each do |child|
+          next unless child.is_a?(ASTNode)
+          return child if child.rule_name == rule_name
+
+          descendant = find_descendant_rule(child.children, rule_name)
+          return descendant if descendant
+        end
+
+        nil
       end
 
       # SQL LIKE pattern matching — supports % wildcard only.

--- a/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.rb
+++ b/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.rb
@@ -195,7 +195,7 @@ module CodingAdventures
 
         # IN (value_list)
         if second_kw == "IN"
-          values = eval_value_list(children[3], row_ctx)
+          values = eval_value_list(find_child_rule(children, "value_list") || children[3], row_ctx)
           return nil if left.nil?
           return values.include?(left)
         end
@@ -217,7 +217,7 @@ module CodingAdventures
             return nil if left.nil? || low.nil? || high.nil?
             return !(low <= left && left <= high)
           when "IN"
-            values = eval_value_list(children[4], row_ctx)
+            values = eval_value_list(find_child_rule(children, "value_list") || children[4], row_ctx)
             return nil if left.nil?
             return !values.include?(left)
           when "LIKE"
@@ -248,11 +248,27 @@ module CodingAdventures
       end
 
       def self.eval_value_list(node, row_ctx)
+        return [] if node.nil?
         if node.is_a?(Token)
           return [eval_expr(node, row_ctx)]
         end
-        node.children.reject { |c| c.is_a?(Token) && c.value == "," }
-            .map { |c| eval_expr(c, row_ctx) }
+        unless node.rule_name == "value_list"
+          return [eval_expr(node, row_ctx)]
+        end
+
+        node.children.each_with_object([]) do |child, values|
+          next if child.is_a?(Token) && child.value == ","
+
+          values.concat(
+            child.is_a?(ASTNode) && child.rule_name == "value_list" ?
+              eval_value_list(child, row_ctx) :
+              [eval_expr(child, row_ctx)]
+          )
+        end
+      end
+
+      def self.find_child_rule(children, rule_name)
+        children.find { |child| child.is_a?(ASTNode) && child.rule_name == rule_name }
       end
 
       # SQL LIKE pattern matching — supports % wildcard only.

--- a/code/packages/ruby/sql_execution_engine/test/test_sql_execution_engine.rb
+++ b/code/packages/ruby/sql_execution_engine/test/test_sql_execution_engine.rb
@@ -163,6 +163,12 @@ class TestSqlExecutionEngine < Minitest::Test
     assert_equal Set["Alice", "Carol"], names
   end
 
+  def test_where_not_in
+    result = run_sql("SELECT name FROM employees WHERE id NOT IN (1, 3)")
+    names = result.rows.map { |r| r["name"] }.to_set
+    assert_equal Set["Bob", "Dave"], names
+  end
+
   # ------------------------------------------------------------------
   # Test 10: WHERE LIKE
   # ------------------------------------------------------------------

--- a/code/packages/rust/graph/CHANGELOG.md
+++ b/code/packages/rust/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # graph changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0
 
 - Added a weighted undirected graph with adjacency-list and adjacency-matrix storage

--- a/code/packages/rust/graph/README.md
+++ b/code/packages/rust/graph/README.md
@@ -16,9 +16,18 @@ Weighted undirected graph for Rust with both adjacency-list and adjacency-matrix
 use graph::{minimum_spanning_tree, shortest_path, Graph, GraphRepr};
 
 let mut g = Graph::new(GraphRepr::AdjacencyList);
+g.add_node_with_properties("London", [(
+    "kind".to_string(),
+    graph::GraphPropertyValue::String("city".to_string()),
+)].into_iter().collect());
 g.add_edge("London", "Paris", 300.0);
 g.add_edge("London", "Amsterdam", 520.0);
 g.add_edge("Amsterdam", "Berlin", 655.0);
+
+assert_eq!(
+    g.edge_properties("Paris", "London").unwrap().get("weight"),
+    Some(&graph::GraphPropertyValue::Number(300.0))
+);
 
 assert_eq!(
     shortest_path(&g, "London", "Berlin"),
@@ -28,6 +37,9 @@ assert_eq!(
 let mst = minimum_spanning_tree(&g).unwrap();
 assert!(!mst.is_empty());
 ```
+
+Graph, node, and edge property bags are cloned on read. The canonical edge
+property `weight` is kept in sync with `edge_weight` and weighted algorithms.
 
 ## Building and Testing
 

--- a/code/packages/rust/graph/src/graph.rs
+++ b/code/packages/rust/graph/src/graph.rs
@@ -12,6 +12,16 @@ pub enum GraphRepr {
 pub type WeightedEdge = (String, String, f64);
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum GraphPropertyValue {
+    String(String),
+    Number(f64),
+    Bool(bool),
+    Null,
+}
+
+pub type GraphPropertyBag = BTreeMap<String, GraphPropertyValue>;
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum GraphError {
     NodeNotFound(String),
     EdgeNotFound(String, String),
@@ -39,6 +49,9 @@ pub struct Graph {
     node_list: Vec<String>,
     node_index: BTreeMap<String, usize>,
     matrix: Vec<Vec<Option<f64>>>,
+    graph_properties: GraphPropertyBag,
+    node_properties: BTreeMap<String, GraphPropertyBag>,
+    edge_properties: BTreeMap<(String, String), GraphPropertyBag>,
 }
 
 impl Graph {
@@ -49,6 +62,9 @@ impl Graph {
             node_list: Vec::new(),
             node_index: BTreeMap::new(),
             matrix: Vec::new(),
+            graph_properties: BTreeMap::new(),
+            node_properties: BTreeMap::new(),
+            edge_properties: BTreeMap::new(),
         }
     }
 
@@ -58,23 +74,35 @@ impl Graph {
 
     pub fn add_node(&mut self, node: impl Into<String>) {
         let node = node.into();
+        self.add_node_with_properties(node, BTreeMap::new());
+    }
+
+    pub fn add_node_with_properties(
+        &mut self,
+        node: impl Into<String>,
+        properties: GraphPropertyBag,
+    ) {
+        let node = node.into();
         match self.repr {
             GraphRepr::AdjacencyList => {
-                self.adj.entry(node).or_default();
+                self.adj.entry(node.clone()).or_default();
             }
             GraphRepr::AdjacencyMatrix => {
-                if self.node_index.contains_key(&node) {
-                    return;
+                if !self.node_index.contains_key(&node) {
+                    let index = self.node_list.len();
+                    self.node_list.push(node.clone());
+                    self.node_index.insert(node.clone(), index);
+                    for row in &mut self.matrix {
+                        row.push(None);
+                    }
+                    self.matrix.push(vec![None; index + 1]);
                 }
-                let index = self.node_list.len();
-                self.node_list.push(node.clone());
-                self.node_index.insert(node, index);
-                for row in &mut self.matrix {
-                    row.push(None);
-                }
-                self.matrix.push(vec![None; index + 1]);
             }
         }
+        self.node_properties
+            .entry(node)
+            .or_default()
+            .extend(properties);
     }
 
     pub fn remove_node(&mut self, node: &str) -> Result<(), GraphError> {
@@ -89,8 +117,11 @@ impl Graph {
                     if let Some(entry) = self.adj.get_mut(neighbor) {
                         entry.remove(node);
                     }
+                    self.edge_properties
+                        .remove(&canonical_endpoints(node, neighbor));
                 }
                 self.adj.remove(node);
+                self.node_properties.remove(node);
                 Ok(())
             }
             GraphRepr::AdjacencyMatrix => {
@@ -98,7 +129,12 @@ impl Graph {
                     .node_index
                     .remove(node)
                     .ok_or_else(|| GraphError::NodeNotFound(node.to_string()))?;
+                for other in &self.node_list {
+                    self.edge_properties
+                        .remove(&canonical_endpoints(node, other));
+                }
                 self.node_list.remove(index);
+                self.node_properties.remove(node);
                 self.matrix.remove(index);
                 for row in &mut self.matrix {
                     row.remove(index);
@@ -128,6 +164,16 @@ impl Graph {
     }
 
     pub fn add_edge(&mut self, left: impl Into<String>, right: impl Into<String>, weight: f64) {
+        self.add_edge_with_properties(left, right, weight, BTreeMap::new());
+    }
+
+    pub fn add_edge_with_properties(
+        &mut self,
+        left: impl Into<String>,
+        right: impl Into<String>,
+        weight: f64,
+        properties: GraphPropertyBag,
+    ) {
         let left = left.into();
         let right = right.into();
         self.add_node(left.clone());
@@ -142,7 +188,7 @@ impl Graph {
                 self.adj
                     .get_mut(&right)
                     .expect("right node must exist")
-                    .insert(left, weight);
+                    .insert(left.clone(), weight);
             }
             GraphRepr::AdjacencyMatrix => {
                 let left_index = self.node_index[&left];
@@ -151,6 +197,10 @@ impl Graph {
                 self.matrix[right_index][left_index] = Some(weight);
             }
         }
+        let edge_key = canonical_endpoints(&left, &right);
+        let edge_properties = self.edge_properties.entry(edge_key).or_default();
+        edge_properties.extend(properties);
+        edge_properties.insert("weight".to_string(), GraphPropertyValue::Number(weight));
     }
 
     pub fn remove_edge(&mut self, left: &str, right: &str) -> Result<(), GraphError> {
@@ -169,6 +219,8 @@ impl Graph {
                 }
                 self.adj.get_mut(left).unwrap().remove(right);
                 self.adj.get_mut(right).unwrap().remove(left);
+                self.edge_properties
+                    .remove(&canonical_endpoints(left, right));
                 Ok(())
             }
             GraphRepr::AdjacencyMatrix => {
@@ -188,6 +240,8 @@ impl Graph {
                 }
                 self.matrix[left_index][right_index] = None;
                 self.matrix[right_index][left_index] = None;
+                self.edge_properties
+                    .remove(&canonical_endpoints(left, right));
                 Ok(())
             }
         }
@@ -230,6 +284,138 @@ impl Graph {
                     .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))
             }
         }
+    }
+
+    pub fn graph_properties(&self) -> GraphPropertyBag {
+        self.graph_properties.clone()
+    }
+
+    pub fn set_graph_property(&mut self, key: impl Into<String>, value: GraphPropertyValue) {
+        self.graph_properties.insert(key.into(), value);
+    }
+
+    pub fn remove_graph_property(&mut self, key: &str) {
+        self.graph_properties.remove(key);
+    }
+
+    pub fn node_properties(&self, node: &str) -> Result<GraphPropertyBag, GraphError> {
+        if !self.has_node(node) {
+            return Err(GraphError::NodeNotFound(node.to_string()));
+        }
+        Ok(self.node_properties.get(node).cloned().unwrap_or_default())
+    }
+
+    pub fn set_node_property(
+        &mut self,
+        node: &str,
+        key: impl Into<String>,
+        value: GraphPropertyValue,
+    ) -> Result<(), GraphError> {
+        if !self.has_node(node) {
+            return Err(GraphError::NodeNotFound(node.to_string()));
+        }
+        self.node_properties
+            .entry(node.to_string())
+            .or_default()
+            .insert(key.into(), value);
+        Ok(())
+    }
+
+    pub fn remove_node_property(&mut self, node: &str, key: &str) -> Result<(), GraphError> {
+        if !self.has_node(node) {
+            return Err(GraphError::NodeNotFound(node.to_string()));
+        }
+        if let Some(properties) = self.node_properties.get_mut(node) {
+            properties.remove(key);
+        }
+        Ok(())
+    }
+
+    pub fn edge_properties(&self, left: &str, right: &str) -> Result<GraphPropertyBag, GraphError> {
+        if !self.has_edge(left, right) {
+            return Err(GraphError::EdgeNotFound(
+                left.to_string(),
+                right.to_string(),
+            ));
+        }
+        let mut properties = self
+            .edge_properties
+            .get(&canonical_endpoints(left, right))
+            .cloned()
+            .unwrap_or_default();
+        properties.insert(
+            "weight".to_string(),
+            GraphPropertyValue::Number(self.edge_weight(left, right)?),
+        );
+        Ok(properties)
+    }
+
+    pub fn set_edge_property(
+        &mut self,
+        left: &str,
+        right: &str,
+        key: impl Into<String>,
+        value: GraphPropertyValue,
+    ) -> Result<(), GraphError> {
+        if !self.has_edge(left, right) {
+            return Err(GraphError::EdgeNotFound(
+                left.to_string(),
+                right.to_string(),
+            ));
+        }
+        let key = key.into();
+        if key == "weight" {
+            match value {
+                GraphPropertyValue::Number(weight) => {
+                    self.set_edge_weight(left, right, weight)?;
+                    self.edge_properties
+                        .entry(canonical_endpoints(left, right))
+                        .or_default()
+                        .insert(key, GraphPropertyValue::Number(weight));
+                    return Ok(());
+                }
+                _ => {
+                    return Err(GraphError::EdgeNotFound(
+                        "weight".to_string(),
+                        "numeric property".to_string(),
+                    ));
+                }
+            }
+        }
+        self.edge_properties
+            .entry(canonical_endpoints(left, right))
+            .or_default()
+            .insert(key, value);
+        Ok(())
+    }
+
+    pub fn remove_edge_property(
+        &mut self,
+        left: &str,
+        right: &str,
+        key: &str,
+    ) -> Result<(), GraphError> {
+        if !self.has_edge(left, right) {
+            return Err(GraphError::EdgeNotFound(
+                left.to_string(),
+                right.to_string(),
+            ));
+        }
+        if key == "weight" {
+            self.set_edge_weight(left, right, 1.0)?;
+            self.edge_properties
+                .entry(canonical_endpoints(left, right))
+                .or_default()
+                .insert("weight".to_string(), GraphPropertyValue::Number(1.0));
+            return Ok(());
+        }
+        if let Some(properties) = self
+            .edge_properties
+            .get_mut(&canonical_endpoints(left, right))
+        {
+            properties.remove(key);
+        }
+        Ok(())
     }
 
     pub fn edges(&self) -> Vec<WeightedEdge> {
@@ -326,6 +512,46 @@ impl Graph {
             GraphRepr::AdjacencyList => self.adj.len(),
             GraphRepr::AdjacencyMatrix => self.node_list.len(),
         }
+    }
+
+    fn set_edge_weight(&mut self, left: &str, right: &str, weight: f64) -> Result<(), GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                if !self.has_edge(left, right) {
+                    return Err(GraphError::EdgeNotFound(
+                        left.to_string(),
+                        right.to_string(),
+                    ));
+                }
+                self.adj
+                    .get_mut(left)
+                    .expect("left node must exist")
+                    .insert(right.to_string(), weight);
+                self.adj
+                    .get_mut(right)
+                    .expect("right node must exist")
+                    .insert(left.to_string(), weight);
+            }
+            GraphRepr::AdjacencyMatrix => {
+                let left_index =
+                    self.node_index.get(left).copied().ok_or_else(|| {
+                        GraphError::EdgeNotFound(left.to_string(), right.to_string())
+                    })?;
+                let right_index =
+                    self.node_index.get(right).copied().ok_or_else(|| {
+                        GraphError::EdgeNotFound(left.to_string(), right.to_string())
+                    })?;
+                if self.matrix[left_index][right_index].is_none() {
+                    return Err(GraphError::EdgeNotFound(
+                        left.to_string(),
+                        right.to_string(),
+                    ));
+                }
+                self.matrix[left_index][right_index] = Some(weight);
+                self.matrix[right_index][left_index] = Some(weight);
+            }
+        }
+        Ok(())
     }
 }
 

--- a/code/packages/rust/graph/src/lib.rs
+++ b/code/packages/rust/graph/src/lib.rs
@@ -2,14 +2,15 @@ pub mod algorithms;
 pub mod graph;
 
 pub use algorithms::{
-    bfs, connected_components, dfs, has_cycle, is_connected, minimum_spanning_tree,
-    shortest_path, TraversalGraph,
+    bfs, connected_components, dfs, has_cycle, is_connected, minimum_spanning_tree, shortest_path,
+    TraversalGraph,
 };
-pub use graph::{Graph, GraphError, GraphRepr, WeightedEdge};
+pub use graph::{Graph, GraphError, GraphPropertyBag, GraphPropertyValue, GraphRepr, WeightedEdge};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn representations() -> [GraphRepr; 2] {
         [GraphRepr::AdjacencyList, GraphRepr::AdjacencyMatrix]
@@ -64,6 +65,67 @@ mod tests {
             assert!(g.has_edge("B", "A"));
             assert_eq!(g.edge_weight("A", "B").unwrap(), 2.5);
             assert_eq!(g.neighbors("A").unwrap(), vec!["B".to_string()]);
+        }
+    }
+
+    #[test]
+    fn property_bags_work_in_both_representations() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            g.set_graph_property("name", GraphPropertyValue::String("city-map".to_string()));
+            g.set_graph_property("version", GraphPropertyValue::Number(1.0));
+            assert_eq!(
+                g.graph_properties().get("name"),
+                Some(&GraphPropertyValue::String("city-map".to_string()))
+            );
+            g.remove_graph_property("version");
+            assert!(!g.graph_properties().contains_key("version"));
+
+            let mut node_properties = BTreeMap::new();
+            node_properties.insert(
+                "kind".to_string(),
+                GraphPropertyValue::String("input".to_string()),
+            );
+            g.add_node_with_properties("A", node_properties);
+            let mut extra_node_properties = BTreeMap::new();
+            extra_node_properties.insert("trainable".to_string(), GraphPropertyValue::Bool(false));
+            g.add_node_with_properties("A", extra_node_properties);
+            g.set_node_property("A", "slot", GraphPropertyValue::Number(0.0))
+                .unwrap();
+            assert_eq!(
+                g.node_properties("A").unwrap().get("kind"),
+                Some(&GraphPropertyValue::String("input".to_string()))
+            );
+
+            let mut edge_properties = BTreeMap::new();
+            edge_properties.insert(
+                "role".to_string(),
+                GraphPropertyValue::String("distance".to_string()),
+            );
+            g.add_edge_with_properties("A", "B", 2.5, edge_properties);
+            assert_eq!(
+                g.edge_properties("B", "A").unwrap().get("weight"),
+                Some(&GraphPropertyValue::Number(2.5))
+            );
+
+            g.set_edge_property("B", "A", "weight", GraphPropertyValue::Number(7.0))
+                .unwrap();
+            assert_eq!(g.edge_weight("A", "B").unwrap(), 7.0);
+            g.set_edge_property("A", "B", "trainable", GraphPropertyValue::Bool(true))
+                .unwrap();
+            g.remove_edge_property("A", "B", "role").unwrap();
+            let properties = g.edge_properties("A", "B").unwrap();
+            assert_eq!(
+                properties.get("trainable"),
+                Some(&GraphPropertyValue::Bool(true))
+            );
+            assert_eq!(
+                properties.get("weight"),
+                Some(&GraphPropertyValue::Number(7.0))
+            );
+
+            g.remove_edge("A", "B").unwrap();
+            assert!(g.edge_properties("A", "B").is_err());
         }
     }
 

--- a/code/packages/swift/graph/CHANGELOG.md
+++ b/code/packages/swift/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with synchronized `weight` edge metadata.
+
 ## 0.1.0
 
 - Add the DT00 undirected weighted graph package for Swift.

--- a/code/packages/swift/graph/README.md
+++ b/code/packages/swift/graph/README.md
@@ -6,5 +6,6 @@ Features:
 
 - adjacency-list and adjacency-matrix representations
 - weighted undirected edges
+- graph, node, and edge property bags
 - BFS, DFS, connectivity, connected components, cycle detection
 - shortest path and minimum spanning tree

--- a/code/packages/swift/graph/Sources/Graph/Graph.swift
+++ b/code/packages/swift/graph/Sources/Graph/Graph.swift
@@ -7,6 +7,15 @@ public enum GraphRepr: String, CaseIterable, Sendable {
 
 public typealias WeightedEdge = (String, String, Double)
 
+public enum GraphPropertyValue: Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+}
+
+public typealias GraphPropertyBag = [String: GraphPropertyValue]
+
 public struct NodeNotFoundError: Error, CustomStringConvertible {
     public let node: String
     public var description: String { "Node not found: '\(node)'" }
@@ -28,6 +37,9 @@ public struct Graph: Sendable {
     private var nodeList: [String]
     private var nodeIndex: [String: Int]
     private var matrix: [[Double?]]
+    private var graphPropertiesStore: GraphPropertyBag
+    private var nodePropertiesStore: [String: GraphPropertyBag]
+    private var edgePropertiesStore: [String: GraphPropertyBag]
 
     public init(repr: GraphRepr = .adjacencyList) {
         self.repr = repr
@@ -35,21 +47,26 @@ public struct Graph: Sendable {
         self.nodeList = []
         self.nodeIndex = [:]
         self.matrix = []
+        self.graphPropertiesStore = [:]
+        self.nodePropertiesStore = [:]
+        self.edgePropertiesStore = [:]
     }
 
     public var size: Int {
         repr == .adjacencyList ? adj.count : nodeList.count
     }
 
-    public mutating func addNode(_ node: String) {
+    public mutating func addNode(_ node: String, properties: GraphPropertyBag = [:]) {
         if repr == .adjacencyList {
             if adj[node] == nil {
                 adj[node] = [:]
             }
+            mergeNodeProperties(node, properties)
             return
         }
 
         if nodeIndex[node] != nil {
+            mergeNodeProperties(node, properties)
             return
         }
 
@@ -60,6 +77,7 @@ public struct Graph: Sendable {
             matrix[row].append(nil)
         }
         matrix.append(Array(repeating: nil, count: index + 1))
+        mergeNodeProperties(node, properties)
     }
 
     public mutating func removeNode(_ node: String) throws {
@@ -69,8 +87,10 @@ public struct Graph: Sendable {
             }
             for neighbor in neighbors.keys {
                 adj[neighbor]?.removeValue(forKey: node)
+                edgePropertiesStore.removeValue(forKey: edgeKey(node, neighbor))
             }
             adj.removeValue(forKey: node)
+            nodePropertiesStore.removeValue(forKey: node)
             return
         }
 
@@ -78,6 +98,10 @@ public struct Graph: Sendable {
             throw NodeNotFoundError(node: node)
         }
 
+        for other in nodeList {
+            edgePropertiesStore.removeValue(forKey: edgeKey(node, other))
+        }
+        nodePropertiesStore.removeValue(forKey: node)
         nodeIndex.removeValue(forKey: node)
         nodeList.remove(at: index)
         matrix.remove(at: index)
@@ -96,13 +120,14 @@ public struct Graph: Sendable {
         return values.sorted()
     }
 
-    public mutating func addEdge(_ left: String, _ right: String, weight: Double = 1.0) {
+    public mutating func addEdge(_ left: String, _ right: String, weight: Double = 1.0, properties: GraphPropertyBag = [:]) {
         addNode(left)
         addNode(right)
 
         if repr == .adjacencyList {
             adj[left, default: [:]][right] = weight
             adj[right, default: [:]][left] = weight
+            mergeEdgeProperties(left, right, weight: weight, properties: properties)
             return
         }
 
@@ -110,6 +135,7 @@ public struct Graph: Sendable {
         let rightIndex = nodeIndex[right]!
         matrix[leftIndex][rightIndex] = weight
         matrix[rightIndex][leftIndex] = weight
+        mergeEdgeProperties(left, right, weight: weight, properties: properties)
     }
 
     public mutating func removeEdge(_ left: String, _ right: String) throws {
@@ -119,6 +145,7 @@ public struct Graph: Sendable {
             }
             adj[left]?.removeValue(forKey: right)
             adj[right]?.removeValue(forKey: left)
+            edgePropertiesStore.removeValue(forKey: edgeKey(left, right))
             return
         }
 
@@ -128,6 +155,7 @@ public struct Graph: Sendable {
 
         matrix[leftIndex][rightIndex] = nil
         matrix[rightIndex][leftIndex] = nil
+        edgePropertiesStore.removeValue(forKey: edgeKey(left, right))
     }
 
     public func hasEdge(_ left: String, _ right: String) -> Bool {
@@ -228,6 +256,101 @@ public struct Graph: Sendable {
 
     public func degree(of node: String) throws -> Int {
         try neighbors(of: node).count
+    }
+
+    public func graphProperties() -> GraphPropertyBag {
+        graphPropertiesStore
+    }
+
+    public mutating func setGraphProperty(_ key: String, value: GraphPropertyValue) {
+        graphPropertiesStore[key] = value
+    }
+
+    public mutating func removeGraphProperty(_ key: String) {
+        graphPropertiesStore.removeValue(forKey: key)
+    }
+
+    public func nodeProperties(_ node: String) throws -> GraphPropertyBag {
+        guard hasNode(node) else {
+            throw NodeNotFoundError(node: node)
+        }
+        return nodePropertiesStore[node] ?? [:]
+    }
+
+    public mutating func setNodeProperty(_ node: String, _ key: String, value: GraphPropertyValue) throws {
+        guard hasNode(node) else {
+            throw NodeNotFoundError(node: node)
+        }
+        nodePropertiesStore[node, default: [:]][key] = value
+    }
+
+    public mutating func removeNodeProperty(_ node: String, _ key: String) throws {
+        guard hasNode(node) else {
+            throw NodeNotFoundError(node: node)
+        }
+        nodePropertiesStore[node]?.removeValue(forKey: key)
+    }
+
+    public func edgeProperties(_ left: String, _ right: String) throws -> GraphPropertyBag {
+        guard hasEdge(left, right) else {
+            throw EdgeNotFoundError(left: left, right: right)
+        }
+        var properties = edgePropertiesStore[edgeKey(left, right)] ?? [:]
+        properties["weight"] = .number(try edgeWeight(left, right))
+        return properties
+    }
+
+    public mutating func setEdgeProperty(_ left: String, _ right: String, _ key: String, value: GraphPropertyValue) throws {
+        guard hasEdge(left, right) else {
+            throw EdgeNotFoundError(left: left, right: right)
+        }
+
+        if key == "weight" {
+            guard case let .number(weight) = value else {
+                throw EdgeNotFoundError(left: "weight", right: "numeric property")
+            }
+            setEdgeWeight(left, right, weight: weight)
+        }
+
+        edgePropertiesStore[edgeKey(left, right), default: [:]][key] = value
+    }
+
+    public mutating func removeEdgeProperty(_ left: String, _ right: String, _ key: String) throws {
+        guard hasEdge(left, right) else {
+            throw EdgeNotFoundError(left: left, right: right)
+        }
+
+        if key == "weight" {
+            setEdgeWeight(left, right, weight: 1.0)
+            edgePropertiesStore[edgeKey(left, right), default: [:]]["weight"] = .number(1.0)
+            return
+        }
+
+        edgePropertiesStore[edgeKey(left, right)]?.removeValue(forKey: key)
+    }
+
+    private mutating func mergeNodeProperties(_ node: String, _ properties: GraphPropertyBag) {
+        nodePropertiesStore[node, default: [:]].merge(properties) { _, next in next }
+    }
+
+    private mutating func mergeEdgeProperties(_ left: String, _ right: String, weight: Double, properties: GraphPropertyBag) {
+        var next = edgePropertiesStore[edgeKey(left, right)] ?? [:]
+        next.merge(properties) { _, value in value }
+        next["weight"] = .number(weight)
+        edgePropertiesStore[edgeKey(left, right)] = next
+    }
+
+    private mutating func setEdgeWeight(_ left: String, _ right: String, weight: Double) {
+        if repr == .adjacencyList {
+            adj[left, default: [:]][right] = weight
+            adj[right, default: [:]][left] = weight
+            return
+        }
+
+        let leftIndex = nodeIndex[left]!
+        let rightIndex = nodeIndex[right]!
+        matrix[leftIndex][rightIndex] = weight
+        matrix[rightIndex][leftIndex] = weight
     }
 }
 
@@ -330,6 +453,11 @@ public func minimumSpanningTree(_ graph: Graph) throws -> [WeightedEdge] {
 
 private func canonical(_ left: String, _ right: String) -> (String, String) {
     left <= right ? (left, right) : (right, left)
+}
+
+private func edgeKey(_ left: String, _ right: String) -> String {
+    let ordered = canonical(left, right)
+    return "\(ordered.0)\u{0}\(ordered.1)"
 }
 
 private func visitCycle(_ graph: Graph, _ node: String, parent: String?, visited: inout Set<String>) -> Bool {

--- a/code/packages/swift/graph/Tests/GraphTests/GraphTests.swift
+++ b/code/packages/swift/graph/Tests/GraphTests/GraphTests.swift
@@ -69,4 +69,39 @@ final class GraphTests: XCTestCase {
             }
         }
     }
+
+    func testPropertyBags() throws {
+        for repr in GraphRepr.allCases {
+            var graph = Graph(repr: repr)
+
+            graph.setGraphProperty("name", value: .string("city-map"))
+            graph.setGraphProperty("version", value: .number(1.0))
+            XCTAssertEqual(graph.graphProperties(), ["name": .string("city-map"), "version": .number(1.0)])
+            graph.removeGraphProperty("version")
+            XCTAssertEqual(graph.graphProperties(), ["name": .string("city-map")])
+
+            graph.addNode("A", properties: ["kind": .string("input")])
+            graph.addNode("A", properties: ["trainable": .bool(false)])
+            try graph.setNodeProperty("A", "slot", value: .number(0.0))
+            XCTAssertEqual(
+                try graph.nodeProperties("A"),
+                ["kind": .string("input"), "trainable": .bool(false), "slot": .number(0.0)]
+            )
+            try graph.removeNodeProperty("A", "slot")
+            XCTAssertEqual(try graph.nodeProperties("A"), ["kind": .string("input"), "trainable": .bool(false)])
+
+            graph.addEdge("A", "B", weight: 2.5, properties: ["role": .string("distance")])
+            XCTAssertEqual(try graph.edgeProperties("B", "A"), ["role": .string("distance"), "weight": .number(2.5)])
+            try graph.setEdgeProperty("B", "A", "weight", value: .number(7.0))
+            XCTAssertEqual(try graph.edgeWeight("A", "B"), 7.0)
+            try graph.setEdgeProperty("A", "B", "trainable", value: .bool(true))
+            try graph.removeEdgeProperty("A", "B", "role")
+            XCTAssertEqual(try graph.edgeProperties("A", "B"), ["weight": .number(7.0), "trainable": .bool(true)])
+
+            try graph.removeEdge("A", "B")
+            XCTAssertThrowsError(try graph.edgeProperties("A", "B")) { error in
+                XCTAssertTrue(error is EdgeNotFoundError)
+            }
+        }
+    }
 }

--- a/code/packages/typescript/graph/CHANGELOG.md
+++ b/code/packages/typescript/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added graph, node, and edge property bags with canonical `weight` edge metadata.
+
 ## 0.1.0
 
 - Initial TypeScript port of the DT00 undirected graph package

--- a/code/packages/typescript/graph/README.md
+++ b/code/packages/typescript/graph/README.md
@@ -16,6 +16,11 @@ The package exposes one generic `Graph<T>` class plus pure algorithm helpers:
 - `shortestPath`
 - `minimumSpanningTree`
 
+Graphs also support portable graph, node, and edge property bags. Edge weights are
+available as the canonical `weight` edge property, so higher-level packages can treat
+weighted graphs, labeled graphs, visualizers, and neural graph builders as the same
+topology-plus-metadata model.
+
 ## Example
 
 ```ts
@@ -26,10 +31,14 @@ import {
 } from "@coding-adventures/graph";
 
 const graph = new Graph<string>(GraphRepr.ADJACENCY_LIST);
-graph.addEdge("London", "Paris", 300);
+graph.addNode("London", { kind: "city" });
+graph.addEdge("London", "Paris", 300, { route: "train" });
 graph.addEdge("Paris", "Berlin", 878);
 graph.addEdge("London", "Amsterdam", 520);
 graph.addEdge("Amsterdam", "Berlin", 655);
+
+console.log(graph.edgeProperties("Paris", "London"));
+// { route: "train", weight: 300 }
 
 console.log(shortestPath(graph, "London", "Berlin"));
 // ["London", "Amsterdam", "Berlin"]
@@ -40,3 +49,4 @@ console.log(shortestPath(graph, "London", "Berlin"));
 - Edges are undirected, so adding `A`-`B` also creates `B`-`A`.
 - Nodes are generic and may be strings, numbers, tuples, or object references.
 - The graph stores isolated nodes as well as connected ones.
+- Property bags are copied on read so callers cannot accidentally mutate the graph.

--- a/code/packages/typescript/graph/src/graph.ts
+++ b/code/packages/typescript/graph/src/graph.ts
@@ -12,6 +12,8 @@ export enum GraphRepr {
   ADJACENCY_MATRIX = "adjacency_matrix",
 }
 
+export type GraphPropertyValue = string | number | boolean | null;
+export type GraphPropertyBag = Record<string, GraphPropertyValue>;
 export type WeightedEdge<T> = readonly [T, T, number];
 
 function nodeSortKey(node: unknown): string {
@@ -52,6 +54,9 @@ export class Graph<T> {
   private readonly _nodeList: T[];
   private readonly _nodeIndex: Map<T, number>;
   private readonly _matrix: Array<Array<number | null>>;
+  private readonly _graphProperties: GraphPropertyBag;
+  private readonly _nodeProperties: Map<T, GraphPropertyBag>;
+  private readonly _edgeProperties: Map<string, GraphPropertyBag>;
 
   constructor(repr: GraphRepr = GraphRepr.ADJACENCY_LIST) {
     this._repr = repr;
@@ -59,6 +64,9 @@ export class Graph<T> {
     this._nodeList = [];
     this._nodeIndex = new Map();
     this._matrix = [];
+    this._graphProperties = {};
+    this._nodeProperties = new Map();
+    this._edgeProperties = new Map();
   }
 
   get repr(): GraphRepr {
@@ -71,21 +79,26 @@ export class Graph<T> {
       : this._nodeList.length;
   }
 
-  addNode(node: T): void {
+  addNode(node: T, properties: GraphPropertyBag = {}): void {
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       if (!this._adj.has(node)) {
         this._adj.set(node, new Map());
+        this._nodeProperties.set(node, {});
       }
+      this.mergeNodeProperties(node, properties);
       return;
     }
 
     if (this._nodeIndex.has(node)) {
+      this.mergeNodeProperties(node, properties);
       return;
     }
 
     const index = this._nodeList.length;
     this._nodeList.push(node);
     this._nodeIndex.set(node, index);
+    this._nodeProperties.set(node, {});
+    this.mergeNodeProperties(node, properties);
 
     for (const row of this._matrix) {
       row.push(null);
@@ -102,15 +115,21 @@ export class Graph<T> {
 
       for (const neighbor of Array.from(neighbors.keys())) {
         this._adj.get(neighbor)?.delete(node);
+        this._edgeProperties.delete(edgeKey(node, neighbor));
       }
 
       this._adj.delete(node);
+      this._nodeProperties.delete(node);
       return;
     }
 
     const index = this._nodeIndex.get(node);
     if (index === undefined) {
       throw new Error(`Node not found: ${String(node)}`);
+    }
+
+    for (const other of this._nodeList) {
+      this._edgeProperties.delete(edgeKey(node, other));
     }
 
     this._nodeIndex.delete(node);
@@ -123,6 +142,7 @@ export class Graph<T> {
     for (let i = index; i < this._nodeList.length; i++) {
       this._nodeIndex.set(this._nodeList[i], i);
     }
+    this._nodeProperties.delete(node);
   }
 
   hasNode(node: T): boolean {
@@ -137,13 +157,20 @@ export class Graph<T> {
       : new Set(this._nodeList);
   }
 
-  addEdge(left: T, right: T, weight = 1.0): void {
+  addEdge(
+    left: T,
+    right: T,
+    weight = 1.0,
+    properties: GraphPropertyBag = {}
+  ): void {
     this.addNode(left);
     this.addNode(right);
+    this.validateWeight(weight);
 
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       this._adj.get(left)!.set(right, weight);
       this._adj.get(right)!.set(left, weight);
+      this.mergeEdgeProperties(left, right, { ...properties, weight });
       return;
     }
 
@@ -151,6 +178,7 @@ export class Graph<T> {
     const rightIndex = this._nodeIndex.get(right)!;
     this._matrix[leftIndex][rightIndex] = weight;
     this._matrix[rightIndex][leftIndex] = weight;
+    this.mergeEdgeProperties(left, right, { ...properties, weight });
   }
 
   removeEdge(left: T, right: T): void {
@@ -165,6 +193,7 @@ export class Graph<T> {
 
       leftNeighbors.delete(right);
       rightNeighbors.delete(left);
+      this._edgeProperties.delete(edgeKey(left, right));
       return;
     }
 
@@ -179,6 +208,7 @@ export class Graph<T> {
 
     this._matrix[leftIndex][rightIndex] = null;
     this._matrix[rightIndex][leftIndex] = null;
+    this._edgeProperties.delete(edgeKey(left, right));
   }
 
   hasEdge(left: T, right: T): boolean {
@@ -262,6 +292,65 @@ export class Graph<T> {
     return weight;
   }
 
+  graphProperties(): GraphPropertyBag {
+    return { ...this._graphProperties };
+  }
+
+  setGraphProperty(key: string, value: GraphPropertyValue): void {
+    this._graphProperties[key] = value;
+  }
+
+  removeGraphProperty(key: string): void {
+    delete this._graphProperties[key];
+  }
+
+  nodeProperties(node: T): GraphPropertyBag {
+    this.assertNode(node);
+    return { ...(this._nodeProperties.get(node) ?? {}) };
+  }
+
+  setNodeProperty(node: T, key: string, value: GraphPropertyValue): void {
+    this.assertNode(node);
+    this._nodeProperties.get(node)![key] = value;
+  }
+
+  removeNodeProperty(node: T, key: string): void {
+    this.assertNode(node);
+    delete this._nodeProperties.get(node)![key];
+  }
+
+  edgeProperties(left: T, right: T): GraphPropertyBag {
+    this.assertEdge(left, right);
+    const properties = this._edgeProperties.get(edgeKey(left, right)) ?? {};
+    return { ...properties, weight: this.edgeWeight(left, right) };
+  }
+
+  setEdgeProperty(
+    left: T,
+    right: T,
+    key: string,
+    value: GraphPropertyValue
+  ): void {
+    this.assertEdge(left, right);
+    if (key === "weight") {
+      if (typeof value !== "number") {
+        throw new Error("Edge property 'weight' must be a number");
+      }
+      this.setEdgeWeight(left, right, value);
+    }
+    this.mergeEdgeProperties(left, right, { [key]: value });
+  }
+
+  removeEdgeProperty(left: T, right: T, key: string): void {
+    this.assertEdge(left, right);
+    if (key === "weight") {
+      this.setEdgeWeight(left, right, 1.0);
+      this.mergeEdgeProperties(left, right, { weight: 1.0 });
+      return;
+    }
+    delete this._edgeProperties.get(edgeKey(left, right))?.[key];
+  }
+
   neighbors(node: T): ReadonlySet<T> {
     if (this._repr === GraphRepr.ADJACENCY_LIST) {
       const neighbors = this._adj.get(node);
@@ -315,5 +404,57 @@ export class Graph<T> {
 
   toString(): string {
     return `Graph(nodes=${this.size}, edges=${this.edges().length}, repr=${this._repr})`;
+  }
+
+  private assertNode(node: T): void {
+    if (!this.hasNode(node)) {
+      throw new Error(`Node not found: ${String(node)}`);
+    }
+  }
+
+  private assertEdge(left: T, right: T): void {
+    if (!this.hasEdge(left, right)) {
+      throw new Error(`Edge not found: ${String(left)} -- ${String(right)}`);
+    }
+  }
+
+  private mergeNodeProperties(node: T, properties: GraphPropertyBag): void {
+    const existing = this._nodeProperties.get(node);
+    if (existing === undefined) {
+      return;
+    }
+    Object.assign(existing, properties);
+  }
+
+  private mergeEdgeProperties(
+    left: T,
+    right: T,
+    properties: GraphPropertyBag
+  ): void {
+    const key = edgeKey(left, right);
+    const existing = this._edgeProperties.get(key) ?? {};
+    Object.assign(existing, properties);
+    this._edgeProperties.set(key, existing);
+  }
+
+  private validateWeight(weight: number): void {
+    if (typeof weight !== "number" || Number.isNaN(weight)) {
+      throw new Error("Edge weight must be a number");
+    }
+  }
+
+  private setEdgeWeight(left: T, right: T, weight: number): void {
+    this.validateWeight(weight);
+
+    if (this._repr === GraphRepr.ADJACENCY_LIST) {
+      this._adj.get(left)!.set(right, weight);
+      this._adj.get(right)!.set(left, weight);
+      return;
+    }
+
+    const leftIndex = this._nodeIndex.get(left)!;
+    const rightIndex = this._nodeIndex.get(right)!;
+    this._matrix[leftIndex][rightIndex] = weight;
+    this._matrix[rightIndex][leftIndex] = weight;
   }
 }

--- a/code/packages/typescript/graph/src/index.ts
+++ b/code/packages/typescript/graph/src/index.ts
@@ -1,4 +1,11 @@
-export { Graph, GraphRepr, compareNodes, type WeightedEdge } from "./graph.js";
+export {
+  Graph,
+  GraphRepr,
+  compareNodes,
+  type GraphPropertyBag,
+  type GraphPropertyValue,
+  type WeightedEdge,
+} from "./graph.js";
 export {
   bfs,
   connectedComponents,

--- a/code/packages/typescript/graph/tests/graph.test.ts
+++ b/code/packages/typescript/graph/tests/graph.test.ts
@@ -113,6 +113,84 @@ describe("edge operations", () => {
   }
 });
 
+describe("property bags", () => {
+  for (const repr of representations) {
+    it(`stores graph properties for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.setGraphProperty("name", "city-map");
+      graph.setGraphProperty("version", 1);
+      expect(graph.graphProperties()).toEqual({
+        name: "city-map",
+        version: 1,
+      });
+
+      graph.removeGraphProperty("version");
+      expect(graph.graphProperties()).toEqual({ name: "city-map" });
+    });
+
+    it(`stores and merges node properties for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addNode("A", { kind: "input" });
+      graph.addNode("A", { trainable: false });
+      graph.setNodeProperty("A", "slot", 0);
+      expect(graph.nodeProperties("A")).toEqual({
+        kind: "input",
+        trainable: false,
+        slot: 0,
+      });
+
+      const copy = graph.nodeProperties("A");
+      copy.kind = "mutated";
+      expect(graph.nodeProperties("A").kind).toBe("input");
+
+      graph.removeNodeProperty("A", "slot");
+      expect(graph.nodeProperties("A")).toEqual({
+        kind: "input",
+        trainable: false,
+      });
+    });
+
+    it(`stores edge properties and treats weight as canonical for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addEdge("A", "B", 2.5, { role: "distance" });
+
+      expect(graph.edgeProperties("A", "B")).toEqual({
+        role: "distance",
+        weight: 2.5,
+      });
+      expect(graph.edgeProperties("B", "A")).toEqual({
+        role: "distance",
+        weight: 2.5,
+      });
+
+      graph.setEdgeProperty("B", "A", "weight", 7);
+      expect(graph.edgeWeight("A", "B")).toBe(7);
+      expect(graph.edgeProperties("A", "B").weight).toBe(7);
+
+      graph.setEdgeProperty("A", "B", "trainable", true);
+      graph.removeEdgeProperty("A", "B", "role");
+      expect(graph.edgeProperties("A", "B")).toEqual({
+        trainable: true,
+        weight: 7,
+      });
+    });
+
+    it(`removes node and edge properties with their structure for ${repr}`, () => {
+      const graph = new Graph<string>(repr);
+      graph.addNode("A", { kind: "input" });
+      graph.addEdge("A", "B", 3, { role: "data" });
+
+      graph.removeEdge("A", "B");
+      expect(() => graph.edgeProperties("A", "B")).toThrow(/Edge not found/);
+
+      graph.addEdge("A", "B", 3, { role: "data" });
+      graph.removeNode("A");
+      expect(() => graph.nodeProperties("A")).toThrow(/Node not found/);
+      expect(() => graph.edgeProperties("A", "B")).toThrow(/Edge not found/);
+    });
+  }
+});
+
 describe("neighborhood queries", () => {
   for (const repr of representations) {
     it(`returns neighbors, weights, and degree for ${repr}`, () => {

--- a/code/packages/wasm/graph/CHANGELOG.md
+++ b/code/packages/wasm/graph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # graph-wasm changelog
 
+## Unreleased
+
+- Added JSON-based graph, node, and edge property bag bindings.
+
 ## 0.1.0
 
 - Added WebAssembly bindings for the Rust `graph` crate

--- a/code/packages/wasm/graph/README.md
+++ b/code/packages/wasm/graph/README.md
@@ -6,6 +6,7 @@ WebAssembly bindings for the Rust [graph](../../rust/graph/) crate.
 
 - `WasmGraph` with adjacency-list and adjacency-matrix backing
 - String-node graph operations for browser and JS runtimes
+- graph, node, and edge property bag helpers through JSON
 - `bfs`, `dfs`, `isConnected`, `connectedComponentsJson`, `hasCycle`
 - `shortestPath` and `minimumSpanningTreeJson`
 
@@ -20,6 +21,7 @@ const graph = WasmGraph.withRepresentation("adjacency_matrix");
 graph.addEdge("London", "Paris", 300);
 graph.addEdge("London", "Amsterdam", 520);
 graph.addEdge("Amsterdam", "Berlin", 655);
+graph.setNodeProperty("London", "kind", JSON.stringify("city"));
 
 graph.shortestPath("London", "Berlin"); // ["London", "Amsterdam", "Berlin"]
 graph.minimumSpanningTreeJson(); // JSON string of weighted edges

--- a/code/packages/wasm/graph/src/lib.rs
+++ b/code/packages/wasm/graph/src/lib.rs
@@ -2,8 +2,9 @@ use graph::{
     bfs as core_bfs, connected_components as core_connected_components, dfs as core_dfs,
     has_cycle as core_has_cycle, is_connected as core_is_connected,
     minimum_spanning_tree as core_minimum_spanning_tree, shortest_path as core_shortest_path,
-    Graph, GraphError, GraphRepr,
+    Graph, GraphError, GraphPropertyBag, GraphPropertyValue, GraphRepr,
 };
+use serde_json::{Map, Value};
 use wasm_bindgen::prelude::*;
 
 fn to_js_error(error: GraphError) -> JsValue {
@@ -18,6 +19,57 @@ fn parse_repr(repr: &str) -> Result<GraphRepr, JsValue> {
             "unknown graph representation; expected adjacency_list or adjacency_matrix",
         )),
     }
+}
+
+fn parse_property_value_json(value_json: &str) -> Result<GraphPropertyValue, JsValue> {
+    let value: Value = serde_json::from_str(value_json)
+        .map_err(|error| JsValue::from_str(&format!("invalid property JSON: {error}")))?;
+    property_value_from_json(value)
+}
+
+fn parse_property_bag_json(properties_json: &str) -> Result<GraphPropertyBag, JsValue> {
+    let value: Value = serde_json::from_str(properties_json)
+        .map_err(|error| JsValue::from_str(&format!("invalid property bag JSON: {error}")))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| JsValue::from_str("property bag JSON must be an object"))?;
+    let mut properties = GraphPropertyBag::new();
+    for (key, value) in object {
+        properties.insert(key.clone(), property_value_from_json(value.clone())?);
+    }
+    Ok(properties)
+}
+
+fn property_value_from_json(value: Value) -> Result<GraphPropertyValue, JsValue> {
+    match value {
+        Value::Null => Ok(GraphPropertyValue::Null),
+        Value::Bool(value) => Ok(GraphPropertyValue::Bool(value)),
+        Value::Number(value) => value
+            .as_f64()
+            .map(GraphPropertyValue::Number)
+            .ok_or_else(|| JsValue::from_str("numeric property is out of range")),
+        Value::String(value) => Ok(GraphPropertyValue::String(value)),
+        Value::Array(_) | Value::Object(_) => Err(JsValue::from_str(
+            "property values must be string, number, boolean, or null",
+        )),
+    }
+}
+
+fn property_value_to_json(value: GraphPropertyValue) -> Value {
+    match value {
+        GraphPropertyValue::String(value) => Value::String(value),
+        GraphPropertyValue::Number(value) => Value::from(value),
+        GraphPropertyValue::Bool(value) => Value::Bool(value),
+        GraphPropertyValue::Null => Value::Null,
+    }
+}
+
+fn property_bag_to_json(properties: GraphPropertyBag) -> String {
+    let mut object = Map::new();
+    for (key, value) in properties {
+        object.insert(key, property_value_to_json(value));
+    }
+    Value::Object(object).to_string()
 }
 
 #[wasm_bindgen]
@@ -53,6 +105,17 @@ impl WasmGraph {
         self.inner.add_node(node);
     }
 
+    #[wasm_bindgen(js_name = "addNodeWithProperties")]
+    pub fn add_node_with_properties(
+        &mut self,
+        node: &str,
+        properties_json: &str,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .add_node_with_properties(node, parse_property_bag_json(properties_json)?);
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = "removeNode")]
     pub fn remove_node(&mut self, node: &str) -> Result<(), JsValue> {
         self.inner.remove_node(node).map_err(to_js_error)
@@ -76,6 +139,23 @@ impl WasmGraph {
         self.inner.add_edge(left, right, weight);
     }
 
+    #[wasm_bindgen(js_name = "addEdgeWithProperties")]
+    pub fn add_edge_with_properties(
+        &mut self,
+        left: &str,
+        right: &str,
+        weight: f64,
+        properties_json: &str,
+    ) -> Result<(), JsValue> {
+        self.inner.add_edge_with_properties(
+            left,
+            right,
+            weight,
+            parse_property_bag_json(properties_json)?,
+        );
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = "removeEdge")]
     pub fn remove_edge(&mut self, left: &str, right: &str) -> Result<(), JsValue> {
         self.inner.remove_edge(left, right).map_err(to_js_error)
@@ -89,6 +169,82 @@ impl WasmGraph {
     #[wasm_bindgen(js_name = "edgeWeight")]
     pub fn edge_weight(&self, left: &str, right: &str) -> Result<f64, JsValue> {
         self.inner.edge_weight(left, right).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "graphPropertiesJson")]
+    pub fn graph_properties_json(&self) -> String {
+        property_bag_to_json(self.inner.graph_properties())
+    }
+
+    #[wasm_bindgen(js_name = "setGraphProperty")]
+    pub fn set_graph_property(&mut self, key: &str, value_json: &str) -> Result<(), JsValue> {
+        self.inner
+            .set_graph_property(key, parse_property_value_json(value_json)?);
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "removeGraphProperty")]
+    pub fn remove_graph_property(&mut self, key: &str) {
+        self.inner.remove_graph_property(key);
+    }
+
+    #[wasm_bindgen(js_name = "nodePropertiesJson")]
+    pub fn node_properties_json(&self, node: &str) -> Result<String, JsValue> {
+        let properties = self.inner.node_properties(node).map_err(to_js_error)?;
+        Ok(property_bag_to_json(properties))
+    }
+
+    #[wasm_bindgen(js_name = "setNodeProperty")]
+    pub fn set_node_property(
+        &mut self,
+        node: &str,
+        key: &str,
+        value_json: &str,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .set_node_property(node, key, parse_property_value_json(value_json)?)
+            .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "removeNodeProperty")]
+    pub fn remove_node_property(&mut self, node: &str, key: &str) -> Result<(), JsValue> {
+        self.inner
+            .remove_node_property(node, key)
+            .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "edgePropertiesJson")]
+    pub fn edge_properties_json(&self, left: &str, right: &str) -> Result<String, JsValue> {
+        let properties = self
+            .inner
+            .edge_properties(left, right)
+            .map_err(to_js_error)?;
+        Ok(property_bag_to_json(properties))
+    }
+
+    #[wasm_bindgen(js_name = "setEdgeProperty")]
+    pub fn set_edge_property(
+        &mut self,
+        left: &str,
+        right: &str,
+        key: &str,
+        value_json: &str,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .set_edge_property(left, right, key, parse_property_value_json(value_json)?)
+            .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "removeEdgeProperty")]
+    pub fn remove_edge_property(
+        &mut self,
+        left: &str,
+        right: &str,
+        key: &str,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .remove_edge_property(left, right, key)
+            .map_err(to_js_error)
     }
 
     #[wasm_bindgen(js_name = "edgesJson")]
@@ -191,6 +347,37 @@ mod tests {
         assert!(graph.has_cycle());
         assert!(graph.edges_json().contains("London"));
         assert!(graph.connected_components_json().contains("Brussels"));
-        assert!(graph.minimum_spanning_tree_json().unwrap().contains("Paris"));
+        assert!(graph
+            .minimum_spanning_tree_json()
+            .unwrap()
+            .contains("Paris"));
+    }
+
+    #[test]
+    fn wrapper_exposes_property_bags_as_json() {
+        let mut graph = WasmGraph::with_representation("adjacency_list").unwrap();
+        graph.set_graph_property("name", "\"city-map\"").unwrap();
+        assert!(graph.graph_properties_json().contains("city-map"));
+
+        graph
+            .add_node_with_properties("A", r#"{"kind":"input"}"#)
+            .unwrap();
+        graph.set_node_property("A", "slot", "0").unwrap();
+        assert!(graph.node_properties_json("A").unwrap().contains("slot"));
+
+        graph
+            .add_edge_with_properties("A", "B", 2.5, r#"{"role":"distance"}"#)
+            .unwrap();
+        assert!(graph
+            .edge_properties_json("B", "A")
+            .unwrap()
+            .contains("distance"));
+        graph.set_edge_property("B", "A", "weight", "7.0").unwrap();
+        assert_eq!(graph.edge_weight("A", "B").unwrap(), 7.0);
+        graph.remove_edge_property("A", "B", "role").unwrap();
+        assert!(!graph
+            .edge_properties_json("A", "B")
+            .unwrap()
+            .contains("role"));
     }
 }

--- a/code/specs/DT00-graph.md
+++ b/code/specs/DT00-graph.md
@@ -92,6 +92,61 @@ The weight is stored alongside the edge. Algorithms that care about weights (lik
 shortest path) use them; algorithms that don't (like BFS) ignore them and treat all edges
 as weight 1.
 
+### Node and edge properties
+
+Graphs also need metadata. A compiler graph may need to know that a node is a parser
+stage. A neural graph may need to know that a node is an activation function and that an
+edge is trainable. A build graph may want to tag edges as `runtime`, `test`, or
+`compile`.
+
+The base graph package owns this capability directly:
+
+```
+node_properties[node]       = PropertyBag
+edge_properties[{u, v}]     = PropertyBag
+graph_properties            = PropertyBag
+```
+
+A **PropertyBag** is a string-keyed map whose values are portable JSON-like scalars:
+
+```
+PropertyValue = string | number | boolean | null
+PropertyBag   = Map<string, PropertyValue>
+```
+
+Language implementations should use the closest idiomatic representation while preserving
+the same semantics:
+
+```
+TypeScript: Record<string, string | number | boolean | null>
+Python:     dict[str, str | int | float | bool | None]
+Go:         map[string]any, restricted by tests/documentation to scalar values
+Rust:       enum GraphPropertyValue { String, Number, Bool, Null }
+Ruby/Perl/Lua/Elixir: native map/hash/table values, restricted to scalar values
+Java/Kotlin/C#/F#: Map/Dictionary<string, object?>
+Swift:      enum GraphPropertyValue
+Dart:       Map<String, Object?>
+Haskell:    data GraphPropertyValue = PropertyString | PropertyNumber | PropertyBool | PropertyNull
+```
+
+Properties are not the runtime. They are facts attached to the graph's structure. A future
+runtime can interpret them, trace them, lower them to matrix operations, or ignore them.
+
+#### The `weight` property
+
+`weight` is the canonical edge property for weighted algorithms. Existing `add_edge(...,
+weight)` and `edge_weight(...)` APIs remain valid, but implementations should also expose
+the weight through the edge property bag:
+
+```
+graph.add_edge("London", "Paris", weight: 300)
+graph.edge_properties("London", "Paris")["weight"] == 300
+```
+
+When callers set the `weight` edge property to a number, `edge_weight` and weighted
+algorithms must observe the same value. If `weight` is absent, the default is `1.0`.
+Non-numeric `weight` values are invalid.
+
 ### Two ways to store a graph
 
 This is one of the most important design decisions in graph programming. There are two
@@ -214,6 +269,9 @@ For adjacency list:
 ```
 nodes: Set<T>
 adj:   Map<T, Map<T, float>>   # neighbor → edge_weight (default 1.0)
+node_properties: Map<T, PropertyBag>
+edge_properties: Map<EdgeKey<T>, PropertyBag>
+graph_properties: PropertyBag
 ```
 
 For adjacency matrix:
@@ -221,10 +279,53 @@ For adjacency matrix:
 nodes:   List<T>               # ordered list for index mapping
 index:   Map<T, int>           # node → row/col index
 matrix:  List<List<float>>     # V×V matrix; 0.0 means no edge
+node_properties: Map<T, PropertyBag>
+edge_properties: Map<EdgeKey<T>, PropertyBag>
+graph_properties: PropertyBag
 ```
 
 Both expose the same public API so every algorithm works on either representation
 without modification.
+
+Edge property keys for undirected graphs are canonicalized because `{u, v}` and `{v, u}`
+are the same edge. Implementations may use tuple keys, stable string keys, or internal
+edge IDs, but the public API must treat both endpoint orders identically.
+
+## Public API
+
+Existing graph APIs remain source-compatible. Property support extends the surface with
+the following common operations:
+
+```
+add_node(node, properties = {})
+add_edge(left, right, weight = 1.0, properties = {})
+
+graph_properties() -> PropertyBag
+set_graph_property(key, value)
+remove_graph_property(key)
+
+node_properties(node) -> PropertyBag
+set_node_property(node, key, value)
+remove_node_property(node, key)
+
+edge_properties(left, right) -> PropertyBag
+set_edge_property(left, right, key, value)
+remove_edge_property(left, right, key)
+```
+
+API naming may follow each language's style (`addNode`, `AddNode`, `add_node`,
+`setNodeProperty`), but semantics must match:
+
+- Returned property bags are copies or read-only views unless the language deliberately
+  documents live mutation.
+- Adding an existing node merges new properties into the existing property bag.
+- Adding an existing edge updates its weight and merges new properties into the existing
+  edge property bag.
+- Removing a node removes its node properties and all incident edge properties.
+- Removing an edge removes its edge properties.
+- Algorithms must not mutate graph, node, or edge properties.
+- Property insertion order is not semantically meaningful.
+- Unknown properties are preserved by copy and serialization operations.
 
 ## Algorithms (Pure Functions)
 

--- a/code/specs/DT01-directed-graph.md
+++ b/code/specs/DT01-directed-graph.md
@@ -8,6 +8,11 @@ directed graphs the right model for any relationship that flows one way: depende
 imports, causality, state transitions. DT01 builds on DT00 (Graph) by adding a second
 adjacency map that tracks predecessors, enabling O(1) lookup in both directions.
 
+DT01 inherits the DT00 property model. Nodes, directed edges, and the graph itself can
+carry property bags. This is deliberately part of the graph foundation rather than a
+neural-network-specific layer, so packages such as state machines, build graphs, graph
+visualizers, and future neural graphs all share the same metadata contract.
+
 ## Layer Position
 
 ```
@@ -100,6 +105,54 @@ When you remove edge A→B:
 
 This doubles memory usage but pays off enormously: many graph algorithms need to
 walk edges in reverse (e.g., finding everything that depends on a changed file).
+
+### Directed edge properties
+
+Directed edge properties are attached to the ordered edge `(u, v)`. Unlike DT00,
+the reverse edge `(v, u)` is different and has its own property bag:
+
+```
+graph.add_edge("A", "B", properties: {"role": "forward"})
+graph.add_edge("B", "A", properties: {"role": "reverse"})
+
+graph.edge_properties("A", "B")["role"] == "forward"
+graph.edge_properties("B", "A")["role"] == "reverse"
+```
+
+This distinction matters for neural graphs:
+
+```
+InputA -> Hidden1   weight: 0.42, trainable: true
+Hidden1 -> Output   weight: 1.20, trainable: true
+```
+
+Both edges may connect related concepts, but their direction, weights, gradients, and
+runtime traces are independent.
+
+Directed graph implementations must expose the same property operations as DT00 using
+language-idiomatic names:
+
+```
+add_node(node, properties = {})
+add_edge(from, to, weight = 1.0, properties = {})
+
+graph_properties() -> PropertyBag
+node_properties(node) -> PropertyBag
+edge_properties(from, to) -> PropertyBag
+
+set_graph_property(key, value)
+set_node_property(node, key, value)
+set_edge_property(from, to, key, value)
+
+remove_graph_property(key)
+remove_node_property(node, key)
+remove_edge_property(from, to, key)
+```
+
+If a directed-graph package internally composes or inherits from DT00 graph, it should
+delegate this behavior to DT00 rather than duplicating a second metadata system. If a
+language currently has a standalone directed graph implementation, it must still match
+the DT00 property semantics so higher-level packages can target one graph contract.
 
 ### Directed Acyclic Graph (DAG)
 
@@ -220,6 +273,22 @@ Valid build order: app → server → auth → db-driver → logger
 ```
 
 Time: O(V + E).
+
+### Multi-directed graph extension
+
+DT01 intentionally keeps one edge per ordered `(from, to)` pair. A future
+`multi-directed-graph` package should build on the same concepts but assign each edge a
+stable edge id so multiple parallel edges can exist between the same nodes:
+
+```
+edge1: A -> B, properties: {"channel": "data", "weight": 0.4}
+edge2: A -> B, properties: {"channel": "trace", "weight": 1.0}
+```
+
+That package should relax the "one ordered pair, one edge" constraint without changing
+the node property, edge property, graph property, traversal, or serialization vocabulary.
+In other words: DT01 is the simple directed graph. `multi-directed-graph` is the same
+semantic model with edge identity added.
 
 ### Strongly Connected Components (Kosaraju's algorithm)
 


### PR DESCRIPTION
## Summary

- Ports the graph, node, and edge property-bag API from the initial TypeScript/Python reference work to the remaining graph packages.
- Keeps `weight` as canonical edge metadata and synchronizes it with each package's edge-weight API.
- Adds coverage and README/changelog notes for C#, Dart, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Ruby, Rust, Swift, and WASM.

## Notes

This is stacked on top of `codex/graph-properties` / PR #1603 so the base spec and TypeScript/Python reference implementation can be reviewed separately from the broad language-port sweep.

## Validation

- `bash BUILD` in `code/packages/typescript/graph`
- `bash BUILD` in `code/packages/python/graph`
- `bash BUILD` in `code/packages/python/directed-graph`
- `bash BUILD` in `code/packages/go/graph`
- `bash BUILD` in `code/packages/rust/graph`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-graph-properties/mise.toml bash BUILD` in `code/packages/dart/graph`
- `bash BUILD` in `code/packages/elixir/graph`
- `bash BUILD` in `code/packages/wasm/graph`
- `bash BUILD` in `code/packages/java/graph`
- `bash BUILD` in `code/packages/kotlin/graph`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-graph-properties/mise.toml bash BUILD` in `code/packages/csharp/graph`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-graph-properties/mise.toml bash BUILD` in `code/packages/fsharp/graph`
- `bash BUILD` in `code/packages/haskell/graph`
- `bash BUILD` in `code/packages/lua/graph`
- `bash BUILD` in `code/packages/perl/graph`
- `ruby -c lib/coding_adventures/graph/graph.rb` in `code/packages/ruby/graph`
- `git diff --check`

Ruby `bash BUILD` was not runnable in this local environment because system Ruby is 2.6 and the gem requires Ruby >= 3.3, plus missing bundled test gems. The Ruby source syntax check passes.