### PR TITLE
Support scalar by-name formal procedure dispatch

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -72,6 +72,9 @@ All notable changes to this package will be documented in this file.
   blocks through the same frame-unwind and pending-goto paths as direct gotos.
 - Tagged pending procedure-crossing label ids so label id `0` no longer
   collides with the no-pending-goto sentinel.
+- Lowered formal procedure dispatch arguments as lazy storage pointers or
+  thunk descriptors, allowing actual procedures with scalar by-name parameters
+  to read or assign through the original argument.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -61,10 +61,13 @@ re-evaluate in the caller's declaring scope; these label/switch descriptor
 paths also cover `value` formals. Procedure formals pass descriptor closures
 containing the callee procedure id and static link; formal calls dispatch
 through generated helpers for statement calls and typed expression calls with
-scalar value arguments, so forwarded procedure formals keep the original
-environment in value or by-name mode. Real-valued formal procedure calls can
-accept integer-returning actual procedures and promote the dispatched result.
-Full ALGOL forms such as escaping thunk descriptors remain future work.
+scalar arguments. The dispatch helpers pass each actual argument as a lazy
+storage pointer or thunk descriptor, evaluating it once for target `value`
+parameters and forwarding it directly for target by-name parameters, so
+forwarded procedure formals keep the original environment in value or by-name
+mode. Real-valued formal procedure calls can accept integer-returning actual
+procedures and promote the dispatched result. Full ALGOL forms such as escaping
+thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -386,26 +386,7 @@ class AlgolIrCompiler:
             for procedure in type_result.semantic.procedures
         }
         if self.has_by_name_parameters:
-            self.procedure_signatures[_THUNK_EVAL_LABEL] = ProcedureSignaturePlan(
-                param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
-                return_type=_INTEGER_TYPE,
-            )
-            self.procedure_signatures[_THUNK_STORE_LABEL] = ProcedureSignaturePlan(
-                param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
-                return_type=_INTEGER_TYPE,
-            )
-            self.procedure_signatures[_THUNK_EVAL_REAL_LABEL] = (
-                ProcedureSignaturePlan(
-                    param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
-                    return_type=_REAL_TYPE,
-                )
-            )
-            self.procedure_signatures[_THUNK_STORE_REAL_LABEL] = (
-                ProcedureSignaturePlan(
-                    param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _REAL_TYPE),
-                    return_type=_INTEGER_TYPE,
-                )
-            )
+            self._ensure_thunk_signatures()
         if self.has_switch_parameters:
             self.procedure_signatures[_SWITCH_EVAL_LABEL] = ProcedureSignaturePlan(
                 param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
@@ -502,7 +483,8 @@ class AlgolIrCompiler:
         self._emit_program_result(root_scope)
         self._emit(IrOp.HALT)
         self._compile_procedures(type_result.semantic.procedures)
-        if self.has_by_name_parameters:
+        if self.has_by_name_parameters or self.eval_thunks:
+            self._ensure_thunk_signatures()
             self._compile_eval_thunk_dispatcher(
                 label=_THUNK_EVAL_LABEL,
                 thunk_kind="word",
@@ -546,6 +528,24 @@ class AlgolIrCompiler:
             frame_memory_label=_FRAME_MEMORY_LABEL,
             heap_memory_label=_HEAP_MEMORY_LABEL,
             procedure_signatures=dict(self.procedure_signatures),
+        )
+
+    def _ensure_thunk_signatures(self) -> None:
+        self.procedure_signatures[_THUNK_EVAL_LABEL] = ProcedureSignaturePlan(
+            param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
+            return_type=_INTEGER_TYPE,
+        )
+        self.procedure_signatures[_THUNK_STORE_LABEL] = ProcedureSignaturePlan(
+            param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _INTEGER_TYPE),
+            return_type=_INTEGER_TYPE,
+        )
+        self.procedure_signatures[_THUNK_EVAL_REAL_LABEL] = ProcedureSignaturePlan(
+            param_types=(_INTEGER_TYPE, _INTEGER_TYPE),
+            return_type=_REAL_TYPE,
+        )
+        self.procedure_signatures[_THUNK_STORE_REAL_LABEL] = ProcedureSignaturePlan(
+            param_types=(_INTEGER_TYPE, _INTEGER_TYPE, _REAL_TYPE),
+            return_type=_INTEGER_TYPE,
         )
 
     def _compile_block(self, block: ASTNode, parent: _FrameScope | None) -> _FrameScope:
@@ -2969,8 +2969,7 @@ class AlgolIrCompiler:
     ) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
         argument_types = tuple(self._expr_type(actual) for actual in actuals)
-        argument_regs: list[int] = []
-        for actual, actual_type in zip(actuals, argument_types, strict=True):
+        for actual_type in argument_types:
             if actual_type not in {
                 _INTEGER_TYPE,
                 _BOOLEAN_TYPE,
@@ -2981,7 +2980,47 @@ class AlgolIrCompiler:
                     f"procedure parameter {call.name!r} cannot pass "
                     f"{actual_type} argument"
                 )
-            argument_regs.append(self._compile_expr(actual, scope))
+        thunk_actuals = [
+            (index, argument, actual_type)
+            for index, (argument, actual_type) in enumerate(
+                zip(actuals, argument_types, strict=True)
+            )
+            if self._requires_by_name_thunk_descriptor(argument)
+        ]
+        descriptor_heap_mark = (
+            self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
+            if thunk_actuals
+            else None
+        )
+        descriptor_offsets = {
+            argument_index: descriptor_index * _THUNK_DESCRIPTOR_SIZE
+            for descriptor_index, (argument_index, _, _) in enumerate(thunk_actuals)
+        }
+        argument_regs: list[int] = []
+        for index, (actual, actual_type) in enumerate(
+            zip(actuals, argument_types, strict=True)
+        ):
+            descriptor = None
+            if descriptor_heap_mark is not None and index in descriptor_offsets:
+                descriptor = self._emit_descriptor_at(
+                    descriptor_heap_mark,
+                    descriptor_offsets[index],
+                )
+            argument_regs.append(
+                self._compile_by_name_actual_pointer(
+                    actual,
+                    ProcedureParameter(
+                        name=f"{call.name}_argument_{index}",
+                        type_name=actual_type,
+                        mode=_NAME_MODE,
+                        symbol_id=-1,
+                        slot_offset=0,
+                        may_write=True,
+                    ),
+                    scope,
+                    descriptor,
+                )
+            )
         descriptor_pointer = self._compile_procedure_parameter_pointer(
             call.name,
             scope,
@@ -2991,9 +3030,13 @@ class AlgolIrCompiler:
                 f"procedure parameter {call.name!r} was not resolved"
             )
         active_thunk_heap_mark = (
-            scope.active_thunk_heap_mark_reg
-            if scope.active_thunk_heap_mark_reg is not None
-            else self._const_reg(0)
+            descriptor_heap_mark
+            if descriptor_heap_mark is not None
+            else (
+                scope.active_thunk_heap_mark_reg
+                if scope.active_thunk_heap_mark_reg is not None
+                else self._const_reg(0)
+            )
         )
         dispatch_label = self._procedure_parameter_dispatch_label(
             argument_types,
@@ -3006,8 +3049,14 @@ class AlgolIrCompiler:
             IrRegister(active_thunk_heap_mark),
             *(IrRegister(argument) for argument in argument_regs),
         )
+        if descriptor_heap_mark is not None:
+            self._store_runtime_state(
+                _RUNTIME_HEAP_POINTER_OFFSET,
+                descriptor_heap_mark,
+            )
         if scope.helper_failure:
             self._emit_helper_return_on_thunk_failure(scope)
+        self._emit_propagate_thunk_failure(scope)
         self._emit_handle_pending_goto_after_call(scope)
         result = self._fresh_reg()
         self._copy_scalar_reg(
@@ -3051,7 +3100,7 @@ class AlgolIrCompiler:
                 param_types=(
                     _INTEGER_TYPE,
                     _INTEGER_TYPE,
-                    *argument_types,
+                    *(_INTEGER_TYPE for _ in argument_types),
                 ),
                 return_type=return_type or _INTEGER_TYPE,
             )
