### PR TITLE
Promote ALGOL real procedure returns

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -60,6 +60,12 @@ All notable changes to this package will be documented in this file.
   the array descriptor, bounds metadata, and element storage at procedure entry.
 - Stored label, switch, and procedure formals as copied ids or descriptor
   pointers at procedure entry even when they are declared in `value` mode.
+- Allowed real-valued formal procedure dispatchers to accept integer-returning
+  procedure actuals and promote their result through the existing real coercion
+  path.
+- Emitted real-returning procedures, eval thunks, and procedure-parameter
+  dispatchers through the WASM backend's dedicated f64 result register so they
+  can also call integer-returning procedures safely.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -13,7 +13,9 @@ returns it.
 Value-only integer procedures lower to generated `_fn_algol_...` functions.
 Calls pass an explicit static link followed by value arguments, procedure frames
 are allocated from the module frame stack, and typed procedures return through
-their procedure-name result slot.
+their procedure-name result slot. Integer and boolean procedure results flow
+through `v1`; real procedure results flow through the WASM backend's dedicated
+f64 result register, `v31`.
 Parameterless typed procedures can also be used by bare name in expression
 positions, following ALGOL's omitted-parentheses call syntax; read-only by-name
 actuals of that form lower through eval thunks so each formal read re-runs the
@@ -59,8 +61,9 @@ paths also cover `value` formals. Procedure formals pass descriptor closures
 containing the callee procedure id and static link; formal calls dispatch
 through generated helpers for statement calls and typed expression calls with
 scalar value arguments, so forwarded procedure formals keep the original
-environment in value or by-name mode. Full ALGOL forms such as escaping thunk
-descriptors remain future work.
+environment in value or by-name mode. Real-valued formal procedure calls can
+accept integer-returning actual procedures and promote the dispatched result.
+Full ALGOL forms such as escaping thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -4046,7 +4046,11 @@ class AlgolIrCompiler:
                 )
             else:
                 value = self._compile_expr(thunk.expression, thunk_scope)
-            self._copy_scalar_reg(type_name=thunk.type_name, dst=_RESULT_REG, src=value)
+            self._copy_scalar_reg(
+                type_name=thunk.type_name,
+                dst=self._result_reg_for_type(thunk.type_name),
+                src=value,
+            )
             self._emit_leave_thunk_helper()
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
@@ -4277,7 +4281,7 @@ class AlgolIrCompiler:
                 )
                 self._copy_scalar_reg(
                     type_name=return_type,
-                    dst=_RESULT_REG,
+                    dst=self._result_reg_for_type(return_type),
                     src=result_value,
                 )
             self._emit(IrOp.RET)
@@ -4410,7 +4414,11 @@ class AlgolIrCompiler:
                 raise CompileError(
                     f"procedure {procedure.name!r} has no result slot"
                 )
-            self._emit_load_symbol(result_symbol, scope, _RESULT_REG)
+            self._emit_load_symbol(
+                result_symbol,
+                scope,
+                self._result_reg_for_type(procedure.return_type),
+            )
         else:
             self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit_leave_frame(scope)
@@ -5326,11 +5334,14 @@ class AlgolIrCompiler:
         if self.current_function_return_type == _REAL_TYPE:
             self._emit(
                 IrOp.LOAD_F64_IMM,
-                IrRegister(_RESULT_REG),
+                IrRegister(_REAL_RESULT_REG),
                 IrFloatImmediate(0.0),
             )
             return
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+
+    def _result_reg_for_type(self, type_name: str | None) -> int:
+        return _REAL_RESULT_REG if type_name == _REAL_TYPE else _RESULT_REG
 
     def _emit_stack_overflow_guard(self, overflow_reg: int) -> None:
         index = self.if_count
@@ -5974,4 +5985,6 @@ def _procedure_return_type_satisfies(
 ) -> bool:
     if actual_type is None:
         return False
+    if expected_type == _REAL_TYPE and actual_type == _INTEGER_TYPE:
+        return True
     return expected_type == actual_type

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -891,6 +891,25 @@ class TestAlgolIrCompiler:
         assert signature.param_types == ("integer", "integer", "integer")
         assert signature.return_type == "real"
 
