### PR TITLE
feat(storage-sqlite): IX-11 — UNIQUE index enforcement (v0.14.0)

### DIFF
--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [0.14.0] - 2026-04-28
+
+### Added
+
+**UNIQUE index enforcement (IX-11)**
+
+`IndexDef.unique` is now an enforced constraint at index level, not a reserved
+field.  `CREATE UNIQUE INDEX` creates an index that rejects duplicate keys at
+both backfill time and (eventually) at runtime insert/update time.
+
+- **`IndexTree.create(..., is_unique=False)`** and **`IndexTree.open(...,
+  is_unique=False)`** — new keyword.  When `True`, `IndexTree.insert(key,
+  rowid)` raises `DuplicateIndexKeyError` if any existing entry shares the
+  same key (independent of rowid).  The check runs **before** any disk write,
+  so the tree is unchanged on rejection.
+- **`IndexTree.is_unique` property** — exposes the flag for callers that need
+  to introspect.
+- **NULL semantics** — per SQLite, `NULL` values in a UNIQUE index are
+  considered distinct from each other.  If any column in the key is `NULL`,
+  the duplicate check is skipped.  This lets multiple rows have `NULL` in a
+  UNIQUE column (single or composite).
+- **`SqliteFileBackend.create_index(IndexDef(unique=True))`** — emits
+  `CREATE UNIQUE INDEX` SQL into `sqlite_schema`, opens the index B-tree in
+  unique mode, and runs the backfill.  If existing rows contain duplicates,
+  the pending pager writes are rolled back and `ConstraintViolation` is
+  raised.  The database is unchanged on failure.
+- **`SqliteFileBackend.list_indexes`** — populates `IndexDef.unique` by
+  parsing the stored `CREATE INDEX` SQL via the new `_parse_index_unique`
+  helper.  The flag round-trips across close/reopen.
+- **`_columns_to_index_sql(name, table, columns, *, unique=False)`** — gained
+  a `unique` keyword that switches to `CREATE UNIQUE INDEX`.
+- **`_parse_index_unique(sql)`** — case-insensitive regex match for
+  `CREATE UNIQUE INDEX`.  Tolerates extra whitespace.
+
+### Spec
+
+- `code/specs/storage-sqlite-v3-auto-index.md` — added IX-11 to the phased
+  build order, documented the storage and backend layer changes, and
+  spelled out NULL-distinct semantics.  Removed the "UNIQUE deferred"
+  non-goal.
+
+### Tests added
+
+- `test_index_tree.py::TestUniqueIndex` — 7 tests: default non-unique,
+  distinct keys allowed, duplicate rejected, multiple NULLs allowed,
+  composite NULL semantics, multi-leaf rejection, round-trip via reopen.
+- `test_backend_index.py::TestUniqueIndex` — 7 tests: round-trip of unique
+  flag, default non-unique, backfill rejection on duplicates, success on
+  distinct data, NULL allowance, persistence across reopen, helper unit
+  test.
+
+### Limitations
+
+- Index maintenance on runtime `insert` / `update` / `delete` is still a
+  pre-existing gap in `SqliteFileBackend` — UNIQUE enforcement only fires
+  at backfill time today.  Once index maintenance lands, runtime UNIQUE
+  enforcement will work automatically with no further `IndexTree` changes.
+- The duplicate scan inside `IndexTree.insert` uses `range_scan` which is
+  O(N) worst case.  A dedicated O(log N) `_has_key` helper is a future
+  optimisation.
+
 ## [0.13.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -109,7 +109,7 @@ from sql_backend.schema import NO_DEFAULT, TriggerDef
 from storage_sqlite import record as _record
 from storage_sqlite.btree import BTree, DuplicateRowidError
 from storage_sqlite.freelist import Freelist
-from storage_sqlite.index_tree import IndexTree
+from storage_sqlite.index_tree import DuplicateIndexKeyError, IndexTree
 from storage_sqlite.pager import Pager
 from storage_sqlite.schema import Schema, SchemaError, initialize_new_database
 
@@ -409,19 +409,42 @@ def _parse_index_columns(sql: str) -> list[str]:
     return cols
 
 
