### PR TITLE
feat(cli-assembly-writer): CLR01 Phase 1 — ECMA-335 conformance fixes

### DIFF
--- a/code/packages/python/cli-assembly-writer/CHANGELOG.md
+++ b/code/packages/python/cli-assembly-writer/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.2.0 — 2026-04-28
+
+### CLR01 Phase 1 — ECMA-335 conformance fixes
+
+Brings the writer closer to real-`dotnet` loadability while keeping
+every existing simulator user (clr-vm-simulator, brainfuck-clr,
+oct-clr, nib-clr) green.  Real `dotnet 9.0.313` still rejects the
+output with `BadImageFormatException` — see `code/specs/CLR01...md`
+"Status (2026-04-28)" for what landed and what remains (CLR02).
+
+Concrete changes in `writer.py`:
+
+- **MS-DOS stub** at file offset 0x40 (canonical 64-byte sequence
+  printing "This program cannot be run in DOS mode.").
+- **`<Module>` pseudo-TypeDef** as TypeDef row 1, per
+  ECMA-335 §II.22.37.  User TypeDef shifts to row 2.
+- **AssemblyRef table** (0x23) with one row pointing at
+  System.Runtime (net9.0 version, ECMA public-key token
+  `b03f5f7f11d50a3a`).
+- **System.Object TypeRef** as TypeRef row 2; user TypeDef's
+  `Extends` column now points at it.
+- **ResolutionScope** on every existing TypeRef rewired from 0
+  (dangling) to AssemblyRef row 1.
+- **`#GUID` metadata stream** + Module Mvid pointing at a
+  deterministic GUID derived from the assembly name.
+- **Stream order** changed to match real C#: #~, #Strings, #US,
+  #GUID, #Blob.
+- **COFF Characteristics** changed from `0x102`
+  (legacy 32-bit-machine) to `0x22` (executable + large-address-
+  aware) to match real-C# AnyCPU output.
+- **Empty tables dropped from the Valid mask**: previously the
+  MemberRef bit was set even with zero rows; real .NET rejects
+  that as corrupt.
+
+Test surface:
+
+- `tests/test_writer.py::test_write_ir_lowered_fat_method_with_locals_and_internal_call`
+  updated to expect `<Module>` at TypeDef row 0 and the user
+  TypeDef at row 1 (the ECMA-335-correct layout).
+- `tests/test_real_dotnet.py` import paths fixed
+  (`CILBytecodeBuilder` from `cil_bytecode_builder`,
+  `CILMethodArtifact` / `CILProgramArtifact` from
+  `ir_to_cil_bytecode`, plus `SequentialCILTokenProvider` for the
+  required `token_provider` field).
+
 ## 0.1.0
 
 - Add a composable CLI assembly writer for wrapping CIL method artifacts in a

--- a/code/packages/python/cli-assembly-writer/CHANGELOG.md
+++ b/code/packages/python/cli-assembly-writer/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
-## 0.2.0 — 2026-04-28
+## 0.2.0 — 2026-04-29
 
-### CLR01 Phase 1 — ECMA-335 conformance fixes
+### CLR01 — ECMA-335 conformance fixes (LANDED end-to-end)
 
-Brings the writer closer to real-`dotnet` loadability while keeping
-every existing simulator user (clr-vm-simulator, brainfuck-clr,
-oct-clr, nib-clr) green.  Real `dotnet 9.0.313` still rejects the
-output with `BadImageFormatException` — see `code/specs/CLR01...md`
-"Status (2026-04-28)" for what landed and what remains (CLR02).
+Real `dotnet 9.0.313` now executes our assemblies and returns the
+expected exit code.  All simulator users (clr-vm-simulator,
+brainfuck-clr, oct-clr, nib-clr) stay green.
+
+The previously-flagged "CLR02 follow-up" turned out to be **one
+bug**, not three: the pre-existing Assembly-table row encoding was
+2 bytes too short (missing the ECMA-335 §II.22.2 `Culture` column).
+Fixed in this same release.
 
 Concrete changes in `writer.py`:
 
@@ -33,6 +36,14 @@ Concrete changes in `writer.py`:
 - **Empty tables dropped from the Valid mask**: previously the
   MemberRef bit was set even with zero rows; real .NET rejects
   that as corrupt.
+- **Assembly row width fix (the actual root-cause)**: the format
+  changed from `<IHHHHIHH>` (8 fields = 20 bytes, missing the
+  Culture column) to `<IHHHHIHHH>` (9 fields = 22 bytes,
+  correctly mapped) per ECMA-335 §II.22.2.  Without this, the
+  AssemblyRef table that follows started 2 bytes early and
+  `System.Reflection.Metadata.AssemblyRefTableReader` read past
+  end-of-stream — that was the cryptic "BadImageFormatException:
+  File is corrupt" we'd been chasing.
 
 Test surface:
 

--- a/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
+++ b/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
@@ -14,6 +14,21 @@ _TEXT_RVA = 0x2000
 _CLI_HEADER_SIZE = 0x48
 _PE_OFFSET = 0x80
 
+# Canonical 64-byte MS-DOS stub sitting between the MZ header and the
+# PE header (file offsets 0x40..0x7F).  Real .NET's ``PEReader``
+# validates that this slot matches the standard pattern before
+# proceeding; without it, the loader rejects the file as corrupt
+# (CLR01).  The bytes are: a tiny x86 prologue that prints "This
+# program cannot be run in DOS mode.\r\r\n$" and exits, followed by
+# eight padding zeros.  ECMA-335 §II.25.2.1 references this exact
+# stub as the conventional content of the slot.
+_DOS_STUB = bytes.fromhex(
+    "0e1fba0e00b409cd21b8014ccd2154686973207072"
+    "6f6772616d2063616e6e6f742062652072756e2069"
+    "6e20444f53206d6f64652e0d0d0a2400000000000000"
+)
+assert len(_DOS_STUB) == _PE_OFFSET - 0x40, "DOS stub must fill 0x40..0x80"
+
 _MODULE_TABLE = 0x00
 _TYPE_REF_TABLE = 0x01
 _TYPE_DEF_TABLE = 0x02
@@ -21,6 +36,15 @@ _METHOD_DEF_TABLE = 0x06
 _MEMBER_REF_TABLE = 0x0A
 _STANDALONE_SIG_TABLE = 0x11
 _ASSEMBLY_TABLE = 0x20
+_ASSEMBLY_REF_TABLE = 0x23
+
+# ECMA public-key token for the standard library assemblies
+# (mscorlib, System.Runtime, …).  Burnt into the runtime; treat as
+# an opaque eight-byte literal.
+_ECMA_PUBLIC_KEY_TOKEN = bytes.fromhex("b03f5f7f11d50a3a")
+
+# net9.0's System.Runtime version.
+_SYSTEM_RUNTIME_VERSION = (9, 0, 0, 0)
 
 _METHOD_DEF_TOKEN_PREFIX = 0x06000000
 _MEMBER_REF_TOKEN_PREFIX = 0x0A000000
@@ -113,6 +137,27 @@ class _BlobHeap:
 
     def bytes(self) -> bytes:
         return bytes(self._data)
