### PR TITLE
feat(prolog): add finite nth stdlib bridge

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.7.0] - 2026-04-28
+
+### Added
+
+- finite `nth0o` and `nth1o` relations for indexing proper lists
+- pytest coverage for zero-based lookup, one-based lookup, index enumeration,
+  out-of-range failure, and improper-list rejection
+
 ## [0.6.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -18,6 +18,8 @@ The first slice includes:
 - `listo(...)`
 - `membero(...)`
 - `msorto(...)`
+- `nth0o(...)`
+- `nth1o(...)`
 - `appendo(...)`
 - `selecto(...)`
 - `permuteo(...)`
@@ -36,6 +38,8 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0o,
+    nth1o,
     permuteo,
     reverseo,
     sorto,
@@ -110,6 +114,18 @@ assert solve_all(
     Order,
     msorto(logic_list(["tea", "cake", "tea"]), Order),
 ) == [logic_list(["cake", "tea", "tea"])]
+
+assert solve_all(
+    program(),
+    X,
+    nth0o(1, logic_list(["tea", "cake", "jam"]), X),
+) == [atom("cake")]
+
+assert solve_all(
+    program(),
+    X,
+    nth1o(2, logic_list(["tea", "cake", "jam"]), X),
+) == [atom("cake")]
 
 assert solve_all(
     program(),

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.6.0"
+version = "0.7.0"
 description = "Relational standard library helpers, combinators, and sequence relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -16,6 +16,8 @@ from logic_stdlib.relations import (
     listo,
     membero,
     msorto,
+    nth0o,
+    nth1o,
     permuteo,
     reverseo,
     selecto,
@@ -35,6 +37,8 @@ __all__ = [
     "listo",
     "membero",
     "msorto",
+    "nth0o",
+    "nth1o",
     "permuteo",
     "reverseo",
     "selecto",
@@ -43,4 +47,4 @@ __all__ = [
     "tailo",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -47,6 +47,8 @@ __all__ = [
     "lengtho",
     "listo",
     "membero",
+    "nth0o",
+    "nth1o",
     "permuteo",
     "reverseo",
     "selecto",
@@ -130,6 +132,18 @@ def msorto(items: object, sorted_items: object) -> GoalExpr:
     """Relate a proper finite list to its sorted ordering while keeping duplicates."""
 
     return native_goal(_msorto_runner, items, sorted_items)
+
+
+def nth0o(index: object, items: object, element: object) -> GoalExpr:
+    """Relate a zero-based index to an element of a proper finite list."""
+
+    return native_goal(_ntho_runner, index, items, element, 0)
+
+
+def nth1o(index: object, items: object, element: object) -> GoalExpr:
+    """Relate a one-based index to an element of a proper finite list."""
+
+    return native_goal(_ntho_runner, index, items, element, 1)
 
 
 def listo(value: object) -> GoalExpr:
@@ -240,6 +254,48 @@ def _msorto_runner(
         eq(sorted_items, logic_list(sorted_values)),
         state,
     )
+
+
+def _ntho_runner(
+    program_value: Program,
+    state: State,
+    args: tuple[Term, ...],
+) -> Iterator[State]:
+    index, items, element, base_term = args
+    if not isinstance(base_term, Number) or not isinstance(base_term.value, int):
+        return
+    base = base_term.value
+    values = _proper_list_items(items, state)
+    if values is None:
+        return
+
+    index_value = _integer_index(index, state)
+    if index_value is not None:
+        offset = index_value - base
+        if offset < 0 or offset >= len(values):
+            return
+        yield from solve_from(program_value, eq(element, values[offset]), state)
+        return
+
+    walked_index = state.substitution.walk(index)
+    if not isinstance(walked_index, LogicVar):
+        return
+
+    for offset, value in enumerate(values):
+        yield from solve_from(
+            program_value,
+            conj(eq(index, num(offset + base)), eq(element, value)),
+            state,
+        )
+
+
+def _integer_index(index: Term, state: State) -> int | None:
+    walked = state.substitution.walk(index)
+    if not isinstance(walked, Number):
+        return None
+    if not isinstance(walked.value, int):
+        return None
+    return walked.value
 
 
 def _proper_list_items(items: Term, state: State) -> list[Term] | None:

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -26,6 +26,8 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0o,
+    nth1o,
     permuteo,
     reverseo,
     selecto,
@@ -39,7 +41,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.6.0"
+        assert __version__ == "0.7.0"
         engine_major, engine_minor, _engine_patch = logic_engine_version.split(".")
         assert (int(engine_major), int(engine_minor)) >= (0, 10)
 
@@ -202,6 +204,55 @@ class TestListRelations:
             conj(
                 eq(marker, "ok"),
                 sorto(logic_list(["tea"], tail="cake"), var("Sorted")),
+            ),
+        ) == []
+
+    def test_nth0o_finds_zero_based_elements(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            nth0o(1, logic_list(["tea", "cake", "jam"]), item),
+        ) == [atom("cake")]
+
+    def test_nth1o_finds_one_based_elements(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            nth1o(2, logic_list(["tea", "cake", "jam"]), item),
+        ) == [atom("cake")]
+
+    def test_ntho_enumerates_index_element_pairs_for_proper_lists(self) -> None:
+        index = var("Index")
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            (index, item),
+            nth0o(index, logic_list(["tea", "cake", "jam"]), item),
+        ) == [
+            (num(0), atom("tea")),
+            (num(1), atom("cake")),
+            (num(2), atom("jam")),
+        ]
+
+    def test_ntho_rejects_out_of_range_and_improper_lists(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), nth0o(3, logic_list(["tea"]), var("Item"))),
+        ) == []
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                nth0o(0, logic_list(["tea"], tail="cake"), var("Item")),
             ),
         ) == []
 

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -11,7 +11,7 @@
   executable logic builtin layer
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`, and
-  `is_list/1`) into the relational standard library
+  `nth0/3`, `nth1/3`, and `is_list/1`) into the relational standard library
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -21,7 +21,7 @@ It keeps parsing side-effect free, then exposes helpers to:
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
-  and `is_list/1` into relational standard-library goals
+  `nth0/3`, `nth1/3`, and `is_list/1` into relational standard-library goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
     "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
-    "coding-adventures-logic-stdlib>=0.6.0",
+    "coding-adventures-logic-stdlib>=0.7.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",
     "coding-adventures-swi-prolog-parser>=0.1.0",
@@ -38,7 +38,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 [project.optional-dependencies]
 dev = [
     "coding-adventures-logic-builtins>=0.13.0",
-    "coding-adventures-logic-stdlib>=0.6.0",
+    "coding-adventures-logic-stdlib>=0.7.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -79,6 +79,8 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0o,
+    nth1o,
     permuteo,
     reverseo,
     selecto,
@@ -173,6 +175,8 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
 
     ternary_list_builtins: dict[str, Callable[[object, object, object], GoalExpr]] = {
         "append": appendo,
+        "nth0": nth0o,
+        "nth1": nth1o,
         "select": selecto,
     }
     if goal.relation.arity == 3 and name in ternary_list_builtins:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -832,6 +832,16 @@ class TestPrologGoalAdapter:
                 term(".", atom("cake"), atom("[]")),
                 LogicVar(id=18),
             ),
+            relation("nth0", 3)(
+                1,
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=22),
+            ),
+            relation("nth1", 3)(
+                2,
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=23),
+            ),
             relation("select", 3)(
                 atom("tea"),
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
@@ -916,6 +926,8 @@ class TestPrologGoalAdapter:
             "reverse(Combined, Reversed), "
             "sort([Item, jam, Item], UniqueSorted), "
             "msort([Item, jam, Item], Sorted), "
+            "nth0(1, Reversed, ZeroBased), "
+            "nth1(2, Reversed, OneBased), "
             "length(Reversed, Count).",
         )
 
@@ -929,6 +941,8 @@ class TestPrologGoalAdapter:
                 parsed.variables["Reversed"],
                 parsed.variables["UniqueSorted"],
                 parsed.variables["Sorted"],
+                parsed.variables["ZeroBased"],
+                parsed.variables["OneBased"],
                 parsed.variables["Count"],
             ),
             adapted,
@@ -939,6 +953,8 @@ class TestPrologGoalAdapter:
                 logic_list(["jam", "tea"]),
                 logic_list(["jam", "tea"]),
                 logic_list(["jam", "tea", "tea"]),
+                atom("tea"),
+                atom("tea"),
                 num(2),
             ),
             (
@@ -947,6 +963,8 @@ class TestPrologGoalAdapter:
                 logic_list(["jam", "cake"]),
                 logic_list(["cake", "jam"]),
                 logic_list(["cake", "cake", "jam"]),
+                atom("cake"),
+                atom("cake"),
                 num(2),
             ),
         ]

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -16,8 +16,8 @@
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
-  and `msort/2`, through the VM path by adapting them to `logic-stdlib`
-  relations.
+  `msort/2`, `nth0/3`, and `nth1/3`, through the VM path by adapting them to
+  `logic-stdlib` relations.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -130,7 +130,7 @@ The package includes end-to-end stress tests for:
 - arithmetic evaluation and comparison
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
-  `sort/2`, and `msort/2`
+  `sort/2`, `msort/2`, `nth0/3`, and `nth1/3`
 - dynamic predicates seeded by initialization directives
 - named Python answer bindings
 - loader term/goal expansion before VM compilation

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -134,6 +134,8 @@ class TestPrologVMStress:
                length(Reversed, Count),
                sort([Item, jam, Item], UniqueSorted),
                msort([Item, jam, Item], Sorted),
+               nth0(1, Reversed, ZeroBased),
+               nth1(2, Reversed, OneBased),
                length(Pair, 2),
                Pair = [left, right].
             """,
@@ -150,6 +152,8 @@ class TestPrologVMStress:
                 "Count": num(2),
                 "UniqueSorted": logic_list(["jam", "tea"]),
                 "Sorted": logic_list(["jam", "tea", "tea"]),
+                "ZeroBased": atom("tea"),
+                "OneBased": atom("tea"),
                 "Pair": logic_list(["left", "right"]),
             },
             {
@@ -160,6 +164,8 @@ class TestPrologVMStress:
                 "Count": num(2),
                 "UniqueSorted": logic_list(["cake", "jam"]),
                 "Sorted": logic_list(["cake", "cake", "jam"]),
+                "ZeroBased": atom("cake"),
+                "OneBased": atom("cake"),
                 "Pair": logic_list(["left", "right"]),
             },
         ]

--- a/code/specs/PR26-prolog-vm-nth-stdlib.md
+++ b/code/specs/PR26-prolog-vm-nth-stdlib.md
@@ -1,0 +1,48 @@
+# PR26: Prolog VM Nth Stdlib
+
+## Summary
+
+This batch adds finite positional list access to the Prolog-on-Logic-VM path.
+The implementation lives in `logic-stdlib` as `nth0o` and `nth1o`, and
+`prolog-loader` adapts parsed Prolog `nth0/3` and `nth1/3` calls onto those
+relations.
+
+## Goals
+
+- add `nth0o(index, list, element)` for zero-based proper-list indexing
+- add `nth1o(index, list, element)` for one-based proper-list indexing
+- enumerate index-element pairs when the list is proper and finite
+- adapt Prolog `nth0/3` and `nth1/3`
+- verify the predicates compose through parsed source, loader adaptation, VM
+  compilation, and VM execution
+
+## Semantics
+
+The first implementation is finite:
+
+- the list argument must be a proper finite list
+- known non-negative integer indexes select one element
+- open index variables enumerate all valid index-element pairs
+- out-of-range, negative, non-integer, open-list, and improper-list cases fail
+
+## Example
+
+```prolog
+?- reverse([tea, jam], Reversed),
+   nth0(1, Reversed, ZeroBased),
+   nth1(2, Reversed, OneBased).
+```
+
+Expected VM answer:
+
+```prolog
+Reversed = [jam, tea],
+ZeroBased = tea,
+OneBased = tea.
+```
+
+## Non-goals
+
+- open-tail list generation
+- `nth0/4` or `nth1/4`
+- CLP(FD)-backed index domains


### PR DESCRIPTION
## Summary

- add finite `nth0o` and `nth1o` relations to `logic-stdlib`
- adapt Prolog `nth0/3` and `nth1/3` through `prolog-loader`
- extend VM stress coverage and document finite positional list semantics in PR26

## Verification

- `bash BUILD` in `code/packages/python/logic-stdlib`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-stdlib`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `/tmp/ca-build-tool-prolog-nth -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-nth-build-plan.json`