### PR TITLE
feat(brainfuck): BF06 — Brainfuck I/O programs JIT via WASI fd_write/fd_read

### DIFF
--- a/code/packages/python/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/python/brainfuck-iir-compiler/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `brainfuck-iir-compiler` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] — BF06: JIT for I/O programs (WASI fd_write / fd_read)
+
+### Added
+
+- **JIT path for programs with `.` / `,`.**  ``BrainfuckVM(jit=True)``
+  now constructs a per-run ``WasiHost`` whose ``stdout`` / ``stdin``
+  callbacks share the same ``output`` bytearray and ``input_buffer``
+  the interpreter path uses.  Programs that previously deopted because
+  ``cir-to-compiler-ir`` lacked a ``call_builtin`` lowering (Hello
+  World et al.) now JIT end-to-end via WASI.
+- ``Heap base offset = 16`` in the load_mem / store_mem lowering so the
+  Brainfuck tape no longer aliases the WASI scratch region the WASM
+  compiler reserves at the bottom of linear memory.
+
 ## [0.2.0] — BF05: JIT to WebAssembly
 
 ### Added

--- a/code/packages/python/brainfuck-iir-compiler/pyproject.toml
+++ b/code/packages/python/brainfuck-iir-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-brainfuck-iir-compiler"
-version = "0.2.0"
+version = "0.3.0"
 description = "Brainfuck → InterpreterIR compiler and BrainfuckVM wrapper around vm-core"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/brainfuck-iir-compiler/src/brainfuck_iir_compiler/vm.py
+++ b/code/packages/python/brainfuck-iir-compiler/src/brainfuck_iir_compiler/vm.py
@@ -221,17 +221,22 @@ class BrainfuckVM:
         self._vm = vm
 
         # ──────────────────────────────────────────────────────────────
-        # JIT path (BF05).  When jit=True we attempt to compile ``main``
-        # to WebAssembly via WASMBackend before falling back to the
-        # interpreter.  Failure modes (call_builtin in source, lowering
-        # error, codegen error) silently deopt to the interpreter — see
-        # BF05 §"Scope of this PR".
+        # JIT path (BF05+BF06).  When jit=True we attempt to compile
+        # ``main`` to WebAssembly via WASMBackend before falling back
+        # to the interpreter.  BF06 wired ``call_builtin "putchar"`` /
+        # ``"getchar"`` through WASI ``fd_write`` / ``fd_read``, so
+        # I/O-using programs JIT too — provided the host can supply
+        # stdout / stdin callbacks.  We construct a per-run WasiHost
+        # bound to the same ``output`` bytearray and ``input_buffer``
+        # the interpreter path already manages.
         # ──────────────────────────────────────────────────────────────
         self._last_jit_compiled = False
-        if self._jit_enabled and self._try_jit_run(vm, module):
-            # JIT ran to completion.  ``output`` is empty for I/O-free
-            # programs (the only ones that succeed here in BF05 V1) —
-            # they perform their work entirely in linear memory.
+        if self._jit_enabled and self._try_jit_run(
+            vm, module, output, input_buffer
+        ):
+            # JIT ran to completion.  ``output`` may now contain bytes
+            # the WASM binary emitted via fd_write — those were
+            # appended by the WasiHost callback we wired in below.
             self._last_metrics = vm.metrics()
             return bytes(output)
 
@@ -246,7 +251,13 @@ class BrainfuckVM:
     # JIT helpers
     # ------------------------------------------------------------------
 
-    def _try_jit_run(self, vm: VMCore, module: IIRModule) -> bool:
+    def _try_jit_run(
+        self,
+        vm: VMCore,
+        module: IIRModule,
+        output: bytearray,
+        input_buffer: list[int],
+    ) -> bool:
         """Try compiling ``main`` to WASM and running the binary.
 
         Returns ``True`` if the JIT produced a binary that ran to
@@ -257,17 +268,42 @@ class BrainfuckVM:
         are imported lazily so that test environments without the WASM
         stack still load this module — a missing import simply forces
         a deopt, which is the correct behaviour anyway.
+
+        ``output`` and ``input_buffer`` are the same buffers the
+        interpreter path uses.  Wiring them through a ``WasiHost``
+        means a JIT'd Hello World writes bytes to ``output`` exactly
+        as the interpreter would, and ``,`` reads pop from
+        ``input_buffer``.
         """
         try:
             from jit_core import JITCore
             from wasm_backend import WASMBackend