+    def test_compiles_integer_return_actual_for_real_procedure_parameter(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "procedure invoke(f); real f; procedure f; "
+                "begin y := f(2); if y = 4.0 then result := 1 else result := 0 end; "
+                "integer procedure twice(x); value x; integer x; "
+                "begin twice := x * 2 end; "
+                "invoke(twice) "
+                "end"
+            )
+        )
+        signature = result.procedure_signatures[
+            "_fn_algol_call_procedure_f64_result_i32"
+        ]
+
+        assert signature.param_types == ("integer", "integer", "integer")
+        assert signature.return_type == "real"
+
     def test_compiles_value_typed_procedure_parameter_expression_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this package will be documented in this file.
 - Treated builtin `print`/`output` calls as read-only during by-name formal
   write analysis, so expression actuals remain valid when a formal is only
   printed.
+- Accepted integer-returning procedure actuals for real-valued formal
+  procedure parameters, matching scalar integer-to-real promotion.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -53,7 +53,9 @@ the semantic model, while later lowering packages now implement scalar
 call-by-name, typed whole-array formals, label formals, switch formals, and
 no-argument statement procedure formals. `value` whole-array parameters are
 also accepted and lowered as copy formals, while `value` label, switch, and
-procedure formals use copied ids or descriptors. The checker keeps guarding the
+procedure formals use copied ids or descriptors. Real-valued formal procedure
+parameters accept integer-returning procedure actuals via the same numeric
+promotion rule used by scalar calls. The checker keeps guarding the
 remaining full-ALGOL gaps, including non-assignable actuals passed to written
 by-name formals and procedure-valued actuals whose parameters are not scalar
 value parameters.

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2344,6 +2344,8 @@ class AlgolTypeChecker:
         expected_type: str,
         actual_type: str,
     ) -> bool:
