### PR TITLE
feat(storage-sqlite): IX-12 — runtime index maintenance (v0.15.0)

### DIFF
--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.15.0] - 2026-04-28
+
+### Added
+
+**Runtime index maintenance (IX-12)**
+
+Secondary indexes are now kept in sync with the table B-tree on every
+DML operation, not only at `create_index` backfill time.  Combined with
+the IX-11 UNIQUE flag, this means `CREATE UNIQUE INDEX` actually rejects
+duplicate inserts at runtime — the IX-11 limitation note is gone.
+
+- **`SqliteFileBackend.insert`** — now walks every index on the target
+  table after the row is committed to the table B-tree, computing the
+  index key from the inserted row and inserting `(key_vals, rowid)` into
+  each index B-tree.  For UNIQUE indexes, a duplicate-key check (with
+  NULL-distinct semantics) runs *before* any mutation so a violation
+  leaves the database byte-for-byte unchanged.
+- **`SqliteFileBackend.update`** — for each index, compares the old key
+  (from the cursor's cached row) to the new key (from the proposed row).
+  If they differ, deletes the old `(key, rowid)` entry and inserts the
+  new one.  No-op for indexes whose columns weren't changed.  UNIQUE
+  pre-check on the new key matches `insert` semantics.
+- **`SqliteFileBackend.delete`** — removes the row's entry from every
+  index before deleting the table B-tree row, using the cursor's cached
+  row to recover the indexed column values.
+- **`SqliteFileBackend._open_indexes_for(table)`** — new private helper
+  that returns `[(name, columns, IndexTree)]` for every index on a
+  table, with each `IndexTree` opened in the right unique mode (parsed
+  from the stored `CREATE INDEX` SQL).
+
+### Tests added
+
+- `test_backend_index.py::TestRuntimeIndexMaintenance` — 9 tests:
+  insert populates index, runtime UNIQUE violation, multiple NULLs
+  allowed, delete removes index entry, update changes index entry,
+  update of non-indexed column skips index, runtime UNIQUE on update,
+  multiple-index maintenance, persistence across reopen.
+
+### Notes
+
+- This closes the IX-11 limitation where UNIQUE only fired at backfill.
+  All UNIQUE checks now occur on every `INSERT`/`UPDATE` automatically.
+- `INSERT` and `UPDATE` no longer auto-commit (unchanged behaviour); the
+  caller — typically the SQL VM — must wrap DML in
+  `begin_transaction`/`commit` to flush dirty pages.
+
 ## [0.14.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -869,6 +869,31 @@ class SqliteFileBackend(Backend):
         """Open a B-tree for *rootpage* with the freelist attached."""
         return BTree.open(self._pager, rootpage, freelist=self._freelist)
 
+    def _open_indexes_for(
+        self, table: str
+    ) -> list[tuple[str, list[str], IndexTree]]:
+        """Return open ``IndexTree`` handles for every index on *table*.
+
+        Each tuple is ``(index_name, indexed_columns, idx_tree)`` where
+        ``idx_tree`` carries its UNIQUE flag (read from the stored
+        ``CREATE INDEX`` SQL).  Used by :meth:`insert`, :meth:`update`, and
+        :meth:`delete` to keep secondary indexes consistent with the table
+        B-tree.
+
+        Returns an empty list when the table has no indexes — the common
+        case for tables that the application has not explicitly indexed.
+        """
+        rows = self._schema.list_indexes(table)
+        result: list[tuple[str, list[str], IndexTree]] = []
+        for name, _tbl_name, rootpage, sql in rows:
+            cols = _parse_index_columns(sql) if sql else []
+            unique = _parse_index_unique(sql)
+            tree = IndexTree.open(
+                self._pager, rootpage, freelist=self._freelist, is_unique=unique
+            )
+            result.append((name, cols, tree))
+        return result
+
     # ── Backend interface: Schema ─────────────────────────────────────────────
 
     def tables(self) -> list[str]:
@@ -943,6 +968,27 @@ class SqliteFileBackend(Backend):
         if non_pk_unique:
             _check_unique(table, full_row, non_pk_unique, tree, columns)
 
+        # Pre-validate UNIQUE indexes before mutating anything: walk every
+        # index on this table and reject the row if any UNIQUE index would
+        # be violated.  Doing this BEFORE the table insert means failures
+        # leave the database byte-for-byte unchanged.
+        indexes = self._open_indexes_for(table)
+        for idx_name, idx_cols, idx_tree in indexes:
+            if not idx_tree.is_unique:
+                continue
+            key_vals: list[SqlValue] = [full_row.get(c) for c in idx_cols]  # type: ignore[misc]
+            if any(v is None for v in key_vals):
+                continue  # NULL-distinct: per SQLite, NULLs don't conflict
+            if next(idx_tree.range_scan(key_vals, key_vals), None) is not None:
+                raise ConstraintViolation(
+                    table=table,
+                    column=", ".join(idx_cols),
+                    message=(
+                        f"UNIQUE constraint failed: index {idx_name!r} "
+                        f"already has key {key_vals!r}"
+                    ),
+                )
+
         payload = _encode_row(rowid, full_row, columns)
         try:
             tree.insert(rowid, payload)
@@ -956,6 +1002,12 @@ class SqliteFileBackend(Backend):
                     message=f"PRIMARY KEY constraint failed: {table}.{pk_cols[0].name}",
                 ) from None
             raise  # Should not happen for non-IPK tables; propagate as-is.
