### PR TITLE
feat(symbolic-vm): Phase 16 — reciprocal hyperbolic power integrals (sech^n/csch^n/coth^n)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 0.36.0 — 2026-04-28
+
+**Phase 16 — Reciprocal hyperbolic power integrals: `sech^n`, `csch^n`, `coth^n`.**
+
+Closes the gap left by Phase 15, which deferred `∫ sech²(x) dx` and all higher
+powers of the three reciprocal hyperbolic functions.  Each family gets a full
+IBP (or identity-based) reduction formula valid for any non-negative integer `n`.
+
+### New module: `recip_hyp_power_integral.py`
+
+Exports three public functions, all pure-recursive with no back-calls into
+`integrate.py` (avoiding circular imports):
+
+| Function | Formula |
+|----------|---------|
+| `sech_power_integral(n,a,b,x)` | IBP: `I_n = sech^(n-2)·tanh/((n-1)a) + (n-2)/(n-1)·I_{n-2}` |
+| `csch_power_integral(n,a,b,x)` | IBP: `I_n = −csch^(n-2)·coth/((n-1)a) − (n-2)/(n-1)·I_{n-2}` |
+| `coth_power_integral(n,a,b,x)` | Identity: `I_n = I_{n-2} − coth^(n-1)/((n-1)a)` |
+
+**sech^n base cases:** `n=0→x`, `n=1→atan(sinh(ax+b))/a`, `n=2→tanh(ax+b)/a`.
+
+**csch^n base cases:** `n=0→x`, `n=1→log(tanh((ax+b)/2))/a`, `n=2→−coth(ax+b)/a`.
+
+**coth^n base cases:** `n=0→x`, `n=1→log(sinh(ax+b))/a`.
+
+The `coth^n` recursion is derived from `coth²=1+csch²` (Pythagorean identity)
+rather than IBP — it produces a cleaner telescoping result with no outer product.
+
+No new IR heads required; all output uses existing heads (`TANH`, `COTH`, `SINH`,
+`ATAN`, `LOG`).
+
+### `integrate.py` changes
+
+1. Imported the three new functions from `recip_hyp_power_integral`.
+2. Added `_try_recip_hyp_power(base, exponent, x)` dispatcher — fires for
+   `SECH`/`CSCH`/`COTH` base with integer exponent ≥ 2 and linear argument.
+3. Call site added immediately after `_try_hyp_power` (~line 544).
+
+### `test_phase15.py` update
+
+`test_sech_squared_unevaluated` renamed to `test_sech_squared_now_evaluates`
+and updated to assert `_was_evaluated` (previously asserted `_is_unevaluated`).
+
+### Tests (`test_phase16.py`) — 34 tests
+
+| Class | Tests | What is verified |
+|-------|-------|-----------------|
+| `TestPhase16_SechPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; Tanh in result |
+| `TestPhase16_CschPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; Coth in result |
+| `TestPhase16_CothPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; Coth power in result |
+| `TestPhase16_Fallthrough` | 3 | poly×sech², non-linear arg, mixed product |
+| `TestPhase16_Regressions` | 3 | Phase 15 bare, Phase 14 sinh^4, Phase 3 exp |
+| `TestPhase16_Macsyma` | 4 | end-to-end via MACSYMA string interface |
+
+Antiderivative correctness verified numerically at two test points per case.
+
+---
+
 ## 0.35.0 — 2026-04-28
 
 **Phase 15 — Reciprocal hyperbolic functions: `coth`, `sech`, `csch`.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.35.0"
+version = "0.36.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -136,6 +136,11 @@ from symbolic_vm.polynomial_bridge import (
     rt_pairs_to_ir,
     to_rational,
 )
+from symbolic_vm.recip_hyp_power_integral import (
+    coth_power_integral,
+    csch_power_integral,
+    sech_power_integral,
+)
 from symbolic_vm.rothstein_trager import rothstein_trager
 from symbolic_vm.sinh_poly_integral import cosh_poly_integral, sinh_poly_integral
 from symbolic_vm.trig_poly_integral import trig_cos_integral, trig_sin_integral
@@ -537,6 +542,10 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
             return result
         # Phase 14: sinhⁿ, coshⁿ reduction formulas.
         result = _try_hyp_power(base, exponent, x)
+        if result is not None:
+            return result
+        # Phase 16: sechⁿ, cschⁿ, cothⁿ reduction formulas.
+        result = _try_recip_hyp_power(base, exponent, x)
         if result is not None:
             return result
         # Phase 8 bonus: ∫ (ax+b)^n dx = (ax+b)^(n+1)/((n+1)·a) or log(ax+b)/a.
@@ -1174,6 +1183,42 @@ def _try_hyp_power(base: IRNode, exponent: IRNode, x: IRSymbol) -> IRNode | None
     if base.head == SINH:
         return sinh_power_integral(n, a_frac, b_frac, x)
     return cosh_power_integral(n, a_frac, b_frac, x)
+
+
+def _try_recip_hyp_power(base: IRNode, exponent: IRNode, x: IRSymbol) -> IRNode | None:
+    """Return ``∫ sech^n(linear) dx``, ``∫ csch^n(linear) dx``, or
+    ``∫ coth^n(linear) dx``, or ``None``.
+
+    Phase 16 — reciprocal hyperbolic power reduction.
+
+    Fires when:
+    - ``base`` is ``IRApply(SECH/CSCH/COTH, (linear,))``.
+    - ``exponent`` is ``IRInteger(n)`` with ``n ≥ 2``.
+    - The argument of the function is a non-constant linear expression ``ax+b``.
+
+    Returns ``None`` for non-reciprocal-hyperbolic bases or non-integer exponents.
+    Falls through for ``n < 2`` (bare n=1 case is handled in Phase 15 dispatch).
+    """
+    if not isinstance(base, IRApply):
+        return None
+    if base.head not in {SECH, CSCH, COTH}:
+        return None
+    if not isinstance(exponent, IRInteger) or exponent.value < 2:
+        return None
+    n = exponent.value
+    if len(base.args) != 1:
+        return None
+    lin = _try_linear(base.args[0], x)
+    if lin is None:
+        return None
+    a_frac, b_frac = lin
+    if a_frac == Fraction(0):
+        return None
+    if base.head == SECH:
+        return sech_power_integral(n, a_frac, b_frac, x)
+    if base.head == CSCH:
+        return csch_power_integral(n, a_frac, b_frac, x)
+    return coth_power_integral(n, a_frac, b_frac, x)
 
 
 def _try_exp_hyp(exp_node: IRNode, hyp_node: IRNode, x: IRSymbol) -> IRNode | None:

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/recip_hyp_power_integral.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/recip_hyp_power_integral.py
@@ -1,0 +1,336 @@
+"""Reciprocal hyperbolic power integration — Phase 16.
+
+Computes antiderivatives for three families:
+
+1. ``∫ sech^n(ax+b) dx``  — via IBP reduction formula (any integer n ≥ 0)
+2. ``∫ csch^n(ax+b) dx``  — via IBP reduction formula (any integer n ≥ 0)
+3. ``∫ coth^n(ax+b) dx``  — via the identity coth² = 1 + csch² (any integer n ≥ 0)
+
+Reduction formulas
+------------------
+
+**sech^n (derivation)**
+
+IBP with ``u = sech^(n-2)(t)``, ``dv = sech²(t) dt``:
+
+    v = tanh(t),   du = -(n-2)·sech^(n-2)(t)·tanh(t) dt
+
+    ∫ sech^n dt = sech^(n-2)·tanh + (n-2) ∫ sech^(n-2)·tanh² dt
+               = sech^(n-2)·tanh + (n-2) ∫ sech^(n-2)·(1 − sech²) dt
+               = sech^(n-2)·tanh + (n-2)·I_{n-2} − (n-2)·I_n
+
+Solving for I_n:
+
+    I_n = sech^(n-2)·tanh / (n-1) + (n-2)/(n-1) · I_{n-2}
+
+Base cases: I_0 = t, I_1 = atan(sinh(t)), I_2 = tanh(t).
+
+With ``t = ax+b``:  ∫ sech^n(ax+b) dx = chain-rule factor 1/a applied as
+coefficient of each base case and main term.
+
+**csch^n (derivation)**
+
+IBP with ``u = csch^(n-2)(t)``, ``dv = csch²(t) dt``:
+
+    v = -coth(t),  du = -(n-2)·csch^(n-2)(t)·coth(t) dt
+
+    ∫ csch^n dt = -csch^(n-2)·coth − (n-2) ∫ csch^(n-2)·coth² dt
+               = -csch^(n-2)·coth − (n-2) ∫ csch^(n-2)·(1 + csch²) dt
+               = -csch^(n-2)·coth − (n-2)·I_{n-2} − (n-2)·I_n
+
+Solving for I_n:
+
+    I_n = -csch^(n-2)·coth / (n-1) − (n-2)/(n-1) · I_{n-2}
+
+Base cases: I_0 = t, I_1 = log(tanh(t/2)), I_2 = -coth(t).
+
+(Note the ``−`` signs — contrast with the ``+`` for sech.)
+
+**coth^n (identity reduction)**
+
+Expand via ``coth²(t) = 1 + csch²(t)``:
+
+    ∫ coth^n dt = ∫ coth^(n-2)·(1 + csch²) dt
+               = I_{n-2} + ∫ coth^(n-2)·csch² dt
+
+For the last integral substitute u = coth(t), du = -csch²(t) dt:
+
+    ∫ coth^(n-2)·csch² dt = -coth^(n-1) / (n-1)
+
+So:  I_n = I_{n-2} - coth^(n-1) / (n-1)
+
+Base cases: I_0 = t, I_1 = log(sinh(t)).
+
+Unlike sech/csch there is no "outer product" term in the recursion step —
+just the previous integral minus a single power.
+
+Design notes
+------------
+
+- ``_frac_ir`` is defined locally (same pattern as ``hyp_power_integral.py``)
+  to avoid a circular import with ``integrate.py``.
+- ``linear_to_ir`` is imported from ``symbolic_vm.polynomial_bridge``.
+- None of the three functions call back into ``integrate.py``, so there is
+  no import cycle.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import (
+    ADD,
+    ATAN,
+    COTH,
+    CSCH,
+    DIV,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SECH,
+    SINH,
+    SUB,
+    TANH,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.polynomial_bridge import linear_to_ir
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def sech_power_integral(
+    n: int,
+    a: Fraction,
+    b: Fraction,
+    x: IRSymbol,
+) -> IRNode:
+    """Return IR for ``∫ sech^n(ax+b) dx``.
+
+    Uses the IBP reduction formula recursively:
+
+        I_n = sech^(n-2)(ax+b)·tanh(ax+b) / ((n-1)·a)
+             + (n-2)/(n-1) · I_{n-2}
+
+    Base cases:
+
+        I_0 = x
+        I_1 = atan(sinh(ax+b)) / a          [Phase 15 _sech_integral formula]
+        I_2 = tanh(ax+b) / a                [most-used identity: ∫sech²=tanh]
+
+    Pre-conditions: ``n ≥ 0``, ``a ≠ 0``.
+
+    Parameters
+    ----------
+    n :
+        Non-negative integer power.
+    a, b :
+        Fraction coefficients of the linear argument ``ax+b``.
+    x :
+        Integration variable symbol.
+
+    Examples
+    --------
+    ::
+
+        # ∫ sech²(x) dx = tanh(x)
+        sech_power_integral(2, Fraction(1), Fraction(0), IRSymbol("x"))
+
+        # ∫ sech³(x) dx = sech(x)·tanh(x)/2 + (1/2)·atan(sinh(x))
+        sech_power_integral(3, Fraction(1), Fraction(0), IRSymbol("x"))
+    """
+    if n == 0:
+        return x
+    arg_ir = linear_to_ir(a, b, x)
+    if n == 1:
+        # ∫ sech(ax+b) dx = atan(sinh(ax+b)) / a
+        atan_sinh = IRApply(ATAN, (IRApply(SINH, (arg_ir,)),))
+        return atan_sinh if a == Fraction(1) else IRApply(DIV, (atan_sinh, _frac_ir(a)))
+    if n == 2:
+        # ∫ sech²(ax+b) dx = tanh(ax+b) / a
+        tanh_ir = IRApply(TANH, (arg_ir,))
+        return tanh_ir if a == Fraction(1) else IRApply(DIV, (tanh_ir, _frac_ir(a)))
+
+    # n ≥ 3:  I_n = sech^(n-2)·tanh / ((n-1)·a)  +  (n-2)/(n-1) · I_{n-2}
+    #
+    # When n-2 == 1 we use SECH(arg_ir) directly instead of POW(SECH, 1).
+    sech_ir = IRApply(SECH, (arg_ir,))
+    tanh_ir = IRApply(TANH, (arg_ir,))
+    sech_pow = (
+        sech_ir
+        if n - 2 == 1
+        else IRApply(POW, (sech_ir, IRInteger(n - 2)))
+    )
+    coeff1 = Fraction(1, n - 1) / a         # 1 / ((n-1)·a)
+    main_term = IRApply(MUL, (_frac_ir(coeff1), IRApply(MUL, (sech_pow, tanh_ir))))
+    rec_coeff = Fraction(n - 2, n - 1)      # (n-2) / (n-1)  — always > 0 for n ≥ 3
+    tail = sech_power_integral(n - 2, a, b, x)
+    return IRApply(ADD, (main_term, IRApply(MUL, (_frac_ir(rec_coeff), tail))))
+
+
+def csch_power_integral(
+    n: int,
+    a: Fraction,
+    b: Fraction,
+    x: IRSymbol,
+) -> IRNode:
+    """Return IR for ``∫ csch^n(ax+b) dx``.
+
+    Uses the IBP reduction formula recursively:
+
+        I_n = −csch^(n-2)(ax+b)·coth(ax+b) / ((n-1)·a)
+             − (n-2)/(n-1) · I_{n-2}
+
+    Base cases:
+
+        I_0 = x
+        I_1 = log(tanh((ax+b)/2)) / a       [Phase 15 _csch_integral formula]
+        I_2 = −coth(ax+b) / a               [note negative sign]
+
+    Pre-conditions: ``n ≥ 0``, ``a ≠ 0``.
+
+    Parameters
+    ----------
+    n :
+        Non-negative integer power.
+    a, b :
+        Fraction coefficients of the linear argument ``ax+b``.
+    x :
+        Integration variable symbol.
+
+    Examples
+    --------
+    ::
+
+        # ∫ csch²(x) dx = -coth(x)
+        csch_power_integral(2, Fraction(1), Fraction(0), IRSymbol("x"))
+
+        # ∫ csch³(x) dx = -csch(x)·coth(x)/2 - (1/2)·log(tanh(x/2))
+        csch_power_integral(3, Fraction(1), Fraction(0), IRSymbol("x"))
+    """
+    if n == 0:
+        return x
+    arg_ir = linear_to_ir(a, b, x)
+    if n == 1:
+        # ∫ csch(ax+b) dx = log(tanh((ax+b)/2)) / a
+        half_a = a / Fraction(2)
+        half_b = b / Fraction(2)
+        half_arg = linear_to_ir(half_a, half_b, x)
+        log_tanh = IRApply(LOG, (IRApply(TANH, (half_arg,)),))
+        return log_tanh if a == Fraction(1) else IRApply(DIV, (log_tanh, _frac_ir(a)))
+    if n == 2:
+        # ∫ csch²(ax+b) dx = -coth(ax+b) / a
+        neg_coth = IRApply(NEG, (IRApply(COTH, (arg_ir,)),))
+        return neg_coth if a == Fraction(1) else IRApply(DIV, (neg_coth, _frac_ir(a)))
+
+    # n ≥ 3:  I_n = -csch^(n-2)·coth / ((n-1)·a)  −  (n-2)/(n-1) · I_{n-2}
+    #
+    # Both terms are negative — use SUB(NEG(main), rec_term) = -(main + rec_term)
+    # Equivalently: result = NEG(main_term) - rec_coeff * tail
+    csch_ir = IRApply(CSCH, (arg_ir,))
+    coth_ir = IRApply(COTH, (arg_ir,))
+    csch_pow = (
+        csch_ir
+        if n - 2 == 1
+        else IRApply(POW, (csch_ir, IRInteger(n - 2)))
+    )
+    coeff1 = Fraction(1, n - 1) / a
+    main_term = IRApply(
+        NEG,
+        (IRApply(MUL, (_frac_ir(coeff1), IRApply(MUL, (csch_pow, coth_ir)))),),
+    )
+    rec_coeff = Fraction(n - 2, n - 1)
+    tail = csch_power_integral(n - 2, a, b, x)
+    return IRApply(SUB, (main_term, IRApply(MUL, (_frac_ir(rec_coeff), tail))))
+
+
+def coth_power_integral(
+    n: int,
+    a: Fraction,
+    b: Fraction,
+    x: IRSymbol,
+) -> IRNode:
+    """Return IR for ``∫ coth^n(ax+b) dx``.
+
+    Uses the identity ``coth²(t) = 1 + csch²(t)`` to derive the reduction:
+
+        I_n = I_{n-2} − coth^(n-1)(ax+b) / ((n-1)·a)
+
+    Base cases:
+
+        I_0 = x
+        I_1 = log(sinh(ax+b)) / a           [Phase 15 _coth_integral formula]
+
+    Note: unlike sech/csch there is no explicit outer-product term involving
+    two hyperbolic functions.  Each step just subtracts one power of coth and
+    recurses down by 2, producing the telescoping series::
+
+        ∫ coth^4(x) dx = x - coth/1 - coth³/3
+        ∫ coth^5(x) dx = log(sinh) - coth²/2 - coth⁴/4
+
+    Pre-conditions: ``n ≥ 0``, ``a ≠ 0``.
+
+    Parameters
+    ----------
+    n :
+        Non-negative integer power.
+    a, b :
+        Fraction coefficients of the linear argument ``ax+b``.
+    x :
+        Integration variable symbol.
+
+    Examples
+    --------
+    ::
+
+        # ∫ coth²(x) dx = x - coth(x)
+        coth_power_integral(2, Fraction(1), Fraction(0), IRSymbol("x"))
+
+        # ∫ coth³(x) dx = log(sinh(x)) - coth²(x)/2
+        coth_power_integral(3, Fraction(1), Fraction(0), IRSymbol("x"))
+    """
+    if n == 0:
+        return x
+    arg_ir = linear_to_ir(a, b, x)
+    if n == 1:
+        # ∫ coth(ax+b) dx = log(sinh(ax+b)) / a
+        log_sinh = IRApply(LOG, (IRApply(SINH, (arg_ir,)),))
+        return log_sinh if a == Fraction(1) else IRApply(DIV, (log_sinh, _frac_ir(a)))
+
+    # n ≥ 2:  I_n = I_{n-2} − coth^(n-1) / ((n-1)·a)
+    #
+    # When n-1 == 1 use COTH(arg_ir) directly.
+    coth_ir = IRApply(COTH, (arg_ir,))
+    coth_pow = (
+        coth_ir
+        if n - 1 == 1
+        else IRApply(POW, (coth_ir, IRInteger(n - 1)))
+    )
+    coeff = Fraction(1, n - 1) / a          # 1 / ((n-1)·a)
+    power_term = IRApply(MUL, (_frac_ir(coeff), coth_pow))
+    tail = coth_power_integral(n - 2, a, b, x)
+    return IRApply(SUB, (tail, power_term))
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _frac_ir(c: Fraction) -> IRNode:
+    """Lift a Fraction to its canonical IR literal.
+
+    Returns ``IRInteger`` when the denominator is 1, ``IRRational`` otherwise.
+    This is a local copy of the same helper in ``hyp_power_integral.py`` —
+    duplicated to avoid a circular import with ``integrate.py``.
+    """
+    if c.denominator == 1:
+        return IRInteger(c.numerator)
+    return IRRational(c.numerator, c.denominator)

--- a/code/packages/python/symbolic-vm/tests/test_phase15.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase15.py
@@ -542,16 +542,16 @@ class TestPhase15_Fallthrough:
         F = _integrate_ir(vm, f)
         _is_unevaluated(f, F)
 
-    def test_sech_squared_unevaluated(self) -> None:
-        """∫ sech²(x) dx is not wired in Phase 15 — returns unevaluated.
+    def test_sech_squared_now_evaluates(self) -> None:
+        """∫ sech²(x) dx = tanh(x) — wired in Phase 16 (IBP power reduction).
 
-        (∫ sech²(x) dx = tanh(x) is a known result; it belongs in a future
-        phase alongside hyperbolic power reductions.)
+        Updated from ``test_sech_squared_unevaluated`` when Phase 16 landed:
+        ``sech^n`` now dispatches through ``_try_recip_hyp_power`` for n ≥ 2.
         """
         vm = _make_vm()
         f = IRApply(POW, (IRApply(SECH, (X,)), IRInteger(2)))
         F = _integrate_ir(vm, f)
-        _is_unevaluated(f, F)
+        _was_evaluated(f, F)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/tests/test_phase16.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase16.py
@@ -1,0 +1,579 @@
+"""Phase 16 integration tests — reciprocal hyperbolic power integrals.
+
+Tests the IBP reduction formulas for:
+- sech^n (hyperbolic secant to integer power n)
+- csch^n (hyperbolic cosecant to integer power n)
+- coth^n (hyperbolic cotangent to integer power n)
+
+Key identities verified:
+  ∫ sech²(ax+b) dx = tanh(ax+b) / a
+  ∫ csch²(ax+b) dx = -coth(ax+b) / a
+  ∫ coth²(ax+b) dx = x - coth(ax+b) / a
+
+Higher-order reduction formulas verified numerically: F'(x) ≈ f(x).
+
+Test points: x₀ = 0.5, x₁ = 1.2  (strictly away from 0; coth/csch undefined at 0)
+"""
+
+from __future__ import annotations
+
+import math
+
+from symbolic_ir import (
+    ADD,
+    COTH,
+    CSCH,
+    DIV,
+    INTEGRATE,
+    MUL,
+    POW,
+    SECH,
+    TANH,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+_INT = IRInteger
+_RAT = lambda n, d: IRRational(n, d)  # noqa: E731
+
+# Test points strictly away from 0 so coth/csch are well-defined.
+_TP = (0.5, 1.2)
+# Shifted test points for ax+b arguments with b ≠ 0
+_TP_SHIFT = (0.8, 1.5)
+
+
+def _make_vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _eval_ir(node: IRNode, x_val: float) -> float:  # noqa: PLR0911
+    """Numerically evaluate an IR tree at x = x_val."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node.name == "x":
+            return x_val
+        raise ValueError(f"Unknown symbol: {node.name}")
+    if not isinstance(node, IRApply):
+        raise TypeError(f"Unexpected node: {node!r}")
+    head = node.head.name
+    if head == "Add":
+        return _eval_ir(node.args[0], x_val) + _eval_ir(node.args[1], x_val)
+    if head == "Sub":
+        return _eval_ir(node.args[0], x_val) - _eval_ir(node.args[1], x_val)
+    if head == "Mul":
+        return _eval_ir(node.args[0], x_val) * _eval_ir(node.args[1], x_val)
+    if head == "Div":
+        return _eval_ir(node.args[0], x_val) / _eval_ir(node.args[1], x_val)
+    if head == "Neg":
+        return -_eval_ir(node.args[0], x_val)
+    if head == "Inv":
+        return 1.0 / _eval_ir(node.args[0], x_val)
+    if head == "Log":
+        return math.log(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Pow":
+        return _eval_ir(node.args[0], x_val) ** _eval_ir(node.args[1], x_val)
+    if head == "Sqrt":
+        return math.sqrt(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Exp":
+        return math.exp(_eval_ir(node.args[0], x_val))
+    if head == "Sin":
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if head == "Cos":
+        return math.cos(_eval_ir(node.args[0], x_val))
+    if head == "Tan":
+        return math.tan(_eval_ir(node.args[0], x_val))
+    if head == "Asin":
+        return math.asin(_eval_ir(node.args[0], x_val))
+    if head == "Acos":
+        return math.acos(_eval_ir(node.args[0], x_val))
+    if head == "Atan":
+        return math.atan(_eval_ir(node.args[0], x_val))
+    if head == "Sinh":
+        return math.sinh(_eval_ir(node.args[0], x_val))
+    if head == "Cosh":
+        return math.cosh(_eval_ir(node.args[0], x_val))
+    if head == "Tanh":
+        return math.tanh(_eval_ir(node.args[0], x_val))
+    if head == "Asinh":
+        return math.asinh(_eval_ir(node.args[0], x_val))
+    if head == "Acosh":
+        return math.acosh(_eval_ir(node.args[0], x_val))
+    if head == "Atanh":
+        return math.atanh(_eval_ir(node.args[0], x_val))
+    if head == "Coth":
+        v = _eval_ir(node.args[0], x_val)
+        return math.cosh(v) / math.sinh(v)
+    if head == "Sech":
+        return 1.0 / math.cosh(_eval_ir(node.args[0], x_val))
+    if head == "Csch":
+        return 1.0 / math.sinh(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"Unhandled head: {head}")
+
+
+def _numerical_deriv(node: IRNode, x_val: float, h: float = 1e-7) -> float:
+    return (_eval_ir(node, x_val + h) - _eval_ir(node, x_val - h)) / (2 * h)
+
+
+def _check_antiderivative(
+    integrand: IRNode,
+    antideriv: IRNode,
+    test_points: tuple[float, ...] = _TP,
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+) -> None:
+    """Verify F'(x) ≈ f(x) numerically at each test point."""
+    for x_val in test_points:
+        expected = _eval_ir(integrand, x_val)
+        actual = _numerical_deriv(antideriv, x_val)
+        tol = atol + rtol * abs(expected)
+        assert abs(actual - expected) < tol, (
+            f"At x={x_val}: F'={actual:.8f}, f={expected:.8f}, "
+            f"diff={abs(actual - expected):.2e}"
+        )
+
+
+def _integrate_ir(vm: VM, integrand_ir: IRNode) -> IRNode:
+    return vm.eval(IRApply(INTEGRATE, (integrand_ir, X)))
+
+
+def _was_evaluated(f: IRNode, F: IRNode) -> None:
+    assert IRApply(INTEGRATE, (f, X)) != F, (
+        "Expected a closed-form antiderivative, got an unevaluated Integrate"
+    )
+
+
+def _is_unevaluated(f: IRNode, F: IRNode) -> None:
+    assert IRApply(INTEGRATE, (f, X)) == F, (
+        "Expected an unevaluated Integrate, got a closed form"
+    )
+
+
+# Shorthand builders
+def _sech(arg: IRNode) -> IRNode:
+    return IRApply(SECH, (arg,))
+
+
+def _csch(arg: IRNode) -> IRNode:
+    return IRApply(CSCH, (arg,))
+
+
+def _coth(arg: IRNode) -> IRNode:
+    return IRApply(COTH, (arg,))
+
+
+def _pow(base: IRNode, exp: IRNode) -> IRNode:
+    return IRApply(POW, (base, exp))
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_SechPowers
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_SechPowers:
+    """∫ sech^n(ax+b) dx via IBP reduction.
+
+    Reduction formula:
+        I_n = sech^(n-2)·tanh / ((n-1)·a)  +  (n-2)/(n-1) · I_{n-2}
+    Bases:
+        I_1 = atan(sinh) / a
+        I_2 = tanh / a          ← the most important identity
+    """
+
+    def test_sech_squared(self) -> None:
+        """∫ sech²(x) dx = tanh(x) — the fundamental sech² identity."""
+        vm = _make_vm()
+        f = _pow(_sech(X), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_cubed(self) -> None:
+        """∫ sech³(x) dx = sech(x)·tanh(x)/2 + (1/2)·atan(sinh(x))."""
+        vm = _make_vm()
+        f = _pow(_sech(X), _INT(3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_fourth(self) -> None:
+        """∫ sech⁴(x) dx — applies reduction twice (n=4 → n=2 → done)."""
+        vm = _make_vm()
+        f = _pow(_sech(X), _INT(4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_fifth(self) -> None:
+        """∫ sech⁵(x) dx — applies reduction three times (n=5 → n=3 → n=1)."""
+        vm = _make_vm()
+        f = _pow(_sech(X), _INT(5))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_squared_a2(self) -> None:
+        """∫ sech²(2x) dx = tanh(2x)/2 — coefficient a=2."""
+        vm = _make_vm()
+        inner = IRApply(MUL, (_INT(2), X))
+        f = _pow(_sech(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_squared_shift(self) -> None:
+        """∫ sech²(x+1) dx = tanh(x+1) — shifted argument."""
+        vm = _make_vm()
+        inner = IRApply(ADD, (X, _INT(1)))
+        f = _pow(_sech(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=_TP_SHIFT)
+
+    def test_sech_squared_fractional_a(self) -> None:
+        """∫ sech²(x/2) dx = 2·tanh(x/2) — fractional coefficient."""
+        vm = _make_vm()
+        inner = IRApply(DIV, (X, _INT(2)))
+        f = _pow(_sech(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_sech_squared_result_contains_tanh(self) -> None:
+        """The antiderivative of sech²(x) explicitly contains Tanh."""
+        vm = _make_vm()
+        f = _pow(_sech(X), _INT(2))
+        F = _integrate_ir(vm, f)
+
+        def _has_tanh(node: IRNode) -> bool:
+            if isinstance(node, IRApply):
+                if node.head == TANH:
+                    return True
+                return any(_has_tanh(c) for c in node.args)
+            return False
+
+        assert _has_tanh(F), f"Expected Tanh in {F!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_CschPowers
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_CschPowers:
+    """∫ csch^n(ax+b) dx via IBP reduction.
+
+    Reduction formula:
+        I_n = -csch^(n-2)·coth / ((n-1)·a)  -  (n-2)/(n-1) · I_{n-2}
+    Bases:
+        I_1 = log(tanh(half)) / a
+        I_2 = -coth / a         ← note the negative sign
+    """
+
+    def test_csch_squared(self) -> None:
+        """∫ csch²(x) dx = -coth(x)."""
+        vm = _make_vm()
+        f = _pow(_csch(X), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_cubed(self) -> None:
+        """∫ csch³(x) dx — one reduction step."""
+        vm = _make_vm()
+        f = _pow(_csch(X), _INT(3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_fourth(self) -> None:
+        """∫ csch⁴(x) dx — two reduction steps."""
+        vm = _make_vm()
+        f = _pow(_csch(X), _INT(4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_fifth(self) -> None:
+        """∫ csch⁵(x) dx — three reduction steps."""
+        vm = _make_vm()
+        f = _pow(_csch(X), _INT(5))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_squared_a2(self) -> None:
+        """∫ csch²(2x) dx = -coth(2x)/2."""
+        vm = _make_vm()
+        inner = IRApply(MUL, (_INT(2), X))
+        f = _pow(_csch(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_squared_shift(self) -> None:
+        """∫ csch²(x+1) dx — shifted argument."""
+        vm = _make_vm()
+        inner = IRApply(ADD, (X, _INT(1)))
+        f = _pow(_csch(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=_TP_SHIFT)
+
+    def test_csch_squared_fractional_a(self) -> None:
+        """∫ csch²(x/2) dx = -2·coth(x/2)."""
+        vm = _make_vm()
+        inner = IRApply(DIV, (X, _INT(2)))
+        f = _pow(_csch(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_csch_squared_result_contains_coth(self) -> None:
+        """The antiderivative of csch²(x) explicitly contains Coth (negated)."""
+        vm = _make_vm()
+        f = _pow(_csch(X), _INT(2))
+        F = _integrate_ir(vm, f)
+
+        def _has_coth(node: IRNode) -> bool:
+            if isinstance(node, IRApply):
+                if node.head == COTH:
+                    return True
+                return any(_has_coth(c) for c in node.args)
+            return False
+
+        assert _has_coth(F), f"Expected Coth in {F!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_CothPowers
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_CothPowers:
+    """∫ coth^n(ax+b) dx via identity coth² = 1 + csch².
+
+    Reduction formula:
+        I_n = I_{n-2} - coth^(n-1) / ((n-1)·a)
+    Bases:
+        I_0 = x
+        I_1 = log(sinh) / a
+    """
+
+    def test_coth_squared(self) -> None:
+        """∫ coth²(x) dx = x - coth(x)."""
+        vm = _make_vm()
+        f = _pow(_coth(X), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_cubed(self) -> None:
+        """∫ coth³(x) dx = log(sinh(x)) - coth²(x)/2."""
+        vm = _make_vm()
+        f = _pow(_coth(X), _INT(3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_fourth(self) -> None:
+        """∫ coth⁴(x) dx — two reductions n=4→2→0, telescoping to x - coth - coth³/3."""
+        vm = _make_vm()
+        f = _pow(_coth(X), _INT(4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_fifth(self) -> None:
+        """∫ coth⁵(x) dx — three reduction steps."""
+        vm = _make_vm()
+        f = _pow(_coth(X), _INT(5))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_squared_a2(self) -> None:
+        """∫ coth²(2x) dx = x - coth(2x)/2."""
+        vm = _make_vm()
+        inner = IRApply(MUL, (_INT(2), X))
+        f = _pow(_coth(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_squared_shift(self) -> None:
+        """∫ coth²(x+1) dx — shifted argument."""
+        vm = _make_vm()
+        inner = IRApply(ADD, (X, _INT(1)))
+        f = _pow(_coth(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=_TP_SHIFT)
+
+    def test_coth_squared_fractional_a(self) -> None:
+        """∫ coth²(x/2) dx = x - 2·coth(x/2)."""
+        vm = _make_vm()
+        inner = IRApply(DIV, (X, _INT(2)))
+        f = _pow(_coth(inner), _INT(2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_coth_squared_result_contains_coth(self) -> None:
+        """The antiderivative of coth²(x) explicitly contains Coth."""
+        vm = _make_vm()
+        f = _pow(_coth(X), _INT(2))
+        F = _integrate_ir(vm, f)
+
+        def _has_coth(node: IRNode) -> bool:
+            if isinstance(node, IRApply):
+                if node.head == COTH:
+                    return True
+                return any(_has_coth(c) for c in node.args)
+            return False
+
+        assert _has_coth(F), f"Expected Coth in {F!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_Fallthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_Fallthrough:
+    """Inputs that must return unevaluated Integrate — deferred cases."""
+
+    def test_poly_times_sech_squared_unevaluated(self) -> None:
+        """∫ x·sech²(x) dx — poly×power not yet implemented."""
+        vm = _make_vm()
+        f = IRApply(MUL, (X, _pow(_sech(X), _INT(2))))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+    def test_sech_nonlinear_arg_squared_unevaluated(self) -> None:
+        """∫ sech²(x²) dx — non-linear argument returns unevaluated."""
+        vm = _make_vm()
+        f = _pow(_sech(IRApply(POW, (X, _INT(2)))), _INT(2))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+    def test_sech_times_csch_unevaluated(self) -> None:
+        """∫ sech(x)·csch(x) dx — mixed product returns unevaluated."""
+        vm = _make_vm()
+        f = IRApply(MUL, (_sech(X), _csch(X)))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_Regressions
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_Regressions:
+    """Regression tests — Phase 15, 14, 13, and 3 results must be unaffected."""
+
+    def test_phase15_sech_bare_still_works(self) -> None:
+        """∫ sech(x) dx still evaluates via Phase 15 (not power reduction)."""
+        vm = _make_vm()
+        f = _sech(X)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        # sech(x) bare antiderivative is atan(sinh(x))
+        for xv in _TP:
+            expected = _eval_ir(f, xv)
+            actual = _numerical_deriv(F, xv)
+            assert abs(actual - expected) < 1e-6
+
+    def test_phase14_sinh_fourth_still_works(self) -> None:
+        """∫ sinh⁴(x) dx still evaluates (Phase 14 regression)."""
+        from symbolic_ir import SINH  # noqa: PLC0415
+
+        vm = _make_vm()
+        f = _pow(IRApply(SINH, (X,)), _INT(4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        for xv in _TP:
+            expected = _eval_ir(f, xv)
+            actual = _numerical_deriv(F, xv)
+            assert abs(actual - expected) < 1e-6
+
+    def test_phase3_exp_2x_still_works(self) -> None:
+        """∫ exp(2x) dx still evaluates (Phase 3 regression)."""
+        from symbolic_ir import EXP  # noqa: PLC0415
+
+        vm = _make_vm()
+        inner = IRApply(MUL, (_INT(2), X))
+        f = IRApply(EXP, (inner,))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        for xv in _TP:
+            expected = _eval_ir(f, xv)
+            actual = _numerical_deriv(F, xv)
+            assert abs(actual - expected) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# TestPhase16_Macsyma
+# ---------------------------------------------------------------------------
+
+
+class TestPhase16_Macsyma:
+    """End-to-end tests via the MACSYMA string interface."""
+
+    def _run(self, source: str) -> IRNode:
+        from macsyma_compiler import compile_macsyma  # noqa: PLC0415
+        from macsyma_parser import parse_macsyma  # noqa: PLC0415
+
+        vm = _make_vm()
+        ast = parse_macsyma(source + ";")
+        stmts = compile_macsyma(ast)
+        result = None
+        for stmt in stmts:
+            result = vm.eval(stmt)
+        return result  # type: ignore[return-value]
+
+    def test_sech_squared_via_macsyma(self) -> None:
+        """integrate(sech(x)^2, x) = tanh(x) via MACSYMA syntax."""
+        result = self._run("integrate(sech(x)^2, x)")
+        f = _pow(_sech(X), _INT(2))
+        _was_evaluated(f, result)
+        _check_antiderivative(f, result)
+
+    def test_csch_squared_via_macsyma(self) -> None:
+        """integrate(csch(x)^2, x) = -coth(x) via MACSYMA syntax."""
+        result = self._run("integrate(csch(x)^2, x)")
+        f = _pow(_csch(X), _INT(2))
+        _was_evaluated(f, result)
+        _check_antiderivative(f, result)
+
+    def test_coth_squared_via_macsyma(self) -> None:
+        """integrate(coth(x)^2, x) = x - coth(x) via MACSYMA syntax."""
+        result = self._run("integrate(coth(x)^2, x)")
+        f = _pow(_coth(X), _INT(2))
+        _was_evaluated(f, result)
+        _check_antiderivative(f, result)
+
+    def test_sech_cubed_via_macsyma(self) -> None:
+        """integrate(sech(x)^3, x) returns a closed form."""
+        result = self._run("integrate(sech(x)^3, x)")
+        f = _pow(_sech(X), _INT(3))
+        _was_evaluated(f, result)
+        _check_antiderivative(f, result)

--- a/code/specs/phase16-recip-hyp-powers.md
+++ b/code/specs/phase16-recip-hyp-powers.md
@@ -1,0 +1,192 @@
+# Phase 16 — Reciprocal Hyperbolic Power Integrals
+
+## Status
+
+**Complete** — shipped in `symbolic-vm` 0.36.0.
+
+---
+
+## Motivation
+
+Phase 15 added bare (n=1) integration for `coth`, `sech`, `csch` and explicitly
+deferred the power case, leaving `∫ sech²(x) dx` unevaluated. Phase 16 closes
+that gap with **IBP reduction formulas** for all three functions:
+
+```
+∫ sech^n(ax+b) dx
+∫ csch^n(ax+b) dx
+∫ coth^n(ax+b) dx
+```
+
+This directly mirrors Phase 14's treatment of `sinh^n` / `cosh^n`
+(in `hyp_power_integral.py`). No new IR heads are needed — all output uses
+existing heads (`TANH`, `COTH`, `SINH`, `ATAN`, `LOG`, `TANH`).
+
+---
+
+## Mathematical Algorithms
+
+### sech^n  (IBP with dv = sech² du → v = tanh)
+
+```
+I_n = sech^(n-2)(ax+b)·tanh(ax+b) / ((n-1)·a)  +  (n-2)/(n-1) · I_{n-2}
+
+Base cases:
+  n = 0  →  x
+  n = 1  →  atan(sinh(ax+b)) / a           [Phase 15 _sech_integral]
+  n = 2  →  tanh(ax+b) / a                 [direct; ← most useful identity]
+```
+
+**Derivation** — IBP with `u = sech^(n-2)(t)`, `dv = sech²(t) dt`:
+```
+v = tanh(t)
+du = -(n-2) sech^(n-2)(t)·tanh(t) dt
+
+∫ sech^n dt = sech^(n-2)·tanh + (n-2) ∫ sech^(n-2)·tanh² dt
+            = sech^(n-2)·tanh + (n-2) ∫ sech^(n-2)·(1−sech²) dt
+            = sech^(n-2)·tanh + (n-2)·I_{n-2} − (n-2)·I_n
+
+⟹  (n-1)·I_n = sech^(n-2)·tanh + (n-2)·I_{n-2}
+```
+
+**Verification** (n=4): `F = sech²·tanh/3 + 2·tanh/3`
+```
+F′ = [sech²(-2tanh² + sech²) + 2sech²] / 3
+   = sech²[-2tanh² + sech² + 2] / 3
+   = sech²[-2(1-sech²) + sech² + 2] / 3
+   = sech²[3sech²] / 3 = sech⁴  ✓
+```
+
+---
+
+### csch^n  (IBP with dv = csch² du → v = −coth)
+
+```
+I_n = −csch^(n-2)(ax+b)·coth(ax+b) / ((n-1)·a)  −  (n-2)/(n-1) · I_{n-2}
+
+Base cases:
+  n = 0  →  x
+  n = 1  →  log(tanh((ax+b)/2)) / a       [Phase 15 _csch_integral]
+  n = 2  →  −coth(ax+b) / a               [direct; note negative sign]
+```
+
+**Derivation** — IBP with `u = csch^(n-2)(t)`, `dv = csch²(t) dt`:
+```
+v = -coth(t)
+du = -(n-2) csch^(n-2)(t)·coth(t) dt
+
+∫ csch^n dt = -csch^(n-2)·coth − (n-2) ∫ csch^(n-2)·coth² dt
+            = -csch^(n-2)·coth − (n-2) ∫ csch^(n-2)·(1+csch²) dt
+            = -csch^(n-2)·coth − (n-2)·I_{n-2} − (n-2)·I_n
+
+⟹  (n-1)·I_n = -csch^(n-2)·coth − (n-2)·I_{n-2}
+```
+
+**Verification** (n=4): `F = -csch²·coth/3 + 2·coth/3`
+```
+F′ = [csch²(2coth² + csch²) - 2csch²] / 3
+   = csch²[2coth² + csch² - 2] / 3
+   = csch²[2(1+csch²) + csch² - 2] / 3
+   = csch²[3csch²] / 3 = csch⁴  ✓
+```
+
+---
+
+### coth^n  (identity coth² = 1 + csch²)
+
+```
+I_n = I_{n-2}  −  coth^(n-1)(ax+b) / ((n-1)·a)
+
+Base cases:
+  n = 0  →  x
+  n = 1  →  log(sinh(ax+b)) / a            [Phase 15 _coth_integral]
+```
+
+**Derivation** — expand via the Pythagorean identity `coth² = 1 + csch²`:
+```
+∫ coth^n dt = ∫ coth^(n-2)·coth² dt
+            = ∫ coth^(n-2)·(1 + csch²) dt
+            = I_{n-2} + ∫ coth^(n-2)·csch² dt
+
+For the last term, substitute t = coth(u), dt = -csch²(u) du:
+  ∫ coth^(n-2)·csch² dt = -coth^(n-1) / (n-1)
+```
+
+**Verification** (n=3): `F = log(sinh(x)) - coth²(x)/2`
+```
+F′ = coth(x) - 2·coth·(-csch²) / 2
+   = coth + coth·csch²
+   = coth(1 + csch²) = coth·coth² = coth³  ✓
+```
+
+---
+
+## Implementation
+
+### New file: `symbolic-vm/src/symbolic_vm/recip_hyp_power_integral.py`
+
+Exports:
+- `sech_power_integral(n, a, b, x)` — IBP reduction, n≥0
+- `csch_power_integral(n, a, b, x)` — IBP reduction, n≥0
+- `coth_power_integral(n, a, b, x)` — identity reduction, n≥0
+
+All three are pure recursive functions with no back-call to `integrate.py`,
+avoiding circular imports. `_frac_ir` is defined locally (same pattern as
+`hyp_power_integral.py`). `linear_to_ir` imported from
+`symbolic_vm.polynomial_bridge`.
+
+### `integrate.py` changes
+
+1. **Import** the three public functions from `recip_hyp_power_integral`.
+2. **Dispatcher** `_try_recip_hyp_power(base, exponent, x)` — checks
+   `base.head ∈ {SECH, CSCH, COTH}`, integer exponent ≥ 2, linear argument.
+3. **Call site** — immediately after the `_try_hyp_power` call (~line 539).
+
+---
+
+## Fallthrough Behaviour (deferred cases)
+
+| Input | Reason |
+|-------|--------|
+| `∫ P(x)·sech^n(ax+b) dx` for `deg P ≥ 1` | poly×recip-hyp IBP deferred |
+| `∫ sech^n(f(x)) dx` for non-linear `f` | non-linear argument not handled |
+| `∫ sech^n(x) · csch^m(x) dx` | mixed products deferred |
+
+---
+
+## Package Versions
+
+| Package | Before | After |
+|---------|--------|-------|
+| `symbolic-vm` | 0.35.0 | 0.36.0 |
+
+`symbolic-ir` and `macsyma-compiler` are **unchanged** — no new IR heads or
+compiler mappings needed.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `symbolic-vm/src/symbolic_vm/recip_hyp_power_integral.py` | **NEW** |
+| `symbolic-vm/src/symbolic_vm/integrate.py` | import + dispatcher + call site |
+| `symbolic-vm/tests/test_phase16.py` | **NEW** ≥32 tests |
+| `symbolic-vm/tests/test_phase15.py` | `test_sech_squared_unevaluated` updated |
+| `symbolic-vm/CHANGELOG.md` | 0.36.0 entry |
+| `symbolic-vm/pyproject.toml` | version 0.36.0 |
+
+---
+
+## Test Coverage
+
+`test_phase16.py` (≥32 tests):
+
+| Class | Tests | What is verified |
+|-------|-------|-----------------|
+| `TestPhase16_SechPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; structure |
+| `TestPhase16_CschPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; structure |
+| `TestPhase16_CothPowers` | 8 | n=2,3,4,5; a=2; b=1; a=1/2; structure |
+| `TestPhase16_Fallthrough` | 3 | poly×sech², non-linear csch, mixed product |
+| `TestPhase16_Regressions` | 3 | Phase 15 bare, Phase 14 sinh^4, Phase 3 exp |
+| `TestPhase16_Macsyma` | 4 | end-to-end via MACSYMA string interface |


### PR DESCRIPTION
## Summary

- Adds IBP reduction formulas for `∫ sech^n(ax+b) dx`, `∫ csch^n(ax+b) dx`, and `∫ coth^n(ax+b) dx` (any integer n ≥ 0), closing the gap left by Phase 15 where `sech²(x)` returned unevaluated
- New module `recip_hyp_power_integral.py` with three pure-recursive functions (`sech_power_integral`, `csch_power_integral`, `coth_power_integral`); no circular imports, no new IR heads needed
- `integrate.py` wired with `_try_recip_hyp_power` dispatcher immediately after `_try_hyp_power`; 34 new tests verify antiderivatives numerically at two test points

## Test plan

- [x] `pytest tests/ -q` — 1093 passed (was 1059 before Phase 16), 86% coverage
- [x] `ruff check src/symbolic_vm/recip_hyp_power_integral.py src/symbolic_vm/integrate.py tests/test_phase16.py tests/test_phase15.py` — all checks passed
- [x] `test_phase15.py::test_sech_squared_now_evaluates` — confirms sech² now has a closed form (previously `test_sech_squared_unevaluated`)
- [x] Security review passed — pure IR tree construction, no I/O, no eval/exec, bounded recursion

🤖 Generated with [Claude Code](https://claude.com/claude-code)