### PR TITLE
Validate nested formal procedure contracts

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -79,6 +79,8 @@ All notable changes to this package will be documented in this file.
   descriptor pointers to actual procedures that declare matching array formals.
 - Lowered label, switch, and procedure arguments through formal procedure
   dispatchers by forwarding label ids and descriptor pointers.
+- Preserved concrete procedure ids in formal procedure call-shape metadata so
+  nested procedure-parameter contracts are checked before IR lowering.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -69,7 +69,8 @@ actuals pass descriptor pointers, and label actuals pass label ids, so
 forwarded procedure formals keep the original environment in value, by-name,
 array, label, switch, or procedure mode. Real-valued formal procedure calls can
 accept integer-returning actual procedures and promote the dispatched result.
-Richer nested procedure-parameter contract propagation remains future work.
+Concrete procedure actuals forwarded through a formal procedure call retain
+enough type-checker metadata to validate nested procedure-parameter contracts.
 
 Direct `goto` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable changes to this package will be documented in this file.
   procedure parameters, recording array argument call shapes for lowering.
 - Accepted procedure-valued actuals with label, switch, and procedure
   parameters for formal procedure parameters.
+- Validated nested procedure-parameter call-shape contracts when a formal
+  procedure call forwards a concrete procedure actual.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -57,9 +57,9 @@ accept procedure-valued actuals with scalar `value` or by-name parameters and
 whole-array, label, switch, or procedure parameters, rejecting only call shapes
 that would pass a non-assignable actual to a written by-name parameter.
 Real-valued formal procedure parameters accept integer-returning procedure
-actuals via the same numeric promotion rule used by scalar calls. The checker
-keeps guarding the remaining full-ALGOL gaps, including richer nested
-procedure-parameter contract propagation through procedure-valued actuals.
+actuals via the same numeric promotion rule used by scalar calls. When a
+formal procedure call forwards a concrete procedure actual into another
+procedure formal, the checker also validates the nested call-shape contract.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -193,6 +193,7 @@ class ProcedureFormalCallShape:
     argument_types: tuple[str, ...]
     argument_kinds: tuple[str, ...] = ()
     argument_assignable: tuple[bool, ...] = ()
+    procedure_argument_ids: tuple[int | None, ...] = ()
     return_type: str | None = None
 
 
@@ -2025,19 +2026,22 @@ class AlgolTypeChecker:
         argument_types: list[str] = []
         argument_kinds: list[str] = []
         argument_assignable: list[bool] = []
+        procedure_argument_ids: list[int | None] = []
         for argument in arguments:
             array_type = self._formal_array_argument_type(argument, scope)
             if array_type is not None:
                 argument_types.append(array_type)
                 argument_kinds.append(ARRAY)
                 argument_assignable.append(False)
+                procedure_argument_ids.append(None)
                 continue
             nonscalar = self._formal_nonscalar_argument_shape(argument, scope)
             if nonscalar is not None:
-                argument_kind, argument_type = nonscalar
+                argument_kind, argument_type, procedure_id = nonscalar
                 argument_types.append(argument_type)
                 argument_kinds.append(argument_kind)
                 argument_assignable.append(False)
+                procedure_argument_ids.append(procedure_id)
                 continue
             actual_type = self._infer_expr(argument, scope)
             argument_types.append(actual_type)
@@ -2046,6 +2050,7 @@ class AlgolTypeChecker:
                 _is_assignable_actual(argument)
                 and self._resolved_bare_procedure_expression(argument) is None
             )
+            procedure_argument_ids.append(None)
             if actual_type != ERROR and actual_type not in {
                 INTEGER,
                 BOOLEAN,
@@ -2071,6 +2076,7 @@ class AlgolTypeChecker:
                     argument_types=tuple(argument_types),
                     argument_kinds=tuple(argument_kinds),
                     argument_assignable=tuple(argument_assignable),
+                    procedure_argument_ids=tuple(procedure_argument_ids),
                     return_type=return_type if role == "expression" else None,
                 ),
             )
@@ -2128,7 +2134,7 @@ class AlgolTypeChecker:
         self,
         argument: ASTNode,
         scope: Scope,
-    ) -> tuple[str, str] | None:
+    ) -> tuple[str, str, int | None] | None:
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
             return None
@@ -2140,9 +2146,9 @@ class AlgolTypeChecker:
             return None
         symbol, _, _ = resolved
         if symbol.kind == LABEL:
-            return LABEL, LABEL
+            return LABEL, LABEL, None
         if symbol.kind == SWITCH:
-            return SWITCH, SWITCH
+            return SWITCH, SWITCH, None
         if symbol.kind == "procedure":
             descriptor = next(
                 (
@@ -2158,9 +2164,9 @@ class AlgolTypeChecker:
                 and not descriptor.parameters
             ):
                 return None
-            return "procedure", symbol.type_name
+            return "procedure", symbol.type_name, symbol.procedure_id
         if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
-            return "procedure", symbol.type_name
+            return "procedure", symbol.type_name, None
         return None
 
     def _record_procedure_parameter_call_shape(
@@ -2419,6 +2425,11 @@ class AlgolTypeChecker:
                     if argument_index < len(shape.argument_assignable)
                     else False
                 )
+                procedure_argument_id = (
+                    shape.procedure_argument_ids[argument_index]
+                    if argument_index < len(shape.procedure_argument_ids)
+                    else None
+                )
                 if argument_kind == ARRAY:
                     if actual_parameter.kind != ARRAY:
                         self._error(
@@ -2467,6 +2478,23 @@ class AlgolTypeChecker:
                             f"{actual_parameter.name!r}",
                         )
                         return False
+                    if procedure_argument_id is not None:
+                        descriptor = self._procedure_descriptor_for_id(
+                            procedure_argument_id
+                        )
+                        if descriptor is None:
+                            self._error(
+                                token,
+                                f"procedure parameter {parameter.name!r} passes a "
+                                "procedure actual with no descriptor",
+                            )
+                            return False
+                        if not self._procedure_actual_satisfies_formal_shapes(
+                            token,
+                            descriptor,
+                            actual_parameter,
+                        ):
+                            return False
                     if not self._procedure_parameter_type_satisfies(
                         expected_type=actual_parameter.type_name,
                         actual_type=actual_type,
@@ -2526,6 +2554,19 @@ class AlgolTypeChecker:
                     return False
                 continue
         return True
+
+    def _procedure_descriptor_for_id(
+        self,
+        procedure_id: int,
+    ) -> ProcedureDescriptor | None:
+        return next(
+            (
+                procedure
+                for procedure in self.semantic_procedures
+                if procedure.procedure_id == procedure_id
+            ),
+            None,
+        )
 
     def _procedure_parameter_type_satisfies(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1050,6 +1050,41 @@ class TestAlgolTypeChecker:
         shape = result.semantic.procedures[1].parameters[0].procedure_call_shapes[0]
         assert shape.argument_kinds == ("procedure",)
         assert shape.argument_types == ("procedure",)
+        assert shape.procedure_argument_ids == (
+            result.semantic.procedures[0].procedure_id,
+        )
+
+    def test_rejects_procedure_parameter_actual_with_nested_arity_mismatch(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure bump; begin result := result + 1 end; "
+            "procedure invoke(p); procedure p; begin p(bump) end; "
+            "procedure use(q); procedure q; begin q(1) end; "
+            "invoke(use) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "accepting 1 argument(s), got 0" in result.diagnostics[0].message
+
+    def test_rejects_procedure_parameter_actual_with_nested_result_mismatch(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure bump; begin result := result + 1 end; "
+            "procedure invoke(p); procedure p; begin p(bump) end; "
+            "procedure use(f); integer f; procedure f; begin result := f end; "
+            "invoke(use) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "expects a integer procedure actual" in result.diagnostics[0].message
 
     def test_rejects_procedure_parameter_actual_with_wrong_label_formal(
         self,

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -72,6 +72,8 @@ All notable changes to this package will be documented in this file.
   procedures, preserving descriptor aliasing and existing `value` array copies.
 - Executed formal procedure calls that forward label, switch, and procedure
   arguments to actual procedures.
+- Rejected formal procedure forwarding when a concrete procedure argument does
+  not satisfy the nested procedure formal contract expected by the receiver.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -24,7 +24,7 @@ the current lane already supports a substantial ALGOL 60 surface:
 - value and by-name parameters, including Jensen-style expression thunks,
   typed whole-array formals with copy or aliasing semantics, and formal
   procedure calls that forward scalar, whole-array, label, switch, or
-  procedure arguments
+  procedure arguments while validating nested procedure-formal contracts
 - label, switch, and procedure formals in value or by-name mode
 - bare no-argument typed procedure names as expression calls, matching ALGOL's
   omitted-parentheses call syntax for parameterless procedures

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -797,6 +797,21 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_formal_procedure_nested_procedure_argument_rejects_mismatch(
+        self,
+    ) -> None:
+        with pytest.raises(AlgolWasmError) as excinfo:
+            compile_source(
+                "begin integer result; "
+                "procedure bump; begin result := result + 1 end; "
+                "procedure invoke(p); procedure p; begin p(bump) end; "
+                "procedure use(q); procedure q; begin q(1) end; "
+                "invoke(use) "
+                "end"
+            )
+
+        assert "accepting 1 argument(s), got 0" in str(excinfo.value)
+
     def test_formal_procedure_by_name_argument_remains_lazy(self) -> None:
         result = compile_source(
             "begin integer result; "


### PR DESCRIPTION
## Summary
- preserve concrete procedure ids in formal procedure call-shape metadata
- validate nested procedure-parameter contracts when a formal procedure forwards a concrete procedure actual
- add type checker and WASM coverage for nested arity/result mismatches while preserving existing typed-procedure forwarding

## Validation
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH=$(find code/packages/python -path '*/src' -type d | tr '\n' ':') python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security
- diff scan found no new process, shell, network, filesystem-write, or credential-handling APIs.