+
+
+class _GuidHeap:
+    """ECMA-335 §II.24.2.5 — fixed 16-byte entries, 1-indexed.
+
+    Index 0 means "no GUID" (some columns accept that).  Real GUIDs
+    start at index 1 and lookup is ``offset = (index - 1) * 16``.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[bytes] = []
+
+    def add(self, guid: bytes) -> int:
+        if len(guid) != 16:
+            msg = f"GUID must be 16 bytes, got {len(guid)}"
+            raise CLIAssemblyWriterError(msg)
+        self._entries.append(guid)
+        return len(self._entries)  # 1-based
+
+    def bytes(self) -> bytes:
+        return b"".join(self._entries)
 
 
 class CLIAssemblyWriter:
@@ -225,6 +270,12 @@ class CLIAssemblyWriter:
     ) -> bytes:
         strings = _StringHeap()
         blobs = _BlobHeap()
+        guids = _GuidHeap()
+        # Module Mvid — a deterministic-but-stable GUID derived from
+        # the assembly name keeps two writes of the same program byte
+        # identical (useful for tests) while still satisfying real
+        # .NET's "Module.Mvid must point at a real GUID" rule.
+        mvid_index = guids.add(_derive_module_mvid(self.config.assembly_name))
         module_name_index = strings.add(self.config.module_name)
         type_name_index = strings.add(self.config.type_name)
         type_namespace_index = strings.add(self.config.type_namespace)
@@ -233,6 +284,31 @@ class CLIAssemblyWriter:
         helper_namespace, helper_name = _split_type_name(self.config.helper_type_name)
         helper_name_index = strings.add(helper_name)
         helper_namespace_index = strings.add(helper_namespace)
+
+        # CLR01 chunk 2: ECMA-335 §II.22.37 mandates that TypeDef row 1
+        # be the special ``<Module>`` pseudo-type that owns module-level
+        # fields and global functions.  Real .NET's metadata loader
+        # rejects any TypeDef table that doesn't begin with this row.
+        # Empty namespace, no fields, no methods (FieldList/MethodList
+        # both pointing at row 1 means the user TypeDef on row 2 owns
+        # everything starting from index 1).
+        module_pseudo_name_index = strings.add("<Module>")
+
+        # CLR01 chunk 3: AssemblyRef table + System.Object TypeRef.
+        # The user's TypeDef must extend something — real .NET refuses
+        # to load assemblies whose user types have ``Extends = 0``.
+        # Real types extend ``System.Object``, which lives in
+        # ``System.Runtime`` for net9.0.  We add (a) one AssemblyRef
+        # row pointing at System.Runtime, (b) one TypeRef row for
+        # System.Object resolving against that AssemblyRef, then
+        # point the user TypeDef's ``Extends`` column at the
+        # System.Object TypeRef.  See spec §II.22.5 / §II.24.2.6.
+        system_runtime_name_index = strings.add("System.Runtime")
+        empty_string_index = strings.add("")
+        ecma_token_blob = blobs.add(_ECMA_PUBLIC_KEY_TOKEN)
+        empty_blob = blobs.add(b"")
+        system_object_name_index = strings.add("Object")
+        system_namespace_index = strings.add("System")
 
         method_name_indices = {
             layout.method.name: strings.add(layout.method.name)
@@ -270,6 +346,7 @@ class CLIAssemblyWriter:
             program,
             method_layouts,
             module_name_index,
+            module_pseudo_name_index,
             type_name_index,
             type_namespace_index,
             assembly_name_index,
@@ -280,14 +357,27 @@ class CLIAssemblyWriter:
             helper_name_indices,
             helper_sig_indices,
             local_sig_indices,
+            mvid_index=mvid_index,
+            system_runtime_name_index=system_runtime_name_index,
+            empty_string_index=empty_string_index,
+            ecma_token_blob=ecma_token_blob,
+            empty_blob=empty_blob,
+            system_object_name_index=system_object_name_index,
+            system_namespace_index=system_namespace_index,
         )
+        # Stream order matches what real C# emits: #~, #Strings, #US,
+        # #GUID, #Blob.  The order isn't load-bearing per ECMA-335 but
+        # some loader paths (notably System.Reflection.Metadata) cache
+        # offsets aggressively and behave poorly with surprising
+        # arrangements.  Match the conventional layout.
         return _metadata_root(
             self.config.metadata_version,
             (
                 ("#~", tables),
                 ("#Strings", strings.bytes()),
-                ("#Blob", blobs.bytes()),
                 ("#US", b"\x00"),
+                ("#GUID", guids.bytes()),
+                ("#Blob", blobs.bytes()),
             ),
         )
 
@@ -296,6 +386,7 @@ class CLIAssemblyWriter:
         program: CILProgramArtifact,
         method_layouts: tuple[_MethodLayout, ...],
         module_name_index: int,
+        module_pseudo_name_index: int,
         type_name_index: int,
         type_namespace_index: int,
         assembly_name_index: int,
@@ -306,26 +397,68 @@ class CLIAssemblyWriter:
         helper_name_indices: dict[CILHelper, int],
         helper_sig_indices: dict[CILHelper, int],
         local_sig_indices: dict[int, int],
+        *,
+        mvid_index: int,
+        system_runtime_name_index: int,
+        empty_string_index: int,
+        ecma_token_blob: int,
+        empty_blob: int,
+        system_object_name_index: int,
+        system_namespace_index: int,
     ) -> bytes:
         tables: dict[int, list[bytes]] = {
             _MODULE_TABLE: [
-                struct.pack("<HHHHH", 0, module_name_index, 0, 0, 0),
+                # Generation, Name, Mvid, EncId, EncBaseId.  Mvid is
+                # a #GUID-heap index pointing at the real GUID we just
+                # added; EncId/EncBaseId stay 0 (no edit-and-continue).
+                struct.pack("<HHHHH", 0, module_name_index, mvid_index, 0, 0),
             ],
             _TYPE_REF_TABLE: [
+                # Row 1: the existing helper TypeRef.  ResolutionScope
+                # rewired (CLR01) from 0 (= dangling) to AssemblyRef row
+                # 1.  ResolutionScope is a coded index with the table
+                # tag in the low 2 bits; AssemblyRef tag = 2, row 1 →
+                # ``(1 << 2) | 2 = 6``.
                 struct.pack(
                     "<HHH",
-                    0,
+                    6,
                     helper_name_index,
                     helper_namespace_index,
                 ),
+                # Row 2: ``System.Object`` in System.Runtime.  Same
+                # AssemblyRef-row-1 coded index in ResolutionScope.
+                struct.pack(
+                    "<HHH",
+                    6,
+                    system_object_name_index,
+                    system_namespace_index,
+                ),
             ],
             _TYPE_DEF_TABLE: [
+                # Row 1: the ``<Module>`` pseudo-TypeDef.  Flags=0,
+                # empty namespace, Extends=0, FieldList=1, MethodList=1.
+                # Owns no methods because the row 2 user TypeDef has
+                # the same MethodList=1 (and no rows follow).
+                struct.pack(
+                    "<IHHHHH",
+                    0,
+                    module_pseudo_name_index,
+                    0,
+                    0,
+                    1,
+                    1,
+                ),
+                # Row 2: the user-supplied TypeDef.  Owns all real
+                # methods starting at MethodDef row 1.  ``Extends`` is
+                # a TypeDefOrRef coded index pointing at TypeRef row
+                # 2 (System.Object); TypeRef tag = 1, row 2 →
+                # ``(2 << 2) | 1 = 9``.
                 struct.pack(
                     "<IHHHHH",
                     0x00100001,
                     type_name_index,
                     type_namespace_index,
-                    0,
+                    9,
                     1,
                     1,
                 ),
@@ -369,9 +502,38 @@ class CLIAssemblyWriter:
                     0,
                 ),
             ],
+            # CLR01 chunk 3: AssemblyRef row pointing at
+            # ``System.Runtime`` (net9.0) with the standard ECMA
+            # public-key token.  Without this row, every TypeRef row's
+            # ResolutionScope dangles and real .NET refuses to load.
+            # Row layout per ECMA-335 §II.22.5:
+            #   USHORT MajorVersion, MinorVersion, BuildNumber,
+            #          RevisionNumber
+            #   ULONG  Flags
+            #   BLOB   PublicKeyOrToken
+            #   STRING Name, Culture
+            #   BLOB   HashValue
+            _ASSEMBLY_REF_TABLE: [
+                struct.pack(
+                    "<HHHHIHHHH",
+                    _SYSTEM_RUNTIME_VERSION[0],
+                    _SYSTEM_RUNTIME_VERSION[1],
+                    _SYSTEM_RUNTIME_VERSION[2],
+                    _SYSTEM_RUNTIME_VERSION[3],
+                    0,
+                    ecma_token_blob,
+                    system_runtime_name_index,
+                    empty_string_index,
+                    empty_blob,
+                ),
+            ],
         }
-        if not tables[_STANDALONE_SIG_TABLE]:
-            del tables[_STANDALONE_SIG_TABLE]
+        # ECMA-335: a table with zero rows must NOT have its bit set
+        # in the valid mask, otherwise real .NET rejects the file as
+        # corrupt.  Drop empties.
+        for empty_table in (_STANDALONE_SIG_TABLE, _MEMBER_REF_TABLE):
+            if not tables.get(empty_table):
+                tables.pop(empty_table, None)
 
         valid_mask = 0
         for table in tables:
@@ -456,10 +618,16 @@ def _build_pe_image(text: bytes) -> bytes:
 
     headers[0:2] = b"MZ"
     struct.pack_into("<I", headers, 0x3C, _PE_OFFSET)
+    headers[0x40 : 0x40 + len(_DOS_STUB)] = _DOS_STUB
     headers[_PE_OFFSET : _PE_OFFSET + 4] = b"PE\x00\x00"
 
     coff_offset = _PE_OFFSET + 4
     optional_offset = coff_offset + 20
+    # COFF Characteristics: real C# emits 0x22 = EXECUTABLE_IMAGE
+    # (0x02) | LARGE_ADDRESS_AWARE (0x20).  We previously emitted
+    # 0x102 with IMAGE_FILE_32BIT_MACHINE (0x100) instead, which is
+    # the legacy "32-bit-only" flag and breaks under modern 64-bit
+    # CoreCLR.  Match the real-C# value.
     struct.pack_into(
         "<HHIIIHH",
         headers,
@@ -470,7 +638,7 @@ def _build_pe_image(text: bytes) -> bytes:
         0,
         0,
         0x00E0,
-        0x0102,
+        0x0022,
     )
 
     optional = bytearray(0xE0)
@@ -627,6 +795,20 @@ def _split_type_name(full_name: str) -> tuple[str, str]:
         msg = f"invalid type name: {full_name}"
         raise CLIAssemblyWriterError(msg)
     return namespace, name
+
+
+def _derive_module_mvid(assembly_name: str) -> bytes:
+    """Return a deterministic 16-byte GUID for the module's Mvid.
+
+    Real C# emits a fresh random GUID per build, but we want byte-
+    stable output for tests.  SHA-256(assembly_name) truncated to 16
+    bytes gives us that, and the result is a valid GUID for any
+    purpose — Mvid only has to be unique per module instance, not
+    cryptographically strong.
+    """
+    import hashlib
+
+    return hashlib.sha256(assembly_name.encode("utf-8")).digest()[:16]
 
 
 def _align(value: int, alignment: int) -> int:

--- a/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
+++ b/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
@@ -490,16 +490,28 @@ class CLIAssemblyWriter:
                 if layout.local_sig_token
             ],
             _ASSEMBLY_TABLE: [
+                # ECMA-335 §II.22.2 — Assembly row has 9 columns:
+                # HashAlgId(U32), MajorVersion(U16), MinorVersion(U16),
+                # BuildNumber(U16), RevisionNumber(U16), Flags(U32),
+                # PublicKey(Blob idx), Name(String idx), Culture(String idx).
+                # Total 22 bytes with narrow heaps.
+                #
+                # The pre-CLR01 row used format ``<IHHHHIHH`` (20 bytes,
+                # 8 fields) — missing the Culture column entirely, AND
+                # mis-mapped: ``assembly_name_index`` ended up in the
+                # PublicKey slot instead of the Name slot.  Real .NET's
+                # AssemblyRefTableReader reads past end-of-stream when
+                # the Assembly table is 2 bytes short, producing the
+                # cryptic ``BadImageFormatException: File is corrupt``
+                # we hit before this fix.
                 struct.pack(
-                    "<IHHHHIHH",
-                    0,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    assembly_name_index,
-                    0,
+                    "<IHHHHIHHH",
+                    0,                        # HashAlgId
+                    1, 0, 0, 0,               # 1.0.0.0
+                    0,                        # Flags
+                    0,                        # PublicKey blob (none)
+                    assembly_name_index,      # Name (string idx)
+                    0,                        # Culture (empty string idx)
                 ),
             ],
             # CLR01 chunk 3: AssemblyRef row pointing at

--- a/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
+++ b/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
@@ -1,0 +1,237 @@
+"""Real-``dotnet`` conformance tests for ``cli-assembly-writer``.
+
+These tests are the *target* of the CLR01 conformance work.  Today
+they all fail with ``System.BadImageFormatException: File is
+corrupt`` — the in-house writer produces assemblies that work on
+``clr-vm-simulator`` but real .NET rejects.  Each chunk of the
+CLR01 fix should knock another test (or another error message) off
+the failure list.
+
+The tests gate themselves behind a ``has_dotnet()`` probe so CI
+without the .NET SDK skips them rather than failing — same pattern
+the repo uses for git/curl/etc-dependent tests.
+
+What "passes" means
+-------------------
+A test passes when:
+
+1. The writer produces an assembly the real ``dotnet`` runtime
+   loads without ``BadImageFormatException``.
+2. The program executes and exits with the expected code.
+
+Both criteria must hold for every test in this file before the
+CLR01 work is considered done.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from cil_bytecode_builder import (
+    CILBuilder,
+    CILMethodArtifact,
+    CILProgramArtifact,
+)
+from cli_assembly_writer import CLIAssemblyConfig, write_cli_assembly
+
+
+def _has_dotnet() -> bool:
+    """Probe for a working ``dotnet`` CLI on PATH."""
+    if shutil.which("dotnet") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["dotnet", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+_DOTNET_AVAILABLE = _has_dotnet()
+_skip_if_no_dotnet = pytest.mark.skipif(
+    not _DOTNET_AVAILABLE,
+    reason="dotnet SDK not available; skipping real-runtime conformance test",
+)
+
+
+def _runtimeconfig_for_net9() -> str:
+    """The minimal ``<name>.runtimeconfig.json`` real .NET expects.
+
+    Without this file alongside the assembly, ``dotnet <name>.exe``
+    fails before even loading the PE because it can't pick a runtime.
+    """
+    return json.dumps({
+        "runtimeOptions": {
+            "tfm": "net9.0",
+            "framework": {
+                "name": "Microsoft.NETCore.App",
+                "version": "9.0.0",
+            },
+        },
+    })
+
+
+def _build_minimal_return_n_program(n: int) -> CILProgramArtifact:
+    """Build the smallest CIL program possible: ``Main`` returns ``n``.
+
+    Used as the target of the conformance fix — nothing else exercises
+    cli-assembly-writer's metadata layout more directly.
+    """
+    builder = CILBuilder()
+    builder.emit_ldc_i4(n)
+    builder.emit_ret()
+    body = builder.body()
+
+    method = CILMethodArtifact(
+        name="Main",
+        body=body,
+        return_type="int32",
+        parameter_types=(),
+        local_types=(),
+        max_stack=8,
+    )
+    return CILProgramArtifact(
+        entry_label="Main",
+        methods=(method,),
+        helper_specs=(),
+        data_offsets={},
+    )
+
+
+@_skip_if_no_dotnet
+def test_return_42_runs_on_real_dotnet(tmp_path: Path) -> None:
+    """The simplest possible smoke test: ``return 42``.
+
+    Currently fails with ``System.BadImageFormatException`` — the
+    target of the CLR01 conformance fix.  When this passes, the
+    minimum viable real-.NET writer is done.
+    """
+    program = _build_minimal_return_n_program(42)
+    artifact = write_cli_assembly(
+        program,
+        CLIAssemblyConfig(
+            assembly_name="ReturnFortyTwo",
+            module_name="ReturnFortyTwo.exe",
+            type_name="ReturnFortyTwo",
+        ),
+    )
+
+    asm_path = tmp_path / "ReturnFortyTwo.exe"
+    cfg_path = tmp_path / "ReturnFortyTwo.runtimeconfig.json"
+    asm_path.write_bytes(artifact.assembly_bytes)
+    cfg_path.write_text(_runtimeconfig_for_net9())
+
+    result = subprocess.run(
+        ["dotnet", str(asm_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    # The expected return code is 42 — the value Main returned.
+    # If we instead see 134 with "BadImageFormatException", the
+    # writer's output isn't loading; that's the conformance bug
+    # CLR01 fixes.
+    assert result.returncode == 42, (
+        f"dotnet rejected the assembly or returned the wrong exit code.\n"
+        f"  exit code: {result.returncode}\n"
+        f"  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+
+
+@_skip_if_no_dotnet
+def test_return_zero_runs_on_real_dotnet(tmp_path: Path) -> None:
+    """Sanity twin: returning 0 is distinguishable from "process
+    crashed before main ran" if we test against multiple return
+    values."""
+    program = _build_minimal_return_n_program(0)
+    artifact = write_cli_assembly(
+        program,
+        CLIAssemblyConfig(
+            assembly_name="ReturnZero",
+            module_name="ReturnZero.exe",
+            type_name="ReturnZero",
+        ),
+    )
+
+    asm_path = tmp_path / "ReturnZero.exe"
+    cfg_path = tmp_path / "ReturnZero.runtimeconfig.json"
+    asm_path.write_bytes(artifact.assembly_bytes)
+    cfg_path.write_text(_runtimeconfig_for_net9())
+
+    result = subprocess.run(
+        ["dotnet", str(asm_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"dotnet exited with {result.returncode}; "
+        f"stderr={result.stderr!r}"
+    )
+
+
+def test_diagnostic_current_failure_message(tmp_path: Path) -> None:
+    """Diagnostic-only — captures the *current* dotnet error message
+    as a baseline for tracking conformance progress.
+
+    This test does NOT skip on missing dotnet (it's also useful as a
+    pure unit test that the writer produces *some* output).  When
+    dotnet is present it asserts that the failure mode is
+    BadImageFormatException specifically — if a future CLR01 fix
+    breaks differently (e.g. METHOD_NOT_FOUND), that's a sign of
+    progress and this test is updated to reflect the new baseline.
+    """
+    program = _build_minimal_return_n_program(42)
+    artifact = write_cli_assembly(
+        program,
+        CLIAssemblyConfig(
+            assembly_name="Diagnostic",
+            module_name="Diagnostic.exe",
+            type_name="Diagnostic",
+        ),
+    )
+    assert len(artifact.assembly_bytes) > 0
+
+    if not _DOTNET_AVAILABLE:
+        pytest.skip("dotnet not available — diagnostic stops at byte production")
+
+    asm_path = tmp_path / "Diagnostic.exe"
+    cfg_path = tmp_path / "Diagnostic.runtimeconfig.json"
+    asm_path.write_bytes(artifact.assembly_bytes)
+    cfg_path.write_text(_runtimeconfig_for_net9())
+
+    result = subprocess.run(
+        ["dotnet", str(asm_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    # As of pre-CLR01: BadImageFormatException, exit code 134.
+    # When the fix lands and changes this, update the assertion.
+    if result.returncode != 42:
+        # Capture the failure mode for diagnostic purposes — if it
+        # changes, we know the fix is making progress.
+        assert "BadImageFormatException" in result.stderr or (
+            result.returncode == 134
+        ), (
+            "Expected the *current* failure to be a BadImageFormat / 134; "
+            f"got exit={result.returncode} stderr={result.stderr!r}.  "
+            "If dotnet now accepts the assembly, this test should be "
+            "removed and the smoke tests above will validate."
+        )

--- a/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
+++ b/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
@@ -187,16 +187,12 @@ def test_return_zero_runs_on_real_dotnet(tmp_path: Path) -> None:
     )
 
 
-def test_diagnostic_current_failure_message(tmp_path: Path) -> None:
-    """Diagnostic-only — captures the *current* dotnet error message
-    as a baseline for tracking conformance progress.
-
-    This test does NOT skip on missing dotnet (it's also useful as a
-    pure unit test that the writer produces *some* output).  When
-    dotnet is present it asserts that the failure mode is
-    BadImageFormatException specifically — if a future CLR01 fix
-    breaks differently (e.g. METHOD_NOT_FOUND), that's a sign of
-    progress and this test is updated to reflect the new baseline.
+def test_writer_produces_nonempty_output() -> None:
+    """Pure unit test — the writer produces some PE bytes for a
+    minimal return-42 program.  Pre-CLR01 this test was where we
+    captured the BadImageFormat baseline; CLR01 has landed (real
+    dotnet now exits 42 — see the smoke tests above), so this is
+    just a non-emptiness check now.
     """
     program = _build_minimal_return_n_program(42)
     artifact = write_cli_assembly(
@@ -208,33 +204,4 @@ def test_diagnostic_current_failure_message(tmp_path: Path) -> None:
         ),
     )
     assert len(artifact.assembly_bytes) > 0
-
-    if not _DOTNET_AVAILABLE:
-        pytest.skip("dotnet not available — diagnostic stops at byte production")
-
-    asm_path = tmp_path / "Diagnostic.exe"
-    cfg_path = tmp_path / "Diagnostic.runtimeconfig.json"
-    asm_path.write_bytes(artifact.assembly_bytes)
-    cfg_path.write_text(_runtimeconfig_for_net9())
-
-    result = subprocess.run(
-        ["dotnet", str(asm_path)],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
-
-    # As of pre-CLR01: BadImageFormatException, exit code 134.
-    # When the fix lands and changes this, update the assertion.
-    if result.returncode != 42:
-        # Capture the failure mode for diagnostic purposes — if it
-        # changes, we know the fix is making progress.
-        assert "BadImageFormatException" in result.stderr or (
-            result.returncode == 134
-        ), (
-            "Expected the *current* failure to be a BadImageFormat / 134; "
-            f"got exit={result.returncode} stderr={result.stderr!r}.  "
-            "If dotnet now accepts the assembly, this test should be "
-            "removed and the smoke tests above will validate."
-        )
+    assert artifact.assembly_bytes[:2] == b"MZ"

--- a/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
+++ b/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
@@ -31,10 +31,11 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from cil_bytecode_builder import (
-    CILBuilder,
+from cil_bytecode_builder import CILBytecodeBuilder
+from ir_to_cil_bytecode import (
     CILMethodArtifact,
     CILProgramArtifact,
+    SequentialCILTokenProvider,
 )
 from cli_assembly_writer import CLIAssemblyConfig, write_cli_assembly
 
@@ -86,10 +87,10 @@ def _build_minimal_return_n_program(n: int) -> CILProgramArtifact:
     Used as the target of the conformance fix — nothing else exercises
     cli-assembly-writer's metadata layout more directly.
     """
-    builder = CILBuilder()
+    builder = CILBytecodeBuilder()
     builder.emit_ldc_i4(n)
     builder.emit_ret()
-    body = builder.body()
+    body = builder.assemble()
 
     method = CILMethodArtifact(
         name="Main",
@@ -102,8 +103,10 @@ def _build_minimal_return_n_program(n: int) -> CILProgramArtifact:
     return CILProgramArtifact(
         entry_label="Main",
         methods=(method,),
-        helper_specs=(),
         data_offsets={},
+        data_size=0,
+        helper_specs=(),
+        token_provider=SequentialCILTokenProvider(("Main",)),
     )
 
 

--- a/code/packages/python/cli-assembly-writer/tests/test_writer.py
+++ b/code/packages/python/cli-assembly-writer/tests/test_writer.py
@@ -80,7 +80,12 @@ def test_write_ir_lowered_fat_method_with_locals_and_internal_call() -> None:
     callee = assembly.resolve_method_definition(0x06000002)
     body = disassemble_clr_method(assembly, entry)
 
-    assert assembly.type_definitions[0].method_tokens == (0x06000001, 0x06000002)
+    # CLR01: TypeDef row 0 is the ECMA-335 ``<Module>`` pseudo-type
+    # (no methods); the user TypeDef is now at row 1 and owns every
+    # MethodDef.
+    assert assembly.type_definitions[0].full_name == "<Module>"
+    assert assembly.type_definitions[0].method_tokens == ()
+    assert assembly.type_definitions[1].method_tokens == (0x06000001, 0x06000002)
     assert entry.header.format == "fat"
     assert entry.local_count == 2
     assert callee.name == "callee"

--- a/code/specs/CLR01-real-dotnet-conformance.md
+++ b/code/specs/CLR01-real-dotnet-conformance.md
@@ -3,95 +3,294 @@
 ## Why this spec exists
 
 Every CLR backend in the repo today
-(``brainfuck-clr-compiler``, ``oct-clr-compiler``, ``nib-clr-compiler``,
-and the new ``twig-clr-compiler``) emits PE/CLI assemblies that run
-**only on the in-house ``clr-vm-simulator``**.  Real ``dotnet`` (tested
-on 9.0.313) rejects every one of them with:
+(`brainfuck-clr-compiler`, `oct-clr-compiler`, `nib-clr-compiler`, the
+prototype `twig-clr-compiler`) emits PE/CLI assemblies that run **only
+on the in-house `clr-vm-simulator`**.  Real `dotnet` (tested on 9.0.313)
+rejects every one of them with:
 
 ```
 System.BadImageFormatException: File is corrupt. (0x8013110E)
 ```
 
-The simulator is permissive in ways real .NET isn't.  This spec brings
-the assembly writer up to ECMA-335 conformance so that the same
-``cli-assembly-writer`` output runs both on the simulator AND on
-``dotnet``.  The fix is repo-wide — every existing CLR backend
-inherits the conformance for free.
+The simulator is permissive in ways real .NET isn't, and no existing
+test in the repo runs CLR output through real `dotnet`.  This spec
+brings `cli-assembly-writer` up to ECMA-335 conformance so the same
+output runs both on the simulator AND on real `dotnet`.  The fix is
+**repo-wide** — every existing CLR backend inherits conformance for
+free.
 
-## The gap, diagnosed
+This is the *first* of two linked "real-runtime correctness" tracks:
+
+| Spec   | Backend | Gap                                                  |
+|--------|---------|------------------------------------------------------|
+| CLR01  | CLR     | `cli-assembly-writer` lacks ECMA-335 essentials      |
+| JVM01* | JVM     | `ir-to-jvm-class-file` uses a class-level static reg |
+|        |         | array → recursion is broken across method calls      |
+
+*JVM01 is implied by the ``test_recursion_factorial_small`` xfail in
+the new ``twig-jvm-compiler``.  It's a separate spec/PR; CLR01
+focuses only on the CLR side.
+
+## Sister sample
 
 I built a known-good reference assembly with C# / `dotnet build` that
-returns 42, and compared it to what ``cli-assembly-writer`` produces
-for the same logical program.  Differences:
+returns 42, and compared it byte-by-byte against what
+`cli-assembly-writer` produces for the same logical program.  The
+gap surface is small but every item has to land for `dotnet` to
+load the file:
 
 | Field                    | Real .NET / C#       | cli-assembly-writer today |
 |--------------------------|----------------------|---------------------------|
 | File size (`return 42`)  | 4608 bytes           | 1536 bytes                |
-| MS-DOS stub @ 0x40       | "This program …"     | zeros                     |
+| MS-DOS stub @ 0x40       | "This program cannot be run in DOS mode." | zeros |
 | TypeDef rows             | `<Module>`, Program  | Program only              |
 | AssemblyRef rows         | 1 (System.Runtime)   | **0**                     |
-| TypeRef resolution scope | AssemblyRef          | None / dangling           |
+| TypeRef resolution scope | `(AssemblyRef × 1)`  | 0 (no parent)             |
+| Manifest                 | TargetFramework attr | absent                    |
 
-The single most important gap is **AssemblyRef**.  Without it, every
-``TypeRef`` row's resolution scope points at nothing, so real .NET
-can't load any external types — including the bare `int32` /
-`object` / `MulticastDelegate` types every assembly transitively
-depends on.
+The **single most important gap is AssemblyRef.**  Without it, every
+`TypeRef` row's resolution scope points at nothing, so real .NET
+can't load any external type — not even the primitive types every
+assembly transitively depends on.
 
-## Plan
+## Detailed byte-level plan
 
-The fix lands in three logical chunks:
+The fix lands in three layered chunks.  Each chunk is independently
+testable: after Chunk 1 the existing simulator tests still pass and
+the conformance fixture's error message changes (no longer "File is
+corrupt"); after Chunk 2 the file loads but may fail later in
+verification; after Chunk 3 a `return 42` assembly exits 42.
 
-1. **AssemblyRef + minimal System.Runtime reference** (this PR).
-   Adds the ``AssemblyRef`` table (0x23), populates it with one
-   entry for ``System.Runtime`` (or ``mscorlib`` for net4x; we'll
-   target net9.0 here), and re-routes existing ``TypeRef`` rows to
-   use that AssemblyRef as their resolution scope.
+### Chunk 1 — DOS stub and ECMA-335 cosmetic header
 
-2. **`<Module>` pseudo-TypeDef and DOS stub** (this PR).
-   ``<Module>`` is the special TypeDef row 1 that owns module-level
-   fields and global functions.  ECMA-335 §II.22.37 requires it as
-   the first row in the TypeDef table; real .NET fails the assembly
-   loader if it's missing.  The DOS stub is the cosmetic 80-byte
-   "This program cannot be run in DOS mode" header at file offset
-   0x40.
+**Files touched:** `cli-assembly-writer/src/cli_assembly_writer/writer.py`
 
-3. **Conformance test fixture** (this PR).
-   A test that:
-     - Generates an assembly via the writer.
-     - Drops it in a temp dir alongside a `runtimeconfig.json`
-       targeting `net9.0`.
-     - Runs `dotnet <name>.exe` as a subprocess.
-     - Asserts the exit code matches the expected value.
-   The test is gated behind a ``has_dotnet()`` probe so CI without
-   the SDK skips rather than fails — same pattern the repo uses for
-   other tool-dependent tests.
+**ECMA-335 reference:** §II.25.2.1 (PE file header) + §II.25.2.2
+(MS-DOS header).
 
-If the three chunks land cleanly and dotnet still rejects the
-assembly, the "File is corrupt" error message will give us a
-specific reason to diagnose next; we add chunks until conformance
-passes.
+The current writer leaves bytes 0x00–0x80 as zeros except `e_lfanew`
+at offset 0x3C.  Real .NET's `PEReader` validates that the MS-DOS
+stub matches the canonical value before continuing.  Add the
+standard 80-byte stub at file offset 0x40:
+
+```
+0e 1f ba 0e 00 b4 09 cd 21 b8 01 4c cd 21 54 68
+69 73 20 70 72 6f 67 72 61 6d 20 63 61 6e 6e 6f
+74 20 62 65 20 72 75 6e 20 69 6e 20 44 4f 53 20
+6d 6f 64 65 2e 0d 0d 0a 24 00 00 00 00 00 00 00
+```
+
+(That's a tiny x86 prologue followed by the printable string "This
+program cannot be run in DOS mode.\r\r\n$".)
+
+**`e_lfanew` at offset 0x3C** must point at the PE header start
+(0x80 today — keep it).
+
+### Chunk 2 — `<Module>` pseudo-TypeDef and metadata heap fixes
+
+**Files touched:** same writer.py.
+
+**ECMA-335 reference:** §II.22.37 (TypeDef row 1 special).
+
+The TypeDef table must have `<Module>` as the **first row**.  It owns
+module-level fields and global functions; user types start at row 2.
+Real .NET's metadata loader hard-rejects any TypeDef table that
+doesn't begin with this row.
+
+Schema: `Flags=0, Name="<Module>", Namespace="", Extends=0,
+FieldList=1, MethodList=1`.
+
+```python
+_TYPE_DEF_TABLE: [
+    # NEW: row 1 — the <Module> pseudo-type.
+    struct.pack(
+        "<IHHHHH",
+        0,                                      # flags
+        strings.add("<Module>"),                # name
+        strings.add(""),                        # namespace (empty)
+        0,                                      # extends (no base type)
+        1,                                      # FieldList (1-based; no fields)
+        1,                                      # MethodList (1-based; first method)
+    ),
+    # row 2: existing user type, but its FieldList / MethodList
+    # indices need to skip past <Module>'s zero-length lists.
+    struct.pack(
+        "<IHHHHH",
+        0x00100001,
+        type_name_index,
+        type_namespace_index,
+        ???,                                    # see below
+        1,
+        1,
+    ),
+],
+```
+
+After this chunk the *first* meaningful real-.NET error message
+should change.  If we still see "File is corrupt", look at the
+`Extends` column on row 2 — Chunk 3 wires that to a real System.Object.
+
+### Chunk 3 — AssemblyRef table + ResolutionScope wiring
+
+**Files touched:** same writer.py.
+
+**ECMA-335 reference:**
+- §II.22.5 (AssemblyRef table).
+- §II.24.2.6 (ResolutionScope coded index).
+
+#### 3a. Emit the AssemblyRef table (0x23)
+
+System.Runtime for net9.0 looks like (from a reference C# build):
+
+| Column          | Value                            |
+|-----------------|----------------------------------|
+| MajorVersion    | 9                                |
+| MinorVersion    | 0                                |
+| BuildNumber     | 0                                |
+| RevisionNumber  | 0                                |
+| Flags           | 0                                |
+| PublicKeyOrToken | 0xb03f5f7f11d50a3a (ECMA token) |
+| Name            | "System.Runtime"                 |
+| Culture         | "" (empty)                       |
+| HashValue       | 0                                |
+
+Encoded row:
+
+```python
+_ASSEMBLY_REF_TABLE = 0x23
+
+_ASSEMBLY_REF_TOKEN_PREFIX = 0x23000000
+
+# AssemblyRef row layout per §II.22.5:
+#   USHORT MajorVersion, MinorVersion, BuildNumber, RevisionNumber
+#   ULONG  Flags
+#   BLOB   PublicKeyOrToken
+#   STRING Name
+#   STRING Culture
+#   BLOB   HashValue
+ecma_token = bytes.fromhex("b03f5f7f11d50a3a")
+ecma_token_blob = blobs.add(ecma_token)
+system_runtime_name = strings.add("System.Runtime")
+empty_culture = strings.add("")
+empty_hash_blob = blobs.add(b"")
+
+_ASSEMBLY_REF_TABLE: [
+    struct.pack(
+        "<HHHHIHHHH",
+        9, 0, 0, 0,                  # 9.0.0.0
+        0,                           # Flags
+        ecma_token_blob,             # PublicKeyOrToken
+        system_runtime_name,         # Name
+        empty_culture,               # Culture
+        empty_hash_blob,             # HashValue
+    ),
+],
+```
+
+#### 3b. ResolutionScope on existing TypeRef rows
+
+ResolutionScope is a coded index packing the table tag in the low 2
+bits.  AssemblyRef = tag 2.  With one AssemblyRef row at index 1,
+the encoded value is `(1 << 2) | 2 = 6`.
+
+```python
+_TYPE_REF_TABLE: [
+    struct.pack(
+        "<HHH",
+        6,  # ResolutionScope = AssemblyRef row 1 (was 0 = dangling)
+        helper_name_index,
+        helper_namespace_index,
+    ),
+],
+```
+
+#### 3c. Update the user TypeDef's `Extends` column
+
+In the table above, `Extends` is a TypeDefOrRef coded index pointing
+to `System.Object`.  We need to *also* add a TypeRef row for
+`System.Object` (in System.Runtime), and reference it from the
+user TypeDef's `Extends` column.
+
+Add a TypeRef row 2:
+
+```python
+_TYPE_REF_TABLE: [
+    # row 1: existing helper TypeRef (rewired in 3b)
+    ...,
+    # row 2: System.Object in System.Runtime
+    struct.pack(
+        "<HHH",
+        6,                                  # AssemblyRef row 1
+        strings.add("Object"),
+        strings.add("System"),
+    ),
+],
+```
+
+`Extends` for the user TypeDef is then a TypeDefOrRef coded index;
+TypeRef = tag 1.  Pointing at TypeRef row 2: `(2 << 2) | 1 = 9`.
+
+### Valid-mask update
+
+The `valid_mask` (the U64 in the tables-stream header at offset 8)
+needs the AssemblyRef bit set: `valid_mask |= 1 << 0x23`.
+
+```python
+valid_mask = 0
+for table in tables:
+    valid_mask |= 1 << table   # table 0x23 is now in the dict
+```
+
+Already handled by the existing loop — the dict-driven valid mask
+"just works" as long as the AssemblyRef table is in `tables`.
+
+## Test fixture (already in this branch)
+
+`code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py`
+is the success criterion for this spec.  It:
+
+1. Builds a minimal "return 42" program via the writer.
+2. Drops it next to a `runtimeconfig.json` targeting `net9.0`.
+3. Runs `dotnet <name>.exe` as a subprocess.
+4. Asserts the exit code is 42.
+
+Currently fails with `BadImageFormatException` (exit 134); each
+chunk above moves the failure past one more loader stage.  Chunk 3
+should make it pass.
+
+The fixture is gated behind a `_has_dotnet()` probe so CI without
+the SDK skips cleanly — same pattern the repo uses for
+git/curl/java-dependent tests.
 
 ## Out of scope for this spec
 
 - **Full ECMA-335 conformance.**  This spec targets the minimum to
-  load and execute a return-only program.  Things like generics,
-  custom attributes, embedded resources, debug symbols, and
-  PEHeader2 details are not in scope.
-- **netfx / mono targets.**  The reference is `net9.0`; the same
-  AssemblyRef + Module fixes work for `mscorlib` too but we don't
-  test against netfx in this spec.
-- **Strong naming.**  Generated assemblies stay unsigned.
+  load and execute a return-only program.  Generics, custom
+  attributes, embedded resources, debug symbols (PDB), strong
+  names, and PEHeader2 fields are explicitly future work.
+- **netfx / mono targets.**  Reference is net9.0.  The same
+  AssemblyRef + Module fixes apply to `mscorlib` for netfx but
+  we don't test against netfx here.
+- **JVM01.**  The recursion limitation in `ir-to-jvm-class-file`
+  is its own track (xfail-marked test in `twig-jvm-compiler`).
+  Same class of "real-runtime correctness" problem; different
+  fix in a different package.
 
-## Test plan
+## Risk register
 
-- Existing `cli-assembly-writer` tests continue to pass (the
-  simulator must keep accepting the output).
-- New `tests/test_real_dotnet.py`:
-    - `test_smoke_return_42` — assembly produced by current writer
-      runs on `dotnet` and exits with code 42.
-    - `test_arithmetic_via_brainfuck_or_twig` — at least one
-      end-to-end path that compiles a real-language program through
-      to dotnet.
-    - Skipped automatically when `dotnet --version` returns
-      non-zero, so CI without the SDK passes cleanly.
+- **Pseudo-token mismatch.**  The simulator may have its own
+  conventions about which token values mean what; if the
+  AssemblyRef token (0x23000001) collides with a simulator-side
+  reserved value, simulator tests may regress.  Mitigation: run
+  *all* existing CLR tests after each chunk, not just the new
+  fixture.
+- **Method body verification.**  Real .NET runs IL verification
+  on method bodies.  Even with metadata fixed, bytecodes the
+  simulator currently emits may fail verification (e.g. wrong
+  stack delta).  Diagnostic: when chunks 1–3 land and dotnet
+  still errors, the next message should be method-body specific
+  ("Common Language Runtime detected an invalid program") and we
+  add chunks for verifier conformance.
+- **net9.0 assumption.**  Some CI environments may have older
+  dotnet.  The `runtimeconfig.json` targets `net9.0`; for older
+  runtimes we'd need a different value or a probe-and-pick.

--- a/code/specs/CLR01-real-dotnet-conformance.md
+++ b/code/specs/CLR01-real-dotnet-conformance.md
@@ -1,0 +1,97 @@
+# CLR01 — Real-`dotnet` conformance for `cli-assembly-writer`
+
+## Why this spec exists
+
+Every CLR backend in the repo today
+(``brainfuck-clr-compiler``, ``oct-clr-compiler``, ``nib-clr-compiler``,
+and the new ``twig-clr-compiler``) emits PE/CLI assemblies that run
+**only on the in-house ``clr-vm-simulator``**.  Real ``dotnet`` (tested
+on 9.0.313) rejects every one of them with:
+
+```
+System.BadImageFormatException: File is corrupt. (0x8013110E)
+```
+
+The simulator is permissive in ways real .NET isn't.  This spec brings
+the assembly writer up to ECMA-335 conformance so that the same
+``cli-assembly-writer`` output runs both on the simulator AND on
+``dotnet``.  The fix is repo-wide — every existing CLR backend
+inherits the conformance for free.
+
+## The gap, diagnosed
+
+I built a known-good reference assembly with C# / `dotnet build` that
+returns 42, and compared it to what ``cli-assembly-writer`` produces
+for the same logical program.  Differences:
+
+| Field                    | Real .NET / C#       | cli-assembly-writer today |
+|--------------------------|----------------------|---------------------------|
+| File size (`return 42`)  | 4608 bytes           | 1536 bytes                |
+| MS-DOS stub @ 0x40       | "This program …"     | zeros                     |
+| TypeDef rows             | `<Module>`, Program  | Program only              |
+| AssemblyRef rows         | 1 (System.Runtime)   | **0**                     |
+| TypeRef resolution scope | AssemblyRef          | None / dangling           |
+
+The single most important gap is **AssemblyRef**.  Without it, every
+``TypeRef`` row's resolution scope points at nothing, so real .NET
+can't load any external types — including the bare `int32` /
+`object` / `MulticastDelegate` types every assembly transitively
+depends on.
+
+## Plan
+
+The fix lands in three logical chunks:
+
+1. **AssemblyRef + minimal System.Runtime reference** (this PR).
+   Adds the ``AssemblyRef`` table (0x23), populates it with one
+   entry for ``System.Runtime`` (or ``mscorlib`` for net4x; we'll
+   target net9.0 here), and re-routes existing ``TypeRef`` rows to
+   use that AssemblyRef as their resolution scope.
+
+2. **`<Module>` pseudo-TypeDef and DOS stub** (this PR).
+   ``<Module>`` is the special TypeDef row 1 that owns module-level
+   fields and global functions.  ECMA-335 §II.22.37 requires it as
+   the first row in the TypeDef table; real .NET fails the assembly
+   loader if it's missing.  The DOS stub is the cosmetic 80-byte
+   "This program cannot be run in DOS mode" header at file offset
+   0x40.
+
+3. **Conformance test fixture** (this PR).
+   A test that:
+     - Generates an assembly via the writer.
+     - Drops it in a temp dir alongside a `runtimeconfig.json`
+       targeting `net9.0`.
+     - Runs `dotnet <name>.exe` as a subprocess.
+     - Asserts the exit code matches the expected value.
+   The test is gated behind a ``has_dotnet()`` probe so CI without
+   the SDK skips rather than fails — same pattern the repo uses for
+   other tool-dependent tests.
+
+If the three chunks land cleanly and dotnet still rejects the
+assembly, the "File is corrupt" error message will give us a
+specific reason to diagnose next; we add chunks until conformance
+passes.
+
+## Out of scope for this spec
+
+- **Full ECMA-335 conformance.**  This spec targets the minimum to
+  load and execute a return-only program.  Things like generics,
+  custom attributes, embedded resources, debug symbols, and
+  PEHeader2 details are not in scope.
+- **netfx / mono targets.**  The reference is `net9.0`; the same
+  AssemblyRef + Module fixes work for `mscorlib` too but we don't
+  test against netfx in this spec.
+- **Strong naming.**  Generated assemblies stay unsigned.
+
+## Test plan
+
+- Existing `cli-assembly-writer` tests continue to pass (the
+  simulator must keep accepting the output).
+- New `tests/test_real_dotnet.py`:
+    - `test_smoke_return_42` — assembly produced by current writer
+      runs on `dotnet` and exits with code 42.
+    - `test_arithmetic_via_brainfuck_or_twig` — at least one
+      end-to-end path that compiles a real-language program through
+      to dotnet.
+    - Skipped automatically when `dotnet --version` returns
+      non-zero, so CI without the SDK passes cleanly.

--- a/code/specs/CLR01-real-dotnet-conformance.md
+++ b/code/specs/CLR01-real-dotnet-conformance.md
@@ -1,5 +1,67 @@
 # CLR01 — Real-`dotnet` conformance for `cli-assembly-writer`
 
+## Status (2026-04-28)
+
+Phase 1 of the spec — *every byte-level fix the original spec listed*
+— has landed in `cli-assembly-writer/src/cli_assembly_writer/writer.py`
+and verified against the simulator (all existing
+brainfuck-clr / oct-clr / nib-clr / clr-vm-simulator tests still
+pass).  Concretely shipped:
+
+1. ✅ Chunk 1: 64-byte canonical MS-DOS stub at file offset 0x40.
+2. ✅ Chunk 2: `<Module>` pseudo-TypeDef as TypeDef row 1 (real-.NET
+   loader requirement per ECMA-335 §II.22.37).
+3. ✅ Chunk 3: AssemblyRef table for System.Runtime + System.Object
+   TypeRef + ResolutionScope wired on every existing TypeRef +
+   user TypeDef's `Extends` column points at System.Object.
+4. ✅ Bonus: `#GUID` metadata stream + Module Mvid pointing at it
+   (real .NET refuses Module rows with `Mvid = 0`).
+5. ✅ Bonus: COFF Characteristics flag set to `0x22` (matches
+   real-C# AnyCPU output) instead of legacy `IMAGE_FILE_32BIT_MACHINE`.
+6. ✅ Bonus: tables with zero rows are no longer flagged in the
+   `Valid` mask (real .NET rejects empty tables).
+
+Real `dotnet` *still* rejects the assembly with
+`BadImageFormatException (0x8013110E)` after all of the above.  The
+remaining gap is finer-grained than the original spec anticipated —
+the loader's "file is corrupt" message doesn't pinpoint a specific
+field — and pursuing it further requires a deeper diff against a
+real C# build.  See **CLR02** below for the next-step spec capturing
+this remaining work.  All simulator tests still pass.
+
+The Phase-1 fixes are independently valuable: they bring our PE/CLI
+output much closer to ECMA-335 conformance and the `clr-vm-simulator`
+inherits the cleaner metadata for free.
+
+## CLR02 (next-step spec — to be opened separately)
+
+Outstanding gap: real `dotnet 9.0.313` rejects the assembly even
+with all Phase-1 fixes applied.  The diagnostic dump shows:
+
+- 5 metadata streams in correct order (#~, #Strings, #US, #GUID,
+  #Blob) — matches real C#.
+- COFF Characteristics, COR header flags, table valid-mask all
+  match real C# byte-for-byte.
+- Module / TypeRef / TypeDef / MethodDef / Assembly / AssemblyRef
+  tables all populated with the right shape.
+
+The remaining failure is almost certainly one of:
+
+- **PE relocations missing.**  Real .NET PE images have a `.reloc`
+  section.  Even for ILOnly assemblies, the loader on some paths
+  expects the relocation table.
+- **Method body header verification.**  Our minimal tiny-format
+  body might fail an obscure CLR verifier check.
+- **Module table layout subtle bug.**  Generation/EncId/EncBaseId
+  encoding could be off in a way the loader checks at load time.
+
+Investigation strategy for CLR02:
+1. Build the smallest possible non-trivial reference assembly with
+   `dotnet build -c Release` and a custom `Program.cs`.
+2. Compare every byte in the metadata stream against ours — not
+   just the table headers but the per-row payloads.
+3. Try a minimal `ilasm`-produced assembly as a third reference.
+
 ## Why this spec exists
 
 Every CLR backend in the repo today

--- a/code/specs/CLR01-real-dotnet-conformance.md
+++ b/code/specs/CLR01-real-dotnet-conformance.md
@@ -1,66 +1,48 @@
 # CLR01 — Real-`dotnet` conformance for `cli-assembly-writer`
 
-## Status (2026-04-28)
+## Status (2026-04-29) — LANDED
 
-Phase 1 of the spec — *every byte-level fix the original spec listed*
-— has landed in `cli-assembly-writer/src/cli_assembly_writer/writer.py`
-and verified against the simulator (all existing
-brainfuck-clr / oct-clr / nib-clr / clr-vm-simulator tests still
-pass).  Concretely shipped:
+CLR01 is **complete**.  Real `dotnet 9.0.313` now runs our
+assemblies end-to-end.  The previously-flagged "CLR02 follow-up"
+turned out to be **one bug**, not three: the pre-existing
+Assembly-table row encoding was 2 bytes too short (missing the
+ECMA-335 §II.22.2 `Culture` column).  Fixed in the same Phase 1
+PR.  Concrete shipped fixes:
 
-1. ✅ Chunk 1: 64-byte canonical MS-DOS stub at file offset 0x40.
-2. ✅ Chunk 2: `<Module>` pseudo-TypeDef as TypeDef row 1 (real-.NET
-   loader requirement per ECMA-335 §II.22.37).
-3. ✅ Chunk 3: AssemblyRef table for System.Runtime + System.Object
-   TypeRef + ResolutionScope wired on every existing TypeRef +
-   user TypeDef's `Extends` column points at System.Object.
-4. ✅ Bonus: `#GUID` metadata stream + Module Mvid pointing at it
-   (real .NET refuses Module rows with `Mvid = 0`).
-5. ✅ Bonus: COFF Characteristics flag set to `0x22` (matches
-   real-C# AnyCPU output) instead of legacy `IMAGE_FILE_32BIT_MACHINE`.
-6. ✅ Bonus: tables with zero rows are no longer flagged in the
-   `Valid` mask (real .NET rejects empty tables).
+1. ✅ 64-byte canonical MS-DOS stub at file offset 0x40.
+2. ✅ `<Module>` pseudo-TypeDef as TypeDef row 1 (ECMA-335 §II.22.37).
+3. ✅ AssemblyRef table for System.Runtime + System.Object
+   TypeRef + ResolutionScope wired on every TypeRef + user
+   TypeDef's `Extends` column → System.Object.
+4. ✅ `#GUID` metadata stream + Module `Mvid` pointing at it.
+5. ✅ COFF Characteristics flag set to `0x22` (matches real-C#
+   AnyCPU output) instead of legacy `IMAGE_FILE_32BIT_MACHINE`.
+6. ✅ Empty tables (MemberRef, StandAloneSig) no longer flagged in
+   the `Valid` mask — real .NET rejects empty-but-marked tables.
+7. ✅ **The actual root-cause fix**: Assembly row format extended
+   from `<IHHHHIHH>` (8 fields = 20 bytes, missing Culture) to
+   `<IHHHHIHHH>` (9 fields = 22 bytes, correctly mapped).  Without
+   this the AssemblyRef table that follows starts 2 bytes early
+   and `System.Reflection.Metadata.AssemblyRefTableReader..ctor`
+   reads past end-of-stream — producing the cryptic
+   "BadImageFormatException: File is corrupt" we hit before.
 
-Real `dotnet` *still* rejects the assembly with
-`BadImageFormatException (0x8013110E)` after all of the above.  The
-remaining gap is finer-grained than the original spec anticipated —
-the loader's "file is corrupt" message doesn't pinpoint a specific
-field — and pursuing it further requires a deeper diff against a
-real C# build.  See **CLR02** below for the next-step spec capturing
-this remaining work.  All simulator tests still pass.
+Diagnostic that found it: a tiny C# program loading our assembly
+via `PEReader.GetMetadataReader` and printing the precise
+out-of-bounds stack trace.  Real `dotnet` itself only ever says
+"File is corrupt"; the framework `System.Reflection.Metadata`
+APIs give actually-actionable errors.
 
-The Phase-1 fixes are independently valuable: they bring our PE/CLI
-output much closer to ECMA-335 conformance and the `clr-vm-simulator`
-inherits the cleaner metadata for free.
+End-to-end test:
 
-## CLR02 (next-step spec — to be opened separately)
+```
+$ python3 build_x42.py        # writes a "return 42" assembly
+$ dotnet X42.exe; echo $?
+42
+```
 
-Outstanding gap: real `dotnet 9.0.313` rejects the assembly even
-with all Phase-1 fixes applied.  The diagnostic dump shows:
-
-- 5 metadata streams in correct order (#~, #Strings, #US, #GUID,
-  #Blob) — matches real C#.
-- COFF Characteristics, COR header flags, table valid-mask all
-  match real C# byte-for-byte.
-- Module / TypeRef / TypeDef / MethodDef / Assembly / AssemblyRef
-  tables all populated with the right shape.
-
-The remaining failure is almost certainly one of:
-
-- **PE relocations missing.**  Real .NET PE images have a `.reloc`
-  section.  Even for ILOnly assemblies, the loader on some paths
-  expects the relocation table.
-- **Method body header verification.**  Our minimal tiny-format
-  body might fail an obscure CLR verifier check.
-- **Module table layout subtle bug.**  Generation/EncId/EncBaseId
-  encoding could be off in a way the loader checks at load time.
-
-Investigation strategy for CLR02:
-1. Build the smallest possible non-trivial reference assembly with
-   `dotnet build -c Release` and a custom `Program.cs`.
-2. Compare every byte in the metadata stream against ours — not
-   just the table headers but the per-row payloads.
-3. Try a minimal `ilasm`-produced assembly as a third reference.
+`tests/test_real_dotnet.py::test_return_42_runs_on_real_dotnet`
+and `test_return_zero_runs_on_real_dotnet` now pass.
 
 ## Why this spec exists
 


### PR DESCRIPTION
## Summary

- Bring `cli-assembly-writer` materially closer to real-`dotnet 9.0` loadability while keeping every existing simulator user (clr-vm-simulator, brainfuck-clr, oct-clr, nib-clr) green.
- Lands the entire byte-level fix list from `code/specs/CLR01-real-dotnet-conformance.md` (DOS stub, `<Module>` pseudo-TypeDef, AssemblyRef + System.Object + ResolutionScope wiring, plus #GUID heap, COFF Characteristics, empty-table cleanup).
- Real `dotnet 9.0.313` still rejects the assembly with `BadImageFormatException` after every Phase-1 fix lands — this remaining gap is captured as **CLR02** in the updated spec, with concrete next-step diagnostic strategies.

## Status

✅ Phase 1 (every byte-level fix the original spec listed) — landed
⏳ CLR02 — separate spec, captures the remaining "file is corrupt" gap

All simulator-side tests still pass; the diagnostic-baseline real-dotnet test (`test_diagnostic_current_failure_message`) passes, capturing the *current* `BadImageFormatException` failure mode so we'll know when CLR02 lands and the failure mode shifts.

## Test plan

- [x] `cli-assembly-writer` 6/8 tests pass (2 real-dotnet smoke tests still failing — that's CLR02)
- [x] `clr-vm-simulator` all 13 tests pass (simulator unaffected by metadata changes)
- [x] `brainfuck-clr-compiler` all 13 tests pass (downstream user inherits new metadata cleanly)
- [ ] `oct-clr-compiler` & `nib-clr-compiler` — to verify in CI
- [ ] CLR02 (separate PR): close the remaining real-dotnet gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)