### PR TITLE
Support ALGOL value array parameters

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -54,6 +54,8 @@ All notable changes to this package will be documented in this file.
 - Lowered integer divide-overflow checks, real division zero-divisor checks,
   and zero-real-base negative exponent checks through the same runtime-failure
   guard path.
+- Lowered `value` whole-array parameters by allocating a callee-local copy of
+  the array descriptor, bounds metadata, and element storage at procedure entry.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -50,9 +50,11 @@ failure propagation from callees back to the by-name formal read. Stores through
 read-only expression thunks still raise targeted `CompileError` diagnostics
 until Phase 5 grows full store-helper coverage. The supported integer by-name
 surface is covered by the WASM acceptance suite, including typed whole-array
-formals passed as descriptor pointers, label formals passed as pending-goto
-targets, and switch formals passed as descriptor closures that re-evaluate in
-the caller's declaring scope. No-argument statement procedure formals pass
+formals passed as descriptor pointers. `value` whole-array formals allocate a
+callee-local descriptor, bounds table, and element storage copy at procedure
+entry, so writes to the formal do not alias the caller's array. Label formals
+pass pending-goto targets, and switch formals pass descriptor closures that
+re-evaluate in the caller's declaring scope. No-argument statement procedure formals pass
 descriptor closures containing the callee procedure id and static link; formal
 calls dispatch through a generated helper so forwarded procedure formals keep
 the original environment. Full ALGOL forms such as typed or argument-taking

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -934,6 +934,47 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(loop_label))
         self._label(end_label)
 
+    def _emit_copy_memory(
+        self, source_pointer: int, target_pointer: int, byte_count: int
+    ) -> None:
+        index = self.loop_count
+        self.loop_count += 1
+        loop_label = f"loop_{index}_start"
+        end_label = f"loop_{index}_end"
+        cursor = self._fresh_reg()
+        done = self._fresh_reg()
+
+        self._copy_reg(dst=cursor, src=_ZERO_REG)
+        self._label(loop_label)
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(done),
+            IrRegister(cursor),
+            IrRegister(byte_count),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(done), IrLabel(end_label))
+        byte = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_BYTE,
+            IrRegister(byte),
+            IrRegister(source_pointer),
+            IrRegister(cursor),
+        )
+        self._emit(
+            IrOp.STORE_BYTE,
+            IrRegister(byte),
+            IrRegister(target_pointer),
+            IrRegister(cursor),
+        )
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(cursor),
+            IrRegister(cursor),
+            IrImmediate(1),
+        )
+        self._emit(IrOp.JUMP, IrLabel(loop_label))
+        self._label(end_label)
+
     def _compile_statement(self, statement: ASTNode, scope: _FrameScope) -> None:
         label = self.labels.get(id(statement))
         if label is not None:
@@ -2782,10 +2823,6 @@ class AlgolIrCompiler:
             zip(actuals, procedure.parameters, strict=True)
         ):
             if parameter.kind == "array":
-                if parameter.mode == _VALUE_MODE:
-                    raise CompileError(
-                        f"value array parameter {parameter.name!r} is not supported yet"
-                    )
                 continue
             if parameter.kind == "label":
                 arguments[index] = self._compile_label_actual_value(argument, scope)
@@ -4336,7 +4373,13 @@ class AlgolIrCompiler:
         )
         self._initialize_scalar_slots(scope)
         for index, parameter in enumerate(procedure.parameters):
