### PR TITLE
Support array arguments in formal procedure dispatch

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -75,6 +75,8 @@ All notable changes to this package will be documented in this file.
 - Lowered formal procedure dispatch arguments as lazy storage pointers or
   thunk descriptors, allowing actual procedures with scalar by-name parameters
   to read or assign through the original argument.
+- Lowered whole-array arguments through formal procedure dispatchers by passing
+  descriptor pointers to actual procedures that declare matching array formals.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -61,13 +61,14 @@ re-evaluate in the caller's declaring scope; these label/switch descriptor
 paths also cover `value` formals. Procedure formals pass descriptor closures
 containing the callee procedure id and static link; formal calls dispatch
 through generated helpers for statement calls and typed expression calls with
-scalar arguments. The dispatch helpers pass each actual argument as a lazy
-storage pointer or thunk descriptor, evaluating it once for target `value`
-parameters and forwarding it directly for target by-name parameters, so
-forwarded procedure formals keep the original environment in value or by-name
-mode. Real-valued formal procedure calls can accept integer-returning actual
-procedures and promote the dispatched result. Full ALGOL forms such as escaping
-thunk descriptors remain future work.
+scalar or whole-array arguments. The dispatch helpers pass scalar actual
+arguments as lazy storage pointers or thunk descriptors, evaluating them once
+for target `value` parameters and forwarding them directly for target by-name
+parameters. Whole-array actuals pass descriptor pointers through the same
+dispatcher family, so forwarded procedure formals keep the original
+environment in value, by-name, or array mode. Real-valued formal procedure
+calls can accept integer-returning actual procedures and promote the dispatched
+result. Full ALGOL forms such as escaping thunk descriptors remain future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -239,7 +239,7 @@ class AlgolIrCompiler:
         self.legacy_variable_slots: dict[str, int] = {}
         self.procedure_signatures: dict[str, ProcedureSignaturePlan] = {}
         self.procedure_parameter_dispatchers: dict[
-            tuple[str | None, tuple[str, ...]],
+            tuple[str | None, tuple[str, ...], tuple[str, ...]],
             str,
         ] = {}
         self.expression_types: dict[int, str] = {}
@@ -505,15 +505,22 @@ class AlgolIrCompiler:
             self._compile_switch_eval_dispatcher()
         if self.has_procedure_parameters:
             self._compile_procedure_call_dispatcher(
+                argument_kinds=tuple(),
                 argument_types=tuple(),
                 label=_PROCEDURE_CALL_LABEL,
                 return_type=None,
             )
-            for (return_type, argument_types), label in sorted(
+            for (return_type, argument_kinds, argument_types), label in sorted(
                 self.procedure_parameter_dispatchers.items(),
-                key=lambda item: (item[0][0] or "", len(item[0][1]), item[0][1]),
+                key=lambda item: (
+                    item[0][0] or "",
+                    len(item[0][2]),
+                    item[0][1],
+                    item[0][2],
+                ),
             ):
                 self._compile_procedure_call_dispatcher(
+                    argument_kinds=argument_kinds,
                     argument_types=argument_types,
                     label=label,
                     return_type=return_type,
@@ -2968,8 +2975,14 @@ class AlgolIrCompiler:
         scope: _FrameScope,
     ) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
-        argument_types = tuple(self._expr_type(actual) for actual in actuals)
-        for actual_type in argument_types:
+        argument_kinds, argument_types = self._formal_argument_shapes(actuals, scope)
+        for argument_kind, actual_type in zip(
+            argument_kinds,
+            argument_types,
+            strict=True,
+        ):
+            if argument_kind == "array":
+                continue
             if actual_type not in {
                 _INTEGER_TYPE,
                 _BOOLEAN_TYPE,
@@ -2985,7 +2998,8 @@ class AlgolIrCompiler:
             for index, (argument, actual_type) in enumerate(
                 zip(actuals, argument_types, strict=True)
             )
-            if self._requires_by_name_thunk_descriptor(argument)
+            if argument_kinds[index] == "scalar"
+            and self._requires_by_name_thunk_descriptor(argument)
         ]
         descriptor_heap_mark = (
             self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
@@ -2997,9 +3011,12 @@ class AlgolIrCompiler:
             for descriptor_index, (argument_index, _, _) in enumerate(thunk_actuals)
         }
         argument_regs: list[int] = []
-        for index, (actual, actual_type) in enumerate(
-            zip(actuals, argument_types, strict=True)
+        for index, (actual, actual_type, argument_kind) in enumerate(
+            zip(actuals, argument_types, argument_kinds, strict=True)
         ):
+            if argument_kind == "array":
+                argument_regs.append(self._compile_array_actual_pointer(actual, scope))
+                continue
             descriptor = None
             if descriptor_heap_mark is not None and index in descriptor_offsets:
                 descriptor = self._emit_descriptor_at(
@@ -3039,6 +3056,7 @@ class AlgolIrCompiler:
             )
         )
         dispatch_label = self._procedure_parameter_dispatch_label(
+            argument_kinds,
             argument_types,
             return_type=call.return_type,
         )
@@ -3068,10 +3086,13 @@ class AlgolIrCompiler:
 
     def _procedure_parameter_dispatch_label(
         self,
+        argument_kinds: tuple[str, ...],
         argument_types: tuple[str, ...],
         *,
         return_type: str | None,
     ) -> str:
+        if len(argument_kinds) != len(argument_types):
+            raise CompileError("procedure parameter dispatch shape is inconsistent")
         if not argument_types and return_type is None:
             self.procedure_signatures.setdefault(
                 _PROCEDURE_CALL_LABEL,
@@ -3081,12 +3102,12 @@ class AlgolIrCompiler:
                 ),
             )
             return _PROCEDURE_CALL_LABEL
