### PR TITLE
feat(prolog): add succ and integer builtin bridge

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - `betweeno(low, high, value)` for finite inclusive integer generation and
   validation, matching the common Prolog `between/3` use case.
+- `integero(term)` for non-bool integer type checks and `succo(predecessor,
+  successor)` for non-negative integer successor generation and validation.
 
 ### Fixed
 

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -20,7 +20,8 @@ ordinary logic goal expressions.
 - `forallo(generator, test)`
 - `groundo(term)`
 - `varo(term)` and `nonvaro(term)`
-- `atomo(term)`, `numbero(term)`, `stringo(term)`, and `compoundo(term)`
+- `atomo(term)`, `integero(term)`, `numbero(term)`, `stringo(term)`, and
+  `compoundo(term)`
 - `atomico(term)` and `callableo(term)`
 - `functoro(term, name, arity)` for inspection and construction
 - `argo(index, term, value)`
@@ -45,6 +46,7 @@ ordinary logic goal expressions.
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
 - `betweeno(low, high, value)` for finite inclusive integer generation
+- `succo(predecessor, successor)` for non-negative integer successor relations
 - `findallo(template, goal, results)`, `bagofo(template, goal, results)`, and `setofo(template, goal, results)`
 
 ## Quick Start
@@ -74,12 +76,14 @@ from logic_builtins import (
     geqo,
     groundo,
     ifthenelseo,
+    integero,
     iso,
     labelingo,
     noto,
     onceo,
     predicate_propertyo,
     same_termo,
+    succo,
     termo_lto,
     univo,
 )
@@ -117,6 +121,8 @@ family = program(rule(child(X, Name), parent(Name, X)))
 
 assert solve_all(program(), X, onceo(eq(X, "first"))) == [atom("first")]
 assert solve_all(program(), X, betweeno(1, 3, X)) == [num(1), num(2), num(3)]
