### PR TITLE
feat(prolog): add finite sort stdlib bridge

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.0] - 2026-04-28
+
+### Added
+
+- finite `sorto` relation for sorting proper lists and removing duplicates
+- finite `msorto` relation for sorting proper lists while preserving duplicates
+- pytest coverage for sorted list output and improper-list rejection
+
 ## [0.5.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -17,17 +17,30 @@ The first slice includes:
 - `lengtho(...)`
 - `listo(...)`
 - `membero(...)`
+- `msorto(...)`
 - `appendo(...)`
 - `selecto(...)`
 - `permuteo(...)`
 - `subsequenceo(...)`
 - `reverseo(...)`
+- `sorto(...)`
 
 ## Quick Start
 
 ```python
 from logic_engine import atom, conj, eq, logic_list, num, program, solve_all, solve_n, var
-from logic_stdlib import appendo, lasto, lengtho, listo, membero, permuteo, reverseo, subsequenceo
+from logic_stdlib import (
+    appendo,
+    lasto,
+    lengtho,
+    listo,
+    membero,
+    msorto,
+    permuteo,
+    reverseo,
+    sorto,
+    subsequenceo,
+)
 
 X = var("X")
 Prefix = var("Prefix")
@@ -85,6 +98,18 @@ assert solve_all(
     X,
     lengtho(logic_list(["tea", "cake", "jam"]), X),
 ) == [num(3)]
+
+assert solve_all(
+    program(),
+    Order,
+    sorto(logic_list(["tea", "cake", "tea"]), Order),
+) == [logic_list(["cake", "tea"])]
+
+assert solve_all(
+    program(),
+    Order,
+    msorto(logic_list(["tea", "cake", "tea"]), Order),
+) == [logic_list(["cake", "tea", "tea"])]
 
 assert solve_all(
     program(),

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.5.0"
+version = "0.6.0"
 description = "Relational standard library helpers, combinators, and sequence relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -15,9 +15,11 @@ from logic_stdlib.relations import (
     lengtho,
     listo,
     membero,
+    msorto,
     permuteo,
     reverseo,
     selecto,
+    sorto,
     subsequenceo,
     tailo,
 )
@@ -32,11 +34,13 @@ __all__ = [
     "lengtho",
     "listo",
     "membero",
+    "msorto",
     "permuteo",
     "reverseo",
     "selecto",
+    "sorto",
     "subsequenceo",
     "tailo",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -23,6 +23,7 @@ from logic_engine import (
     Number,
     Program,
     State,
+    String,
     Term,
     conj,
     defer,
@@ -32,6 +33,7 @@ from logic_engine import (
     logic_list,
     native_goal,
     num,
+    reify,
     solve_from,
     term,
 )
@@ -48,9 +50,13 @@ __all__ = [
     "permuteo",
     "reverseo",
     "selecto",
+    "msorto",
     "subsequenceo",
+    "sorto",
     "tailo",
 ]
+
+type TermSortKey = tuple[object, ...]
 
 
 def emptyo(value: object) -> GoalExpr:
@@ -107,6 +113,23 @@ def lengtho(items: object, length: object) -> GoalExpr:
     """
 
     return native_goal(_lengtho_runner, items, length)
+
+
+def sorto(items: object, sorted_items: object) -> GoalExpr:
+    """Relate a proper finite list to its duplicate-free sorted ordering.
+
+    Sorting uses the same Prolog-inspired standard term order as the builtin
+    term comparison predicates. The input list must be proper and finite; open
+    tails fail rather than starting an unbounded search.
+    """
+
+    return native_goal(_sorto_runner, items, sorted_items)
+
+
+def msorto(items: object, sorted_items: object) -> GoalExpr:
+    """Relate a proper finite list to its sorted ordering while keeping duplicates."""
+
+    return native_goal(_msorto_runner, items, sorted_items)
 
 
 def listo(value: object) -> GoalExpr:
@@ -177,6 +200,82 @@ def _proper_list_length(items: Term, state: State) -> int | None:
         if isinstance(current, LogicVar):
             return None
         return None
+
+
+def _sorto_runner(
+    program_value: Program,
+    state: State,
+    args: tuple[Term, ...],
+) -> Iterator[State]:
+    items, sorted_items = args
+    values = _proper_list_items(items, state)
+    if values is None:
+        return
+
+    unique: dict[Term, Term] = {}
+    for value in values:
+        unique.setdefault(value, value)
+
+    sorted_values = sorted(unique.values(), key=_term_sort_key)
+    yield from solve_from(
+        program_value,
+        eq(sorted_items, logic_list(sorted_values)),
+        state,
+    )
+
+
+def _msorto_runner(
+    program_value: Program,
+    state: State,
+    args: tuple[Term, ...],
+) -> Iterator[State]:
+    items, sorted_items = args
+    values = _proper_list_items(items, state)
+    if values is None:
+        return
+
+    sorted_values = sorted(values, key=_term_sort_key)
+    yield from solve_from(
+        program_value,
+        eq(sorted_items, logic_list(sorted_values)),
+        state,
+    )
+
+
+def _proper_list_items(items: Term, state: State) -> list[Term] | None:
+    values: list[Term] = []
+    current = state.substitution.walk(items)
+
+    while True:
+        if isinstance(current, Atom) and current.symbol.name == "[]":
+            return values
+        if (
+            isinstance(current, Compound)
+            and current.functor.name == "."
+            and len(current.args) == 2
+        ):
+            values.append(reify(current.args[0], state.substitution))
+            current = state.substitution.walk(current.args[1])
+            continue
+        return None
+
+
+def _term_sort_key(term_value: Term) -> TermSortKey:
+    if isinstance(term_value, LogicVar):
+        return (0, term_value.id, str(term_value.display_name or ""))
+    if isinstance(term_value, Number):
+        return (1, term_value.value)
+    if isinstance(term_value, Atom):
+        return (2, term_value.symbol.namespace or "", term_value.symbol.name)
+    if isinstance(term_value, String):
+        return (3, term_value.value)
+    return (
+        4,
+        len(term_value.args),
+        term_value.functor.namespace or "",
+        term_value.functor.name,
+        tuple(_term_sort_key(argument) for argument in term_value.args),
+    )
 
 
 def membero(member: object, items: object) -> GoalExpr:

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -25,9 +25,11 @@ from logic_stdlib import (
     lengtho,
     listo,
     membero,
+    msorto,
     permuteo,
     reverseo,
     selecto,
+    sorto,
     subsequenceo,
     tailo,
 )
@@ -37,7 +39,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.5.0"
+        assert __version__ == "0.6.0"
         engine_major, engine_minor, _engine_patch = logic_engine_version.split(".")
         assert (int(engine_major), int(engine_minor)) >= (0, 10)
 
@@ -171,6 +173,36 @@ class TestListRelations:
             program(),
             marker,
             conj(eq(marker, "ok"), lengtho(logic_list(["tea"]), -1)),
+        ) == []
+
+    def test_sorto_sorts_a_proper_list_and_removes_duplicates(self) -> None:
+        sorted_items = var("SortedItems")
+
+        assert solve_all(
+            program(),
+            sorted_items,
+            sorto(logic_list(["tea", "cake", "tea", "jam"]), sorted_items),
+        ) == [logic_list(["cake", "jam", "tea"])]
+
+    def test_msorto_sorts_a_proper_list_and_keeps_duplicates(self) -> None:
+        sorted_items = var("SortedItems")
+
+        assert solve_all(
+            program(),
+            sorted_items,
+            msorto(logic_list([3, 1, 2, 1]), sorted_items),
+        ) == [logic_list([1, 1, 2, 3])]
+
+    def test_sorto_rejects_improper_lists(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                sorto(logic_list(["tea"], tail="cake"), var("Sorted")),
+            ),
         ) == []
 
     def test_membero_enumerates_members_of_a_concrete_list(self) -> None:

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -10,8 +10,8 @@
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
   executable logic builtin layer
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
-  `permutation/2`, `reverse/2`, `last/2`, `length/2`, and `is_list/1`) into
-  the relational standard library
+  `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`, and
+  `is_list/1`) into the relational standard library
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -20,8 +20,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,
-  `permutation/2`, `reverse/2`, `last/2`, `length/2`, and `is_list/1` into relational
-  standard-library goals
+  `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
+  and `is_list/1` into relational standard-library goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
     "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