@@ -4246,16 +4295,26 @@ class AlgolIrCompiler:
                 IrRegister(self._const_reg(procedure.procedure_id)),
             )
             self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
-            call_arguments = [
-                self._coerce_reg_to_type(
-                    _VALUE_PARAM_BASE_REG + arg_index,
+            call_arguments: list[int] = []
+            for arg_index, (argument_type, parameter) in enumerate(
+                zip(argument_types, procedure.parameters, strict=True)
+            ):
+                argument_pointer = _VALUE_PARAM_BASE_REG + arg_index
+                if parameter.mode == _NAME_MODE:
+                    call_arguments.append(argument_pointer)
+                    continue
+                argument_value = self._emit_load_by_name_argument_value(
+                    argument_pointer,
                     argument_type,
-                    expected_type=parameter.type_name,
+                    active_thunk_heap_mark,
                 )
-                for arg_index, (argument_type, parameter) in enumerate(
-                    zip(argument_types, procedure.parameters, strict=True)
+                call_arguments.append(
+                    self._coerce_reg_to_type(
+                        argument_value,
+                        argument_type,
+                        expected_type=parameter.type_name,
+                    )
                 )
-            ]
             self._emit(
                 IrOp.CALL,
                 IrLabel(procedure.label),
@@ -4309,14 +4368,95 @@ class AlgolIrCompiler:
             argument_types,
             strict=True,
         ):
-            if parameter.kind != "scalar" or parameter.mode != _VALUE_MODE:
+            if parameter.kind != "scalar":
                 return False
-            if parameter.type_name == argument_type:
-                continue
-            if parameter.type_name == _REAL_TYPE and argument_type == _INTEGER_TYPE:
-                continue
+            if parameter.mode == _VALUE_MODE:
+                if parameter.type_name == argument_type:
+                    continue
+                if parameter.type_name == _REAL_TYPE and argument_type == _INTEGER_TYPE:
+                    continue
+                return False
+            if parameter.mode == _NAME_MODE:
+                if parameter.type_name == argument_type:
+                    continue
+                return False
             return False
         return True
+
+    def _emit_load_by_name_argument_value(
+        self,
+        pointer: int,
+        type_name: str,
+        active_thunk_heap_mark: int,
+    ) -> int:
+        tag = self._fresh_reg()
+        index = self.if_count
+        self.if_count += 1
+        storage_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        dst = self._fresh_reg()
+        self._emit(
+            IrOp.AND_IMM,
+            IrRegister(tag),
+            IrRegister(pointer),
+            IrImmediate(_THUNK_DESCRIPTOR_TAG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(tag), IrLabel(storage_label))
+        descriptor = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(descriptor),
+            IrRegister(pointer),
+            IrImmediate(-_THUNK_DESCRIPTOR_TAG),
+        )
+        self._emit(
+            IrOp.CALL,
+            IrLabel(
+                _THUNK_EVAL_REAL_LABEL
+                if type_name == _REAL_TYPE
+                else _THUNK_EVAL_LABEL
+            ),
+            IrRegister(descriptor),
+            IrRegister(active_thunk_heap_mark),
+        )
+        self._emit_dispatcher_return_on_runtime_transfer()
+        self._copy_scalar_reg(
+            type_name=type_name,
+            dst=dst,
+            src=_REAL_RESULT_REG if type_name == _REAL_TYPE else _RESULT_REG,
+        )
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(storage_label)
+        self._emit_load_scalar(type_name, dst, pointer, 0)
+        self._label(end_label)
+        return dst
+
+    def _emit_dispatcher_return_on_runtime_transfer(self) -> None:
+        failed = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, failed)
+        pending_label = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_PENDING_GOTO_LABEL_OFFSET, pending_label)
+        should_return = self._fresh_reg()
+        self._emit(
+            IrOp.ADD,
+            IrRegister(should_return),
+            IrRegister(failed),
+            IrRegister(pending_label),
+        )
+        index = self.if_count
+        self.if_count += 1
+        continue_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(should_return),
+            IrLabel(continue_label),
+        )
+        self._emit_zero_result_reg()
+        self._emit(IrOp.RET)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(continue_label)
+        self._label(end_label)
 
     def _compile_procedure(self, procedure: ProcedureDescriptor) -> None:
         body = self._find_ast_by_id(procedure.body_node_id)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -872,6 +872,27 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_procedure_parameter_call_with_by_name_actual(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure invoke(p); procedure p; "
+                "begin integer y; y := 3; p(y); result := y end; "
+                "procedure bump(x); integer x; begin x := x + 4 end; "
+                "invoke(bump) "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert "_fn_algol_call_procedure_i32" in labels
+        assert IrOp.AND_IMM in opcodes
+
     def test_compiles_value_procedure_parameter_call_with_value_argument(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this package will be documented in this file.
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent
   blocks while continuing to reject recursive self-selection.
+- Accepted procedure-valued actuals with scalar by-name parameters for formal
+  procedure parameters, while rejecting call shapes that would pass a
+  non-assignable actual to a written by-name parameter.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -52,12 +52,13 @@ the semantic model, while later lowering packages now implement scalar
 call-by-name, typed whole-array formals, label formals, switch formals, and
 no-argument statement procedure formals. `value` whole-array parameters are
 also accepted and lowered as copy formals, while `value` label, switch, and
-procedure formals use copied ids or descriptors. Real-valued formal procedure
-parameters accept integer-returning procedure actuals via the same numeric
-promotion rule used by scalar calls. The checker keeps guarding the
-remaining full-ALGOL gaps, including non-assignable actuals passed to written
-by-name formals and procedure-valued actuals whose parameters are not scalar
-value parameters.
+procedure formals use copied ids or descriptors. Formal procedure parameters
+accept procedure-valued actuals with scalar `value` or by-name parameters,
+rejecting only call shapes that would pass a non-assignable actual to a written
+by-name parameter. Real-valued formal procedure parameters accept
+integer-returning procedure actuals via the same numeric promotion rule used by
+scalar calls. The checker keeps guarding the remaining full-ALGOL gaps,
+including non-scalar parameters on procedure-valued actuals.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -191,6 +191,7 @@ class ProcedureFormalCallShape:
 
     role: str
     argument_types: tuple[str, ...]
+    argument_assignable: tuple[bool, ...] = ()
     return_type: str | None = None
 
 
@@ -2021,9 +2022,14 @@ class AlgolTypeChecker:
         role: str,
     ) -> ResolvedProcedureCall:
         argument_types: list[str] = []
+        argument_assignable: list[bool] = []
         for argument in arguments:
             actual_type = self._infer_expr(argument, scope)
             argument_types.append(actual_type)
+            argument_assignable.append(
+                _is_assignable_actual(argument)
+                and self._resolved_bare_procedure_expression(argument) is None
+            )
             if actual_type != ERROR and actual_type not in {
                 INTEGER,
                 BOOLEAN,
@@ -2047,6 +2053,7 @@ class AlgolTypeChecker:
                 ProcedureFormalCallShape(
                     role=role,
                     argument_types=tuple(argument_types),
+                    argument_assignable=tuple(argument_assignable),
                     return_type=return_type if role == "expression" else None,
                 ),
             )
@@ -2307,24 +2314,34 @@ class AlgolTypeChecker:
                         f"argument(s), got {actual}",
                     )
                 return False