-def _columns_to_index_sql(name: str, table: str, columns: list[str]) -> str:
+def _columns_to_index_sql(
+    name: str, table: str, columns: list[str], *, unique: bool = False
+) -> str:
     """Serialise an index definition as a quoted ``CREATE INDEX`` statement.
 
     All identifiers are double-quoted via :func:`_quote_identifier` to
     prevent DDL injection when user-supplied names contain SQL metacharacters.
-    The output is stored verbatim in ``sqlite_schema`` and is parseable by
-    both :func:`_parse_index_columns` and by the real ``sqlite3`` CLI::
+    When *unique* is ``True``, emits ``CREATE UNIQUE INDEX``.  The output is
+    stored verbatim in ``sqlite_schema`` and is parseable by both
+    :func:`_parse_index_columns` / :func:`_parse_index_unique` and by the real
+    ``sqlite3`` CLI::
 
         _columns_to_index_sql("idx_orders_user_id", "orders", ["user_id"])
         # → 'CREATE INDEX "idx_orders_user_id" ON "orders" ("user_id")'
+
+        _columns_to_index_sql("idx_users_email", "users", ["email"], unique=True)
+        # → 'CREATE UNIQUE INDEX "idx_users_email" ON "users" ("email")'
     """
     col_list = ", ".join(_quote_identifier(c) for c in columns)
-    return f"CREATE INDEX {_quote_identifier(name)} ON {_quote_identifier(table)} ({col_list})"
+    keyword = "CREATE UNIQUE INDEX" if unique else "CREATE INDEX"
+    return f"{keyword} {_quote_identifier(name)} ON {_quote_identifier(table)} ({col_list})"
+
+
+_UNIQUE_INDEX_RE = re.compile(r"\bCREATE\s+UNIQUE\s+INDEX\b", re.IGNORECASE)
+
+
+def _parse_index_unique(sql: str | None) -> bool:
+    """Return ``True`` if *sql* is a ``CREATE UNIQUE INDEX`` statement.
+
+    Tolerates extra whitespace and case variation.  Returns ``False`` for
+    ``None`` (rows written without an ``sql`` field) and for ``CREATE
+    INDEX`` (no ``UNIQUE`` keyword).
+    """
+    if sql is None:
+        return False
+    return _UNIQUE_INDEX_RE.search(sql) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -1298,16 +1321,39 @@ class SqliteFileBackend(Backend):
                 raise ColumnNotFound(table=index.table, column=col)
 
         # 4. Allocate index storage and write the schema row.
-        sql = _columns_to_index_sql(index.name, index.table, index.columns)
+        sql = _columns_to_index_sql(
+            index.name, index.table, index.columns, unique=index.unique
+        )
         idx_rootpage = self._schema.create_index(index.name, index.table, sql)
 
-        # 5. Backfill existing rows.
+        # 5. Backfill existing rows.  When the index is UNIQUE,
+        #    ``IndexTree.insert`` raises :class:`DuplicateIndexKeyError` if a
+        #    duplicate is encountered during backfill — translate that to a
+        #    public :class:`~sql_backend.ConstraintViolation` so callers see
+        #    the same error type they would see from a runtime insert.
         table_tree = self._open_tree(rootpage)
-        idx_tree = IndexTree.open(self._pager, idx_rootpage, freelist=self._freelist)
-        for rowid, payload in table_tree.scan():
-            row = _decode_row(rowid, payload, columns)
-            key_vals: list[SqlValue] = [row.get(col) for col in index.columns]  # type: ignore[misc]
-            idx_tree.insert(key_vals, rowid)
+        idx_tree = IndexTree.open(
+            self._pager, idx_rootpage, freelist=self._freelist, is_unique=index.unique
+        )
+        try:
+            for rowid, payload in table_tree.scan():
+                row = _decode_row(rowid, payload, columns)
+                key_vals: list[SqlValue] = [row.get(col) for col in index.columns]  # type: ignore[misc]
+                idx_tree.insert(key_vals, rowid)
+        except DuplicateIndexKeyError as e:
+            # Backfill found pre-existing duplicates — abort the index
+            # creation by rolling back the pending writes (the schema row
+            # and any partial index pages) so the database is unchanged.
+            self._pager.rollback()
+            self._schema = Schema(self._pager, freelist=self._freelist)
+            raise ConstraintViolation(
+                table=index.table,
+                column=", ".join(index.columns),
+                message=(
+                    f"cannot create UNIQUE INDEX {index.name!r}: "
+                    f"existing rows contain duplicate values ({e})"
+                ),
+            ) from None
 
         # Commit the backfill so it is durable.
         self._update_commit_header()
