### PR TITLE
feat(twig): TW02 — Twig → JVM (real java target)

### DIFF
--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,24 @@
 # ir-to-jvm-class-file
 
+## 0.6.1 — 2026-04-28
+
+### Fixed — JVM01: caller-saves around `IrOp.CALL` so recursion works on real `java`
+
+The "register" model uses a class-level static `int[]` array
+shared across every `invokestatic`, so a recursive call would
+clobber the caller's register values.  `IrOp.CALL` emission now
+snapshots every register slot into JVM locals immediately before
+the `invokestatic` and restores them immediately after (skipping
+`r1`, the return-value slot).  Each callable's `max_locals` is
+bumped to `reg_count` to cover the snapshot stash.
+
+This is the minimal-diff path described in
+`code/specs/JVM01-jvm-per-method-locals.md` — the bigger
+descriptor rewrite stays as a future cleanup option.
+
+Regression test:
+`tests/test_oct_8bit_e2e.py::test_call_preserves_caller_registers`.
+
 ## 0.6.0 — 2026-04-27
 
 ### Added — LANG20: `JVMCodeGenerator` — `CodeGenerator[IrProgram, JVMClassArtifact]` adapter

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -364,7 +364,8 @@ class _JvmClassLowerer:
             self._build_syscall_method(),
         ]
         methods.extend(
-            self._build_callable_method(region) for region in callable_regions
+            self._build_callable_method(region, reg_count)
+            for region in callable_regions
         )
         if self.config.emit_main_wrapper:
             methods.append(self._build_main_method())
@@ -564,6 +565,60 @@ class _JvmClassLowerer:
             _OP_INVOKESTATIC,
             self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
         )
+
+    # ------------------------------------------------------------------
+    # JVM01 — caller-saves convention around CALL
+    # ------------------------------------------------------------------
+    #
+    # The static ``__ca_regs`` array holds every "IR register" and is
+    # shared across method invocations.  That breaks recursion: when
+    # ``fact(5)`` calls ``fact(4)``, ``fact(5)``'s own parameter
+    # register r2 (= 5) is overwritten by the call setup writing 4
+    # there.  When ``fact(4)`` returns, the outer multiplication
+    # reads r2 = 4 instead of 5.
+    #
+    # Fix: each ``IrOp.CALL`` sandwich ``save → invoke → restore``.
+    # The save sequence snapshots the entire static array into JVM
+    # locals 0..N-1 (per-method, isolated by the JVM frame
+    # discipline).  The restore sequence writes everything back
+    # *except* register 1 — that's the convention HALT/RET use to
+    # carry the callee's return value back to the caller.
+    #
+    # Cost: 2 × N bytecode pairs per CALL.  N is small (the IR's
+    # max register index + 1) so the overhead is bounded.
+
+    def _emit_caller_save_registers(
+        self, builder: _BytecodeBuilder, reg_count: int
+    ) -> None:
+        """Snapshot static-array regs 0..reg_count-1 → JVM locals 0..N-1."""
+        for reg_idx in range(reg_count):
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._helper_reg_field, _DESC_INT_ARRAY),
+            )
+            self._emit_push_int(builder, reg_idx)
+            builder.emit_opcode(_OP_IALOAD)
+            self._emit_istore(builder, reg_idx)
+
+    def _emit_caller_restore_registers(
+        self, builder: _BytecodeBuilder, reg_count: int
+    ) -> None:
+        """Write JVM locals 0..N-1 back to static-array regs.
+
+        Skips index 1 — the callee's return value lives there per the
+        existing HALT/RET convention, and we want the caller to see
+        the new value, not the saved-pre-call one.
+        """
+        for reg_idx in range(reg_count):
+            if reg_idx == 1:
+                continue  # preserve callee's return value
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._helper_reg_field, _DESC_INT_ARRAY),
+            )
+            self._emit_push_int(builder, reg_idx)
+            self._emit_iload(builder, reg_idx)
+            builder.emit_opcode(_OP_IASTORE)
 
     def _build_class_initializer(
         self,
@@ -877,8 +932,15 @@ class _JvmClassLowerer:
             max_locals=3,          # 0=syscall_num, 1=arg_reg, 2=read_byte
         )
 
-    def _build_callable_method(self, region: _CallableRegion) -> _MethodSpec:
+    def _build_callable_method(
+        self, region: _CallableRegion, reg_count: int
+    ) -> _MethodSpec:
         builder = _BytecodeBuilder()
+        # ``reg_count`` is the program-wide max register count; the
+        # caller-saves CALL convention (JVM01) uses JVM locals
+        # 0..reg_count-1 to snapshot the static-array register state
+        # across nested calls.  We pass it through so the method's
+        # ``max_locals`` can be set high enough below.
 
         for instruction in region.instructions:
             if instruction.opcode == IrOp.LABEL:
@@ -1132,6 +1194,23 @@ class _JvmClassLowerer:
 
             if instruction.opcode == IrOp.CALL:
                 label = _as_label(instruction.operands[0], "CALL target")
+                # ── JVM01: caller-saves convention around CALL ────────
+                # All "IR registers" live in a class-level static int
+                # array (``__ca_regs``).  Without intervention, a
+                # recursive call clobbers the caller's register state
+                # — fact(5)'s own param r2 = 5 gets overwritten when
+                # fact(4) is set up.
+                #
+                # Fix: snapshot the entire static array into JVM locals
+                # before the call, restore everything except register 1
+                # afterwards (register 1 carries the callee's return
+                # value, by long-standing convention with HALT/RET).
+                #
+                # JVM locals are per-method (the JVM spec guarantees
+                # fresh frames per invokestatic), so the snapshot is
+                # private to each invocation — this is what makes
+                # recursion work.
+                self._emit_caller_save_registers(builder, reg_count)
                 self._emit_push_int(builder, 1)
                 builder.emit_u2_instruction(
                     _OP_INVOKESTATIC,
@@ -1141,6 +1220,7 @@ class _JvmClassLowerer:
                     _OP_INVOKESTATIC,
                     self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
                 )
+                self._emit_caller_restore_registers(builder, reg_count)
                 continue
 
             if instruction.opcode == IrOp.RET or instruction.opcode == IrOp.HALT:
@@ -1179,7 +1259,11 @@ class _JvmClassLowerer:
             descriptor=_DESC_NOARGS_INT,
             code=code,
             max_stack=16,
-            max_locals=0,
+            # JVM01: caller-saves convention uses JVM locals
+            # 0..reg_count-1 as snapshot storage across CALL
+            # boundaries.  Reserve at least ``reg_count`` locals so
+            # the JVM verifier accepts the method.
+            max_locals=reg_count,
         )
 
     def _build_main_method(self) -> _MethodSpec:

--- a/code/packages/python/ir-to-jvm-class-file/tests/test_oct_8bit_e2e.py
+++ b/code/packages/python/ir-to-jvm-class-file/tests/test_oct_8bit_e2e.py
@@ -200,6 +200,34 @@ class TestOct8BitArithmetic:
 
         assert _compile_and_run(program, "OctAnd") == bytes([0x0F])
 
+    def test_call_preserves_caller_registers(self) -> None:
+        """JVM01 regression: ``IrOp.CALL`` snapshots all caller registers
+        to JVM locals and restores them after the callee returns
+        (skipping ``r1``, the return-value slot).
+
+        Without the fix, the callee's writes to ``r2`` leak back to the
+        caller — ``r2`` reads as 7 instead of 99.  With the fix, the
+        caller observes its original value.
+
+        Output byte 99 (= ``b'c'``) confirms r2 round-tripped intact.
+        """
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+
+        # ── helper region: clobber r2, return immediately ─────────────
+        program.add_instruction(IrInstruction(IrOp.LABEL,    [IrLabel("helper")],   id=-1))
+        program.add_instruction(IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(7)],    id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.RET,      [],                    id=gen.next()))
+
+        # ── _start: load r2 = 99, call helper, write r2 ───────────────
+        program.add_instruction(IrInstruction(IrOp.LABEL,    [IrLabel("_start")],   id=-1))
+        program.add_instruction(IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(99)],   id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.CALL,     [IrLabel("helper")],   id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.SYSCALL,  [_imm(1), _reg(2)],    id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.HALT,     [],                    id=gen.next()))
+
+        assert _compile_and_run(program, "JvmCallSaves") == bytes([99])
+
     def test_multiple_outputs(self) -> None:
         """Compute two values and write both; verifies multi-instruction programs."""
         gen = IDGenerator()

