### PR TITLE
feat(storage-sqlite): IX-14 — AUTOINCREMENT (v0.17.0)

### DIFF
--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-28
+
+### Added
+
+- **`ColumnDef.autoincrement`** — new boolean field, defaults to `False`.
+  Set on a column declared `INTEGER PRIMARY KEY AUTOINCREMENT` to request
+  monotonic rowid assignment (no reuse of deleted rowids).  The
+  constraint is enforced by `storage-sqlite` 0.17+ via the
+  `sqlite_sequence` table; in-memory backends may treat it as a hint.
+
 ## [0.9.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/sql-backend/src/sql_backend/schema.py
+++ b/code/packages/python/sql-backend/src/sql_backend/schema.py
@@ -97,6 +97,7 @@ class ColumnDef:
     not_null: bool = False
     primary_key: bool = False
     unique: bool = False
+    autoincrement: bool = False
     default: ColumnDefault = field(default=NO_DEFAULT)
     check_expr: object = field(default=None, compare=False, hash=False)
     # (ref_table, ref_col_or_None) — None ref_col means "reference the PK".

--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [0.17.0] - 2026-04-28
+
+### Added
+
+**AUTOINCREMENT (IX-14)**
+
+`INTEGER PRIMARY KEY AUTOINCREMENT` is now supported and matches real
+SQLite's monotonicity guarantee: rowids assigned by the system are
+strictly greater than every rowid that has *ever* lived in the table,
+even ones that have been deleted.  Plain `INTEGER PRIMARY KEY`
+(without `AUTOINCREMENT`) keeps its existing rowid-reuse behaviour.
+
+- **`SqliteFileBackend.create_table`** — when any column is declared
+  `AUTOINCREMENT`, lazily creates the `sqlite_sequence` system table
+  (schema `(name TEXT, seq INTEGER)`).  This matches SQLite's behaviour
+  where the table appears in `.tables` once any AUTOINCREMENT table
+  exists.
+- **`SqliteFileBackend._get_seq(table)` / `_set_seq(table, value)`** —
+  new private helpers that read/write `sqlite_sequence` directly via
+  the table's B-tree, bypassing the public `insert` to avoid recursion.
+- **`_choose_rowid(..., current_seq=0)`** — gained an optional
+  `current_seq` keyword.  When non-zero, the returned rowid is
+  `max(max_existing_rowid, current_seq) + 1`, guaranteeing monotonicity.
+- **`SqliteFileBackend.insert`** — for AUTOINCREMENT tables, fetches
+  `current_seq` from `sqlite_sequence`, picks a rowid that exceeds it,
+  and bumps the seq after a successful insert.  Explicit-rowid inserts
+  that overshoot the sequence also bump it (matches SQLite).
+- **`_columns_to_sql`** — emits `AUTOINCREMENT` after `PRIMARY KEY` so
+  the flag round-trips through `sqlite_schema`.
+- **`_parse_one_column`** — recognises the `AUTOINCREMENT` keyword.
+
+### Fixed
+
+- **NOT NULL on auto-assigned IPK columns** — pre-existing latent bug:
+  `INSERT` without an explicit value for an `INTEGER PRIMARY KEY` column
+  would fail the `NOT NULL` check before `_choose_rowid` could fill in
+  the auto-assigned rowid.  Now `_check_not_null` runs after rowid
+  assignment, so `INSERT INTO items (name) VALUES ('x')` works on
+  IPK tables (with or without `AUTOINCREMENT`).
+
+### Tests added
+
+- `test_backend.py::TestAutoincrement` — 10 tests: lazy
+  `sqlite_sequence` creation, no creation for plain IPK, sequential
+  rowid assignment, deleted-rowid not reused under AUTOINCREMENT,
+  contrast test (plain IPK does reuse), explicit rowid bumps sequence,
+  persistence across reopen, schema round-trip, SQL emit, parser.
+
 ## [0.16.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -113,6 +113,12 @@ from storage_sqlite.index_tree import DuplicateIndexKeyError, IndexTree
 from storage_sqlite.pager import Pager
 from storage_sqlite.schema import Schema, SchemaError, initialize_new_database
 
