### PR TITLE
Forward non-scalar arguments through formal procedures

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -77,6 +77,8 @@ All notable changes to this package will be documented in this file.
   to read or assign through the original argument.
 - Lowered whole-array arguments through formal procedure dispatchers by passing
   descriptor pointers to actual procedures that declare matching array formals.
+- Lowered label, switch, and procedure arguments through formal procedure
+  dispatchers by forwarding label ids and descriptor pointers.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -61,14 +61,15 @@ re-evaluate in the caller's declaring scope; these label/switch descriptor
 paths also cover `value` formals. Procedure formals pass descriptor closures
 containing the callee procedure id and static link; formal calls dispatch
 through generated helpers for statement calls and typed expression calls with
-scalar or whole-array arguments. The dispatch helpers pass scalar actual
-arguments as lazy storage pointers or thunk descriptors, evaluating them once
-for target `value` parameters and forwarding them directly for target by-name
-parameters. Whole-array actuals pass descriptor pointers through the same
-dispatcher family, so forwarded procedure formals keep the original
-environment in value, by-name, or array mode. Real-valued formal procedure
-calls can accept integer-returning actual procedures and promote the dispatched
-result. Full ALGOL forms such as escaping thunk descriptors remain future work.
+scalar, whole-array, label, switch, or procedure arguments. The dispatch
+helpers pass scalar actual arguments as lazy storage pointers or thunk
+descriptors, evaluating them once for target `value` parameters and forwarding
+them directly for target by-name parameters. Whole-array, switch, and procedure
+actuals pass descriptor pointers, and label actuals pass label ids, so
+forwarded procedure formals keep the original environment in value, by-name,
+array, label, switch, or procedure mode. Real-valued formal procedure calls can
+accept integer-returning actual procedures and promote the dispatched result.
+Richer nested procedure-parameter contract propagation remains future work.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2981,7 +2981,7 @@ class AlgolIrCompiler:
             argument_types,
             strict=True,
         ):
-            if argument_kind == "array":
+            if argument_kind != "scalar":
                 continue
             if actual_type not in {
                 _INTEGER_TYPE,
@@ -3001,14 +3001,50 @@ class AlgolIrCompiler:
             if argument_kinds[index] == "scalar"
             and self._requires_by_name_thunk_descriptor(argument)
         ]
+        switch_actuals = [
+            (index, argument, actual_type)
+            for index, (argument, actual_type) in enumerate(
+                zip(actuals, argument_types, strict=True)
+            )
+            if argument_kinds[index] == "switch"
+        ]
+        procedure_actuals = [
+            (index, argument, actual_type)
+            for index, (argument, actual_type) in enumerate(
+                zip(actuals, argument_types, strict=True)
+            )
+            if argument_kinds[index] == "procedure"
+        ]
+        temp_descriptor_bytes = (
+            len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+            + len(switch_actuals) * _SWITCH_DESCRIPTOR_SIZE
+            + len(procedure_actuals) * _PROCEDURE_DESCRIPTOR_SIZE
+        )
         descriptor_heap_mark = (
-            self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
-            if thunk_actuals
+            self._emit_reserve_temp_descriptor_space(temp_descriptor_bytes, scope)
+            if temp_descriptor_bytes
             else None
         )
         descriptor_offsets = {
             argument_index: descriptor_index * _THUNK_DESCRIPTOR_SIZE
             for descriptor_index, (argument_index, _, _) in enumerate(thunk_actuals)
+        }
+        switch_descriptor_offsets = {
+            argument_index: (
+                len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+                + descriptor_index * _SWITCH_DESCRIPTOR_SIZE
+            )
+            for descriptor_index, (argument_index, _, _) in enumerate(switch_actuals)
+        }
+        procedure_descriptor_offsets = {
+            argument_index: (
+                len(thunk_actuals) * _THUNK_DESCRIPTOR_SIZE
+                + len(switch_actuals) * _SWITCH_DESCRIPTOR_SIZE
+                + descriptor_index * _PROCEDURE_DESCRIPTOR_SIZE
+            )
+            for descriptor_index, (argument_index, _, _) in enumerate(
+                procedure_actuals
+            )
         }
         argument_regs: list[int] = []
         for index, (actual, actual_type, argument_kind) in enumerate(
@@ -3016,6 +3052,37 @@ class AlgolIrCompiler:
         ):
             if argument_kind == "array":
                 argument_regs.append(self._compile_array_actual_pointer(actual, scope))
