### PR TITLE
Mark EOF HTML doctypes force quirks

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -85,3 +85,5 @@ documented in this file.
   text preservation.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`
   and whitespace-only DOCTYPE names.
+- DOCTYPE declarations cut off by EOF after a name now emit the current name
+  with force-quirks mode enabled.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -32,7 +32,8 @@ open comment remain literal comment data and surface a recoverable
 `nested-comment` diagnostic. Comment endings also recover from `--!>` with an
 `incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
-inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`.
+inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
+also emits the current name in force-quirks mode.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `CDATA section`, `script_data`, `script_data_escaped`, and
 `script_data_double_escaped` entry states for parser-controlled tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4903,7 +4903,12 @@ from = "doctype_name"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_name"
@@ -4942,7 +4947,12 @@ from = "after_doctype_name"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "after_doctype_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -10411,6 +10411,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10510,6 +10511,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 40);
+    assert_eq!(html1.cases.len(), 42);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 40);
+    assert_eq!(file.tests.len(), 41);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -108,23 +108,24 @@ fn html5lib_smoke_fixture_file_parses() {
     assert!(file.tests[0].last_start_tag.is_none());
     assert_eq!(file.tests[2].initial_states, vec!["Data state".to_string()]);
     assert_eq!(file.tests[4].errors[0].code, "missing-doctype-name");
-    assert_eq!(file.tests[6].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[6].errors[0].line, 1);
-    assert_eq!(file.tests[6].errors[0].col, 9);
+    assert_eq!(file.tests[5].errors[0].code, "eof-in-doctype");
+    assert_eq!(file.tests[7].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[7].errors[0].line, 1);
+    assert_eq!(file.tests[7].errors[0].col, 9);
     assert_eq!(
-        file.tests[7].errors[0].code,
+        file.tests[8].errors[0].code,
         "abrupt-closing-of-empty-comment"
     );
     assert_eq!(
-        file.tests[9].initial_states,
+        file.tests[10].initial_states,
         vec!["RCDATA state".to_string()]
     );
-    assert_eq!(file.tests[9].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(file.tests[10].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
-        file.tests[11].initial_states,
+        file.tests[12].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[11].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[12].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -149,21 +150,20 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 40);
+    assert_eq!(normalized.cases.len(), 41);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
         vec!["missing-doctype-name".to_string()]
     );
     assert_eq!(
-        normalized.cases[7].diagnostics,
-        vec!["abrupt-closing-of-empty-comment".to_string()]
+        normalized.cases[5].diagnostics,
+        vec!["eof-in-doctype".to_string()]
     );
     assert_eq!(
-        normalized.cases[9].initial_state.as_deref(),
-        Some("RCDATA state")
+        normalized.cases[8].diagnostics,
+        vec!["abrupt-closing-of-empty-comment".to_string()]
     );
-    assert_eq!(normalized.cases[9].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
         normalized.cases[10].initial_state.as_deref(),
         Some("RCDATA state")
@@ -174,10 +174,18 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     );
     assert_eq!(
         normalized.cases[11].initial_state.as_deref(),
-        Some("RAWTEXT state")
+        Some("RCDATA state")
     );
     assert_eq!(
         normalized.cases[11].last_start_tag.as_deref(),
+        Some("title")
+    );
+    assert_eq!(
+        normalized.cases[12].initial_state.as_deref(),
+        Some("RAWTEXT state")
+    );
+    assert_eq!(
+        normalized.cases[12].last_start_tag.as_deref(),
         Some("style")
     );
 }
@@ -221,7 +229,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 40);
+    assert_eq!(suite.cases.len(), 41);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -67,6 +67,30 @@
       ]
     },
     {
+      "id": "doctype-name-eof-quirks",
+      "description": "DOCTYPE name cut off by EOF emits the current name and marks force-quirks",
+      "input": "<!DOCTYPE html",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-doctype"
+      ]
+    },
+    {
+      "id": "doctype-after-name-eof-quirks",
+      "description": "DOCTYPE after-name state cut off by EOF marks force-quirks",
+      "input": "<!DOCTYPE html ",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-doctype"
+      ]
+    },
+    {
       "id": "comment-eof-recovery",
       "input": "<!--open",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -79,6 +79,18 @@
     },
     {
       "id": "html5lib-smoke-6",
+      "description": "doctype name eof force quirks",
+      "input": "<!DOCTYPE html",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-doctype"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-7",
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "tokens": [
@@ -88,7 +100,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-7",
+      "id": "html5lib-smoke-8",
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "tokens": [
@@ -100,7 +112,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-8",
+      "id": "html5lib-smoke-9",
       "description": "abrupt empty comment close",
       "input": "Before<!-->After",
       "tokens": [
@@ -114,7 +126,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-9",
+      "id": "html5lib-smoke-10",
       "description": "dash prefixed empty comment close",
       "input": "Before<!--->After",
       "tokens": [
@@ -126,7 +138,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-10",
+      "id": "html5lib-smoke-11",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -139,7 +151,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-12",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -151,7 +163,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-13",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -164,7 +176,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-14",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -175,7 +187,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-15",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -188,7 +200,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-16",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -201,7 +213,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-17",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -211,7 +223,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-18",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -221,7 +233,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-19",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -233,7 +245,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-20",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -243,7 +255,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-21",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -253,7 +265,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-22",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -266,7 +278,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-23",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -276,7 +288,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-24",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -286,7 +298,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-25",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -299,7 +311,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -313,7 +325,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -327,7 +339,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -344,7 +356,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -354,7 +366,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -364,7 +376,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -374,7 +386,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -384,7 +396,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -396,7 +408,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -409,7 +421,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -422,7 +434,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -437,7 +449,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -450,7 +462,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -464,7 +476,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -477,7 +489,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -491,7 +503,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -49,6 +49,16 @@
       ]
     },
     {
+      "description": "doctype name eof force quirks",
+      "input": "<!DOCTYPE html",
+      "output": [
+        ["DOCTYPE", "html", null, null, false]
+      ],
+      "errors": [
+        {"code": "eof-in-doctype", "line": 1, "col": 15}
+      ]
+    },
+    {
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -105,6 +105,45 @@ fn default_html_lexer_marks_whitespace_only_doctype_force_quirks() {
 }
 
 #[test]
+fn default_html_lexer_marks_doctype_name_eof_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!DOCTYPE html").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-doctype"));
+}
+
+#[test]
+fn default_html_lexer_marks_after_doctype_name_eof_force_quirks() {
+    let tokens = lex_html("<!DOCTYPE html ").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Mark force-quirks mode when EOF cuts off the DOCTYPE name or after-name states.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for `<!DOCTYPE html` and `<!DOCTYPE html ` recovery.
- Regenerate static Rust source and normalized fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt -p coding-adventures-html-lexer -p state-machine-tokenizer -p state-machine-markup-deserializer -p state-machine-source-compiler`
- `cargo test -p coding-adventures-html-lexer --test html_lexer_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test conformance_test -- --nocapture`
- `cargo test -p coding-adventures-html-lexer --test html1_authoring_test -- --nocapture`
- `cargo test -p state-machine-markup-deserializer --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test -p state-machine-source-compiler --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check -p coding-adventures-html-lexer --tests`
- `cargo check -p state-machine-tokenizer --tests`
- `git diff --check`