+# Name of the system table that tracks AUTOINCREMENT high-water marks per
+# table.  Created lazily on first ``CREATE TABLE ... AUTOINCREMENT``.  Schema:
+# ``CREATE TABLE sqlite_sequence (name TEXT, seq INTEGER)``.
+_SEQUENCE_TABLE: str = "sqlite_sequence"
+
+
 # ---------------------------------------------------------------------------
 # SQL column-definition helpers
 # ---------------------------------------------------------------------------
@@ -161,6 +167,9 @@ def _columns_to_sql(table: str, columns: list[ColumnDef]) -> str:
         tokens: list[str] = [col.name, col.type_name]
         if col.primary_key:
             tokens.append("PRIMARY KEY")
+            # AUTOINCREMENT may only follow PRIMARY KEY in SQLite syntax.
+            if col.autoincrement:
+                tokens.append("AUTOINCREMENT")
         # NOT NULL: emit only when not implied by PRIMARY KEY to match sqlite3's
         # output style; PRIMARY KEY already implies NOT NULL in SQLite.
         if col.not_null and not col.primary_key:
@@ -286,6 +295,7 @@ def _parse_one_column(col_sql: str) -> ColumnDef | None:
     not_null = False
     primary_key = False
     unique = False
+    autoincrement = False
     default: object = NO_DEFAULT
 
     i = 2
@@ -294,6 +304,9 @@ def _parse_one_column(col_sql: str) -> ColumnDef | None:
         if tok_upper == "PRIMARY" and i + 1 < len(tokens) and tokens[i + 1].upper() == "KEY":
             primary_key = True
             i += 2
+        elif tok_upper == "AUTOINCREMENT":
+            autoincrement = True
+            i += 1
         elif tok_upper == "NOT" and i + 1 < len(tokens) and tokens[i + 1].upper() == "NULL":
             not_null = True
             i += 2
@@ -304,7 +317,7 @@ def _parse_one_column(col_sql: str) -> ColumnDef | None:
             default = _parse_literal(tokens[i + 1])
             i += 2
         else:
-            i += 1  # skip unknown token (e.g. AUTO_INCREMENT, REFERENCES, …)
+            i += 1  # skip unknown token (e.g. REFERENCES, COLLATE, …)
 
     return ColumnDef(
         name=name,
@@ -312,6 +325,7 @@ def _parse_one_column(col_sql: str) -> ColumnDef | None:
         not_null=not_null,
         primary_key=primary_key,
         unique=unique,
+        autoincrement=autoincrement,
         default=default,
     )
 
@@ -605,15 +619,25 @@ def _find_max_rowid(tree: BTree) -> int:
     return max_rid
 
 
-def _choose_rowid(row: Row, columns: list[ColumnDef], tree: BTree) -> int:
+def _choose_rowid(
+    row: Row,
+    columns: list[ColumnDef],
+    tree: BTree,
+    *,
+    current_seq: int = 0,
+) -> int:
     """Determine the rowid to use when inserting *row*.
 
     Rules (mirroring SQLite's behaviour):
 
     1. If the table has an INTEGER PRIMARY KEY column AND the row supplies a
        non-NULL value for it, use that value as the rowid.
-    2. Otherwise (no IPK, or IPK column is absent/NULL in this row), assign
-       ``max_existing_rowid + 1``.
+    2. Otherwise (no IPK, or IPK column is absent/NULL in this row):
+       - For plain ``INTEGER PRIMARY KEY``: ``max_existing_rowid + 1``.
+       - For ``INTEGER PRIMARY KEY AUTOINCREMENT`` (caller supplies
+         *current_seq* > 0): ``max(max_existing_rowid, current_seq) + 1``.
+         This makes deleted rowids never reusable — the monotonicity
+         guarantee that AUTOINCREMENT provides over plain IPK.
     """
     for col in columns:
         if _is_ipk(col):