@@ -1357,9 +1403,13 @@ class SqliteFileBackend(Backend):
         result: list[IndexDef] = []
         for name, tbl_name, _, sql in rows:
             columns = _parse_index_columns(sql) if sql else []
+            unique = _parse_index_unique(sql)
             auto = name.startswith("auto_")
             result.append(
-                IndexDef(name=name, table=tbl_name, columns=columns, unique=False, auto=auto)
+                IndexDef(
+                    name=name, table=tbl_name, columns=columns,
+                    unique=unique, auto=auto,
+                )
             )
         return result
 

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/index_tree.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/index_tree.py
@@ -593,7 +593,7 @@ class IndexTree:
     full sort key is always unique — there are no ties at the leaf level.
     """
 
-    __slots__ = ("_freelist", "_pager", "_root_page")
+    __slots__ = ("_freelist", "_is_unique", "_pager", "_root_page")
 
     def __init__(
         self,
@@ -601,10 +601,12 @@ class IndexTree:
         root_page: int,
         *,
         freelist: Freelist | None = None,
+        is_unique: bool = False,
     ) -> None:
         self._pager: Pager = pager
         self._root_page: int = root_page
         self._freelist: Freelist | None = freelist
+        self._is_unique: bool = is_unique
 
     # ── Construction ──────────────────────────────────────────────────────────
 
@@ -614,19 +616,26 @@ class IndexTree:
         pager: Pager,
         *,
         freelist: Freelist | None = None,
+        is_unique: bool = False,
     ) -> IndexTree:
         """Allocate a fresh root page and return an attached IndexTree.
 
         The root page is initialised as an empty index leaf (type 0x0A).
         Pass the same *pager* and optional *freelist* that the rest of the
         database uses.
+
+        When *is_unique* is ``True``, :meth:`insert` rejects entries whose
+        key portion duplicates an existing entry, regardless of rowid.  Per
+        SQLite's UNIQUE-index semantics, ``NULL`` values are treated as
+        distinct from each other — multiple rows with ``NULL`` in any indexed
+        column do not conflict.
         """
         pgno = freelist.allocate() if freelist is not None else pager.allocate()
         ps = pager.page_size
         buf = bytearray(ps)
         _write_idx_leaf_hdr(buf, 0, ncells=0, content_start=ps)
         pager.write(pgno, bytes(buf))
-        return cls(pager, pgno, freelist=freelist)
+        return cls(pager, pgno, freelist=freelist, is_unique=is_unique)
 
     @classmethod
     def open(
@@ -635,9 +644,21 @@ class IndexTree:
         rootpage: int,
         *,
         freelist: Freelist | None = None,
+        is_unique: bool = False,
     ) -> IndexTree:
-        """Open an existing index B-tree rooted at *rootpage*."""
-        return cls(pager, rootpage, freelist=freelist)
+        """Open an existing index B-tree rooted at *rootpage*.
+
+        Pass ``is_unique=True`` for indexes created via ``CREATE UNIQUE
+        INDEX``.  The flag is not stored in the page format — the caller
+        (typically the schema layer) recovers it from the index's ``CREATE
+        INDEX`` SQL in ``sqlite_schema``.
+        """
+        return cls(pager, rootpage, freelist=freelist, is_unique=is_unique)
+
+    @property
+    def is_unique(self) -> bool:
+        """Whether this index enforces uniqueness on the key portion."""
+        return self._is_unique
 
     # ── Properties ────────────────────────────────────────────────────────────
 
@@ -670,7 +691,13 @@ class IndexTree:
         transparently at all tree levels.
 
         Raises :class:`DuplicateIndexKeyError` if the exact same
-        ``(key, rowid)`` pair already exists.
+        ``(key, rowid)`` pair already exists.  When this index was created
+        with ``is_unique=True``, also raises ``DuplicateIndexKeyError`` if
+        any existing entry shares the same *key* (independent of rowid),
+        unless any column in *key* is ``NULL`` — per SQLite, ``NULL``
+        values are considered distinct from each other in unique indexes,
+        so multiple entries with ``NULL`` in any indexed column are
+        permitted.
 
         Parameters
         ----------
@@ -680,6 +707,17 @@ class IndexTree:
         rowid:
             The table rowid that this index entry points to.
         """
