### PR TITLE
feat(prolog): adapt list stdlib predicates

### DIFF
--- a/code/packages/python/prolog-loader/BUILD
+++ b/code/packages/python/prolog-loader/BUILD
@@ -1,4 +1,4 @@
 uv venv --quiet --clear
-uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ".[dev]" --quiet
+uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ../logic-stdlib -e ".[dev]" --quiet
 .venv/bin/python -c "import pathlib, platform; [p.unlink() for p in pathlib.Path('.venv/lib').glob('python*/site-packages/coverage/tracer*.so')] if platform.system() == 'Darwin' else None"
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -9,6 +9,9 @@
   linked project's module/import context
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
   executable logic builtin layer
+- adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
+  `permutation/2`, `reverse/2`, `last/2`, and `is_list/1`) into the relational
+  standard library
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -19,6 +19,9 @@ It keeps parsing side-effect free, then exposes helpers to:
   meta-goal forms like `call/1`, `once/1`, `not/1`, `\\+/1`, and `phrase/2,3`
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
+- adapt common list predicates such as `member/2`, `append/3`, `select/3`,
+  `permutation/2`, `reverse/2`, `last/2`, and `is_list/1` into relational
+  standard-library goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
     "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
+    "coding-adventures-logic-stdlib>=0.4.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",
     "coding-adventures-swi-prolog-parser>=0.1.0",
@@ -37,6 +38,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 [project.optional-dependencies]
 dev = [
     "coding-adventures-logic-builtins>=0.13.0",
+    "coding-adventures-logic-stdlib>=0.4.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",
@@ -47,6 +49,7 @@ dev = [
 coding-adventures-iso-prolog-parser = { path = "../iso-prolog-parser", editable = true }
 coding-adventures-logic-builtins = { path = "../logic-builtins", editable = true }
 coding-adventures-logic-engine = { path = "../logic-engine", editable = true }
+coding-adventures-logic-stdlib = { path = "../logic-stdlib", editable = true }
 coding-adventures-prolog-core = { path = "../prolog-core", editable = true }
 coding-adventures-prolog-parser = { path = "../prolog-parser", editable = true }
 coding-adventures-swi-prolog-parser = { path = "../swi-prolog-parser", editable = true }

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -72,6 +72,7 @@ from logic_engine import (
     relation,
     term,
 )
+from logic_stdlib import appendo, lasto, listo, membero, permuteo, reverseo, selecto
 from prolog_core import expand_dcg_phrase
 
 _PREDICATE_INDICATOR = relation("/", 2)
@@ -129,6 +130,12 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     if goal.relation.arity == 1 and name in unary_term_builtins:
         return unary_term_builtins[name](args[0])
 
+    unary_list_builtins: dict[str, Callable[[object], GoalExpr]] = {
+        "is_list": listo,
+    }
+    if goal.relation.arity == 1 and name in unary_list_builtins:
+        return unary_list_builtins[name](args[0])
+
     binary_arithmetic_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
         "is": iso,
         "=:=": numeqo,
@@ -140,6 +147,22 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     }
     if goal.relation.arity == 2 and name in binary_arithmetic_builtins:
         return binary_arithmetic_builtins[name](args[0], args[1])
+
+    binary_list_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
+        "last": lasto,
+        "member": membero,
+        "permutation": permuteo,
+        "reverse": reverseo,
+    }
+    if goal.relation.arity == 2 and name in binary_list_builtins:
+        return binary_list_builtins[name](args[0], args[1])
+
+    ternary_list_builtins: dict[str, Callable[[object, object, object], GoalExpr]] = {
+        "append": appendo,
+        "select": selecto,
+    }
+    if goal.relation.arity == 3 and name in ternary_list_builtins:
+        return ternary_list_builtins[name](*args)
 
     if name == "call" and goal.relation.arity == 1:
         return _adapt_callable_goal(args[0])

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -19,6 +19,7 @@ from logic_engine import (
     disj,
     eq,
     fresh,
+    logic_list,
     program,
     reify,
     relation,
@@ -794,6 +795,35 @@ class TestPrologGoalAdapter:
             relation("setof", 3)(atom("ok"), term("memo", atom("ok")), LogicVar(id=13)),
             relation("forall", 2)(term("memo", atom("ok")), term("memo", atom("ok"))),
             relation("copy_term", 2)(term("box", LogicVar(id=15)), LogicVar(id=14)),
+            relation("is_list", 1)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+            ),
+            relation("last", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                atom("cake"),
+            ),
+            relation("member", 2)(
+                atom("tea"),
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+            ),
+            relation("permutation", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=16),
+            ),
+            relation("reverse", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=17),
+            ),
+            relation("append", 3)(
+                term(".", atom("tea"), atom("[]")),
+                term(".", atom("cake"), atom("[]")),
+                LogicVar(id=18),
+            ),
+            relation("select", 3)(
+                atom("tea"),
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=19),
+            ),
         ],
     )
     def test_adapt_prolog_goal_rewrites_supported_relation_calls(
@@ -865,6 +895,36 @@ class TestPrologGoalAdapter:
             parsed.variables["Result"],
             adapted,
         ) == [atom("else")]
