### PR TITLE
Add HTML comment end bang recovery

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -81,3 +81,5 @@ documented in this file.
   recovery and `<!--->` empty-comment closure.
 - HTML comment less-than-sign handling for nested-looking `<!--` sequences
   inside open comments, preserving the text while reporting `nested-comment`.
+- HTML comment end-bang handling for `--!>` recovery and non-closing `--!`
+  text preservation.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -29,7 +29,8 @@ Comment tokenization includes the standard start-dash recovery cases for empty
 HTML comments such as `<!-->` and `<!--->`, while still preserving normal
 Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an
 open comment remain literal comment data and surface a recoverable
-`nested-comment` diagnostic.
+`nested-comment` diagnostic. Comment endings also recover from `--!>` with an
+`incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `CDATA section`, `script_data`, `script_data_escaped`, and
 `script_data_double_escaped` entry states for parser-controlled tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -491,6 +491,9 @@ id = "comment_end_dash"
 id = "comment_end"
 
 [[states]]
+id = "comment_end_bang"
+
+[[states]]
 id = "bogus_comment"
 
 [[states]]
@@ -4525,6 +4528,11 @@ actions = ["append_comment(-)", "append_comment(current)"]
 
 [[transitions]]
 from = "comment_end"
+matcher = { literal = "!" }
+to = "comment_end_bang"
+
+[[transitions]]
+from = "comment_end"
 matcher = { literal = ">" }
 to = "data"
 actions = ["emit_current_token"]
@@ -4552,6 +4560,37 @@ from = "comment_end"
 matcher = { anything = true }
 to = "comment"
 actions = ["append_comment(--)", "append_comment(current)"]
+
+[[transitions]]
+from = "comment_end_bang"
+matcher = { literal = "-" }
+to = "comment_end_dash"
+actions = ["append_comment(--!)"]
+
+[[transitions]]
+from = "comment_end_bang"
+matcher = { literal = ">" }
+to = "data"
+actions = ["parse_error(incorrectly-closed-comment)", "emit_current_token"]
+
+[[transitions]]
+from = "comment_end_bang"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-comment)",
+  "append_comment(--!)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "comment_end_bang"
+matcher = { anything = true }
+to = "comment"
+consume = false
+actions = ["append_comment(--!)"]
 
 [[transitions]]
 from = "bogus_comment"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -601,6 +601,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "comment_end_bang".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "comment_end_dash".to_string(),
             initial: false,
             accepting: false,
@@ -9575,6 +9582,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "comment_end".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("!".to_string())),
+            to: vec![
+                "comment_end_bang".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_end".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -9635,6 +9655,70 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_comment(current)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_end_bang".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("-".to_string())),
+            to: vec![
+                "comment_end_dash".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_comment(--!)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_end_bang".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(incorrectly-closed-comment)".to_string(),
+                "emit_current_token".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_end_bang".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(eof-in-comment)".to_string(),
+                "append_comment(--!)".to_string(),
+                "emit_current_token".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "comment_end_bang".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_comment(--!)".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "bogus_comment".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 37);
+    assert_eq!(html1.cases.len(), 38);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 38);
+    assert_eq!(file.tests.len(), 39);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -148,7 +148,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 38);
+    assert_eq!(normalized.cases.len(), 39);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[6].diagnostics,
@@ -213,7 +213,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 38);
+    assert_eq!(suite.cases.len(), 39);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -93,6 +93,20 @@
       ]
     },
     {
+      "id": "comment-incorrectly-closed-bang",
+      "description": "Comment end bang before > closes the comment with an incorrectly-closed-comment diagnostic",
+      "input": "Before<!--x--!>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=x)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ]
+    },
+    {
       "id": "mosaic-title-rcdata-end-tag",
       "description": "Seeded title RCDATA context emits the matching end tag",
       "input": "Hello</title>",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -477,6 +477,20 @@
       "diagnostics": [
         "nested-comment"
       ]
+    },
+    {
+      "id": "html5lib-smoke-39",
+      "description": "incorrectly closed comment end bang",
+      "input": "Before<!--x--!>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=x)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ]
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -425,6 +425,18 @@
       "errors": [
         {"code": "nested-comment", "line": 1, "col": 17}
       ]
+    },
+    {
+      "description": "incorrectly closed comment end bang",
+      "input": "Before<!--x--!>After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "x"],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "incorrectly-closed-comment", "line": 1, "col": 15}
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -125,6 +125,43 @@ fn default_html_lexer_reports_nested_comment_opener() {
 }
 
 #[test]
+fn default_html_lexer_recovers_incorrectly_closed_comment() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<!--x--!>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("x".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "incorrectly-closed-comment"));
+}
+
+#[test]
+fn default_html_lexer_preserves_bang_after_comment_end_when_not_closing() {
+    let tokens = lex_html("Before<!--x--!y-->After").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("x--!y".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_chunked_input_and_unicode_any_matcher() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Add the HTML `comment_end_bang` tokenizer state for `--!` recovery inside comments.
- Emit `incorrectly-closed-comment` for `--!>` while preserving non-closing `--!` text in the comment body.
- Regenerate static Rust source and extend Venture/html5lib smoke fixtures, docs, and wrapper tests.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt -p coding-adventures-html-lexer -p state-machine-tokenizer -p state-machine-markup-deserializer -p state-machine-source-compiler`
- `cargo test -p coding-adventures-html-lexer --test html_lexer_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test conformance_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test html1_authoring_test -- --nocapture`
- `cargo test -p state-machine-markup-deserializer --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test -p state-machine-source-compiler --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check -p coding-adventures-html-lexer --tests`
- `cargo check -p state-machine-tokenizer --tests`
- `git diff --check`