+        # UNIQUE enforcement: check for an existing entry with the same key
+        # before doing any disk writes.  NULL-distinct semantics: skip the
+        # check when any key column is NULL, mirroring SQLite's behaviour.
+        if self._is_unique and not any(v is None for v in key):
+            existing = next(self.range_scan(key, key), None)
+            if existing is not None:
+                raise DuplicateIndexKeyError(
+                    f"UNIQUE constraint violated: key {key!r} already exists "
+                    f"in index (existing rowid {existing[1]})"
+                )
+
         # Build the leaf record: [*key_vals, rowid].
         payload = record_encode([*key, rowid])
         total = len(payload)

--- a/code/packages/python/storage-sqlite/tests/test_backend_index.py
+++ b/code/packages/python/storage-sqlite/tests/test_backend_index.py
@@ -490,3 +490,123 @@ class TestOracleIndexVisible:
             # scan_index must yield correct rowids.
             rowids = list(b.scan_index("idx_score", [90], [90]))
             assert sorted(rowids) == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# UNIQUE index enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueIndex:
+    """``IndexDef.unique=True`` is enforced at create_index and survives reopen."""
+
+    def _setup_users(self, b: SqliteFileBackend) -> None:
+        b.create_table(
+            "users",
+            [
+                ColumnDef("id", "INTEGER", primary_key=True),
+                ColumnDef("email", "TEXT"),
+                ColumnDef("name", "TEXT"),
+            ],
+            if_not_exists=False,
+        )
+
+    def test_create_unique_index_writes_unique_keyword(self, tmp_path: Path) -> None:
+        """list_indexes round-trips the unique flag."""
+        path = str(tmp_path / "u1.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.create_index(
+                IndexDef(name="idx_email", table="users", columns=["email"], unique=True)
+            )
+            idxs = b.list_indexes("users")
+            assert len(idxs) == 1
+            assert idxs[0].unique is True
+            assert idxs[0].name == "idx_email"
+
+    def test_create_non_unique_index_default(self, tmp_path: Path) -> None:
+        """Plain CREATE INDEX is non-unique."""
+        path = str(tmp_path / "u2.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.create_index(
+                IndexDef(name="idx_name", table="users", columns=["name"])
+            )
+            idxs = b.list_indexes("users")
+            assert idxs[0].unique is False
+
+    def test_create_unique_rejects_existing_duplicates(self, tmp_path: Path) -> None:
+        """Backfill of a UNIQUE index over duplicate data raises ConstraintViolation."""
+        from sql_backend import ConstraintViolation
+        path = str(tmp_path / "u3.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.insert("users", {"id": 1, "email": "alice@example.com", "name": "Alice"})
+            b.insert("users", {"id": 2, "email": "alice@example.com", "name": "Alice2"})
+            with pytest.raises(ConstraintViolation, match="UNIQUE INDEX"):
+                b.create_index(
+                    IndexDef(
+                        name="idx_email", table="users",
+                        columns=["email"], unique=True,
+                    )
+                )
+            # The schema must remain unchanged after the failure.
+            assert b.list_indexes("users") == []
+
+    def test_create_unique_succeeds_with_distinct_data(self, tmp_path: Path) -> None:
+        """Backfill succeeds when existing rows have unique values."""
+        path = str(tmp_path / "u4.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.insert("users", {"id": 1, "email": "a@example.com", "name": "A"})
+            b.insert("users", {"id": 2, "email": "b@example.com", "name": "B"})
+            b.create_index(
+                IndexDef(
+                    name="idx_email", table="users",
+                    columns=["email"], unique=True,
+                )
+            )
+            rowids = list(b.scan_index("idx_email", ["a@example.com"], ["a@example.com"]))
+            assert rowids == [1]
+
+    def test_create_unique_allows_null_duplicates(self, tmp_path: Path) -> None:
+        """Multiple rows with NULL in an indexed column do not conflict."""
+        path = str(tmp_path / "u5.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.insert("users", {"id": 1, "name": "alice"})  # email omitted → NULL
+            b.insert("users", {"id": 2, "name": "bob"})    # email omitted → NULL
+            # A UNIQUE index on email succeeds because NULLs are distinct.
+            b.create_index(
+                IndexDef(
+                    name="idx_email", table="users",
+                    columns=["email"], unique=True,
+                )
+            )
+            assert b.list_indexes("users")[0].unique is True
+
+    def test_unique_flag_survives_reopen(self, tmp_path: Path) -> None:
+        """After close + reopen, list_indexes still reports the unique flag."""
+        path = str(tmp_path / "u6.db")
+        with SqliteFileBackend(path) as b:
+            self._setup_users(b)
+            b.create_index(
+                IndexDef(
+                    name="idx_email", table="users",
+                    columns=["email"], unique=True,
+                )
+            )
+        with SqliteFileBackend(path) as b2:
+            idxs = b2.list_indexes("users")
+            assert len(idxs) == 1
+            assert idxs[0].unique is True
+
+    def test_parse_index_unique_helper(self) -> None:
+        """_parse_index_unique recognises CREATE UNIQUE INDEX (case-insensitive)."""
+        from storage_sqlite.backend import _parse_index_unique
+        assert _parse_index_unique('CREATE UNIQUE INDEX "x" ON "t" ("c")') is True
+        assert _parse_index_unique('create unique index "x" ON "t" ("c")') is True
+        assert _parse_index_unique('CREATE  UNIQUE  INDEX "x" ON "t" ("c")') is True
+        assert _parse_index_unique('CREATE INDEX "x" ON "t" ("c")') is False
+        assert _parse_index_unique(None) is False
+        assert _parse_index_unique("") is False

--- a/code/packages/python/storage-sqlite/tests/test_index_tree.py
+++ b/code/packages/python/storage-sqlite/tests/test_index_tree.py
@@ -833,3 +833,106 @@ class TestErrorPaths:
         tree.free_all(fl2)  # free_all injects freelist temporarily
         pager.close()
         del root
+
+
+# ── Section: UNIQUE index enforcement ────────────────────────────────────────
+
+
+class TestUniqueIndex:
+    """``is_unique=True`` rejects duplicate keys but allows multiple NULLs."""
+
+    def test_default_is_not_unique(self, tmp_path: Path) -> None:
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager)
+        assert tree.is_unique is False
+        # Two entries with the same key but distinct rowids are allowed.
+        tree.insert([42], 1)
+        tree.insert([42], 2)
+        rowids = [rid for _, rid in tree.range_scan([42], [42])]
+        assert rowids == [1, 2]
+        pager.close()
+
+    def test_unique_allows_distinct_keys(self, tmp_path: Path) -> None:
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager, is_unique=True)
+        assert tree.is_unique is True
+        tree.insert([1], 1)
+        tree.insert([2], 2)
+        tree.insert([3], 3)
+        rowids = [rid for _, rid in tree.range_scan(None, None)]
+        assert rowids == [1, 2, 3]
+        pager.close()
+
+    def test_unique_rejects_duplicate_key(self, tmp_path: Path) -> None:
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager, is_unique=True)
+        tree.insert([42], 1)
+        with pytest.raises(DuplicateIndexKeyError, match="UNIQUE"):
+            tree.insert([42], 2)  # same key, different rowid
+        # The failed insert leaves the tree unchanged.
+        rowids = [rid for _, rid in tree.range_scan([42], [42])]
+        assert rowids == [1]
+        pager.close()
+
+    def test_unique_allows_multiple_nulls(self, tmp_path: Path) -> None:
+        """SQLite UNIQUE indexes treat NULLs as distinct from each other."""
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager, is_unique=True)
+        tree.insert([None], 1)
+        tree.insert([None], 2)  # second NULL is allowed
+        tree.insert([None], 3)
+        rowids = [rid for _, rid in tree.range_scan([None], [None])]
+        assert rowids == [1, 2, 3]
+        pager.close()
+
+    def test_unique_partial_null_in_composite_allows_duplicates(
+        self, tmp_path: Path
+    ) -> None:
+        """Composite UNIQUE: any NULL column makes the row 'distinct'."""
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager, is_unique=True)
+        tree.insert([1, None], 1)
+        # Same first column, both have NULL in second column — distinct per SQLite.
+        tree.insert([1, None], 2)
+        # But (1, "x") inserted twice must be rejected.
+        tree.insert([1, "x"], 3)
+        with pytest.raises(DuplicateIndexKeyError):
+            tree.insert([1, "x"], 4)
+        pager.close()
+
+    def test_unique_rejects_after_split(self, tmp_path: Path) -> None:
+        """Unique enforcement still works when the tree has multiple leaves."""
+        pager = _make_pager(tmp_path)
+        tree = IndexTree.create(pager, is_unique=True)
+        # Insert enough entries to force several splits (PAGE_SIZE / cell_size).
+        for i in range(200):
+            tree.insert([i], i + 1)
+        # Now try to re-insert an existing key with a different rowid.
+        with pytest.raises(DuplicateIndexKeyError):
+            tree.insert([100], 9999)
+        # And an existing key with a smaller rowid.
+        with pytest.raises(DuplicateIndexKeyError):
+            tree.insert([0], 0)
+        pager.close()
+
+    def test_unique_flag_round_trip_via_open(self, tmp_path: Path) -> None:
+        """Reopening with is_unique=True restores enforcement."""
+        db = str(tmp_path / "uniq.db")
+        pager = Pager.create(db)
+        pgno = pager.allocate()
+        page1 = bytearray(PAGE_SIZE)
+        page1[:100] = Header.new_database(page_size=PAGE_SIZE).to_bytes()
+        pager.write(1, bytes(page1))
+        del pgno
+        tree = IndexTree.create(pager, is_unique=True)
+        tree.insert([1], 1)
+        root = tree.root_page
+        pager.commit()
+        pager.close()
+
+        pager2 = Pager.open(db)
+        tree2 = IndexTree.open(pager2, root, is_unique=True)
+        assert tree2.is_unique is True
+        with pytest.raises(DuplicateIndexKeyError):
+            tree2.insert([1], 99)
+        pager2.close()