-            for actual_parameter, actual_type in zip(
-                descriptor.parameters,
-                shape.argument_types,
-                strict=True,
+            for argument_index, (actual_parameter, actual_type) in enumerate(
+                zip(
+                    descriptor.parameters,
+                    shape.argument_types,
+                    strict=True,
+                )
             ):
-                if (
-                    actual_parameter.kind != "scalar"
-                    or actual_parameter.mode != VALUE
-                ):
+                argument_assignable = (
+                    shape.argument_assignable[argument_index]
+                    if argument_index < len(shape.argument_assignable)
+                    else False
+                )
+                if actual_parameter.kind != "scalar":
                     self._error(
                         token,
                         f"procedure parameter {parameter.name!r} expects a "
-                        "procedure actual with scalar value parameters in this "
-                        "phase",
+                        "procedure actual with scalar parameters",
+                    )
+                    return False
+                if actual_parameter.mode not in {VALUE, NAME}:
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} expects a "
+                        "procedure actual with scalar value or name parameters",
                     )
                     return False
                 if not self._parameter_accepts_type(
-                    VALUE,
+                    actual_parameter.mode,
                     actual_parameter.type_name,
                     actual_type,
                 ):
@@ -2334,6 +2351,16 @@ class AlgolTypeChecker:
                         f"{actual_type} to actual parameter "
                         f"{actual_parameter.name!r} expecting "
                         f"{actual_parameter.type_name}",
