### PR TITLE
feat(prolog): add finite length stdlib bridge

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.5.0] - 2026-04-28
+
+### Added
+
+- finite `lengtho` relation for counting proper lists and generating known-size
+  list skeletons
+- pytest coverage for counting, validation, skeleton generation, and rejection
+  of improper lists or negative lengths
+
 ## [0.4.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -14,6 +14,7 @@ The first slice includes:
 - `heado(...)`
 - `tailo(...)`
 - `lasto(...)`
+- `lengtho(...)`
 - `listo(...)`
 - `membero(...)`
 - `appendo(...)`
@@ -25,8 +26,8 @@ The first slice includes:
 ## Quick Start
 
 ```python
-from logic_engine import atom, conj, eq, logic_list, program, solve_all, solve_n, var
-from logic_stdlib import appendo, lasto, listo, membero, permuteo, reverseo, subsequenceo
+from logic_engine import atom, conj, eq, logic_list, num, program, solve_all, solve_n, var
+from logic_stdlib import appendo, lasto, lengtho, listo, membero, permuteo, reverseo, subsequenceo
 
 X = var("X")
 Prefix = var("Prefix")
@@ -78,6 +79,12 @@ assert solve_all(
     X,
     lasto(logic_list(["tea", "cake", "jam"]), X),
 ) == [atom("jam")]
+
+assert solve_all(
+    program(),
+    X,
+    lengtho(logic_list(["tea", "cake", "jam"]), X),
+) == [num(3)]
 
 assert solve_all(
     program(),

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.4.0"
+version = "0.5.0"
 description = "Relational standard library helpers, combinators, and sequence relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
-dependencies = ["coding-adventures-logic-engine>=0.3.0"]
+dependencies = ["coding-adventures-logic-engine>=0.10.0"]
 keywords = ["logic-programming", "prolog", "kanren", "relations", "education"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -12,6 +12,7 @@ from logic_stdlib.relations import (
     emptyo,
     heado,
     lasto,
+    lengtho,
     listo,
     membero,
     permuteo,
@@ -28,6 +29,7 @@ __all__ = [
     "emptyo",
     "heado",
     "lasto",
+    "lengtho",
     "listo",
     "membero",
     "permuteo",
@@ -37,4 +39,4 @@ __all__ = [
     "tailo",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -13,7 +13,28 @@ describe relations, not one-way deterministic computations.
 
 from __future__ import annotations
 
-from logic_engine import GoalExpr, conj, defer, disj, eq, fresh, logic_list, term
+from collections.abc import Iterator
+
+from logic_engine import (
+    Atom,
+    Compound,
+    GoalExpr,
+    LogicVar,
+    Number,
+    Program,
+    State,
+    Term,
+    conj,
+    defer,
+    disj,
+    eq,
+    fresh,
+    logic_list,
+    native_goal,
+    num,
+    solve_from,
+    term,
+)
 
 __all__ = [
     "appendo",
@@ -21,6 +42,7 @@ __all__ = [
     "emptyo",
     "heado",
     "lasto",
+    "lengtho",
     "listo",
     "membero",
     "permuteo",
@@ -70,6 +92,23 @@ def lasto(items: object, last: object) -> GoalExpr:
     )
 
 
+def lengtho(items: object, length: object) -> GoalExpr:
+    """Relate a proper finite list to its length.
+
+    This intentionally covers the practical finite cases first:
+
+    - counting an already proper list
+    - validating a list against a known non-negative integer length
+    - creating a fresh list skeleton for a known non-negative integer length
+
+    When both sides are unknown, the relation fails instead of enumerating an
+    infinite stream of longer and longer lists. Full open-ended generation
+    belongs with a future CLP(FD)/fair-search story.
+    """
+
+    return native_goal(_lengtho_runner, items, length)
+
+
 def listo(value: object) -> GoalExpr:
     """Succeed exactly when ``value`` is a proper finite list.
 
@@ -89,6 +128,55 @@ def listo(value: object) -> GoalExpr:
             ),
         ),
     )
+
+
+def _lengtho_runner(
+    program_value: Program,
+    state: State,
+    args: tuple[Term, ...],
+) -> Iterator[State]:
+    items, length = args
+    walked_length = state.substitution.walk(length)
+
+    if isinstance(walked_length, Number):
+        length_value = walked_length.value
+        if not isinstance(length_value, int) or length_value < 0:
+            return
+        yield from solve_from(
+            program_value,
+            fresh(
+                length_value,
+                lambda *elements: eq(items, logic_list(list(elements))),
+            ),
+            state,
+        )
+        return
+
+    known_length = _proper_list_length(items, state)
+    if known_length is None:
+        return
+
+    yield from solve_from(program_value, eq(length, num(known_length)), state)
+
+
+def _proper_list_length(items: Term, state: State) -> int | None:
+    count = 0
+    current = state.substitution.walk(items)
+
+    while True:
+        if isinstance(current, Atom) and current.symbol.name == "[]":
+            return count
+        if (
+            isinstance(current, Compound)
+            and current.functor.name == "."
+            and len(current.args) == 2
+        ):
+            count += 1
+            current = state.substitution.walk(current.args[1])
+            continue
+        if isinstance(current, LogicVar):
+            return None
+        return None
 
 
 def membero(member: object, items: object) -> GoalExpr:

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -8,6 +8,7 @@ from logic_engine import (
     conj,
     eq,
     logic_list,
+    num,
     program,
     solve_all,
     solve_n,
@@ -21,6 +22,7 @@ from logic_stdlib import (
     emptyo,
     heado,
     lasto,
+    lengtho,
     listo,
     membero,
     permuteo,
@@ -35,9 +37,9 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.4.0"
+        assert __version__ == "0.5.0"
         engine_major, engine_minor, _engine_patch = logic_engine_version.split(".")
-        assert (int(engine_major), int(engine_minor)) >= (0, 4)
+        assert (int(engine_major), int(engine_minor)) >= (0, 10)
 
 
 class TestListRelations:
@@ -120,6 +122,56 @@ class TestListRelations:
             last,
             lasto(logic_list(["tea"]), last),
         ) == [atom("tea")]
+
+    def test_lengtho_counts_a_proper_list(self) -> None:
+        length = var("Length")
+
+        assert solve_all(
+            program(),
+            length,
+            lengtho(logic_list(["tea", "cake", "jam"]), length),
+        ) == [num(3)]
+
+    def test_lengtho_validates_a_known_non_negative_length(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                lengtho(logic_list(["tea", "cake"]), 2),
+            ),
+        ) == [atom("ok")]
+
+    def test_lengtho_creates_a_fresh_skeleton_for_known_lengths(self) -> None:
+        items = var("Items")
+
+        assert solve_all(
+            program(),
+            items,
+            conj(
+                lengtho(items, 2),
+                eq(items, logic_list(["tea", "cake"])),
+            ),
+        ) == [logic_list(["tea", "cake"])]
+
+    def test_lengtho_rejects_improper_lists_and_negative_lengths(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                lengtho(logic_list(["tea"], tail="cake"), marker),
+            ),
+        ) == []
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), lengtho(logic_list(["tea"]), -1)),
+        ) == []
 
     def test_membero_enumerates_members_of_a_concrete_list(self) -> None:
         item = var("Item")

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -10,8 +10,8 @@
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
   executable logic builtin layer
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
-  `permutation/2`, `reverse/2`, `last/2`, and `is_list/1`) into the relational
-  standard library
+  `permutation/2`, `reverse/2`, `last/2`, `length/2`, and `is_list/1`) into
+  the relational standard library
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -20,7 +20,7 @@ It keeps parsing side-effect free, then exposes helpers to:
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,
-  `permutation/2`, `reverse/2`, `last/2`, and `is_list/1` into relational
+  `permutation/2`, `reverse/2`, `last/2`, `length/2`, and `is_list/1` into relational
   standard-library goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
     "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
-    "coding-adventures-logic-stdlib>=0.4.0",
+    "coding-adventures-logic-stdlib>=0.5.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",
     "coding-adventures-swi-prolog-parser>=0.1.0",
@@ -38,7 +38,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 [project.optional-dependencies]
 dev = [
     "coding-adventures-logic-builtins>=0.13.0",
-    "coding-adventures-logic-stdlib>=0.4.0",
+    "coding-adventures-logic-stdlib>=0.5.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -72,7 +72,16 @@ from logic_engine import (
     relation,
     term,
 )
-from logic_stdlib import appendo, lasto, listo, membero, permuteo, reverseo, selecto
+from logic_stdlib import (
+    appendo,
+    lasto,
+    lengtho,
+    listo,
+    membero,
+    permuteo,
+    reverseo,
+    selecto,
+)
 from prolog_core import expand_dcg_phrase
 
 _PREDICATE_INDICATOR = relation("/", 2)
@@ -150,6 +159,7 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
 
     binary_list_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
         "last": lasto,
+        "length": lengtho,
         "member": membero,
         "permutation": permuteo,
         "reverse": reverseo,

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -20,6 +20,7 @@ from logic_engine import (
     eq,
     fresh,
     logic_list,
+    num,
     program,
     reify,
     relation,
@@ -802,6 +803,10 @@ class TestPrologGoalAdapter:
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
                 atom("cake"),
             ),
+            relation("length", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                2,
+            ),
             relation("member", 2)(
                 atom("tea"),
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
@@ -900,7 +905,8 @@ class TestPrologGoalAdapter:
         parsed = parse_swi_query(
             "?- member(Item, [tea, cake]), "
             "append([Item], [jam], Combined), "
-            "reverse(Combined, Reversed).",
+            "reverse(Combined, Reversed), "
+            "length(Reversed, Count).",
         )
 
         adapted = adapt_prolog_goal(parsed.goal)
@@ -911,6 +917,7 @@ class TestPrologGoalAdapter:
                 parsed.variables["Item"],
                 parsed.variables["Combined"],
                 parsed.variables["Reversed"],
+                parsed.variables["Count"],
             ),
             adapted,
         ) == [
@@ -918,11 +925,13 @@ class TestPrologGoalAdapter:
                 atom("tea"),
                 logic_list(["tea", "jam"]),
                 logic_list(["jam", "tea"]),
+                num(2),
             ),
             (
                 atom("cake"),
                 logic_list(["cake", "jam"]),
                 logic_list(["jam", "cake"]),
+                num(2),
             ),
         ]
 

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -15,8 +15,8 @@
   `query_module=...`.
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
-- Run common Prolog list predicates through the VM path by adapting them to
-  `logic-stdlib` relations.
+- Run common Prolog list predicates, including finite `length/2`, through the
+  VM path by adapting them to `logic-stdlib` relations.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -129,6 +129,7 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - collection predicates such as `findall/3`
+- common list predicates such as `member/2`, `append/3`, and `length/2`
 - dynamic predicates seeded by initialization directives
 - named Python answer bindings
 - loader term/goal expansion before VM compilation

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -130,7 +130,10 @@ class TestPrologVMStress:
             ?- member(Item, [tea, cake]),
                append([Item], [jam], Combined),
                reverse(Combined, Reversed),
-               select(Item, [tea, cake, jam], Remainder).
+               select(Item, [tea, cake, jam], Remainder),
+               length(Reversed, Count),
+               length(Pair, 2),
+               Pair = [left, right].
             """,
         )
 
@@ -142,12 +145,16 @@ class TestPrologVMStress:
                 "Combined": logic_list(["tea", "jam"]),
                 "Reversed": logic_list(["jam", "tea"]),
                 "Remainder": logic_list(["cake", "jam"]),
+                "Count": num(2),
+                "Pair": logic_list(["left", "right"]),
             },
             {
                 "Item": atom("cake"),
                 "Combined": logic_list(["cake", "jam"]),
                 "Reversed": logic_list(["jam", "cake"]),
                 "Remainder": logic_list(["tea", "jam"]),
+                "Count": num(2),
+                "Pair": logic_list(["left", "right"]),
             },
         ]
 

--- a/code/specs/PR24-prolog-vm-length-stdlib.md
+++ b/code/specs/PR24-prolog-vm-length-stdlib.md
@@ -1,0 +1,70 @@
+# PR24: Prolog VM Length Stdlib
+
+## Summary
+
+This batch adds finite `length/2` support to the Prolog-on-Logic-VM path by
+introducing `lengtho` in `logic-stdlib` and adapting parsed Prolog
+`length(List, Length)` calls to that relation.
+
+`length/2` is one of the most common list predicates in everyday Prolog. Adding
+it after the first list-stdlib bridge makes the VM path much more usable for
+real examples without requiring the parser or VM to grow a separate evaluator.
+
+## Goals
+
+- add `lengtho(list, length)` to the host-language relational standard library
+- count proper finite lists
+- validate a proper list against a known non-negative integer length
+- create a fresh list skeleton when the length is a known non-negative integer
+- adapt Prolog `length/2` in `prolog-loader`
+- prove `length/2` works through parsed source, loader adaptation, VM
+  compilation, and VM execution
+
+## Semantics
+
+The first implementation is deliberately finite and conservative:
+
+- `lengtho([a, b, c], N)` yields `N = 3`
+- `lengtho(List, 2)` creates a two-cell list skeleton that can unify with later
+  goals
+- improper lists fail
+- negative or non-integer lengths fail
+- `lengtho(List, N)` with both sides unknown fails instead of enumerating an
+  infinite stream of list lengths
+
+The final case is a conscious boundary. Full open-ended generation belongs with
+future CLP(FD) and fair-search work, not with the first practical list-length
+bridge.
+
+## Example
+
+```prolog
+?- member(Item, [tea, cake]),
+   append([Item], [jam], Combined),
+   reverse(Combined, Reversed),
+   length(Reversed, Count),
+   length(Pair, 2),
+   Pair = [left, right].
+```
+
+Expected VM answers:
+
+```prolog
+Item = tea,
+Combined = [tea, jam],
+Reversed = [jam, tea],
+Count = 2,
+Pair = [left, right].
+
+Item = cake,
+Combined = [cake, jam],
+Reversed = [jam, cake],
+Count = 2,
+Pair = [left, right].
+```
+
+## Non-goals
+
+- CLP(FD)-backed length domains
+- fair infinite enumeration for `length(List, N)` with both arguments unknown
+- full SWI `library(lists)` parity


### PR DESCRIPTION
## Summary

- add `lengtho` to `logic-stdlib` for finite proper-list counting, validation, and known-length skeleton generation
- adapt Prolog `length/2` through `prolog-loader` so source queries can use it on the VM path
- extend VM stress coverage and document the finite semantics in PR24

## Verification

- `bash BUILD` in `code/packages/python/logic-stdlib`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-stdlib`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `/tmp/ca-build-tool-prolog-length -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-length-build-plan.json`