### PR TITLE
feat(mini-sqlite): bytes (BLOB) parameter binding (v1.7.1)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [1.9.0] - 2026-04-28
+
+### Added
+
+**Bytes (BLOB) parameter binding**
+
+`bytes`, `bytearray`, and `memoryview` parameters can now be bound to `?`
+placeholders.  They render as the SQLite blob-literal form `X'<hex>'`,
+which round-trips through the SQL lexer (it already accepts `X'...'`
+since the BLOB-type work in 1.7.0).
+
+```python
+conn.execute("INSERT INTO blobs (data) VALUES (?)", (b"\xde\xad\xbe\xef",))
+```
+
+- **`binding._to_sql_literal`** — the previous `NotSupportedError` for
+  byte parameters is replaced with `f"X'{bytes(value).hex()}'"`.  The
+  explicit `bytes(value)` coercion materialises a fresh object so a
+  hostile `bytes` subclass overriding `.hex()` cannot inject SQL.
+- **`bytearray` / `memoryview`** are coerced via `bytes(...)` and render
+  identically to `bytes`.
+- **Empty bytes** render as `X''` (parses as a zero-length blob).
+
+### Tests added
+
+- `tests/test_binding.py` — 5 new tests: bytes round-trip, empty bytes,
+  bytearray, memoryview, and a hostile-subclass injection-defense test.
+- `tests/test_cursor.py::test_bytes_param_round_trip` — end-to-end
+  insert + select of binary data through `Connection.execute`.
+
+### Removed
+
+- `test_bytes_not_supported` — replaced by the round-trip tests above.
+
 ## [1.8.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/binding.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/binding.py
@@ -20,8 +20,8 @@ Type mapping — the output must parse as a valid SQL literal:
     True / False          → 1 / 0   (sqlite3 convention)
     int / float           → repr-style numeric literal
     str                   → single-quoted, with embedded ``'`` doubled
-    bytes / bytearray     → not supported in v1 (PEP 249 allows a driver
-                            to raise NotSupportedError for BLOB)
+    bytes / bytearray /   → ``X'<hex>'`` SQLite blob-literal form
+    memoryview              (lower-case hex; empty bytes → ``X''``)
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from .errors import NotSupportedError, ProgrammingError
+from .errors import ProgrammingError
 
 # A named parameter is ``:identifier`` where identifier follows Python-ish
 # identifier rules (letter or underscore, then letters/digits/underscores).
@@ -204,5 +204,8 @@ def _to_sql_literal(value: Any) -> str:
         escaped = s.replace("\\", "\\\\").replace("'", "\\'")
         return f"'{escaped}'"
     if isinstance(value, bytes | bytearray | memoryview):
-        raise NotSupportedError("BLOB parameters are not supported in v1")
+        # SQLite blob-literal syntax: X'<hex>' (lowercase hex by convention).
+        # bytes(value) coerces bytearray and memoryview into a fresh bytes
+        # object so a hostile subclass cannot override .hex().
+        return f"X'{bytes(value).hex()}'"
     raise ProgrammingError(f"cannot bind value of type {type(value).__name__}")

--- a/code/packages/python/mini-sqlite/tests/test_binding.py
+++ b/code/packages/python/mini-sqlite/tests/test_binding.py
@@ -49,9 +49,35 @@ def test_too_many_params():
         substitute("VALUES (?)", (1, 2))
 
 
-def test_bytes_not_supported():
-    with pytest.raises(mini_sqlite.NotSupportedError):
-        substitute("VALUES (?)", (b"x",))
+def test_bytes_render_as_blob_literal():
+    """``bytes`` parameters render as the SQLite ``X'<hex>'`` blob literal."""
+    assert substitute("VALUES (?)", (b"\xde\xad\xbe\xef",)) == "VALUES (X'deadbeef')"
+
+
+def test_empty_bytes_render_as_empty_blob_literal():
+    assert substitute("VALUES (?)", (b"",)) == "VALUES (X'')"
+
+
+def test_bytearray_renders_same_as_bytes():
+    assert substitute("VALUES (?)", (bytearray(b"\x00\xff"),)) == "VALUES (X'00ff')"
+
+
+def test_memoryview_renders_same_as_bytes():
+    assert substitute("VALUES (?)", (memoryview(b"\xab\xcd"),)) == "VALUES (X'abcd')"
+
+
+def test_bytes_subclass_cannot_inject_via_hex():
+    """A ``bytes`` subclass overriding ``hex`` must not bypass the literal form.
+
+    The implementation calls ``bytes(value).hex()`` which materialises a
+    fresh ``bytes`` object, so a subclass-defined ``.hex`` is bypassed.
+    """
+    class Evil(bytes):
+        def hex(self, *a, **kw):  # noqa: ANN002, ANN003, ANN202
+            return "00'; DROP TABLE t--"
+
+    out = substitute("VALUES (?)", (Evil(b"\x01\x02"),))
+    assert out == "VALUES (X'0102')"
 
 
 def test_unsupported_type():

--- a/code/packages/python/mini-sqlite/tests/test_cursor.py
+++ b/code/packages/python/mini-sqlite/tests/test_cursor.py
@@ -172,3 +172,14 @@ def test_named_param_reused_in_same_statement():
     )
     names = sorted(row[0] for row in cur)
     assert names == ["Alice", "Bob"]
+
+
+def test_bytes_param_round_trip():
+    """``bytes`` parameters insert and read back as the same bytes (BLOB)."""
+    conn = mini_sqlite.connect(":memory:")
+    conn.execute("CREATE TABLE blobs (id INTEGER PRIMARY KEY, data BLOB)")
+    conn.execute("INSERT INTO blobs (id, data) VALUES (?, ?)", (1, b"\xde\xad\xbe\xef"))
+    conn.execute("INSERT INTO blobs (id, data) VALUES (?, ?)", (2, b""))
+    conn.commit()
+    rows = conn.execute("SELECT id, data FROM blobs ORDER BY id").fetchall()
+    assert rows == [(1, b"\xde\xad\xbe\xef"), (2, b"")]


### PR DESCRIPTION
## Summary

- `bytes`, `bytearray`, and `memoryview` parameters can now be bound to `?` placeholders
- They render as the SQLite blob-literal form `X'<hex>'`, which round-trips through the lexer (it already accepts `X'...'` since the BLOB-type work in 1.7.0)
- Closes the only known TODO in `binding._to_sql_literal` (previously raised `NotSupportedError` for BLOB params)
- 5 new unit tests + 1 end-to-end test, all 565 mini-sqlite tests pass; ruff clean
- Security review passed in one round with thorough SQL-injection analysis

```python
conn.execute("INSERT INTO blobs (data) VALUES (?)", (b\"\\xde\\xad\\xbe\\xef\",))
```

## Implementation note

The literal is built as `f\"X'{bytes(value).hex()}'\"`. The explicit `bytes(value)` coercion materialises a fresh object so a hostile `bytes` subclass overriding `.hex()` cannot inject SQL. `bytes.hex()` returns only `[0-9a-f]` chars by CPython contract, so the literal is unforgeable.

## Test plan

- [x] All 565 mini-sqlite tests pass
- [x] `ruff check src/ tests/` — clean
- [x] Security review passed (deep empirical analysis: hostile-subclass bypass, hex-output guarantees, lexer interaction, side-effect safety)
- [x] Tested: round-trip bytes, empty bytes (`X''`), bytearray, memoryview, hostile-subclass injection defense, end-to-end via `Connection.execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)