### PR TITLE
feat(twig): TW00 — tiny purely-functional Lisp-precursor on the LANG VM

### DIFF
--- a/code/grammars/twig.grammar
+++ b/code/grammars/twig.grammar
@@ -1,0 +1,86 @@
+# Parser grammar for Twig
+# @version 1
+#
+# Twig is a tiny purely-functional Lisp-precursor.  The grammar is
+# small enough to fit in one screen — eight production rules plus a
+# few atoms.
+#
+# How the grammar-driven parser uses this file
+# --------------------------------------------
+# Token names (UPPERCASE) match types defined in ``twig.tokens``.
+# Keyword references in double quotes — ``"define"``, ``"lambda"`` —
+# match KEYWORD tokens whose value equals that string.  Order in an
+# alternation matters: PEG semantics try each branch left-to-right
+# and commit on the first that succeeds, so we list the keyword
+# forms before the generic application rule (which would otherwise
+# greedily consume the ``(`` of every keyword form).
+#
+# Why not ``letrec`` or first-class environments?
+# -----------------------------------------------
+# v1 deliberately omits ``letrec``.  Recursion happens via top-level
+# ``define`` (which works because the body sees the global
+# function table at apply time).  Local recursive bindings require
+# closure cycles and are deferred to TW01 + mark-sweep GC.  See
+# ``code/specs/TW00-twig-language.md``.
+
+# A program is a sequence of forms.  An empty file is valid (it
+# compiles to an empty Twig module that returns ``nil``).
+program = { form } ;
+
+# A form is either a top-level (define ...) or any expression.
+# Top-level expressions accumulate into the synthesised ``main``
+# function whose value is the value of the final expression.
+form = define | expr ;
+
+# (define name expr)              — value binding
+# (define (name args*) expr+)     — function-definition sugar
+#
+# The two shapes share the leading "define" keyword.  The parser
+# distinguishes them by what follows: a NAME token starts the value
+# form, an LPAREN starts the function-sugar form.
+define = LPAREN "define" name_or_signature expr { expr } RPAREN ;
+
+name_or_signature = NAME | LPAREN NAME { NAME } RPAREN ;
+
+# An expression is one of:
+#   - an atom (literal or bare name reference)
+#   - a quoted symbol (sugar for (quote name))
+#   - a parenthesised compound form
+expr = atom | quoted | compound ;
+
+atom = INTEGER | BOOL_TRUE | BOOL_FALSE | "nil" | NAME ;
+
+quoted = QUOTE NAME ;
+
+# The compound forms.  Order matters: keyword-led forms come first
+# so they win over the generic ``apply`` alternative.  Each keyword
+# form is wrapped in its own non-terminal for clarity.
+compound = if_form
+         | let_form
+         | begin_form
+         | lambda_form
+         | quote_form
+         | apply ;
+
+if_form     = LPAREN "if"     expr expr expr RPAREN ;
+
+# (let ((x e1) (y e2) ...) body+)
+# Bindings are mutually independent (Scheme ``let``, not ``let*``).
+let_form    = LPAREN "let" LPAREN { binding } RPAREN expr { expr } RPAREN ;
+binding     = LPAREN NAME expr RPAREN ;
+
+# (begin e1 e2 ...) — sequencing, returns the value of the last expr.
+begin_form  = LPAREN "begin" expr { expr } RPAREN ;
+
+# (lambda (params) body+) — anonymous function.  TW00 supports full
+# closure capture via host-side closure objects (see compiler.py).
+lambda_form = LPAREN "lambda" LPAREN { NAME } RPAREN expr { expr } RPAREN ;
+
+# (quote name) — alternative to '-prefix syntax for symbol literals.
+quote_form  = LPAREN "quote" NAME RPAREN ;
+
+# Generic application: (fn arg0 arg1 ...).  The function position
+# can itself be any expression (so higher-order calls like
+# ``((compose f g) x)`` work), and zero arguments is fine
+# (``(thunk)``).
+apply       = LPAREN expr { expr } RPAREN ;

--- a/code/grammars/twig.tokens
+++ b/code/grammars/twig.tokens
@@ -1,0 +1,94 @@
+# Token definitions for Twig
+# @version 1
+#
+# Twig is a tiny purely-functional Lisp-precursor.  Source is a
+# stream of S-expressions; lexing is correspondingly minimal — a few
+# punctuation characters plus identifiers, integer literals, and the
+# Scheme-style ``#t`` / ``#f`` boolean syntax.
+#
+# Example source showing every token kind:
+#
+#   (define (length xs)         ; comment to end of line
+#     (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+#
+# The ``;`` to end-of-line comment + ``WHITESPACE`` skip pattern keep
+# the parser stream clean — neither comments nor whitespace ever
+# reach the parser.
+#
+# Token ordering matters: literals before patterns, longer literals
+# before shorter ones that are prefixes (``#t`` vs ``#``).  The
+# grammar-driven lexer tries each rule top-to-bottom and commits on
+# the first match, so we put the unambiguous shapes early.
+
+# ---------------------------------------------------------------------------
+# Punctuation literals
+# ---------------------------------------------------------------------------
+LPAREN     = "("
+RPAREN     = ")"
+QUOTE      = "'"
+
+# ---------------------------------------------------------------------------
+# Boolean literals
+#
+# Scheme/Lisp tradition: ``#t`` and ``#f``.  These are exact two-character
+# literals and must come before any pattern that could swallow ``#``.
+# ---------------------------------------------------------------------------
+BOOL_TRUE  = "#t"
+BOOL_FALSE = "#f"
+
+# ---------------------------------------------------------------------------
+# Numeric literals
+#
+# Twig V1 has only signed integers.  The leading ``-?`` handles
+# negative literals (``-7``) while the lexer's longest-match rule
+# ensures that bare ``-`` (the subtraction operator) still tokenises
+# as a NAME because ``/-?[0-9]+/`` requires at least one digit.
+# Floats / rationals can be added later by extending this regex.
+# ---------------------------------------------------------------------------
+INTEGER    = /-?[0-9]+/
+
+# ---------------------------------------------------------------------------
+# Identifiers — names, operators, predicates
+#
+# Lisp names are very permissive: arithmetic operators (``+`` / ``-`` /
+# ``*`` / ``/``), comparisons (``=`` / ``<`` / ``>``), trailing ``?``
+# for predicates (``null?`` / ``pair?``), trailing ``!`` for mutators
+# (none in V1, but we admit the syntax for forward compatibility),
+# plus underscores and dollar signs.  Digits are allowed inside an
+# identifier but not at its start — ``42`` is an INTEGER, ``f42`` is
+# a NAME.
+# ---------------------------------------------------------------------------
+NAME       = /[A-Za-z+\-*/=<>!?_$][A-Za-z+\-*/=<>!?_$0-9]*/
+
+# ---------------------------------------------------------------------------
+# Keyword promotion
+#
+# Words listed below, when they would otherwise lex as NAME, are
+# emitted by the GrammarLexer as KEYWORD tokens with the matched word
+# as the token's ``value``.  The parser's grammar tests for them with
+# string literals (``"define"``, ``"if"``, ...) and dispatches to the
+# corresponding rule.
+#
+# ``nil`` is here so the parser can recognise the empty-list literal
+# without us having to special-case the value of every NAME token.
+# ---------------------------------------------------------------------------
+keywords:
+  define
+  lambda
+  let
+  if
+  begin
+  quote
+  nil
+
+# ---------------------------------------------------------------------------
+# Skip patterns — consumed silently, never reach the parser
+# ---------------------------------------------------------------------------
+# WHITESPACE captures all the usual suspects + ``\r`` for Windows
+# line endings (the Python lexer normalises CRLF here so the line
+# counter stays accurate).  COMMENT is the Lisp ``;`` line comment,
+# which runs to the next newline (the newline itself is consumed by
+# WHITESPACE).
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+  COMMENT    = /;[^\n]*/

--- a/code/packages/python/twig/BUILD
+++ b/code/packages/python/twig/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ".[dev]" --quiet
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig/BUILD
+++ b/code/packages/python/twig/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../virtual-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig/BUILD
+++ b/code/packages/python/twig/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../virtual-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ".[dev]" --quiet
+uv pip install -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig/CHANGELOG.md
+++ b/code/packages/python/twig/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog — twig
+
+All notable changes to this package will be documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-04-28 (TW00 initial release)
+
+### Added
+
+- **Lexer + parser** built on the repo's grammar-driven pipeline
+  (``grammar-tools`` + ``lexer`` + ``parser``).  Source-of-truth
+  grammar files live in ``code/grammars/twig.tokens`` and
+  ``code/grammars/twig.grammar``.  The package's ``lexer.py`` and
+  ``parser.py`` are thin shims that load those files — same shape
+  as Brainfuck, Dartmouth BASIC, ALGOL, etc.
+- **Typed AST** — ``ast_extract.extract_program`` lifts the generic
+  ``ASTNode`` tree into a small set of typed dataclasses
+  (``Define`` / ``If`` / ``Let`` / ``Lambda`` / ``Apply`` / …) so
+  the compiler walks an exhaustive set of cases rather than a
+  ``rule_name`` switch.
+- **Heap** — refcounted host-side heap supporting cons cells,
+  interned symbols, and closures.  Symbols are not refcounted; cons
+  cells and closures own any nested handles via ``incref`` /
+  ``decref``.  Cycles leak in v1 (no ``letrec`` to construct them in
+  the surface, but possible via top-level defines pointing at each
+  other) — TW01's mark-sweep handles them.
+- **Free-variable analysis** — ``free_vars.free_vars(lam, globals_)``
+  returns the ordered list of names a lambda captures, used by the
+  compiler to emit ``call_builtin "make_closure"`` with the right
+  capture list.
+- **Compiler** — typed AST → ``IIRModule``.  Top-level functions
+  become direct-call IIR functions; anonymous lambdas become
+  gensym'd top-level IIR functions whose leading parameters hold
+  captured values; apply-site dispatch chooses direct ``call`` vs.
+  indirect ``call_builtin "apply_closure"`` at compile time.
+- **TwigVM** — wraps ``vm-core``, registers builtins, owns a per-run
+  heap and globals table, overrides ``jmp_if_true`` /
+  ``jmp_if_false`` so ``if`` uses Scheme truthiness (``0`` is
+  truthy; only ``#f`` and ``nil`` are falsy).
+- **Builtins**: ``+``, ``-``, ``*``, ``/``, ``=``, ``<``, ``>``,
+  ``cons``, ``car``, ``cdr``, ``null?``, ``pair?``, ``number?``,
+  ``symbol?``, ``print``.
+- TW00 spec: ``code/specs/TW00-twig-language.md``.
+
+### Notes
+
+- TW01 will replace refcounting with mark-sweep, add ``letrec``,
+  and promote the heap operations from ``call_builtin`` into
+  native IIR ops via a new ``gc-core`` package.
+- TW02 will compile Twig to BEAM bytecode directly (no Erlang
+  source intermediary) — analogous to how ``wasm-backend`` produces
+  WASM bytes natively.

--- a/code/packages/python/twig/README.md
+++ b/code/packages/python/twig/README.md
@@ -1,0 +1,47 @@
+# twig
+
+Twig is a tiny purely-functional Lisp-precursor that runs on
+``vm-core``.  Eight forms total, no macros, full closures via a
+host-side refcounted heap.
+
+See [TW00 spec](../../../specs/TW00-twig-language.md) for the v1
+surface and the multi-spec roadmap (TW01: mark-sweep GC + letrec;
+TW02: direct BEAM bytecode emission).
+
+## Why Twig exists
+
+Brainfuck proved out the LANG VM end-to-end on a flat byte tape.
+Twig pushes the same infrastructure into territory that Brainfuck
+never touches:
+
+* **Heap allocation with lifetime management** — cons cells, symbols,
+  and closures live in a host-side ``Heap`` exposed through
+  ``call_builtin``.  TW00 ships reference counting; TW01 swaps in
+  mark-sweep without changing the language surface.
+* **First-class functions with captured environments** — the
+  compiler does free-variable analysis at lambda sites and
+  routes apply-of-local through ``call_builtin "apply_closure"``.
+* **A roadmap to a real Lisp** — Twig's surface is a strict subset
+  of Scheme R5RS (minus macros).  Adding ``letrec``, ``set!`` (or
+  rejecting it permanently for purely-functional reasons), and
+  ``cond`` is straightforward when the GC layer is solid.
+
+## Quick start
+
+```python
+from twig import TwigVM
+
+vm = TwigVM()
+output, value = vm.run("""
+  (define (length xs)
+    (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+  (length (cons 1 (cons 2 (cons 3 nil))))
+""")
+print(value)   # 3
+```
+
+## Status
+
+- ✅ TW00: lexer / parser / compiler / refcounted heap / TwigVM.
+- ⏭ TW01: ``letrec``, mark-sweep GC, cycle handling.
+- ⏭ TW02: Twig → BEAM bytecode (direct, no Erlang source).

--- a/code/packages/python/twig/pyproject.toml
+++ b/code/packages/python/twig/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-twig"
+version = "0.1.0"
+description = "Twig: a tiny purely-functional Lisp precursor that runs on vm-core"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["twig", "lisp", "scheme", "functional", "interpreter-ir", "vm", "gc", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Interpreters",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+dependencies = [
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-interpreter-ir",
+    "coding-adventures-vm-core",
+]
+
+[tool.uv.sources]
+coding-adventures-grammar-tools = { path = "../grammar-tools", editable = true }
+coding-adventures-lexer = { path = "../lexer", editable = true }
+coding-adventures-parser = { path = "../parser", editable = true }
+coding-adventures-interpreter-ir = { path = "../interpreter-ir", editable = true }
+coding-adventures-vm-core = { path = "../vm-core", editable = true }
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=twig --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/twig"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/twig"]

--- a/code/packages/python/twig/src/twig/__init__.py
+++ b/code/packages/python/twig/src/twig/__init__.py
@@ -1,0 +1,52 @@
+"""Twig — a tiny purely-functional Lisp-precursor on the LANG VM.
+
+See ``code/specs/TW00-twig-language.md`` for the v1 surface, the
+roadmap toward a full Lisp, and the GC / BEAM-bytecode follow-ons.
+
+Quick start::
+
+    from twig import TwigVM
+
+    vm = TwigVM()
+    output, value = vm.run('''
+        (define (length xs)
+          (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+        (length (cons 1 (cons 2 (cons 3 nil))))
+    ''')
+    assert value == 3
+"""
+
+from __future__ import annotations
+
+from twig.ast_extract import extract_program
+from twig.compiler import compile_program
+from twig.errors import (
+    TwigCompileError,
+    TwigError,
+    TwigParseError,
+    TwigRuntimeError,
+)
+from twig.heap import NIL, Heap, HeapHandle, HeapStats
+from twig.lexer import tokenize_twig
+from twig.parser import parse_twig
+from twig.vm import TwigVM
+
+__all__ = [
+    # High-level entry
+    "TwigVM",
+    # Pipeline stages
+    "tokenize_twig",
+    "parse_twig",
+    "extract_program",
+    "compile_program",
+    # Heap surface
+    "Heap",
+    "HeapHandle",
+    "HeapStats",
+    "NIL",
+    # Errors
+    "TwigError",
+    "TwigParseError",
+    "TwigCompileError",
+    "TwigRuntimeError",
+]