--- a/code/specs/storage-sqlite-v3-auto-index.md
+++ b/code/specs/storage-sqlite-v3-auto-index.md
@@ -461,8 +461,58 @@ assert any(
 |---|---|---|
 | IX-7 | `QueryEvent` emitted by `sql_vm`; `should_drop` on `IndexPolicy`; `cold_window` on `HitCountPolicy`; `on_query_event` on `IndexAdvisor`; engine wires event callback | `sql-vm`, `mini-sqlite` |
 | IX-8 | Composite (multi-column) index advisor + planner prefix-match selection + `IndexScan.columns` list | `mini-sqlite`, `sql-planner`, `sql-codegen`, `sql-vm` |
+| IX-11 | UNIQUE index enforcement — `IndexTree.is_unique` flag, `CREATE UNIQUE INDEX` round-trip, backfill duplicate-rejection | `storage-sqlite` |
 
 Each phase is a separate feature branch and PR.
+
+---
+
+## UNIQUE index enforcement (IX-11)
+
+`IndexDef.unique` is now an enforced constraint, not a reserved field.
+
+### Storage layer (`storage_sqlite.index_tree.IndexTree`)
+
+`IndexTree.create()` and `IndexTree.open()` accept an `is_unique: bool = False`
+keyword.  When `True`, `IndexTree.insert(key, rowid)` raises
+`DuplicateIndexKeyError` if any existing entry shares the same key — independent
+of rowid.  The check is implemented as a `range_scan(key, key)` lookup before
+the leaf write, so no partial state leaks on rejection.
+
+The `is_unique` flag is **not** persisted in the index page format itself — it
+is recovered from the `CREATE UNIQUE INDEX` SQL stored in `sqlite_schema`.
+This matches SQLite's own approach (the page format has no per-index "unique"
+bit; uniqueness lives in the schema text).
+
+### NULL semantics
+
+Per SQLite's UNIQUE-index rule, `NULL` values are considered **distinct from
+each other**.  If any column in *key* is `NULL`, the duplicate check is
+skipped — multiple rows with `NULL` in any indexed column may coexist.  This
+applies to single-column and composite UNIQUE indexes alike.
+
+### Backend layer (`SqliteFileBackend`)
+
+* `_columns_to_index_sql(name, table, columns, *, unique=False)` — emits
+  `CREATE UNIQUE INDEX` when `unique=True`.
+* `_parse_index_unique(sql)` — case-insensitive regex match for
+  `CREATE UNIQUE INDEX`.  Used by `list_indexes` to populate
+  `IndexDef.unique` on read.
+* `create_index(IndexDef(..., unique=True))` — performs the backfill
+  through a unique-mode `IndexTree`.  If existing rows contain duplicates,
+  the pending pager writes are rolled back and `ConstraintViolation` is
+  raised.  The database state is unchanged on failure.
+
+### Limitations of the IX-11 implementation
+
+* Index maintenance on runtime `insert` / `update` / `delete` is **not yet
+  wired** in `SqliteFileBackend` (a pre-existing gap, deferred to a separate
+  phase).  Once that lands, UNIQUE enforcement will fire on every row
+  modification automatically — no further changes to `IndexTree` are needed.
+* The duplicate scan inside `IndexTree.insert` uses `range_scan(key, key)`
+  which is O(N) in the worst case (entries before *key* are walked before
+  early-exit kicks in).  A dedicated O(log N) `_has_key(key)` helper is a
+  future optimisation.
 
 ---
 