-        key = (return_type, argument_types)
+        key = (return_type, argument_kinds, argument_types)
         label = self.procedure_parameter_dispatchers.get(key)
         if label is None:
             suffix = "_".join(
-                _procedure_parameter_dispatch_type_tag(type_name)
-                for type_name in argument_types
+                _procedure_parameter_dispatch_type_tag(type_name, kind=kind)
+                for kind, type_name in zip(argument_kinds, argument_types, strict=True)
             )
             if return_type is None:
                 label = f"{_PROCEDURE_CALL_LABEL}_{suffix}"
@@ -3105,6 +3126,43 @@ class AlgolIrCompiler:
                 return_type=return_type or _INTEGER_TYPE,
             )
         return label
+
+    def _formal_argument_shapes(
+        self,
+        actuals: list[ASTNode],
+        scope: _FrameScope,
+    ) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        argument_kinds: list[str] = []
+        argument_types: list[str] = []
+        for actual in actuals:
+            array_type = self._formal_array_argument_type(actual, scope)
+            if array_type is not None:
+                argument_kinds.append("array")
+                argument_types.append(array_type)
+                continue
+            argument_kinds.append("scalar")
+            argument_types.append(self._expr_type(actual))
+        return tuple(argument_kinds), tuple(argument_types)
+
+    def _formal_array_argument_type(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> str | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_name(variable)
+        if name is None:
+            return None
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None or resolved[0].kind != "array":
+            return None
+        access = self._require_array_access(name, "actual")
+        descriptor = self.arrays.get(access.array_id)
+        if descriptor is None:
+            raise CompileError(f"array actual {name.value!r} has no descriptor")
+        return descriptor.element_type
 
     def _compile_builtin_output(self, node: ASTNode, scope: _FrameScope) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
@@ -4253,6 +4311,7 @@ class AlgolIrCompiler:
     def _compile_procedure_call_dispatcher(
         self,
         *,
+        argument_kinds: tuple[str, ...],
         argument_types: tuple[str, ...],
         label: str,
         return_type: str | None,
@@ -4279,6 +4338,7 @@ class AlgolIrCompiler:
         for procedure in self.procedures.values():
             if not self._procedure_matches_dispatch_shape(
                 procedure,
+                argument_kinds,
                 argument_types,
                 return_type=return_type,
             ):
@@ -4296,10 +4356,13 @@ class AlgolIrCompiler:
             )
             self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
             call_arguments: list[int] = []
-            for arg_index, (argument_type, parameter) in enumerate(
-                zip(argument_types, procedure.parameters, strict=True)
+            for arg_index, (argument_kind, argument_type, parameter) in enumerate(
+                zip(argument_kinds, argument_types, procedure.parameters, strict=True)
             ):
                 argument_pointer = _VALUE_PARAM_BASE_REG + arg_index
+                if argument_kind == "array":
+                    call_arguments.append(argument_pointer)
+                    continue
                 if parameter.mode == _NAME_MODE:
                     call_arguments.append(argument_pointer)
                     continue
@@ -4349,6 +4412,7 @@ class AlgolIrCompiler:
     def _procedure_matches_dispatch_shape(
         self,
         procedure: ProcedureDescriptor,
+        argument_kinds: tuple[str, ...],
         argument_types: tuple[str, ...],
         *,
         return_type: str | None,
@@ -4361,13 +4425,24 @@ class AlgolIrCompiler:
             actual_type=procedure.return_type,
         ):
             return False
+        if len(argument_kinds) != len(argument_types):
+            return False
         if len(procedure.parameters) != len(argument_types):
             return False
-        for parameter, argument_type in zip(
+        for argument_kind, parameter, argument_type in zip(
+            argument_kinds,
             procedure.parameters,
             argument_types,
             strict=True,
         ):
+            if argument_kind == "array":
+                if parameter.kind != "array":
+                    return False
+                if parameter.type_name != argument_type:
+                    return False
+                continue
+            if argument_kind != "scalar":
+                return False
             if parameter.kind != "scalar":
                 return False
             if parameter.mode == _VALUE_MODE:
@@ -6116,19 +6191,30 @@ def _has_comparison(children: list[ASTNode | Token]) -> bool:
     )
 
 
-def _procedure_parameter_dispatch_type_tag(type_name: str) -> str:
+def _procedure_parameter_dispatch_type_tag(
+    type_name: str,
+    *,
+    kind: str = "scalar",
+) -> str:
     tags = {
         _INTEGER_TYPE: "i32",
         _BOOLEAN_TYPE: "bool",
         _REAL_TYPE: "f64",
         _STRING_TYPE: "str",
     }
+    if kind not in {"array", "scalar"}:
+        raise CompileError(
+            f"unsupported procedure parameter dispatch argument kind {kind!r}"
+        )
     try:
-        return tags[type_name]
+        tag = tags[type_name]
     except KeyError as exc:
         raise CompileError(
             f"unsupported procedure parameter dispatch type {type_name!r}"
         ) from exc
+    if kind == "array":
+        return f"array_{tag}"
+    return tag
 
 
 def _procedure_return_type_satisfies(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -893,6 +893,40 @@ class TestAlgolIrCompiler:
         assert "_fn_algol_call_procedure_i32" in labels
         assert IrOp.AND_IMM in opcodes
 
+    def test_compiles_procedure_parameter_call_with_array_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:2]; "
+                "procedure invoke(p); procedure p; begin p(a) end; "
+                "procedure first(xs); integer xs; array xs; "
+                "begin result := xs[1] end; "
+                "a[1] := 9; invoke(first) "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_call_procedure_array_i32" in labels
+        assert (
+            result.procedure_signatures[
+                "_fn_algol_call_procedure_array_i32"
+            ].param_types
+            == ("integer", "integer", "integer")
+        )
+        assert any(
+            instruction.operands[0].name == "_fn_algol_call_procedure_array_i32"
+            for instruction in calls
+        )
+
     def test_compiles_value_procedure_parameter_call_with_value_argument(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -935,6 +969,27 @@ class TestAlgolIrCompiler:
 
         assert signature.param_types == ("integer", "integer", "integer")
         assert signature.return_type == "real"
+
+    def test_compiles_typed_procedure_parameter_call_with_array_argument(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:2]; "
+                "procedure invoke(f); integer f; procedure f; "
+                "begin result := f(a) end; "
+                "integer procedure first(xs); integer xs; array xs; "
+                "begin first := xs[1] end; "
+                "a[1] := 11; invoke(first) "
+                "end"
+            )
+        )
+        signature = result.procedure_signatures[
+            "_fn_algol_call_procedure_i32_result_array_i32"
+        ]
+
+        assert signature.param_types == ("integer", "integer", "integer")
+        assert signature.return_type == "integer"
 
     def test_compiles_integer_return_actual_for_real_procedure_parameter(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this package will be documented in this file.
 - Accepted procedure-valued actuals with scalar by-name parameters for formal
   procedure parameters, while rejecting call shapes that would pass a
   non-assignable actual to a written by-name parameter.
+- Accepted procedure-valued actuals with whole-array parameters for formal
+  procedure parameters, recording array argument call shapes for lowering.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -53,12 +53,13 @@ call-by-name, typed whole-array formals, label formals, switch formals, and
 no-argument statement procedure formals. `value` whole-array parameters are
 also accepted and lowered as copy formals, while `value` label, switch, and
 procedure formals use copied ids or descriptors. Formal procedure parameters
-accept procedure-valued actuals with scalar `value` or by-name parameters,
-rejecting only call shapes that would pass a non-assignable actual to a written
-by-name parameter. Real-valued formal procedure parameters accept
-integer-returning procedure actuals via the same numeric promotion rule used by
-scalar calls. The checker keeps guarding the remaining full-ALGOL gaps,
-including non-scalar parameters on procedure-valued actuals.
+accept procedure-valued actuals with scalar `value` or by-name parameters and
+whole-array parameters, rejecting only call shapes that would pass a
+non-assignable actual to a written by-name parameter. Real-valued formal
+procedure parameters accept integer-returning procedure actuals via the same
+numeric promotion rule used by scalar calls. The checker keeps guarding the
+remaining full-ALGOL gaps, including label, switch, procedure, and other
+non-array non-scalar parameters on procedure-valued actuals.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -191,6 +191,7 @@ class ProcedureFormalCallShape:
 
     role: str
     argument_types: tuple[str, ...]
+    argument_kinds: tuple[str, ...] = ()
     argument_assignable: tuple[bool, ...] = ()
     return_type: str | None = None
 
@@ -2022,10 +2023,18 @@ class AlgolTypeChecker:
         role: str,
     ) -> ResolvedProcedureCall:
         argument_types: list[str] = []
+        argument_kinds: list[str] = []
         argument_assignable: list[bool] = []
         for argument in arguments:
+            array_type = self._formal_array_argument_type(argument, scope)
+            if array_type is not None:
+                argument_types.append(array_type)
+                argument_kinds.append(ARRAY)
+                argument_assignable.append(False)
+                continue
             actual_type = self._infer_expr(argument, scope)
             argument_types.append(actual_type)
+            argument_kinds.append("scalar")
             argument_assignable.append(
                 _is_assignable_actual(argument)
                 and self._resolved_bare_procedure_expression(argument) is None
@@ -2053,6 +2062,7 @@ class AlgolTypeChecker:
                 ProcedureFormalCallShape(
                     role=role,
                     argument_types=tuple(argument_types),
+                    argument_kinds=tuple(argument_kinds),
                     argument_assignable=tuple(argument_assignable),
                     return_type=return_type if role == "expression" else None,
                 ),
@@ -2074,6 +2084,38 @@ class AlgolTypeChecker:
         )
         self.resolved_procedure_calls.append(call)
         return call
+
+    def _formal_array_argument_type(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+    ) -> str | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None or resolved[0].kind != ARRAY:
+            return None
+        access = self._check_array_access(
+            variable,
+            scope,
+            role="actual",
+            allow_whole=True,
+        )
+        if access is None:
+            return ERROR
+        descriptor = next(
+            (
+                array
+                for array in self.semantic_arrays
+                if array.array_id == access.array_id
+            ),
+            None,
+        )
+        return ERROR if descriptor is None else descriptor.element_type
 
     def _record_procedure_parameter_call_shape(
         self,
@@ -2321,11 +2363,35 @@ class AlgolTypeChecker:
                     strict=True,
                 )
             ):