+assert solve_all(program(), X, succo(2, X)) == [num(3)]
+assert solve_all(program(), X, conj(eq(X, 3), integero(X))) == [num(3)]
 assert solve_all(
     program(),
     X,

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.14.0"
-description = "Prolog-inspired integer generators, finite-domain constraints, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
+version = "0.15.0"
+description = "Prolog-inspired integer generators, successor relations, finite-domain constraints, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -49,6 +49,7 @@ from logic_builtins.builtins import (
     gto,
     ifthenelseo,
     iftheno,
+    integero,
     iso,
     labelingo,
     leqo,
@@ -69,6 +70,7 @@ from logic_builtins.builtins import (
     setofo,
     stringo,
     sub,
+    succo,
     termo_geqo,
     termo_gto,
     termo_leqo,
@@ -124,6 +126,7 @@ __all__ = [
     "groundo",
     "ifthenelseo",
     "iftheno",
+    "integero",
     "iso",
     "labelingo",
     "leqo",
@@ -144,6 +147,7 @@ __all__ = [
     "setofo",
     "stringo",
     "sub",
+    "succo",
     "termo_geqo",
     "termo_gto",
     "termo_leqo",
@@ -153,4 +157,4 @@ __all__ = [
     "varo",
 ]
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -102,6 +102,7 @@ __all__ = [
     "groundo",
     "ifthenelseo",
     "iftheno",
+    "integero",
     "iso",
     "leqo",
     "labelingo",
@@ -127,6 +128,7 @@ __all__ = [
     "clauseo",
     "stringo",
     "sub",
+    "succo",
     "termo_geqo",
     "termo_gto",
     "termo_leqo",
@@ -203,6 +205,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("gto", 2),
     ("ifthenelseo", 3),
     ("iftheno", 2),
+    ("integero", 1),
     ("iso", 2),
     ("labelingo", 1),
     ("leqo", 2),
@@ -219,6 +222,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("same_termo", 2),
     ("setofo", 3),
     ("stringo", 1),
+    ("succo", 2),
     ("termo_geqo", 2),
     ("termo_gto", 2),
     ("termo_leqo", 2),
@@ -1669,6 +1673,43 @@ def betweeno(low: object, high: object, value: object) -> GoalExpr:
     return native_goal(run, low, high, value)
 
 
+def succo(predecessor: object, successor: object) -> GoalExpr:
+    """Relate a non-negative integer to its successor."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        predecessor_term, successor_term = args
+        predecessor_reified = _reified(predecessor_term, state)
+        successor_reified = _reified(successor_term, state)
+        predecessor_value = _integer_value(predecessor_reified)
+        successor_value = _integer_value(successor_reified)
+
+        if predecessor_value is not None and successor_value is not None:
+            if predecessor_value >= 0 and successor_value == predecessor_value + 1:
+                yield state
+            return
+
+        if predecessor_value is not None:
+            if predecessor_value < 0 or not isinstance(successor_reified, LogicVar):
+                return
+            yield from solve_from(
+                program_value,
+                eq(successor_term, num(predecessor_value + 1)),
+                state,
+            )
+            return
+
+        if successor_value is not None:
+            if successor_value <= 0 or not isinstance(predecessor_reified, LogicVar):
+                return
+            yield from solve_from(
+                program_value,
+                eq(predecessor_term, num(successor_value - 1)),
+                state,
+            )
+
+    return native_goal(run, predecessor, successor)
+
+
 def callo(goal: object) -> GoalExpr:
     """Run a goal supplied as data.
 
@@ -1781,6 +1822,16 @@ def numbero(term_value: object) -> GoalExpr:
     """Succeed when the current value is a number."""
 
     return _type_checko(term_value, Number)
+
+
+def integero(term_value: object) -> GoalExpr:
+    """Succeed when the current value is a non-bool integer."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        (target,) = args
+        yield from _succeed_if(_reified_integer(target, state) is not None, state)
+
+    return native_goal(run, term_value)
 
 
 def stringo(term_value: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -69,6 +69,7 @@ from logic_builtins import (
     gto,
     ifthenelseo,
     iftheno,
+    integero,
     iso,
     labelingo,
     leqo,
@@ -89,6 +90,7 @@ from logic_builtins import (
     setofo,
     stringo,
     sub,
+    succo,
     termo_geqo,
     termo_gto,
     termo_leqo,
@@ -103,7 +105,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.14.0"
+        assert __version__ == "0.15.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -492,6 +494,46 @@ class TestArithmeticBuiltins:
         assert solve_all(program(), value, betweeno(5, 2, value)) == []
         assert solve_all(program(), value, betweeno(1.5, 3, value)) == []
         assert solve_all(program(), value, betweeno(1, 3, "tea")) == []
+
+    def test_integero_accepts_integer_numbers_only(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), integero(3)),
+        ) == [atom("ok")]
+        assert solve_all(program(), marker, conj(eq(marker, "ok"), integero(3.5))) == []
+        assert solve_all(program(), marker, conj(eq(marker, "ok"), integero("3"))) == []
+
+    def test_succo_validates_and_generates_successors(self) -> None:
+        value = var("Value")
+        predecessor = var("Predecessor")
+
+        assert solve_all(program(), value, succo(2, value)) == [num(3)]
+        assert solve_all(program(), predecessor, succo(predecessor, 3)) == [num(2)]
+        assert solve_all(
+            program(),
+            value,
+            conj(eq(value, "ok"), succo(2, 3)),
+        ) == [atom("ok")]
+
+    def test_succo_rejects_negative_non_integer_and_too_open_cases(self) -> None:
+        left = var("Left")
+        right = var("Right")
+        marker = var("Marker")
+
+        assert solve_all(program(), marker, conj(eq(marker, "ok"), succo(-1, 0))) == []
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), succo(1.5, 2.5)),
+        ) == []
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), succo(left, right)),
+        ) == []
 
     def test_arithmetic_goals_compose_with_relation_search(self) -> None:
         score = relation("score", 2)

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -11,6 +11,8 @@
   executable logic builtin layer
 - adapt Prolog `between/3` into the logic builtin layer for finite integer
   generation and validation
+- adapt Prolog `integer/1` and `succ/2` into the logic builtin layer for
+  integer type checks and successor relations
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
   `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1`) into the

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -12,7 +12,7 @@ It keeps parsing side-effect free, then exposes helpers to:
 - run those initialization goals explicitly against the loaded `Program`
 - adapt parsed Prolog builtin calls like `call/1`, `dynamic/1`, `assertz/1`,
   and `predicate_property/2` into runtime goals before execution
-- adapt finite integer generation with `between/3`
+- adapt finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
 - adapt `phrase/2` and `phrase/3` into executable DCG runtime calls
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports

--- a/code/packages/python/prolog-loader/pyproject.toml
+++ b/code/packages/python/prolog-loader/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
     "coding-adventures-iso-prolog-parser>=0.1.0",
-    "coding-adventures-logic-builtins>=0.14.0",
+    "coding-adventures-logic-builtins>=0.15.0",
     "coding-adventures-logic-engine>=0.10.0",
     "coding-adventures-logic-stdlib>=0.8.0",
     "coding-adventures-prolog-core>=0.1.0",
@@ -37,7 +37,7 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 
 [project.optional-dependencies]
 dev = [
-    "coding-adventures-logic-builtins>=0.14.0",
+    "coding-adventures-logic-builtins>=0.15.0",
     "coding-adventures-logic-stdlib>=0.8.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -31,6 +31,7 @@ from logic_builtins import (
     gto,
     ifthenelseo,
     iftheno,
+    integero,
     iso,
     leqo,
     lto,
@@ -46,6 +47,7 @@ from logic_builtins import (
     same_termo,
     setofo,
     stringo,
+    succo,
     termo_geqo,
     termo_gto,
     termo_leqo,
@@ -138,6 +140,7 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         "ground": groundo,
         "atom": atomo,
         "atomic": atomico,
+        "integer": integero,
         "number": numbero,
         "string": stringo,
         "compound": compoundo,
@@ -154,6 +157,7 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
 
     binary_arithmetic_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
         "is": iso,
+        "succ": succo,
         "=:=": numeqo,
         "=\\=": numneqo,
         "<": lto,

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -730,6 +730,7 @@ class TestPrologGoalAdapter:
             relation("ground", 1)(atom("x")),
             relation("atom", 1)(atom("x")),
             relation("atomic", 1)(atom("x")),
+            relation("integer", 1)(1),
             relation("number", 1)(1),
             relation("string", 1)("hello"),
             relation("compound", 1)(term("pair", atom("a"), atom("b"))),
@@ -781,6 +782,7 @@ class TestPrologGoalAdapter:
             relation("fail", 0)(),
             relation("!", 0)(),
             relation("is", 2)(LogicVar(id=10), term("+", 1, 2)),
+            relation("succ", 2)(1, LogicVar(id=29)),
             relation("=:=", 2)(term("+", 1, 2), 3),
             relation("=\\=", 2)(term("+", 1, 2), 4),
             relation("<", 2)(1, 2),
@@ -934,14 +936,18 @@ class TestPrologGoalAdapter:
 
     def test_adapt_prolog_goal_rewrites_between_generator(self) -> None:
         parsed = parse_swi_query(
-            "?- between(1, 4, Value), Value > 2.",
+            "?- between(1, 4, Value), succ(Value, Next), integer(Next), Next > 3.",
         )
 
         adapted = adapt_prolog_goal(parsed.goal)
 
-        assert solve_all(program(), parsed.variables["Value"], adapted) == [
-            num(3),
-            num(4),
+        assert solve_all(
+            program(),
+            (parsed.variables["Value"], parsed.variables["Next"]),
+            adapted,
+        ) == [
+            (num(3), num(4)),
+            (num(4), num(5)),
         ]
 
     def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -17,6 +17,8 @@
   VM path with committed condition semantics.
 - Run Prolog `between/3` through the VM path for finite integer generation and
   validation.
+- Run Prolog `integer/1` and `succ/2` through the VM path for integer type
+  checks and successor relations.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -128,7 +128,7 @@ The package includes end-to-end stress tests for:
 - linked modules and imported predicates
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
-- finite integer generation with `between/3`
+- finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -141,6 +141,8 @@ class TestPrologVMStress:
                nth0(1, Reversed, ZeroRestBased, ZeroRest),
                nth1(2, Reversed, OneRestBased, OneRest),
                length(Pair, 2),
+               succ(Count, NextCount),
+               integer(NextCount),
                Pair = [left, right].
             """,
         )
@@ -162,6 +164,7 @@ class TestPrologVMStress:
                 "ZeroRest": logic_list(["jam"]),
                 "OneRestBased": atom("tea"),
                 "OneRest": logic_list(["jam"]),
+                "NextCount": num(3),
                 "Pair": logic_list(["left", "right"]),
             },
             {
@@ -178,6 +181,7 @@ class TestPrologVMStress:
                 "ZeroRest": logic_list(["jam"]),
                 "OneRestBased": atom("cake"),
                 "OneRest": logic_list(["jam"]),
+                "NextCount": num(3),
                 "Pair": logic_list(["left", "right"]),
             },
         ]

--- a/code/specs/PR29-prolog-vm-succ-integer-builtins.md
+++ b/code/specs/PR29-prolog-vm-succ-integer-builtins.md
@@ -1,0 +1,47 @@
+# PR29: Prolog VM Succ Integer Builtins
+
+## Summary
+
+This batch adds the next finite integer builtins to the Prolog-on-Logic-VM
+path. The host library exposes `integero(term)` and `succo(predecessor,
+successor)` in `logic-builtins`, while `prolog-loader` adapts parsed
+`integer/1` and `succ/2` calls before VM compilation.
+
+## Goals
+
+- add `integero(term)` for non-bool integer type checks
+- add `succo(predecessor, successor)` for non-negative integer successor
+  relations
+- adapt parsed Prolog `integer/1` and `succ/2`
+- verify parser -> loader -> VM execution
+
+## Semantics
+
+- `integero(term)` succeeds when the reified term is an integer and not a bool
+- `succo(left, right)` succeeds when `left >= 0` and `right = left + 1`
+- if one side of `succo/2` is a concrete valid integer and the other is open,
+  the open side is generated
+- negative predecessors, zero successors without a predecessor, non-integers,
+  and two-open-variable calls fail
+
+## Example
+
+```prolog
+?- between(1, 3, Count),
+   succ(Count, Next),
+   integer(Next).
+```
+
+Expected:
+
+```prolog
+Count = 1, Next = 2 ;
+Count = 2, Next = 3 ;
+Count = 3, Next = 4.
+```
+
+## Non-Goals
+
+- delayed CLP(FD)-style successor constraints
+- unbounded Peano-style generation
+- exception-throwing ISO error modes


### PR DESCRIPTION
## Summary

- add `integero(term)` and `succo(predecessor, successor)` to `logic-builtins`
- adapt parsed Prolog `integer/1` and `succ/2` through `prolog-loader`
- extend Prolog VM stress coverage so parsed source exercises both builtins through the Logic VM path

## Verification

- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in all three packages
- `go build -o /tmp/ca-build-tool-prolog-succ-integer .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-succ-integer -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-succ-integer-build-plan.json`