### PR TITLE
Handle HTML doctype system recovery

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -90,3 +90,5 @@ documented in this file.
 - DOCTYPE `PUBLIC` and `SYSTEM` identifier states now preserve quoted public
   and system identifiers on emitted tokens, including force-quirks recovery for
   missing identifiers.
+- Standalone `SYSTEM` doctypes and trailing junk after system identifiers are
+  now covered, with unexpected trailing junk marking force-quirks mode.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -37,6 +37,8 @@ also emits the current name in force-quirks mode. Mosaic-era `PUBLIC` and
 `SYSTEM` identifiers are preserved on emitted DOCTYPE tokens, so legacy
 declarations such as `<!DOCTYPE html PUBLIC "...">` keep the information the
 future tree-construction/parser layer will need for compatibility decisions.
+DOCTYPE system-identifier recovery marks force-quirks mode for missing
+identifiers and unexpected trailing junk.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `CDATA section`, `script_data`, `script_data_escaped`, and
 `script_data_double_escaped` entry states for parser-controlled tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5941,7 +5941,10 @@ from = "after_doctype_system_identifier"
 matcher = { anything = true }
 to = "bogus_doctype"
 consume = false
-actions = ["parse_error(unexpected-character-after-doctype-system-identifier)"]
+actions = [
+  "parse_error(unexpected-character-after-doctype-system-identifier)",
+  "mark_force_quirks",
+]
 
 [[transitions]]
 from = "bogus_doctype"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -12495,6 +12495,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(unexpected-character-after-doctype-system-identifier)".to_string(),
+                "mark_force_quirks".to_string(),
             ],
             consume: false,
         },

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 45);
+    assert_eq!(html1.cases.len(), 48);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 44);
+    assert_eq!(file.tests.len(), 47);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -113,23 +113,31 @@ fn html5lib_smoke_fixture_file_parses() {
         file.tests[8].errors[0].code,
         "missing-doctype-public-identifier"
     );
-    assert_eq!(file.tests[10].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[10].errors[0].line, 1);
-    assert_eq!(file.tests[10].errors[0].col, 9);
+    assert_eq!(
+        file.tests[10].errors[0].code,
+        "missing-doctype-system-identifier"
+    );
     assert_eq!(
         file.tests[11].errors[0].code,
+        "unexpected-character-after-doctype-system-identifier"
+    );
+    assert_eq!(file.tests[13].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[13].errors[0].line, 1);
+    assert_eq!(file.tests[13].errors[0].col, 9);
+    assert_eq!(
+        file.tests[14].errors[0].code,
         "abrupt-closing-of-empty-comment"
     );
     assert_eq!(
-        file.tests[13].initial_states,
+        file.tests[16].initial_states,
         vec!["RCDATA state".to_string()]
     );
-    assert_eq!(file.tests[13].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(file.tests[16].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
-        file.tests[15].initial_states,
+        file.tests[18].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[15].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[18].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -154,7 +162,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 44);
+    assert_eq!(normalized.cases.len(), 47);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -169,31 +177,39 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
         vec!["missing-doctype-public-identifier".to_string()]
     );
     assert_eq!(
+        normalized.cases[10].diagnostics,
+        vec!["missing-doctype-system-identifier".to_string()]
+    );
+    assert_eq!(
         normalized.cases[11].diagnostics,
+        vec!["unexpected-character-after-doctype-system-identifier".to_string()]
+    );
+    assert_eq!(
+        normalized.cases[14].diagnostics,
         vec!["abrupt-closing-of-empty-comment".to_string()]
     );
     assert_eq!(
-        normalized.cases[13].initial_state.as_deref(),
+        normalized.cases[16].initial_state.as_deref(),
         Some("RCDATA state")
     );
     assert_eq!(
-        normalized.cases[13].last_start_tag.as_deref(),
+        normalized.cases[16].last_start_tag.as_deref(),
         Some("title")
     );
     assert_eq!(
-        normalized.cases[14].initial_state.as_deref(),
+        normalized.cases[17].initial_state.as_deref(),
         Some("RCDATA state")
     );
     assert_eq!(
-        normalized.cases[14].last_start_tag.as_deref(),
+        normalized.cases[17].last_start_tag.as_deref(),
         Some("title")
     );
     assert_eq!(
-        normalized.cases[15].initial_state.as_deref(),
+        normalized.cases[18].initial_state.as_deref(),
         Some("RAWTEXT state")
     );
     assert_eq!(
-        normalized.cases[15].last_start_tag.as_deref(),
+        normalized.cases[18].last_start_tag.as_deref(),
         Some("style")
     );
 }
