### PR TITLE
Mark missing HTML doctype names force quirks

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -83,3 +83,5 @@ documented in this file.
   inside open comments, preserving the text while reporting `nested-comment`.
 - HTML comment end-bang handling for `--!>` recovery and non-closing `--!`
   text preservation.
+- Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`
+  and whitespace-only DOCTYPE names.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -31,6 +31,8 @@ Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an
 open comment remain literal comment data and surface a recoverable
 `nested-comment` diagnostic. Comment endings also recover from `--!>` with an
 `incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
+DOCTYPE tokenization reports missing names and marks force-quirks mode for
+inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `CDATA section`, `script_data`, `script_data_escaped`, and
 `script_data_double_escaped` entry states for parser-controlled tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4797,14 +4797,23 @@ to = "before_doctype_name"
 from = "doctype_after_keyword"
 matcher = { literal = ">" }
 to = "data"
-actions = ["emit_current_token"]
+actions = [
+  "parse_error(missing-doctype-name)",
+  "mark_force_quirks",
+  "emit_current_token",
+]
 
 [[transitions]]
 from = "doctype_after_keyword"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_after_keyword"
@@ -4839,14 +4848,23 @@ to = "before_doctype_name"
 from = "before_doctype_name"
 matcher = { literal = ">" }
 to = "data"
-actions = ["parse_error(missing-doctype-name)", "emit_current_token"]
+actions = [
+  "parse_error(missing-doctype-name)",
+  "mark_force_quirks",
+  "emit_current_token",
+]
 
 [[transitions]]
 from = "before_doctype_name"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "before_doctype_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -10190,6 +10190,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(missing-doctype-name)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -10206,6 +10208,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10291,6 +10294,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(missing-doctype-name)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -10307,6 +10311,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 38);