--- a/code/packages/python/twig/src/twig/ast_extract.py
+++ b/code/packages/python/twig/src/twig/ast_extract.py
@@ -1,0 +1,347 @@
+"""Convert the generic ``ASTNode`` tree into typed Twig nodes.
+
+The grammar-driven parser emits one ASTNode per non-terminal (e.g.
+``program``, ``form``, ``expr``, ``compound``, ``apply``).  These
+wrapping non-terminals exist to make the grammar readable but they
+have no semantic content of their own — the *meaningful* shapes
+(``define``, ``if_form``, ``apply``, …) are nested inside.
+
+This module walks the generic tree and lifts each meaningful
+subtree into a typed node from :mod:`twig.ast_nodes`.  Compiler and
+analyser code downstream then deals with a small, exhaustive set of
+classes rather than a sea of ``rule_name`` checks.
+
+The conversion is a straightforward recursive descent.  Each
+extractor function consumes one ``ASTNode`` and returns one typed
+node, or raises :class:`TwigParseError` if the shape is unexpected
+(which only happens if the grammar file has drifted out of sync
+with this module — both are kept aligned by tests).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lang_parser import ASTNode
+
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    BoolLit,
+    Define,
+    Expr,
+    Form,
+    If,
+    IntLit,
+    Lambda,
+    Let,
+    NilLit,
+    Program,
+    SymLit,
+    VarRef,
+)
+from twig.errors import TwigParseError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_token(node: Any, type_name: str | None = None) -> bool:
+    """True iff *node* is a Token (not an ASTNode), optionally of
+    a given ``type``.
+
+    The lang_parser stream includes ``Token`` objects whose ``type``
+    is either a ``TokenType`` enum member (``LPAREN``, ``RPAREN``,
+    ``KEYWORD``, ``NAME``) or a custom string emitted by the lexer
+    (``"INTEGER"``, ``"BOOL_TRUE"``, ``"BOOL_FALSE"``).  The grammar
+    lexer normalises these uniformly so we just compare the string
+    representation.
+    """
+    if isinstance(node, ASTNode):
+        return False
+    if type_name is None:
+        return True
+    actual = getattr(node, "type", None)
+    if actual is None:
+        return False
+    name = getattr(actual, "name", None) or str(actual)
+    return name == type_name
+
+
+def _ast_children(node: ASTNode) -> list[ASTNode]:
+    """Return only ``ASTNode`` children, skipping bare tokens.
+
+    Many grammar rules include literal punctuation like ``LPAREN`` /
+    ``RPAREN`` in the children list; downstream code is rarely
+    interested in those.  This helper filters them out so we can
+    focus on the structural sub-rules.
+    """
+    return [c for c in node.children if isinstance(c, ASTNode)]
+
+
+def _expect_rule(node: ASTNode, *names: str) -> None:
+    if node.rule_name not in names:
+        raise TwigParseError(
+            f"expected {' | '.join(names)} but got {node.rule_name!r}"
+        )
+
+
+def _pos(node: ASTNode | Any) -> tuple[int | None, int | None]:
+    """Best-effort source-position extraction."""
+    line = getattr(node, "start_line", None) or getattr(node, "line", None)
+    col = getattr(node, "start_column", None) or getattr(node, "column", None)
+    return line, col
+
+
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
+
+
+def extract_program(root: ASTNode) -> Program:
+    """Convert a parsed ``program`` ASTNode into a :class:`Program`."""
+    _expect_rule(root, "program")
+    forms: list[Form] = []
+    for child in _ast_children(root):
+        _expect_rule(child, "form")
+        forms.append(_extract_form(child))
+    return Program(forms=forms)
+
+
+# ---------------------------------------------------------------------------
+# Forms (define | expr)
+# ---------------------------------------------------------------------------
+
+
+def _extract_form(node: ASTNode) -> Form:
+    # ``form = define | expr ;`` — the AST has exactly one ASTNode child.
+    inner = _ast_children(node)[0]
+    if inner.rule_name == "define":
+        return _extract_define(inner)
+    if inner.rule_name == "expr":
+        return _extract_expr(inner)
+    raise TwigParseError(f"unexpected form child: {inner.rule_name!r}")
+
+
+def _extract_define(node: ASTNode) -> Define:
+    # define = LPAREN "define" name_or_signature expr { expr } RPAREN
+    line, col = _pos(node)
+    children = _ast_children(node)
+    sig_node = children[0]
+    body_exprs = [_extract_expr(c) for c in children[1:]]
+    if not body_exprs:
+        raise TwigParseError("(define …) must have a body expression",
+                             line=line, column=col)
+
+    # name_or_signature = NAME | LPAREN NAME { NAME } RPAREN
+    sig_children = sig_node.children
+    name_tokens = [c for c in sig_children if _is_token(c, "NAME")]
+    if not name_tokens:
+        raise TwigParseError("(define …) missing a name", line=line, column=col)
+
+    if len(name_tokens) == 1 and not _has_paren(sig_children):
+        # Plain (define name expr) — single body expression expected.
+        if len(body_exprs) != 1:
+            raise TwigParseError(
+                "(define name expr) takes exactly one body expression — "
+                "use (define (name args...) body+) for multi-expression bodies",
+                line=line, column=col,
+            )
+        return Define(
+            name=str(name_tokens[0].value),
+            expr=body_exprs[0],
+            line=line, column=col,
+        )
+
+    # Function-sugar form: (define (name args...) body+)
+    fn_name = str(name_tokens[0].value)
+    params = [str(t.value) for t in name_tokens[1:]]
+    lam = Lambda(params=params, body=body_exprs, line=line, column=col)
+    return Define(name=fn_name, expr=lam, line=line, column=col)
+
+
+def _has_paren(children: list[Any]) -> bool:
+    return any(_is_token(c, "LPAREN") for c in children)
+
+
+# ---------------------------------------------------------------------------
+# Expressions
+# ---------------------------------------------------------------------------
+
+
+def _extract_expr(node: ASTNode) -> Expr:
+    _expect_rule(node, "expr")
+    inner = _ast_children(node)[0]
+    if inner.rule_name == "atom":
+        return _extract_atom(inner)
+    if inner.rule_name == "quoted":
+        return _extract_quoted(inner)
+    if inner.rule_name == "compound":
+        return _extract_compound(inner)
+    raise TwigParseError(f"unexpected expr child: {inner.rule_name!r}")
+
+
+def _extract_atom(node: ASTNode) -> Expr:
+    # atom = INTEGER | BOOL_TRUE | BOOL_FALSE | "nil" | NAME
+    line, col = _pos(node)
+    # Atom children are bare tokens, not ASTNodes.
+    tok = next((c for c in node.children if not isinstance(c, ASTNode)), None)
+    if tok is None:
+        raise TwigParseError("empty atom", line=line, column=col)
+    type_name = getattr(getattr(tok, "type", None), "name", None) or str(tok.type)
+
+    if type_name == "INTEGER":
+        return IntLit(value=int(tok.value), line=line, column=col)
+    if type_name == "BOOL_TRUE":
+        return BoolLit(value=True, line=line, column=col)
+    if type_name == "BOOL_FALSE":
+        return BoolLit(value=False, line=line, column=col)
+    if type_name == "KEYWORD" and tok.value == "nil":
+        return NilLit(line=line, column=col)
+    if type_name == "NAME":
+        return VarRef(name=str(tok.value), line=line, column=col)
+    raise TwigParseError(
+        f"unexpected atom token: type={type_name!r} value={tok.value!r}",
+        line=line, column=col,
+    )
+
+
+def _extract_quoted(node: ASTNode) -> SymLit:
+    # quoted = QUOTE NAME — bare tokens, no nested ASTNodes
+    line, col = _pos(node)
+    name_tok = next(
+        (c for c in node.children if _is_token(c, "NAME")), None
+    )
+    if name_tok is None:
+        raise TwigParseError("expected NAME after '", line=line, column=col)
+    return SymLit(name=str(name_tok.value), line=line, column=col)
+
+
+def _extract_compound(node: ASTNode) -> Expr:
+    inner = _ast_children(node)[0]
+    line, col = _pos(node)
+    rule = inner.rule_name
+    if rule == "if_form":
+        return _extract_if(inner)
+    if rule == "let_form":
+        return _extract_let(inner)
+    if rule == "begin_form":
+        return _extract_begin(inner)
+    if rule == "lambda_form":
+        return _extract_lambda(inner)
+    if rule == "quote_form":
+        return _extract_quote_form(inner)
+    if rule == "apply":
+        return _extract_apply(inner)
+    raise TwigParseError(
+        f"unexpected compound child: {rule!r}", line=line, column=col,
+    )
+
+
+def _extract_if(node: ASTNode) -> If:
+    # if_form = LPAREN "if" expr expr expr RPAREN
+    line, col = _pos(node)
+    exprs = [_extract_expr(c) for c in _ast_children(node) if c.rule_name == "expr"]
+    if len(exprs) != 3:
+        raise TwigParseError(
+            "(if …) takes exactly 3 expressions",
+            line=line, column=col,
+        )
+    return If(
+        cond=exprs[0],
+        then_branch=exprs[1],
+        else_branch=exprs[2],
+        line=line, column=col,
+    )
+
+
+def _extract_let(node: ASTNode) -> Let:
+    # let_form = LPAREN "let" LPAREN { binding } RPAREN expr { expr } RPAREN
+    line, col = _pos(node)
+    bindings: list[tuple[str, Expr]] = []
+    body: list[Expr] = []
+    for child in _ast_children(node):
+        if child.rule_name == "binding":
+            bindings.append(_extract_binding(child))
+        elif child.rule_name == "expr":
+            body.append(_extract_expr(child))
+    if not body:
+        raise TwigParseError(
+            "(let (...) ...) needs at least one body expression",
+            line=line, column=col,
+        )
+    return Let(bindings=bindings, body=body, line=line, column=col)
+
+
+def _extract_binding(node: ASTNode) -> tuple[str, Expr]:
+    # binding = LPAREN NAME expr RPAREN
+    name_tok = next((c for c in node.children if _is_token(c, "NAME")), None)
+    expr_node = next(
+        (c for c in node.children if isinstance(c, ASTNode) and c.rule_name == "expr"),
+        None,
+    )
+    if name_tok is None or expr_node is None:
+        line, col = _pos(node)
+        raise TwigParseError(
+            "malformed binding — expected (name expr)",
+            line=line, column=col,
+        )
+    return str(name_tok.value), _extract_expr(expr_node)
+
+
+def _extract_begin(node: ASTNode) -> Begin:
+    # begin_form = LPAREN "begin" expr { expr } RPAREN
+    line, col = _pos(node)
+    exprs = [_extract_expr(c) for c in _ast_children(node) if c.rule_name == "expr"]
+    if not exprs:
+        raise TwigParseError(
+            "(begin …) needs at least one expression",
+            line=line, column=col,
+        )
+    return Begin(exprs=exprs, line=line, column=col)
+
+
+def _extract_lambda(node: ASTNode) -> Lambda:
+    # lambda_form = LPAREN "lambda" LPAREN { NAME } RPAREN expr { expr } RPAREN
+    line, col = _pos(node)
+    # Walk children: collect the NAMEs (params) before the first expr.
+    params: list[str] = []
+    body: list[Expr] = []
+    seen_first_expr = False
+    for child in node.children:
+        if isinstance(child, ASTNode) and child.rule_name == "expr":
+            body.append(_extract_expr(child))
+            seen_first_expr = True
+        elif _is_token(child, "NAME") and not seen_first_expr:
+            params.append(str(child.value))
+    if not body:
+        raise TwigParseError(
+            "(lambda (...) …) needs at least one body expression",
+            line=line, column=col,
+        )
+    return Lambda(params=params, body=body, line=line, column=col)
+
+
+def _extract_quote_form(node: ASTNode) -> SymLit:
+    # quote_form = LPAREN "quote" NAME RPAREN
+    line, col = _pos(node)
+    name_tok = next((c for c in node.children if _is_token(c, "NAME")), None)
+    if name_tok is None:
+        raise TwigParseError(
+            "(quote …) needs a name",
+            line=line, column=col,
+        )
+    return SymLit(name=str(name_tok.value), line=line, column=col)
+
+
+def _extract_apply(node: ASTNode) -> Apply:
+    # apply = LPAREN expr { expr } RPAREN
+    line, col = _pos(node)
+    exprs = [_extract_expr(c) for c in _ast_children(node) if c.rule_name == "expr"]
+    if not exprs:
+        raise TwigParseError(
+            "empty application '()' — use 'nil' for the empty list",
+            line=line, column=col,
+        )
+    return Apply(fn=exprs[0], args=exprs[1:], line=line, column=col)

--- a/code/packages/python/twig/src/twig/ast_nodes.py
+++ b/code/packages/python/twig/src/twig/ast_nodes.py
@@ -1,0 +1,181 @@
+"""Typed AST nodes for Twig.
+
+Why a typed AST on top of the generic ``ASTNode``?
+==================================================
+The grammar-driven parser emits a generic :class:`lang_parser.ASTNode`
+tree where each node carries a ``rule_name`` and a list of children
+that mix ASTNodes with ``Token``s.  Walking that tree directly in the
+compiler means a sea of ``isinstance`` checks and ``rule_name``
+dispatches with no static structure.
+
+Twig has eight semantic forms.  Lifting the generic AST into typed
+dataclasses (:class:`If`, :class:`Lambda`, :class:`Apply`, …) gives
+the compiler and the free-variable analyser a small, exhaustive
+set of cases to handle, with each variant carrying exactly the
+fields it needs.  This is the same pattern that ``compiler-ir`` and
+``interpreter-ir`` use for their own IR shapes.
+
+Conversion happens in :mod:`twig.ast_extract`.  Source positions are
+preserved on every node for future LSP / debugger integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Atoms
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IntLit:
+    value: int
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass(frozen=True)
+class BoolLit:
+    value: bool
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass(frozen=True)
+class NilLit:
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass(frozen=True)
+class SymLit:
+    """A quoted symbol: ``'foo`` or ``(quote foo)``."""
+
+    name: str
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass(frozen=True)
+class VarRef:
+    """A bare name reference: ``x``, ``length``, ``+``, ``cons``."""
+
+    name: str
+    line: int | None = None
+    column: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Compound expressions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class If:
+    cond: Expr
+    then_branch: Expr
+    else_branch: Expr
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class Let:
+    """Mutually-independent (Scheme ``let``, not ``let*``) bindings.
+
+    ``body`` is one or more expressions; the value of the last one is
+    the value of the ``let``.
+    """
+
+    bindings: list[tuple[str, Expr]]
+    body: list[Expr] = field(default_factory=list)
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class Begin:
+    exprs: list[Expr]
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class Lambda:
+    """Anonymous function.
+
+    Free variables are resolved at compile time: every name that
+    appears in ``body``, isn't a parameter, and isn't a top-level
+    ``define`` becomes a *captured* variable, computed by
+    :mod:`twig.free_vars`.
+    """
+
+    params: list[str]
+    body: list[Expr]
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class Apply:
+    """Function application: ``(fn arg0 arg1 ...)``.
+
+    The compiler decides at compile time whether this is a direct
+    call (``fn`` is a top-level name) or an indirect closure call
+    (``fn`` is anything else).
+    """
+
+    fn: Expr
+    args: list[Expr]
+    line: int | None = None
+    column: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Top-level forms
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Define:
+    """``(define name expr)`` or its function-sugar variant."""
+
+    name: str
+    expr: Expr
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class Program:
+    """A whole compilation unit.
+
+    ``forms`` is the ordered sequence of top-level defines and
+    expressions.  Top-level expressions accumulate into the
+    synthesised ``main`` function during compilation.
+    """
+
+    forms: list[Form]
+
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+
+# A type-checker-friendly union of every expression kind.
+Expr = (
+    IntLit
+    | BoolLit
+    | NilLit
+    | SymLit
+    | VarRef
+    | If
+    | Let
+    | Begin
+    | Lambda
+    | Apply
+)
+
+Form = Expr | Define