+            from wasm_runtime import WasiHost
+            from wasm_runtime.wasi_host import WasiConfig
         except ImportError:
             return False
 
+        # ── BF06: route stdout/stdin through the same buffers used by
+        # the interpreter path.  WASI fd_write decodes bytes as Latin-1
+        # before calling stdout (1 byte → 1 char), so the round-trip
+        # back to bytes via ``encode("latin-1")`` is exact.
+        def stdout_cb(text: str) -> None:
+            output.extend(text.encode("latin-1"))
+
+        def stdin_cb(n: int) -> bytes:
+            chunk = bytes(input_buffer[:n])
+            del input_buffer[:n]
+            return chunk
+
         try:
+            # ``WasiHost`` only takes stdout/stderr as keyword args; stdin
+            # must come through a ``WasiConfig``.  Build a minimal config
+            # with both callbacks wired and let the host wrap it.
+            config = WasiConfig(stdin=stdin_cb, stdout=stdout_cb)
+            host = WasiHost(config)
             jit = JITCore(
                 vm,
-                WASMBackend(),
+                WASMBackend(host=host),
                 threshold_fully_typed=0,
                 threshold_partial=10,
                 threshold_untyped=100,

--- a/code/packages/python/brainfuck-iir-compiler/tests/test_jit.py
+++ b/code/packages/python/brainfuck-iir-compiler/tests/test_jit.py
@@ -65,44 +65,53 @@ def test_zero_cell_idiom_jits() -> None:
 
 
 # ---------------------------------------------------------------------------
-# I/O programs gracefully deopt
+# I/O programs JIT through WASI (BF06)
 # ---------------------------------------------------------------------------
 #
-# These programs include `.` or `,`, which compile to ``call_builtin``.
-# ``cir-to-compiler-ir`` does not yet lower ``call_builtin`` (BF06).
-# The JIT path's exception handler catches the lowering failure and
-# falls back to the interpreter — so the user-visible behaviour is
-# identical to ``jit=False``.
+# `.` and `,` compile to ``call_builtin "putchar"`` / ``"getchar"``.
+# ``cir-to-compiler-ir`` lowers those to ``IrOp.SYSCALL`` (1 / 2),
+# which ``ir-to-wasm-compiler`` emits as WASI ``fd_write`` / ``fd_read``
+# imports.  ``BrainfuckVM`` constructs a per-run ``WasiHost`` that
+# routes those imports back to the same ``output`` / ``input_buffer``
+# the interpreter uses.
 
 
-def test_putchar_program_deopts_and_runs_interpreted() -> None:
+def test_putchar_program_jits() -> None:
     vm = BrainfuckVM(jit=True)
     out = vm.run("+++.")
-    assert out == b"\x03"  # interpreter ran correctly
-    assert vm.is_jit_compiled is False, (
-        "programs with `.` should deopt because call_builtin is not yet "
-        "lowered (BF06)"
+    assert out == b"\x03"
+    assert vm.is_jit_compiled is True, (
+        "programs with `.` now JIT via WASI fd_write (BF06)"
     )
 
 
-def test_getchar_program_deopts_and_runs_interpreted() -> None:
+def test_getchar_program_jits() -> None:
     vm = BrainfuckVM(jit=True)
     out = vm.run(",.", input_bytes=b"X")
-    assert out == b"X"  # interpreter ran correctly
-    assert vm.is_jit_compiled is False
+    assert out == b"X"
+    assert vm.is_jit_compiled is True
 
 
-def test_hello_world_deopts_and_runs_interpreted() -> None:
-    """The classic Hello World — uses many `.` calls — must deopt
-    cleanly and produce the right bytes via the interpreter.
-    """
+def test_hello_world_jits_via_wasi() -> None:
+    """The classic Hello World — runs JIT'd via WASI fd_write."""
     hello = (
         "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>."
         ">---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."
     )
     vm = BrainfuckVM(jit=True)
     assert vm.run(hello) == b"Hello World!\n"
-    assert vm.is_jit_compiled is False
+    assert vm.is_jit_compiled is True
+
+
+def test_high_byte_output_round_trips_through_latin1() -> None:
+    """WASI decodes bytes as Latin-1 before invoking the stdout
+    callback, so non-ASCII bytes (128-255) must round-trip cleanly.
+    """
+    # 200 increments wraps to byte 200 (0xC8).  Output it.
+    source = ("+" * 200) + "."
+    vm = BrainfuckVM(jit=True)
+    assert vm.run(source) == b"\xc8"
+    assert vm.is_jit_compiled is True
 
 
 # ---------------------------------------------------------------------------
@@ -132,14 +141,19 @@ def test_jit_and_interpreted_produce_same_output_for_io_programs() -> None:
 def test_is_jit_compiled_resets_on_each_run() -> None:
     """A successful JIT run sets is_jit_compiled True; a subsequent
     run that deopts must reset it to False (and vice versa).
+
+    With BF06 wired, both ``+++`` and ``+++.`` JIT, so to exercise the
+    deopt direction we use ``jit=False`` for the middle run.
     """
-    vm = BrainfuckVM(jit=True)
+    vm_jit = BrainfuckVM(jit=True)
+    vm_jit.run("+++")
+    assert vm_jit.is_jit_compiled is True
 
-    vm.run("+++")
-    assert vm.is_jit_compiled is True
+    # Same wrapper, second run still JITs.
+    vm_jit.run("+++.")
+    assert vm_jit.is_jit_compiled is True
 
-    vm.run("+++.")
-    assert vm.is_jit_compiled is False
-
-    vm.run("++>+<")
-    assert vm.is_jit_compiled is True
+    # A wrapper with jit=False never JITs, regardless of program.
+    vm_no_jit = BrainfuckVM(jit=False)
+    vm_no_jit.run("+++.")
+    assert vm_no_jit.is_jit_compiled is False

--- a/code/packages/python/cir-to-compiler-ir/CHANGELOG.md
+++ b/code/packages/python/cir-to-compiler-ir/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] — 2026-04-28 (BF06)
+
+### Added
+
+- **Lowerings for `call_builtin "putchar"` and `"getchar"`.**  Both
+  map to the static IR's ``IrOp.SYSCALL`` (1 = ``fd_write``,
+  2 = ``fd_read``), which ``ir-to-wasm-compiler`` already emits as
+  WASI imports.  Lowering ``call_builtin`` to ``SYSCALL`` is what
+  makes Brainfuck programs with ``.`` / ``,`` JIT to WebAssembly via
+  the in-house ``wasm-runtime`` (BF06).
+- Other ``call_builtin`` names (anything except ``putchar`` /
+  ``getchar``) still hit the unknown-op path, which the JIT backend
+  catches as ``CIRLoweringError`` and treats as a graceful deopt.
+
+### Changed
+
+- **`load_mem` / `store_mem` use a 16-byte heap-base offset.**  The
+  WASM backend places a 16-byte WASI scratch region at the bottom of
+  linear memory whenever a program emits SYSCALL.  Lowering tape
+  access to ``mem[0 + offset]`` aliased the tape's first 16 cells
+  with that scratch and produced corrupted output for any non-trivial
+  I/O program.  The lowering now uses ``mem[16 + offset]``, costing
+  16 bytes of unused linear memory but cleanly avoiding the collision.
+
 ## [0.2.0] — 2026-04-28
 
 ### Added