--- a/code/packages/python/twig-jvm-compiler/BUILD
+++ b/code/packages/python/twig-jvm-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ../twig -e ../compiler-ir -e ../codegen-core -e ../ir-optimizer -e ../jvm-class-file -e ../ir-to-jvm-class-file -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig-jvm-compiler/BUILD
+++ b/code/packages/python/twig-jvm-compiler/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ../twig -e ../compiler-ir -e ../codegen-core -e ../ir-optimizer -e ../jvm-class-file -e ../ir-to-jvm-class-file -e ".[dev]" --quiet
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ../twig -e ../compiler-ir -e ../ir-optimizer -e ../jvm-class-file -e ../ir-to-jvm-class-file -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog — twig-jvm-compiler
+
+## [0.1.0] — TW02 v1
+
+### Added
+
+- ``compile_to_ir(source)`` — Twig → ``IrProgram`` for the v1
+  surface (integer arithmetic, ``if``/``let``/``begin``,
+  top-level ``define`` for both values and functions,
+  non-recursive function calls — see "Known limitation" below
+  for the recursion gap).
+- ``compile_source(source)`` — full pipeline: parse + extract +
+  IR emit + ir-optimizer + lower_ir_to_jvm_class_file → .class
+  bytes.
+- ``run_source(source)`` — write the .class file to a temp dir
+  and invoke real ``java -cp <dir> <ClassName>``.  Returns the
+  process's stdout / stderr / exit code.
+- TW02 spec at ``code/specs/TW02-twig-jvm-compiler.md``.
+
+### Notes
+
+- Lambdas / cons cells / symbols / ``print`` raise
+  ``TwigCompileError``.  TW02.5 adds them.
+- Output is a single byte to stdout via ``SYSCALL 1`` — same
+  convention ``test_oct_8bit_e2e.py`` uses for the existing
+  Oct-on-JVM tests.
+
+### Known limitation: recursion is broken
+
+``ir-to-jvm-class-file`` stores every "IR register" in a
+class-level static int array shared across every method
+invocation.  That works for one-level calls but breaks
+recursion: when ``fact(5)`` calls ``fact(4)``, ``fact(5)``'s own
+parameter register r2 gets overwritten with 4, and the outer
+multiplication then uses 4 instead of 5.
+
+The fix is in the JVM backend itself — it should use real
+per-method JVM locals instead of a static array — and is its
+own infrastructure PR (tracked alongside CLR01 under the
+"real-runtime correctness" banner).  The factorial test is
+marked ``pytest.mark.xfail(strict=True)`` so when that fix
+lands, the test starts passing and pytest flags the marker
+for removal.
+
+Non-recursive function calls work correctly today, including
+multi-arg functions and nested calls like ``(inc (dbl 5))``.

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -25,7 +25,7 @@
   convention ``test_oct_8bit_e2e.py`` uses for the existing
   Oct-on-JVM tests.
 
-### Known limitation: recursion is broken
+### Known limitation: recursion (tracked as JVM01)
 
 ``ir-to-jvm-class-file`` stores every "IR register" in a
 class-level static int array shared across every method
@@ -34,13 +34,14 @@ recursion: when ``fact(5)`` calls ``fact(4)``, ``fact(5)``'s own
 parameter register r2 gets overwritten with 4, and the outer
 multiplication then uses 4 instead of 5.
 
-The fix is in the JVM backend itself — it should use real
-per-method JVM locals instead of a static array — and is its
-own infrastructure PR (tracked alongside CLR01 under the
-"real-runtime correctness" banner).  The factorial test is
-marked ``pytest.mark.xfail(strict=True)`` so when that fix
-lands, the test starts passing and pytest flags the marker
-for removal.
+**This is tracked as a first-class numbered work item at
+``code/specs/JVM01-jvm-per-method-locals.md``** — same
+prominence as CLR01.  No xfail markers, no hidden TODOs; the
+spec describes the exact byte-level changes needed (switch the
+backend from class-level static-int-array storage to real
+per-method JVM locals + parameter passing on the operand
+stack).  When JVM01 lands the recursion tests get added back
+and pass without any change to ``twig-jvm-compiler``.
 
 Non-recursive function calls work correctly today, including
 multi-arg functions and nested calls like ``(inc (dbl 5))``.

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — twig-jvm-compiler
 
+## [0.1.1] — 2026-04-28
+
+### Fixed — JVM01 paired fix: copy params to body-local holding registers
+
+`_emit_function` now copies each parameter out of its arrival
+register (`r2`, `r3`, …) into a fresh body-local holding
+register at function entry.  Without this, a recursive body
+read of `n` happened against the same register the upcoming
+call's arg-marshalling overwrote — the caller-save in
+`ir-to-jvm-class-file` then snapshotted the *already-clobbered*
+value, defeating the fix.  Together with the
+`ir-to-jvm-class-file` 0.6.1 caller-saves change, recursion
+(e.g. `(fact 5) → 120`) now runs correctly on real `java`.
+
+### Added
+
+- `tests/test_real_jvm.py::test_recursion_factorial` — runs
+  `(define (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) (fact 5)`
+  through real `java` and asserts stdout is byte 120.
+
+### Removed
+
+- "Known limitation: recursion (tracked as JVM01)" note — the
+  limitation is gone.
+
 ## [0.1.0] — TW02 v1
 
 ### Added
@@ -7,8 +32,8 @@
 - ``compile_to_ir(source)`` — Twig → ``IrProgram`` for the v1
   surface (integer arithmetic, ``if``/``let``/``begin``,
   top-level ``define`` for both values and functions,
-  non-recursive function calls — see "Known limitation" below
-  for the recursion gap).
+  function calls including recursion — see 0.1.1 for the
+  JVM01 recursion fix).
 - ``compile_source(source)`` — full pipeline: parse + extract +
   IR emit + ir-optimizer + lower_ir_to_jvm_class_file → .class
   bytes.
@@ -25,23 +50,7 @@
   convention ``test_oct_8bit_e2e.py`` uses for the existing
   Oct-on-JVM tests.
 
-### Known limitation: recursion (tracked as JVM01)
+### Note
 
-``ir-to-jvm-class-file`` stores every "IR register" in a
-class-level static int array shared across every method
-invocation.  That works for one-level calls but breaks
-recursion: when ``fact(5)`` calls ``fact(4)``, ``fact(5)``'s own
-parameter register r2 gets overwritten with 4, and the outer
-multiplication then uses 4 instead of 5.
-
-**This is tracked as a first-class numbered work item at
-``code/specs/JVM01-jvm-per-method-locals.md``** — same
-prominence as CLR01.  No xfail markers, no hidden TODOs; the
-spec describes the exact byte-level changes needed (switch the
-backend from class-level static-int-array storage to real
-per-method JVM locals + parameter passing on the operand
-stack).  When JVM01 lands the recursion tests get added back
-and pass without any change to ``twig-jvm-compiler``.
-
-Non-recursive function calls work correctly today, including
-multi-arg functions and nested calls like ``(inc (dbl 5))``.
+Recursion was a known limitation in 0.1.0 tracked as JVM01;
+0.1.1 lands the fix (see entry above).

--- a/code/packages/python/twig-jvm-compiler/README.md
+++ b/code/packages/python/twig-jvm-compiler/README.md
@@ -1,0 +1,55 @@
+# twig-jvm-compiler
+
+Twig → JVM class file (`*.class`) compiler — the first non-Python
+target for Twig, running on **real `java`**, not a simulator.
+
+See [TW02 spec](../../../specs/TW02-twig-jvm-compiler.md) for the
+v1 surface and the multi-step roadmap.
+
+## Architecture
+
+```
+Twig source
+   ↓  parse_twig + extract_program        (twig package)
+typed AST
+   ↓  twig_jvm_compiler.compile_to_ir     (this package)
+IrProgram
+   ↓  ir-optimizer
+IrProgram (optimised)
+   ↓  lower_ir_to_jvm_class_file          (existing)
+.class file bytes
+   ↓  java -cp <dir> <ClassName>          (real JVM)
+program output
+```
+
+## V1 surface
+
+- Integer literals, booleans
+- Arithmetic: `+`, `-`, `*`, `/`
+- Comparison: `=`, `<`, `>`
+- Control flow: `if`, `let`, `begin`
+- **Top-level `define`** for both values (literal RHS) and
+  functions
+- Recursive function calls
+- Output: the program's final value is written as a single byte
+  to stdout via `SYSCALL 1`
+
+## Quick start
+
+```python
+from twig_jvm_compiler import compile_source, run_source
+
+# Compile to .class bytes:
+result = compile_source("(+ 1 2)")
+print(len(result.class_bytes), "bytes")
+
+# Compile + run on real java:
+out = run_source("(+ 1 2)")
+print(out.stdout)  # b'\x03'
+```
+
+## Testing on real `java`
+
+The integration tests in `tests/test_real_jvm.py` invoke
+`subprocess.run(["java", ...])` and assert on actual JVM output.
+They skip cleanly when `java` is not on PATH.

--- a/code/packages/python/twig-jvm-compiler/pyproject.toml
+++ b/code/packages/python/twig-jvm-compiler/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-twig-jvm-compiler"
+version = "0.1.0"
+description = "Twig → JVM class file (real java target) — first non-Python target for Twig"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["twig", "lisp", "jvm", "java", "compiler", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+dependencies = [
+    "coding-adventures-twig",
+    "coding-adventures-compiler-ir",
+    "coding-adventures-ir-optimizer",
+    "coding-adventures-jvm-class-file",
+    "coding-adventures-ir-to-jvm-class-file",
+]
+
+[tool.uv.sources]
+coding-adventures-twig = { path = "../twig", editable = true }
+coding-adventures-compiler-ir = { path = "../compiler-ir", editable = true }
+coding-adventures-ir-optimizer = { path = "../ir-optimizer", editable = true }
+coding-adventures-jvm-class-file = { path = "../jvm-class-file", editable = true }
+coding-adventures-ir-to-jvm-class-file = { path = "../ir-to-jvm-class-file", editable = true }
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=twig_jvm_compiler --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/twig_jvm_compiler"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/twig_jvm_compiler"]

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/__init__.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/__init__.py
@@ -1,0 +1,28 @@
+"""``twig-jvm-compiler`` — Twig source → JVM class file (real java).
+
+See ``code/specs/TW02-twig-jvm-compiler.md`` for the v1 surface
+and the multi-step roadmap (TW02.5: lambdas / cons cells / print;
+TW04: BEAM; TW05: WASM updates).
+"""
+
+from __future__ import annotations
+
+from twig_jvm_compiler.compiler import (
+    ExecutionResult,
+    PackageError,
+    PackageResult,
+    compile_source,
+    compile_to_ir,
+    java_available,
+    run_source,
+)
+
+__all__ = [
+    "ExecutionResult",
+    "PackageError",
+    "PackageResult",
+    "compile_source",
+    "compile_to_ir",
+    "java_available",
+    "run_source",
+]

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
@@ -287,11 +287,19 @@ class _Compiler:
         # Open the labelled region.
         self._emit(IrOp.LABEL, IrLabel(name=name), id=-1)
 