+                    )
+                    return False
+                if actual_parameter.mode == NAME and (
+                    actual_parameter.may_write and not argument_assignable
+                ):
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} passes a "
+                        f"non-assignable actual to written by-name parameter "
+                        f"{actual_parameter.name!r}",
                     )
                     return False
         return True

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -930,7 +930,7 @@ class TestAlgolTypeChecker:
             in result.diagnostics[0].message
         )
 
-    def test_rejects_procedure_parameter_actual_with_by_name_formal(
+    def test_accepts_procedure_parameter_actual_with_read_only_by_name_formal(
         self,
     ) -> None:
         ast = parse_algol(
@@ -942,11 +942,25 @@ class TestAlgolTypeChecker:
         )
         result = check_algol(ast)
 
-        assert not result.ok
-        assert (
-            "expects a procedure actual with scalar value parameters"
-            in result.diagnostics[0].message
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.procedure_call_shapes[0].argument_assignable == (False,)
+
+    def test_rejects_procedure_parameter_actual_with_written_literal_by_name_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p(7) end; "
+            "procedure set(x); integer x; begin x := x + 1 end; "
+            "invoke(set) "
+            "end"
         )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "non-assignable actual" in result.diagnostics[0].message
 
     def test_rejects_typed_procedure_parameter_void_actual(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -66,6 +66,8 @@ All notable changes to this package will be documented in this file.
   integer `result` return convention when present.
 - Executed switch entries that target labels in lexical parent blocks,
   including procedure-crossing escapes to the first label in a program.
+- Executed formal procedure calls whose actual procedure expects scalar
+  by-name parameters, preserving lazy reads and writable caller variables.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -713,6 +713,42 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_procedure_parameter_statement_call_passes_read_only_by_name_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p(result + 3) end; "
+            "procedure set(x); integer x; begin result := x end; "
+            "result := 2; invoke(set) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
+    def test_procedure_parameter_statement_call_passes_writable_by_name_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; "
+            "begin integer y; y := 3; p(y); result := y end; "
+            "procedure bump(x); integer x; begin x := x + 4 end; "
+            "invoke(bump) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_formal_procedure_by_name_argument_remains_lazy(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure next; begin result := result + 1; next := result end; "
+            "procedure invoke(p); procedure p; begin p(next) end; "
+            "procedure use(x); integer x; begin result := x + x end; "
+            "result := 0; invoke(use) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [3]
+
     def test_forwarded_procedure_parameter_with_argument_uses_static_link(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- allow formal procedure parameters to accept procedure actuals with scalar by-name parameters, including written formals when call arguments are assignable
- lower formal procedure call arguments as lazy cells/thunks so dispatchers can either evaluate them once for value targets or forward them by name for name targets
- add type-checker, IR, and WASM regressions for read-only by-name, writable by-name, lazy procedure-expression, and guarded non-assignable cases

## Tests
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security Review
- Reviewed added diff for subprocess/shell execution, unsafe eval/exec, network/file permission changes, deserialization, secrets handling, and permission changes. No new risky operations introduced.