### PR TITLE
feat(storage-sqlite): IX-13 — auto-create UNIQUE indexes for UNIQUE columns (v0.16.0)

### DIFF
--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.16.0] - 2026-04-28
+
+### Added
+
+**Auto-created UNIQUE indexes for UNIQUE / PRIMARY KEY columns (IX-13)**
+
+`CREATE TABLE` now auto-creates a UNIQUE index for every column declared
+`UNIQUE` or non-IPK `PRIMARY KEY`, matching SQLite's own behaviour.  These
+indexes use the SQLite-standard ``sqlite_autoindex_<table>_<n>`` naming
+convention and provide O(log n) UNIQUE enforcement on every
+insert/update via the IX-12 runtime maintenance path.
+
+- **`SqliteFileBackend.create_table`** — after writing the table schema,
+  scans the column list and calls `create_index` for each column that
+  satisfies `effective_unique() and not _is_ipk(col)`.  Auto-indexes are
+  named `sqlite_autoindex_<table>_<n>` (1-indexed by appearance) and
+  marked `unique=True, auto=True`.  Integer PRIMARY KEY columns are
+  skipped — uniqueness is enforced by the rowid B-tree itself.
+- **`SqliteFileBackend.list_indexes`** — `auto` detection now recognises
+  both naming conventions: `auto_*` (IndexAdvisor) and `sqlite_autoindex_*`
+  (UNIQUE auto-indexes).
+
+### Removed
+
+- **`_check_unique`** — the O(n) per-insert UNIQUE constraint scan is
+  gone.  Auto-created UNIQUE indexes provide the same enforcement at
+  O(log n) via the IX-12 runtime maintenance path.  Behaviour is
+  unchanged from a user perspective: the same `ConstraintViolation` is
+  raised on a UNIQUE collision, only faster.
+
+### Tests added
+
+- `test_backend_index.py::TestAutoUniqueIndex` — 8 tests: UNIQUE column
+  creates auto-index, no auto-index for IPK column, auto-index for
+  non-IPK PRIMARY KEY (e.g. `TEXT PRIMARY KEY`), multiple UNIQUE columns
+  each get an index, runtime enforcement on insert, NULLs do not
+  conflict, persistence across reopen, runtime enforcement on update.
+
+### Notes
+
+- This effectively closes the loop on the IX-11/12 series: any column
+  declared `UNIQUE` in `CREATE TABLE` is now enforced via an index from
+  the moment the table is created — no separate `CREATE UNIQUE INDEX`
+  statement needed.
+- 636 total tests pass (628 + 8 new); ruff clean.
+
 ## [0.15.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -665,50 +665,6 @@ def _check_not_null(table: str, row: Row, columns: list[ColumnDef]) -> None:
             )
 
 
-def _check_unique(
-    table: str,
-    row: Row,
-    columns: list[ColumnDef],
-    tree: BTree,
-    tree_columns: list[ColumnDef],
-    ignore_rowid: int | None = None,
-) -> None:
-    """Raise :class:`~sql_backend.ConstraintViolation` if a UNIQUE column
-    already contains the value being inserted/updated.
-
-    NULL values never conflict (SQL semantics). *ignore_rowid* is the rowid
-    of the row being updated so it is not compared against itself.
-
-    This is O(n) per unique column. Acceptable for v1; future versions can
-    add in-memory uniqueness indexes.
-    """
-    unique_cols = [c for c in columns if c.effective_unique()]
-    if not unique_cols:
-        return
-
-    new_vals = {col.name: row.get(col.name) for col in unique_cols}
-    # Optimisation: if none of the unique-column values are non-NULL we can
-    # skip the scan entirely.
-    if all(v is None for v in new_vals.values()):
-        return
-
-    for existing_rowid, payload in tree.scan():
-        if existing_rowid == ignore_rowid:
-            continue
-        existing_row = _decode_row(existing_rowid, payload, tree_columns)
-        for col in unique_cols:
-            new_val = new_vals[col.name]
-            if new_val is None:
-                continue  # NULL never conflicts
-            if existing_row.get(col.name) == new_val:
-                label = "PRIMARY KEY" if col.primary_key else "UNIQUE"
-                raise ConstraintViolation(
-                    table=table,
-                    column=col.name,
-                    message=f"{label} constraint failed: {table}.{col.name}",
-                )
-
-
 # ---------------------------------------------------------------------------
 # BTreeCursor
 # ---------------------------------------------------------------------------
@@ -963,15 +919,15 @@ class SqliteFileBackend(Backend):
         # Determine the rowid and check primary-key uniqueness.
         rowid = _choose_rowid(full_row, columns, tree)
 
