### PR TITLE
feat(prolog): resolve VM queries in module context

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -5,6 +5,8 @@
 - preserve source query variables across `goal_expansion/2` rewrites
 - rewrite module-qualified callable arguments inside `findall/3`, `bagof/3`,
   `setof/3`, and `forall/2`
+- expose `rewrite_loaded_prolog_query(...)` for ad-hoc queries that need a
+  linked project's module/import context
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -24,6 +24,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   source references like `library(...)` without hard-coding one search policy
 - apply explicit `term_expansion/2` and `goal_expansion/2` passes during load
   without making parsing itself stateful or magical
+- rewrite ad-hoc parsed queries through a linked project's module/import
+  context
 - expose a convenience runner for executing initialization goals with the shared
   Prolog builtin adapter enabled
 

--- a/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/__init__.py
@@ -18,6 +18,7 @@ from prolog_loader.loader import (
     load_swi_prolog_project,
     load_swi_prolog_project_from_files,
     load_swi_prolog_source,
+    rewrite_loaded_prolog_query,
     run_initialization_goals,
     run_prolog_initialization_goals,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "load_swi_prolog_project_from_files",
     "load_swi_prolog_source",
     "link_loaded_prolog_sources",
+    "rewrite_loaded_prolog_query",
     "run_initialization_goals",
     "run_prolog_initialization_goals",
 ]

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -341,16 +341,6 @@ def link_loaded_prolog_sources(
 ) -> LoadedPrologProject:
     """Link loaded sources into one namespace-aware executable project."""
 
-    module_sources: dict[Symbol, LoadedPrologSource] = {}
-    for loaded_source in loaded_sources:
-        if loaded_source.module_spec is None:
-            continue
-        module_name = loaded_source.module_spec.name
-        if module_name in module_sources:
-            msg = f"duplicate module declaration for {module_name}"
-            raise ValueError(msg)
-        module_sources[module_name] = loaded_source
-
     linked_clauses: list[Clause] = []
     linked_queries: list[ParsedQuery] = []
     linked_modules: list[PrologModule] = []
