### PR TITLE
Mark truncated doctype keywords force quirks

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -92,3 +92,5 @@ documented in this file.
   missing identifiers.
 - Standalone `SYSTEM` doctypes and trailing junk after system identifiers are
   now covered, with unexpected trailing junk marking force-quirks mode.
+- DOCTYPE declarations cut off while matching the `DOCTYPE` keyword now emit a
+  force-quirks token instead of a clean partial declaration.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -33,7 +33,7 @@ open comment remain literal comment data and surface a recoverable
 `incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
 inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
-also emits the current name in force-quirks mode. Mosaic-era `PUBLIC` and
+or inside the `DOCTYPE` keyword emits a force-quirks token. Mosaic-era `PUBLIC` and
 `SYSTEM` identifiers are preserved on emitted DOCTYPE tokens, so legacy
 declarations such as `<!DOCTYPE html PUBLIC "...">` keep the information the
 future tree-construction/parser layer will need for compatibility decisions.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4694,7 +4694,12 @@ from = "doctype_keyword_o"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_o"
@@ -4721,7 +4726,12 @@ from = "doctype_keyword_c"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_c"
@@ -4748,7 +4758,12 @@ from = "doctype_keyword_t"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_t"
@@ -4775,7 +4790,12 @@ from = "doctype_keyword_y"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_y"
@@ -4802,7 +4822,12 @@ from = "doctype_keyword_p"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_p"
@@ -4829,7 +4854,12 @@ from = "doctype_keyword_e"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-doctype)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-doctype)",
+  "mark_force_quirks",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "doctype_keyword_e"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9966,6 +9966,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10026,6 +10027,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10086,6 +10088,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10146,6 +10149,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10206,6 +10210,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -10266,6 +10271,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-doctype)".to_string(),
+                "mark_force_quirks".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 48);
+    assert_eq!(html1.cases.len(), 49);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 47);
+    assert_eq!(file.tests.len(), 48);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -109,35 +109,36 @@ fn html5lib_smoke_fixture_file_parses() {
     assert_eq!(file.tests[2].initial_states, vec!["Data state".to_string()]);
     assert_eq!(file.tests[4].errors[0].code, "missing-doctype-name");
     assert_eq!(file.tests[5].errors[0].code, "eof-in-doctype");
+    assert_eq!(file.tests[6].errors[0].code, "eof-in-doctype");
     assert_eq!(
-        file.tests[8].errors[0].code,
+        file.tests[9].errors[0].code,
         "missing-doctype-public-identifier"
     );
     assert_eq!(
-        file.tests[10].errors[0].code,
+        file.tests[11].errors[0].code,
         "missing-doctype-system-identifier"
     );
     assert_eq!(
-        file.tests[11].errors[0].code,
+        file.tests[12].errors[0].code,
         "unexpected-character-after-doctype-system-identifier"
     );
-    assert_eq!(file.tests[13].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[13].errors[0].line, 1);
-    assert_eq!(file.tests[13].errors[0].col, 9);
+    assert_eq!(file.tests[14].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[14].errors[0].line, 1);
+    assert_eq!(file.tests[14].errors[0].col, 9);
     assert_eq!(
-        file.tests[14].errors[0].code,
+        file.tests[15].errors[0].code,
         "abrupt-closing-of-empty-comment"
     );
     assert_eq!(
-        file.tests[16].initial_states,
+        file.tests[17].initial_states,
         vec!["RCDATA state".to_string()]
     );
-    assert_eq!(file.tests[16].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(file.tests[17].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
-        file.tests[18].initial_states,
+        file.tests[19].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[18].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[19].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -162,7 +163,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 47);
+    assert_eq!(normalized.cases.len(), 48);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -173,28 +174,24 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
         vec!["eof-in-doctype".to_string()]
     );
     assert_eq!(
-        normalized.cases[8].diagnostics,
+        normalized.cases[6].diagnostics,
+        vec!["eof-in-doctype".to_string()]
+    );
+    assert_eq!(
+        normalized.cases[9].diagnostics,
         vec!["missing-doctype-public-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[10].diagnostics,
+        normalized.cases[11].diagnostics,
         vec!["missing-doctype-system-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[11].diagnostics,
+        normalized.cases[12].diagnostics,
         vec!["unexpected-character-after-doctype-system-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[14].diagnostics,
+        normalized.cases[15].diagnostics,
         vec!["abrupt-closing-of-empty-comment".to_string()]
-    );
-    assert_eq!(
-        normalized.cases[16].initial_state.as_deref(),
-        Some("RCDATA state")
-    );
-    assert_eq!(
-        normalized.cases[16].last_start_tag.as_deref(),
-        Some("title")
     );
     assert_eq!(
         normalized.cases[17].initial_state.as_deref(),
@@ -206,10 +203,18 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     );
     assert_eq!(
         normalized.cases[18].initial_state.as_deref(),
-        Some("RAWTEXT state")
+        Some("RCDATA state")
     );
     assert_eq!(
         normalized.cases[18].last_start_tag.as_deref(),
+        Some("title")
+    );
+    assert_eq!(
+        normalized.cases[19].initial_state.as_deref(),
+        Some("RAWTEXT state")
+    );
+    assert_eq!(
+        normalized.cases[19].last_start_tag.as_deref(),
         Some("style")
     );
 }
@@ -253,7 +258,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 47);
+    assert_eq!(suite.cases.len(), 48);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -79,6 +79,18 @@
       ]
     },
     {
+      "id": "doctype-keyword-eof-quirks",
+      "description": "DOCTYPE keyword cut off by EOF emits a force-quirks doctype",
+      "input": "<!DOC",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-doctype"
+      ]
+    },
+    {
       "id": "doctype-after-name-eof-quirks",
       "description": "DOCTYPE after-name state cut off by EOF marks force-quirks",
       "input": "<!DOCTYPE html ",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -91,6 +91,18 @@
     },
     {
       "id": "html5lib-smoke-7",
+      "description": "doctype keyword eof force quirks",
+      "input": "<!DOC",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-doctype"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-8",
       "description": "doctype public identifier",
       "input": "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML//EN\">",
       "tokens": [
@@ -100,7 +112,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-8",
+      "id": "html5lib-smoke-9",
       "description": "doctype public and system identifiers",
       "input": "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01//EN' \"about:legacy-compat\">",
       "tokens": [
@@ -110,7 +122,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-9",
+      "id": "html5lib-smoke-10",
       "description": "doctype missing public identifier",
       "input": "<!DOCTYPE html PUBLIC>",
       "tokens": [
@@ -122,7 +134,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-10",
+      "id": "html5lib-smoke-11",
       "description": "doctype system identifier",
       "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
       "tokens": [
@@ -132,7 +144,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-12",
       "description": "doctype missing system identifier",
       "input": "<!DOCTYPE html SYSTEM>",
       "tokens": [
@@ -144,7 +156,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-13",
       "description": "doctype trailing junk after system identifier",
       "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>",
       "tokens": [
@@ -156,7 +168,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-14",
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "tokens": [
@@ -166,7 +178,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-15",
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "tokens": [
@@ -178,7 +190,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-16",
       "description": "abrupt empty comment close",
       "input": "Before<!-->After",
       "tokens": [
@@ -192,7 +204,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-17",
       "description": "dash prefixed empty comment close",
       "input": "Before<!--->After",
       "tokens": [
@@ -204,7 +216,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-18",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -217,7 +229,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-19",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -229,7 +241,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-20",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -242,7 +254,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-21",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -253,7 +265,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-22",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -266,7 +278,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-23",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -279,7 +291,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-24",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -289,7 +301,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-25",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -299,7 +311,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -311,7 +323,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -321,7 +333,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -331,7 +343,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -344,7 +356,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -354,7 +366,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -364,7 +376,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -377,7 +389,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -391,7 +403,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -405,7 +417,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -422,7 +434,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -432,7 +444,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -442,7 +454,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -452,7 +464,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -462,7 +474,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -474,7 +486,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -487,7 +499,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -500,7 +512,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -515,7 +527,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -528,7 +540,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -542,7 +554,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -555,7 +567,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -569,7 +581,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -59,6 +59,16 @@
       ]
     },
     {
+      "description": "doctype keyword eof force quirks",
+      "input": "<!DOC",
+      "output": [
+        ["DOCTYPE", null, null, null, false]
+      ],
+      "errors": [
+        {"code": "eof-in-doctype", "line": 1, "col": 6}
+      ]
+    },
+    {
       "description": "doctype public identifier",
       "input": "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML//EN\">",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -136,6 +136,31 @@ fn default_html_lexer_marks_doctype_name_eof_force_quirks() {
 }
 
 #[test]
+fn default_html_lexer_marks_doctype_keyword_eof_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!DOC").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: None,
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-doctype"));
+}
+
+#[test]
 fn default_html_lexer_marks_after_doctype_name_eof_force_quirks() {
     let tokens = lex_html("<!DOCTYPE html ").unwrap();
 


### PR DESCRIPTION
## Summary
- Mark force-quirks mode when EOF cuts off the `DOCTYPE` keyword recognition states.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for a truncated keyword like `<!DOC`.
- Regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`