+    assert_eq!(html1.cases.len(), 40);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 39);
+    assert_eq!(file.tests.len(), 40);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -107,23 +107,24 @@ fn html5lib_smoke_fixture_file_parses() {
     assert!(file.tests[0].initial_states.is_empty());
     assert!(file.tests[0].last_start_tag.is_none());
     assert_eq!(file.tests[2].initial_states, vec!["Data state".to_string()]);
-    assert_eq!(file.tests[5].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[5].errors[0].line, 1);
-    assert_eq!(file.tests[5].errors[0].col, 9);
+    assert_eq!(file.tests[4].errors[0].code, "missing-doctype-name");
+    assert_eq!(file.tests[6].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[6].errors[0].line, 1);
+    assert_eq!(file.tests[6].errors[0].col, 9);
     assert_eq!(
-        file.tests[6].errors[0].code,
+        file.tests[7].errors[0].code,
         "abrupt-closing-of-empty-comment"
     );
     assert_eq!(
-        file.tests[8].initial_states,
+        file.tests[9].initial_states,
         vec!["RCDATA state".to_string()]
     );
-    assert_eq!(file.tests[8].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(file.tests[9].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
-        file.tests[10].initial_states,
+        file.tests[11].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[10].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[11].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -148,17 +149,16 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 39);
+    assert_eq!(normalized.cases.len(), 40);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
-        normalized.cases[6].diagnostics,
-        vec!["abrupt-closing-of-empty-comment".to_string()]
+        normalized.cases[4].diagnostics,
+        vec!["missing-doctype-name".to_string()]
     );
     assert_eq!(
-        normalized.cases[8].initial_state.as_deref(),
-        Some("RCDATA state")
+        normalized.cases[7].diagnostics,
+        vec!["abrupt-closing-of-empty-comment".to_string()]
     );
-    assert_eq!(normalized.cases[8].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
         normalized.cases[9].initial_state.as_deref(),
         Some("RCDATA state")
@@ -166,10 +166,18 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     assert_eq!(normalized.cases[9].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
         normalized.cases[10].initial_state.as_deref(),
-        Some("RAWTEXT state")
+        Some("RCDATA state")
     );
     assert_eq!(
         normalized.cases[10].last_start_tag.as_deref(),
+        Some("title")
+    );
+    assert_eq!(
+        normalized.cases[11].initial_state.as_deref(),
+        Some("RAWTEXT state")
+    );
+    assert_eq!(
+        normalized.cases[11].last_start_tag.as_deref(),
         Some("style")
     );
 }
@@ -213,7 +221,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 39);
+    assert_eq!(suite.cases.len(), 40);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -43,6 +43,30 @@
       ]
     },
     {
+      "id": "doctype-missing-name-quirks",
+      "description": "DOCTYPE without a name emits a force-quirks doctype",
+      "input": "<!DOCTYPE>",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-doctype-name"
+      ]
+    },
+    {
+      "id": "doctype-whitespace-only-name-quirks",
+      "description": "DOCTYPE with only whitespace before > emits a force-quirks doctype",
+      "input": "<!DOCTYPE >",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-doctype-name"
+      ]
+    },
+    {
       "id": "comment-eof-recovery",
       "input": "<!--open",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -67,6 +67,18 @@
     },
     {
       "id": "html5lib-smoke-5",
+      "description": "doctype missing name force quirks",
+      "input": "<!DOCTYPE>",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-doctype-name"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-6",
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "tokens": [
@@ -76,7 +88,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-6",
+      "id": "html5lib-smoke-7",
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "tokens": [
@@ -88,7 +100,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-7",
+      "id": "html5lib-smoke-8",
       "description": "abrupt empty comment close",
       "input": "Before<!-->After",
       "tokens": [
@@ -102,7 +114,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-8",
+      "id": "html5lib-smoke-9",
       "description": "dash prefixed empty comment close",
       "input": "Before<!--->After",
       "tokens": [
@@ -114,7 +126,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-9",
+      "id": "html5lib-smoke-10",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -127,7 +139,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-10",
+      "id": "html5lib-smoke-11",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -139,7 +151,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-12",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -152,7 +164,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-13",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -163,7 +175,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-14",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -176,7 +188,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-15",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -189,7 +201,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-16",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -199,7 +211,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-17",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -209,7 +221,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-18",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -221,7 +233,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-19",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -231,7 +243,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-20",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -241,7 +253,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-21",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -254,7 +266,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-22",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -264,7 +276,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-23",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -274,7 +286,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-24",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -287,7 +299,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-25",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -301,7 +313,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -315,7 +327,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -332,7 +344,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -342,7 +354,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -352,7 +364,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -362,7 +374,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -372,7 +384,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -384,7 +396,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -397,7 +409,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -410,7 +422,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -425,7 +437,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -438,7 +450,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -452,7 +464,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -465,7 +477,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -479,7 +491,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -131,7 +131,8 @@ def normalize_case(index: int, test: dict[str, Any]) -> dict[str, Any]:
             tokens.append(f"Comment(data={token[1]})")
         elif kind == "DOCTYPE":
             force_quirks = not bool(token[4])
-            tokens.append(f"Doctype(name={token[1]}, force_quirks={str(force_quirks).lower()})")
+            name = "null" if token[1] is None else token[1]
+            tokens.append(f"Doctype(name={name}, force_quirks={str(force_quirks).lower()})")
 
     if pending_text:
         tokens.append(f"Text(data={pending_text})")

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -39,6 +39,16 @@
       ]
     },
     {
+      "description": "doctype missing name force quirks",
+      "input": "<!DOCTYPE>",
+      "output": [
+        ["DOCTYPE", null, null, null, false]
+      ],
+      "errors": [
+        {"code": "missing-doctype-name", "line": 1, "col": 10}
+      ]
+    },
+    {
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -66,6 +66,45 @@ fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
 }
 
 #[test]
+fn default_html_lexer_marks_missing_doctype_name_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!DOCTYPE>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: None,
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "missing-doctype-name"));
+}
+
+#[test]
+fn default_html_lexer_marks_whitespace_only_doctype_force_quirks() {
+    let tokens = lex_html("<!DOCTYPE >").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Doctype {
+                name: None,
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Mark force-quirks mode for missing-name DOCTYPE recovery in `doctype_after_keyword` and `before_doctype_name`.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for `<!DOCTYPE>` and `<!DOCTYPE >`.
- Teach the html5lib normalizer to render null DOCTYPE names as `Doctype(name=null, ...)`, then regenerate the static Rust source and normalized fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt -p coding-adventures-html-lexer -p state-machine-tokenizer -p state-machine-markup-deserializer -p state-machine-source-compiler`
- `cargo test -p coding-adventures-html-lexer --test html_lexer_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test conformance_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test html1_authoring_test -- --nocapture`
- `cargo test -p state-machine-markup-deserializer --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test -p state-machine-source-compiler --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check -p coding-adventures-html-lexer --tests`
- `cargo check -p state-machine-tokenizer --tests`
- `git diff --check`