-        # For non-IPK UNIQUE columns, scan for duplicates before inserting.
-        non_pk_unique = [c for c in columns if c.effective_unique() and not _is_ipk(c)]
-        if non_pk_unique:
-            _check_unique(table, full_row, non_pk_unique, tree, columns)
-
         # Pre-validate UNIQUE indexes before mutating anything: walk every
         # index on this table and reject the row if any UNIQUE index would
         # be violated.  Doing this BEFORE the table insert means failures
         # leave the database byte-for-byte unchanged.
+        #
+        # Per-column UNIQUE / non-IPK PRIMARY KEY constraints declared in
+        # CREATE TABLE are enforced via auto-created UNIQUE indexes (named
+        # ``sqlite_autoindex_<table>_<n>``), so the index walk below covers
+        # them automatically — no separate O(n) scan is needed.
         indexes = self._open_indexes_for(table)
         for idx_name, idx_cols, idx_tree in indexes:
             if not idx_tree.is_unique:
@@ -1132,6 +1088,14 @@ class SqliteFileBackend(Backend):
         Generates the ``CREATE TABLE`` SQL, stores it in ``sqlite_schema``,
         and allocates a fresh root page for the new B-tree.
 
+        For every column with ``effective_unique()`` (i.e. ``UNIQUE`` or
+        non-IPK ``PRIMARY KEY``), a UNIQUE auto-index is also created with
+        the SQLite-standard ``sqlite_autoindex_<table>_<n>`` name.  These
+        indexes provide O(log n) UNIQUE enforcement on every insert/update
+        via the IX-12 runtime maintenance path.  Integer PRIMARY KEY
+        columns (the IPK case) are skipped — their uniqueness is already
+        enforced by the rowid B-tree itself.
+
         If *if_not_exists* is ``True`` and the table already exists, this is a
         no-op. Otherwise raises :class:`~sql_backend.TableAlreadyExists`.
         """
@@ -1142,6 +1106,23 @@ class SqliteFileBackend(Backend):
 
         sql = _columns_to_sql(table, columns)
         self._schema.create_table(table, sql)
+
+        # Auto-create UNIQUE indexes for every column declared UNIQUE or
+        # non-IPK PRIMARY KEY.  The table is empty so backfill is a no-op;
+        # subsequent inserts will populate the index via runtime maintenance
+        # (see :meth:`insert`).
+        auto_idx_n = 0
+        for col in columns:
+            if not col.effective_unique() or _is_ipk(col):
+                continue
+            auto_idx_n += 1
+            auto_name = f"sqlite_autoindex_{table}_{auto_idx_n}"
+            self.create_index(
+                IndexDef(
+                    name=auto_name, table=table,
+                    columns=[col.name], unique=True, auto=True,
+                )
+            )
 
     def drop_table(self, table: str, if_exists: bool) -> None:
         """Drop *table*, freeing all its pages.
@@ -1498,7 +1479,13 @@ class SqliteFileBackend(Backend):
         for name, tbl_name, _, sql in rows:
             columns = _parse_index_columns(sql) if sql else []
             unique = _parse_index_unique(sql)