@@ -358,38 +348,12 @@ def link_loaded_prolog_sources(
     initialization_terms: list[Term] = []
     initialization_goals: list[GoalExpr] = []
     dynamic_relations: list[Relation] = []
-    source_resolvers: dict[int, RelationResolver] = {}
-    module_resolvers: dict[Symbol, RelationResolver] = {}
+    source_resolvers, module_resolvers = _resolvers_for_sources(loaded_sources)
 
     for loaded_source in loaded_sources:
         if loaded_source.module_spec is not None:
             linked_modules.append(loaded_source.module_spec)
 
-        current_module = (
-            loaded_source.module_spec.name
-            if loaded_source.module_spec is not None
-            else _USER_MODULE
-        )
-        qualify_local = loaded_source.module_spec is not None
-        local_keys = {
-            clause_value.head.relation.key() for clause_value in loaded_source.clauses
-        }
-        import_resolution = _import_resolution(
-            loaded_source,
-            local_keys,
-            module_sources,
-        )
-        resolver = _resolver_for_source(
-            current_module,
-            qualify_local=qualify_local,
-            local_keys=local_keys,
-            import_resolution=import_resolution,
-        )
-        source_resolvers[id(loaded_source)] = resolver
-        if loaded_source.module_spec is not None:
-            module_resolvers[loaded_source.module_spec.name] = resolver
-
-    for loaded_source in loaded_sources:
         resolver = source_resolvers[id(loaded_source)]
 
         linked_clauses.extend(
@@ -420,6 +384,23 @@ def link_loaded_prolog_sources(
         initialization_terms=tuple(initialization_terms),
         initialization_goals=tuple(initialization_goals),
     )
+
+
+def rewrite_loaded_prolog_query(
+    loaded_project: LoadedPrologProject,
+    query_value: ParsedQuery,
+    *,
+    module: str | Symbol | None = None,
+) -> ParsedQuery:
+    """Rewrite an ad-hoc query through a linked project's module context."""
+
+    _, module_resolvers = _resolvers_for_sources(loaded_project.sources)
+    module_name = _query_module_name(loaded_project, module)
+    resolver = module_resolvers.get(module_name)
+    if resolver is None:
+        msg = f"query module {module_name.name} is not part of the loaded project"
+        raise ValueError(msg)
+    return _rewrite_query(query_value, resolver, module_resolvers)
 
 
 def run_initialization_goals(
@@ -1195,6 +1176,64 @@ def _qualified_relation(module_name: Symbol, relation_value: Relation) -> Relati
         symbol=sym(f"{module_name.name}:{relation_value.symbol.name}"),
         arity=relation_value.arity,
     )
+
+
+def _resolvers_for_sources(
+    loaded_sources: tuple[LoadedPrologSource, ...],
+) -> tuple[dict[int, RelationResolver], dict[Symbol, RelationResolver]]:
+    module_sources: dict[Symbol, LoadedPrologSource] = {}
+    for loaded_source in loaded_sources:
+        if loaded_source.module_spec is None:
+            continue
+        module_name = loaded_source.module_spec.name
+        if module_name in module_sources:
+            msg = f"duplicate module declaration for {module_name}"
+            raise ValueError(msg)
+        module_sources[module_name] = loaded_source
+
+    source_resolvers: dict[int, RelationResolver] = {}
+    module_resolvers: dict[Symbol, RelationResolver] = {}
+    for loaded_source in loaded_sources:
+        current_module = (
+            loaded_source.module_spec.name
+            if loaded_source.module_spec is not None
+            else _USER_MODULE
+        )
+        qualify_local = loaded_source.module_spec is not None
+        local_keys = {
+            clause_value.head.relation.key() for clause_value in loaded_source.clauses
+        }
+        import_resolution = _import_resolution(
+            loaded_source,
+            local_keys,
+            module_sources,
+        )
+        resolver = _resolver_for_source(
+            current_module,
+            qualify_local=qualify_local,
+            local_keys=local_keys,
+            import_resolution=import_resolution,
+        )
+        source_resolvers[id(loaded_source)] = resolver
+        module_resolvers[current_module] = resolver
+
+    return source_resolvers, module_resolvers
+
+
+def _query_module_name(
+    loaded_project: LoadedPrologProject,
+    module: str | Symbol | None,
+) -> Symbol:
+    if isinstance(module, Symbol):
+        return module
+    if module is not None:
+        return sym(module)
+    if not loaded_project.sources:
+        return _USER_MODULE
+    first_source = loaded_project.sources[0]
+    if first_source.module_spec is None:
+        return _USER_MODULE
+    return first_source.module_spec.name
 
 
 def _import_resolution(

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -26,6 +26,7 @@ from logic_engine import (
     term,
     visible_clauses_for,
 )
+from swi_prolog_parser import parse_swi_query
 
 from prolog_loader import (
     LoadedPrologProject,
@@ -40,6 +41,7 @@ from prolog_loader import (
     load_swi_prolog_project,
     load_swi_prolog_project_from_files,
     load_swi_prolog_source,
+    rewrite_loaded_prolog_query,
     run_initialization_goals,
     run_prolog_initialization_goals,
 )
@@ -296,6 +298,44 @@ class TestPrologLoader:
             atom("bart"),
             atom("lisa"),
         ]
+
+    def test_rewrite_loaded_prolog_query_uses_module_import_context(self) -> None:
+        project = load_swi_prolog_project(
+            """
+            :- module(family, [ancestor/2]).
+            ancestor(homer, bart).
+            ancestor(homer, lisa).
+            """,
+            """
+            :- module(app, []).
+            :- use_module(family, [ancestor/2]).
+            """,
+        )
+
+        query = rewrite_loaded_prolog_query(
+            project,
+            parse_swi_query("?- ancestor(homer, Who)."),
+            module="app",
+        )
+
+        assert solve_all(project.program, query.variables["Who"], query.goal) == [
+            atom("bart"),
+            atom("lisa"),
+        ]
+
+    def test_rewrite_loaded_prolog_query_rejects_unknown_query_module(self) -> None:
+        project = load_swi_prolog_project(
+            """
+            :- module(app, []).
+            """,
+        )
+
+        with pytest.raises(ValueError, match="query module missing"):
+            rewrite_loaded_prolog_query(
+                project,
+                parse_swi_query("?- anything."),
+                module="missing",
+            )
 
     def test_load_swi_prolog_project_keeps_local_definitions_over_imports(self) -> None:
         project = load_swi_prolog_project(

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -11,6 +11,8 @@
   initialized dynamic state, optional query commits, and raw query values.
 - Add file-backed Prolog VM compile/runtime helpers for loading `.pl` files and
   linked project file graphs through `prolog-loader`.
+- Add module-aware ad-hoc query rewriting for project runtimes via
+  `query_module=...`.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -104,8 +104,21 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 ]
 ```
 
-For linked file graphs with source-level `?-` queries, use
-`compile_swi_prolog_project_from_files(...)` and the compiled query helpers.
+For linked file graphs, use `create_swi_prolog_project_file_runtime(...)`.
+Pass `query_module=...` when later ad-hoc queries should resolve through a
+module's imports:
+
+```python
+from logic_engine import atom
+from prolog_vm_compiler import create_swi_prolog_project_file_runtime
+
+runtime = create_swi_prolog_project_file_runtime("app.pl", query_module="app")
+
+assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] == [
+    {"Who": atom("bart")},
+    {"Who": atom("lisa")},
+]
+```
 
 ## Stress Coverage
 

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -47,6 +47,7 @@ from prolog_loader import (
     load_swi_prolog_project,
     load_swi_prolog_project_from_files,
     load_swi_prolog_source,
+    rewrite_loaded_prolog_query,
 )
 from prolog_parser import ParsedQuery
 from swi_prolog_parser import parse_swi_query
@@ -132,6 +133,7 @@ class PrologVMRuntime:
     state: State
     operator_table: OperatorTable | None = None
     adapt_builtins: bool = True
+    query_rewriter: Callable[[ParsedQuery], ParsedQuery] | None = None
 
     def query(
         self,
@@ -143,6 +145,8 @@ class PrologVMRuntime:
         """Run an ad-hoc query and return source-variable bindings."""
 
         parsed_query = self._parse_query(source)
+        if self.query_rewriter is not None:
+            parsed_query = self.query_rewriter(parsed_query)
         goal = _adapt_goal(parsed_query.goal, adapt_builtins=self.adapt_builtins)
         outputs = tuple(parsed_query.variables.values())
         proof_states = solve_from(self.vm.assembled_program(), goal, self.state)
@@ -302,6 +306,7 @@ def create_prolog_vm_runtime(
     initialize: bool = True,
     operator_table: OperatorTable | None = None,
     adapt_builtins: bool = True,
+    query_rewriter: Callable[[ParsedQuery], ParsedQuery] | None = None,
 ) -> PrologVMRuntime:
     """Create a stateful ad-hoc query runtime from a compiled program."""
 
@@ -312,6 +317,7 @@ def create_prolog_vm_runtime(
         state=State(),
         operator_table=operator_table,
         adapt_builtins=adapt_builtins,
+        query_rewriter=query_rewriter,
     )
     if initialize:
         runtime.run_initializations()
@@ -361,6 +367,7 @@ def create_swi_prolog_file_runtime(
 
 def create_swi_prolog_project_runtime(
     *sources: str,
+    query_module: str | Symbol | None = None,
     initialize: bool = True,
     adapt_builtins: bool = True,
 ) -> PrologVMRuntime:
@@ -375,12 +382,18 @@ def create_swi_prolog_project_runtime(
         initialize=initialize,
         operator_table=_project_operator_table(loaded_project),
         adapt_builtins=adapt_builtins,
+        query_rewriter=lambda query_value: rewrite_loaded_prolog_query(
+            loaded_project,
+            query_value,
+            module=query_module,
+        ),
     )
 
 
 def create_swi_prolog_project_file_runtime(
     *entry_paths: str | Path,
     source_resolver: SourceResolver | None = None,
+    query_module: str | Symbol | None = None,
     initialize: bool = True,
     adapt_builtins: bool = True,
 ) -> PrologVMRuntime:
@@ -398,6 +411,11 @@ def create_swi_prolog_project_file_runtime(
         initialize=initialize,
         operator_table=_project_operator_table(loaded_project),
         adapt_builtins=adapt_builtins,
+        query_rewriter=lambda query_value: rewrite_loaded_prolog_query(
+            loaded_project,
+            query_value,
+            module=query_module,
+        ),
     )
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_runtime.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_runtime.py
@@ -163,6 +163,27 @@ class TestPrologVMRuntime:
             {"Who": atom("lisa")},
         ]
 
+    def test_project_runtime_resolves_ad_hoc_queries_in_module_context(self) -> None:
+        runtime = create_swi_prolog_project_runtime(
+            """
+            :- module(family, [ancestor/2]).
+            ancestor(homer, bart).
+            ancestor(homer, lisa).
+            """,
+            """
+            :- module(app, []).
+            :- use_module(family, [ancestor/2]).
+            """,
+            query_module="app",
+        )
+
+        answers = runtime.query("ancestor(homer, Who)")
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Who": atom("bart")},
+            {"Who": atom("lisa")},
+        ]
+
     def test_project_file_runtime_answers_consulted_global_queries(
         self,
         tmp_path: Path,
@@ -178,6 +199,36 @@ class TestPrologVMRuntime:
         runtime = create_swi_prolog_project_file_runtime(app_path)
 
         assert [answer.as_dict() for answer in runtime.query("parent(homer, Who)")] == [
+            {"Who": atom("bart")},
+            {"Who": atom("lisa")},
+        ]
+
+    def test_project_file_runtime_resolves_ad_hoc_queries_in_module_context(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        family_path = tmp_path / "family.pl"
+        family_path.write_text(
+            ":- module(family, [ancestor/2]).\n"
+            "ancestor(homer, bart).\n"
+            "ancestor(homer, lisa).\n",
+            encoding="utf-8",
+        )
+        app_path = tmp_path / "app.pl"
+        app_path.write_text(
+            ":- module(app, []).\n"
+            ":- use_module(family, [ancestor/2]).\n",
+            encoding="utf-8",
+        )
+
+        runtime = create_swi_prolog_project_file_runtime(
+            app_path,
+            query_module="app",
+        )
+
+        answers = runtime.query("ancestor(homer, Who)")
+
+        assert [answer.as_dict() for answer in answers] == [
             {"Who": atom("bart")},
             {"Who": atom("lisa")},
         ]

--- a/code/specs/PR21-prolog-vm-module-query-runtime.md
+++ b/code/specs/PR21-prolog-vm-module-query-runtime.md
@@ -1,0 +1,53 @@
+# PR21: Prolog VM Module Query Runtime
+
+## Summary
+
+This batch lets stateful Prolog VM runtimes answer ad-hoc top-level queries in a
+linked module context.
+
+Before this layer, source-level `?-` queries embedded in a project were
+module-aware, but later runtime queries were parsed directly and could only
+address global predicates reliably. This adds a public loader query rewrite hook
+and threads it into the VM runtime so imported predicates resolve the same way
+they do during project linking.
+
+## Goals
+
+- expose module-aware ad-hoc query rewriting from `prolog-loader`
+- let project runtimes choose a default query module
+- resolve imported predicates for later runtime query strings
+- preserve explicit `module:goal` support through the existing rewrite path
+- keep non-project and single-file runtimes unchanged
+
+## Public API
+
+`prolog-loader` now exposes:
+
+```python
+rewrite_loaded_prolog_query(...)
+```
+
+`prolog-vm-compiler` project runtime constructors now accept:
+
+```python
+query_module="app"
+```
+
+Example:
+
+```python
+from prolog_vm_compiler import create_swi_prolog_project_file_runtime
+
+runtime = create_swi_prolog_project_file_runtime("app.pl", query_module="app")
+
+answers = runtime.query("ancestor(homer, Who)")
+```
+
+If `app.pl` imports `ancestor/2` from another module, the runtime query is
+rewritten to the linked module-qualified relation before execution.
+
+## Non-goals
+
+- REPL commands such as `consult/1` typed at the query prompt
+- dynamic runtime changes to a module's import table
+- package/library search policies beyond the existing `SourceResolver` hook


### PR DESCRIPTION
## Summary

- expose `rewrite_loaded_prolog_query(...)` from `prolog-loader` for ad-hoc module/import-aware query rewriting
- thread query rewriting into project VM runtimes with `query_module=...`
- document/spec PR21 and cover module-context ad-hoc runtime queries for in-memory and file-backed projects

## Verification

- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`