-    "coding-adventures-logic-stdlib>=0.5.0",
+    "coding-adventures-logic-stdlib>=0.6.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",
     "coding-adventures-swi-prolog-parser>=0.1.0",
@@ -38,7 +38,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 [project.optional-dependencies]
 dev = [
     "coding-adventures-logic-builtins>=0.13.0",
-    "coding-adventures-logic-stdlib>=0.5.0",
+    "coding-adventures-logic-stdlib>=0.6.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -78,9 +78,11 @@ from logic_stdlib import (
     lengtho,
     listo,
     membero,
+    msorto,
     permuteo,
     reverseo,
     selecto,
+    sorto,
 )
 from prolog_core import expand_dcg_phrase
 
@@ -161,8 +163,10 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         "last": lasto,
         "length": lengtho,
         "member": membero,
+        "msort": msorto,
         "permutation": permuteo,
         "reverse": reverseo,
+        "sort": sorto,
     }
     if goal.relation.arity == 2 and name in binary_list_builtins:
         return binary_list_builtins[name](args[0], args[1])

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -811,6 +811,10 @@ class TestPrologGoalAdapter:
                 atom("tea"),
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
             ),
+            relation("msort", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=20),
+            ),
             relation("permutation", 2)(
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
                 LogicVar(id=16),
@@ -818,6 +822,10 @@ class TestPrologGoalAdapter:
             relation("reverse", 2)(
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
                 LogicVar(id=17),
+            ),
+            relation("sort", 2)(
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=21),
             ),
             relation("append", 3)(
                 term(".", atom("tea"), atom("[]")),
@@ -906,6 +914,8 @@ class TestPrologGoalAdapter:
             "?- member(Item, [tea, cake]), "
             "append([Item], [jam], Combined), "
             "reverse(Combined, Reversed), "
+            "sort([Item, jam, Item], UniqueSorted), "
+            "msort([Item, jam, Item], Sorted), "
             "length(Reversed, Count).",
         )
 
