### PR TITLE
feat(prolog): add finite nth rest stdlib bridge

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.8.0] - 2026-04-28
+
+### Added
+
+- finite `nth0_resto` and `nth1_resto` relations for positional selection with
+  the remaining list
+- pytest coverage for zero-based selection, one-based selection, enumeration,
+  out-of-range failure, and improper-list rejection
+
 ## [0.7.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -18,7 +18,9 @@ The first slice includes:
 - `listo(...)`
 - `membero(...)`
 - `msorto(...)`
+- `nth0_resto(...)`
 - `nth0o(...)`
+- `nth1_resto(...)`
 - `nth1o(...)`
 - `appendo(...)`
 - `selecto(...)`
@@ -38,7 +40,9 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0_resto,
     nth0o,
+    nth1_resto,
     nth1o,
     permuteo,
     reverseo,
@@ -126,6 +130,18 @@ assert solve_all(
     X,
     nth1o(2, logic_list(["tea", "cake", "jam"]), X),
 ) == [atom("cake")]
+
+assert solve_all(
+    program(),
+    (X, Order),
+    nth0_resto(1, logic_list(["tea", "cake", "jam"]), X, Order),
+) == [(atom("cake"), logic_list(["tea", "jam"]))]
+
+assert solve_all(
+    program(),
+    (X, Order),
+    nth1_resto(2, logic_list(["tea", "cake", "jam"]), X, Order),
+) == [(atom("cake"), logic_list(["tea", "jam"]))]
 
 assert solve_all(
     program(),

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.7.0"
+version = "0.8.0"
 description = "Relational standard library helpers, combinators, and sequence relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -16,7 +16,9 @@ from logic_stdlib.relations import (
     listo,
     membero,
     msorto,
+    nth0_resto,
     nth0o,
+    nth1_resto,
     nth1o,
     permuteo,
     reverseo,
@@ -37,7 +39,9 @@ __all__ = [
     "listo",
     "membero",
     "msorto",
+    "nth0_resto",
     "nth0o",
+    "nth1_resto",
     "nth1o",
     "permuteo",
     "reverseo",
@@ -47,4 +51,4 @@ __all__ = [
     "tailo",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -47,7 +47,9 @@ __all__ = [
     "lengtho",
     "listo",
     "membero",
+    "nth0_resto",
     "nth0o",
+    "nth1_resto",
     "nth1o",
     "permuteo",
     "reverseo",
@@ -140,10 +142,32 @@ def nth0o(index: object, items: object, element: object) -> GoalExpr:
     return native_goal(_ntho_runner, index, items, element, 0)
 
 
+def nth0_resto(
+    index: object,
+    items: object,
+    element: object,
+    rest: object,
+) -> GoalExpr:
+    """Relate zero-based selection to the list with that element removed."""
+
+    return native_goal(_nth_resto_runner, index, items, element, rest, 0)
+
+
 def nth1o(index: object, items: object, element: object) -> GoalExpr:
     """Relate a one-based index to an element of a proper finite list."""
 
     return native_goal(_ntho_runner, index, items, element, 1)
+
+
+def nth1_resto(
+    index: object,
+    items: object,
+    element: object,
+    rest: object,
+) -> GoalExpr:
+    """Relate one-based selection to the list with that element removed."""
+
+    return native_goal(_nth_resto_runner, index, items, element, rest, 1)
 
 
 def listo(value: object) -> GoalExpr:
@@ -285,6 +309,49 @@ def _ntho_runner(
         yield from solve_from(
             program_value,
             conj(eq(index, num(offset + base)), eq(element, value)),
+            state,
+        )
+
+
+def _nth_resto_runner(
+    program_value: Program,
+    state: State,
+    args: tuple[Term, ...],
+) -> Iterator[State]:
+    index, items, element, rest, base_term = args
+    if not isinstance(base_term, Number) or not isinstance(base_term.value, int):
+        return
+    base = base_term.value
+    values = _proper_list_items(items, state)
+    if values is None:
+        return
+
+    index_value = _integer_index(index, state)
+    if index_value is not None:
+        offset = index_value - base
+        if offset < 0 or offset >= len(values):
+            return
+        remaining = [*values[:offset], *values[offset + 1 :]]
+        yield from solve_from(
+            program_value,
+            conj(eq(element, values[offset]), eq(rest, logic_list(remaining))),
+            state,
+        )
+        return
+
+    walked_index = state.substitution.walk(index)
+    if not isinstance(walked_index, LogicVar):
+        return
+
+    for offset, value in enumerate(values):
+        remaining = [*values[:offset], *values[offset + 1 :]]
+        yield from solve_from(
+            program_value,
+            conj(
+                eq(index, num(offset + base)),
+                eq(element, value),
+                eq(rest, logic_list(remaining)),
+            ),
             state,
         )
 

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -26,7 +26,9 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0_resto,
     nth0o,
+    nth1_resto,
     nth1o,
     permuteo,
     reverseo,
@@ -41,7 +43,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.7.0"
+        assert __version__ == "0.8.0"
         engine_major, engine_minor, _engine_patch = logic_engine_version.split(".")
         assert (int(engine_major), int(engine_minor)) >= (0, 10)
 
@@ -253,6 +255,66 @@ class TestListRelations:
             conj(
                 eq(marker, "ok"),
                 nth0o(0, logic_list(["tea"], tail="cake"), var("Item")),
+            ),
+        ) == []
+
+    def test_nth0_resto_removes_zero_based_selected_element(self) -> None:
+        item = var("Item")
+        rest = var("Rest")
+
+        assert solve_all(
+            program(),
+            (item, rest),
+            nth0_resto(1, logic_list(["tea", "cake", "jam"]), item, rest),
+        ) == [(atom("cake"), logic_list(["tea", "jam"]))]
+
+    def test_nth1_resto_removes_one_based_selected_element(self) -> None:
+        item = var("Item")
+        rest = var("Rest")
+
+        assert solve_all(
+            program(),
+            (item, rest),
+            nth1_resto(2, logic_list(["tea", "cake", "jam"]), item, rest),
+        ) == [(atom("cake"), logic_list(["tea", "jam"]))]
+
+    def test_nth_resto_enumerates_index_element_rest_triples(self) -> None:
+        index = var("Index")
+        item = var("Item")
+        rest = var("Rest")
+
+        assert solve_all(
+            program(),
+            (index, item, rest),
+            nth0_resto(index, logic_list(["tea", "cake", "jam"]), item, rest),
+        ) == [
+            (num(0), atom("tea"), logic_list(["cake", "jam"])),
+            (num(1), atom("cake"), logic_list(["tea", "jam"])),
+            (num(2), atom("jam"), logic_list(["tea", "cake"])),
+        ]
+
+    def test_nth_resto_rejects_out_of_range_and_improper_lists(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                nth0_resto(3, logic_list(["tea"]), var("Item"), var("Rest")),
+            ),
+        ) == []
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                nth0_resto(
+                    0,
+                    logic_list(["tea"], tail="cake"),
+                    var("Item"),
+                    var("Rest"),
+                ),
             ),
         ) == []
 

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -10,8 +10,9 @@
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
   executable logic builtin layer
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
-  `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`, and
-  `nth0/3`, `nth1/3`, and `is_list/1`) into the relational standard library
+  `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
+  `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1`) into the
+  relational standard library
 - expand builtin adaptation for truth/failure/cut, arithmetic, collections,
   `forall/2`, and `copy_term/2`
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -21,7 +21,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
-  `nth0/3`, `nth1/3`, and `is_list/1` into relational standard-library goals
+  `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1` into relational
+  standard-library goals
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
     "coding-adventures-logic-builtins>=0.13.0",
     "coding-adventures-logic-engine>=0.10.0",
-    "coding-adventures-logic-stdlib>=0.7.0",
+    "coding-adventures-logic-stdlib>=0.8.0",
     "coding-adventures-prolog-core>=0.1.0",
     "coding-adventures-prolog-parser>=0.1.0",
     "coding-adventures-swi-prolog-parser>=0.1.0",
@@ -38,7 +38,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 [project.optional-dependencies]
 dev = [
     "coding-adventures-logic-builtins>=0.13.0",
-    "coding-adventures-logic-stdlib>=0.7.0",
+    "coding-adventures-logic-stdlib>=0.8.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -79,7 +79,9 @@ from logic_stdlib import (
     listo,
     membero,
     msorto,
+    nth0_resto,
     nth0o,
+    nth1_resto,
     nth1o,
     permuteo,
     reverseo,
@@ -181,6 +183,16 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     }
     if goal.relation.arity == 3 and name in ternary_list_builtins:
         return ternary_list_builtins[name](*args)
+
+    quaternary_list_builtins: dict[
+        str,
+        Callable[[object, object, object, object], GoalExpr],
+    ] = {
+        "nth0": nth0_resto,
+        "nth1": nth1_resto,
+    }
+    if goal.relation.arity == 4 and name in quaternary_list_builtins:
+        return quaternary_list_builtins[name](*args)
 
     if name == "call" and goal.relation.arity == 1:
         return _adapt_callable_goal(args[0])

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -842,6 +842,18 @@ class TestPrologGoalAdapter:
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
                 LogicVar(id=23),
             ),
+            relation("nth0", 4)(
+                1,
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=24),
+                LogicVar(id=25),
+            ),
+            relation("nth1", 4)(
+                2,
+                term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
+                LogicVar(id=26),
+                LogicVar(id=27),
+            ),
             relation("select", 3)(
                 atom("tea"),
                 term(".", atom("tea"), term(".", atom("cake"), atom("[]"))),
@@ -928,6 +940,8 @@ class TestPrologGoalAdapter:
             "msort([Item, jam, Item], Sorted), "
             "nth0(1, Reversed, ZeroBased), "
             "nth1(2, Reversed, OneBased), "
+            "nth0(1, Reversed, ZeroRestBased, ZeroRest), "
+            "nth1(2, Reversed, OneRestBased, OneRest), "
             "length(Reversed, Count).",
         )
 
@@ -943,6 +957,10 @@ class TestPrologGoalAdapter:
                 parsed.variables["Sorted"],
                 parsed.variables["ZeroBased"],
                 parsed.variables["OneBased"],
+                parsed.variables["ZeroRestBased"],
+                parsed.variables["ZeroRest"],
+                parsed.variables["OneRestBased"],
+                parsed.variables["OneRest"],
                 parsed.variables["Count"],
             ),
             adapted,
@@ -955,6 +973,10 @@ class TestPrologGoalAdapter:
                 logic_list(["jam", "tea", "tea"]),
                 atom("tea"),
                 atom("tea"),
+                atom("tea"),
+                logic_list(["jam"]),
+                atom("tea"),
+                logic_list(["jam"]),
                 num(2),
             ),
             (
@@ -965,6 +987,10 @@ class TestPrologGoalAdapter:
                 logic_list(["cake", "cake", "jam"]),
                 atom("cake"),
                 atom("cake"),
+                atom("cake"),
+                logic_list(["jam"]),
+                atom("cake"),
+                logic_list(["jam"]),
                 num(2),
             ),
         ]

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -16,8 +16,8 @@
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
-  `msort/2`, `nth0/3`, and `nth1/3`, through the VM path by adapting them to
-  `logic-stdlib` relations.
+  `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
+  by adapting them to `logic-stdlib` relations.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -130,7 +130,7 @@ The package includes end-to-end stress tests for:
 - arithmetic evaluation and comparison
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
-  `sort/2`, `msort/2`, `nth0/3`, and `nth1/3`
+  `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`
 - dynamic predicates seeded by initialization directives
 - named Python answer bindings
 - loader term/goal expansion before VM compilation

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -136,6 +136,8 @@ class TestPrologVMStress:
                msort([Item, jam, Item], Sorted),
                nth0(1, Reversed, ZeroBased),
                nth1(2, Reversed, OneBased),