+                continue
+            if argument_kind == "label":
+                argument_regs.append(self._compile_label_actual_value(actual, scope))
+                continue
+            if argument_kind == "switch":
+                descriptor = None
+                if (
+                    descriptor_heap_mark is not None
+                    and index in switch_descriptor_offsets
+                ):
+                    descriptor = self._emit_descriptor_at(
+                        descriptor_heap_mark,
+                        switch_descriptor_offsets[index],
+                    )
+                argument_regs.append(
+                    self._compile_switch_actual_pointer(actual, scope, descriptor)
+                )
+                continue
+            if argument_kind == "procedure":
+                descriptor = None
+                if (
+                    descriptor_heap_mark is not None
+                    and index in procedure_descriptor_offsets
+                ):
+                    descriptor = self._emit_descriptor_at(
+                        descriptor_heap_mark,
+                        procedure_descriptor_offsets[index],
+                    )
+                argument_regs.append(
+                    self._compile_procedure_actual_pointer(actual, scope, descriptor)
+                )
                 continue
             descriptor = None
             if descriptor_heap_mark is not None and index in descriptor_offsets:
@@ -3140,6 +3207,12 @@ class AlgolIrCompiler:
                 argument_kinds.append("array")
                 argument_types.append(array_type)
                 continue
+            nonscalar = self._formal_nonscalar_argument_shape(actual, scope)
+            if nonscalar is not None:
+                argument_kind, argument_type = nonscalar
+                argument_kinds.append(argument_kind)
+                argument_types.append(argument_type)
+                continue
             argument_kinds.append("scalar")
             argument_types.append(self._expr_type(actual))
         return tuple(argument_kinds), tuple(argument_types)
@@ -3163,6 +3236,42 @@ class AlgolIrCompiler:
         if descriptor is None:
             raise CompileError(f"array actual {name.value!r} has no descriptor")
         return descriptor.element_type
+
+    def _formal_nonscalar_argument_shape(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> tuple[str, str] | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_name(variable)
+        if name is None:
+            return None
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            return None
+        symbol, _ = resolved
+        if symbol.kind == "label":
+            return "label", "label"
+        if symbol.kind == "switch":
+            return "switch", "switch"
+        if symbol.kind == "procedure":
+            procedure = (
+                self.procedures.get(symbol.procedure_id)
+                if symbol.procedure_id is not None
+                else None
+            )
+            if (
+                procedure is not None
+                and procedure.return_type is not None
+                and not procedure.parameters
+            ):
+                return None
+            return "procedure", symbol.type_name
+        if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
+            return "procedure", symbol.type_name
+        return None
 
     def _compile_builtin_output(self, node: ASTNode, scope: _FrameScope) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
@@ -4360,7 +4469,7 @@ class AlgolIrCompiler:
                 zip(argument_kinds, argument_types, procedure.parameters, strict=True)
             ):
                 argument_pointer = _VALUE_PARAM_BASE_REG + arg_index
-                if argument_kind == "array":
+                if argument_kind in {"array", "label", "switch", "procedure"}:
                     call_arguments.append(argument_pointer)
                     continue
                 if parameter.mode == _NAME_MODE:
@@ -4439,6 +4548,23 @@ class AlgolIrCompiler:
                 if parameter.kind != "array":
                     return False
                 if parameter.type_name != argument_type:
+                    return False
+                continue
+            if argument_kind == "label":
+                if parameter.kind != "label":
+                    return False
+                continue
+            if argument_kind == "switch":
+                if parameter.kind != "switch":
+                    return False
+                continue
+            if argument_kind == "procedure":
+                if parameter.kind != "procedure":
+                    return False
+                if not _procedure_parameter_type_satisfies(
+                    expected_type=parameter.type_name,
+                    actual_type=argument_type,
+                ):
                     return False
                 continue
             if argument_kind != "scalar":
@@ -6202,6 +6328,19 @@ def _procedure_parameter_dispatch_type_tag(
         _REAL_TYPE: "f64",
         _STRING_TYPE: "str",
     }
+    if kind == "label":
+        return "label"
+    if kind == "switch":
+        return "switch"
+    if kind == "procedure":
+        if type_name == "procedure":
+            return "procedure"
+        try:
+            return f"procedure_{tags[type_name]}"
+        except KeyError as exc:
+            raise CompileError(
+                f"unsupported procedure parameter dispatch type {type_name!r}"
+            ) from exc
     if kind not in {"array", "scalar"}:
         raise CompileError(
             f"unsupported procedure parameter dispatch argument kind {kind!r}"
@@ -6215,6 +6354,19 @@ def _procedure_parameter_dispatch_type_tag(
     if kind == "array":
         return f"array_{tag}"
     return tag
+
+
+def _procedure_parameter_type_satisfies(
+    *,
+    expected_type: str,
+    actual_type: str,
+) -> bool:
+    if expected_type == "procedure" or actual_type == "procedure":
+        return expected_type == actual_type
+    return _procedure_return_type_satisfies(
+        expected_type=expected_type,
+        actual_type=actual_type,
+    )
 
 
 def _procedure_return_type_satisfies(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -927,6 +927,57 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_procedure_parameter_call_with_label_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure invoke(p); procedure p; begin p(done) end; "
+                "procedure jump(l); label l; begin result := 9; goto l end; "
+                "invoke(jump); done: "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures["_fn_algol_call_procedure_label"].param_types
+            == ("integer", "integer", "integer")
+        )
+
+    def test_compiles_procedure_parameter_call_with_switch_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; switch s := done; "
+                "procedure invoke(p); procedure p; begin p(s) end; "
+                "procedure jump(sw); switch sw; begin goto sw[1] end; "
+                "invoke(jump); done: "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures["_fn_algol_call_procedure_switch"].param_types
+            == ("integer", "integer", "integer")
+        )
+
+    def test_compiles_procedure_parameter_call_with_procedure_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure bump; begin result := result + 1 end; "
+                "procedure invoke(p); procedure p; begin p(bump) end; "
+                "procedure use(q); procedure q; begin q; q end; "
+                "result := 0; invoke(use) "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures[
+                "_fn_algol_call_procedure_procedure"
+            ].param_types
+            == ("integer", "integer", "integer")
+        )
+
     def test_compiles_value_procedure_parameter_call_with_value_argument(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -51,6 +51,8 @@ All notable changes to this package will be documented in this file.
   non-assignable actual to a written by-name parameter.
 - Accepted procedure-valued actuals with whole-array parameters for formal
   procedure parameters, recording array argument call shapes for lowering.
+- Accepted procedure-valued actuals with label, switch, and procedure
+  parameters for formal procedure parameters.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -54,12 +54,12 @@ no-argument statement procedure formals. `value` whole-array parameters are
 also accepted and lowered as copy formals, while `value` label, switch, and
 procedure formals use copied ids or descriptors. Formal procedure parameters
 accept procedure-valued actuals with scalar `value` or by-name parameters and
-whole-array parameters, rejecting only call shapes that would pass a
-non-assignable actual to a written by-name parameter. Real-valued formal
-procedure parameters accept integer-returning procedure actuals via the same
-numeric promotion rule used by scalar calls. The checker keeps guarding the
-remaining full-ALGOL gaps, including label, switch, procedure, and other
-non-array non-scalar parameters on procedure-valued actuals.
+whole-array, label, switch, or procedure parameters, rejecting only call shapes
+that would pass a non-assignable actual to a written by-name parameter.
+Real-valued formal procedure parameters accept integer-returning procedure
+actuals via the same numeric promotion rule used by scalar calls. The checker
+keeps guarding the remaining full-ALGOL gaps, including richer nested
+procedure-parameter contract propagation through procedure-valued actuals.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2032,6 +2032,13 @@ class AlgolTypeChecker:
                 argument_kinds.append(ARRAY)
                 argument_assignable.append(False)
                 continue
+            nonscalar = self._formal_nonscalar_argument_shape(argument, scope)
+            if nonscalar is not None:
+                argument_kind, argument_type = nonscalar
+                argument_types.append(argument_type)
+                argument_kinds.append(argument_kind)
+                argument_assignable.append(False)
+                continue
             actual_type = self._infer_expr(argument, scope)
             argument_types.append(actual_type)
             argument_kinds.append("scalar")
@@ -2116,6 +2123,45 @@ class AlgolTypeChecker:
             None,
         )
         return ERROR if descriptor is None else descriptor.element_type