@@ -917,6 +927,8 @@ class TestPrologGoalAdapter:
                 parsed.variables["Item"],
                 parsed.variables["Combined"],
                 parsed.variables["Reversed"],
+                parsed.variables["UniqueSorted"],
+                parsed.variables["Sorted"],
                 parsed.variables["Count"],
             ),
             adapted,
@@ -925,12 +937,16 @@ class TestPrologGoalAdapter:
                 atom("tea"),
                 logic_list(["tea", "jam"]),
                 logic_list(["jam", "tea"]),
+                logic_list(["jam", "tea"]),
+                logic_list(["jam", "tea", "tea"]),
                 num(2),
             ),
             (
                 atom("cake"),
                 logic_list(["cake", "jam"]),
                 logic_list(["jam", "cake"]),
+                logic_list(["cake", "jam"]),
+                logic_list(["cake", "cake", "jam"]),
                 num(2),
             ),
         ]

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -15,8 +15,9 @@
   `query_module=...`.
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
-- Run common Prolog list predicates, including finite `length/2`, through the
-  VM path by adapting them to `logic-stdlib` relations.
+- Run common Prolog list predicates, including finite `length/2`, `sort/2`,
+  and `msort/2`, through the VM path by adapting them to `logic-stdlib`
+  relations.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -129,7 +129,8 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - collection predicates such as `findall/3`
-- common list predicates such as `member/2`, `append/3`, and `length/2`
+- common list predicates such as `member/2`, `append/3`, `length/2`,
+  `sort/2`, and `msort/2`
 - dynamic predicates seeded by initialization directives
 - named Python answer bindings
 - loader term/goal expansion before VM compilation

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -132,6 +132,8 @@ class TestPrologVMStress:
                reverse(Combined, Reversed),
                select(Item, [tea, cake, jam], Remainder),
                length(Reversed, Count),