@@ -623,7 +647,13 @@ def _choose_rowid(row: Row, columns: list[ColumnDef], tree: BTree) -> int:
             # IPK absent or NULL → fall through to auto-assign.
             break
 
-    return _find_max_rowid(tree) + 1
+    max_rid = _find_max_rowid(tree)
+    return max(max_rid, current_seq) + 1
+
+
+def _has_autoincrement(columns: list[ColumnDef]) -> bool:
+    """Return ``True`` if any column in *columns* is declared AUTOINCREMENT."""
+    return any(c.autoincrement for c in columns)
 
 
 # ---------------------------------------------------------------------------
@@ -825,6 +855,78 @@ class SqliteFileBackend(Backend):
         """Open a B-tree for *rootpage* with the freelist attached."""
         return BTree.open(self._pager, rootpage, freelist=self._freelist)
 
+    # ── AUTOINCREMENT / sqlite_sequence helpers ───────────────────────────────
+
+    def _ensure_sequence_table(self) -> None:
+        """Create ``sqlite_sequence`` if it doesn't already exist.
+
+        Idempotent — does nothing when the table is already present.  The
+        schema matches real SQLite's: two columns, ``name TEXT`` and
+        ``seq INTEGER``.  Called on demand from :meth:`create_table` when
+        an ``AUTOINCREMENT`` column is declared.
+        """
+        if self._schema.find_table(_SEQUENCE_TABLE) is not None:
+            return
+        cols = [
+            ColumnDef(name="name", type_name="TEXT"),
+            ColumnDef(name="seq", type_name="INTEGER"),
+        ]
+        sql = _columns_to_sql(_SEQUENCE_TABLE, cols)
+        self._schema.create_table(_SEQUENCE_TABLE, sql)
+
+    def _seq_columns(self) -> list[ColumnDef]:
+        """Return the column list for the ``sqlite_sequence`` table."""
+        return [
+            ColumnDef(name="name", type_name="TEXT"),
+            ColumnDef(name="seq", type_name="INTEGER"),
+        ]
+
+    def _get_seq(self, table: str) -> int:
+        """Return the current sequence value for *table*, or 0 if absent.
+
+        Reads the ``sqlite_sequence`` row whose ``name`` matches *table*.
+        Missing table or missing row both return 0 — the caller treats 0
+        as "no rows have ever been inserted, start from 1".
+        """
+        if self._schema.find_table(_SEQUENCE_TABLE) is None:
+            return 0
+        rootpage, _ = self._require_table(_SEQUENCE_TABLE)
+        tree = self._open_tree(rootpage)
+        for _rowid, payload in tree.scan():
+            row = _decode_row(_rowid, payload, self._seq_columns())
+            if row.get("name") == table:
+                seq = row.get("seq")
+                return int(seq) if isinstance(seq, int) else 0
+        return 0
+
+    def _set_seq(self, table: str, value: int) -> None:
+        """Update or insert the ``sqlite_sequence`` row for *table*.
+
+        If a row with ``name == table`` already exists, its ``seq`` field
+        is rewritten to *value*; otherwise a new row is appended.  Bypasses
+        :meth:`insert` to avoid recursion through the AUTOINCREMENT path
+        (the sequence table is itself never an AUTOINCREMENT table).
+        """
+        rootpage, _ = self._require_table(_SEQUENCE_TABLE)
+        tree = self._open_tree(rootpage)
+        seq_cols = self._seq_columns()
+        # Update an existing row in place if one is found.
+        for rowid, payload in tree.scan():
+            row = _decode_row(rowid, payload, seq_cols)
+            if row.get("name") == table:
+                new_payload = _encode_row(
+                    rowid, {"name": table, "seq": value}, seq_cols
+                )
+                tree.update(rowid, new_payload)
+                return
+        # Otherwise insert a new row.  Use max-rowid + 1 directly — the
+        # sequence table is not itself AUTOINCREMENT.
+        new_rowid = _find_max_rowid(tree) + 1
+        new_payload = _encode_row(
+            new_rowid, {"name": table, "seq": value}, seq_cols
+        )
+        tree.insert(new_rowid, new_payload)
+
     def _open_indexes_for(
         self, table: str
     ) -> list[tuple[str, list[str], IndexTree]]:
@@ -911,13 +1013,29 @@ class SqliteFileBackend(Backend):
             if key not in known:
                 raise ColumnNotFound(table=table, column=key)
 
-        # Constraint checks.
-        _check_not_null(table, full_row, columns)
-
         tree = self._open_tree(rootpage)
 
-        # Determine the rowid and check primary-key uniqueness.
-        rowid = _choose_rowid(full_row, columns, tree)
+        # Determine the rowid.  For AUTOINCREMENT tables, the chosen rowid
+        # must be strictly greater than every rowid that has *ever* lived
+        # in the table — even ones that have since been deleted — so we
+        # consult ``sqlite_sequence`` for the high-water mark.
+        autoinc = _has_autoincrement(columns)
+        current_seq = self._get_seq(table) if autoinc else 0
+        rowid = _choose_rowid(full_row, columns, tree, current_seq=current_seq)
+
+        # Write the chosen rowid back into the IPK column so the NOT NULL
+        # check below sees the auto-assigned value, not the NULL placeholder
+        # left there by _apply_defaults.  PRIMARY KEY implies NOT NULL, so
+        # without this step every "INSERT without explicit IPK value" would
+        # fail the constraint check before the auto-assign got a chance.
+        for col in columns:
+            if _is_ipk(col):
+                full_row[col.name] = rowid
+                break
+
+        # Constraint checks (run after rowid assignment for the IPK reason
+        # above; the order doesn't matter for non-IPK columns).
+        _check_not_null(table, full_row, columns)
 
         # Pre-validate UNIQUE indexes before mutating anything: walk every
         # index on this table and reject the row if any UNIQUE index would
@@ -964,6 +1082,12 @@ class SqliteFileBackend(Backend):
         for _idx_name, idx_cols, idx_tree in indexes:
             key_vals = [full_row.get(c) for c in idx_cols]  # type: ignore[misc]
             idx_tree.insert(key_vals, rowid)