-        # Bind parameters to their fixed register slots.
-        ctx = _FnCtx(locals_={
-            param: IrRegister(index=_REG_PARAM_BASE + i)
-            for i, param in enumerate(lam.params)
-        })
+        # Copy each parameter out of its *arrival* register
+        # (``_REG_PARAM_BASE + i`` — the slot the caller wrote to)
+        # into a fresh body-local *holding* register (index ≥ 10).
+        # Why: subsequent ``CALL`` sites in the body marshal arguments
+        # into the same arrival slots, which would clobber the param
+        # value before recursive use.  Holding registers sit above the
+        # param window, so call-site arg setup never touches them.
+        ctx = _FnCtx(locals_={})
+        for i, param in enumerate(lam.params):
+            arrival = IrRegister(index=_REG_PARAM_BASE + i)
+            body_local = self._fresh_holding(ctx)
+            self._emit_move(body_local, arrival)
+            ctx.locals_[param] = body_local
 
         last: IrRegister | None = None
         for expr in lam.body:

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
@@ -1,0 +1,683 @@
+"""Twig → JVM compiler — TW02 v1.
+
+Pipeline
+========
+::
+
+    Twig source
+        ↓ parse + extract     (twig package)
+    typed AST
+        ↓ Compiler.compile()  (this module)
+    IrProgram
+        ↓ ir-optimizer
+    IrProgram (optimised)
+        ↓ lower_ir_to_jvm_class_file
+    .class bytes
+        ↓ java -cp <dir> <ClassName>
+    program output (a single byte on stdout)
+
+Why "first non-Python target"
+=============================
+JVM gets the first real-runtime target slot because the in-house
+``ir-to-jvm-class-file`` already produces real-``java``-compatible
+class files (see ``test_oct_8bit_e2e.py`` in that package — it
+runs the compiler's output through real ``java`` and asserts on
+JVM stdout).  CLR is blocked behind ``cli-assembly-writer``
+conformance work (CLR01).
+
+Calling convention notes (see TW02 spec)
+========================================
+The JVM backend emits one ``invokestatic`` per ``IrOp.CALL``
+with descriptor ``()I`` — no arguments, returns int.  Caller and
+callee communicate through a shared register array provided by
+the runtime.  Param ``i`` of every function lives at register
+``2 + i`` (registers 0 and 1 are reserved scratch / HALT-result).
+
+Nested calls work because the compiler evaluates each argument
+into a *holding* register (index ≥ 10) before moving values into
+the param-slot registers right at the call site — that way
+``(f (g x) y)`` doesn't have ``g``'s arg setup stomp on ``f``'s
+arg-0 slot.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+
+from compiler_ir import (
+    IDGenerator,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+from ir_optimizer import IrOptimizer, OptimizationResult
+from ir_to_jvm_class_file import (
+    JvmBackendConfig,
+    JVMClassArtifact,
+    lower_ir_to_jvm_class_file,
+    write_class_file,
+)
+from twig import (
+    TwigCompileError,
+    TwigError,
+    extract_program,
+    parse_twig,
+)
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    BoolLit,
+    Define,
+    Expr,
+    If,
+    IntLit,
+    Lambda,
+    Let,
+    NilLit,
+    Program,
+    SymLit,
+    VarRef,
+)
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PackageResult:
+    """Aggregated artefacts from one compile run."""
+
+    source: str
+    class_name: str
+    ast: Program
+    raw_ir: IrProgram
+    optimization: OptimizationResult
+    optimized_ir: IrProgram
+    artifact: JVMClassArtifact
+    class_bytes: bytes
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Compilation result + real-``java`` invocation output."""
+
+    compilation: PackageResult
+    stdout: bytes
+    stderr: bytes
+    returncode: int
+
+
+class PackageError(TwigError):
+    """Stage-tagged failure during compilation or execution."""
+
+    def __init__(
+        self,
+        stage: str,
+        message: str,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(f"[{stage}] {message}")
+        self.stage = stage
+        self.message = message
+        self.cause = cause
+
+
+# ---------------------------------------------------------------------------
+# Builtins recognised in v1
+# ---------------------------------------------------------------------------
+
+
+# Each entry maps a Twig builtin name to the binary ``IrOp`` for its
+# single-instruction emission.  v1 only supports the binary ones.
+_BINARY_OPS: dict[str, IrOp] = {
+    "+": IrOp.ADD,
+    "-": IrOp.SUB,
+    "*": IrOp.MUL,
+    "/": IrOp.DIV,
+    "=": IrOp.CMP_EQ,
+    "<": IrOp.CMP_LT,
+    ">": IrOp.CMP_GT,
+}
+
+_V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
+    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
+)
+
+# Convention shared with the JVM backend's helper register array:
+#   register 0  — scratch zero (also the SYSCALL-arg slot for SYSCALL 1)
+#   register 1  — HALT result / function return value
+#   register 2..N — function parameter slots (param i → register 2 + i)
+#   register 10..  — compiler-allocated holding registers for intermediate
+#                    values; using a high base keeps them clear of
+#                    parameter slots, so nested calls don't clobber.
+_REG_HALT_RESULT = 1
+_REG_PARAM_BASE = 2
+_REG_HOLDING_BASE = 10
+
+
+# ---------------------------------------------------------------------------
+# Per-function compilation context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FnCtx:
+    """Mutable state during compilation of one IR function region.
+
+    A ``_FnCtx`` is created either for the synthetic ``_start``
+    region (top-level expressions of the program) or for each
+    user-defined function discovered in the AST.
+    """
+
+    # Map of *local* names to the register they live in.  Populated
+    # from function parameters at function entry, extended as
+    # ``let`` bindings introduce new names.
+    locals_: dict[str, IrRegister]
+
+    # Next holding-register index to allocate for intermediate values.
+    next_holding: int = _REG_HOLDING_BASE
+
+    # Fresh-label counter (per region, so labels don't collide).
+    next_label: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+class _Compiler:
+    """Walks the typed Twig AST and emits one ``IrProgram``.
+
+    A program is one or more *callable regions*: the synthesised
+    ``_start`` region (top-level expressions) and one region per
+    top-level ``(define (f ...) ...)``.  The JVM backend emits each
+    region as a separate ``invokestatic`` target.
+    """
+
+    def __init__(self) -> None:
+        self._program = IrProgram(entry_label="_start")
+        self._gen = IDGenerator()
+
+        # Top-level value defines folded to compile-time constants.
+        # ``(define x 42)`` → ``_value_consts["x"] = 42``; references
+        # to ``x`` anywhere in the program emit ``LOAD_IMM`` of 42.
+        # (v1 only supports literal RHS for value defines.)
+        self._value_consts: dict[str, int] = {}
+
+        # Names of top-level function defines and their parameter
+        # names.  Used to (a) decide direct-call dispatch at apply
+        # sites and (b) lay out parameters into the shared register
+        # convention.
+        self._fn_params: dict[str, list[str]] = {}
+
+    # ------------------------------------------------------------------
+    # Top-level driver
+    # ------------------------------------------------------------------
+
+    def compile(self, program: Program) -> IrProgram:
+        # ── Pre-pass 1: classify and validate every top-level form ─────
+        # We need the function table built before any function body
+        # compiles, so calls can find the callee even with mutual
+        # recursion.
+        top_level_exprs: list[Expr] = []
+        function_defs: list[tuple[str, Lambda]] = []
+        for form in program.forms:
+            if isinstance(form, Define):
+                self._classify_define(form)
+                if isinstance(form.expr, Lambda):
+                    function_defs.append((form.name, form.expr))
+            else:
+                # Bare top-level expression — accumulates into _start.
+                top_level_exprs.append(form)
+
+        # ── Emit each user function as its own callable region ────────
+        for name, lam in function_defs:
+            self._emit_function(name, lam)
+
+        # ── Emit the synthesised _start region ────────────────────────
+        self._emit_start(top_level_exprs)
+        return self._program
+
+    # ------------------------------------------------------------------
+    # Top-level form classification
+    # ------------------------------------------------------------------
+
+    def _classify_define(self, form: Define) -> None:
+        """Validate and record one top-level ``(define ...)``."""
+        if isinstance(form.expr, Lambda):
+            # Function define — record its parameter list so apply
+            # sites know how many args to plumb through.
+            self._fn_params[form.name] = list(form.expr.params)
+            return
+
+        # Value define — must have a literal RHS in v1.
+        if isinstance(form.expr, IntLit):
+            self._value_consts[form.name] = int(form.expr.value)
+            return
+        if isinstance(form.expr, BoolLit):
+            self._value_consts[form.name] = 1 if form.expr.value else 0
+            return
+
+        raise TwigCompileError(
+            f"(define {form.name} ...) — TW02 v1 only supports literal "
+            "RHS for value defines.  Use a top-level function for "
+            "computed values."
+        )
+
+    # ------------------------------------------------------------------
+    # Function emission
+    # ------------------------------------------------------------------
+
+    def _emit_function(self, name: str, lam: Lambda) -> None:
+        """Compile one ``(define (name params) body...)`` into a
+        labeled region of the IR program.
+
+        Parameters live at registers ``_REG_PARAM_BASE + i``.  The
+        body's value is moved into ``_REG_HALT_RESULT`` and the
+        region ends with ``IrOp.RET``.
+        """
+        # Open the labelled region.
+        self._emit(IrOp.LABEL, IrLabel(name=name), id=-1)
+
+        # Bind parameters to their fixed register slots.
+        ctx = _FnCtx(locals_={
+            param: IrRegister(index=_REG_PARAM_BASE + i)
+            for i, param in enumerate(lam.params)
+        })
+
+        last: IrRegister | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            raise TwigCompileError(f"function {name!r} has empty body")
+
+        # Move result into the HALT-result register and return.
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.RET)
+
+    def _emit_start(self, exprs: list[Expr]) -> None:
+        """Compile the synthesised ``_start`` region.
+
+        Top-level expressions evaluate in order; the last one's
+        value is written as a single byte to stdout via
+        ``SYSCALL 1``, then ``HALT`` exits the program.
+        """
+        self._emit(IrOp.LABEL, IrLabel(name="_start"), id=-1)
+        ctx = _FnCtx(locals_={})
+
+        last: IrRegister | None = None
+        for expr in exprs:
+            last = self._compile_expr(expr, ctx)
+
+        if last is None:
+            # Empty program → output 0.
+            zero = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
+            last = zero
+
+        # Write the final value as a byte to stdout via SYSCALL 1.
+        # The JVM backend expects (imm number, register arg).
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.SYSCALL, IrImmediate(1), IrRegister(_REG_HALT_RESULT))
+        self._emit(IrOp.HALT)
+
+    # ------------------------------------------------------------------
+    # Expression compilation
+    # ------------------------------------------------------------------
+
+    def _compile_expr(self, expr: Expr, ctx: _FnCtx) -> IrRegister:
+        """Compile ``expr``; return the register holding its value."""
+        if isinstance(expr, IntLit):
+            return self._compile_int(expr.value, ctx)
+        if isinstance(expr, BoolLit):
+            return self._compile_int(1 if expr.value else 0, ctx)
+        if isinstance(expr, NilLit):
+            raise TwigCompileError(
+                "nil is not yet supported by the JVM backend (heap "
+                "objects come in TW02.5)"
+            )
+        if isinstance(expr, SymLit):
+            raise TwigCompileError(
+                "symbols are not yet supported by the JVM backend "
+                "(heap objects come in TW02.5)"
+            )
+        if isinstance(expr, VarRef):
+            return self._compile_var_ref(expr, ctx)
+        if isinstance(expr, If):
+            return self._compile_if(expr, ctx)
+        if isinstance(expr, Let):
+            return self._compile_let(expr, ctx)
+        if isinstance(expr, Begin):
+            last: IrRegister | None = None
+            for e in expr.exprs:
+                last = self._compile_expr(e, ctx)
+            assert last is not None
+            return last
+        if isinstance(expr, Lambda):
+            raise TwigCompileError(
+                "lambdas are not yet supported by the JVM backend "
+                "(closure synthesis lands in TW02.5)"
+            )
+        if isinstance(expr, Apply):
+            return self._compile_apply(expr, ctx)
+        raise TwigCompileError(
+            f"unhandled expression type: {type(expr).__name__}"
+        )
+
+    # ------------------------------------------------------------------
+    # Atoms
+    # ------------------------------------------------------------------
+
+    def _compile_int(self, value: int, ctx: _FnCtx) -> IrRegister:
+        reg = self._fresh_holding(ctx)
+        self._emit(IrOp.LOAD_IMM, reg, IrImmediate(value))
+        return reg
+
+    def _compile_var_ref(self, expr: VarRef, ctx: _FnCtx) -> IrRegister:
+        # Local (parameter or let-binding)?
+        if expr.name in ctx.locals_:
+            return ctx.locals_[expr.name]
+
+        # Top-level value-constant?  Inline it.
+        if expr.name in self._value_consts:
+            return self._compile_int(self._value_consts[expr.name], ctx)
+
+        # Top-level function reference (not a call) is not yet a thing
+        # in v1 — first-class function values need closures.
+        if expr.name in self._fn_params:
+            raise TwigCompileError(
+                f"top-level function {expr.name!r} can't be passed as a "
+                "value yet — closures land in TW02.5"
+            )
+
+        raise TwigCompileError(f"unbound name {expr.name!r}")
+
+    # ------------------------------------------------------------------
+    # Compound forms
+    # ------------------------------------------------------------------
+
+    def _compile_if(self, expr: If, ctx: _FnCtx) -> IrRegister:
+        """``if`` lowers to ``BRANCH_Z`` + ``JUMP`` over labelled blocks.
+
+        The ``then`` and ``else`` branches each produce a value;
+        we move both into the same ``result`` register so the
+        post-``if`` code can use it uniformly.
+        """
+        cond = self._compile_expr(expr.cond, ctx)
+        else_label = self._fresh_label(ctx, "else")
+        end_label = self._fresh_label(ctx, "endif")
+        result = self._fresh_holding(ctx)
+
+        self._emit(IrOp.BRANCH_Z, cond, IrLabel(else_label))
+
+        then_v = self._compile_expr(expr.then_branch, ctx)
+        self._emit_move(result, then_v)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+
+        self._emit(IrOp.LABEL, IrLabel(else_label), id=-1)
+        else_v = self._compile_expr(expr.else_branch, ctx)
+        self._emit_move(result, else_v)
+
+        self._emit(IrOp.LABEL, IrLabel(end_label), id=-1)
+        return result
+
+    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
+        """Mutually-independent (Scheme ``let``) bindings.
+
+        Each RHS is compiled in the *outer* scope.  After all RHS
+        regs are computed, we extend ``ctx.locals_`` so the body
+        sees them — and restore the prior bindings after the body
+        in case the let was nested inside something else that uses
+        the same names.
+        """
+        binding_regs: list[tuple[str, IrRegister]] = []
+        for name, rhs in expr.bindings:
+            v = self._compile_expr(rhs, ctx)
+            binding_regs.append((name, v))
+
+        saved: dict[str, IrRegister | None] = {}
+        for name, reg in binding_regs:
+            saved[name] = ctx.locals_.get(name)
+            ctx.locals_[name] = reg
+
+        last: IrRegister | None = None
+        for e in expr.body:
+            last = self._compile_expr(e, ctx)
+        assert last is not None
+
+        for name, prior in saved.items():
+            if prior is None:
+                del ctx.locals_[name]
+            else:
+                ctx.locals_[name] = prior
+
+        return last
+
+    def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
+        """Function application, dispatched at compile time:
+
+        * ``(+ a b)`` and other binary builtins → emit the
+          corresponding ``IrOp`` directly (one IR instruction).
+        * ``(f a b)`` where ``f`` is a top-level function → emit
+          the move-args-into-param-slots dance, then ``IrOp.CALL``.
+        * Anything else (locals being applied, unknown names) is
+          rejected — first-class function values come in TW02.5.
+        """
+        if not isinstance(expr.fn, VarRef):
+            raise TwigCompileError(
+                "TW02 v1 only supports direct calls of top-level names"
+            )
+        name = expr.fn.name
+
+        if name in _V1_REJECTED_BUILTINS:
+            raise TwigCompileError(
+                f"builtin {name!r} is not yet supported by the JVM "
+                "backend — see TW02.5"
+            )
+
+        # Direct binary builtin
+        if name in _BINARY_OPS:
+            if len(expr.args) != 2:
+                raise TwigCompileError(
+                    f"{name!r} expects 2 arguments in TW02 v1, got "
+                    f"{len(expr.args)}"
+                )
+            left = self._compile_expr(expr.args[0], ctx)
+            right = self._compile_expr(expr.args[1], ctx)
+            dest = self._fresh_holding(ctx)
+            self._emit(_BINARY_OPS[name], dest, left, right)
+            return dest
+
+        # Direct user-function call
+        if name in self._fn_params:
+            params = self._fn_params[name]
+            if len(expr.args) != len(params):
+                raise TwigCompileError(
+                    f"function {name!r} takes {len(params)} arguments, "
+                    f"got {len(expr.args)}"
+                )
+
+            # Step 1: evaluate every argument into its own holding
+            # register.  We must NOT eval directly into r2/r3 —
+            # nested calls (g x) would clobber f's r2 with x.
+            arg_regs: list[IrRegister] = [
+                self._compile_expr(a, ctx) for a in expr.args
+            ]
+
+            # Step 2: copy holding regs into the function's param
+            # slots (registers 2, 3, ...).
+            for i, src in enumerate(arg_regs):
+                self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+
+            # Step 3: invoke.
+            self._emit(IrOp.CALL, IrLabel(name))
+
+            # Step 4: result is in register 1.  Copy out so the
+            # caller can use it without worrying about a future
+            # call clobbering it.
+            dest = self._fresh_holding(ctx)
+            self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+            return dest
+
+        raise TwigCompileError(
+            f"unknown function {name!r}.  TW02 v1 supports only the "
+            "binary builtins +, -, *, /, =, <, > and top-level "
+            "(define (f ...) ...) functions."
+        )
+
+    # ------------------------------------------------------------------
+    # IR-emission helpers
+    # ------------------------------------------------------------------
+
+    def _emit(self, opcode: IrOp, *operands: object, id: int | None = None) -> None:
+        """Append one ``IrInstruction`` to the program.
+
+        ``id=-1`` is used for ``LABEL`` instructions (matches the
+        rest of the repo); regular instructions take a fresh ID
+        from ``_gen``.
+        """
+        self._program.add_instruction(
+            IrInstruction(
+                opcode=opcode,
+                operands=list(operands),  # type: ignore[arg-type]
+                id=self._gen.next() if id is None else id,
+            )
+        )
+
+    def _emit_move(self, dst: IrRegister, src: IrRegister) -> None:
+        """Move ``src`` into ``dst`` via ``ADD_IMM dst, src, 0``.
+
+        The IR has no dedicated MOV opcode; ``ADD_IMM`` with a
+        zero immediate is the canonical equivalent — used
+        throughout brainfuck-ir-compiler and friends.  When ``dst``
+        already equals ``src`` the move is a no-op (still emitted
+        for clarity; the optimiser cleans it up).
+        """
+        if dst == src:
+            return
+        self._emit(IrOp.ADD_IMM, dst, src, IrImmediate(0))
+
+    def _fresh_holding(self, ctx: _FnCtx) -> IrRegister:
+        idx = ctx.next_holding
+        ctx.next_holding += 1
+        return IrRegister(index=idx)
+
+    def _fresh_label(self, ctx: _FnCtx, prefix: str) -> str:
+        ctx.next_label += 1
+        return f"{prefix}_{ctx.next_label}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compile_to_ir(source: str) -> IrProgram:
+    """Compile Twig source to an unoptimised :class:`IrProgram`."""
+    ast = parse_twig(source)
+    program = extract_program(ast)
+    return _Compiler().compile(program)
+
+
+def compile_source(
+    source: str,
+    *,
+    class_name: str = "TwigProgram",
+    optimize: bool = True,
+) -> PackageResult:
+    """Run the full Twig → JVM class file pipeline."""
+    try:
+        ast = parse_twig(source)
+        twig_program = extract_program(ast)
+    except Exception as exc:
+        raise PackageError("parse", str(exc), exc) from exc
+
+    try:
+        raw_ir = _Compiler().compile(twig_program)
+    except TwigCompileError:
+        raise
+    except Exception as exc:  # pragma: no cover
+        raise PackageError("ir-emit", str(exc), exc) from exc
+
+    if optimize:
+        optimization = IrOptimizer.default_passes().optimize(raw_ir)
+        optimized_ir = optimization.program
+    else:
+        optimization = OptimizationResult(program=raw_ir)
+        optimized_ir = raw_ir
+
+    try:
+        artifact = lower_ir_to_jvm_class_file(
+            optimized_ir,
+            JvmBackendConfig(class_name=class_name, emit_main_wrapper=True),
+        )
+    except Exception as exc:
+        raise PackageError("lower-jvm", str(exc), exc) from exc
+
+    return PackageResult(
+        source=source,
+        class_name=class_name,
+        ast=twig_program,
+        raw_ir=raw_ir,
+        optimization=optimization,
+        optimized_ir=optimized_ir,
+        artifact=artifact,
+        class_bytes=artifact.class_bytes,
+    )
+
+
+def java_available() -> bool:
+    """Return ``True`` iff a working ``java`` binary is on PATH."""
+    if shutil.which("java") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["java", "-version"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def run_source(
+    source: str,
+    *,
+    class_name: str = "TwigProgram",
+    optimize: bool = True,
+    timeout_seconds: int = 30,
+) -> ExecutionResult:
+    """Compile and execute on the **real** ``java`` runtime.
+
+    Writes the class file to a fresh temp dir and invokes
+    ``java -cp <tmp> <class_name>`` as a subprocess.  Returns the
+    captured stdout / stderr / exit code so tests can assert on
+    real JVM output.
+    """
+    compilation = compile_source(
+        source, class_name=class_name, optimize=optimize
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        write_class_file(compilation.artifact, tmp)
+        proc = subprocess.run(
+            ["java", "-cp", tmp, class_name],
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    return ExecutionResult(
+        compilation=compilation,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        returncode=proc.returncode,
+    )

--- a/code/packages/python/twig-jvm-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_compile.py
@@ -1,0 +1,170 @@
+"""Compile-only tests for ``twig-jvm-compiler``.
+
+These stop at the IR stage — no JVM invocation.  End-to-end tests
+that actually run on real ``java`` live in :mod:`test_real_jvm`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from compiler_ir import IrOp
+from twig.errors import TwigCompileError
+
+from twig_jvm_compiler import compile_to_ir
+
+
+def test_integer_literal_emits_load_imm() -> None:
+    prog = compile_to_ir("42")
+    assert IrOp.LOAD_IMM in [i.opcode for i in prog.instructions]
+    assert IrOp.HALT in [i.opcode for i in prog.instructions]
+
+
+def test_addition_emits_add() -> None:
+    prog = compile_to_ir("(+ 1 2)")
+    assert IrOp.ADD in [i.opcode for i in prog.instructions]
+
+
+def test_subtraction_emits_sub() -> None:
+    assert IrOp.SUB in [i.opcode for i in compile_to_ir("(- 10 3)").instructions]
+
+
+def test_multiplication_emits_mul() -> None:
+    assert IrOp.MUL in [i.opcode for i in compile_to_ir("(* 3 4)").instructions]
+
+
+def test_division_emits_div() -> None:
+    assert IrOp.DIV in [i.opcode for i in compile_to_ir("(/ 20 4)").instructions]
+
+
+def test_eq_lt_gt_emit_cmp() -> None:
+    p = compile_to_ir("(= 1 1)")
+    assert IrOp.CMP_EQ in [i.opcode for i in p.instructions]
+    p = compile_to_ir("(< 1 2)")
+    assert IrOp.CMP_LT in [i.opcode for i in p.instructions]
+    p = compile_to_ir("(> 2 1)")
+    assert IrOp.CMP_GT in [i.opcode for i in p.instructions]
+
+
+def test_if_emits_branch_and_jump() -> None:
+    prog = compile_to_ir("(if (= 1 1) 100 200)")
+    ops = [i.opcode for i in prog.instructions]
+    assert IrOp.BRANCH_Z in ops
+    assert IrOp.JUMP in ops
+    assert IrOp.LABEL in ops
+
+
+def test_let_compiles() -> None:
+    prog = compile_to_ir("(let ((x 5)) (* x x))")
+    assert IrOp.MUL in [i.opcode for i in prog.instructions]
+
+
+def test_begin_compiles() -> None:
+    prog = compile_to_ir("(begin 1 2 3)")
+    assert IrOp.HALT in [i.opcode for i in prog.instructions]
+
+
+def test_top_level_value_define_inlined() -> None:
+    """``(define x 42)`` folds to the literal at every reference."""
+    prog = compile_to_ir("(define x 42) (+ x x)")
+    # No globals machinery — both x references should appear as
+    # LOAD_IMM 42 in the program.
+    load_imms = [
+        instr
+        for instr in prog.instructions
+        if instr.opcode == IrOp.LOAD_IMM
+    ]
+    forty_two_loads = [
+        i for i in load_imms
+        if any(getattr(o, "value", None) == 42 for o in i.operands)
+    ]
+    assert len(forty_two_loads) >= 2
+
+
+def test_top_level_function_define_emits_callable_region() -> None:
+    """``(define (f x) ...)`` emits a labelled IR region."""
+    prog = compile_to_ir("(define (square x) (* x x)) (square 3)")
+    labels = [
+        instr.operands[0].name  # type: ignore[attr-defined]
+        for instr in prog.instructions
+        if instr.opcode == IrOp.LABEL
+    ]
+    assert "square" in labels
+    assert "_start" in labels
+
+
+def test_function_call_emits_call_op() -> None:
+    prog = compile_to_ir("(define (f x) x) (f 7)")
+    assert IrOp.CALL in [i.opcode for i in prog.instructions]
+
+
+def test_recursion_compiles() -> None:
+    """``fact`` references itself — compile shouldn't fail on
+    forward reference because we pre-collect function names."""
+    prog = compile_to_ir(
+        "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) (fact 4)"
+    )
+    assert IrOp.CALL in [i.opcode for i in prog.instructions]
+    # The recursive call inside fact's body references "fact"
+    # before fact's region is fully emitted — this works because
+    # we pre-scan all top-level defines first.
+
+
+def test_mutual_recursion_compiles() -> None:
+    src = """
+    (define (even? n) (if (= n 0) 1 (odd? (- n 1))))
+    (define (odd? n) (if (= n 0) 0 (even? (- n 1))))
+    (even? 4)
+    """
+    prog = compile_to_ir(src)
+    assert IrOp.CALL in [i.opcode for i in prog.instructions]
+
+
+# ---------------------------------------------------------------------------
+# Rejections
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="lambda"):
+        compile_to_ir("(lambda (x) x)")
+
+
+def test_cons_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="cons"):
+        compile_to_ir("(cons 1 2)")
+
+
+def test_print_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="print"):
+        compile_to_ir("(print 1)")
+
+
+def test_nil_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="nil"):
+        compile_to_ir("nil")
+
+
+def test_quoted_symbol_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="symbols"):
+        compile_to_ir("'foo")
+
+
+def test_unbound_name_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="unbound"):
+        compile_to_ir("undefined")
+
+
+def test_non_literal_value_define_rejected() -> None:
+    """``(define x (+ 1 2))`` is out of scope until TW02.5."""
+    with pytest.raises(TwigCompileError, match="literal RHS"):
+        compile_to_ir("(define x (+ 1 2))")
+
+
+def test_wrong_arity_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="2 arguments"):
+        compile_to_ir("(+ 1 2 3)")
+
+
+def test_function_arity_mismatch_rejected() -> None:
+    with pytest.raises(TwigCompileError, match="takes 1 arguments"):
+        compile_to_ir("(define (f x) x) (f 1 2)")

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -86,32 +86,15 @@ def test_function_with_two_params() -> None:
     assert result.stdout == bytes([33])
 
 
-@requires_java
-@pytest.mark.xfail(
-    reason=(
-        "Recursion is broken under the current ir-to-jvm-class-file "
-        "calling convention.  That backend stores all 'registers' in "
-        "a class-level static int array shared across every method "
-        "invocation — so when fact(5) calls fact(4), fact(5)'s own "
-        "parameter register r2 gets overwritten with 4, and the "
-        "outer multiplication uses 4 instead of 5.  The fix lives in "
-        "ir-to-jvm-class-file (use real per-method JVM locals instead "
-        "of a static array), which is a separate infrastructure PR.  "
-        "Tracked alongside CLR01 as the 'real-runtime correctness' "
-        "track.  When that lands, this xfail reverts to a passing test."
-    ),
-    strict=True,
-)
-def test_recursion_factorial_small() -> None:
-    """Documented xfail: recursion under the static-register-array
-    convention is broken.  See marker reason for the gap and fix."""
-    src = """
-        (define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))
-        (fact 5)
-    """
-    result = run_source(src, class_name="TwigFact")
-    assert result.returncode == 0, result.stderr
-    assert result.stdout == bytes([120])
+# NOTE: Recursion (e.g. ``(define (fact n) ... (fact (- n 1)))``) is
+# tracked as a known gap in JVM01 — the current
+# ``ir-to-jvm-class-file`` stores all "registers" in a class-level
+# static int array shared across every method invocation, so a
+# recursive call clobbers the caller's parameter values.  No xfail
+# marker here on purpose — the fix is a tracked, numbered spec
+# (``code/specs/JVM01-jvm-per-method-locals.md``) at the same
+# prominence as CLR01, so it can't get lost.  When JVM01 lands, a
+# recursion test goes here.
 
 
 @requires_java

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -1,0 +1,138 @@
+"""End-to-end tests for ``twig-jvm-compiler`` running on real ``java``.
+
+These tests:
+
+1. Compile Twig source to a real JVM ``.class`` file via the
+   in-house ``ir-to-jvm-class-file`` pipeline.
+2. Write the file to a fresh temp dir.
+3. Invoke ``java -cp <tmp> <ClassName>`` as a subprocess.
+4. Assert on the captured stdout bytes.
+
+The tests skip cleanly when ``java`` isn't on PATH — same pattern
+the existing ``test_oct_8bit_e2e.py`` uses for Oct-on-JVM tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from twig_jvm_compiler import java_available, run_source
+
+requires_java = pytest.mark.skipif(
+    not java_available(),
+    reason="'java' binary not found on PATH",
+)
+
+
+@requires_java
+def test_arithmetic_addition() -> None:
+    """``(+ 1 2)`` writes byte 3 to stdout."""
+    result = run_source("(+ 1 2)", class_name="TwigAdd")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([3])
+
+
+@requires_java
+def test_arithmetic_subtraction() -> None:
+    result = run_source("(- 10 3)", class_name="TwigSub")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([7])
+
+
+@requires_java
+def test_arithmetic_multiplication() -> None:
+    result = run_source("(* 6 7)", class_name="TwigMul")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([42])
+
+
+@requires_java
+def test_let_binding() -> None:
+    result = run_source("(let ((x 5)) (* x x))", class_name="TwigLet")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([25])
+
+
+@requires_java
+def test_if_taken() -> None:
+    result = run_source("(if (= 1 1) 100 200)", class_name="TwigIfT")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([100])
+
+
+@requires_java
+def test_if_not_taken() -> None:
+    result = run_source("(if (= 1 2) 100 200)", class_name="TwigIfF")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([200])
+
+
+@requires_java
+def test_top_level_function_call() -> None:
+    """``(define (square x) (* x x)) (square 7)`` writes byte 49."""
+    src = "(define (square x) (* x x)) (square 7)"
+    result = run_source(src, class_name="TwigSquare")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([49])
+
+
+@requires_java
+def test_function_with_two_params() -> None:
+    """Verifies the param-slot calling convention for arity > 1."""
+    src = "(define (add3 a b) (+ a (+ b 3))) (add3 10 20)"
+    result = run_source(src, class_name="TwigAdd3")
+    assert result.returncode == 0, result.stderr
+    # 10 + 20 + 3 = 33
+    assert result.stdout == bytes([33])
+
+
+@requires_java
+@pytest.mark.xfail(
+    reason=(
+        "Recursion is broken under the current ir-to-jvm-class-file "
+        "calling convention.  That backend stores all 'registers' in "
+        "a class-level static int array shared across every method "
+        "invocation — so when fact(5) calls fact(4), fact(5)'s own "
+        "parameter register r2 gets overwritten with 4, and the "
+        "outer multiplication uses 4 instead of 5.  The fix lives in "
+        "ir-to-jvm-class-file (use real per-method JVM locals instead "
+        "of a static array), which is a separate infrastructure PR.  "
+        "Tracked alongside CLR01 as the 'real-runtime correctness' "
+        "track.  When that lands, this xfail reverts to a passing test."
+    ),
+    strict=True,
+)
+def test_recursion_factorial_small() -> None:
+    """Documented xfail: recursion under the static-register-array
+    convention is broken.  See marker reason for the gap and fix."""
+    src = """
+        (define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))
+        (fact 5)
+    """
+    result = run_source(src, class_name="TwigFact")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([120])
+
+
+@requires_java
+def test_top_level_value_define_inlined() -> None:
+    """``(define x 42)`` value-defines fold to compile-time constants."""
+    src = "(define x 42) x"
+    result = run_source(src, class_name="TwigVal")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([42])
+
+
+@requires_java
+def test_nested_function_calls() -> None:
+    """``(f (g x))`` — the holding-register convention must
+    survive a nested call without clobbering arg slots."""
+    src = """
+        (define (inc x) (+ x 1))
+        (define (dbl x) (* x 2))
+        (inc (dbl 5))
+    """
+    result = run_source(src, class_name="TwigNested")
+    assert result.returncode == 0, result.stderr
+    # dbl(5) = 10, inc(10) = 11
+    assert result.stdout == bytes([11])

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -86,15 +86,28 @@ def test_function_with_two_params() -> None:
     assert result.stdout == bytes([33])
 
 
-# NOTE: Recursion (e.g. ``(define (fact n) ... (fact (- n 1)))``) is
-# tracked as a known gap in JVM01 — the current
-# ``ir-to-jvm-class-file`` stores all "registers" in a class-level
-# static int array shared across every method invocation, so a
-# recursive call clobbers the caller's parameter values.  No xfail
-# marker here on purpose — the fix is a tracked, numbered spec
-# (``code/specs/JVM01-jvm-per-method-locals.md``) at the same
-# prominence as CLR01, so it can't get lost.  When JVM01 lands, a
-# recursion test goes here.
+@requires_java
+def test_recursion_factorial() -> None:
+    """Recursive ``fact`` — the JVM01 fix preserves param values
+    across a recursive call.  Two cooperating mechanisms:
+
+    1. ``ir-to-jvm-class-file`` snapshots the static register array
+       to JVM locals around every CALL and restores after (skipping
+       r1, the return-value slot).
+    2. ``twig-jvm-compiler`` copies each param out of its arrival
+       slot into a body-local holding register at function entry,
+       so call-site arg marshalling never clobbers the live param.
+
+    ``5! = 120`` and 120 = 0x78 = ``b'x'``.
+    """
+    src = """
+        (define (fact n)
+          (if (= n 0) 1 (* n (fact (- n 1)))))
+        (fact 5)
+    """
+    result = run_source(src, class_name="TwigFact")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([120])
 
 
 @requires_java

--- a/code/specs/JVM01-jvm-per-method-locals.md
+++ b/code/specs/JVM01-jvm-per-method-locals.md
@@ -1,5 +1,40 @@
 # JVM01 — Per-method JVM locals for `ir-to-jvm-class-file`
 
+> **Status (2026-04-28):** Landed via the *minimal-diff* path
+> described in "Implementation as landed" below.  The bigger
+> per-method-locals refactor in the original plan is no longer
+> required — keeping the spec for context, with a note on what
+> was actually shipped.
+
+## Implementation as landed
+
+Two cooperating changes made recursion correct on real `java`
+without rewriting every callable's descriptor:
+
+1. **Caller-saves at the JVM backend** —
+   `ir-to-jvm-class-file/backend.py` now snapshots every register
+   slot of the static `__ca_regs` array into JVM locals
+   immediately before each `IrOp.CALL`, then restores them
+   immediately after (skipping `r1`, the return-value slot).  This
+   gives every CALL the *effect* of per-method locals without
+   changing method descriptors or the helper-array contract.
+   Each callable's `max_locals` is bumped to `reg_count`.
+2. **Compiler-side param copy** — `twig-jvm-compiler/compiler.py`
+   `_emit_function` now copies each parameter out of its arrival
+   register (`r2`, `r3`, …) into a fresh body-local holding
+   register at function entry.  Without this, the body's read of
+   `n` happens against the same register the upcoming call's
+   arg-marshalling overwrites — the caller-save then snapshots
+   the *already-clobbered* value, defeating the fix.
+
+Regression tests:
+- `ir-to-jvm-class-file/tests/test_oct_8bit_e2e.py::test_call_preserves_caller_registers`
+- `twig-jvm-compiler/tests/test_real_jvm.py::test_recursion_factorial`
+
+The full per-method-locals refactor below is preserved as the
+"clean" target if we ever want to retire the static `__ca_regs`
+array entirely.
+
 ## Why this spec exists
 
 `ir-to-jvm-class-file` produces real-`java`-compatible class files,

--- a/code/specs/JVM01-jvm-per-method-locals.md
+++ b/code/specs/JVM01-jvm-per-method-locals.md
@@ -1,0 +1,179 @@
+# JVM01 — Per-method JVM locals for `ir-to-jvm-class-file`
+
+## Why this spec exists
+
+`ir-to-jvm-class-file` produces real-`java`-compatible class files,
+unlike the CLR equivalent (which has its own conformance gap, see
+CLR01).  But it has a **calling-convention bug** that breaks
+recursion: every "IR register" is stored in a class-level
+``__ca_regs`` static int array shared across every method
+invocation.
+
+Concrete failure: `(define (fact n) (if (= n 0) 1 (* n (fact (- n
+1))))) (fact 5)` should output byte 120, but outputs 0.  When
+`fact(5)` calls `fact(4)`, `fact(5)`'s own parameter register r2
+(holding 5) gets overwritten with 4 by the call setup.  After
+`fact(4)` returns, the outer multiplication reads r2 as 4 and
+short-circuits the result chain.
+
+The CLR backend doesn't have this problem because each invokestatic
+takes parameters via the JVM operand stack, so each method gets a
+fresh local frame.  JVM01 brings the JVM backend up to the same
+model.
+
+## Sister track
+
+This spec is the JVM-side companion to CLR01:
+
+| Spec   | Backend | Gap                                                 |
+|--------|---------|-----------------------------------------------------|
+| CLR01  | CLR     | `cli-assembly-writer` lacks ECMA-335 essentials     |
+| JVM01  | JVM     | `ir-to-jvm-class-file` uses class-level static reg  |
+|        |         | array → recursion is broken                         |
+
+Both track to the same outcome — real-runtime correctness for
+languages compiled through the in-house IR pipeline.
+
+## Detailed plan
+
+### What changes
+
+The JVM backend currently emits each callable method with descriptor
+``()I`` (no args, returns int) and uses two helper static methods —
+`__ca_regGet(int) -> int` and `__ca_regSet(int, int) -> void` —
+that read and write a class-level static int array.  Caller and
+callee communicate by writing to specific shared register indices
+before/after the call.
+
+**The fix:**
+
+1. Each callable method's descriptor becomes ``(I*N)I`` where N
+   is the program-wide maximum register count.  N is already
+   computed as `reg_count` at backend-entry time.
+2. Method body: every `_emit_reg_get(idx)` call becomes an `iload
+   idx` (raw JVM instruction).  Every `_emit_reg_set(idx, value)`
+   pattern becomes "value-on-stack + `istore idx`".
+3. CALL emission: caller pushes `iload 0`, `iload 1`, …, `iload
+   N-1` onto the JVM operand stack, invokestatic with the new
+   descriptor, then `istore 1` to land the return value into local
+   1 (preserving the existing "register 1 == HALT result"
+   convention).
+4. Main wrapper: pushes `N` zeros (`iconst_0` × N) before
+   invokestatic on `_start`.
+5. The static `__ca_regs` field and the `__ca_regGet` / `__ca_regSet`
+   helper methods become unused.  We can either remove them
+   (cleaner) or leave them in place as dead code (smaller diff).
+   Remove.
+
+### Why this works
+
+JVM method frames are per-invocation: each invokestatic creates a
+fresh local-variable array on the JVM call stack.  So when
+`fact(5)` calls `fact(4)`, `fact(4)`'s locals are independent of
+`fact(5)`'s.  After `fact(4)` returns, `fact(5)`'s locals (including
+its r2 = 5) are intact.
+
+Parameter passing becomes "values on the JVM operand stack at the
+invokestatic site" — exactly what the JVM was designed for.
+
+### Sites that change in `backend.py`
+
+| Site                              | Today                       | After |
+|-----------------------------------|-----------------------------|-------|
+| Callable method descriptor        | `_DESC_NOARGS_INT` (`()I`)  | `(I*N)I` |
+| `_emit_reg_get(builder, idx)`     | invokestatic helper         | `iload idx` |
+| `_emit_reg_set(builder, idx, v)`  | invokestatic helper         | `bipush v; istore idx` |
+| Compute-then-store patterns       | push idx, value, invokestatic helper | `value-on-stack; istore idx` |
+| `IrOp.CALL` emission              | invokestatic ()I; helper_set 1 | iload 0..N-1; invokestatic (I*N)I; istore 1 |
+| `_build_main_method`              | invokestatic _start ()I; pop; return | iconst_0 × N; invokestatic _start (I*N)I; pop; return |
+| `_helper_reg_get` / `_helper_reg_set` | full method bodies      | remove |
+| `__ca_regs` field                 | int[] static                | remove |
+| `_build_class_initializer`        | allocates `__ca_regs`       | drop the alloc; keep memory init |
+
+The compute-then-store patterns are the bulk of the work.  There
+are 44 occurrences in `backend.py`.  Each follows a pattern roughly
+like:
+
+```python
+self._emit_push_int(builder, dst.index)         # push dst index
+self._emit_reg_get(builder, lhs.index)          # push lhs value
+self._emit_reg_get(builder, rhs.index)          # push rhs value
+builder.emit_opcode(_OP_IADD)                   # compute on stack
+builder.emit_u2_instruction(                    # invoke helper_set
+    _OP_INVOKESTATIC,
+    self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
+)
+```
+
+Translates to:
+
+```python
+self._emit_iload(builder, lhs.index)            # iload lhs
+self._emit_iload(builder, rhs.index)            # iload rhs
+builder.emit_opcode(_OP_IADD)                   # compute on stack
+self._emit_istore(builder, dst.index)           # istore dst
+```
+
+A helper `_emit_compute_into(builder, dst, op_emitter)` could
+collapse the pattern, but isn't required.
+
+### Max-locals / max-stack
+
+After this change, every callable method has `max_locals = N` (the
+program-wide register count, also the parameter count).
+`max_stack` is dictated by the deepest expression — the existing
+computation should keep working since the JVM-stack effects of
+`iload`/`istore` match the helper-method effects (push int / pop
+int).
+
+The class file's CodeAttribute for each method needs the descriptor
+update reflected in its `local_variable_table` if one is emitted
+(today probably not — verify when implementing).
+
+### Test plan
+
+- Existing `test_oct_8bit_e2e.py` tests must keep passing — they
+  cover non-recursive arithmetic + I/O programs, and the new model
+  doesn't change semantics for those.
+- New test in `ir-to-jvm-class-file/tests/`:
+  - `test_recursion.py::test_simple_recursion` — a hand-built IR
+    program that recursively halves an input and verifies the
+    output matches.
+- New test in `twig-jvm-compiler/tests/test_real_jvm.py`:
+  - Re-add `test_recursion_factorial_small` — `(fact 5) == 120`.
+  - Add `test_mutual_recursion_even_odd` — `(even? 4) == 1`.
+
+When JVM01 lands, those tests pass without any change to
+`twig-jvm-compiler` (it produces the same IR; only the backend's
+emission of that IR changes).
+
+## Out of scope for JVM01
+
+- **Closures.**  TW02.5 will add lambda support to twig — that's
+  separate language-frontend work.  JVM01 only fixes the calling
+  convention so closures CAN work later.
+- **Tail-call optimisation.**  JVM has no proper TCO.  Programs
+  that need deep recursion will still blow the JVM stack.  TCO via
+  trampolining or `recur`-style explicit-loop is a TW02.5 / TW03
+  language-level decision, not a JVM backend issue.
+- **Generics, exceptions, virtual dispatch.**  Not needed for the
+  current language frontends.
+
+## Risk register
+
+- **Method-body verification.**  Real `java` runs class-file
+  verification at load time — bytecode that worked under the
+  static-helper model may need different `max_stack` /
+  `max_locals` claims after the rewrite.  Mitigation: run all
+  existing JVM tests after each chunk; verifier errors will be
+  specific and pointable.
+- **Unintentional behavioural change.**  Switching to per-method
+  locals means cross-method state via the static array is gone.
+  If any test or user-program relies on writing to a register in
+  one method and reading it in another (via direct `_helper_reg_get`
+  call, not through CALL), that breaks.  Mitigation: grep the
+  repo for direct calls to `__ca_regGet` / `__ca_regSet` from
+  outside the backend.
+- **Class file size.**  Heavier method descriptors mean slightly
+  larger constant-pool entries.  Negligible — N is small (currently
+  bounded by the IR's `_max_register_index() + 1`).

--- a/code/specs/TW02-twig-jvm-compiler.md
+++ b/code/specs/TW02-twig-jvm-compiler.md
@@ -1,0 +1,140 @@
+# TW02 — Twig → JVM (real `java` target)
+
+## Overview
+
+This is the **first non-Python target for Twig** to ship.  Twig
+source compiles, via the in-house ``compiler-ir`` +
+``ir-to-jvm-class-file`` chain, to a real JVM class file that
+executes on the actual ``java`` runtime — not just a simulator.
+The repo's JVM stack already produces real-runtime-conformant
+class files (``test_oct_8bit_e2e.py`` invokes
+``subprocess.run(["java", ...])`` and asserts on real JVM output),
+which is why JVM lands ahead of CLR in the roadmap: CLR needs
+``cli-assembly-writer`` conformance work first (see ``CLR01-
+real-dotnet-conformance.md``).
+
+## Roadmap reorder
+
+| Spec  | Target  | Status                                              |
+|-------|---------|-----------------------------------------------------|
+| TW00  | vm-core | Merged                                              |
+| TW02  | **JVM** | **This spec — runs on real ``java``**               |
+| TW03  | CLR     | Blocked on CLR01 (cli-assembly-writer conformance)  |
+| TW04  | BEAM    | After TW03; direct .beam bytes (no Erlang source)   |
+| TW05  | WASM    | Updates to wasm-runtime + Twig WASM target          |
+
+## What runs in TW02 v1
+
+**Functions are in.**  A functional language without functions is
+just a calculator — earlier scoping that excluded them was wrong.
+
+### Surface
+- Integer literals; booleans (``#t``/``#f``)
+- Arithmetic: ``+``, ``-``, ``*``, ``/``
+- Comparison: ``=``, ``<``, ``>``
+- Control flow: ``if``, ``let``, ``begin``
+- Top-level value defines with **literal RHS**:
+  ``(define x 42)`` — accumulates into the synthesised initialiser
+- **Top-level function defines:**
+  ``(define (f x y) body)`` — emit one JVM static method per
+  function; recursion works because methods reach each other via
+  ``invokestatic``
+- Function application of a top-level name:
+  ``(f a b)`` — direct call, args pre-loaded into the
+  shared-register convention the IR backend expects
+- Builtin application: ``(+ a b)`` etc. — emit the corresponding
+  ``IrOp``
+
+### Output convention
+The program's *final* top-level expression's value (or the value
+of the last ``begin``) is written as a single byte to
+``System.out`` via ``SYSCALL 1`` (the JVM backend's stdout-write
+helper).  Tests assert on the captured stdout bytes — the same
+convention ``test_oct_8bit_e2e.py`` already uses.
+
+This is a v1 simplification — multi-byte / multi-line output and a
+proper ``print`` builtin land in TW02.5.
+
+### NOT in TW02 v1
+- **`lambda`** — closures need synthetic JVM classes per lambda;
+  TW02.5 once the function calling convention is settled.
+- **`cons` / `car` / `cdr` / symbols / `nil`** — heap objects.
+  TW03 territory once we know how the runtime classes look.
+- **`print`** as a multi-arg / formatting builtin.
+- **Tail-call optimisation.**  JVM has no proper TCO; the v1
+  approach is plain recursion bounded by the JVM stack.
+
+## Architecture
+
+```
+Twig source
+   ↓  parse_twig + extract_program          (twig package)
+typed AST
+   ↓  twig_jvm_compiler.compile_to_ir       (this package)
+IrProgram
+   ↓  ir-optimizer (default passes)
+IrProgram (optimised)
+   ↓  lower_ir_to_jvm_class_file            (existing)
+JVMClassArtifact
+   ↓  write_class_file                      (existing)
+.class file on disk
+   ↓  java -cp <dir> <ClassName>            (real runtime)
+program output
+```
+
+## Calling convention
+
+The JVM backend emits one ``invokestatic`` per ``IrOp.CALL`` with
+descriptor ``()I`` — **no arguments, returns int**.  Caller and
+callee share a class-level register array (the runtime's
+``_helper_reg_get`` / ``_helper_reg_set`` machinery), so parameter
+passing happens by writing args into specific shared registers
+before the call.
+
+For Twig:
+
+- Parameter ``i`` of every function lives at register ``2 + i``.
+  (``0`` is scratch zero, ``1`` is the HALT-result convention.)
+- Caller for ``(f a b)``:
+  1. Evaluate ``a`` into a fresh holding register (``≥10``)
+  2. Evaluate ``b`` into another fresh holding register
+  3. ``ADD_IMM r2, holding_a, 0`` (move into param-0 slot)
+  4. ``ADD_IMM r3, holding_b, 0`` (move into param-1 slot)
+  5. ``CALL f``
+  6. Result is in register 1; copy to a fresh register if the
+     calling expression continues
+- Callee for ``f``: parameter ``x`` resolves to register 2,
+  ``y`` to register 3, etc.  Body computes its result; final
+  ``RET`` (or the synthesised ``HALT`` for ``_start``) loads
+  register 1 and returns.
+
+The two-step "into holding register, then into param slot"
+pattern is what makes nested calls work — without it,
+``(f (g x) y)`` would have ``g``'s arg setup clobber ``f``'s
+arg-0 slot.
+
+## Tests
+
+- **Compile-only:** golden IR shapes for each surface form;
+  rejection paths (lambda, cons, …).
+- **Real-JVM end-to-end** (gated behind ``_java_available()``,
+  same pattern as ``test_oct_8bit_e2e.py``):
+  - Pure arithmetic: ``(+ 1 2)`` writes byte 3.
+  - Function call: ``(define (square x) (* x x)) (square 7)``
+    writes byte 49.
+  - Recursion: ``(define (sum n) (if (= n 0) 0 (+ n (sum (- n 1))))) (sum 10)``
+    writes byte 55.
+  - Conditional: ``(if (= 1 1) 100 200)`` writes byte 100.
+  - ``let``: ``(let ((x 5)) (* x x))`` writes byte 25.
+- Coverage target: ≥ 80%.
+
+## Out of scope (TW02.5 / future)
+
+- ``lambda`` and closures (synthetic JVM classes per lambda).
+- ``cons`` / ``car`` / ``cdr`` / symbols / ``nil`` (heap objects
+  via runtime support classes).
+- ``print`` as a multi-arg / formatting builtin (writing strings,
+  not just bytes).
+- Tail-call optimisation.
+- Negative byte ranges via two's-complement / explicit signed
+  output handling.


### PR DESCRIPTION
## Summary

First non-Python target for Twig.  Source compiles, via the in-house \`compiler-ir\` + \`ir-to-jvm-class-file\` chain, to a real \`.class\` file that runs on **real \`java\`** (verified on OpenJDK 25).  No simulator.

JVM is the cleanest first target because the repo's JVM stack already produces real-runtime-compatible class files — \`test_oct_8bit_e2e.py\` invokes \`subprocess.run([\"java\", ...])\` and asserts on actual JVM stdout.  CLR is blocked behind ECMA-335 conformance work in \`cli-assembly-writer\` (CLR01 spec on \`claude/cli-assembly-real-dotnet\`).

## V1 surface

- Integer literals, booleans
- Arithmetic / comparison: \`+ - * / = < >\`
- Control flow: \`if\`, \`let\`, \`begin\`
- Top-level \`(define x literal)\` — folds to compile-time constant
- **Top-level \`(define (f x y) body)\` functions** — your point about a functional language needing functions landed
- Direct function calls \`(f a b)\` (non-recursive — see "Known limitation")
- Final value written as a byte to stdout via \`SYSCALL 1\`

## Known limitation: recursion

\`ir-to-jvm-class-file\` stores every IR register in a class-level static int array shared across every method invocation.  Non-recursive calls work fine.  Recursion breaks because \`fact(5)\`'s own parameter register r2 gets overwritten by \`fact(4)\`'s call setup.

The fix is in \`ir-to-jvm-class-file\` (use real per-method JVM locals instead of a static array) — same "real-runtime correctness" track as CLR01.  The factorial test is marked \`pytest.mark.xfail(strict=True)\` so when the backend fix lands, the test starts passing and pytest flags the marker for removal.

## Test plan

- [x] 33 tests passing on real OpenJDK 25
  - 22 compile-only (IR shape + rejection paths)
  - 11 end-to-end through real \`java\` (gated on \`java_available()\`)
- [x] 1 documented xfail for the recursion gap
- [x] Coverage 88.66% (≥ 80% gate)
- [x] \`ruff check\` clean
- [x] Spec at \`code/specs/TW02-twig-jvm-compiler.md\`

End-to-end programs that work today:
\`\`\`scheme
(+ 1 2)                              ; → 3
(let ((x 5)) (* x x))                ; → 25
(if (= 1 1) 100 200)                 ; → 100
(define (square x) (* x x)) (square 7) ; → 49
(define (add3 a b) (+ a (+ b 3))) (add3 10 20) ; → 33
(define (inc x) (+ x 1)) (define (dbl x) (* x 2)) (inc (dbl 5)) ; → 11
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)