### PR TITLE
feat(prolog): support if-then VM control

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- `iftheno(...)` and `ifthenelseo(...)` now preserve rule-local variable
+  freshening when their condition and branches can be represented as callable
+  terms.
+
 ## [0.13.0] - 2026-04-22
 
 ### Added

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -1316,6 +1316,42 @@ def iftheno(condition: object, then_goal: object) -> GoalExpr:
 
     condition_goal = _as_goal(condition)
     called_then = _as_goal(then_goal)
+    condition_term = _goal_term_or_none(condition_goal)
+    then_term = _goal_term_or_none(called_then)
+
+    if condition_term is not None and then_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            condition_goal_term, then_goal_term = args
+            try:
+                called_condition = goal_from_term(
+                    _reified(condition_goal_term, state),
+                )
+            except TypeError:
+                return
+
+            condition_proofs = solve_from(program_value, called_condition, state)
+            first_condition_state = next(condition_proofs, None)
+            if first_condition_state is None:
+                return
+
+            try:
+                called_then_goal = goal_from_term(
+                    _reified(then_goal_term, first_condition_state),
+                )
+            except TypeError:
+                return
+            yield from solve_from(
+                program_value,
+                called_then_goal,
+                first_condition_state,
+            )
+
+        return native_goal(run_terms, condition_term, then_term)
 
     def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
         condition_proofs = solve_from(program_value, condition_goal, state)
@@ -1333,6 +1369,54 @@ def ifthenelseo(condition: object, then_goal: object, else_goal: object) -> Goal
     condition_goal = _as_goal(condition)
     called_then = _as_goal(then_goal)
     called_else = _as_goal(else_goal)
+    condition_term = _goal_term_or_none(condition_goal)
+    then_term = _goal_term_or_none(called_then)
+    else_term = _goal_term_or_none(called_else)
+
+    if (
+        condition_term is not None
+        and then_term is not None
+        and else_term is not None
+    ):
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            condition_goal_term, then_goal_term, else_goal_term = args
+            try:
+                called_condition = goal_from_term(
+                    _reified(condition_goal_term, state),
+                )
+            except TypeError:
+                return
+
+            condition_proofs = solve_from(program_value, called_condition, state)
+            first_condition_state = next(condition_proofs, None)
+            if first_condition_state is None:
+                try:
+                    called_else_goal = goal_from_term(
+                        _reified(else_goal_term, state),
+                    )
+                except TypeError:
+                    return
+                yield from solve_from(program_value, called_else_goal, state)
+                return
+
+            try:
+                called_then_goal = goal_from_term(
+                    _reified(then_goal_term, first_condition_state),
+                )
+            except TypeError:
+                return
+            yield from solve_from(
+                program_value,
+                called_then_goal,
+                first_condition_state,
+            )
+
+        return native_goal(run_terms, condition_term, then_term, else_term)
 
     def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
         condition_proofs = solve_from(program_value, condition_goal, state)
@@ -1343,6 +1427,13 @@ def ifthenelseo(condition: object, then_goal: object, else_goal: object) -> Goal
         yield from solve_from(program_value, called_then, first_condition_state)
 
     return native_goal(run)
+
+
+def _goal_term_or_none(goal: GoalExpr) -> Term | None:
+    try:
+        return goal_as_term(goal)
+    except TypeError:
+        return None
 
 
 def forallo(generator: object, test: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -184,6 +184,28 @@ class TestAdvancedControlBuiltins:
             ),
         ) == [atom("else")]
 
+    def test_ifthenelseo_freshens_rule_local_variables(self) -> None:
+        candidate = relation("candidate", 1)
+        chosen = relation("chosen", 1)
+        choice = var("Choice")
+        result = var("Result")
+        output = var("Output")
+
+        prog = program(
+            fact(candidate("first")),
+            fact(candidate("second")),
+            rule(
+                chosen(result),
+                ifthenelseo(
+                    candidate(choice),
+                    eq(result, choice),
+                    eq(result, "none"),
+                ),
+            ),
+        )
+
+        assert solve_all(prog, output, chosen(output)) == [atom("first")]
+
     def test_forallo_succeeds_when_every_generated_proof_passes(self) -> None:
         marker = var("Marker")
         item = var("Item")

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -7,6 +7,8 @@
   `setof/3`, and `forall/2`
 - expose `rewrite_loaded_prolog_query(...)` for ad-hoc queries that need a
   linked project's module/import context
+- adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
+  executable logic builtin layer
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -17,6 +17,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   module-local predicates and weak imports
 - rewrite explicit `module:goal` qualification during linking, including common
   meta-goal forms like `call/1`, `once/1`, `not/1`, `\\+/1`, and `phrase/2,3`
