### PR TITLE
feat(prolog): adapt callable clpfd forms

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -13,6 +13,9 @@
   generation and validation
 - adapt Prolog `integer/1` and `succ/2` into the logic builtin layer for
   integer type checks and successor relations
+- adapt callable CLP(FD) forms (`in/2`, `ins/2`, `#=/2`, `#\=/2`, `#</2`,
+  `#=</2`, `#>/2`, `#>=/2`, `all_different/1`, `all_distinct/1`, `label/1`,
+  and `labeling/2`) into the finite-domain builtin layer
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
   `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1`) into the

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -13,6 +13,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - adapt parsed Prolog builtin calls like `call/1`, `dynamic/1`, `assertz/1`,
   and `predicate_property/2` into runtime goals before execution
 - adapt finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
+- adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
+  `all_different/1`, and `labeling/2`
 - adapt `phrase/2` and `phrase/3` into executable DCG runtime calls
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from logic_builtins import (
     abolisho,
+    all_differento,
     argo,
     assertao,
     assertzo,
@@ -23,6 +24,16 @@ from logic_builtins import (
     cuto,
     dynamico,
     failo,
+    fd_addo,
+    fd_eqo,
+    fd_geqo,
+    fd_gto,
+    fd_ino,
+    fd_leqo,
+    fd_lto,
+    fd_mulo,
+    fd_neqo,
+    fd_subo,
     findallo,
     forallo,
     functoro,
@@ -33,6 +44,7 @@ from logic_builtins import (
     iftheno,
     integero,
     iso,
+    labelingo,
     leqo,
     lto,
     nonvaro,
@@ -150,6 +162,8 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return unary_term_builtins[name](args[0])
 
     unary_list_builtins: dict[str, Callable[[object], GoalExpr]] = {
+        "all_different": all_differento,
+        "all_distinct": all_differento,
         "is_list": listo,
     }
     if goal.relation.arity == 1 and name in unary_list_builtins:
@@ -167,6 +181,22 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     }
     if goal.relation.arity == 2 and name in binary_arithmetic_builtins:
         return binary_arithmetic_builtins[name](args[0], args[1])
+
+    binary_fd_builtins: dict[str, Callable[[object, object], GoalExpr]] = {
+        "#\\=": fd_neqo,
+        "#<": fd_lto,
+        "#=<": fd_leqo,
+        "#>": fd_gto,
+        "#>=": fd_geqo,
+        "in": fd_ino,
+    }
+    if goal.relation.arity == 2 and name == "#=":
+        return _adapt_fd_equality(args[0], args[1])
+    if goal.relation.arity == 2 and name == "ins":
+        ins_goal = _adapt_fd_ins(args[0], args[1])
+        return goal if ins_goal is None else ins_goal
+    if goal.relation.arity == 2 and name in binary_fd_builtins:
+        return binary_fd_builtins[name](args[0], args[1])
 
     ternary_arithmetic_builtins: dict[
         str,
@@ -234,6 +264,10 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return setofo(args[0], _adapt_callable_goal(args[1]), args[2])
     if name == "forall" and goal.relation.arity == 2:
         return forallo(_adapt_callable_goal(args[0]), _adapt_callable_goal(args[1]))
+    if name == "labeling" and goal.relation.arity == 2:
+        return labelingo(args[1])
+    if name == "label" and goal.relation.arity == 1:
+        return labelingo(args[0])
     if name == "functor" and goal.relation.arity == 3:
         return functoro(*args)
     if name == "arg" and goal.relation.arity == 3:
@@ -278,6 +312,41 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return goal if property_goal is None else property_goal
 
     return goal
+
+
+def _adapt_fd_equality(left: Term, right: Term) -> GoalExpr:
+    right_expression = _adapt_fd_arithmetic_expression(right, left)
+    if right_expression is not None:
+        return right_expression
+
+    left_expression = _adapt_fd_arithmetic_expression(left, right)
+    if left_expression is not None:
+        return left_expression
+
+    return fd_eqo(left, right)
+
+
+def _adapt_fd_arithmetic_expression(expression: Term, result: Term) -> GoalExpr | None:
+    if not isinstance(expression, Compound) or len(expression.args) != 2:
+        return None
+    if expression.functor.namespace is not None:
+        return None
+
+    left, right = expression.args
+    if expression.functor.name == "+":
+        return fd_addo(left, right, result)
+    if expression.functor.name == "-":
+        return fd_subo(left, right, result)
+    if expression.functor.name == "*":
+        return fd_mulo(left, right, result)
+    return None
+
+
+def _adapt_fd_ins(targets: Term, domain: Term) -> GoalExpr | None:
+    items = _logic_list_items(targets)
+    if items is None:
+        return None
+    return conj(*(fd_ino(item, domain) for item in items))
 
 
 def _adapt_if_then_else(goal: DisjExpr) -> GoalExpr | None:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -783,6 +783,25 @@ class TestPrologGoalAdapter:
             relation("!", 0)(),
             relation("is", 2)(LogicVar(id=10), term("+", 1, 2)),
             relation("succ", 2)(1, LogicVar(id=29)),
+            relation("#=", 2)(LogicVar(id=30), term("+", LogicVar(id=31), 1)),
+            relation("#\\=", 2)(LogicVar(id=32), LogicVar(id=33)),
+            relation("#<", 2)(LogicVar(id=34), LogicVar(id=35)),
+            relation("#=<", 2)(LogicVar(id=36), LogicVar(id=37)),
+            relation("#>", 2)(LogicVar(id=38), LogicVar(id=39)),
+            relation("#>=", 2)(LogicVar(id=40), LogicVar(id=41)),
+            relation("in", 2)(LogicVar(id=42), logic_list([1, 2, 3])),
+            relation("ins", 2)(
+                logic_list([LogicVar(id=43)]),
+                logic_list([1, 2, 3]),
+            ),
+            relation("all_different", 1)(
+                logic_list([LogicVar(id=44), LogicVar(id=45)])
+            ),
+            relation("all_distinct", 1)(
+                logic_list([LogicVar(id=46), LogicVar(id=47)])
+            ),
+            relation("labeling", 2)(logic_list([]), logic_list([LogicVar(id=48)])),
+            relation("label", 1)(logic_list([LogicVar(id=49)])),
             relation("=:=", 2)(term("+", 1, 2), 3),
             relation("=\\=", 2)(term("+", 1, 2), 4),
             relation("<", 2)(1, 2),
@@ -948,6 +967,28 @@ class TestPrologGoalAdapter:
         ) == [
             (num(3), num(4)),
             (num(4), num(5)),
+        ]
+
+    def test_adapt_prolog_goal_rewrites_clpfd_callable_forms(self) -> None:
+        parsed = parse_swi_query(
+            "?- ins([X,Y], [1,2,3]), "
+            "in(Z, [1,2,3,4,5,6]), "
+            "#<(X,Y), "
+            "#=(Z, +(X,Y)), "
+            "all_different([X,Y]), "
+            "labeling([], [X,Y,Z]).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            (parsed.variables["X"], parsed.variables["Y"], parsed.variables["Z"]),
+            adapted,
+        ) == [
+            (num(1), num(2), num(3)),
+            (num(1), num(3), num(4)),
+            (num(2), num(3), num(5)),
         ]
 
     def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -19,6 +19,8 @@
   validation.
 - Run Prolog `integer/1` and `succ/2` through the VM path for integer type
   checks and successor relations.
+- Run callable CLP(FD) forms through the VM path, including finite domains,
+  arithmetic equality constraints, all-different, and labeling.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -129,6 +129,7 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
+- callable CLP(FD) forms for finite-domain puzzles
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -186,6 +186,26 @@ class TestPrologVMStress:
             },
         ]
 