-            if parameter.kind == "array" or parameter.mode == _NAME_MODE:
+            if parameter.kind == "array":
+                self._store_array_parameter(
+                    parameter,
+                    _VALUE_PARAM_BASE_REG + index,
+                    scope,
+                )
+            elif parameter.mode == _NAME_MODE:
                 self._store_word_reg(
                     value_reg=_VALUE_PARAM_BASE_REG + index,
                     base_reg=scope.frame_base_reg,
@@ -4369,6 +4412,168 @@ class AlgolIrCompiler:
         self._emit_leave_frame(scope)
         self._emit(IrOp.RET)
         self.current_function_return_type = previous_return_type
+
+    def _store_array_parameter(
+        self,
+        parameter: ProcedureParameter,
+        source_descriptor: int,
+        scope: _FrameScope,
+    ) -> None:
+        descriptor = source_descriptor
+        if parameter.mode == _VALUE_MODE:
+            descriptor = self._copy_value_array_descriptor(source_descriptor, scope)
+        self._store_word_reg(
+            value_reg=descriptor,
+            base_reg=scope.frame_base_reg,
+            offset=parameter.slot_offset,
+        )
+
+    def _copy_value_array_descriptor(
+        self,
+        source_descriptor: int,
+        scope: _FrameScope,
+    ) -> int:
+        element_type = self._fresh_reg()
+        dimension_count = self._fresh_reg()
+        total_count = self._fresh_reg()
+        element_width = self._fresh_reg()
+        source_data_pointer = self._fresh_reg()
+        source_bounds_pointer = self._fresh_reg()
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            element_type,
+            source_descriptor,
+            0,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            dimension_count,
+            source_descriptor,
+            _ARRAY_DIMENSION_COUNT_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            total_count,
+            source_descriptor,
+            _ARRAY_TOTAL_COUNT_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            element_width,
+            source_descriptor,
+            _ARRAY_ELEMENT_WIDTH_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            source_data_pointer,
+            source_descriptor,
+            _ARRAY_DATA_POINTER_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            source_bounds_pointer,
+            source_descriptor,
+            _ARRAY_BOUNDS_POINTER_OFFSET,
+        )
+
+        bounds_bytes = self._fresh_reg()
+        self._emit(
+            IrOp.MUL,
+            IrRegister(bounds_bytes),
+            IrRegister(dimension_count),
+            IrRegister(self._const_reg(_ARRAY_DIMENSION_ENTRY_SIZE)),
+        )
+        data_bytes = self._fresh_reg()
+        self._emit(
+            IrOp.MUL,
+            IrRegister(data_bytes),
+            IrRegister(total_count),
+            IrRegister(element_width),
+        )
+        tail_bytes = self._fresh_reg()
+        self._emit(
+            IrOp.ADD,
+            IrRegister(tail_bytes),
+            IrRegister(bounds_bytes),
+            IrRegister(data_bytes),
+        )
+        allocation_size = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(allocation_size),
+            IrRegister(tail_bytes),
+            IrImmediate(_ARRAY_DESCRIPTOR_SIZE),
+        )
+
+        heap_pointer = self._fresh_reg()
+        heap_limit = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, heap_pointer)
+        self._load_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, heap_limit)
+        new_heap_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.ADD,
+            IrRegister(new_heap_pointer),
+            IrRegister(heap_pointer),
+            IrRegister(allocation_size),
+        )
+        heap_exhausted = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(heap_exhausted),
+            IrRegister(new_heap_pointer),
+            IrRegister(heap_limit),
+        )
+        self._emit_runtime_failure_guard(heap_exhausted, scope)
+        self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, new_heap_pointer)
+
+        bounds_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(bounds_pointer),
+            IrRegister(heap_pointer),
+            IrImmediate(_ARRAY_DESCRIPTOR_SIZE),
+        )
+        data_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.ADD,
+            IrRegister(data_pointer),
+            IrRegister(bounds_pointer),
+            IrRegister(bounds_bytes),
+        )
+
+        self._store_word_reg(
+            value_reg=element_type,
+            base_reg=heap_pointer,
+            offset=0,
+        )
+        self._store_word_reg(
+            value_reg=dimension_count,
+            base_reg=heap_pointer,
+            offset=_ARRAY_DIMENSION_COUNT_OFFSET,
+        )
+        self._store_word_reg(
+            value_reg=total_count,
+            base_reg=heap_pointer,
+            offset=_ARRAY_TOTAL_COUNT_OFFSET,
+        )
+        self._store_word_reg(
+            value_reg=element_width,
+            base_reg=heap_pointer,
+            offset=_ARRAY_ELEMENT_WIDTH_OFFSET,
+        )
+        self._store_word_reg(
+            value_reg=data_pointer,
+            base_reg=heap_pointer,
+            offset=_ARRAY_DATA_POINTER_OFFSET,
+        )
+        self._store_word_reg(
+            value_reg=bounds_pointer,
+            base_reg=heap_pointer,
+            offset=_ARRAY_BOUNDS_POINTER_OFFSET,
+        )
+        self._emit_copy_memory(source_bounds_pointer, bounds_pointer, bounds_bytes)
+        self._emit_copy_memory(source_data_pointer, data_pointer, data_bytes)
+        return heap_pointer
 
     def _compile_array_load(self, variable: ASTNode, scope: _FrameScope) -> int:
         name = _variable_head_name(variable)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1007,6 +1007,22 @@ class TestAlgolIrCompiler:
         assert signature.param_count == 3
         assert signature.param_types == ("integer", "integer", "integer")
 