+               sort([Item, jam, Item], UniqueSorted),
+               msort([Item, jam, Item], Sorted),
                length(Pair, 2),
                Pair = [left, right].
             """,
@@ -146,6 +148,8 @@ class TestPrologVMStress:
                 "Reversed": logic_list(["jam", "tea"]),
                 "Remainder": logic_list(["cake", "jam"]),
                 "Count": num(2),
+                "UniqueSorted": logic_list(["jam", "tea"]),
+                "Sorted": logic_list(["jam", "tea", "tea"]),
                 "Pair": logic_list(["left", "right"]),
             },
             {
@@ -154,6 +158,8 @@ class TestPrologVMStress:
                 "Reversed": logic_list(["jam", "cake"]),
                 "Remainder": logic_list(["tea", "jam"]),
                 "Count": num(2),
+                "UniqueSorted": logic_list(["cake", "jam"]),
+                "Sorted": logic_list(["cake", "cake", "jam"]),
                 "Pair": logic_list(["left", "right"]),
             },
         ]

--- a/code/specs/PR25-prolog-vm-sort-stdlib.md
+++ b/code/specs/PR25-prolog-vm-sort-stdlib.md
@@ -1,0 +1,52 @@
+# PR25: Prolog VM Sort Stdlib
+
+## Summary
+
+This batch adds finite `sort/2` and `msort/2` support to the Prolog-on-Logic-VM
+path. The implementation lives in `logic-stdlib` as `sorto` and `msorto`, and
+`prolog-loader` adapts parsed Prolog calls onto those shared relations.
+
+## Goals
+
+- add `sorto(list, sorted)` for duplicate-free finite sorting
+- add `msorto(list, sorted)` for finite sorting that preserves duplicates
+- adapt Prolog `sort/2` and `msort/2`
+- verify the predicates compose through parsed source, loader adaptation, VM
+  compilation, and VM execution
+
+## Semantics
+
+The first implementation is intentionally finite:
+
+- the input must be a proper finite list
+- open tails and improper lists fail
+- `sort/2` removes duplicate terms before sorting
+- `msort/2` keeps duplicate terms
+- sorting follows the Prolog-inspired standard term order already used by term
+  comparison and `setof/3`
+
+## Example
+
+```prolog
+?- member(Item, [tea, cake]),
+   sort([Item, jam, Item], UniqueSorted),
+   msort([Item, jam, Item], Sorted).
+```
+
+Expected VM answers:
+
+```prolog
+Item = tea,
+UniqueSorted = [jam, tea],
+Sorted = [jam, tea, tea].
+
+Item = cake,
+UniqueSorted = [cake, jam],
+Sorted = [cake, cake, jam].
+```
+
+## Non-goals
+
+- `keysort/2`
+- custom comparison predicates
+- sorting open list tails


### PR DESCRIPTION
## Summary

- add finite `sorto` and `msorto` relations to `logic-stdlib`
- adapt Prolog `sort/2` and `msort/2` through `prolog-loader`
- extend VM stress coverage and document the finite sort semantics in PR25

## Verification

- `bash BUILD` in `code/packages/python/logic-stdlib`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-stdlib`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `/tmp/ca-build-tool-prolog-sort -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-sort-build-plan.json`