--- a/code/packages/python/cir-to-compiler-ir/pyproject.toml
+++ b/code/packages/python/cir-to-compiler-ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cir-to-compiler-ir"
-version = "0.2.0"
+version = "0.3.0"
 description = "LANG21 bridge: lowers list[CIRInstr] to IrProgram for any ir-to-* backend"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cir-to-compiler-ir/src/cir_to_compiler_ir/lowering.py
+++ b/code/packages/python/cir-to-compiler-ir/src/cir_to_compiler_ir/lowering.py
@@ -113,6 +113,25 @@ _INT_TYPES: frozenset[str] = frozenset(
 
 _FLOAT_TYPES: frozenset[str] = frozenset({"f32", "f64"})
 
+# ---------------------------------------------------------------------------
+# Heap base offset for ``load_mem`` / ``store_mem`` lowering.
+# ---------------------------------------------------------------------------
+#
+# When the WASM backend compiles a program that uses both byte-tape
+# memory ops AND WASI ``fd_write`` / ``fd_read`` (BF06: Brainfuck's
+# `.` / `,`), it places a 16-byte WASI scratch region at the bottom of
+# linear memory.  A naive ``base = 0`` for tape access would alias the
+# tape's first 16 cells with that scratch — every ``putchar`` would
+# trample tape cells 0..15.
+#
+# Fix: pad past the WASI scratch.  ``_HEAP_BASE_OFFSET`` reserves the
+# first 16 bytes of linear memory for backend use; tape cell N lives
+# at WASM linear-memory address ``_HEAP_BASE_OFFSET + N``.  This costs
+# 16 bytes per program and zero ops at runtime (the offset is a
+# compile-time constant), and cleanly avoids the collision regardless
+# of whether the final program uses WASI.
+_HEAP_BASE_OFFSET = 16
+
 
 # ---------------------------------------------------------------------------
 # _CIRLowerer — the actual lowering engine
@@ -720,7 +739,7 @@ class _CIRLowerer:
                 ptr_reg = ptr_operand
 
             base = self._fresh()
-            self._emit(IrOp.LOAD_IMM, base, IrImmediate(0))
+            self._emit(IrOp.LOAD_IMM, base, IrImmediate(_HEAP_BASE_OFFSET))
             self._emit(IrOp.LOAD_BYTE, dest_reg, base, ptr_reg)
             return
 
@@ -746,9 +765,64 @@ class _CIRLowerer:
                 val_reg = val_operand
 
             base = self._fresh()
-            self._emit(IrOp.LOAD_IMM, base, IrImmediate(0))
+            self._emit(IrOp.LOAD_IMM, base, IrImmediate(_HEAP_BASE_OFFSET))
             self._emit(IrOp.STORE_BYTE, val_reg, base, ptr_reg)
             return
+
+        # ── WASI byte-level I/O (BF06) ──────────────────────────────────────
+        #
+        # ``call_builtin`` is a generic host-call seam in IIR.  Different
+        # languages register different host callables behind it (Brainfuck:
+        # ``putchar`` / ``getchar``; Twig: ``cons`` / ``car`` / ``cdr`` /
+        # ``apply_closure`` / …).  ``ir-to-wasm-compiler`` already knows
+        # how to emit WASI ``fd_write`` / ``fd_read`` sequences from the
+        # ``IrOp.SYSCALL`` opcode — see
+        # ``ir_to_wasm_compiler.compiler._emit_wasi_write`` /
+        # ``_emit_wasi_read``.  So for the byte-I/O builtins we lower
+        # ``call_builtin`` straight to ``SYSCALL`` and inherit the WASI
+        # plumbing for free.
+        #
+        # CIR shapes:
+        #   call_builtin dest=None  srcs=["putchar", "v"]   type="void"
+        #     →   SYSCALL imm=1, val_reg
+        #
+        #   call_builtin dest="v"   srcs=["getchar"]        type="u8"
+        #     →   SYSCALL imm=2, dest_reg
+        #
+        # Every other ``call_builtin`` name still falls through to the
+        # generic "unknown op" path below, which causes the JIT to deopt
+        # to the interpreter — that's the documented contract.
+
+        if op == "call_builtin" and instr.srcs:
+            builtin = str(instr.srcs[0])
+            if builtin == "putchar":
+                if len(instr.srcs) < 2:
+                    raise CIRLoweringError(
+                        "call_builtin 'putchar' expects 1 value argument"
+                    )
+                val_operand = self._operand(instr.srcs[1])
+                if isinstance(val_operand, IrImmediate):
+                    val_reg = self._fresh()
+                    self._emit(IrOp.LOAD_IMM, val_reg, val_operand)
+                else:
+                    val_reg = val_operand
+                self._emit(IrOp.SYSCALL, IrImmediate(1), val_reg)
+                return
+
+            if builtin == "getchar":
+                if dest is None:
+                    raise CIRLoweringError(
+                        "call_builtin 'getchar' must have a dest register"
+                    )
+                dest_reg = self._var(dest)
+                self._emit(IrOp.SYSCALL, IrImmediate(2), dest_reg)
+                return
+
+            # Fall through — other builtin names hit the unknown-op branch
+            # below.  This is the deliberate deopt path: the JIT backend
+            # converts ``CIRLoweringError`` into a "deopt to interpreter"
+            # signal so unsupported builtins simply slow down rather than
+            # crash.
 
         # ── Unsupported ops ──────────────────────────────────────────────────
 

--- a/code/packages/python/cir-to-compiler-ir/tests/test_cir_to_compiler_ir.py
+++ b/code/packages/python/cir-to-compiler-ir/tests/test_cir_to_compiler_ir.py
@@ -638,6 +638,61 @@ class TestMemoryAccess:
 
 
 # ---------------------------------------------------------------------------
+# 11c. Byte-level WASI I/O  (call_builtin "putchar" / "getchar") — BF06
+# ---------------------------------------------------------------------------
+
+class TestCallBuiltinIO:
+    def test_putchar_lowers_to_syscall_1(self):
+        instrs = [
+            CIRInstr("const_u8", "v", [65], "u8"),
+            CIRInstr("call_builtin", None, ["putchar", "v"], "void"),
+            CIRInstr("ret_void", None, [], "void"),
+        ]
+        prog = lower_cir_to_ir_program(instrs)
+        sysc = next(i for i in prog.instructions if i.opcode == IrOp.SYSCALL)
+        assert sysc.operands[0] == IrImmediate(value=1)  # fd_write
+        assert isinstance(sysc.operands[1], IrRegister)
+
+    def test_getchar_lowers_to_syscall_2(self):
+        instrs = [
+            CIRInstr("call_builtin", "v", ["getchar"], "u8"),
+            CIRInstr("ret_void", None, [], "void"),
+        ]
+        prog = lower_cir_to_ir_program(instrs)
+        sysc = next(i for i in prog.instructions if i.opcode == IrOp.SYSCALL)
+        assert sysc.operands[0] == IrImmediate(value=2)  # fd_read
+
+    def test_putchar_with_immediate_materialises_into_scratch(self):
+        instrs = [
+            CIRInstr("call_builtin", None, ["putchar", 65], "void"),
+            CIRInstr("ret_void", None, [], "void"),
+        ]
+        prog = lower_cir_to_ir_program(instrs)
+        # LOAD_IMM scratch=65; SYSCALL 1, scratch; HALT
+        assert _instrs(prog) == _ops(IrOp.LOAD_IMM, IrOp.SYSCALL, IrOp.HALT)
+
+    def test_putchar_missing_value_raises(self):
+        instrs = [CIRInstr("call_builtin", None, ["putchar"], "void")]
+        with pytest.raises(CIRLoweringError, match="putchar"):
+            lower_cir_to_ir_program(instrs)
+
+    def test_getchar_without_dest_raises(self):
+        instrs = [CIRInstr("call_builtin", None, ["getchar"], "u8")]
+        with pytest.raises(CIRLoweringError, match="getchar"):
+            lower_cir_to_ir_program(instrs)
+
+    def test_unknown_builtin_falls_through_to_unknown_op(self):
+        # "alloc_cons" is the canonical Twig cons-cell allocator — it has
+        # no WASI lowering today, so it must hit the unknown-op path,
+        # which the JIT backend translates into a graceful deopt.
+        instrs = [
+            CIRInstr("call_builtin", "h", ["alloc_cons", "a", "b"], "any"),
+        ]
+        with pytest.raises(CIRLoweringError):
+            lower_cir_to_ir_program(instrs)
+
+
+# ---------------------------------------------------------------------------
 # 12. Error cases
 # ---------------------------------------------------------------------------
 

--- a/code/packages/python/wasm-backend/CHANGELOG.md
+++ b/code/packages/python/wasm-backend/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] — 2026-04-28 (BF06)
+
+### Added
+
+- ``WASMBackend(host=…)`` accepts an optional ``wasm_runtime.WasiHost``.
+  When supplied, ``run()`` instantiates the underlying ``WasmRuntime``
+  with that host so programs that emit WASI ``fd_write`` / ``fd_read``
+  imports route stdout / stdin through caller-supplied callbacks.
+  ``host=None`` (the default) preserves the existing behaviour: a fresh
+  default ``WasmRuntime`` per run, stdout discarded, stdin EOF.
+
 ## [0.1.1] — 2026-04-27
 
 ### Added

