### PR TITLE
Allow ALGOL programs without result

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -66,6 +66,8 @@ All notable changes to this package will be documented in this file.
 - Emitted real-returning procedures, eval thunks, and procedure-parameter
   dispatchers through the WASM backend's dedicated f64 result register so they
   can also call integer-returning procedures safely.
+- Allowed top-level ALGOL programs without a root integer `result` scalar to
+  compile by returning `0` from the WASM `_start` wrapper.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -6,9 +6,10 @@ The compiler accepts a checked ALGOL AST and emits `compiler_ir.IrProgram`
 instructions that the existing structured IR-to-WASM lowerer can consume.
 The outermost ALGOL block becomes `_start`. Integer variables live in planned
 activation-frame slots, and scalar reads/writes lower to `LOAD_WORD` and
-`STORE_WORD` through the semantic model's static-link metadata. The variable
-named `result` is loaded into `v1` before `HALT` so the generated WASM function
-returns it.
+`STORE_WORD` through the semantic model's static-link metadata. If the root
+block declares an integer scalar named `result`, it is loaded into `v1` before
+`HALT` so the generated WASM function returns it; otherwise `_start` returns
+`0`.
 
 Value-only integer procedures lower to generated `_fn_algol_...` functions.
 Calls pass an explicit static link followed by value arguments, procedure frames

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -499,12 +499,7 @@ class AlgolIrCompiler:
         self.current_function_return_type = _INTEGER_TYPE
         root_scope = self._compile_block(block, parent=None)
 
-        result_symbol = root_scope.semantic_block.scope.symbols.get("result")
-        if result_symbol is None:
-            raise CompileError(
-                "compiled ALGOL programs must declare integer variable 'result'"
-            )
-        self._emit_load_symbol(result_symbol, root_scope, _RESULT_REG)
+        self._emit_program_result(root_scope)
         self._emit(IrOp.HALT)
         self._compile_procedures(type_result.semantic.procedures)
         if self.has_by_name_parameters:
@@ -5109,6 +5104,17 @@ class AlgolIrCompiler:
             IrRegister(scope.frame_base_reg),
             IrRegister(offset_reg),
         )
+
+    def _emit_program_result(self, scope: _FrameScope) -> None:
+        result_symbol = scope.semantic_block.scope.symbols.get("result")
+        if (
+            result_symbol is not None
+            and result_symbol.kind == "scalar"
+            and result_symbol.type_name == _INTEGER_TYPE
+        ):
+            self._emit_load_symbol(result_symbol, scope, _RESULT_REG)
+            return
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
 
     def _emit_load_scalar(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -3,7 +3,7 @@
 import pytest
 from algol_parser import parse_algol
 from algol_type_checker import FRAME_WORD_SIZE, FrameSlot, check_algol
-from compiler_ir import IrOp
+from compiler_ir import IrImmediate, IrOp, IrRegister
 from lang_parser import ASTNode
 
 from algol_ir_compiler import CompileError, __version__, compile_algol
@@ -1181,9 +1181,29 @@ class TestAlgolIrCompiler:
         with pytest.raises(CompileError, match="must contain a block"):
             compile_algol(ASTNode("program", []))
 
-    def test_raises_for_missing_result_variable(self) -> None:
-        with pytest.raises(CompileError, match="result"):
-            compile_algol(parse_algol("begin integer x; x := 1 end"))
+    def test_compiles_without_result_variable(self) -> None:
+        result = compile_algol(parse_algol("begin integer x; x := 1 end"))
+        halt_index = next(
+            index
+            for index, instruction in enumerate(result.program.instructions)
+            if instruction.opcode == IrOp.HALT
+        )
+
+        fallback = result.program.instructions[halt_index - 1]
+        assert fallback.opcode == IrOp.LOAD_IMM
+        assert fallback.operands == [IrRegister(1), IrImmediate(0)]
+
+    def test_non_integer_result_name_does_not_drive_program_return(self) -> None:
+        result = compile_algol(parse_algol("begin real result; result := 2.5 end"))
+        halt_index = next(
+            index
+            for index, instruction in enumerate(result.program.instructions)
+            if instruction.opcode == IrOp.HALT
+        )
+
+        fallback = result.program.instructions[halt_index - 1]
+        assert fallback.opcode == IrOp.LOAD_IMM
+        assert fallback.operands == [IrRegister(1), IrImmediate(0)]
 
     def test_compiles_integer_exponentiation_loop(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to this package will be documented in this file.
 - Executed real-returning procedures that call integer-returning procedures by
   keeping integer call results and real function returns in separate WASM
   virtual registers.
+- Compiled top-level ALGOL programs without a root integer `result` scalar by
+  returning `0` from the WASM `_start` wrapper while preserving the existing
+  integer `result` return convention when present.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -8,9 +8,10 @@ This package is the orchestration layer for the first ALGOL 60 compiled lane:
 ALGOL source -> parse -> type-check -> IR -> WASM module -> WASM bytes
 ```
 
-Programs still declare an integer variable named `result`; `_start` returns
-that value after the outer block finishes. Within that shape, the current lane
-already supports a substantial ALGOL 60 surface:
+When the root block declares an integer scalar named `result`, `_start` returns
+that value after the outer block finishes. Programs without that compatibility
+variable now compile normally and return `0` from `_start`. Within that shape,
+the current lane already supports a substantial ALGOL 60 surface:
 
 - nested blocks and nested procedures with lexical access through static links
 - `integer`, `boolean`, `real`, and `string` scalar values
@@ -42,6 +43,12 @@ from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
 compiled = compile_source("begin integer result; result := 7 end")
 assert WasmRuntime().load_and_run(compiled.binary, "_start", []) == [7]
 
+print_only = compile_source("begin print('Hi') end")
+captured_print: list[str] = []
+runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured_print.append)))
+assert runtime.load_and_run(print_only.binary, "_start", []) == [0]
+assert "".join(captured_print) == "Hi"
+
 with_array = compile_source(
     "begin integer result; integer array a[1:3]; "
     "a[2] := 9; result := a[2] end"
@@ -61,11 +68,11 @@ showcase = compile_source(
     "result := a[2] + a[3] "
     "end"
 )
-captured: list[str] = []
-runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+captured_showcase: list[str] = []
+runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured_showcase.append)))
 
 assert runtime.load_and_run(showcase.binary, "_start", []) == [12]
-assert "".join(captured) == "ALGOL 2 7.000"
+assert "".join(captured_showcase) == "ALGOL 2 7.000"
 ```
 
 ## Golden Fixtures

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -45,6 +45,22 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
+    def test_program_without_result_variable_returns_zero(self) -> None:
+        compiled = compile_source("begin print('Hi') end")
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(compiled.binary, "_start", []) == [0]
+        assert "".join(captured) == "Hi"
+
+    def test_non_integer_result_name_returns_zero(self) -> None:
+        compiled = compile_source("begin real result; result := 2.5; print(result) end")
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(compiled.binary, "_start", []) == [0]
+        assert "".join(captured) == "2.500"
+
     def test_procedure_call_expression_by_name_runs_through_eval_thunk(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- stop requiring every compiled ALGOL program to declare a root integer `result` variable
- preserve the existing compatibility convention when a root integer scalar named `result` is present
- return `0` from the WASM `_start` wrapper for print-only programs, non-integer `result` names, and other normal programs without a synthetic return slot
- document the relaxed wrapper behavior and add IR/WASM regressions

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- Reviewed added diff for subprocess/shell execution, unsafe eval/exec, network/file permission changes, deserialization, and secrets handling. No new risky operations introduced.