@@ -237,7 +253,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 44);
+    assert_eq!(suite.cases.len(), 47);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -121,6 +121,39 @@
       ]
     },
     {
+      "id": "doctype-system-identifier",
+      "description": "DOCTYPE SYSTEM declarations preserve the system identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "id": "doctype-missing-system-identifier-quirks",
+      "description": "DOCTYPE SYSTEM without an identifier marks force-quirks",
+      "input": "<!DOCTYPE html SYSTEM>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-doctype-system-identifier"
+      ]
+    },
+    {
+      "id": "doctype-trailing-junk-after-system-identifier-quirks",
+      "description": "Unexpected text after a system identifier marks force-quirks",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-character-after-doctype-system-identifier"
+      ]
+    },
+    {
       "id": "comment-eof-recovery",
       "input": "<!--open",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -123,6 +123,40 @@
     },
     {
       "id": "html5lib-smoke-10",
+      "description": "doctype system identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=false)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-11",
+      "description": "doctype missing system identifier",
+      "input": "<!DOCTYPE html SYSTEM>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-doctype-system-identifier"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-12",
+      "description": "doctype trailing junk after system identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-character-after-doctype-system-identifier"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-13",
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "tokens": [
@@ -132,7 +166,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-14",
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "tokens": [
@@ -144,7 +178,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-15",
       "description": "abrupt empty comment close",
       "input": "Before<!-->After",
       "tokens": [
@@ -158,7 +192,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-16",
       "description": "dash prefixed empty comment close",
       "input": "Before<!--->After",
       "tokens": [
@@ -170,7 +204,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-17",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -183,7 +217,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-18",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -195,7 +229,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-19",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -208,7 +242,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-20",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -219,7 +253,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-21",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -232,7 +266,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-22",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -245,7 +279,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-23",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -255,7 +289,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-24",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -265,7 +299,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-25",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -277,7 +311,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-26",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -287,7 +321,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-27",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -297,7 +331,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-28",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -310,7 +344,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-29",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -320,7 +354,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-30",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -330,7 +364,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-31",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -343,7 +377,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-32",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -357,7 +391,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-33",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -371,7 +405,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-34",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -388,7 +422,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-35",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -398,7 +432,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-36",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -408,7 +442,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-37",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -418,7 +452,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-38",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -428,7 +462,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-39",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -440,7 +474,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-40",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -453,7 +487,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-41",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -466,7 +500,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-42",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -481,7 +515,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-43",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -494,7 +528,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-44",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -508,7 +542,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-45",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -521,7 +555,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-46",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -535,7 +569,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-47",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -83,6 +83,33 @@
       ]
     },
     {
+      "description": "doctype system identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
+      "output": [
+        ["DOCTYPE", "html", null, "about:legacy-compat", true]
+      ]
+    },
+    {
+      "description": "doctype missing system identifier",
+      "input": "<!DOCTYPE html SYSTEM>",
+      "output": [
+        ["DOCTYPE", "html", null, null, false]
+      ],
+      "errors": [
+        {"code": "missing-doctype-system-identifier", "line": 1, "col": 23}
+      ]
+    },
+    {
+      "description": "doctype trailing junk after system identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>",
+      "output": [
+        ["DOCTYPE", "html", null, "about:legacy-compat", false]
+      ],
+      "errors": [
+        {"code": "unexpected-character-after-doctype-system-identifier", "line": 1, "col": 45}
+      ]
+    },
+    {
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -192,6 +192,24 @@ fn default_html_lexer_supports_public_and_system_doctype_identifiers() {
 }
 
 #[test]
+fn default_html_lexer_supports_standalone_system_doctype_identifier() {
+    let tokens = lex_html("<!DOCTYPE html SYSTEM \"about:legacy-compat\">").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: Some("about:legacy-compat".to_string()),
+                force_quirks: false,
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_marks_missing_public_identifier_force_quirks() {
     let mut lexer = create_html_lexer().unwrap();
 
@@ -214,6 +232,57 @@ fn default_html_lexer_marks_missing_public_identifier_force_quirks() {
         .diagnostics()
         .iter()
         .any(|diagnostic| diagnostic.code == "missing-doctype-public-identifier"));
+}
+
+#[test]
+fn default_html_lexer_marks_missing_system_identifier_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!DOCTYPE html SYSTEM>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "missing-doctype-system-identifier"));
+}
+
+#[test]
+fn default_html_lexer_marks_trailing_junk_after_system_identifier_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: Some("about:legacy-compat".to_string()),
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer.diagnostics().iter().any(
+        |diagnostic| diagnostic.code == "unexpected-character-after-doctype-system-identifier"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Mark force-quirks mode when unexpected trailing text appears after a quoted DOCTYPE system identifier.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for standalone `SYSTEM` doctypes, missing system identifiers, and trailing system-identifier junk.
- Regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`
- After rebasing on latest `origin/main`: `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- After rebasing on latest `origin/main`: `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- After rebasing on latest `origin/main`: `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- After rebasing on latest `origin/main`: `git diff --check HEAD~1 HEAD`