@@ -522,8 +572,6 @@ Each phase is a separate feature branch and PR.
 ## Non-goals (v3)
 
 - **Three-or-more column composite indexes** — deferred to v4.
-- **UNIQUE index enforcement** — `IndexDef.unique` field reserved but not
-  enforced. Deferred to a dedicated uniqueness spec.
 - **`ANALYZE` / statistics-based cost model** — first-match / prefix-length
   heuristic only. Deferred to v4.
 - **Index-only scans** — deferred to v4.


### PR DESCRIPTION
## Summary

- `IndexDef.unique` is now an enforced constraint. `CREATE UNIQUE INDEX` rejects duplicate keys at backfill time and (once index maintenance lands) at every insert
- `IndexTree.create(..., is_unique=False)` and `IndexTree.open(..., is_unique=False)` gained the keyword. When `True`, `insert(key, rowid)` raises `DuplicateIndexKeyError` if any existing entry shares the key — independent of rowid
- NULL-distinct semantics per SQLite: any `NULL` column in the key skips the duplicate check, so multiple rows with `NULL` may coexist
- `SqliteFileBackend.create_index` rolls back the pager and raises `ConstraintViolation` if the backfill detects pre-existing duplicates
- `list_indexes` populates `IndexDef.unique` via the new `_parse_index_unique` helper, surviving close + reopen
- 14 new tests (7 unit + 7 backend), 619 total pass, ruff clean
- Spec `storage-sqlite-v3-auto-index.md` updated with IX-11 phase

## Test plan

- [x] All 619 tests pass (`uv run pytest --no-cov`)
- [x] `uv run ruff check src/ tests/` — clean
- [x] Security review passed (one round, no findings)
- [x] Tested: distinct keys allowed, duplicate rejected, multiple NULLs allowed, composite NULL semantics, multi-leaf rejection, round-trip via reopen, backfill rejects pre-existing duplicates, _parse_index_unique helper

## Limitations

- Index maintenance on runtime `insert`/`update`/`delete` is still a pre-existing gap — UNIQUE only fires at backfill today. Once index maintenance lands, runtime UNIQUE will work automatically.
- Duplicate scan inside `IndexTree.insert` uses `range_scan` (O(N) worst case). Future optimization: dedicated O(log N) `_has_key` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)