--- a/code/packages/python/twig/src/twig/compiler.py
+++ b/code/packages/python/twig/src/twig/compiler.py
@@ -1,0 +1,655 @@
+"""Twig compiler: typed AST → ``IIRModule``.
+
+Pipeline shape
+==============
+::
+
+    Twig source
+      → parse_twig                  (lexer + grammar parser)
+      → extract_program             (typed AST)
+      → compile_program (this file) → IIRModule
+      → vm-core / TwigVM runtime
+
+What this compiler emits
+========================
+* One ``IIRFunction`` for the program's synthesised ``main``,
+  containing the value defines and top-level expressions in source
+  order.  ``main`` returns the value of the final top-level
+  expression (or ``nil`` if the program has none).
+* One ``IIRFunction`` per top-level ``(define (f ...) ...)``.
+* One ``IIRFunction`` per anonymous ``lambda`` expression.  These
+  use gensym'd names like ``__lambda_3`` and accept the captured
+  free-variable values as their *leading* parameters, followed by
+  the user-declared parameters.
+
+Apply-site dispatch
+===================
+The compiler decides at compile time whether an ``Apply`` is a
+direct call or an indirect closure call:
+
+* If ``apply.fn`` is a ``VarRef`` whose name is a top-level *function*
+  define **or** a builtin → emit ``IIRInstr("call", dest, [name, ...args])``.
+* Otherwise (locals, value-globals, computed expressions) → emit
+  ``IIRInstr("call_builtin", dest, ["apply_closure", handle, ...args])``.
+
+The ``apply_closure`` builtin lives in the host (TwigVM) and
+re-enters ``vm.execute`` with the closure's captured environment
+prepended to the user-supplied arguments.
+
+Globals
+=======
+Top-level ``(define name expr)`` of a *value* (not a function) is
+implemented via host builtins:
+
+* The synthesised ``main`` evaluates the RHS and emits
+  ``call_builtin "global_set" "name" value`` to stash it.
+* References to value-globals compile to
+  ``call_builtin "global_get" "name"``.
+
+Function defines do not go through ``global_*`` — references to them
+compile to direct ``call``s, which is faster and matches Scheme's
+top-level semantics.
+
+Why all type hints are ``"any"``
+================================
+Twig is dynamically typed.  Every emitted instruction carries
+``type_hint="any"`` so the VM's profiler can later observe runtime
+types and feed them back into JIT specialisation (a future spec).
+The ``IIRFunction.type_status`` is left at ``UNTYPED`` for the same
+reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from interpreter_ir import (
+    FunctionTypeStatus,
+    IIRFunction,
+    IIRInstr,
+    IIRModule,
+)
+
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    BoolLit,
+    Define,
+    Expr,
+    If,
+    IntLit,
+    Lambda,
+    Let,
+    NilLit,
+    Program,
+    SymLit,
+    VarRef,
+)
+from twig.errors import TwigCompileError
+from twig.free_vars import free_vars
+
+# ---------------------------------------------------------------------------
+# Built-in names
+# ---------------------------------------------------------------------------
+#
+# Builtins are host-side callables registered with ``vm-core``'s
+# ``BuiltinRegistry`` by ``TwigVM``.  They are invoked through
+# ``call_builtin``.  The compiler treats their names as part of the
+# global namespace: a reference to ``+`` or ``cons`` resolves to a
+# direct builtin call, never a "name not found" error.
+BUILTINS: frozenset[str] = frozenset(
+    {
+        # Arithmetic / comparison
+        "+", "-", "*", "/", "=", "<", ">",
+        # Cons cells
+        "cons", "car", "cdr",
+        # Predicates
+        "null?", "pair?", "number?", "symbol?",
+        # I/O
+        "print",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-function compilation context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FnCtx:
+    """Mutable state while compiling one IIRFunction body."""
+
+    instrs: list[IIRInstr] = field(default_factory=list)
+    locals_: set[str] = field(default_factory=set)
+    """Names introduced at this function's top level (params + lets).
+
+    Used by free-var analysis when a nested lambda computes its
+    captures: any name that is *currently bound* in this frame is a
+    legitimate capture, anything else must be a global or a typo.
+    """
+
+    label_counter: int = 0
+    var_counter: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level compiler driver
+# ---------------------------------------------------------------------------
+
+
+class _Compiler:
+    """Compile a :class:`Program` into an ``IIRModule``."""
+
+    def __init__(self, *, module_name: str = "twig") -> None:
+        self._module_name = module_name
+        # Top-level function names (define of a lambda).
+        self._fn_globals: set[str] = set()
+        # Top-level value names (define of a non-lambda).
+        self._value_globals: set[str] = set()
+        # Cumulative function table — populated as we compile each
+        # top-level define and each anonymous lambda.
+        self._functions: list[IIRFunction] = []
+        # Gensym counter for synthetic top-level function names.
+        self._lambda_counter: int = 0
+
+    # ------------------------------------------------------------------
+    # Public entry
+    # ------------------------------------------------------------------
+
+    def compile(self, program: Program) -> IIRModule:
+        # ── Pre-pass: classify every top-level define ─────────────────
+        # We need this before walking bodies because free-variable
+        # analysis at lambda sites needs to know which names are
+        # globals and therefore *don't* count as free.
+        for form in program.forms:
+            if isinstance(form, Define):
+                if isinstance(form.expr, Lambda):
+                    self._fn_globals.add(form.name)
+                else:
+                    self._value_globals.add(form.name)
+
+        # ── Compile every top-level form ──────────────────────────────
+        # Function defines become IIRFunctions; value defines and
+        # bare top-level expressions accumulate into ``main``.
+        main_ctx = _FnCtx()
+        last_main_value: str | None = None
+        for form in program.forms:
+            if isinstance(form, Define) and isinstance(form.expr, Lambda):
+                self._compile_top_level_lambda(form.name, form.expr)
+            elif isinstance(form, Define):
+                # (define x expr) — evaluate at top level, store in globals.
+                v = self._compile_expr(form.expr, main_ctx)
+                name_reg = self._string_arg(main_ctx, form.name)
+                self._emit_call_builtin(
+                    main_ctx,
+                    builtin="global_set",
+                    args=[name_reg, v],
+                    dest=None,
+                )
+                last_main_value = None  # define returns nothing useful
+            else:
+                # Bare top-level expression.  Its value becomes the
+                # candidate return value for ``main``.
+                last_main_value = self._compile_expr(form, main_ctx)
+
+        # ── Synthesised ``main`` ──────────────────────────────────────
+        if last_main_value is not None:
+            main_ctx.instrs.append(
+                IIRInstr("ret", None, [last_main_value], type_hint="any")
+            )
+        else:
+            # No final value-producing expression → return nil.
+            nil_var = self._fresh(main_ctx, "nil")
+            self._emit_call_builtin(
+                main_ctx, builtin="make_nil", args=[], dest=nil_var
+            )
+            main_ctx.instrs.append(
+                IIRInstr("ret", None, [nil_var], type_hint="any")
+            )
+
+        self._functions.append(
+            IIRFunction(
+                name="main",
+                params=[],
+                return_type="any",
+                instructions=main_ctx.instrs,
+                register_count=self._reg_count(main_ctx),
+                type_status=FunctionTypeStatus.UNTYPED,
+            )
+        )
+
+        return IIRModule(
+            name=self._module_name,
+            functions=self._functions,
+            entry_point="main",
+            language="twig",
+        )
+
+    # ------------------------------------------------------------------
+    # Function compilation
+    # ------------------------------------------------------------------
+
+    def _compile_top_level_lambda(self, name: str, lam: Lambda) -> None:
+        """Compile ``(define (name args...) body+)``.
+
+        Top-level functions never have free variables (TW00 doesn't
+        permit forward references that aren't themselves globals),
+        so the IIR signature is just the user-declared parameters.
+        Captured-var prefixing is for *anonymous* lambdas only.
+        """
+        ctx = _FnCtx()
+        ctx.locals_.update(lam.params)
+
+        last: str | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            # Empty body would have been rejected by the parser, but
+            # guard defensively.
+            raise TwigCompileError(f"function {name!r} has empty body")
+        ctx.instrs.append(IIRInstr("ret", None, [last], type_hint="any"))
+
+        self._functions.append(
+            IIRFunction(
+                name=name,
+                params=[(p, "any") for p in lam.params],
+                return_type="any",
+                instructions=ctx.instrs,
+                register_count=self._reg_count(ctx),
+                type_status=FunctionTypeStatus.UNTYPED,
+            )
+        )
+
+    def _compile_anonymous_lambda(self, lam: Lambda, outer: _FnCtx) -> str:
+        """Compile a ``lambda`` expression occurring inside another
+        function.
+
+        Emits a fresh top-level IIRFunction and returns the name of
+        a register in ``outer`` holding a *closure handle* — produced
+        by ``call_builtin "make_closure" <fn_name> captured...``.
+        The fresh function takes the captured variables as its
+        leading parameters, followed by the user-declared params.
+        """
+        # 1. Compute free variables — names referenced in the body
+        #    that aren't params and aren't globals.
+        globals_ = self._fn_globals | self._value_globals | BUILTINS
+        captures = free_vars(lam, globals_)
+
+        # All captures must be currently bound in ``outer``; if not,
+        # the user wrote a name that doesn't resolve to anything.
+        for c in captures:
+            if c not in outer.locals_:
+                raise TwigCompileError(
+                    f"unbound name {c!r} captured by lambda — "
+                    "did you forget a (define) or a (let ...) binding?"
+                )
+
+        # 2. Build the inner function's IIR.
+        fn_name = f"__lambda_{self._lambda_counter}"
+        self._lambda_counter += 1
+
+        inner = _FnCtx()
+        # The inner function's parameter list is captures ++ params.
+        inner.locals_.update(captures)
+        inner.locals_.update(lam.params)
+
+        last: str | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, inner)
+        if last is None:
+            raise TwigCompileError("lambda has empty body")
+        inner.instrs.append(IIRInstr("ret", None, [last], type_hint="any"))
+
+        all_params = [(c, "any") for c in captures] + [
+            (p, "any") for p in lam.params
+        ]
+        self._functions.append(
+            IIRFunction(
+                name=fn_name,
+                params=all_params,
+                return_type="any",
+                instructions=inner.instrs,
+                register_count=self._reg_count(inner),
+                type_status=FunctionTypeStatus.UNTYPED,
+            )
+        )
+
+        # 3. Emit ``make_closure`` at the call site.  The fn_name
+        # itself is a string literal — we must materialise it via
+        # ``const`` so it survives ``frame.resolve``.  The captured
+        # values are already register names from ``outer``'s scope.
+        fn_name_reg = self._string_arg(outer, fn_name)
+        dest = self._fresh(outer, "clos")
+        srcs: list[str | int | float | bool] = [
+            "make_closure", fn_name_reg, *captures,
+        ]
+        outer.instrs.append(
+            IIRInstr("call_builtin", dest, srcs, type_hint="any")
+        )
+        return dest
+
+    # ------------------------------------------------------------------
+    # Expression compilation
+    # ------------------------------------------------------------------
+
+    def _compile_expr(self, expr: Expr, ctx: _FnCtx) -> str:
+        """Compile ``expr`` into ``ctx``; return the dest register."""
+        if isinstance(expr, IntLit):
+            v = self._fresh(ctx, "n")
+            ctx.instrs.append(
+                IIRInstr("const", v, [expr.value], type_hint="any")
+            )
+            return v
+
+        if isinstance(expr, BoolLit):
+            v = self._fresh(ctx, "b")
+            ctx.instrs.append(
+                IIRInstr("const", v, [expr.value], type_hint="any")
+            )
+            return v
+
+        if isinstance(expr, NilLit):
+            v = self._fresh(ctx, "nil")
+            self._emit_call_builtin(
+                ctx, builtin="make_nil", args=[], dest=v
+            )
+            return v
+
+        if isinstance(expr, SymLit):
+            name_reg = self._string_arg(ctx, expr.name)
+            v = self._fresh(ctx, "sym")
+            self._emit_call_builtin(
+                ctx, builtin="make_symbol", args=[name_reg], dest=v
+            )
+            return v
+
+        if isinstance(expr, VarRef):
+            return self._compile_var_ref(expr, ctx)
+
+        if isinstance(expr, If):
+            return self._compile_if(expr, ctx)
+
+        if isinstance(expr, Begin):
+            last: str | None = None
+            for e in expr.exprs:
+                last = self._compile_expr(e, ctx)
+            assert last is not None  # parser rejects empty (begin)
+            return last
+
+        if isinstance(expr, Let):
+            return self._compile_let(expr, ctx)
+
+        if isinstance(expr, Lambda):
+            return self._compile_anonymous_lambda(expr, ctx)
+
+        if isinstance(expr, Apply):
+            return self._compile_apply(expr, ctx)
+
+        raise TwigCompileError(
+            f"unhandled expression type: {type(expr).__name__}"
+        )
+
+    def _compile_var_ref(self, expr: VarRef, ctx: _FnCtx) -> str:
+        """Compile a bare-name reference."""
+        name = expr.name
+
+        # Local? (parameter or let-binding)
+        if name in ctx.locals_:
+            # The IIR's register file is keyed by name, so we just
+            # return the name directly — the next instruction that
+            # reads it will resolve through ``frame.resolve``.
+            return name
+
+        # Top-level function?  Functions are first-class — we wrap
+        # them in a 0-capture closure so the value can be passed
+        # around or applied later.
+        if name in self._fn_globals:
+            name_reg = self._string_arg(ctx, name)
+            v = self._fresh(ctx, "fnref")
+            self._emit_call_builtin(
+                ctx, builtin="make_closure", args=[name_reg], dest=v
+            )
+            return v
+
+        # Top-level value?  Look up via host-side global table.
+        if name in self._value_globals:
+            name_reg = self._string_arg(ctx, name)
+            v = self._fresh(ctx, "g")
+            self._emit_call_builtin(
+                ctx, builtin="global_get", args=[name_reg], dest=v
+            )
+            return v
+
+        # Builtin?  Like top-level functions, expose as a closure
+        # handle so users can pass ``+`` to ``map`` (in a future
+        # version) without special-casing.
+        if name in BUILTINS:
+            name_reg = self._string_arg(ctx, name)
+            v = self._fresh(ctx, "bref")
+            self._emit_call_builtin(
+                ctx,
+                builtin="make_builtin_closure",
+                args=[name_reg],
+                dest=v,
+            )
+            return v
+
+        raise TwigCompileError(
+            f"unbound name {name!r} (no local, define, or builtin matches)"
+        )
+
+    def _compile_if(self, expr: If, ctx: _FnCtx) -> str:
+        """``if`` lowers to standard ``label`` + ``jmp_if_false`` + ``jmp``."""
+        cond = self._compile_expr(expr.cond, ctx)
+        else_label = self._fresh_label(ctx, "else")
+        end_label = self._fresh_label(ctx, "endif")
+        result = self._fresh(ctx, "ifv")
+
+        ctx.instrs.append(
+            IIRInstr(
+                "jmp_if_false",
+                None,
+                [cond, else_label],
+                type_hint="void",
+            )
+        )
+
+        # Then branch — compile and move the value into ``result``
+        # via the host-side ``_move`` builtin.  ``_move`` is a
+        # faithful identity function that preserves the value's
+        # *Python type*; the alternative ``add result, then_v, 0``
+        # would coerce booleans (``True + 0 == 1``).
+        then_v = self._compile_expr(expr.then_branch, ctx)
+        ctx.instrs.append(
+            IIRInstr(
+                "call_builtin", result, ["_move", then_v], type_hint="any"
+            )
+        )
+        ctx.instrs.append(
+            IIRInstr("jmp", None, [end_label], type_hint="void")
+        )
+
+        # Else branch — same shape.
+        ctx.instrs.append(
+            IIRInstr("label", None, [else_label], type_hint="void")
+        )
+        else_v = self._compile_expr(expr.else_branch, ctx)
+        ctx.instrs.append(
+            IIRInstr(
+                "call_builtin", result, ["_move", else_v], type_hint="any"
+            )
+        )
+
+        ctx.instrs.append(
+            IIRInstr("label", None, [end_label], type_hint="void")
+        )
+        return result
+
+    def _compile_let(self, expr: Let, ctx: _FnCtx) -> str:
+        """Mutually-independent bindings — Scheme ``let`` semantics.
+
+        Each RHS is compiled in the *outer* scope (no binding sees
+        another's name yet); the body is then compiled with all
+        binding names added to ``locals_``.
+        """
+        # Compile RHSs in outer scope.
+        binding_values: list[tuple[str, str]] = []
+        for name, rhs in expr.bindings:
+            v = self._compile_expr(rhs, ctx)
+            binding_values.append((name, v))
+
+        # Bind into ``locals_`` via add-zero copy so the binding
+        # names exist as named registers in the frame.
+        added_names: list[str] = []
+        for name, src in binding_values:
+            if name in ctx.locals_:
+                # Already a local — overwriting is fine; vm-core
+                # reuses the register slot.
+                pass
+            else:
+                ctx.locals_.add(name)
+                added_names.append(name)
+            # Use a host-side identity builtin so the value moves
+            # without being coerced.  Plain ``add x 0`` would turn
+            # ``True`` into ``1`` because Python's ``bool`` is a
+            # subclass of ``int``.
+            ctx.instrs.append(
+                IIRInstr("call_builtin", name, ["_move", src], type_hint="any")
+            )
+
+        # Compile body.
+        last: str | None = None
+        for e in expr.body:
+            last = self._compile_expr(e, ctx)
+        assert last is not None
+
+        # Pop ``let`` names back out of ``locals_`` (so subsequent
+        # code in the enclosing scope doesn't think they're bound).
+        for name in added_names:
+            ctx.locals_.discard(name)
+
+        return last
+
+    def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> str:
+        """``Apply`` — direct call vs. closure call decided at compile time."""
+        # Direct call: fn is a VarRef whose name is a top-level
+        # function or a builtin.
+        if isinstance(expr.fn, VarRef):
+            name = expr.fn.name
+
+            if name in self._fn_globals:
+                # Direct user-defined call.
+                arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+                dest = self._fresh(ctx, "r")
+                srcs: list[str | int | float | bool] = [name, *arg_regs]
+                ctx.instrs.append(
+                    IIRInstr("call", dest, srcs, type_hint="any")
+                )
+                return dest
+
+            if name in BUILTINS:
+                # Direct builtin call.
+                arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+                dest = self._fresh(ctx, "r")
+                srcs = [name, *arg_regs]
+                ctx.instrs.append(
+                    IIRInstr("call_builtin", dest, srcs, type_hint="any")
+                )
+                return dest
+
+        # Indirect call: compile the fn expression to get a closure
+        # handle, then ``call_builtin "apply_closure" handle args...``.
+        fn_handle = self._compile_expr(expr.fn, ctx)
+        arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+        dest = self._fresh(ctx, "r")
+        srcs = ["apply_closure", fn_handle, *arg_regs]
+        ctx.instrs.append(
+            IIRInstr("call_builtin", dest, srcs, type_hint="any")
+        )
+        return dest
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _fresh(self, ctx: _FnCtx, prefix: str) -> str:
+        ctx.var_counter += 1
+        return f"_{prefix}{ctx.var_counter}"
+
+    def _fresh_label(self, ctx: _FnCtx, prefix: str) -> str:
+        ctx.label_counter += 1
+        return f"_{prefix}{ctx.label_counter}"
+
+    def _emit_call_builtin(
+        self,
+        ctx: _FnCtx,
+        *,
+        builtin: str,
+        args: list,
+        dest: str | None,
+    ) -> None:
+        """Emit a ``call_builtin`` instruction.
+
+        ``builtin`` is the literal builtin name; it is stored as
+        ``srcs[0]`` and read by ``vm-core``'s ``handle_call_builtin``
+        without being resolved through the frame.  ``args`` are the
+        runtime argument values — each goes into ``srcs[1:]`` and IS
+        resolved through the frame, so any *string* in ``args`` must
+        be a register name.
+
+        Raw string literals (e.g. a function name passed to
+        ``make_closure`` or a global key passed to ``global_set``)
+        therefore need to be materialised into a register first.
+        :meth:`_string_arg` does that.
+        """
+        srcs: list[str | int | float | bool] = [builtin, *args]
+        ctx.instrs.append(
+            IIRInstr(
+                "call_builtin",
+                dest,
+                srcs,
+                type_hint="any" if dest is not None else "void",
+            )
+        )
+
+    def _string_arg(self, ctx: _FnCtx, value: str) -> str:
+        """Materialise a Python string into a fresh register and
+        return that register's name.
+
+        Used when a builtin call needs a *literal* string as one of
+        its runtime arguments — e.g.
+        ``call_builtin "make_closure" <fn_name> ...``.  The IIR's
+        ``call_builtin`` resolves every entry in ``srcs[1:]`` through
+        the frame's name-to-register map, so a bare string would be
+        looked up as a variable and fail.  Wrapping the string in a
+        ``const`` works because ``const`` stores its argument
+        verbatim, including string values.
+        """
+        var = self._fresh(ctx, "s")
+        ctx.instrs.append(IIRInstr("const", var, [value], type_hint="any"))
+        return var
+
+    def _reg_count(self, ctx: _FnCtx) -> int:
+        # vm-core's RegisterFile is fixed-size.  Be generous: count
+        # every distinct dest name we emitted plus a small buffer.
+        names: set[str] = set()
+        for instr in ctx.instrs:
+            if instr.dest is not None:
+                names.add(instr.dest)
+            for src in instr.srcs:
+                if isinstance(src, str):
+                    names.add(src)
+        return max(len(names) + 8, 16)
+
+
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
+
+
+def compile_program(
+    program: Program, *, module_name: str = "twig"
+) -> IIRModule:
+    """Compile a typed :class:`Program` into an ``IIRModule``."""
+    return _Compiler(module_name=module_name).compile(program)

--- a/code/packages/python/twig/src/twig/errors.py
+++ b/code/packages/python/twig/src/twig/errors.py
@@ -1,0 +1,57 @@
+"""Errors raised by the Twig front-end and runtime.
+
+Why a layered hierarchy
+-----------------------
+Twig has three distinct failure surfaces:
+
+* **Parse-time**  — malformed source: bad tokens, unmatched parens,
+  unsupported constructs.  These never reach the compiler.
+* **Compile-time** — well-formed source but unsupported semantics:
+  free-variable references that can't be resolved, malformed
+  ``define`` / ``lambda`` headers, etc.
+* **Runtime**     — execution-time problems: type errors,
+  out-of-bounds heap handles, division by zero.
+
+Tools (an LSP, a notebook kernel, a REPL) want to handle these
+classes differently — for example, a parser error has a source
+location while a runtime error has a value and a frame.  Giving each
+its own exception class with a stable identity keeps that easy.
+
+All three inherit from :class:`TwigError` so callers that just want
+"something went wrong with the user's program" can catch one.
+"""
+
+from __future__ import annotations
+
+
+class TwigError(Exception):
+    """Base class for every Twig-level failure."""
+
+
+class TwigParseError(TwigError):
+    """Source text could not be parsed.
+
+    Carries an optional ``line`` / ``column`` for editor integrations.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        line: int | None = None,
+        column: int | None = None,
+    ) -> None:
+        if line is not None and column is not None:
+            super().__init__(f"{message} (line {line}, col {column})")
+        else:
+            super().__init__(message)
+        self.line = line
+        self.column = column
+
+
+class TwigCompileError(TwigError):
+    """Twig source is well-formed but cannot be compiled to IIR."""
+
+
+class TwigRuntimeError(TwigError):
+    """A Twig program raised an error during execution."""

--- a/code/packages/python/twig/src/twig/free_vars.py
+++ b/code/packages/python/twig/src/twig/free_vars.py
@@ -1,0 +1,131 @@
+"""Free-variable analysis for Twig lambdas.
+
+When a ``lambda`` appears inside a function body it may reference
+names that are *neither* parameters of the lambda *nor* top-level
+``define``-bound globals.  Those names need to be captured at
+closure-construction time and stashed inside the closure object so
+they're available when the closure is later applied.
+
+This module computes that set.  ``free_vars(lam, ...)`` returns the
+ordered list of names — order is significant because the compiler
+emits them as the leading parameters of the gensym'd IIR function
+the lambda compiles to, and as the leading arguments to
+``call_builtin "make_closure"`` at the lambda site.
+
+Algorithm
+---------
+A standard set-based traversal:
+
+* ``names_used(expr)`` — the set of names referenced anywhere in
+  ``expr``, ignoring ``define``s (top-level defines never appear
+  inside expressions in TW00).
+* ``free_vars(lam, globals)`` — start from ``names_used(body)``,
+  subtract the lambda's own ``params``, subtract ``globals``
+  (top-level names visible everywhere), subtract names introduced
+  by inner ``let`` bindings or nested lambda parameters before they
+  are read.
+
+The traversal is purely structural — no environment threading
+needed beyond a single "currently-bound" set passed down recursive
+calls.  Output is a deterministic list (insertion order via a
+``dict`` so closures get stable shapes across runs).
+"""
+
+from __future__ import annotations
+
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    BoolLit,
+    Expr,
+    If,
+    IntLit,
+    Lambda,
+    Let,
+    NilLit,
+    SymLit,
+    VarRef,
+)
+
+
+def free_vars(lam: Lambda, globals_: set[str]) -> list[str]:
+    """Return the free variables of ``lam``, in stable order.
+
+    ``globals_`` is the set of top-level ``define``-bound names; any
+    reference to one of these does *not* count as free (they're
+    looked up by name at apply time, not captured).
+    """
+    bound: set[str] = set(lam.params)
+    found: dict[str, None] = {}
+    for expr in lam.body:
+        _walk(expr, bound, globals_, found)
+    return list(found.keys())
+
+
+def _walk(
+    expr: Expr,
+    bound: set[str],
+    globals_: set[str],
+    found: dict[str, None],
+) -> None:
+    """Recurse into ``expr``, adding any free name into ``found``.
+
+    ``bound`` is the set of names already bound at this point —
+    parameters of any enclosing lambda plus any ``let`` bindings
+    we've descended into.  ``globals_`` is the immutable top-level
+    set.  ``found`` is the result accumulator (a dict to preserve
+    insertion order without allocating a list per recursive call).
+    """
+    if isinstance(expr, VarRef):
+        # A reference is "free" iff it's neither bound here nor a
+        # global.  Builtins (``+``, ``cons``, …) live alongside
+        # user globals in ``globals_`` — the wrapper passes them
+        # in.  This avoids special-casing every builtin name here.
+        if expr.name not in bound and expr.name not in globals_:
+            found[expr.name] = None
+        return
+
+    if isinstance(expr, IntLit | BoolLit | NilLit | SymLit):
+        return  # literals contain no references
+
+    if isinstance(expr, If):
+        _walk(expr.cond, bound, globals_, found)
+        _walk(expr.then_branch, bound, globals_, found)
+        _walk(expr.else_branch, bound, globals_, found)
+        return
+
+    if isinstance(expr, Begin):
+        for e in expr.exprs:
+            _walk(e, bound, globals_, found)
+        return
+
+    if isinstance(expr, Let):
+        # Scheme-style ``let``: bindings see the *outer* scope.  The
+        # body sees ``bound ∪ {names from bindings}``.  We handle
+        # that by walking each binding RHS in the outer scope, then
+        # extending ``bound`` for the body.
+        for _name, rhs in expr.bindings:
+            _walk(rhs, bound, globals_, found)
+        body_bound = bound | {n for (n, _) in expr.bindings}
+        for e in expr.body:
+            _walk(e, body_bound, globals_, found)
+        return
+
+    if isinstance(expr, Lambda):
+        # An inner lambda introduces its own parameters as bound
+        # names for its body.  Free variables of the *inner* body
+        # that aren't params of either lambda *and* aren't globals
+        # become free variables of the *outer* lambda too — they
+        # bubble up.
+        inner_bound = bound | set(expr.params)
+        for e in expr.body:
+            _walk(e, inner_bound, globals_, found)
+        return
+
+    if isinstance(expr, Apply):
+        _walk(expr.fn, bound, globals_, found)
+        for arg in expr.args:
+            _walk(arg, bound, globals_, found)
+        return
+
+    raise TypeError(f"unhandled expression type: {type(expr).__name__}")