--- a/code/packages/python/wasm-backend/pyproject.toml
+++ b/code/packages/python/wasm-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-wasm-backend"
-version = "0.1.0"
+version = "0.2.0"
 description = "WebAssembly 1.0 BackendProtocol implementation for the LANG JIT/AOT pipeline"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/code/packages/python/wasm-backend/src/wasm_backend/backend.py
+++ b/code/packages/python/wasm-backend/src/wasm_backend/backend.py
@@ -186,8 +186,29 @@ class WASMBackend:
     #: for diagnostics (stored in ``CodegenResult.backend_name``).
     name: str = "wasm"
 
-    def __init__(self, *, entry_label: str = "_start") -> None:
+    def __init__(
+        self,
+        *,
+        entry_label: str = "_start",
+        host: Any = None,
+    ) -> None:
+        """Construct a WASM JIT backend.
+
+        Parameters
+        ----------
+        entry_label:
+            The exported WASM function name to invoke on ``run()``.
+        host:
+            Optional ``wasm_runtime.WasiHost`` instance.  When supplied,
+            ``run()`` instantiates ``WasmRuntime`` with this host so
+            programs that emit WASI ``fd_write`` / ``fd_read`` calls
+            (BF06: Brainfuck `.` / `,`) can route stdout/stdin through
+            caller-supplied callbacks.  ``None`` preserves the
+            BF05-era behaviour: a fresh default ``WasmRuntime`` per
+            run, with stdout discarded and stdin returning EOF.
+        """
         self.entry_label = entry_label