+                argument_kind = (
+                    shape.argument_kinds[argument_index]
+                    if argument_index < len(shape.argument_kinds)
+                    else "scalar"
+                )
                 argument_assignable = (
                     shape.argument_assignable[argument_index]
                     if argument_index < len(shape.argument_assignable)
                     else False
                 )
+                if argument_kind == ARRAY:
+                    if actual_parameter.kind != ARRAY:
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes an "
+                            "array to a scalar actual parameter "
+                            f"{actual_parameter.name!r}",
+                        )
+                        return False
+                    if actual_parameter.type_name != actual_type:
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes "
+                            f"{actual_type} array to actual parameter "
+                            f"{actual_parameter.name!r} expecting "
+                            f"{actual_parameter.type_name}",
+                        )
+                        return False
+                    continue
                 if actual_parameter.kind != "scalar":
                     self._error(
                         token,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -892,6 +892,28 @@ class TestAlgolTypeChecker:
         assert parameter.type_name == "real"
         assert parameter.procedure_call_shapes[0].return_type == "real"
 
+    def test_accepts_typed_procedure_parameter_with_array_argument_actual(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:2]; "
+            "procedure invoke(f); integer f; procedure f; "
+            "begin result := f(a) end; "
+            "integer procedure first(xs); integer xs; array xs; "
+            "begin first := xs[1] end; "
+            "invoke(first) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        shape = parameter.procedure_call_shapes[0]
+        assert shape.return_type == "integer"
+        assert shape.argument_kinds == ("array",)
+        assert shape.argument_types == ("integer",)
+
     def test_accepts_integer_procedure_actual_for_real_procedure_parameter(
         self,
     ) -> None:
@@ -946,6 +968,39 @@ class TestAlgolTypeChecker:
         assert result.semantic is not None
         parameter = result.semantic.procedures[0].parameters[0]
         assert parameter.procedure_call_shapes[0].argument_assignable == (False,)
+
+    def test_accepts_procedure_parameter_actual_with_array_formal(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:2]; "
+            "procedure invoke(p); procedure p; begin p(a) end; "
+            "procedure first(xs); integer xs; array xs; "
+            "begin result := xs[1] end; "
+            "invoke(first) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        shape = parameter.procedure_call_shapes[0]
+        assert shape.argument_kinds == ("array",)
+        assert shape.argument_types == ("integer",)
+        assert any(access.role == "actual" for access in result.semantic.array_accesses)
+
+    def test_rejects_procedure_parameter_actual_with_wrong_array_type(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real array a[1:2]; "
+            "procedure invoke(p); procedure p; begin p(a) end; "
+            "procedure first(xs); integer xs; array xs; "
+            "begin result := xs[1] end; "
+            "invoke(first) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "passes real array" in result.diagnostics[0].message
 
     def test_rejects_procedure_parameter_actual_with_written_literal_by_name_formal(
         self,

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -68,6 +68,8 @@ All notable changes to this package will be documented in this file.
   including procedure-crossing escapes to the first label in a program.
 - Executed formal procedure calls whose actual procedure expects scalar
   by-name parameters, preserving lazy reads and writable caller variables.
+- Executed formal procedure calls that forward whole-array arguments to actual
+  procedures, preserving descriptor aliasing and existing `value` array copies.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,9 +21,10 @@ the current lane already supports a substantial ALGOL 60 surface:
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer exponents
-- value and by-name parameters, including Jensen-style expression thunks and
-  typed whole-array formals with copy or aliasing semantics, plus label,
-  switch, and procedure formals in value or by-name mode
+- value and by-name parameters, including Jensen-style expression thunks,
+  typed whole-array formals with copy or aliasing semantics, and formal
+  procedure calls that forward scalar or whole-array arguments
+- label, switch, and procedure formals in value or by-name mode
 - bare no-argument typed procedure names as expression calls, matching ALGOL's
   omitted-parentheses call syntax for parameterless procedures
 - labels, local and nonlocal `goto`, switch designators, and conditional

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -738,6 +738,28 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_procedure_parameter_statement_call_passes_array_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:2]; "
+            "procedure invoke(p); procedure p; begin p(a) end; "
+            "procedure first(xs); integer xs; array xs; "
+            "begin result := xs[1] end; "
+            "a[1] := 9; invoke(first) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
+    def test_formal_procedure_array_argument_honors_value_array_copy(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:2]; "
+            "procedure invoke(p); procedure p; begin p(a) end; "
+            "procedure mutate(xs); value xs; integer xs; array xs; "
+            "begin xs[1] := 5 end; "
+            "a[1] := 9; invoke(mutate); result := a[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_formal_procedure_by_name_argument_remains_lazy(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -785,6 +807,20 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_typed_procedure_parameter_expression_call_passes_array_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:2]; "
+            "procedure invoke(f); integer f; procedure f; "
+            "begin result := f(a) end; "
+            "integer procedure first(xs); integer xs; array xs; "
+            "begin first := xs[1] end; "
+            "a[1] := 11; invoke(first) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
 
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- record whole-array argument kinds in formal procedure call shapes so procedure-valued actual validation can match array formals
- lower array arguments through formal procedure dispatchers as descriptor pointers, including typed expression dispatch labels
- add type checker, IR, and WASM coverage for statement calls, typed expression calls, type mismatches, and value-array copy behavior

## Validation
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security
- diff scan found no new process, shell, network, filesystem-write, or credential-handling APIs; only existing `token` variable references were flagged by the broad keyword pass.