+
+        # Maintain secondary indexes: insert (key_vals, rowid) into each.
+        # UNIQUE checks above ensure this cannot raise DuplicateIndexKeyError.
+        for _idx_name, idx_cols, idx_tree in indexes:
+            key_vals = [full_row.get(c) for c in idx_cols]  # type: ignore[misc]
+            idx_tree.insert(key_vals, rowid)
 
     def update(
         self,
@@ -995,8 +1047,41 @@ class SqliteFileBackend(Backend):
 
         tree = self._open_tree(rootpage)
         rowid = cursor._current_rowid  # noqa: SLF001
+
+        # Maintain secondary indexes.  For each index, decide whether the new
+        # row's key differs from the old; if so, the old entry must be
+        # deleted and the new entry inserted.  Pre-validate UNIQUE indexes
+        # *before* any mutation so a violation leaves state unchanged.
+        indexes = self._open_indexes_for(table)
+        index_changes: list[tuple[IndexTree, list[SqlValue], list[SqlValue]]] = []
+        for idx_name, idx_cols, idx_tree in indexes:
+            old_key: list[SqlValue] = [current_row.get(c) for c in idx_cols]  # type: ignore[misc]
+            new_key: list[SqlValue] = [proposed.get(c) for c in idx_cols]  # type: ignore[misc]
+            if old_key == new_key:
+                continue  # nothing to do for this index
+            index_changes.append((idx_tree, old_key, new_key))
+            # UNIQUE pre-check on the new key (NULL-distinct).
+            if (
+                idx_tree.is_unique
+                and not any(v is None for v in new_key)
+                and next(idx_tree.range_scan(new_key, new_key), None) is not None
+            ):
+                raise ConstraintViolation(
+                    table=table,
+                    column=", ".join(idx_cols),
+                    message=(
+                        f"UNIQUE constraint failed: index {idx_name!r} "
+                        f"already has key {new_key!r}"
+                    ),
+                )
+
         new_payload = _encode_row(rowid, proposed, columns)
         tree.update(rowid, new_payload)
+
+        # Apply the index entry rotations now that the table row is in place.
+        for idx_tree, old_key, new_key in index_changes:
+            idx_tree.delete(old_key, rowid)
+            idx_tree.insert(new_key, rowid)
 
         # Update cursor's cached row so further reads are consistent.
         cursor._current_row = proposed  # noqa: SLF001
@@ -1019,6 +1104,15 @@ class SqliteFileBackend(Backend):
         rootpage, _ = self._require_table(table)
         tree = self._open_tree(rootpage)
         rowid = cursor._current_rowid  # noqa: SLF001
+
+        # Remove this row's entries from every secondary index BEFORE the
+        # table row goes away, so we can still read the indexed column values
+        # from the cursor's cached row.
+        current_row: Row = cursor._current_row or {}  # noqa: SLF001
+        for _idx_name, idx_cols, idx_tree in self._open_indexes_for(table):
+            key_vals: list[SqlValue] = [current_row.get(c) for c in idx_cols]  # type: ignore[misc]
+            idx_tree.delete(key_vals, rowid)
+
         tree.delete(rowid)
 
         # Clear cursor position — the row no longer exists.

--- a/code/packages/python/storage-sqlite/tests/test_backend_index.py
+++ b/code/packages/python/storage-sqlite/tests/test_backend_index.py
@@ -610,3 +610,156 @@ class TestUniqueIndex:
         assert _parse_index_unique('CREATE INDEX "x" ON "t" ("c")') is False
         assert _parse_index_unique(None) is False
         assert _parse_index_unique("") is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime index maintenance (insert / update / delete keep indexes in sync)
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeIndexMaintenance:
+    """Indexes are updated transparently on every insert/update/delete."""
+
+    def _setup(self, b: SqliteFileBackend, *, unique: bool = False) -> None:
+        b.create_table(
+            "users",
+            [
+                ColumnDef("id", "INTEGER", primary_key=True),
+                ColumnDef("email", "TEXT"),
+                ColumnDef("age", "INTEGER"),
+            ],
+            if_not_exists=False,
+        )
+        b.create_index(
+            IndexDef(
+                name="idx_email", table="users",
+                columns=["email"], unique=unique,
+            )
+        )
+
+    def test_insert_populates_index(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "rim1.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            b.insert("users", {"id": 2, "email": "b@x.com", "age": 31})
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+            assert list(b.scan_index("idx_email", ["b@x.com"], ["b@x.com"])) == [2]
+
+    def test_insert_unique_runtime_violation(self, tmp_path: Path) -> None:
+        from sql_backend import ConstraintViolation
+        path = str(tmp_path / "rim2.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b, unique=True)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            with pytest.raises(ConstraintViolation, match="UNIQUE constraint"):
+                b.insert("users", {"id": 2, "email": "a@x.com", "age": 31})
+            # Failed insert must leave the table and the index unchanged.
+            cursor = b.scan("users")
+            rows = []
+            while (r := cursor.next()) is not None:
+                rows.append(r)
+            assert [row["id"] for row in rows] == [1]
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+
+    def test_insert_unique_allows_multiple_nulls(self, tmp_path: Path) -> None:
+        """NULLs in a UNIQUE index column do not conflict (SQLite semantics)."""
+        path = str(tmp_path / "rim3.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b, unique=True)
+            b.insert("users", {"id": 1, "age": 30})  # email = NULL
+            b.insert("users", {"id": 2, "age": 31})  # email = NULL
+            b.insert("users", {"id": 3, "age": 32})  # email = NULL
+            # All three rows are reachable via the table scan.
+            cursor = b.scan("users")
+            rows = []
+            while (r := cursor.next()) is not None:
+                rows.append(r)
+            assert sorted(row["id"] for row in rows) == [1, 2, 3]
+
+    def test_delete_removes_index_entry(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "rim4.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            b.insert("users", {"id": 2, "email": "b@x.com", "age": 31})
+            cursor = b.scan("users")
+            cursor.next()  # row 1
+            b.delete("users", cursor)
+            # Index must no longer reference the deleted row.
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == []
+            # The other row's entry must still be there.
+            assert list(b.scan_index("idx_email", ["b@x.com"], ["b@x.com"])) == [2]
+
+    def test_update_changes_index_entry(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "rim5.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.insert("users", {"id": 1, "email": "old@x.com", "age": 30})
+            cursor = b.scan("users")
+            cursor.next()
+            b.update("users", cursor, {"email": "new@x.com"})
+            # Old key must be gone, new key present.
+            assert list(b.scan_index("idx_email", ["old@x.com"], ["old@x.com"])) == []
+            assert list(b.scan_index("idx_email", ["new@x.com"], ["new@x.com"])) == [1]
+
+    def test_update_non_indexed_column_skips_index(self, tmp_path: Path) -> None:
+        """Updating a non-indexed column must not touch the index B-tree."""
+        path = str(tmp_path / "rim6.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            cursor = b.scan("users")
+            cursor.next()
+            b.update("users", cursor, {"age": 99})
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+
+    def test_update_unique_runtime_violation(self, tmp_path: Path) -> None:
+        from sql_backend import ConstraintViolation
+        path = str(tmp_path / "rim7.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b, unique=True)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            b.insert("users", {"id": 2, "email": "b@x.com", "age": 31})
+            cursor = b.scan("users")
+            cursor.next()  # row 1 (email=a@x.com)
+            with pytest.raises(ConstraintViolation, match="UNIQUE constraint"):
+                b.update("users", cursor, {"email": "b@x.com"})
+            # State unchanged: row 1 keeps a@x.com, row 2 keeps b@x.com.
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+            assert list(b.scan_index("idx_email", ["b@x.com"], ["b@x.com"])) == [2]
+
+    def test_multiple_indexes_all_maintained(self, tmp_path: Path) -> None:
+        """A table with two indexes: insert/delete updates both."""
+        path = str(tmp_path / "rim8.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.create_index(
+                IndexDef(name="idx_age", table="users", columns=["age"])
+            )
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            b.insert("users", {"id": 2, "email": "b@x.com", "age": 30})
+            assert sorted(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+            assert sorted(b.scan_index("idx_age", [30], [30])) == [1, 2]
+            # Delete row 1 — both indexes lose its entry.
+            cursor = b.scan("users")
+            cursor.next()
+            b.delete("users", cursor)
+            assert list(b.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == []
+            assert sorted(b.scan_index("idx_age", [30], [30])) == [2]
+
+    def test_index_persists_across_reopen(self, tmp_path: Path) -> None:
+        """Runtime-maintained index entries survive close + reopen."""
+        path = str(tmp_path / "rim9.db")
+        with SqliteFileBackend(path) as b:
+            self._setup(b)
+            b.insert("users", {"id": 1, "email": "a@x.com", "age": 30})
+            b.insert("users", {"id": 2, "email": "b@x.com", "age": 31})
+            # Flush dirty pages.  Pure DML inserts do not auto-commit; the
+            # backend assumes the caller (typically the SQL VM) wraps work
+            # in begin_transaction/commit boundaries.
+            h = b.begin_transaction()
+            b.commit(h)
+        with SqliteFileBackend(path) as b2:
+            assert list(b2.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
+            assert list(b2.scan_index("idx_email", ["b@x.com"], ["b@x.com"])) == [2]


### PR DESCRIPTION
## Summary

- Secondary indexes are now kept in sync with the table B-tree on every `insert`/`update`/`delete`, not only at `create_index` backfill time
- Closes the IX-11 limitation: `CREATE UNIQUE INDEX` now rejects duplicate keys at runtime, with NULL-distinct semantics on every DML operation
- New private helper `_open_indexes_for(table)` returns open `IndexTree` handles for every index, each in the right unique mode (recovered from stored SQL)
- `insert` pre-validates UNIQUE indexes before any mutation so a violation leaves the database byte-for-byte unchanged
- `update` rotates index entries (delete old + insert new) only for indexes whose key columns actually changed
- `delete` removes the row's entry from every index using the cursor's cached row before the table-B-tree delete
- 9 new tests, 628 total pass, ruff clean
- Security review passed in one round

## Test plan

- [x] All 628 tests pass (`uv run pytest --no-cov`)
- [x] `uv run ruff check src/ tests/` — clean
- [x] Security review passed (no findings)
- [x] Tested: insert populates index, runtime UNIQUE violation rejected, multiple NULLs allowed, delete removes entry, update changes entry, update of non-indexed column skips index, runtime UNIQUE on update, multiple-index maintenance, persistence across reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)