+    def test_compiles_value_array_parameter_copy(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer array xs[1:2]; integer result; "
+                "procedure setfirst(a); value a; integer a; array a; "
+                "begin a[1] := 9 end; "
+                "xs[1] := 4; setfirst(xs); result := xs[1] "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.LOAD_BYTE in opcodes
+        assert IrOp.STORE_BYTE in opcodes
+        assert IrOp.CMP_GT in opcodes
+
     def test_compiles_array_parameter_dimension_guard(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this package will be documented in this file.
   as assignable scalar storage.
 - Accepted parser-tolerated repeated/trailing semicolons through existing
   statement-list traversal.
+- Accepted `value` array parameters as checked whole-array copy formals while
+  preserving element-type validation at call sites.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -49,9 +49,10 @@ Unsupported ALGOL 60 features are reported as diagnostics instead of being
 silently accepted by the compiled pipeline. By-name parameters are accepted in
 the semantic model, while later lowering packages now implement scalar
 call-by-name, typed whole-array formals, label formals, switch formals, and
-no-argument statement procedure formals. The checker keeps guarding the
+no-argument statement procedure formals. `value` whole-array parameters are
+also accepted and lowered as copy formals. The checker keeps guarding the
 remaining full-ALGOL gaps, including non-assignable actuals passed to written
-by-name formals, value array/label/switch/procedure parameters, and richer
+by-name formals, value label/switch/procedure parameters, and richer
 procedure-valued parameters with arguments or return values.
 
 ```python

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -796,12 +796,6 @@ class AlgolTypeChecker:
             parameter_kind = parameter_spec.kind
             parameter_type = parameter_spec.type_name
             if parameter_kind == ARRAY:
-                if mode == VALUE:
-                    self._error(
-                        formal,
-                        f"value parameter {formal.value!r} cannot be an array in "
-                        "this phase",
-                    )
                 if parameter_type is None:
                     parameter_type = REAL
             elif parameter_kind == LABEL:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -736,17 +736,21 @@ class TestAlgolTypeChecker:
         assert parameter.type_name == "integer"
         assert any(access.role == "actual" for access in result.semantic.array_accesses)
 
-    def test_rejects_value_array_parameter_in_this_phase(self) -> None:
+    def test_accepts_value_array_parameter_copy_mode(self) -> None:
         ast = parse_algol(
             "begin integer result; "
-            "procedure probe(a); value a; integer a; array a; begin end; "
-            "result := 0 "
+            "integer array xs[1:2]; "
+            "procedure probe(a); value a; integer a; array a; begin a[1] := 9 end; "
+            "probe(xs); result := xs[1] "
             "end"
         )
         result = check_algol(ast)
 
-        assert not result.ok
-        assert "cannot be an array in this phase" in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "array"
+        assert parameter.mode == "value"
 
     def test_accepts_label_parameter_and_direct_label_actual(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this package will be documented in this file.
 - Returned `0` for integer divide overflow, real division by zero, and
   zero-real-base negative exponentiation through the same ALGOL runtime
   failure path.
+- Executed `value` whole-array parameters as callee-local descriptor and
+  element copies so assignments inside the procedure do not alias the caller.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,7 +21,8 @@ already supports a substantial ALGOL 60 surface:
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks and
-  typed whole-array, label, switch, and no-argument statement procedure formals
+  typed whole-array formals with copy or aliasing semantics, plus label,
+  switch, and no-argument statement procedure formals
 - bare no-argument typed procedure names as expression calls, matching ALGOL's
   omitted-parentheses call syntax for parameterless procedures
 - labels, local and nonlocal `goto`, switch designators, and conditional

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -866,6 +866,27 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_value_array_parameter_copies_descriptor_and_elements(self) -> None:
+        result = compile_source(
+            "begin integer array xs[2:3]; integer result; "
+            "procedure setfirst(a); value a; integer a; array a; "
+            "begin result := a[2]; a[2] := 9; result := result * 10 + a[2] end; "
+            "xs[2] := 4; setfirst(xs); result := result * 10 + xs[2] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [494]
+
+    def test_real_value_array_parameter_copies_without_aliasing(self) -> None:
+        result = compile_source(
+            "begin real array xs[1:1]; integer result; "
+            "procedure bump(a); value a; real a; array a; "
+            "begin a[1] := a[1] + 1.5; if a[1] > 3.0 then result := 7 end; "
+            "xs[1] := 2.0; bump(xs); "
+            "if xs[1] < 3.0 then result := result + 1 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
     def test_array_parameter_runtime_dimension_mismatch_returns_from_callee(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- accept `value` array parameters in the ALGOL type checker while preserving whole-array and element-type validation
- lower value whole-array formals by allocating callee-local descriptor, bounds, and element-storage copies at procedure entry
- add IR and WASM coverage for integer and real value-array copy semantics plus docs/changelog notes

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- New code only emits bounded heap allocation and byte-copy IR for caller-provided array descriptors already validated by the type checker/runtime descriptor guards.
- Heap exhaustion uses the existing ALGOL runtime-failure unwind path.
- No new file I/O, shell execution, subprocess use, network access, deserialization, or unsafe dynamic execution paths.