+    def test_clpfd_callable_forms_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- ins([X,Y], [1,2,3]),
+               in(Z, [1,2,3,4,5,6]),
+               #<(X,Y),
+               #=(Z, +(X,Y)),
+               all_different([X,Y]),
+               labeling([], [X,Y,Z]).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"X": num(1), "Y": num(2), "Z": num(3)},
+            {"X": num(1), "Y": num(3), "Z": num(4)},
+            {"X": num(2), "Y": num(3), "Z": num(5)},
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR30-prolog-vm-clpfd-adapter.md
+++ b/code/specs/PR30-prolog-vm-clpfd-adapter.md
@@ -1,0 +1,51 @@
+# PR30: Prolog VM CLP(FD) Adapter
+
+## Summary
+
+This batch bridges parsed callable CLP(FD) forms into the existing
+`logic-builtins` finite-domain engine. It intentionally supports callable
+predicate forms that parse today while leaving infix operator parsing for a
+later grammar/operator-table batch.
+
+## Goals
+
+- adapt `in/2` to `fd_ino`
+- adapt `ins/2` over proper variable lists
+- adapt `#=/2`, `#\=/2`, `#</2`, `#=</2`, `#>/2`, and `#>=/2`
+- lower simple `#=(Result, +(Left, Right))`, `-(...)`, and `*(...)` forms
+- adapt `all_different/1`, `all_distinct/1`, `label/1`, and `labeling/2`
+- verify parser-to-loader-to-VM execution
+
+## Semantics
+
+- domains are finite and concrete; list domains work today
+- `ins/2` requires a proper finite target list
+- `labeling/2` currently ignores options and labels its second argument
+- `#=/2` falls back to FD equality when neither side is a supported arithmetic
+  expression
+
+## Example
+
+```prolog
+?- ins([X,Y], [1,2,3]),
+   in(Z, [1,2,3,4,5,6]),
+   #<(X,Y),
+   #=(Z, +(X,Y)),
+   all_different([X,Y]),
+   labeling([], [X,Y,Z]).
+```
+
+Expected:
+
+```prolog
+X = 1, Y = 2, Z = 3 ;
+X = 1, Y = 3, Z = 4 ;
+X = 2, Y = 3, Z = 5.
+```
+
+## Non-Goals
+
+- infix CLP(FD) operator parsing, such as `X #= Y + 1`
+- `1..4` range syntax parsing
+- labeling option semantics
+- full recursive arithmetic-expression lowering


### PR DESCRIPTION
## Summary

- adapt callable CLP(FD) forms into the existing finite-domain builtin layer
- support `in/2`, `ins/2`, comparison constraints, simple arithmetic equality lowering, all-different aliases, and labeling calls
- add parser-to-loader and full Prolog VM stress coverage plus PR30 spec notes

## Verification

- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `go build -o /tmp/ca-build-tool-prolog-clpfd .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-clpfd -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-clpfd-build-plan.json`