+
+        # AUTOINCREMENT bookkeeping: bump the sqlite_sequence high-water
+        # mark whenever the new rowid exceeds it.  Explicit-rowid inserts
+        # that overshoot the sequence also bump it (matches SQLite).
+        if autoinc and rowid > current_seq:
+            self._set_seq(table, rowid)
 
     def update(
         self,
@@ -1106,6 +1230,12 @@ class SqliteFileBackend(Backend):
 
         sql = _columns_to_sql(table, columns)
         self._schema.create_table(table, sql)
+
+        # Bootstrap sqlite_sequence on first use of AUTOINCREMENT — matches
+        # SQLite's lazy-creation behaviour (the table appears in `.tables`
+        # once any AUTOINCREMENT table has been declared).
+        if _has_autoincrement(columns):
+            self._ensure_sequence_table()
 
         # Auto-create UNIQUE indexes for every column declared UNIQUE or
         # non-IPK PRIMARY KEY.  The table is empty so backfill is a no-op;

--- a/code/packages/python/storage-sqlite/tests/test_backend.py
+++ b/code/packages/python/storage-sqlite/tests/test_backend.py
@@ -1153,3 +1153,168 @@ def _scan_all(backend: SqliteFileBackend, table: str) -> list[dict]:
             break
         rows.append(row)
     return rows
+
+
+# ---------------------------------------------------------------------------
+# AUTOINCREMENT — sqlite_sequence high-water tracking
+# ---------------------------------------------------------------------------
+
+
+class TestAutoincrement:
+    """``INTEGER PRIMARY KEY AUTOINCREMENT`` never reuses deleted rowids."""
+
+    def _autoinc_columns(self) -> list[ColumnDef]:
+        return [
+            ColumnDef(
+                name="id", type_name="INTEGER",
+                primary_key=True, autoincrement=True,
+            ),
+            ColumnDef(name="name", type_name="TEXT"),
+        ]
+
+    def test_creating_autoincrement_table_creates_sqlite_sequence(
+        self, tmp_path: Path
+    ) -> None:
+        path = str(tmp_path / "ai1.db")
+        with SqliteFileBackend(path) as b:
+            assert "sqlite_sequence" not in b.tables()
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            assert "sqlite_sequence" in b.tables()
+
+    def test_no_sqlite_sequence_for_plain_ipk(self, tmp_path: Path) -> None:
+        """Plain INTEGER PRIMARY KEY (no AUTOINCREMENT) does NOT bootstrap."""
+        path = str(tmp_path / "ai2.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "items",
+                [
+                    ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+                    ColumnDef(name="name", type_name="TEXT"),
+                ],
+                if_not_exists=False,
+            )
+            assert "sqlite_sequence" not in b.tables()
+
+    def test_autoinc_assigns_rowids_sequentially(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "ai3.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            b.insert("items", {"name": "a"})
+            b.insert("items", {"name": "b"})
+            b.insert("items", {"name": "c"})
+            rows = sorted(_scan_all(b, "items"), key=lambda r: r["id"])
+            assert [r["id"] for r in rows] == [1, 2, 3]
+
+    def test_autoinc_does_not_reuse_deleted_rowid(self, tmp_path: Path) -> None:
+        """The whole point of AUTOINCREMENT vs plain IPK."""
+        path = str(tmp_path / "ai4.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            b.insert("items", {"name": "a"})  # id=1
+            b.insert("items", {"name": "b"})  # id=2
+            b.insert("items", {"name": "c"})  # id=3
+
+            cursor = b.scan("items")
+            while (r := cursor.next()) is not None:
+                if r["id"] == 3:
+                    b.delete("items", cursor)
+                    break
+
+            b.insert("items", {"name": "d"})  # MUST be id=4, not id=3
+            rows = sorted(_scan_all(b, "items"), key=lambda r: r["id"])
+            assert [r["id"] for r in rows] == [1, 2, 4]
+
+    def test_plain_ipk_does_reuse_deleted_rowid_at_max(self, tmp_path: Path) -> None:
+        """Without AUTOINCREMENT, deleting the max rowid lets it be reused.
+
+        This is the legacy SQLite behaviour for plain INTEGER PRIMARY KEY —
+        and is the contrast that motivates AUTOINCREMENT.
+        """
+        path = str(tmp_path / "ai5.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table(
+                "items",
+                [
+                    ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+                    ColumnDef(name="name", type_name="TEXT"),
+                ],
+                if_not_exists=False,
+            )
+            b.insert("items", {"name": "a"})  # id=1
+            b.insert("items", {"name": "b"})  # id=2
+            cursor = b.scan("items")
+            while (r := cursor.next()) is not None:
+                if r["id"] == 2:
+                    b.delete("items", cursor)
+                    break
+            b.insert("items", {"name": "c"})  # id=2 (reused)
+            rows = sorted(_scan_all(b, "items"), key=lambda r: r["id"])
+            assert [r["id"] for r in rows] == [1, 2]
+
+    def test_autoinc_explicit_rowid_bumps_sequence(self, tmp_path: Path) -> None:
+        """Inserting an explicit rowid above the sequence bumps it."""
+        path = str(tmp_path / "ai6.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            b.insert("items", {"id": 100, "name": "explicit"})
+            b.insert("items", {"name": "next"})  # MUST be id=101
+            rows = sorted(_scan_all(b, "items"), key=lambda r: r["id"])
+            assert [r["id"] for r in rows] == [100, 101]
+
+    def test_autoinc_persists_across_reopen(self, tmp_path: Path) -> None:
+        """The high-water seq is stored in sqlite_sequence so it survives reopen."""
+        path = str(tmp_path / "ai7.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            b.insert("items", {"name": "a"})
+            b.insert("items", {"name": "b"})
+            cursor = b.scan("items")
+            while (r := cursor.next()) is not None:
+                if r["id"] == 2:
+                    b.delete("items", cursor)
+                    break
+            h = b.begin_transaction()
+            b.commit(h)
+
+        with SqliteFileBackend(path) as b2:
+            b2.insert("items", {"name": "after-reopen"})
+            rows = sorted(_scan_all(b2, "items"), key=lambda r: r["id"])
+            # First row (id=1) survives, deleted id=2 is NOT reused.
+            assert [r["id"] for r in rows] == [1, 3]
+
+    def test_autoincrement_round_trips_through_create_table_sql(
+        self, tmp_path: Path
+    ) -> None:
+        """Closing and reopening must preserve the AUTOINCREMENT flag in the schema."""
+        path = str(tmp_path / "ai8.db")
+        with SqliteFileBackend(path) as b:
+            b.create_table("items", self._autoinc_columns(), if_not_exists=False)
+            h = b.begin_transaction()
+            b.commit(h)
+
+        with SqliteFileBackend(path) as b2:
+            cols = b2.columns("items")
+            id_col = next(c for c in cols if c.name == "id")
+            assert id_col.primary_key is True
+            assert id_col.autoincrement is True
+
+    def test_columns_to_sql_emits_autoincrement(self) -> None:
+        """The CREATE TABLE SQL emitter wraps AUTOINCREMENT after PRIMARY KEY."""
+        from storage_sqlite.backend import _columns_to_sql
+        sql = _columns_to_sql(
+            "t",
+            [
+                ColumnDef(
+                    name="id", type_name="INTEGER",
+                    primary_key=True, autoincrement=True,
+                ),
+            ],
+        )
+        assert "PRIMARY KEY AUTOINCREMENT" in sql
+
+    def test_parse_one_column_recognises_autoincrement(self) -> None:
+        from storage_sqlite.backend import _parse_one_column
+        col = _parse_one_column("id INTEGER PRIMARY KEY AUTOINCREMENT")
+        assert col is not None
+        assert col.primary_key is True
+        assert col.autoincrement is True


### PR DESCRIPTION
## Summary

- `INTEGER PRIMARY KEY AUTOINCREMENT` is now supported with real SQLite's monotonicity guarantee: rowids never reuse deleted values
- Plain `INTEGER PRIMARY KEY` keeps its existing rowid-reuse behaviour (for contrast)
- New `ColumnDef.autoincrement` field on sql-backend (v0.10.0) — round-trips through `CREATE TABLE` SQL
- `sqlite_sequence` system table is created lazily on first AUTOINCREMENT table — matches SQLite
- Private helpers `_get_seq` / `_set_seq` read/write the sequence table directly via B-tree primitives (no recursion through public insert)
- Fixed a pre-existing latent bug: `_check_not_null` ran before `_choose_rowid`, so `INSERT` without an explicit IPK value failed even for plain IPK tables. Now the rowid is assigned first and written into the row before NOT NULL validation
- 10 new tests, 646 total pass; 132 sql-backend tests pass; ruff clean
- Security review passed in one round

## Test plan

- [x] All 646 storage-sqlite tests pass (`uv run pytest --no-cov`)
- [x] All 132 sql-backend tests pass
- [x] `uv run ruff check src/ tests/` — clean on both packages
- [x] Security review passed (no findings)
- [x] Tested: lazy `sqlite_sequence` creation, no creation for plain IPK, sequential rowid assignment, deleted-rowid not reused under AUTOINCREMENT, contrast test (plain IPK does reuse), explicit rowid bumps sequence, persistence across reopen, schema round-trip, SQL emit, parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)