### PR TITLE
feat(prolog): add finite between builtin bridge

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `betweeno(low, high, value)` for finite inclusive integer generation and
+  validation, matching the common Prolog `between/3` use case.
+
 ### Fixed
 
 - `iftheno(...)` and `ifthenelseo(...)` now preserve rule-local variable

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -44,6 +44,7 @@ ordinary logic goal expressions.
 - arithmetic expression constructors: `add`, `sub`, `mul`, `div`, `floordiv`, `mod`, and `neg`
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
+- `betweeno(low, high, value)` for finite inclusive integer generation
 - `findallo(template, goal, results)`, `bagofo(template, goal, results)`, and `setofo(template, goal, results)`
 
 ## Quick Start
@@ -53,6 +54,7 @@ from logic_builtins import (
     add,
     assertzo,
     argo,
+    betweeno,
     calltermo,
     clauseo,
     compare_termo,
@@ -114,6 +116,7 @@ memo = relation("memo", 1)
 family = program(rule(child(X, Name), parent(Name, X)))
 
 assert solve_all(program(), X, onceo(eq(X, "first"))) == [atom("first")]
+assert solve_all(program(), X, betweeno(1, 3, X)) == [num(1), num(2), num(3)]
 assert solve_all(
     program(),
     X,

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.13.0"
-description = "Prolog-inspired finite-domain sum constraints, examples, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
+version = "0.14.0"
+description = "Prolog-inspired integer generators, finite-domain constraints, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -16,6 +16,7 @@ from logic_builtins.builtins import (
     atomico,
     atomo,
     bagofo,
+    betweeno,
     callableo,
     callo,
     calltermo,
@@ -88,6 +89,7 @@ __all__ = [
     "atomico",
     "atomo",
     "bagofo",
+    "betweeno",
     "callo",
     "callableo",
     "calltermo",
@@ -151,4 +153,4 @@ __all__ = [
     "varo",
 ]
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -68,6 +68,7 @@ __all__ = [
     "argo",
     "atomico",
     "atomo",
+    "betweeno",
     "callo",
     "callableo",
     "calltermo",
@@ -171,6 +172,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("atomico", 1),
     ("atomo", 1),
     ("bagofo", 3),
+    ("betweeno", 3),
     ("callableo", 1),
     ("callo", 1),
     ("calltermo", 1),
@@ -380,6 +382,12 @@ def _integer_value(term_value: object) -> int | None:
     if isinstance(term_value, int):
         return term_value
     return None
+
+
+def _reified_integer(term_value: Term, state: State) -> int | None:
+    """Read one reified term as a concrete non-bool integer."""
+
+    return _integer_value(_reified(term_value, state))
 
 
 def _domain_from_items(items: Iterable[object]) -> frozenset[int]:
@@ -1633,6 +1641,32 @@ def geqo(left: object, right: object) -> GoalExpr:
         right,
         lambda left_value, right_value: left_value >= right_value,
     )
+
+
+def betweeno(low: object, high: object, value: object) -> GoalExpr:
+    """Generate or validate an integer between two finite inclusive bounds."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        low_term, high_term, value_term = args
+        low_value = _reified_integer(low_term, state)
+        high_value = _reified_integer(high_term, state)
+        if low_value is None or high_value is None or high_value < low_value:
+            return
+
+        value_reified = _reified(value_term, state)
+        value_integer = _integer_value(value_reified)
+        if value_integer is not None:
+            if low_value <= value_integer <= high_value:
+                yield state
+            return
+
+        if not isinstance(value_reified, LogicVar):
+            return
+
+        for candidate in range(low_value, high_value + 1):
+            yield from solve_from(program_value, eq(value_term, num(candidate)), state)
+
+    return native_goal(run, low, high, value)
 
 
 def callo(goal: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -36,6 +36,7 @@ from logic_builtins import (
     atomico,
     atomo,
     bagofo,
+    betweeno,
     callableo,
     callo,
     calltermo,
@@ -102,7 +103,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.13.0"
+        assert __version__ == "0.14.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -460,6 +461,37 @@ class TestArithmeticBuiltins:
             marker,
             conj(eq(marker, "ok"), lto(add(open_value, 1), 3)),
         ) == []
+
+    def test_betweeno_enumerates_inclusive_integer_ranges(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, betweeno(2, 5, value)) == [
+            num(2),
+            num(3),
+            num(4),
+            num(5),
+        ]
+
+    def test_betweeno_validates_bound_values(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), betweeno(2, 5, 4)),
+        ) == [atom("ok")]
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), betweeno(2, 5, 8)),
+        ) == []
+
+    def test_betweeno_rejects_non_integer_and_descending_ranges(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, betweeno(5, 2, value)) == []
+        assert solve_all(program(), value, betweeno(1.5, 3, value)) == []
+        assert solve_all(program(), value, betweeno(1, 3, "tea")) == []
 
     def test_arithmetic_goals_compose_with_relation_search(self) -> None:
         score = relation("score", 2)

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -9,6 +9,8 @@
   linked project's module/import context
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the
   executable logic builtin layer
+- adapt Prolog `between/3` into the logic builtin layer for finite integer
+  generation and validation
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
   `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1`) into the

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -12,6 +12,7 @@ It keeps parsing side-effect free, then exposes helpers to:
 - run those initialization goals explicitly against the loaded `Program`
 - adapt parsed Prolog builtin calls like `call/1`, `dynamic/1`, `assertz/1`,
   and `predicate_property/2` into runtime goals before execution
+- adapt finite integer generation with `between/3`
 - adapt `phrase/2` and `phrase/3` into executable DCG runtime calls
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
-    "coding-adventures-logic-builtins>=0.13.0",
+    "coding-adventures-logic-builtins>=0.14.0",
     "coding-adventures-logic-engine>=0.10.0",
     "coding-adventures-logic-stdlib>=0.8.0",
     "coding-adventures-prolog-core>=0.1.0",
@@ -37,7 +37,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 
 [project.optional-dependencies]
 dev = [
-    "coding-adventures-logic-builtins>=0.13.0",
+    "coding-adventures-logic-builtins>=0.14.0",
     "coding-adventures-logic-stdlib>=0.8.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -12,6 +12,7 @@ from logic_builtins import (
     atomico,
     atomo,
     bagofo,
+    betweeno,
     callableo,
     calltermo,
     clauseo,
@@ -162,6 +163,15 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     }
     if goal.relation.arity == 2 and name in binary_arithmetic_builtins:
         return binary_arithmetic_builtins[name](args[0], args[1])
+
+    ternary_arithmetic_builtins: dict[
+        str,
+        Callable[[object, object, object], GoalExpr],
+    ] = {
+        "between": betweeno,
+    }
+    if goal.relation.arity == 3 and name in ternary_arithmetic_builtins:
+        return ternary_arithmetic_builtins[name](*args)
 
     binary_list_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
         "last": lasto,

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -787,6 +787,7 @@ class TestPrologGoalAdapter:
             relation("=<", 2)(1, 1),
             relation(">", 2)(2, 1),
             relation(">=", 2)(2, 2),
+            relation("between", 3)(1, 3, LogicVar(id=28)),
             relation("findall", 3)(
                 atom("ok"),
                 term("memo", atom("ok")),
@@ -930,6 +931,18 @@ class TestPrologGoalAdapter:
             parsed.variables["Result"],
             adapted,
         ) == [atom("else")]
+
+    def test_adapt_prolog_goal_rewrites_between_generator(self) -> None:
+        parsed = parse_swi_query(
+            "?- between(1, 4, Value), Value > 2.",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(program(), parsed.variables["Value"], adapted) == [
+            num(3),
+            num(4),
+        ]
 
     def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:
         parsed = parse_swi_query(

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -15,6 +15,8 @@
   `query_module=...`.
 - Run Prolog `->/2` and `(If -> Then ; Else)` control constructs through the
   VM path with committed condition semantics.
+- Run Prolog `between/3` through the VM path for finite integer generation and
+  validation.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -128,6 +128,7 @@ The package includes end-to-end stress tests for:
 - linked modules and imported predicates
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
+- finite integer generation with `between/3`
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -58,6 +58,7 @@ class TestPrologVMStress:
             tokens --> [one], [two].
 
             ?- findall(Child, older_child(homer, Child), Older),
+               findall(Number, (between(1, 4, Number), Number > 2), Numbers),
                phrase(tokens, [one, two], Rest),
                Score is 1 + 2 * 3,
                Score =:= 7.
@@ -69,6 +70,7 @@ class TestPrologVMStress:
         assert len(answers) == 1
         answer = answers[0].as_dict()
         assert answer["Older"] == logic_list(["bart"])
+        assert answer["Numbers"] == logic_list([3, 4])
         assert answer["Rest"] == logic_list([])
         assert answer["Score"] == num(7)
 

--- a/code/specs/PR28-prolog-vm-between-stdlib.md
+++ b/code/specs/PR28-prolog-vm-between-stdlib.md
@@ -1,0 +1,41 @@
+# PR28: Prolog VM Between Stdlib
+
+## Summary
+
+This batch adds finite `between/3` support to the Prolog-on-Logic-VM path. The
+host library exposes it as `betweeno(low, high, value)` in `logic-builtins`, and
+`prolog-loader` adapts parsed `between/3` calls before VM compilation.
+
+## Goals
+
+- add `betweeno(low, high, value)` to the builtin goal layer
+- generate inclusive integer ranges when `value` is open
+- validate a bound integer value against finite bounds
+- adapt parsed Prolog `between/3`
+- verify parser -> loader -> VM execution inside collection queries
+
+## Semantics
+
+- `low` and `high` must be concrete non-bool integers
+- `value` may be an open logic variable or a concrete non-bool integer
+- generation is deterministic ascending order from `low` through `high`
+- descending ranges, non-integer bounds, and non-integer values fail
+
+## Example
+
+```prolog
+?- between(1, 4, Number), Number > 2.
+```
+
+Expected:
+
+```prolog
+Number = 3 ;
+Number = 4.
+```
+
+## Non-Goals
+
+- symbolic or unbounded integer ranges
+- CLP(FD)-backed delayed bounds
+- support for SWI-Prolog's `inf`/`infinite` bounds


### PR DESCRIPTION
## Summary

- add `betweeno(low, high, value)` to `logic-builtins` for finite inclusive integer generation and validation
- adapt parsed Prolog `between/3` calls through `prolog-loader`
- extend Prolog VM stress coverage with `between/3` inside `findall/3`

## Verification

- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in all three packages
- `go build -o /tmp/ca-build-tool-prolog-between .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-between -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-between-build-plan.json`