+- adapt Prolog control constructs such as `->/2` and
+  `(If -> Then ; Else)` into executable builtin goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -28,6 +28,8 @@ from logic_builtins import (
     geqo,
     groundo,
     gto,
+    ifthenelseo,
+    iftheno,
     iso,
     leqo,
     lto,
@@ -73,6 +75,7 @@ from logic_engine import (
 from prolog_core import expand_dcg_phrase
 
 _PREDICATE_INDICATOR = relation("/", 2)
+_IF_THEN = "->"
 type IndicatorBuilder = Callable[[Term, Term], GoalExpr]
 
 
@@ -88,6 +91,9 @@ def adapt_prolog_goal(goal: GoalExpr) -> GoalExpr:
     if isinstance(goal, ConjExpr):
         return conj(*(adapt_prolog_goal(child) for child in goal.goals))
     if isinstance(goal, DisjExpr):
+        if_then_else = _adapt_if_then_else(goal)
+        if if_then_else is not None:
+            return if_then_else
         return disj(*(adapt_prolog_goal(child) for child in goal.goals))
     if isinstance(goal, FreshExpr):
         return FreshExpr(
@@ -149,6 +155,8 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
             return goal
     if name == "once" and goal.relation.arity == 1:
         return onceo(_adapt_callable_goal(args[0]))
+    if name == _IF_THEN and goal.relation.arity == 2:
+        return iftheno(_adapt_callable_goal(args[0]), _adapt_callable_goal(args[1]))
     if name in {"not", "\\+"} and goal.relation.arity == 1:
         return noto(_adapt_callable_goal(args[0]))
     if name == "findall" and goal.relation.arity == 3:
@@ -203,6 +211,24 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return goal if property_goal is None else property_goal
 
     return goal
+
+
+def _adapt_if_then_else(goal: DisjExpr) -> GoalExpr | None:
+    if len(goal.goals) != 2:
+        return None
+    condition_then, else_goal = goal.goals
+    if (
+        not isinstance(condition_then, RelationCall)
+        or condition_then.relation.symbol.name != _IF_THEN
+        or condition_then.relation.arity != 2
+    ):
+        return None
+    condition, then_goal = condition_then.args
+    return ifthenelseo(
+        _adapt_callable_goal(condition),
+        _adapt_callable_goal(then_goal),
+        adapt_prolog_goal(else_goal),
+    )
 
 
 def _adapt_callable_goal(term_value: Term) -> GoalExpr:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -19,6 +19,7 @@ from logic_engine import (
     disj,
     eq,
     fresh,
+    program,
     reify,
     relation,
     solve_all,
@@ -742,6 +743,7 @@ class TestPrologGoalAdapter:
                 atom("[]"),
             ),
             relation("once", 1)(term("memo", atom("ok"))),
+            relation("->", 2)(term("memo", atom("ok")), term("memo", atom("then"))),
             relation("not", 1)(term("memo", atom("missing"))),
             relation("\\+", 1)(term("memo", atom("missing"))),
             relation("functor", 3)(term("memo", atom("ok")), atom("memo"), 1),
@@ -837,6 +839,32 @@ class TestPrologGoalAdapter:
         assert isinstance(adapted, ConjExpr)
         assert isinstance(adapted.goals[1], DisjExpr)
         assert isinstance(adapted.goals[2], FreshExpr)
+
+    def test_adapt_prolog_goal_rewrites_if_then_else_control(self) -> None:
+        parsed = parse_swi_query(
+            "?- ((X = first ; X = second) -> Result = X ; Result = none).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            parsed.variables["Result"],
+            adapted,
+        ) == [atom("first")]
+
+    def test_adapt_prolog_goal_uses_else_branch_from_original_state(self) -> None:
+        parsed = parse_swi_query(
+            "?- (fail -> Result = then ; Result = else).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            parsed.variables["Result"],
+            adapted,
+        ) == [atom("else")]
 
     def test_adapt_prolog_goal_preserves_unsupported_shapes(self) -> None:
         variable_indicator = LogicVar(id=1)

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -13,6 +13,8 @@
   linked project file graphs through `prolog-loader`.
 - Add module-aware ad-hoc query rewriting for project runtimes via
   `query_module=...`.
+- Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
+  VM path with committed condition semantics.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -102,6 +102,28 @@ class TestPrologVMStress:
             {"Chosen": atom("first")},
         ]
 
+    def test_if_then_else_commits_to_first_condition_solution(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            candidate(first).
+            candidate(second).
+
+            chosen(Value) :-
+                (candidate(Candidate) -> Value = Candidate ; Value = none).
+
+            fallback(Value) :-
+                (missing(Candidate) -> Value = Candidate ; Value = none).
+
+            ?- chosen(Chosen), fallback(Fallback).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Chosen": atom("first"), "Fallback": atom("none")},
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR22-prolog-vm-if-then-runtime.md
+++ b/code/specs/PR22-prolog-vm-if-then-runtime.md
@@ -1,0 +1,48 @@
+# PR22: Prolog VM If-Then Runtime
+
+## Summary
+
+This batch connects parsed Prolog if-then control constructs to the executable
+Logic VM path.
+
+The logic builtin layer already had `iftheno(...)` and `ifthenelseo(...)`.
+This layer teaches the Prolog loader adapter to map source-level `->/2` and
+`(If -> Then ; Else)` into those builtins, then verifies the compiled VM path
+preserves committed condition semantics.
+
+## Goals
+
+- adapt `If -> Then` into `iftheno(...)`
+- adapt `If -> Then ; Else` into `ifthenelseo(...)`
+- commit to the first proof of `If`
+- keep `Then` branch backtracking after the committed condition proof
+- run `Else` from the original state when `If` fails
+- preserve rule-local variable freshening for callable condition and branch
+  terms
+
+## Example
+
+```prolog
+candidate(first).
+candidate(second).
+
+chosen(Value) :-
+    (candidate(Candidate) -> Value = Candidate ; Value = none).
+
+?- chosen(Chosen).
+```
+
+The VM should return only:
+
+```prolog
+Chosen = first
+```
+
+The condition commits to the first `candidate/1` proof, so `second` is not
+explored and the `else` branch is not run.
+
+## Non-goals
+
+- soft-cut `*->/2`
+- catch/throw exception control
+- full ISO top-level tracing/debugging semantics


### PR DESCRIPTION
## Summary

- adapt Prolog `->/2` and `(If -> Then ; Else)` into executable control builtins
- make `iftheno(...)` / `ifthenelseo(...)` preserve rule-local variable freshening for callable subgoals
- add PR22 spec plus builtin, loader, and Prolog VM stress coverage for committed condition semantics

## Verification

- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-builtins`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`