--- a/code/packages/python/twig/src/twig/heap.py
+++ b/code/packages/python/twig/src/twig/heap.py
@@ -1,0 +1,414 @@
+"""Twig's host-side heap with refcounted GC primitives.
+
+Why this exists
+===============
+``vm-core`` itself is heap-free — its register file holds Python
+primitives and that's it.  Twig needs three kinds of heap-allocated
+objects (cons cells, symbols, closures), all of which need lifetime
+management.  TW00's design puts that machinery here, on the host
+side, exposed to ``vm-core`` only via :func:`call_builtin` boundaries
+(``cons``, ``car``, ``cdr``, ``apply_closure``, …).
+
+Why reference counting first?
+=============================
+Three reasons:
+
+1. **Visibility.**  Refcounting is the simplest correct GC algorithm.
+   Reading this file teaches the algorithm directly — every alloc
+   bumps a counter, every release drops one, freeing happens at zero.
+   Mark-sweep (TW01) hides allocation costs and amortises collection;
+   visible refcounting is more pedagogical for a starting point.
+2. **Correctness for v1.**  TW00 has no ``letrec`` and no nested
+   closures that mutually reference each other after construction, so
+   programs cannot construct cycles in the v1 surface.  Refcounting
+   suffices.
+3. **Easy to swap.**  ``Heap`` is the only place that knows about
+   refcounts.  TW01's mark-sweep replacement is a drop-in.
+
+Tagged values
+=============
+Twig values are one of:
+
+* ``int`` — Twig integers (``0``, ``42``, ``-7``)
+* ``bool`` — Twig booleans (``#t`` / ``#f``)
+* :data:`NIL` — a singleton sentinel for Twig's ``nil``
+* :class:`HeapHandle` — an opaque integer handle to a heap object
+
+Predicates use ``isinstance`` checks.  ``bool`` must be checked
+*before* ``int`` because ``bool`` is a subclass of ``int`` in Python.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Sentinel: nil
+# ---------------------------------------------------------------------------
+
+
+class _Nil:
+    """The unique value of Twig's ``nil``.
+
+    Made a class (not just ``None``) so the empty list is observably
+    distinct from the absence of a value at the host boundary.  Twig
+    code that returns ``nil`` is *returning a value*; Python ``None``
+    means "no return value at all".
+    """
+
+    __slots__ = ()
+    _instance: _Nil | None = None
+
+    def __new__(cls) -> _Nil:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "nil"
+
+    def __bool__(self) -> bool:
+        return False  # nil is falsy in Twig
+
+
+NIL: _Nil = _Nil()
+
+
+# ---------------------------------------------------------------------------
+# Heap handle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HeapHandle:
+    """An opaque handle into the :class:`Heap`.
+
+    The wrapped integer is *not* a Twig value.  Callers should never
+    perform arithmetic on it; they pass handles around through
+    ``vm-core``'s register file as Python objects, and only the
+    :class:`Heap` interprets them.
+    """
+
+    id: int
+
+    def __repr__(self) -> str:
+        return f"<handle:{self.id}>"
+
+
+# ---------------------------------------------------------------------------
+# Internal object kinds
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Cons:
+    """Cons cell: a 2-slot heap object with arbitrary Twig values."""
+
+    car: Any
+    cdr: Any
+
+
+@dataclass
+class _Symbol:
+    """Interned symbol — one record per unique name in a heap."""
+
+    name: str
+
+
+@dataclass
+class _Closure:
+    """First-class function value.
+
+    ``fn_name`` is a top-level IIR function name (gensym'd for
+    ``lambda`` expressions, the user-supplied name for ``define``).
+    ``captured`` is the snapshot of free-variable values taken at
+    closure-construction time, in fixed order matching the IIR
+    function's leading parameters.
+    """
+
+    fn_name: str
+    captured: list[Any]
+
+
+# ---------------------------------------------------------------------------
+# Heap statistics
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HeapStats:
+    """A snapshot of a :class:`Heap`'s lifetime counters.
+
+    The counters are aggregate (never reset between programs), so
+    successive snapshots show monotonic growth.  Use
+    ``Heap.reset_stats()`` to zero them between independent runs.
+    """
+
+    live_objects: int
+    peak_objects: int
+    total_allocs: int
+    total_releases: int
+
+
+# ---------------------------------------------------------------------------
+# Heap
+# ---------------------------------------------------------------------------
+
+
+class Heap:
+    """A host-side refcounted heap for Twig.
+
+    All allocation routes through one of:
+
+    * :meth:`alloc_cons` — for cons cells (returns a fresh handle).
+    * :meth:`make_symbol` — for symbols (interns by name; same name
+      always returns the same handle).
+    * :meth:`alloc_closure` — for first-class functions.
+
+    Read-only access:
+
+    * :meth:`car` / :meth:`cdr` for cons cells.
+    * :meth:`symbol_name` for symbols.
+    * :meth:`closure_fn` / :meth:`closure_captured` for closures.
+
+    Lifetime:
+
+    * :meth:`incref` bumps a handle's refcount.
+    * :meth:`decref` drops it; reaching zero frees the object and
+      decrefs any inner handles.
+    * Symbols are deliberately *not* refcounted — they're interned
+      for the lifetime of the heap and shared by every reference.
+
+    Bound checks: every method that accepts a handle validates the
+    handle is live.  Out-of-bounds access raises
+    :class:`TwigRuntimeError` rather than silently returning garbage.
+    """
+
+    def __init__(self) -> None:
+        # Storage: one Python dict mapping handle ID → object.
+        # We use a dict (not a list) so we can leave gaps when an
+        # object is freed; allocations always advance ``_next_id``
+        # rather than reusing slots.  Slot reuse is a TW01 concern
+        # tied to mark-sweep compaction.
+        self._objects: dict[int, Any] = {}
+        self._refcounts: dict[int, int] = {}
+        self._symbols: dict[str, int] = {}
+        self._next_id: int = 1  # 0 reserved as a "null handle" sentinel
+
+        # Lifetime statistics — useful for tests asserting GC correctness
+        # ("after a clean program, ``live_objects`` returns to 0").
+        self._peak_objects: int = 0
+        self._total_allocs: int = 0
+        self._total_releases: int = 0
+
+    # ------------------------------------------------------------------
+    # Allocation
+    # ------------------------------------------------------------------
+
+    def alloc_cons(self, car: Any, cdr: Any) -> HeapHandle:
+        """Allocate a fresh cons cell.
+
+        Both ``car`` and ``cdr`` may be any Twig value.  If either is a
+        :class:`HeapHandle` we ``incref`` it before storing — the cons
+        cell now owns an additional reference, and freeing the cons
+        cell will release them.
+        """
+        handle = self._fresh_handle()
+        self._objects[handle.id] = _Cons(car=car, cdr=cdr)
+        self._refcounts[handle.id] = 1
+        self._note_alloc()
+        if isinstance(car, HeapHandle):
+            self.incref(car)
+        if isinstance(cdr, HeapHandle):
+            self.incref(cdr)
+        return handle
+
+    def make_symbol(self, name: str) -> HeapHandle:
+        """Return the interned symbol handle for ``name``.
+
+        Symbols are interned by name (Scheme semantics).  Two
+        ``make_symbol("foo")`` calls return the same handle.  Symbols
+        do *not* participate in refcounting — they live for the
+        lifetime of the heap.
+        """
+        existing = self._symbols.get(name)
+        if existing is not None:
+            return HeapHandle(existing)
+        handle = self._fresh_handle()
+        self._objects[handle.id] = _Symbol(name=name)
+        # Symbol refcount stays "infinite" — represented here by
+        # absence from ``_refcounts``.  decref() treats missing keys
+        # as no-ops, so we never accidentally free an interned symbol.
+        self._symbols[name] = handle.id
+        self._note_alloc()
+        return handle
+
+    def alloc_closure(
+        self, fn_name: str, captured: list[Any]
+    ) -> HeapHandle:
+        """Allocate a closure.
+
+        ``captured`` is the list of free-variable values to be passed
+        as the leading arguments at apply time.  Any handles in
+        ``captured`` are increfed so the closure owns them.
+        """
+        handle = self._fresh_handle()
+        # Defensive copy: the caller may keep mutating their list.
+        self._objects[handle.id] = _Closure(
+            fn_name=fn_name, captured=list(captured)
+        )
+        self._refcounts[handle.id] = 1
+        self._note_alloc()
+        for v in captured:
+            if isinstance(v, HeapHandle):
+                self.incref(v)
+        return handle
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def car(self, handle: HeapHandle) -> Any:
+        cell = self._require_cons(handle)
+        return cell.car
+
+    def cdr(self, handle: HeapHandle) -> Any:
+        cell = self._require_cons(handle)
+        return cell.cdr
+
+    def symbol_name(self, handle: HeapHandle) -> str:
+        obj = self._require_object(handle)
+        if not isinstance(obj, _Symbol):
+            from twig.errors import TwigRuntimeError
+
+            raise TwigRuntimeError(f"{handle!r} is not a symbol")
+        return obj.name
+
+    def closure_fn(self, handle: HeapHandle) -> str:
+        return self._require_closure(handle).fn_name
+
+    def closure_captured(self, handle: HeapHandle) -> list[Any]:
+        # Return a copy: callers shouldn't mutate the heap's storage.
+        return list(self._require_closure(handle).captured)
+
+    # ------------------------------------------------------------------
+    # Predicates
+    # ------------------------------------------------------------------
+
+    def is_cons(self, value: Any) -> bool:
+        return (
+            isinstance(value, HeapHandle)
+            and isinstance(self._objects.get(value.id), _Cons)
+        )
+
+    def is_symbol(self, value: Any) -> bool:
+        return (
+            isinstance(value, HeapHandle)
+            and isinstance(self._objects.get(value.id), _Symbol)
+        )
+
+    def is_closure(self, value: Any) -> bool:
+        return (
+            isinstance(value, HeapHandle)
+            and isinstance(self._objects.get(value.id), _Closure)
+        )
+
+    # ------------------------------------------------------------------
+    # GC primitives
+    # ------------------------------------------------------------------
+
+    def incref(self, handle: HeapHandle) -> None:
+        """Increment the refcount.  No-op for symbols (interned)."""
+        if handle.id not in self._refcounts:
+            return
+        self._refcounts[handle.id] += 1
+
+    def decref(self, handle: HeapHandle) -> None:
+        """Decrement the refcount.  Frees the object on reaching 0.
+
+        Freeing a cons cell or closure recursively decrefs any nested
+        handles, so dropping the head of a list correctly releases
+        the entire spine.
+        """
+        if handle.id not in self._refcounts:
+            return  # symbol or already-freed: no-op
+        self._refcounts[handle.id] -= 1
+        if self._refcounts[handle.id] <= 0:
+            self._free(handle.id)
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def stats(self) -> HeapStats:
+        return HeapStats(
+            live_objects=len(self._objects),
+            peak_objects=self._peak_objects,
+            total_allocs=self._total_allocs,
+            total_releases=self._total_releases,
+        )
+
+    def reset_stats(self) -> None:
+        self._peak_objects = len(self._objects)
+        self._total_allocs = 0
+        self._total_releases = 0
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fresh_handle(self) -> HeapHandle:
+        handle = HeapHandle(self._next_id)
+        self._next_id += 1
+        return handle
+
+    def _note_alloc(self) -> None:
+        self._total_allocs += 1
+        live = len(self._objects)
+        if live > self._peak_objects:
+            self._peak_objects = live
+
+    def _require_object(self, handle: HeapHandle) -> Any:
+        obj = self._objects.get(handle.id)
+        if obj is None:
+            from twig.errors import TwigRuntimeError
+
+            raise TwigRuntimeError(f"{handle!r} is not a live heap handle")
+        return obj
+
+    def _require_cons(self, handle: HeapHandle) -> _Cons:
+        obj = self._require_object(handle)
+        if not isinstance(obj, _Cons):
+            from twig.errors import TwigRuntimeError
+
+            raise TwigRuntimeError(f"{handle!r} is not a cons cell")
+        return obj
+
+    def _require_closure(self, handle: HeapHandle) -> _Closure:
+        obj = self._require_object(handle)
+        if not isinstance(obj, _Closure):
+            from twig.errors import TwigRuntimeError
+
+            raise TwigRuntimeError(f"{handle!r} is not a closure")
+        return obj
+
+    def _free(self, handle_id: int) -> None:
+        obj = self._objects.pop(handle_id, None)
+        self._refcounts.pop(handle_id, None)
+        self._total_releases += 1
+        if obj is None:
+            return
+        # Recursively decref any nested handles.  We must do this
+        # *after* removing the object from ``_objects`` so a cycle
+        # that somehow got built does not infinite-loop the
+        # refcounter.  TW00 doesn't construct cycles, but defending
+        # against them is cheap.
+        if isinstance(obj, _Cons):
+            for inner in (obj.car, obj.cdr):
+                if isinstance(inner, HeapHandle):
+                    self.decref(inner)
+        elif isinstance(obj, _Closure):
+            for inner in obj.captured:
+                if isinstance(inner, HeapHandle):
+                    self.decref(inner)

--- a/code/packages/python/twig/src/twig/lexer.py
+++ b/code/packages/python/twig/src/twig/lexer.py
@@ -1,0 +1,59 @@
+"""Twig lexer — thin wrapper around the generic ``GrammarLexer``.
+
+The Twig token grammar lives in ``code/grammars/twig.tokens``; this
+module just locates the file, hands it to ``parse_token_grammar``,
+and constructs a ``GrammarLexer`` over the resulting
+``TokenGrammar``.
+
+Mirrors the pattern already used by every other language in the
+repo (Brainfuck, Dartmouth BASIC, ALGOL, Prolog…) — a single
+source-of-truth grammar file feeds every implementation, and the
+language-specific package is the thin shim that loads it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+
+# ---------------------------------------------------------------------------
+# Grammar file location
+# ---------------------------------------------------------------------------
+#
+# Walk up from this module to ``code/``, then into ``grammars/``:
+#
+#   src/twig/lexer.py
+#   ├─ src/twig/        (parent)
+#   ├─ src/             (parent)
+#   ├─ twig/            (parent — package dir)
+#   ├─ python/          (parent)
+#   ├─ packages/        (parent)
+#   └─ code/            (parent) → ``grammars/twig.tokens``
+
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+TWIG_TOKENS_PATH = GRAMMAR_DIR / "twig.tokens"
+
+
+def create_twig_lexer(source: str) -> GrammarLexer:
+    """Build a ``GrammarLexer`` configured for Twig source.
+
+    Reads ``twig.tokens`` from the grammars directory and returns a
+    lexer ready to call ``.tokenize()``.  The resulting token stream
+    contains ``LPAREN`` / ``RPAREN`` / ``QUOTE`` / ``BOOL_TRUE`` /
+    ``BOOL_FALSE`` / ``INTEGER`` / ``KEYWORD`` / ``NAME`` tokens, with
+    whitespace and ``;`` comments already discarded.
+    """
+    grammar = parse_token_grammar(TWIG_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_twig(source: str) -> list[Token]:
+    """Tokenise Twig source text into a flat list of ``Token``.
+
+    The terminating ``EOF`` token is included by the GrammarLexer.
+    Position tracking (``line`` / ``column``) on each token enables
+    LSP-style error messages in the parser and compiler.
+    """
+    return create_twig_lexer(source).tokenize()

--- a/code/packages/python/twig/src/twig/parser.py
+++ b/code/packages/python/twig/src/twig/parser.py
@@ -1,0 +1,51 @@
+"""Twig parser — thin wrapper around the generic ``GrammarParser``.
+
+Loads ``code/grammars/twig.grammar`` and feeds it the token stream
+produced by :mod:`twig.lexer`.  The result is a generic
+:class:`lang_parser.ASTNode` tree whose ``rule_name`` fields match
+the production names from the grammar (``program``, ``define``,
+``if_form``, ``let_form``, ``begin_form``, ``lambda_form``,
+``quote_form``, ``apply``, ``atom``, ``binding``, …).
+
+Downstream walkers (``twig.free_vars``, ``twig.compiler``) dispatch
+on ``rule_name`` to interpret each subtree.  This matches how
+``brainfuck-iir-compiler`` consumes the Brainfuck AST: the lexer
+and parser are language-agnostic infrastructure, and the language
+package supplies thin lex/parse wrappers plus a typed walker that
+turns the generic AST into the language's semantic actions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+
+from twig.lexer import tokenize_twig
+
+# Grammar file location — same walk-up as ``lexer.py``.
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+TWIG_GRAMMAR_PATH = GRAMMAR_DIR / "twig.grammar"
+
+
+def create_twig_parser(source: str) -> GrammarParser:
+    """Build a ``GrammarParser`` ready to parse Twig source.
+
+    Combines the Twig token stream with the rules from
+    ``twig.grammar``.  Call ``.parse()`` to get the AST root.
+    """
+    tokens = tokenize_twig(source)
+    grammar = parse_parser_grammar(TWIG_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_twig(source: str) -> ASTNode:
+    """Parse Twig source into a generic ``ASTNode`` tree.
+
+    Raises whatever the underlying ``GrammarParser`` raises on
+    malformed input (typically a parse error mentioning the token
+    that triggered the failure).  An empty source returns a
+    ``program`` node with no children.
+    """
+    return create_twig_parser(source).parse()

--- a/code/packages/python/twig/src/twig/vm.py
+++ b/code/packages/python/twig/src/twig/vm.py
@@ -1,0 +1,418 @@
+"""``TwigVM`` — wrap ``vm-core`` with Twig's heap + builtins.
+
+What this wrapper does
+======================
+``vm-core`` is general-purpose: it knows nothing about cons cells,
+closures, or symbols.  Twig's host registers all of that machinery
+through the ``BuiltinRegistry`` interface — every builtin name the
+compiler emits in ``call_builtin`` resolves here to a Python
+callable that operates on the host's :class:`Heap`.
+
+Why a single wrapper class
+==========================
+Other languages in the repo (BrainfuckVM, …) follow the same shape:
+one wrapper that owns the per-run state, sets up vm-core, runs the
+program, and returns the program's output.  Twig follows suit.  The
+``run()`` method is the high-level entry point; ``execute_module``
+is the loop that handles re-entry on ``apply_closure``.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from interpreter_ir import IIRModule
+from vm_core import VMCore, VMMetrics
+
+from twig.ast_extract import extract_program
+from twig.compiler import compile_program
+from twig.errors import TwigRuntimeError
+from twig.heap import NIL, Heap, HeapHandle
+from twig.parser import parse_twig
+
+
+class TwigVM:
+    """Twig-configured ``vm-core`` runtime.
+
+    Construct once, call :meth:`run` for each program.  Each ``run``
+    builds a fresh execution environment (heap, globals, output
+    buffer) so programs don't leak state into one another.
+
+    Parameters
+    ----------
+    max_frames:
+        Forwarded to ``VMCore`` — the call-stack-depth ceiling.
+        Defaults to 256, which comfortably handles factorial of 100
+        but bounds runaway recursion.
+    """
+
+    def __init__(self, *, max_frames: int = 256) -> None:
+        self._max_frames = max_frames
+        self._last_metrics: VMMetrics | None = None
+        self._last_heap: Heap | None = None
+        self._last_globals: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compile(self, source: str) -> IIRModule:
+        """Lex, parse, and compile ``source`` into an :class:`IIRModule`."""
+        return compile_program(extract_program(parse_twig(source)))
+
+    def run(self, source: str) -> tuple[str, Any]:
+        """Compile and run ``source``.
+
+        Returns a tuple ``(stdout, value)`` where ``stdout`` is the
+        concatenation of every ``print`` call's output (newline-
+        separated, like Scheme's ``display``) and ``value`` is the
+        program's final expression value (or ``nil`` if the program
+        had no top-level expression).
+        """
+        return self.execute_module(self.compile(source))
+
+    def execute_module(self, module: IIRModule) -> tuple[str, Any]:
+        """Execute a compiled module — useful for reusing one IIR across
+        multiple runs (e.g. driver loops, benchmarks).
+        """
+        heap = Heap()
+        globals_table: dict[str, Any] = {}
+        output = io.StringIO()
+
+        # The VM is *re-entrant* during this run because
+        # ``apply_closure`` calls vm.execute again.  We need to share
+        # the heap, globals, and output across these re-entries — we
+        # do so by closing over them in the builtin callables.
+        #
+        # We also override ``jmp_if_true`` / ``jmp_if_false`` to use
+        # *Scheme* truthiness instead of vm-core's default Python
+        # truthiness.  Scheme says only ``#f`` and ``nil`` are
+        # falsy; everything else (including ``0``) is truthy.  This
+        # matters surprisingly often — a programmer writing ``(if x
+        # ...)`` to mean "is x present?" expects ``0`` to count as
+        # present.
+        vm = VMCore(
+            max_frames=self._max_frames,
+            profiler_enabled=False,
+            opcodes={
+                "jmp_if_true": _make_jmp_if(truthy=True),
+                "jmp_if_false": _make_jmp_if(truthy=False),
+            },
+        )
+        self._register_builtins(vm, heap, globals_table, output, module)
+
+        result = vm.execute(module, fn="main")
+
+        self._last_metrics = vm.metrics()
+        self._last_heap = heap
+        self._last_globals = globals_table
+        return output.getvalue(), result
+
+    # ------------------------------------------------------------------
+    # Read-only properties
+    # ------------------------------------------------------------------
+
+    @property
+    def metrics(self) -> VMMetrics | None:
+        return self._last_metrics
+
+    @property
+    def heap(self) -> Heap | None:
+        """The :class:`Heap` from the most recent run.
+
+        Useful for tests asserting GC correctness — e.g. that
+        ``heap.stats().live_objects`` returns to zero after a clean
+        program.
+        """
+        return self._last_heap
+
+    @property
+    def globals_(self) -> dict[str, Any] | None:
+        """Snapshot of the global table from the most recent run."""
+        return self._last_globals
+
+    # ------------------------------------------------------------------
+    # Builtin wiring
+    # ------------------------------------------------------------------
+
+    def _register_builtins(
+        self,
+        vm: VMCore,
+        heap: Heap,
+        globals_table: dict[str, Any],
+        output: io.StringIO,
+        module: IIRModule,
+    ) -> None:
+        """Wire every builtin name the compiler emits to a host callable."""
+
+        # ── Arithmetic + comparison ───────────────────────────────────
+        # Variadic for ``+`` / ``*`` / ``=`` to match Scheme; binary
+        # for the rest, which matches our compile-site shape.
+
+        def add(args: list[Any]) -> int:
+            return sum(_int(a) for a in args)
+
+        def sub(args: list[Any]) -> int:
+            if not args:
+                raise TwigRuntimeError("(- ) needs at least one argument")
+            if len(args) == 1:
+                return -_int(args[0])
+            head, *rest = args
+            return _int(head) - sum(_int(a) for a in rest)
+
+        def mul(args: list[Any]) -> int:
+            result = 1
+            for a in args:
+                result *= _int(a)
+            return result
+
+        def div(args: list[Any]) -> int:
+            if len(args) != 2:
+                raise TwigRuntimeError("(/ ) requires exactly 2 arguments")
+            num, den = _int(args[0]), _int(args[1])
+            if den == 0:
+                raise TwigRuntimeError("division by zero")
+            # Python ``//`` floors; Scheme integer division truncates.
+            # Use truncation for predictable behaviour with negatives.
+            q = abs(num) // abs(den)
+            return q if (num >= 0) == (den >= 0) else -q
+
+        def eq(args: list[Any]) -> bool:
+            if len(args) < 2:
+                return True
+            first = args[0]
+            return all(_value_eq(first, a) for a in args[1:])
+
+        def lt(args: list[Any]) -> bool:
+            return _int(args[0]) < _int(args[1])
+
+        def gt(args: list[Any]) -> bool:
+            return _int(args[0]) > _int(args[1])
+
+        # ── Cons / car / cdr ──────────────────────────────────────────
+        def cons(args: list[Any]) -> HeapHandle:
+            if len(args) != 2:
+                raise TwigRuntimeError("(cons a b) takes exactly 2 arguments")
+            return heap.alloc_cons(args[0], args[1])
+
+        def car(args: list[Any]) -> Any:
+            return heap.car(_handle(args[0]))
+
+        def cdr(args: list[Any]) -> Any:
+            return heap.cdr(_handle(args[0]))
+
+        # ── Predicates ────────────────────────────────────────────────
+        def is_null(args: list[Any]) -> bool:
+            return args[0] is NIL
+
+        def is_pair(args: list[Any]) -> bool:
+            return heap.is_cons(args[0])
+
+        def is_number(args: list[Any]) -> bool:
+            v = args[0]
+            return isinstance(v, int) and not isinstance(v, bool)
+
+        def is_symbol(args: list[Any]) -> bool:
+            return heap.is_symbol(args[0])
+
+        # ── I/O ───────────────────────────────────────────────────────
+        def do_print(args: list[Any]) -> Any:
+            output.write(_format(args[0], heap))
+            output.write("\n")
+            return NIL
+
+        # ── Heap construction (compiler-emitted plumbing) ─────────────
+        def make_nil(_args: list[Any]) -> Any:
+            return NIL
+
+        def make_symbol(args: list[Any]) -> HeapHandle:
+            return heap.make_symbol(str(args[0]))
+
+        def make_closure(args: list[Any]) -> HeapHandle:
+            # args = [fn_name, capt0, capt1, ...]
+            fn_name = str(args[0])
+            captured = list(args[1:])
+            return heap.alloc_closure(fn_name, captured)
+
+        def make_builtin_closure(args: list[Any]) -> HeapHandle:
+            # First-class builtin: store the builtin name as the
+            # ``fn_name`` plus a sentinel marker so apply_closure
+            # knows to route through call_builtin instead of vm.execute.
+            name = str(args[0])
+            return heap.alloc_closure(f"__builtin__:{name}", [])
+
+        def apply_closure(args: list[Any]) -> Any:
+            # args = [closure_handle, user_arg0, user_arg1, ...]
+            handle = _handle(args[0])
+            user_args = list(args[1:])
+            fn_name = heap.closure_fn(handle)
+            captured = heap.closure_captured(handle)
+
+            if fn_name.startswith("__builtin__:"):
+                # First-class builtin: forward to the same builtin
+                # registry.
+                name = fn_name[len("__builtin__:"):]
+                return vm.builtins.call(name, user_args)
+
+            full_args = list(captured) + user_args
+            # Re-enter the VM by calling ``execute`` — but because
+            # ``execute`` resets ``_frames`` / ``_module`` /
+            # ``_interrupted`` on entry (it expects to be the
+            # outermost call), we must save those fields, let the
+            # call run, then restore them so the dispatch loop the
+            # outer caller is mid-way through resumes correctly.
+            #
+            # This is a deliberate V1 trade-off — the cleaner fix
+            # is to add a public "call into a function from a
+            # builtin" entry point on ``vm-core``.  TW01 / future
+            # GC work is the natural place to design that API.
+            saved_frames = vm._frames
+            saved_module = vm._module
+            saved_interrupted = vm._interrupted
+            try:
+                return vm.execute(module, fn=fn_name, args=full_args)
+            finally:
+                vm._frames = saved_frames
+                vm._module = saved_module
+                vm._interrupted = saved_interrupted
+
+        def global_get(args: list[Any]) -> Any:
+            name = str(args[0])
+            if name not in globals_table:
+                raise TwigRuntimeError(f"unbound global {name!r}")
+            return globals_table[name]
+
+        def global_set(args: list[Any]) -> Any:
+            name = str(args[0])
+            globals_table[name] = args[1]
+            return NIL
+
+        def move(args: list[Any]) -> Any:
+            """Type-faithful identity.  The compiler uses this to merge
+            two control-flow branches into one register without going
+            through ``add x 0``, which would coerce ``True`` to ``1``
+            because Python's ``bool`` is a subclass of ``int``.
+            """
+            return args[0]
+
+        # Register everything.
+        for name, fn in {
+            "+": add,
+            "-": sub,
+            "*": mul,
+            "/": div,
+            "=": eq,
+            "<": lt,
+            ">": gt,
+            "cons": cons,
+            "car": car,
+            "cdr": cdr,
+            "null?": is_null,
+            "pair?": is_pair,
+            "number?": is_number,
+            "symbol?": is_symbol,
+            "print": do_print,
+            "make_nil": make_nil,
+            "make_symbol": make_symbol,
+            "make_closure": make_closure,
+            "make_builtin_closure": make_builtin_closure,
+            "apply_closure": apply_closure,
+            "global_get": global_get,
+            "global_set": global_set,
+            "_move": move,
+        }.items():
+            vm.register_builtin(name, fn)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — runtime-value coercions
+# ---------------------------------------------------------------------------
+
+
+def _int(value: Any) -> int:
+    """Coerce a Twig value to a Python int, or raise a useful error."""
+    if isinstance(value, bool):
+        # bool is a subclass of int; reject to match Scheme's
+        # numeric-tower predicates ("#t is not a number").
+        raise TwigRuntimeError(f"expected number, got boolean: {value!r}")
+    if isinstance(value, int):
+        return value
+    raise TwigRuntimeError(f"expected number, got {type(value).__name__}")
+
+
+def _handle(value: Any) -> HeapHandle:
+    """Coerce a Twig value to a HeapHandle, or raise a useful error."""
+    if isinstance(value, HeapHandle):
+        return value
+    raise TwigRuntimeError(f"expected heap handle, got {type(value).__name__}")
+
+
+def _value_eq(a: Any, b: Any) -> bool:
+    """Twig's ``=`` — value equality on numbers and atomic comparison
+    elsewhere.  Two heap handles compare equal iff they are the same
+    handle (matching Scheme's ``eq?`` for symbols / cons / closures).
+    """
+    if isinstance(a, bool) or isinstance(b, bool):
+        return a is b
+    if isinstance(a, int) and isinstance(b, int):
+        return a == b
+    return a is b
+
+
+def _scheme_truthy(value: Any) -> bool:
+    """Twig follows Scheme truthiness: only ``#f`` and ``nil`` are
+    false.  Everything else — including ``0`` and the empty cons
+    cell — is true.  Without this override, vm-core would treat
+    ``0`` as falsy (Python semantics), which surprises programmers
+    using ``if`` to test for "is this number present?".
+    """
+    if value is False:
+        return False
+    return value is not NIL
+
+
+def _make_jmp_if(*, truthy: bool):
+    """Build a vm-core opcode handler implementing Scheme truthiness.
+
+    ``truthy=True`` produces a handler equivalent to ``jmp_if_true``;
+    ``truthy=False`` produces ``jmp_if_false``.  Both consult
+    :func:`_scheme_truthy` for the test, then update ``frame.ip``
+    via the same ``frame.fn.label_index`` call vm-core's standard
+    handlers use.
+    """
+    def handle(_vm: Any, frame: Any, instr: Any) -> None:
+        cond = frame.resolve(instr.srcs[0])
+        if _scheme_truthy(cond) is truthy:
+            target = str(instr.srcs[1])
+            frame.ip = frame.fn.label_index(target)
+        return None
+
+    return handle
+
+
+def _format(value: Any, heap: Heap) -> str:
+    """Pretty-print a Twig value for the ``print`` builtin."""
+    if value is NIL:
+        return "nil"
+    if isinstance(value, bool):
+        return "#t" if value else "#f"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, HeapHandle):
+        if heap.is_symbol(value):
+            return heap.symbol_name(value)
+        if heap.is_cons(value):
+            # Render as ``(a b c)`` for proper lists, ``(a . b)``
+            # for improper.  Standard Scheme display.
+            parts: list[str] = []
+            current: Any = value
+            while heap.is_cons(current):
+                parts.append(_format(heap.car(current), heap))
+                current = heap.cdr(current)
+            if current is NIL:
+                return "(" + " ".join(parts) + ")"
+            return "(" + " ".join(parts) + " . " + _format(current, heap) + ")"
+        if heap.is_closure(value):
+            return f"#<closure:{heap.closure_fn(value)}>"
+    return repr(value)

