### PR TITLE
Add HTML comment start dash state

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -77,3 +77,5 @@ documented in this file.
 - Markup declaration `<![CDATA[` opener support that reaches the CDATA section
   state from data-state lexing while preserving malformed partial openers as
   bogus comments.
+- HTML comment start-dash handling, including `<!-->` abrupt empty-comment
+  recovery and `<!--->` empty-comment closure.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -25,6 +25,9 @@ the project, but the first real HTML authoring artifact that must keep HTML
 The default lexer already resolves the core named character references and the
 classic Latin-1 entity set, preserving entity-name case so legacy names such as
 `Agrave` and `agrave` remain distinct.
+Comment tokenization includes the standard start-dash recovery cases for empty
+HTML comments such as `<!-->` and `<!--->`, while still preserving normal
+Mosaic-era `<!--note-->` comments.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `CDATA section`, `script_data`, `script_data_escaped`, and
 `script_data_double_escaped` entry states for parser-controlled tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -467,6 +467,9 @@ id = "cdata_open_cdata"
 id = "comment_start"
 
 [[states]]
+id = "comment_start_dash"
+
+[[states]]
 id = "comment"
 
 [[states]]
@@ -4325,7 +4328,7 @@ actions = [
 [[transitions]]
 from = "comment_start"
 matcher = { literal = "-" }
-to = "comment"
+to = "comment_start_dash"
 
 [[transitions]]
 from = "comment_start"
@@ -4348,6 +4351,33 @@ from = "comment_start"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = ["append_comment(-)", "append_comment(current)"]
+
+[[transitions]]
+from = "comment_start_dash"
+matcher = { literal = ">" }
+to = "data"
+actions = [
+  "parse_error(abrupt-closing-of-empty-comment)",
+  "emit_current_token",
+]
+
+[[transitions]]
+from = "comment_start_dash"
+matcher = { literal = "-" }
+to = "comment_end"
+
+[[transitions]]
+from = "comment_start_dash"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "comment_start_dash"
+matcher = { anything = true }
+to = "comment"
+actions = ["append_comment(current)"]
 
 [[transitions]]
 from = "comment"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -615,6 +615,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "comment_start_dash".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "data".to_string(),
             initial: true,
             accepting: false,
@@ -9124,7 +9131,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Literal("-".to_string())),
             to: vec![
-                "comment".to_string(),
+                "comment_start_dash".to_string(),
             ],
             guard: None,
             stack_pop: None,
@@ -9177,6 +9184,67 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_comment(-)".to_string(),
+                "append_comment(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_start_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(abrupt-closing-of-empty-comment)".to_string(),
+                "emit_current_token".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_start_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("-".to_string())),
+            to: vec![
+                "comment_end".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_start_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(eof-in-comment)".to_string(),
+                "emit_current_token".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "comment_start_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
                 "append_comment(current)".to_string(),
             ],
             consume: true,

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 34);
+    assert_eq!(html1.cases.len(), 36);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 35);
+    assert_eq!(file.tests.len(), 37);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -111,15 +111,19 @@ fn html5lib_smoke_fixture_file_parses() {
     assert_eq!(file.tests[5].errors[0].line, 1);
     assert_eq!(file.tests[5].errors[0].col, 9);
     assert_eq!(
-        file.tests[6].initial_states,
-        vec!["RCDATA state".to_string()]
+        file.tests[6].errors[0].code,
+        "abrupt-closing-of-empty-comment"
     );
-    assert_eq!(file.tests[6].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
         file.tests[8].initial_states,
+        vec!["RCDATA state".to_string()]
+    );
+    assert_eq!(file.tests[8].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        file.tests[10].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[8].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[10].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -144,23 +148,30 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 35);
+    assert_eq!(normalized.cases.len(), 37);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
-        normalized.cases[6].initial_state.as_deref(),
-        Some("RCDATA state")
+        normalized.cases[6].diagnostics,
+        vec!["abrupt-closing-of-empty-comment".to_string()]
     );
-    assert_eq!(normalized.cases[6].last_start_tag.as_deref(), Some("title"));
-    assert_eq!(
-        normalized.cases[7].initial_state.as_deref(),
-        Some("RCDATA state")
-    );
-    assert_eq!(normalized.cases[7].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
         normalized.cases[8].initial_state.as_deref(),
+        Some("RCDATA state")
+    );
+    assert_eq!(normalized.cases[8].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        normalized.cases[9].initial_state.as_deref(),
+        Some("RCDATA state")
+    );
+    assert_eq!(normalized.cases[9].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        normalized.cases[10].initial_state.as_deref(),
         Some("RAWTEXT state")
     );