+        self._host = host
 
     # ------------------------------------------------------------------
     # BackendProtocol — compile()
@@ -331,7 +352,12 @@ class WASMBackend:
         try:
             from wasm_runtime import WasmRuntime
 
-            results = WasmRuntime().load_and_run(binary, self.entry_label, args)
+            runtime = (
+                WasmRuntime(host=self._host)
+                if self._host is not None
+                else WasmRuntime()
+            )
+            results = runtime.load_and_run(binary, self.entry_label, args)
             return results[0] if results else None
         except Exception:
             return None

--- a/code/specs/BF06-brainfuck-jit-io.md
+++ b/code/specs/BF06-brainfuck-jit-io.md
@@ -1,0 +1,142 @@
+# BF06 — Brainfuck JIT for I/O programs (WASI fd_write / fd_read)
+
+## Overview
+
+BF05 wired `BrainfuckVM(jit=True)` so that Brainfuck programs without
+I/O JIT to WebAssembly via the in-house WASM stack.  Programs that use
+`.` or `,` (i.e. that emit `call_builtin "putchar"` / `"getchar"` in
+their IIR) silently deopted to the interpreter because
+`cir-to-compiler-ir` didn't know how to lower `call_builtin` and
+`WASMBackend.compile()` returned `None`.
+
+This spec closes that gap.  After BF06, the canonical Hello World
+Brainfuck program JITs end-to-end:
+
+```python
+vm = BrainfuckVM(jit=True)
+vm.run(HELLO_WORLD)          # prints "Hello World!\n" via WASI fd_write
+assert vm.is_jit_compiled    # True
+```
+
+## How it works (and how surprisingly little new code is needed)
+
+When BF05 landed I expected BF06 to require new IIR ops and substantial
+plumbing.  In fact, **`ir-to-wasm-compiler` already supports WASI**.  The
+existing `IrOp.SYSCALL` opcode emits the right WASI sequence via
+`_emit_wasi_write` / `_emit_wasi_read` (see
+`ir-to-wasm-compiler/compiler.py:913-973`):
+
+- `SYSCALL imm=1, reg`  →  WASI `fd_write(1, iovec, 1, nwritten)` with
+  the byte from `reg` written to scratch memory.
+- `SYSCALL imm=2, reg`  →  WASI `fd_read(0, iovec, 1, nread)` with the
+  byte placed back into `reg`.
+
+`brainfuck-ir-compiler` already uses these for the static-AOT path.  And
+`wasm-runtime` already has a `WasiHost` with `fd_write` / `fd_read`
+implementations that route to `stdout` / `stdin` callbacks.
+
+So BF06 is just three small pieces of glue:
+
+1. **`cir-to-compiler-ir` lowering** for `call_builtin "putchar"` and
+   `"getchar"` to the existing `IrOp.SYSCALL` pattern.
+2. **`wasm-backend` accepts a `WasiHost`** (or the bits to construct
+   one) so the WASM runtime can route stdout/stdin to caller-supplied
+   buffers.
+3. **`BrainfuckVM(jit=True)`** constructs a per-run `WasiHost` with the
+   same `output` bytearray and `input_bytes` it already manages for the
+   interpreter path.
+
+## The `cir-to-compiler-ir` lowering
+
+```
+CIR:  call_builtin dest=None  srcs=["putchar", "v"]   type="void"
+IR :  SYSCALL imm=1, val_reg                  ; val_reg = self._var("v")
+
+CIR:  call_builtin dest="v"   srcs=["getchar"]        type="u8"
+IR :  SYSCALL imm=2, dest_reg                 ; dest_reg = self._var("v")
+```
+
+Other `call_builtin` names are still rejected with `CIRLoweringError`
+(deopt-friendly) until specific lowerings are added — this keeps the
+surface tight and predictable.
+
+The lowering goes in `cir_to_compiler_ir/lowering.py` next to the
+existing `load_mem` / `store_mem` cases (BF05).  It checks
+`instr.srcs[0]` (a literal string — the builtin name) to dispatch.
+
+## `wasm-backend` host wiring
+
+`WASMBackend.run()` currently constructs a default `WasmRuntime()`.
+BF06 lets the caller supply a `WasiHost`:
+
+```python
+class WASMBackend:
+    def __init__(self, *, entry_label: str = "_start",
+                 host: "WasiHost | None" = None) -> None:
+        self.entry_label = entry_label
+        self._host = host
+
+    def run(self, binary, args):
+        ...
+        results = WasmRuntime(host=self._host).load_and_run(...)
+```
+
+When `host=None`, behaviour is unchanged — Tetrad's existing tests
+keep passing.
+
+## `BrainfuckVM` integration
+
+The wrapper already maintains per-run `output: bytearray` and
+`input_buffer: list[int]`.  BF06 routes those through WASI:
+
+```python
+output_chunks: list[str] = []
+def stdout_cb(text: str) -> None:
+    # WASI emits Latin-1 strings — round-trip back to bytes after.
+    output_chunks.append(text)
+
+def stdin_cb(n: int) -> bytes:
+    chunk = bytes(input_buffer[:n])
+    del input_buffer[:n]
+    return chunk
+
+host = WasiHost(stdout=stdout_cb, stdin=stdin_cb)
+backend = WASMBackend(host=host)
+jit = JITCore(vm, backend, threshold_fully_typed=0)
+...
+# After run:
+output += "".join(output_chunks).encode("latin-1")
+```
+
+This keeps the interpreter path's per-run behaviour identical for the
+JIT path: same `tape_size`, same `max_steps` (well — `max_steps`
+doesn't apply to the JIT'd binary; that's a known V1 trade-off, see
+"Out of scope" below).
+
+## Tests
+
+- `cir-to-compiler-ir`: new tests for `call_builtin "putchar"` /
+  `"getchar"` lowering.
+- `wasm-backend`: run with a `host=` parameter actually routes
+  stdout/stdin.
+- `brainfuck-iir-compiler`:
+  - `BrainfuckVM(jit=True).run("+++.")` JITs and emits `b"\x03"`.
+  - Hello World JITs and matches the interpreter byte-for-byte.
+  - `,.` echo with `input_bytes=b"X"` JITs and emits `b"X"`.
+  - Updated TW04-era assertions (`is_jit_compiled is True` for I/O
+    programs, was `False`).
+
+## Out of scope
+
+- **`max_steps` enforcement inside the JIT'd binary.**  The interpreter
+  enforces fuel by counting `label` crossings; the WASM binary doesn't
+  expose that hook.  Programs that JIT and run forever can only be
+  stopped by host-level interruption.  Fix: if `max_steps` is set,
+  fall back to the interpreter (deopt) — or BF07 adds fuel injection
+  in the WASM compiler.  V1 simply documents the limitation.
+- **Other `call_builtin` names** beyond `putchar` / `getchar`.  Those
+  remain `CIRLoweringError` for now and so deopt to the interpreter.
+- **Multiple-byte writes per fd_write call.**  WASI supports it but
+  Brainfuck's IR emits one SYSCALL per `.`, so each call writes a
+  single byte.  A peephole pass that batches consecutive `.` operations
+  is a future optimisation.