-            auto = name.startswith("auto_")
+            # Two auto-index naming conventions:
+            #   * ``auto_*`` — IndexAdvisor (IX-7/8) auto-created indexes for
+            #     query acceleration.
+            #   * ``sqlite_autoindex_*`` — UNIQUE auto-indexes created by
+            #     ``create_table`` for ``UNIQUE`` / non-IPK ``PRIMARY KEY``
+            #     columns (SQLite naming convention).
+            auto = name.startswith("auto_") or name.startswith("sqlite_autoindex_")
             result.append(
                 IndexDef(
                     name=name, table=tbl_name, columns=columns,

--- a/code/packages/python/storage-sqlite/tests/test_backend_index.py
+++ b/code/packages/python/storage-sqlite/tests/test_backend_index.py
@@ -763,3 +763,157 @@ class TestRuntimeIndexMaintenance:
         with SqliteFileBackend(path) as b2:
             assert list(b2.scan_index("idx_email", ["a@x.com"], ["a@x.com"])) == [1]
             assert list(b2.scan_index("idx_email", ["b@x.com"], ["b@x.com"])) == [2]
+
+
+# ---------------------------------------------------------------------------
+# Auto-created UNIQUE indexes for UNIQUE columns
+# ---------------------------------------------------------------------------
+
+
+class TestAutoUniqueIndex:
+    """``CREATE TABLE`` with UNIQUE columns auto-creates UNIQUE indexes."""
+
+    def test_unique_column_creates_auto_index(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "au1.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "users",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            idxs = b.list_indexes("users")
+            assert len(idxs) == 1
+            assert idxs[0].name == "sqlite_autoindex_users_1"
+            assert idxs[0].columns == ["email"]
+            assert idxs[0].unique is True
+            assert idxs[0].auto is True
+
+    def test_no_auto_index_for_ipk_column(self, tmp_path: Path) -> None:
+        """The INTEGER PRIMARY KEY column is the rowid — no auto-index."""
+        path = str(tmp_path / "au2.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "items",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("name", "TEXT"),
+                ],
+                if_not_exists=False,
+            )
+            assert b.list_indexes("items") == []
+
+    def test_auto_index_for_non_ipk_primary_key(self, tmp_path: Path) -> None:
+        """A TEXT PRIMARY KEY is not an IPK, so it gets an auto-index."""
+        path = str(tmp_path / "au3.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "kv",
+                [
+                    ColumnDef("key", "TEXT", primary_key=True),
+                    ColumnDef("value", "TEXT"),
+                ],
+                if_not_exists=False,
+            )
+            idxs = b.list_indexes("kv")
+            assert len(idxs) == 1
+            assert idxs[0].columns == ["key"]
+            assert idxs[0].unique is True
+
+    def test_multiple_unique_columns_each_get_an_index(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "au4.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "people",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                    ColumnDef("ssn", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            idxs = b.list_indexes("people")
+            names = sorted(i.name for i in idxs)
+            assert names == ["sqlite_autoindex_people_1", "sqlite_autoindex_people_2"]
+            cols = sorted(i.columns[0] for i in idxs)
+            assert cols == ["email", "ssn"]
+            assert all(i.unique for i in idxs)
+
+    def test_auto_index_enforces_uniqueness_at_runtime(self, tmp_path: Path) -> None:
+        """Inserting a duplicate UNIQUE column value raises ConstraintViolation."""
+        from sql_backend import ConstraintViolation
+        path = str(tmp_path / "au5.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "users",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            b.insert("users", {"id": 1, "email": "alice@x.com"})
+            with pytest.raises(ConstraintViolation, match="UNIQUE"):
+                b.insert("users", {"id": 2, "email": "alice@x.com"})
+
+    def test_auto_index_allows_multiple_nulls(self, tmp_path: Path) -> None:
+        """NULLs in a UNIQUE column do not conflict (SQLite semantics)."""
+        path = str(tmp_path / "au6.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "users",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            b.insert("users", {"id": 1})  # email = NULL
+            b.insert("users", {"id": 2})  # email = NULL
+            b.insert("users", {"id": 3, "email": "alice@x.com"})
+            cursor = b.scan("users")
+            ids = []
+            while (r := cursor.next()) is not None:
+                ids.append(r["id"])
+            assert sorted(ids) == [1, 2, 3]
+
+    def test_auto_index_survives_reopen(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "au7.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "users",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            h = b.begin_transaction()
+            b.commit(h)
+        with SqliteFileBackend(path) as b2:
+            idxs = b2.list_indexes("users")
+            assert len(idxs) == 1
+            assert idxs[0].name == "sqlite_autoindex_users_1"
+            assert idxs[0].unique is True
+
+    def test_auto_index_enforces_on_update(self, tmp_path: Path) -> None:
+        """Updating a UNIQUE column to an existing value raises."""
+        from sql_backend import ConstraintViolation
+        path = str(tmp_path / "au8.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "users",
+                [
+                    ColumnDef("id", "INTEGER", primary_key=True),
+                    ColumnDef("email", "TEXT", unique=True),
+                ],
+                if_not_exists=False,
+            )
+            b.insert("users", {"id": 1, "email": "a@x.com"})
+            b.insert("users", {"id": 2, "email": "b@x.com"})
+            cursor = b.scan("users")
+            cursor.next()  # row 1
+            with pytest.raises(ConstraintViolation, match="UNIQUE"):
+                b.update("users", cursor, {"email": "b@x.com"})


### PR DESCRIPTION
## Summary

- `CREATE TABLE` now auto-creates a UNIQUE index for every column declared `UNIQUE` or non-IPK `PRIMARY KEY`, matching real SQLite's behaviour
- Auto-indexes use the standard `sqlite_autoindex_<table>_<n>` naming convention
- INTEGER PRIMARY KEY columns are skipped (uniqueness is via the rowid B-tree)
- Closes the loop on IX-11/IX-12: any `UNIQUE` column declaration is now enforced via an index from the moment the table exists, with no separate `CREATE UNIQUE INDEX` needed
- Removed the dead O(n) `_check_unique` helper — auto-indexes provide the same enforcement at O(log n) via IX-12 runtime maintenance
- `list_indexes` recognises both `auto_*` and `sqlite_autoindex_*` naming conventions for the `auto` flag
- 8 new tests, 636 total pass, ruff clean
- Security review passed in one round

## Test plan

- [x] All 636 tests pass (`uv run pytest --no-cov`)
- [x] `uv run ruff check src/ tests/` — clean
- [x] Security review passed (no findings)
- [x] Tested: UNIQUE column creates auto-index, no auto-index for IPK column, auto-index for non-IPK PRIMARY KEY (e.g. TEXT PRIMARY KEY), multiple UNIQUE columns each get an index, runtime enforcement on insert, multiple NULLs allowed, persistence across reopen, runtime enforcement on update

🤖 Generated with [Claude Code](https://claude.com/claude-code)