+
+    def _formal_nonscalar_argument_shape(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+    ) -> tuple[str, str] | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            return None
+        symbol, _, _ = resolved
+        if symbol.kind == LABEL:
+            return LABEL, LABEL
+        if symbol.kind == SWITCH:
+            return SWITCH, SWITCH
+        if symbol.kind == "procedure":
+            descriptor = next(
+                (
+                    procedure
+                    for procedure in self.semantic_procedures
+                    if procedure.procedure_id == symbol.procedure_id
+                ),
+                None,
+            )
+            if (
+                descriptor is not None
+                and descriptor.return_type is not None
+                and not descriptor.parameters
+            ):
+                return None
+            return "procedure", symbol.type_name
+        if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
+            return "procedure", symbol.type_name
+        return None
 
     def _record_procedure_parameter_call_shape(
         self,
@@ -2392,6 +2438,55 @@ class AlgolTypeChecker:
                         )
                         return False
                     continue
+                if argument_kind == LABEL:
+                    if actual_parameter.kind != LABEL:
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes a "
+                            "label to non-label actual parameter "
+                            f"{actual_parameter.name!r}",
+                        )
+                        return False
+                    continue
+                if argument_kind == SWITCH:
+                    if actual_parameter.kind != SWITCH:
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes a "
+                            "switch to non-switch actual parameter "
+                            f"{actual_parameter.name!r}",
+                        )
+                        return False
+                    continue
+                if argument_kind == "procedure":
+                    if actual_parameter.kind != "procedure":
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes a "
+                            "procedure to non-procedure actual parameter "
+                            f"{actual_parameter.name!r}",
+                        )
+                        return False
+                    if not self._procedure_parameter_type_satisfies(
+                        expected_type=actual_parameter.type_name,
+                        actual_type=actual_type,
+                    ):
+                        self._error(
+                            token,
+                            f"procedure parameter {parameter.name!r} passes "
+                            f"{actual_type} procedure to actual parameter "
+                            f"{actual_parameter.name!r} expecting "
+                            f"{actual_parameter.type_name}",
+                        )
+                        return False
+                    continue
+                if argument_kind != "scalar":
+                    self._error(
+                        token,
+                        f"procedure parameter {parameter.name!r} has unsupported "
+                        f"{argument_kind} argument shape",
+                    )
+                    return False
                 if actual_parameter.kind != "scalar":
                     self._error(
                         token,
@@ -2429,7 +2524,21 @@ class AlgolTypeChecker:
                         f"{actual_parameter.name!r}",
                     )
                     return False
+                continue
         return True