+
+    def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:
+        parsed = parse_swi_query(
+            "?- member(Item, [tea, cake]), "
+            "append([Item], [jam], Combined), "
+            "reverse(Combined, Reversed).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            (
+                parsed.variables["Item"],
+                parsed.variables["Combined"],
+                parsed.variables["Reversed"],
+            ),
+            adapted,
+        ) == [
+            (
+                atom("tea"),
+                logic_list(["tea", "jam"]),
+                logic_list(["jam", "tea"]),
+            ),
+            (
+                atom("cake"),
+                logic_list(["cake", "jam"]),
+                logic_list(["jam", "cake"]),
+            ),
+        ]
 
     def test_adapt_prolog_goal_preserves_unsupported_shapes(self) -> None:
         variable_indicator = LogicVar(id=1)

--- a/code/packages/python/prolog-vm-compiler/BUILD
+++ b/code/packages/python/prolog-vm-compiler/BUILD
@@ -1,4 +1,4 @@
 uv venv --quiet --clear
-uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ../logic-instructions -e ../logic-vm -e ../prolog-loader -e ".[dev]" --quiet
+uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ../lexer -e ../parser -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../prolog-core -e ../prolog-lexer -e ../iso-prolog-lexer -e ../swi-prolog-lexer -e ../prolog-parser -e ../prolog-operator-parser -e ../iso-prolog-parser -e ../swi-prolog-parser -e ../logic-builtins -e ../logic-stdlib -e ../logic-instructions -e ../logic-vm -e ../prolog-loader -e ".[dev]" --quiet
 .venv/bin/python -c "import pathlib, platform; [p.unlink() for p in pathlib.Path('.venv/lib').glob('python*/site-packages/coverage/tracer*.so')] if platform.system() == 'Darwin' else None"
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -15,6 +15,8 @@
   `query_module=...`.
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
+- Run common Prolog list predicates through the VM path by adapting them to
+  `logic-stdlib` relations.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -124,6 +124,33 @@ class TestPrologVMStress:
             {"Chosen": atom("first"), "Fallback": atom("none")},
         ]
 
+    def test_list_stdlib_predicates_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- member(Item, [tea, cake]),
+               append([Item], [jam], Combined),
+               reverse(Combined, Reversed),
+               select(Item, [tea, cake, jam], Remainder).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {
+                "Item": atom("tea"),
+                "Combined": logic_list(["tea", "jam"]),
+                "Reversed": logic_list(["jam", "tea"]),
+                "Remainder": logic_list(["cake", "jam"]),
+            },
+            {
+                "Item": atom("cake"),
+                "Combined": logic_list(["cake", "jam"]),
+                "Reversed": logic_list(["jam", "cake"]),
+                "Remainder": logic_list(["tea", "jam"]),
+            },
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR23-prolog-vm-list-stdlib.md
+++ b/code/specs/PR23-prolog-vm-list-stdlib.md
@@ -1,0 +1,51 @@
+# PR23: Prolog VM List Stdlib
+
+## Summary
+
+This batch connects common Prolog list predicates to the existing relational
+standard library when source is loaded for the Logic VM path.
+
+The Python library already has reusable list relations such as `membero`,
+`appendo`, `selecto`, `permuteo`, and `reverseo`. This layer makes ordinary
+Prolog source call those relations through familiar predicate names.
+
+## Goals
+
+- adapt `is_list/1` to `listo`
+- adapt `last/2` to `lasto`
+- adapt `member/2` to `membero`
+- adapt `permutation/2` to `permuteo`
+- adapt `reverse/2` to `reverseo`
+- adapt `append/3` to `appendo`
+- adapt `select/3` to `selecto`
+- verify the adapted predicates compose through compiled VM source queries
+
+## Example
+
+```prolog
+?- member(Item, [tea, cake]),
+   append([Item], [jam], Combined),
+   reverse(Combined, Reversed),
+   select(Item, [tea, cake, jam], Remainder).
+```
+
+Expected VM answers:
+
+```prolog
+Item = tea,
+Combined = [tea, jam],
+Reversed = [jam, tea],
+Remainder = [cake, jam].
+
+Item = cake,
+Combined = [cake, jam],
+Reversed = [jam, cake],
+Remainder = [tea, jam].
+```
+
+## Non-goals
+
+- full SWI `library(lists)` parity
+- `length/2`, which still needs a good finite-domain/natural-number story for
+  relational generation
+- higher-order list predicates such as `maplist/N`


### PR DESCRIPTION
## Summary

- adapt common Prolog list predicates to existing `logic-stdlib` relations
- add `logic-stdlib` as a `prolog-loader` dependency/source
- document/spec PR23 and add loader plus VM stress coverage for `member/2`, `append/3`, `reverse/2`, and `select/3`

## Verification

- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`