--- a/code/packages/python/twig/tests/test_free_vars.py
+++ b/code/packages/python/twig/tests/test_free_vars.py
@@ -1,0 +1,138 @@
+"""Free-variable analysis tests."""
+
+from __future__ import annotations
+
+from twig.ast_extract import extract_program
+from twig.ast_nodes import Define, Lambda
+from twig.free_vars import free_vars
+from twig.parser import parse_twig
+
+
+def _first_lambda(source: str) -> Lambda:
+    """Extract the first ``Lambda`` AST node found by walking the program.
+
+    Used by tests to grab the inner lambda inside ``(define (f ...) ...)``
+    or similar wrappings.
+    """
+    prog = extract_program(parse_twig(source))
+    for form in prog.forms:
+        if isinstance(form, Lambda):
+            return form
+        if isinstance(form, Define) and isinstance(form.expr, Lambda):
+            # The function body is a lambda; the *inner* lambda we want
+            # is whatever lambda the body returns/contains.  Walk it.
+            return _walk_for_lambda(form.expr)
+    raise AssertionError("no lambda in program")
+
+
+def _walk_for_lambda(lam: Lambda) -> Lambda:
+    """Find the first nested lambda inside ``lam``'s body, or return
+    ``lam`` if it has no nested lambdas (so simple lambdas can still
+    be retrieved)."""
+    # Look one level deep; tests use simple shapes.
+    for expr in lam.body:
+        if isinstance(expr, Lambda):
+            return expr
+    return lam
+
+
+def test_lambda_with_no_free_vars() -> None:
+    lam = _first_lambda("(lambda (x) (+ x 1))")
+    assert free_vars(lam, globals_={"+"}) == []
+
+
+def test_lambda_captures_outer_param() -> None:
+    """``(define (adder n) (lambda (x) (+ x n)))`` — the inner
+    lambda captures ``n``."""
+    lam = _first_lambda("(define (adder n) (lambda (x) (+ x n)))")
+    assert free_vars(lam, globals_={"+"}) == ["n"]
+
+
+def test_globals_are_not_captured() -> None:
+    """References to top-level defines and builtins do not become
+    captures."""
+    lam = _first_lambda("(define (mkthunk) (lambda () (+ x 1)))")
+    captures = free_vars(lam, globals_={"+", "x"})
+    assert captures == []
+
+
+def test_let_bound_names_dont_escape() -> None:
+    src = "(define (f) (lambda () (let ((y 1)) y)))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_=set()) == []
+
+
+def test_let_rhs_in_outer_scope() -> None:
+    """``(let ((y x)) y)`` — ``x`` in the RHS is in outer scope, so
+    the enclosing lambda must capture it."""
+    src = "(define (mk) (lambda () (let ((y x)) y)))"
+    lam = _first_lambda(src)
+    captures = free_vars(lam, globals_=set())
+    assert captures == ["x"]
+
+
+def test_nested_lambdas_bubble_captures_up() -> None:
+    """An inner lambda's free variable must also be free in the
+    *outer* lambda when it isn't bound there either."""
+    src = """
+    (define (mk)
+      (lambda (a)
+        (lambda (b) (+ a b zzz))))
+    """
+    # Grab the outer lambda inside ``mk``'s define.
+    prog = extract_program(parse_twig(src))
+    outer_def = prog.forms[0]
+    assert isinstance(outer_def, Define)
+    outer_lam = outer_def.expr  # the (lambda (a) ...) directly
+    assert isinstance(outer_lam, Lambda)
+    captures = free_vars(outer_lam, globals_={"+"})
+    # ``a`` is a param of outer_lam, ``b`` is a param of inner.
+    # ``zzz`` is unbound everywhere → bubbles up.
+    assert captures == ["zzz"]
+
+
+def test_capture_order_is_stable() -> None:
+    """Captures preserve first-encounter order — important because
+    the compiler emits them as the leading parameters of the
+    gensym'd IIR function.  Unstable order would change the
+    function signature run-to-run."""
+    src = "(define (mk) (lambda () (+ a b c a b)))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_={"+"}) == ["a", "b", "c"]
+
+
+def test_if_branches_walked() -> None:
+    """``If`` is handled — free vars in cond / then / else all bubble up."""
+    src = "(define (mk) (lambda () (if a b c)))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_=set()) == ["a", "b", "c"]
+
+
+def test_begin_walks_every_expr() -> None:
+    src = "(define (mk) (lambda () (begin a b c)))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_=set()) == ["a", "b", "c"]
+
+
+def test_let_body_uses_extended_scope() -> None:
+    """Names introduced by ``let`` are bound in the body, so they
+    don't escape as captures."""
+    src = "(define (mk) (lambda () (let ((y 5)) (+ y z))))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_={"+"}) == ["z"]
+
+
+def test_literals_have_no_free_vars() -> None:
+    src = "(define (mk) (lambda () 42))"
+    lam = _first_lambda(src)
+    assert free_vars(lam, globals_=set()) == []
+
+
+def test_unhandled_node_type_raises() -> None:
+    """Defensive: ``_walk`` rejects an AST shape it doesn't know."""
+    import pytest
+
+    from twig.free_vars import _walk
+
+    with pytest.raises(TypeError):
+        _walk("not-an-expr", set(), set(), {})