-    assert_eq!(normalized.cases[8].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(
+        normalized.cases[10].last_start_tag.as_deref(),
+        Some("style")
+    );
 }
 
 #[test]
@@ -202,7 +213,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 35);
+    assert_eq!(suite.cases.len(), 37);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -54,6 +54,31 @@
       ]
     },
     {
+      "id": "comment-abrupt-empty-close",
+      "description": "HTML comment opener <!--> emits an empty comment with an abrupt close diagnostic",
+      "input": "Before<!-->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ]
+    },
+    {
+      "id": "comment-dash-prefixed-empty-close",
+      "description": "HTML comment opener <!---> closes as an empty comment before returning to data",
+      "input": "Before<!--->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
       "id": "mosaic-title-rcdata-end-tag",
       "description": "Seeded title RCDATA context emits the matching end tag",
       "input": "Hello</title>",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -89,6 +89,32 @@
     },
     {
       "id": "html5lib-smoke-7",
+      "description": "abrupt empty comment close",
+      "input": "Before<!-->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-8",
+      "description": "dash prefixed empty comment close",
+      "input": "Before<!--->After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-9",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -101,7 +127,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-8",
+      "id": "html5lib-smoke-10",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -113,7 +139,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-9",
+      "id": "html5lib-smoke-11",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -126,7 +152,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-10",
+      "id": "html5lib-smoke-12",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -137,7 +163,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-13",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -150,7 +176,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-14",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -163,7 +189,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-15",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -173,7 +199,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-16",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -183,7 +209,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-17",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -195,7 +221,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-18",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -205,7 +231,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-19",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -215,7 +241,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-20",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -228,7 +254,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-21",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -238,7 +264,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-22",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -248,7 +274,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-23",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -261,7 +287,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-24",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -275,7 +301,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-25",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -289,7 +315,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-26",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -306,7 +332,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-27",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -316,7 +342,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-28",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -326,7 +352,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-29",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -336,7 +362,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-30",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -346,7 +372,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-31",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -358,7 +384,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-32",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -371,7 +397,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-33",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -384,7 +410,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-34",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -399,7 +425,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-35",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -412,7 +438,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-36",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -426,7 +452,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-37",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -56,6 +56,27 @@
       ]
     },
     {
+      "description": "abrupt empty comment close",
+      "input": "Before<!-->After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", ""],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "abrupt-closing-of-empty-comment", "line": 1, "col": 11}
+      ]
+    },
+    {
+      "description": "dash prefixed empty comment close",
+      "input": "Before<!--->After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", ""],
+        ["Character", "After"]
+      ]
+    },
+    {
       "description": "rcdata matching end tag emits end tag token",
       "initialStates": ["RCDATA state"],
       "lastStartTag": "title",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -66,6 +66,43 @@ fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
 }
 
 #[test]
+fn default_html_lexer_recovers_abrupt_empty_html_comment() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<!-->After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment(String::new()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "abrupt-closing-of-empty-comment"));
+}
+
+#[test]
+fn default_html_lexer_closes_dash_prefixed_empty_html_comment() {
+    let tokens = lex_html("Before<!--->After").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment(String::new()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_chunked_input_and_unicode_any_matcher() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Add a `comment_start_dash` tokenizer state after the `<!--` opener so empty-comment recovery follows the HTML state-machine shape more closely.
- Support `<!-->` abrupt empty-comment recovery with diagnostics and `<!--->` empty-comment closure while preserving normal comment behavior.
- Regenerate static Rust source and extend Venture/html5lib smoke fixtures, docs, and wrapper tests.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt -p coding-adventures-html-lexer -p state-machine-tokenizer -p state-machine-markup-deserializer -p state-machine-source-compiler`
- `cargo test -p coding-adventures-html-lexer --test html_lexer_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test conformance_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test html1_authoring_test -- --nocapture`
- `cargo test -p state-machine-markup-deserializer --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test -p state-machine-source-compiler --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check -p coding-adventures-html-lexer --tests`
- `cargo check -p state-machine-tokenizer --tests`
- `git diff --check`