+
+    def _procedure_parameter_type_satisfies(
+        self,
+        *,
+        expected_type: str,
+        actual_type: str,
+    ) -> bool:
+        if expected_type == "procedure" or actual_type == "procedure":
+            return expected_type == actual_type
+        return self._procedure_return_type_satisfies(
+            expected_type=expected_type,
+            actual_type=actual_type,
+        )
 
     def _procedure_return_type_satisfies(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1002,6 +1002,70 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "passes real array" in result.diagnostics[0].message
 
+    def test_accepts_procedure_parameter_actual_with_label_formal(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p(done) end; "
+            "procedure jump(l); label l; begin result := 9; goto l end; "
+            "invoke(jump); done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("label",)
+        assert shape.argument_types == ("label",)
+
+    def test_accepts_procedure_parameter_actual_with_switch_formal(self) -> None:
+        ast = parse_algol(
+            "begin integer result; switch s := done; "
+            "procedure invoke(p); procedure p; begin p(s) end; "
+            "procedure jump(sw); switch sw; begin goto sw[1] end; "
+            "invoke(jump); done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("switch",)
+        assert shape.argument_types == ("switch",)
+
+    def test_accepts_procedure_parameter_actual_with_procedure_formal(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure bump; begin result := result + 1 end; "
+            "procedure invoke(p); procedure p; begin p(bump) end; "
+            "procedure use(q); procedure q; begin q end; "
+            "invoke(use) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[1].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("procedure",)
+        assert shape.argument_types == ("procedure",)
+
+    def test_rejects_procedure_parameter_actual_with_wrong_label_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p(done) end; "
+            "procedure set(x); value x; integer x; begin result := x end; "
+            "invoke(set); done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "passes a label" in result.diagnostics[0].message
+
     def test_rejects_procedure_parameter_actual_with_written_literal_by_name_formal(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -70,6 +70,8 @@ All notable changes to this package will be documented in this file.
   by-name parameters, preserving lazy reads and writable caller variables.
 - Executed formal procedure calls that forward whole-array arguments to actual
   procedures, preserving descriptor aliasing and existing `value` array copies.
+- Executed formal procedure calls that forward label, switch, and procedure
+  arguments to actual procedures.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -23,7 +23,8 @@ the current lane already supports a substantial ALGOL 60 surface:
   ALGOL-left-associative exponentiation for integer exponents
 - value and by-name parameters, including Jensen-style expression thunks,
   typed whole-array formals with copy or aliasing semantics, and formal
-  procedure calls that forward scalar or whole-array arguments
+  procedure calls that forward scalar, whole-array, label, switch, or
+  procedure arguments
 - label, switch, and procedure formals in value or by-name mode
 - bare no-argument typed procedure names as expression calls, matching ALGOL's
   omitted-parentheses call syntax for parameterless procedures

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -760,6 +760,43 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_procedure_parameter_statement_call_passes_label_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure invoke(p); procedure p; begin p(done) end; "
+            "procedure jump(l); label l; begin result := 9; goto l end; "
+            "invoke(jump); result := 0; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
+    def test_procedure_parameter_statement_call_passes_switch_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; switch s := left, right; "
+            "procedure invoke(p); procedure p; begin p(s) end; "
+            "procedure jump(sw); switch sw; begin goto sw[2] end; "
+            "invoke(jump); result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 8; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_procedure_parameter_statement_call_passes_procedure_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure bump; begin result := result + 1 end; "
+            "procedure invoke(p); procedure p; begin p(bump) end; "
+            "procedure use(q); procedure q; begin q; q end; "
+            "result := 0; invoke(use) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_formal_procedure_by_name_argument_remains_lazy(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -821,6 +858,19 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
+    def test_formal_procedure_call_passes_typed_procedure_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure twice(x); value x; integer x; "
+            "begin twice := x * 2 end; "
+            "procedure invoke(p); procedure p; begin p(twice) end; "
+            "procedure use(f); integer f; procedure f; "
+            "begin result := f(4) end; "
+            "invoke(use) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- classify formal procedure call arguments as scalar, array, label, switch, or procedure before type inference so labels and descriptors are not mistaken for scalar reads
- lower label ids plus switch/procedure descriptor pointers through formal procedure dispatch helpers
- preserve existing bare no-arg typed procedure expression behavior while adding label, switch, procedure, and typed-procedure forwarding coverage

## Validation
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security
- diff scan found no new process, shell, network, filesystem-write, or credential-handling APIs.