--- a/code/packages/python/twig/tests/test_heap.py
+++ b/code/packages/python/twig/tests/test_heap.py
@@ -1,0 +1,227 @@
+"""Heap tests for Twig.
+
+Cover the GC primitives directly so we can assert refcount correctness
+without going through the full compile-execute pipeline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from twig.errors import TwigRuntimeError
+from twig.heap import NIL, Heap, HeapHandle
+
+# ---------------------------------------------------------------------------
+# Cons cells
+# ---------------------------------------------------------------------------
+
+
+def test_alloc_cons_returns_handle() -> None:
+    heap = Heap()
+    h = heap.alloc_cons(1, 2)
+    assert isinstance(h, HeapHandle)
+    assert heap.is_cons(h)
+
+
+def test_car_cdr_round_trip() -> None:
+    heap = Heap()
+    h = heap.alloc_cons(10, 20)
+    assert heap.car(h) == 10
+    assert heap.cdr(h) == 20
+
+
+def test_nested_cons_round_trip() -> None:
+    heap = Heap()
+    inner = heap.alloc_cons(1, 2)
+    outer = heap.alloc_cons(inner, NIL)
+    assert heap.car(outer) is inner
+    assert heap.cdr(outer) is NIL
+
+
+# ---------------------------------------------------------------------------
+# Symbols
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_interning() -> None:
+    heap = Heap()
+    a = heap.make_symbol("foo")
+    b = heap.make_symbol("foo")
+    c = heap.make_symbol("bar")
+    assert a == b
+    assert a != c
+    assert heap.is_symbol(a)
+
+
+def test_symbol_name_round_trip() -> None:
+    heap = Heap()
+    h = heap.make_symbol("hello")
+    assert heap.symbol_name(h) == "hello"
+
+
+def test_symbol_name_on_non_symbol_raises() -> None:
+    heap = Heap()
+    cons = heap.alloc_cons(1, 2)
+    with pytest.raises(TwigRuntimeError):
+        heap.symbol_name(cons)
+
+
+# ---------------------------------------------------------------------------
+# Closures
+# ---------------------------------------------------------------------------
+
+
+def test_alloc_closure() -> None:
+    heap = Heap()
+    h = heap.alloc_closure("__lambda_0", [1, 2, 3])
+    assert heap.is_closure(h)
+    assert heap.closure_fn(h) == "__lambda_0"
+    assert heap.closure_captured(h) == [1, 2, 3]
+
+
+def test_closure_captured_is_a_copy() -> None:
+    """Mutating the returned captured list must not affect the heap."""
+    heap = Heap()
+    h = heap.alloc_closure("f", [1, 2, 3])
+    captured = heap.closure_captured(h)
+    captured.append(99)
+    assert heap.closure_captured(h) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Refcounting
+# ---------------------------------------------------------------------------
+
+
+def test_decref_to_zero_frees_object() -> None:
+    heap = Heap()
+    h = heap.alloc_cons(1, 2)
+    assert heap.stats().live_objects == 1
+    heap.decref(h)
+    assert heap.stats().live_objects == 0
+
+
+def test_storing_handle_in_cons_increfs_inner() -> None:
+    heap = Heap()
+    inner = heap.alloc_cons(1, 2)
+    outer = heap.alloc_cons(inner, NIL)
+    # The inner handle should now have refcount 2 (caller + outer's car).
+    # We assert via decref behaviour: dropping outer should free outer
+    # AND drop inner's count back to 1, leaving it alive.
+    heap.decref(outer)
+    assert heap.is_cons(inner)
+    heap.decref(inner)
+    assert heap.stats().live_objects == 0
+
+
+def test_decref_recurses_through_chain() -> None:
+    """Drop the head of a 3-element list; heap should drop to zero."""
+    heap = Heap()
+    a = heap.alloc_cons(3, NIL)
+    b = heap.alloc_cons(2, a)
+    c = heap.alloc_cons(1, b)
+    # We hold one ref each to a, b, c.  Drop our refs to a, b — they
+    # stay alive because c still references them.
+    heap.decref(a)
+    heap.decref(b)
+    assert heap.stats().live_objects == 3
+    # Dropping c should cascade.
+    heap.decref(c)
+    assert heap.stats().live_objects == 0
+
+
+def test_symbols_are_not_refcounted() -> None:
+    """Symbols are interned for the heap's lifetime — decref is a no-op."""
+    heap = Heap()
+    h = heap.make_symbol("x")
+    heap.decref(h)
+    heap.decref(h)
+    assert heap.is_symbol(h)
+
+
+def test_closure_decref_recurses_through_captures() -> None:
+    heap = Heap()
+    capt = heap.alloc_cons(1, 2)
+    clos = heap.alloc_closure("f", [capt])
+    # Drop the caller's ref to capt; clos still holds it.
+    heap.decref(capt)
+    assert heap.is_cons(capt)
+    # Dropping the closure should cascade to capt.
+    heap.decref(clos)
+    assert heap.stats().live_objects == 0
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+def test_peak_objects_is_monotonic() -> None:
+    heap = Heap()
+    a = heap.alloc_cons(1, 2)
+    b = heap.alloc_cons(3, 4)
+    c = heap.alloc_cons(5, 6)
+    assert heap.stats().peak_objects == 3
+    heap.decref(a)
+    heap.decref(b)
+    heap.decref(c)
+    # peak_objects stays 3 even though live drops to 0.
+    assert heap.stats().peak_objects == 3
+
+
+def test_total_allocs_counts_all_allocations() -> None:
+    heap = Heap()
+    heap.alloc_cons(1, 2)
+    heap.make_symbol("x")
+    heap.alloc_closure("f", [])
+    assert heap.stats().total_allocs == 3
+
+
+def test_reset_stats_zeroes_counters() -> None:
+    heap = Heap()
+    heap.alloc_cons(1, 2)
+    heap.reset_stats()
+    s = heap.stats()
+    assert s.total_allocs == 0
+    assert s.total_releases == 0
+
+
+# ---------------------------------------------------------------------------
+# Bounds checking
+# ---------------------------------------------------------------------------
+
+
+def test_car_on_dangling_handle_raises() -> None:
+    heap = Heap()
+    h = heap.alloc_cons(1, 2)
+    heap.decref(h)
+    with pytest.raises(TwigRuntimeError):
+        heap.car(h)
+
+
+def test_car_on_symbol_raises() -> None:
+    heap = Heap()
+    s = heap.make_symbol("x")
+    with pytest.raises(TwigRuntimeError):
+        heap.car(s)
+
+
+def test_closure_fn_on_cons_raises() -> None:
+    heap = Heap()
+    c = heap.alloc_cons(1, 2)
+    with pytest.raises(TwigRuntimeError):
+        heap.closure_fn(c)
+
+
+# ---------------------------------------------------------------------------
+# nil
+# ---------------------------------------------------------------------------
+
+
+def test_nil_is_singleton() -> None:
+    from twig.heap import _Nil  # noqa: PLC2701 - testing internals
+    assert _Nil() is NIL
+
+
+def test_nil_is_falsy_in_python() -> None:
+    assert not NIL

