### PR TITLE
Support nonlocal ALGOL switch entry labels

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -68,6 +68,10 @@ All notable changes to this package will be documented in this file.
   can also call integer-returning procedures safely.
 - Allowed top-level ALGOL programs without a root integer `result` scalar to
   compile by returning `0` from the WASM `_start` wrapper.
+- Lowered switch declaration entries that target labels in lexical parent
+  blocks through the same frame-unwind and pending-goto paths as direct gotos.
+- Tagged pending procedure-crossing label ids so label id `0` no longer
+  collides with the no-pending-goto sentinel.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -75,12 +75,12 @@ control-flow lowering handles forward, backward, and nonlocal block jumps.
 Local conditional designational expressions now lower as condition-controlled
 branch points that only evaluate the selected target. Local switch selections
 evaluate their integer index once, compare against one-based switch entries,
-and lower the chosen designational entry into the same local jump path. An
-out-of-range switch index follows the existing runtime-failure path and returns
-`0`. Switch declaration entries that select another switch remain guarded
-before IR lowering so recursive switch descriptors cannot expand without
-bound. Procedure-crossing gotos and nonlocal switch/designational forms remain
-guarded before IR generation.
+and lower the chosen designational entry into the same jump path. Switch entries
+may target labels in lexical parent blocks; those entries unwind exited frames
+or propagate pending procedure-crossing gotos just like direct designational
+gotos. An out-of-range switch index follows the existing runtime-failure path
+and returns `0`. Recursive switch self-selection remains guarded before IR
+lowering so descriptors cannot expand without bound.
 
 This phase keeps ALGOL frame memory and its 32-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -5390,9 +5390,16 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         label_reg: int,
     ) -> None:
+        tagged_label = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(tagged_label),
+            IrRegister(label_reg),
+            IrImmediate(1),
+        )
         self._store_runtime_state(
             _RUNTIME_PENDING_GOTO_LABEL_OFFSET,
-            label_reg,
+            tagged_label,
         )
         self._emit_zero_result_reg()
         if not scope.helper_failure:
@@ -5433,7 +5440,7 @@ class AlgolIrCompiler:
                 IrOp.CMP_EQ,
                 IrRegister(matches),
                 IrRegister(pending_label),
-                IrRegister(self._const_reg(label.label_id)),
+                IrRegister(self._const_reg(label.label_id + 1)),
             )
             self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(next_label))
             self._store_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, _ZERO_REG)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -423,6 +423,30 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.RET) >= 2
         assert any(label.startswith("algol_label_") for label in labels)
 
+    def test_compiles_nonlocal_switch_entry_label_with_frame_unwind(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "result := 0; "
+                "begin switch s := done; result := 5; goto s[1]; result := 99 end; "
+                "done: result := result + 2 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.CMP_EQ in opcodes
+        assert any(label.startswith("switch_0_1_next") for label in labels)
+        assert any(
+            label.startswith("algol_label_") and label.endswith("_done")
+            for label in labels
+        )
+
     def test_compiles_nested_switch_selection_entry(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to this package will be documented in this file.
   printed.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
+- Accepted switch declaration entries that target labels in lexical parent
+  blocks while continuing to reject recursive self-selection.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -39,13 +39,12 @@ accesses that preserve the static-link delta and subscript count needed by the
 IR and WASM lowering stages.
 Labels receive stable label descriptors and direct local `goto` statements
 resolve to those descriptors. Direct nonlocal block `goto` statements resolve
-to outer active blocks in the same procedure/function; jumps that cross a
-procedure boundary remain guarded. Switch declarations receive stable
-descriptors whose entries point at checked local designational expressions, and
-switch selection use sites resolve to their chosen switch symbol. Nonlocal
-switch selections and nonlocal conditional/switch designational branches remain
-guarded with targeted diagnostics. Switch entries that recursively select
-another switch are also guarded until the later dispatch-lowering phase.
+to outer active blocks, and procedure-crossing transfers resolve to pending
+label ids that later lowering can propagate through calls. Switch declarations
+receive stable descriptors whose entries point at checked designational
+expressions, including entries that target labels in lexical parent blocks, and
+switch selection use sites resolve to their chosen switch symbol. Recursive
+self-selection inside a switch entry remains guarded with a targeted diagnostic.
 
 Unsupported ALGOL 60 features are reported as diagnostics instead of being
 silently accepted by the compiled pipeline. By-name parameters are accepted in

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -743,7 +743,7 @@ class AlgolTypeChecker:
             self._check_designational(
                 entry,
                 scope,
-                allow_nonlocal_label=False,
+                allow_nonlocal_label=True,
                 allow_switch_selection=True,
                 active_switch_id=switch_id,
             )

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -206,6 +206,19 @@ class TestAlgolTypeChecker:
         assert selection.use_block_id != selection.declaration_block_id
         assert selection.lexical_depth_delta == 1
 
+    def test_accepts_switch_entry_targeting_nonlocal_label(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "begin switch s := done; goto s[1] end; "
+            "done: result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert len(result.semantic.switches) == 1
+
     def test_accepts_nested_switch_selection_entries(self) -> None:
         ast = parse_algol(
             "begin integer result, i; "

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to this package will be documented in this file.
 - Compiled top-level ALGOL programs without a root integer `result` scalar by
   returning `0` from the WASM `_start` wrapper while preserving the existing
   integer `result` return convention when present.
+- Executed switch entries that target labels in lexical parent blocks,
+  including procedure-crossing escapes to the first label in a program.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -462,6 +462,16 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_procedure_crossing_goto_can_target_first_label(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape; begin result := 4; goto done; result := 99 end; "
+            "result := 0; escape; result := 1; "
+            "done: result := result + 3 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_procedure_crossing_goto_propagates_through_intermediate_procedure(
         self,
     ) -> None:
@@ -529,6 +539,27 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_switch_entry_can_target_nonlocal_label(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "result := 0; "
+            "begin switch s := done; result := 5; goto s[1]; result := 99 end; "
+            "done: result := result + 2 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_procedure_switch_entry_can_escape_to_outer_label(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape; "
+            "begin switch s := done; result := 4; goto s[1]; result := 99 end; "
+            "result := 0; escape; result := 1; "
+            "done: result := result + 3 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
     def test_switch_entry_can_be_conditional_designational(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- allow switch declaration entries to target labels in lexical parent blocks while keeping recursive self-selection guarded
- tag pending procedure-crossing goto label ids so label id `0` no longer collides with the no-pending sentinel
- add type-checker, IR, and WASM regressions for nonlocal switch-entry labels and first-label procedure escapes

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- Reviewed added diff for subprocess/shell execution, unsafe eval/exec, network/file permission changes, deserialization, secrets handling, and permission changes. No new risky operations introduced.