### PR DESCRIPTION
## Summary

- **Hello World now JITs.** Brainfuck programs that use \`.\` / \`,\` lower through \`cir-to-compiler-ir\` → \`IrOp.SYSCALL\` → WASI imports → execution on the in-house \`wasm-runtime\`.  No external deps — the entire pipeline is in this repo.
- **\`call_builtin \"putchar\"\` / \`\"getchar\"\` lowerings** in \`cir-to-compiler-ir\`.  Other builtin names still hit the unknown-op path, which the JIT translates into a graceful deopt.
- **\`WASMBackend(host=...)\`** now accepts an optional \`WasiHost\` so callers can wire \`stdout\` / \`stdin\` into per-run callbacks.
- **\`BrainfuckVM(jit=True)\`** constructs a per-run \`WasiHost\` whose callbacks share the same \`output\` bytearray and \`input_buffer\` list the interpreter uses.

Spec: [BF06-brainfuck-jit-io.md](code/specs/BF06-brainfuck-jit-io.md).

## Why this was much smaller than expected

When BF05 landed I scoped BF06 as a multi-package effort: new IrOps, new lowerings in \`ir-to-wasm-compiler\`, new WASI host plumbing, etc.  Reading the code revealed that **\`ir-to-wasm-compiler\` already supports WASI** via existing \`IrOp.SYSCALL\` (\`_emit_wasi_write\` / \`_emit_wasi_read\`), and \`wasm-runtime\` already has a complete \`WasiHost\` with \`fd_write\` / \`fd_read\` implementations.  So BF06 collapsed to three small pieces of glue:

1. cir-to-compiler-ir lowering: 4 new lines in the dispatch table.
2. wasm-backend: one new constructor kwarg.
3. BrainfuckVM: a 30-line block constructing the WasiHost from per-run buffers.

## One trap, one fix

Hello World initially produced \`b'H\\xfd\\x07\\x00\\x03...'\` — first byte right, everything else garbage.  The cause: the WASM compiler places a 16-byte WASI scratch region at linear-memory offset 0 whenever a program emits SYSCALL.  Brainfuck's tape lived at the same offset, so every \`putchar\` corrupted tape cells 0..15.  Fix: \`cir-to-compiler-ir\`'s \`load_mem\` / \`store_mem\` lowering now uses \`base = 16\` instead of \`base = 0\` — costs 16 bytes per WASM module, eliminates the collision unconditionally.

## Test plan

- [x] 74 brainfuck-iir-compiler tests passing
- [x] 78 cir-to-compiler-ir tests passing (includes 6 new \`call_builtin\` lowering tests)
- [x] 57 wasm-backend tests passing
- [x] Coverage: BF 96.82%, cir-to-compiler-ir 90.88%, wasm-backend 94.44%
- [x] \`ruff check\` clean across all three modified packages
- [x] Hello World JITs and outputs \`Hello World!\\n\` byte-for-byte
- [x] High-bit byte (0xC8) round-trips through WASI Latin-1 decode/encode
- [x] Echo (\`,.\`) JITs with caller-supplied input
- [x] Security review passed (1 round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)