+               nth0(1, Reversed, ZeroRestBased, ZeroRest),
+               nth1(2, Reversed, OneRestBased, OneRest),
                length(Pair, 2),
                Pair = [left, right].
             """,
@@ -154,6 +156,10 @@ class TestPrologVMStress:
                 "Sorted": logic_list(["jam", "tea", "tea"]),
                 "ZeroBased": atom("tea"),
                 "OneBased": atom("tea"),
+                "ZeroRestBased": atom("tea"),
+                "ZeroRest": logic_list(["jam"]),
+                "OneRestBased": atom("tea"),
+                "OneRest": logic_list(["jam"]),
                 "Pair": logic_list(["left", "right"]),
             },
             {
@@ -166,6 +172,10 @@ class TestPrologVMStress:
                 "Sorted": logic_list(["cake", "cake", "jam"]),
                 "ZeroBased": atom("cake"),
                 "OneBased": atom("cake"),
+                "ZeroRestBased": atom("cake"),
+                "ZeroRest": logic_list(["jam"]),
+                "OneRestBased": atom("cake"),
+                "OneRest": logic_list(["jam"]),
                 "Pair": logic_list(["left", "right"]),
             },
         ]

--- a/code/specs/PR27-prolog-vm-nth-rest-stdlib.md
+++ b/code/specs/PR27-prolog-vm-nth-rest-stdlib.md
@@ -1,0 +1,48 @@
+# PR27: Prolog VM Nth Rest Stdlib
+
+## Summary
+
+This batch extends finite positional list access with Prolog `nth0/4` and
+`nth1/4`. The implementation lives in `logic-stdlib` as `nth0_resto` and
+`nth1_resto`, while `prolog-loader` adapts parsed source calls into those
+relations before Logic VM execution.
+
+## Goals
+
+- add `nth0_resto(index, list, element, rest)`
+- add `nth1_resto(index, list, element, rest)`
+- support known integer indexes over proper finite lists
+- enumerate index-element-rest triples for proper finite lists
+- adapt Prolog `nth0/4` and `nth1/4`
+- verify parser -> loader -> VM execution
+
+## Semantics
+
+- list arguments must be proper and finite
+- known indexes select one element and the remaining list
+- open index variables enumerate all valid positions
+- out-of-range, negative, non-integer, open-list, and improper-list cases fail
+
+## Example
+
+```prolog
+?- reverse([tea, jam], Reversed),
+   nth0(1, Reversed, ZeroBased, ZeroRest),
+   nth1(2, Reversed, OneBased, OneRest).
+```
+
+Expected:
+
+```prolog
+Reversed = [jam, tea],
+ZeroBased = tea,
+ZeroRest = [jam],
+OneBased = tea,
+OneRest = [jam].
+```
+
+## Non-Goals
+
+- open-tail list generation
+- CLP(FD)-backed index domains
+- non-finite list search


### PR DESCRIPTION
## Summary

- add finite `nth0_resto/4` and `nth1_resto/4` relations to `logic-stdlib`
- adapt parsed Prolog `nth0/4` and `nth1/4` calls through `prolog-loader`
- extend parser -> loader -> Logic VM stress coverage for nth rest selection

## Verification

- `bash BUILD` in `code/packages/python/logic-stdlib`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in all three packages
- `go build -o /tmp/ca-build-tool-prolog-nth-rest .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-nth-rest -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-nth-rest-build-plan.json`