+        if expected_type == REAL and actual_type == INTEGER:
+            return True
         return expected_type == actual_type
 
     def _resolve_builtin_procedure(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -879,6 +879,26 @@ class TestAlgolTypeChecker:
         assert parameter.type_name == "real"
         assert parameter.procedure_call_shapes[0].return_type == "real"
 
+    def test_accepts_integer_procedure_actual_for_real_procedure_parameter(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 4.0 then result := 1 else result := 0 end; "
+            "integer procedure twice(x); value x; integer x; "
+            "begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.type_name == "real"
+        assert parameter.procedure_call_shapes[0].return_type == "real"
+
     def test_rejects_procedure_parameter_actual_with_mismatched_arity(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -56,6 +56,11 @@ All notable changes to this package will be documented in this file.
   element copies so assignments inside the procedure do not alias the caller.
 - Executed `value` label, switch, and procedure formals through the same copied
   label-id and descriptor paths as their by-name counterparts.
+- Executed real-valued formal procedure calls with integer-returning procedure
+  actuals by promoting the dispatched result to real before storing it.
+- Executed real-returning procedures that call integer-returning procedures by
+  keeping integer call results and real function returns in separate WASM
+  virtual registers.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -703,6 +703,31 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
 
+    def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 4.0 then result := 1 else result := 0 end; "
+            "integer procedure twice(x); value x; integer x; "
+            "begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_real_procedure_can_call_integer_procedure(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "integer procedure twice(x); value x; integer x; "
+            "begin twice := x * 2 end; "
+            "real procedure wrap(x); value x; integer x; "
+            "begin wrap := twice(x) end; "
+            "y := wrap(2); "
+            "if y = 4.0 then result := 1 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
     def test_value_typed_procedure_parameter_expression_call_returns_real(self) -> None:
         result = compile_source(
             "begin integer result; real y; "

--- a/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
@@ -70,6 +70,8 @@ round-trip, export check.
   convention.
 - Function signatures can require explicit call operands for generated callers
   that must not fall back to the legacy v2, v3, ... convention.
+- F64-returning functions now return through the dedicated f64 scratch register
+  so real results no longer conflict with integer call results in `v1`.
 
 ## [0.5.0] — 2026-04-20
 

--- a/code/packages/python/ir-to-wasm-compiler/README.md
+++ b/code/packages/python/ir-to-wasm-compiler/README.md
@@ -23,3 +23,9 @@ module = IrToWasmCompiler().compile(
     ],
 )
 ```
+
+## Register Conventions
+
+Generated functions return `i32` values through virtual register `v1` and
+`f64` values through virtual register `v31`. Calls mirror the same convention:
+integer results are copied into `v1`, while real results are copied into `v31`.

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -899,8 +899,9 @@ class _FunctionLowerer:
                     )
                     self._emit_local_set(result_reg)
             case IrOp.RET | IrOp.HALT:
-                if self.function.signature.wasm_result_types:
-                    self._emit_local_get(_REG_SCRATCH)
+                result_reg = _function_result_register(self.function.signature)
+                if result_reg is not None:
+                    self._emit_local_get(result_reg)
                 self._emit_opcode("return")
             case IrOp.NOP:
                 self._emit_opcode("nop")
@@ -1085,7 +1086,7 @@ class _DispatchLoopLowerer(_FunctionLowerer):
             end
           end loop                           ← falls through on out-of-range $pc
         end block
-        local.get _REG_SCRATCH              ← function return value
+        local.get function result register  ← function return value
         end function
 
     br depth table (from inside block $seg_N):
@@ -1127,8 +1128,9 @@ class _DispatchLoopLowerer(_FunctionLowerer):
         self._emit_opcode("end")
 
         # Function return value (HALT via br 2 lands here)
-        if self.function.signature.wasm_result_types:
-            self._emit_local_get(_REG_SCRATCH)
+        result_reg = _function_result_register(self.function.signature)
+        if result_reg is not None:
+            self._emit_local_get(result_reg)
         self._emit_opcode("end")
 
         return FunctionBody(
@@ -1300,6 +1302,7 @@ def _make_function_ir(
         [
             1,
             _REG_VAR_BASE + max(signature.param_count - 1, 0),
+            _function_result_register(signature) or 1,
             _REG_F64_SCRATCH if _needs_f64_scratch(instructions, signatures) else 1,
         ]
         + [
@@ -1398,6 +1401,16 @@ _REG_F64_SCRATCH = 31
 _REG_VAR_BASE = 2
 
 
+def _function_result_register(signature: FunctionSignature) -> int | None:
+    if not signature.wasm_result_types:
+        return None
+    return (
+        _REG_F64_SCRATCH
+        if signature.wasm_result_types[0] == ValueType.F64
+        else _REG_SCRATCH
+    )
+
+
 def _infer_register_types(
     *,
     instructions: list[IrInstruction],
@@ -1415,10 +1428,11 @@ def _infer_register_types(
             f"{signature.label} param {param_index}",
         )
 
-    if signature.wasm_result_types:
+    result_reg = _function_result_register(signature)
+    if result_reg is not None:
         _assign_register_type(
             reg_types,
-            _REG_SCRATCH,
+            result_reg,
             signature.wasm_result_types[0],
             f"{signature.label} result",
         )

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -156,7 +156,7 @@ def test_compile_f64_function_with_typed_signature() -> None:
     program.add_instruction(
         IrInstruction(
             IrOp.F64_ADD,
-            [IrRegister(1), IrRegister(2), IrRegister(3)],
+            [IrRegister(31), IrRegister(2), IrRegister(3)],
             id=gen.next(),
         )
     )
@@ -176,6 +176,54 @@ def test_compile_f64_function_with_typed_signature() -> None:
     )
 
     assert _runtime_result(module, "add_real", [1.25, 2.5]) == [3.75]
+
+
+def test_compile_f64_function_can_call_i32_function() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_real_from_double")
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [IrLabel("_fn_real_from_double")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(7)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.CALL, [IrLabel("_fn_double")], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.F64_FROM_I32,
+            [IrRegister(31), IrRegister(1)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [IrLabel("_fn_double")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.ADD,
+            [IrRegister(1), IrRegister(2), IrRegister(2)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_real_from_double",
+                param_count=0,
+                export_name="real_from_double",
+                result_types=(ValueType.F64,),
+            ),
+            FunctionSignature(label="_fn_double", param_count=1),
+        ],
+    )
+
+    assert _runtime_result(module, "real_from_double", []) == [14.0]
 
 
 def test_compile_f64_memory_load_store() -> None:
@@ -206,7 +254,7 @@ def test_compile_f64_memory_load_store() -> None:
     program.add_instruction(
         IrInstruction(
             IrOp.LOAD_F64,
-            [IrRegister(1), IrRegister(2), IrRegister(3)],
+            [IrRegister(31), IrRegister(2), IrRegister(3)],
             id=gen.next(),
         )
     )


### PR DESCRIPTION
## Summary
- allow integer-returning procedure actuals where a real-valued formal procedure is expected
- make IR-to-WASM f64-returning functions use the dedicated f64 result register so integer call results in v1 no longer conflict with real returns
- update ALGOL real-returning procedures, eval thunks, and procedure-parameter dispatchers to write results through the same f64 return convention
- add typechecker, IR, generic WASM lowering, and ALGOL WASM regressions

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/ir-to-wasm-compiler/tests -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- Reviewed added diff for subprocess/shell execution, unsafe eval/exec, network/file permission changes, deserialization, and secrets handling. No new risky operations introduced.
- Note: broad ruff over `ir-to-wasm-compiler` still reports pre-existing lint debt outside this change; the package test suite passes.