--- a/code/packages/python/twig/tests/test_integration.py
+++ b/code/packages/python/twig/tests/test_integration.py
@@ -1,0 +1,358 @@
+"""End-to-end integration tests for Twig.
+
+These tests exercise the full pipeline: source → lex → parse →
+extract → compile → vm-core execute → observable output.  If
+anything in the chain breaks, these tests fail loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from twig import NIL, TwigVM
+from twig.errors import TwigCompileError, TwigRuntimeError
+
+
+@pytest.fixture
+def vm() -> TwigVM:
+    return TwigVM()
+
+
+# ---------------------------------------------------------------------------
+# Atoms
+# ---------------------------------------------------------------------------
+
+
+def test_integer_returns_value(vm: TwigVM) -> None:
+    _, val = vm.run("42")
+    assert val == 42
+
+
+def test_negative_integer(vm: TwigVM) -> None:
+    _, val = vm.run("-7")
+    assert val == -7
+
+
+def test_boolean_true(vm: TwigVM) -> None:
+    _, val = vm.run("#t")
+    assert val is True
+
+
+def test_boolean_false(vm: TwigVM) -> None:
+    _, val = vm.run("#f")
+    assert val is False
+
+
+def test_nil(vm: TwigVM) -> None:
+    _, val = vm.run("nil")
+    assert val is NIL
+
+
+def test_empty_program_returns_nil(vm: TwigVM) -> None:
+    _, val = vm.run("")
+    assert val is NIL
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_addition(vm: TwigVM) -> None:
+    _, val = vm.run("(+ 1 2 3)")
+    assert val == 6
+
+
+def test_subtraction(vm: TwigVM) -> None:
+    _, val = vm.run("(- 10 3 2)")
+    assert val == 5
+
+
+def test_unary_negation(vm: TwigVM) -> None:
+    _, val = vm.run("(- 5)")
+    assert val == -5
+
+
+def test_multiplication(vm: TwigVM) -> None:
+    _, val = vm.run("(* 2 3 4)")
+    assert val == 24
+
+
+def test_division(vm: TwigVM) -> None:
+    _, val = vm.run("(/ 20 4)")
+    assert val == 5
+
+
+def test_division_by_zero_raises(vm: TwigVM) -> None:
+    with pytest.raises(TwigRuntimeError):
+        vm.run("(/ 1 0)")
+
+
+def test_equality(vm: TwigVM) -> None:
+    _, val = vm.run("(= 1 1 1)")
+    assert val is True
+    _, val = vm.run("(= 1 2)")
+    assert val is False
+
+
+def test_comparison(vm: TwigVM) -> None:
+    _, val = vm.run("(< 1 2)")
+    assert val is True
+    _, val = vm.run("(> 1 2)")
+    assert val is False
+
+
+# ---------------------------------------------------------------------------
+# Control flow
+# ---------------------------------------------------------------------------
+
+
+def test_if_taken(vm: TwigVM) -> None:
+    _, val = vm.run("(if #t 1 2)")
+    assert val == 1
+
+
+def test_if_not_taken(vm: TwigVM) -> None:
+    _, val = vm.run("(if #f 1 2)")
+    assert val == 2
+
+
+def test_if_with_nil_is_falsy(vm: TwigVM) -> None:
+    _, val = vm.run("(if nil 1 2)")
+    assert val == 2
+
+
+def test_if_with_zero_is_truthy(vm: TwigVM) -> None:
+    """Scheme says only ``#f`` and ``nil`` are falsy.  ``0`` is true."""
+    _, val = vm.run("(if 0 1 2)")
+    assert val == 1
+
+
+def test_let_introduces_bindings(vm: TwigVM) -> None:
+    _, val = vm.run("(let ((a 1) (b 2)) (+ a b))")
+    assert val == 3
+
+
+def test_nested_let(vm: TwigVM) -> None:
+    _, val = vm.run("(let ((a 1)) (let ((b 2)) (+ a b)))")
+    assert val == 3
+
+
+def test_begin_returns_last(vm: TwigVM) -> None:
+    _, val = vm.run("(begin 1 2 3)")
+    assert val == 3
+
+
+# ---------------------------------------------------------------------------
+# Cons cells
+# ---------------------------------------------------------------------------
+
+
+def test_cons_car_cdr(vm: TwigVM) -> None:
+    _, val = vm.run("(car (cons 1 2))")
+    assert val == 1
+    _, val = vm.run("(cdr (cons 1 2))")
+    assert val == 2
+
+
+def test_proper_list_length(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define (length xs)
+          (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+        (length (cons 1 (cons 2 (cons 3 nil))))
+    """)
+    assert val == 3
+
+
+def test_pair_predicate(vm: TwigVM) -> None:
+    _, val = vm.run("(pair? (cons 1 2))")
+    assert val is True
+    _, val = vm.run("(pair? nil)")
+    assert val is False
+    _, val = vm.run("(pair? 42)")
+    assert val is False
+
+
+def test_null_predicate(vm: TwigVM) -> None:
+    _, val = vm.run("(null? nil)")
+    assert val is True
+    _, val = vm.run("(null? (cons 1 2))")
+    assert val is False
+
+
+def test_number_predicate(vm: TwigVM) -> None:
+    _, val = vm.run("(number? 42)")
+    assert val is True
+    _, val = vm.run("(number? #t)")
+    assert val is False
+    _, val = vm.run("(number? 'foo)")
+    assert val is False
+
+
+def test_symbol_predicate(vm: TwigVM) -> None:
+    _, val = vm.run("(symbol? 'foo)")
+    assert val is True
+    _, val = vm.run("(symbol? 42)")
+    assert val is False
+
+
+# ---------------------------------------------------------------------------
+# Recursion + define
+# ---------------------------------------------------------------------------
+
+
+def test_factorial(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define (fact n)
+          (if (= n 0) 1 (* n (fact (- n 1)))))
+        (fact 6)
+    """)
+    assert val == 720
+
+
+def test_mutual_recursion(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define (even? n)
+          (if (= n 0) #t (odd? (- n 1))))
+        (define (odd? n)
+          (if (= n 0) #f (even? (- n 1))))
+        (even? 10)
+    """)
+    assert val is True
+
+
+def test_define_value(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define x 42)
+        (+ x 8)
+    """)
+    assert val == 50
+
+
+# ---------------------------------------------------------------------------
+# Closures
+# ---------------------------------------------------------------------------
+
+
+def test_simple_closure(vm: TwigVM) -> None:
+    """The classic adder."""
+    _, val = vm.run("""
+        (define (adder n) (lambda (x) (+ x n)))
+        (define add5 (adder 5))
+        (add5 3)
+    """)
+    assert val == 8
+
+
+def test_closure_captures_multiple_vars(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define (mk a b) (lambda (c) (+ a b c)))
+        ((mk 1 2) 100)
+    """)
+    assert val == 103
+
+
+def test_inline_lambda(vm: TwigVM) -> None:
+    _, val = vm.run("((lambda (x) (* x 2)) 21)")
+    assert val == 42
+
+
+def test_higher_order_inc_twice(vm: TwigVM) -> None:
+    _, val = vm.run("""
+        (define (apply-twice f x) (f (f x)))
+        (define (inc x) (+ x 1))
+        (apply-twice inc 5)
+    """)
+    assert val == 7
+
+
+def test_first_class_builtin(vm: TwigVM) -> None:
+    """Pass a builtin (``+``) as a value."""
+    _, val = vm.run("""
+        (define (apply-it f a b) (f a b))
+        (apply-it + 3 4)
+    """)
+    assert val == 7
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+def test_print_emits_to_stdout(vm: TwigVM) -> None:
+    out, _ = vm.run("(print 42)")
+    assert out == "42\n"
+
+
+def test_print_multiple_lines(vm: TwigVM) -> None:
+    out, _ = vm.run("(begin (print 1) (print 2))")
+    assert out == "1\n2\n"
+
+
+def test_print_list(vm: TwigVM) -> None:
+    out, _ = vm.run("(print (cons 1 (cons 2 (cons 3 nil))))")
+    assert out == "(1 2 3)\n"
+
+
+def test_print_improper_list(vm: TwigVM) -> None:
+    out, _ = vm.run("(print (cons 1 2))")
+    assert out == "(1 . 2)\n"
+
+
+def test_print_symbol(vm: TwigVM) -> None:
+    out, _ = vm.run("(print 'hello)")
+    assert out == "hello\n"
+
+
+def test_print_nil(vm: TwigVM) -> None:
+    out, _ = vm.run("(print nil)")
+    assert out == "nil\n"
+
+
+def test_print_booleans(vm: TwigVM) -> None:
+    out, _ = vm.run("(begin (print #t) (print #f))")
+    assert out == "#t\n#f\n"
+
+
+# ---------------------------------------------------------------------------
+# GC / heap behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_clean_program_releases_temporary_cons_cells(vm: TwigVM) -> None:
+    """A program that allocates cons cells but doesn't store them
+    anywhere should leave the heap with most allocations released
+    (we don't promise zero — globals + the returned value live on)."""
+    vm.run("""
+        (define (range n)
+          (if (= n 0) nil (cons n (range (- n 1)))))
+        (define (length xs)
+          (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+        (length (range 5))
+    """)
+    heap = vm.heap
+    assert heap is not None
+    stats = heap.stats()
+    # We allocated at least 5 cons cells.
+    assert stats.total_allocs >= 5
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_unbound_name_compile_error(vm: TwigVM) -> None:
+    with pytest.raises(TwigCompileError):
+        vm.run("(no-such-name 1 2)")
+
+
+def test_car_on_non_pair_runtime_error(vm: TwigVM) -> None:
+    with pytest.raises(TwigRuntimeError):
+        vm.run("(car 42)")
+
+
+def test_division_by_zero_runtime_error(vm: TwigVM) -> None:
+    with pytest.raises(TwigRuntimeError):
+        vm.run("(/ 5 0)")

--- a/code/packages/python/twig/tests/test_lexer.py
+++ b/code/packages/python/twig/tests/test_lexer.py
@@ -1,0 +1,108 @@
+"""Lexer tests for Twig.
+
+These tests check that the grammar-driven ``GrammarLexer``,
+configured by ``code/grammars/twig.tokens``, recognises every
+documented token shape and discards comments / whitespace.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from twig.lexer import tokenize_twig
+
+
+def _types(source: str) -> list[str]:
+    """Return the bare type names of every non-EOF token, as strings.
+
+    Token types come back as ``TokenType.LPAREN`` enum members for
+    the standard punctuation but as plain strings for our custom
+    tokens (``INTEGER``, ``BOOL_TRUE``, etc.).  We normalise via
+    ``.name`` if available.
+    """
+    return [
+        getattr(t.type, "name", None) or str(t.type)
+        for t in tokenize_twig(source)
+        if str(t.type) != "EOF" and getattr(t.type, "name", "") != "EOF"
+    ]
+
+
+def _values(source: str) -> list:
+    return [t.value for t in tokenize_twig(source) if str(t.type) != "EOF"
+            and getattr(t.type, "name", "") != "EOF"]
+
+
+def test_empty_source_produces_only_eof() -> None:
+    toks = tokenize_twig("")
+    assert all(
+        getattr(t.type, "name", "") == "EOF" or str(t.type) == "EOF"
+        for t in toks
+    )
+
+
+def test_punctuation() -> None:
+    assert _types("(())") == ["LPAREN", "LPAREN", "RPAREN", "RPAREN"]
+
+
+def test_quote_char() -> None:
+    assert _types("'foo") == ["QUOTE", "NAME"]
+
+
+def test_integer_positive() -> None:
+    assert _values("42") == ["42"]
+
+
+def test_integer_negative() -> None:
+    assert _values("-7") == ["-7"]
+
+
+def test_negative_then_name() -> None:
+    """``-foo`` tokenises as a NAME (the subtraction op + foo would be
+    two tokens, but the lexer's longest-match rule picks NAME because
+    INTEGER's regex requires at least one digit after ``-``)."""
+    types = _types("-foo")
+    # Could be a single NAME, or LPAREN-style separator behaviour.
+    # We just assert it lexes without an exception.
+    assert types == ["NAME"]
+
+
+def test_boolean_literals() -> None:
+    assert _types("#t #f") == ["BOOL_TRUE", "BOOL_FALSE"]
+
+
+def test_keyword_promotion() -> None:
+    """``define`` / ``lambda`` / ``let`` / ``if`` / ``begin`` /
+    ``quote`` / ``nil`` are promoted to KEYWORD tokens."""
+    src = "define lambda let if begin quote nil"
+    types = _types(src)
+    assert types == ["KEYWORD"] * 7
+
+
+def test_keyword_value_preserved() -> None:
+    toks = tokenize_twig("define")
+    kw = [t for t in toks if str(t.type) != "EOF"
+          and getattr(t.type, "name", "") != "EOF"][0]
+    assert kw.value == "define"
+
+
+def test_identifiers_with_punctuation() -> None:
+    types = _types("null? pair? + - * / = <= >=")
+    assert all(t == "NAME" for t in types)
+
+
+def test_comment_is_skipped() -> None:
+    src = "+ ; this is a comment\n42"
+    types = _types(src)
+    assert types == ["NAME", "INTEGER"]
+
+
+def test_whitespace_is_skipped() -> None:
+    src = "(\t\n  +\n\n42  \r\n)"
+    types = _types(src)
+    assert types == ["LPAREN", "NAME", "INTEGER", "RPAREN"]
+
+
+def test_unknown_character_raises() -> None:
+    # ``@`` is not in any token grammar rule — the lexer should fail.
+    with pytest.raises(Exception):  # noqa: B017 — wrapped error from generic lexer
+        tokenize_twig("(foo @ bar)")

--- a/code/packages/python/twig/tests/test_parser.py
+++ b/code/packages/python/twig/tests/test_parser.py
@@ -1,0 +1,209 @@
+"""Parser + typed-AST extraction tests for Twig."""
+
+from __future__ import annotations
+
+import pytest
+
+from twig.ast_extract import extract_program
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    BoolLit,
+    Define,
+    If,
+    IntLit,
+    Lambda,
+    Let,
+    NilLit,
+    Program,
+    SymLit,
+    VarRef,
+)
+from twig.parser import parse_twig
+
+
+def _parse(source: str) -> Program:
+    return extract_program(parse_twig(source))
+
+
+# ---------------------------------------------------------------------------
+# Atoms
+# ---------------------------------------------------------------------------
+
+
+def test_empty_program() -> None:
+    assert _parse("").forms == []
+
+
+def test_integer_literal() -> None:
+    prog = _parse("42")
+    assert prog.forms[0] == IntLit(value=42, line=1, column=1)
+
+
+def test_negative_integer() -> None:
+    prog = _parse("-7")
+    assert isinstance(prog.forms[0], IntLit)
+    assert prog.forms[0].value == -7
+
+
+def test_boolean_literals() -> None:
+    prog = _parse("#t #f")
+    assert isinstance(prog.forms[0], BoolLit) and prog.forms[0].value is True
+    assert isinstance(prog.forms[1], BoolLit) and prog.forms[1].value is False
+
+
+def test_nil_literal() -> None:
+    prog = _parse("nil")
+    assert isinstance(prog.forms[0], NilLit)
+
+
+def test_var_reference() -> None:
+    prog = _parse("foo")
+    assert isinstance(prog.forms[0], VarRef) and prog.forms[0].name == "foo"
+
+
+def test_quoted_symbol_apostrophe() -> None:
+    prog = _parse("'hello")
+    assert isinstance(prog.forms[0], SymLit) and prog.forms[0].name == "hello"
+
+
+def test_quoted_symbol_quote_form() -> None:
+    prog = _parse("(quote hello)")
+    assert isinstance(prog.forms[0], SymLit) and prog.forms[0].name == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Compound forms
+# ---------------------------------------------------------------------------
+
+
+def test_if_form() -> None:
+    prog = _parse("(if #t 1 2)")
+    assert isinstance(prog.forms[0], If)
+    assert isinstance(prog.forms[0].cond, BoolLit)
+    assert isinstance(prog.forms[0].then_branch, IntLit)
+    assert isinstance(prog.forms[0].else_branch, IntLit)
+
+
+def test_let_form() -> None:
+    prog = _parse("(let ((a 1) (b 2)) (+ a b))")
+    let = prog.forms[0]
+    assert isinstance(let, Let)
+    assert [n for (n, _) in let.bindings] == ["a", "b"]
+    assert len(let.body) == 1
+
+
+def test_let_multiple_body_exprs() -> None:
+    prog = _parse("(let ((x 5)) (print x) x)")
+    let = prog.forms[0]
+    assert isinstance(let, Let)
+    assert len(let.body) == 2
+
+
+def test_begin_form() -> None:
+    prog = _parse("(begin 1 2 3)")
+    assert isinstance(prog.forms[0], Begin)
+    assert len(prog.forms[0].exprs) == 3
+
+
+def test_lambda_form() -> None:
+    prog = _parse("(lambda (x y) (+ x y))")
+    lam = prog.forms[0]
+    assert isinstance(lam, Lambda)
+    assert lam.params == ["x", "y"]
+
+
+def test_lambda_with_no_params() -> None:
+    prog = _parse("(lambda () 42)")
+    lam = prog.forms[0]
+    assert isinstance(lam, Lambda) and lam.params == []
+
+
+# ---------------------------------------------------------------------------
+# Define
+# ---------------------------------------------------------------------------
+
+
+def test_define_value() -> None:
+    prog = _parse("(define x 42)")
+    d = prog.forms[0]
+    assert isinstance(d, Define)
+    assert d.name == "x"
+    assert isinstance(d.expr, IntLit)
+
+
+def test_define_function_sugar() -> None:
+    prog = _parse("(define (f x y) (+ x y))")
+    d = prog.forms[0]
+    assert isinstance(d, Define)
+    assert d.name == "f"
+    assert isinstance(d.expr, Lambda)
+    assert d.expr.params == ["x", "y"]
+
+
+def test_define_function_multi_body() -> None:
+    prog = _parse("(define (f x) (print x) x)")
+    d = prog.forms[0]
+    assert isinstance(d, Define) and isinstance(d.expr, Lambda)
+    assert len(d.expr.body) == 2
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def test_apply() -> None:
+    prog = _parse("(+ 1 2 3)")
+    app = prog.forms[0]
+    assert isinstance(app, Apply)
+    assert isinstance(app.fn, VarRef) and app.fn.name == "+"
+    assert len(app.args) == 3
+
+
+def test_apply_zero_args() -> None:
+    prog = _parse("(thunk)")
+    app = prog.forms[0]
+    assert isinstance(app, Apply) and app.args == []
+
+
+def test_apply_higher_order() -> None:
+    """``((f x) y)`` — the function position is itself a call."""
+    prog = _parse("((f x) y)")
+    outer = prog.forms[0]
+    assert isinstance(outer, Apply)
+    assert isinstance(outer.fn, Apply)
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+def test_comments_are_dropped() -> None:
+    prog = _parse("; preamble\n42 ; trailing\n")
+    assert isinstance(prog.forms[0], IntLit) and prog.forms[0].value == 42
+    assert len(prog.forms) == 1
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_open_paren_raises() -> None:
+    with pytest.raises(Exception):  # noqa: B017 — generic GrammarParseError
+        _parse("(+ 1 2")
+
+
+def test_unmatched_close_paren_raises() -> None:
+    with pytest.raises(Exception):  # noqa: B017
+        _parse("1 2)")
+
+
+def test_define_value_with_extra_exprs_raises() -> None:
+    """``(define x 1 2)`` is ambiguous — neither value nor function form."""
+    from twig.errors import TwigParseError
+
+    with pytest.raises(TwigParseError):
+        _parse("(define x 1 2)")

--- a/code/specs/TW00-twig-language.md
+++ b/code/specs/TW00-twig-language.md
@@ -1,0 +1,327 @@
+# TW00 — Twig: a Lisp precursor on the LANG VM
+
+## Overview
+
+Twig is a tiny purely-functional, S-expression language that runs on
+`vm-core`.  It is explicitly designed as a **precursor to a full Lisp
+implementation** — the surface and semantics are a strict subset that
+will grow over subsequent specs.
+
+The two motivating goals:
+
+1. **Add a host-side heap and GC primitives** to the LANG VM
+   infrastructure.  Brainfuck's tape is a flat byte array; Twig
+   introduces *cons cells* — variable-sized heap objects with parent
+   references.  The GC layer that emerges here will eventually serve
+   every other LANG-pipeline language that needs heap allocation.
+2. **Drive a multi-target compiler experience.**  Twig will eventually
+   compile to BEAM (Erlang's VM) in addition to running through
+   `vm-core`.  Designing the language with that future in mind keeps
+   the semantics aligned (immutability, atoms-as-symbols, lists-as-cons,
+   tail-call recursion).
+
+## Roadmap
+
+| Spec | Scope                                                      |
+|------|------------------------------------------------------------|
+| TW00 | This spec — language v1, runs through `vm-core`.           |
+|      | **Includes full closures** via host-side closure objects.  |
+| TW01 | `gc-core` package, native IIR heap ops, mark-sweep GC,     |
+|      | `letrec`, cycle handling.                                  |
+| TW02 | Twig → BEAM bytecode emission (direct, no Erlang source).  |
+|      | Mirrors how `wasm-backend` produces WASM bytes natively.   |
+
+This spec is **TW00 only**.  Everything below is the v1 surface.
+
+## v1 surface
+
+```
+program     ::= form*
+form        ::= define | expr
+define      ::= ( "define" name expr )
+              | ( "define" ( name name* ) expr+ )       ; sugar for define-lambda
+
+expr        ::= literal | name | quote | if | let | begin | lambda | apply
+
+literal     ::= integer | "#t" | "#f" | "nil"
+quote       ::= "'" name | ( "quote" name )
+if          ::= ( "if" expr expr expr )
+let         ::= ( "let" ( ( name expr )* ) expr+ )
+begin       ::= ( "begin" expr+ )
+lambda      ::= ( "lambda" ( name* ) expr+ )            ; v1: top-level only
+apply       ::= ( expr expr* )
+
+builtin     ::= "+" | "-" | "*" | "/" | "=" | "<" | ">"
+              | "cons" | "car" | "cdr"
+              | "null?" | "pair?" | "number?" | "symbol?"
+              | "print"
+```
+
+### First-class closures — **included in v1**
+
+Lambdas can appear anywhere and capture lexical variables.  The classic
+adder example just works:
+
+```scheme
+(define (adder n) (lambda (x) (+ x n)))
+(define add5 (adder 5))
+(print (add5 3))   ; 8
+```
+
+How: each `lambda` becomes a fresh top-level `IIRFunction` (the compiler
+gensyms a unique name).  At the lambda's source location the compiler
+performs a free-variable analysis and emits
+
+```
+call_builtin "make_closure" "lambda_<gensym>" capt1 capt2 ...
+```
+
+returning a closure *handle* (an integer pointing into the host
+`Heap`'s closure table).  Applying a value that's a closure handle —
+i.e. when the call's function position is a local variable, not a
+top-level name — emits
+
+```
+call_builtin "apply_closure" handle arg1 arg2 ...
+```
+
+The host's `apply_closure` looks up `(fn_name, captured)` from the
+heap and re-enters `vm.execute(module, fn=fn_name, args=captured + user_args)`.
+
+This requires **zero changes to vm-core or IIR** — closures sit
+entirely on the `call_builtin` seam.  The trade-off is that every
+closure invocation pays a Python callback plus a `vm.execute()`
+re-entry; for an educational interpreter that is fine.  Promoting
+`apply_closure` to a native `call_indirect` IIR op is a future
+optimization, not a v1 concern.
+
+### Apply-site dispatch (compile-time decision)
+
+The compiler picks the call shape at compile time, not runtime:
+
+| Function position           | Emitted IIR                               |
+|-----------------------------|-------------------------------------------|
+| Top-level name              | `call <name>, ...args`  (direct)          |
+| Local variable / parameter  | `call_builtin "apply_closure", v, ...args`|
+| Builtin name (`+`, `cons`)  | `call_builtin "<name>", ...args`          |
+
+This means top-level recursion stays on the fast path; only locals
+holding closures pay the indirect cost.
+
+### Recursion
+
+Top-level `define` produces a callable name in the global function table.
+Recursion works the natural way:
+
+```scheme
+(define (fact n)
+  (if (= n 0) 1 (* n (fact (- n 1)))))
+
+(print (fact 5))   ; 120
+```
+
+Mutual recursion works too (functions can reference each other by name).
+
+### `letrec`?
+
+Not in v1.  `letrec` introduces *local* recursive bindings and would
+require closure objects with self-reference — a TW01 / TW03 concern.
+
+### Macros?
+
+Out of scope.  No quasiquote, no `defmacro`, no `syntax-rules`.  This is
+deliberately deferred — macros add real lexer/parser complexity (special
+quote forms, hygienic expansion) and aren't required for a Lisp-precursor
+that already proves out the GC and dispatch layers.
+
+## Type model
+
+Twig values come in two kinds:
+
+| Kind           | Examples                | IIR representation                  |
+|----------------|-------------------------|-------------------------------------|
+| **Immediate**  | integers, booleans, nil | tagged ints (see below)             |
+| **Heap**       | cons cells, symbols     | integer handle into the host `Heap` |
+
+### Tagged immediates
+
+Twig's IIR runtime uses Python `int` values everywhere.  We tag them so
+the runtime can tell numbers from heap handles from booleans:
+
+```
+bit pattern        | value
+-------------------|------------------
+... xxxx xxx0      | integer (low bit clear)
+0000 0001          | nil  (== integer 1, never a real number)
+0000 0011          | #f   (== integer 3)
+0000 0101          | #t   (== integer 5)
+... xxxx 1001      | heap handle (low nibble = 0b1001)
+```
+
+The exact tagging scheme matters less than *consistency* — TW00 just
+needs to round-trip values through `call_builtin` boundaries without
+losing kind information.  TW02 (BEAM) and TW03 (mark-sweep) will
+formalise the encoding.  For V1 we use a small dataclass on the host
+side (`HeapHandle`) and let `vm-core`'s builtin registry pass them
+through without conversion.
+
+### Symbols
+
+Symbols (`'foo`) are heap-interned strings.  The `Heap` keeps a
+`symbols: dict[str, int]` table; `quote` of a name returns the existing
+handle (or allocates one fresh).  Two `'foo`s compare `eq?`.
+
+### Cons cells
+
+A cons cell is a 2-slot heap object: `(car, cdr)`.  Both slots hold
+arbitrary Twig values (immediates *or* handles).  `cons` allocates,
+`car`/`cdr` read.
+
+## Pipeline
+
+```
+Twig source
+   │
+   ▼  twig.parse_twig          (this spec — lexer + parser → AST)
+ASTNode tree
+   │
+   ▼  twig.compile_to_iir      (this spec — AST → IIRModule)
+IIRModule
+   │
+   ▼  TwigVM.run               (this spec — vm-core wrapper)
+   │   ├── vm-core executes IIR
+   │   └── call_builtin → Heap (cons / car / cdr / make_symbol / print)
+program output (printed bytes + final value)
+```
+
+## Compiler details
+
+### Top-level functions
+
+A top-level `(define (f x y) body)` becomes one `IIRFunction` named
+`f` with parameters `[("x", "any"), ("y", "any")]` and `return_type =
+"any"` (Twig is dynamically typed).  Top-level *value* defines
+`(define x expr)` are assembled into a synthesized `_init` function
+that runs before `main`; `main` is a synthesized function holding any
+top-level expressions in source order.
+
+### Builtin dispatch
+
+Arithmetic and predicates are emitted as `call_builtin` with the
+operator name as `srcs[0]`:
+
+```
+(+ a b)       →  call_builtin "+", a, b   → result
+(cons a b)    →  call_builtin "cons", a, b → handle
+(car p)       →  call_builtin "car", p    → element
+(null? x)     →  call_builtin "null?", x  → bool
+```
+
+The `TwigVM` registers the matching host callables.
+
+### Type hints
+
+Every emitted IIR instruction carries `type_hint = "any"` because Twig
+is dynamically typed.  This deliberately exercises the
+`UNTYPED`/`PARTIALLY_TYPED` branches of the JIT pipeline once we wire
+them up later.
+
+### `if`
+
+```
+(if c t e)
+```
+
+→ standard `jmp_if_false` / `jmp` over labels.  Truthiness: only `#f`
+and `nil` are false; everything else is true.  This matches Scheme.
+
+### `let`
+
+`(let ((x e1) (y e2)) body)` → evaluate `e1` into `x`, `e2` into `y`,
+then evaluate `body`.  Bindings are mutually independent (no
+sequential like `let*`).  Scope is lexical: the `body` sees `x`/`y`
+plus the surrounding scope.
+
+Implementation: each binding becomes a fresh assignment; the IIR
+register file handles scoping naturally because `frame.assign(name,
+val)` reuses slots.
+
+## The `Heap` class (the GC playground)
+
+Twig's heap is a host-side Python object exposed to `vm-core` via
+builtins.  V1 uses **reference counting**.  It hosts three object kinds:
+
+```python
+class Heap:
+    # cons cells
+    def alloc_cons(self, car: Any, cdr: Any) -> int: ...
+    def car(self, handle: int) -> Any: ...
+    def cdr(self, handle: int) -> Any: ...
+
+    # symbols — interned by name
+    def make_symbol(self, name: str) -> int: ...
+    def symbol_name(self, handle: int) -> str: ...
+
+    # closures — fn_name + captured values
+    def alloc_closure(self, fn_name: str, captured: list[Any]) -> int: ...
+    def closure_fn(self, handle: int) -> str: ...
+    def closure_captured(self, handle: int) -> list[Any]: ...
+
+    # GC plumbing
+    def incref(self, handle: int) -> None: ...
+    def decref(self, handle: int) -> None: ...
+    def is_handle(self, value: Any) -> bool: ...
+    def stats(self) -> HeapStats: ...   # { live_objects, peak_objects, total_allocs }
+```
+
+V1 rules:
+
+- Allocations get `refcount = 1`.
+- Storing a handle into another heap object (cons cell or closure
+  capture list) calls `incref` on the inner value.
+- The TwigVM walks the result of `main` and decrefs at run end.
+- Symbols are *not* refcounted — they're interned for the run.
+
+V1 limitations (intentional, addressed in TW01):
+
+- **Cycles leak.** TW00 doesn't have `letrec`, so building a cycle
+  takes deliberate effort, but it's still possible (e.g. via top-level
+  defines that reference each other and store closure handles into
+  cons cells).  V1 just leaks; TW01's mark-sweep handles it.
+- No compaction.  Handle integers are never reused after free — fine
+  for the short-lived programs the v1 interpreter targets.
+
+## Tests
+
+- Lexer tests: integers, symbols, parens, quotes, comments (`;`), strings
+  out of scope, edge cases (empty input, lone parens).
+- Parser tests: simple lists, nested lists, `define`, `define-lambda`
+  sugar, error cases (unmatched parens, lone closing).
+- Compiler tests: golden IIR for canonical programs.
+- Heap tests: alloc / car / cdr round-trip, refcount on overwrite,
+  `live_objects` returns to zero after a clean program.
+- Execution tests: factorial, range, length, mutual recursion (`even?` /
+  `odd?`), arithmetic edge cases (division, comparison), nil / `#t` / `#f`
+  truthiness.
+- Top-level-only-lambda check: a nested lambda raises a clear
+  `TwigCompileError` at compile time.
+
+Coverage target: **≥ 95%**.
+
+## Out of scope
+
+- **Native IIR heap ops + mark-sweep GC + cycle handling + `letrec`** → TW01.
+- **Direct BEAM bytecode emission** (no Erlang source intermediary,
+  matching the way `wasm-backend` produces WASM bytes) → TW02.
+- **Macros, quasiquote, syntax-rules** → indefinite future.
+- **Tail-call optimisation in the interpreter.**  vm-core has no TCO;
+  recursion is bounded by Python's stack.  Programs that need deep
+  recursion can be rewritten with `let` bodies that return their
+  recursive call directly — but the spec does not promise TCO until
+  TW02 (where BEAM gives it for free).
+- **Strings** as a first-class type.  V1 has integers, booleans, nil,
+  symbols, cons cells, closures.  Strings can come later as a thin
+  wrapper over cons-of-chars or as a new heap object.
+- **`call_indirect` as a native IIR op.**  Closures route through
+  `call_builtin "apply_closure"` for v1.  Promoting that to a real
+  IIR op is a JIT-era optimization.


### PR DESCRIPTION
## Summary

**Twig** is a new educational language: a tiny purely-functional Lisp-precursor designed to push the LANG VM into territory it hasn't had to handle yet — heap allocation with lifetime management, first-class closures with captured environments, and an explicit GC layer.  Eight forms total, no macros, full closures.

Spec: [TW00-twig-language.md](code/specs/TW00-twig-language.md).

## What it includes

- **Grammar files** — \`code/grammars/twig.tokens\` and \`twig.grammar\`, consumed by the repo's grammar-driven lexer and parser (same pattern as Brainfuck, Dartmouth BASIC, ALGOL, Prolog).
- **Typed AST** — \`ast_extract.py\` lifts the generic \`ASTNode\` tree into typed dataclasses (\`Define\` / \`If\` / \`Let\` / \`Lambda\` / \`Apply\` / …).
- **Refcounted Heap** — \`heap.py\` hosts cons cells, interned symbols, and closure objects with visible \`incref\` / \`decref\` semantics.  This is the GC-primitives playground: TW01 will swap in mark-sweep with no language-surface change.
- **Free-variable analysis** — \`free_vars.py\` walks lambda bodies to compute captures in stable order.
- **Compiler** — typed AST → \`IIRModule\`.  Top-level functions become direct-call IIR functions; anonymous lambdas become gensym'd top-level IIR functions whose leading parameters carry captured values; apply-site dispatch picks direct \`call\` vs \`call_builtin \"apply_closure\"\` at compile time.
- **TwigVM** — wraps \`vm-core\`, registers builtins (\`+\` / \`-\` / \`*\` / \`/\` / \`=\` / \`<\` / \`>\` / \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`number?\` / \`symbol?\` / \`print\`), manages per-run heap and globals.  Overrides \`jmp_if_*\` so \`if\` uses Scheme truthiness (only \`#f\` and \`nil\` are falsy; \`0\` is truthy).

## Programs that work today

\`\`\`scheme
(define (length xs)
  (if (null? xs) 0 (+ 1 (length (cdr xs)))))
(define (range n)
  (if (= n 0) nil (cons n (range (- n 1)))))

(length (range 100))           ; 100

(define (adder n) (lambda (x) (+ x n)))
((adder 5) 3)                  ; 8

(define (apply-twice f x) (f (f x)))
(apply-twice (lambda (x) (* x 2)) 7)   ; 28
\`\`\`

Mutual recursion, higher-order functions, closures over multiple captured variables, first-class builtins (\`(apply-it + 3 4)\`), proper Latin-1-byte-faithful \`print\` of cons-cell lists — all working and tested.

## Roadmap (this PR is TW00 only)

- **TW01** — replace refcounting with mark-sweep, add \`letrec\`, promote heap operations from \`call_builtin\` into native IIR ops via a new \`gc-core\` package.
- **TW02** — Twig → BEAM bytecode (direct, no Erlang source intermediary), analogous to how \`wasm-backend\` produces WASM bytes natively.

## Test plan

- [x] 116 tests passing across lexer / parser / heap / free-vars / integration
- [x] 95.05% line coverage (≥95% gate)
- [x] \`ruff check\` clean
- [x] All canonical Lisp idioms work: factorial, mutual-recursive even?/odd?, list length, range, adder closure, apply-twice HOF
- [x] Heap accounting tested directly: refcount round-trips, recursive cleanup through cons chains, closure captures, dangling-handle errors
- [x] Security review passed (1 round) — apply_closure save/restore is exception-safe, heap.decref pops object before recursing (cycle-safe), per-run state isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)