### PR TITLE
Mark invalid doctype keywords force quirks

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -94,3 +94,5 @@ documented in this file.
   now covered, with unexpected trailing junk marking force-quirks mode.
 - DOCTYPE declarations cut off while matching the `DOCTYPE` keyword now emit a
   force-quirks token instead of a clean partial declaration.
+- Malformed `DOCTYPE` keyword text now marks force-quirks mode while preserving
+  the recovered keyword text as the best-effort DOCTYPE name.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -33,7 +33,8 @@ open comment remain literal comment data and surface a recoverable
 `incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
 inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
-or inside the `DOCTYPE` keyword emits a force-quirks token. Mosaic-era `PUBLIC` and
+or inside the `DOCTYPE` keyword emits a force-quirks token. Malformed
+`DOCTYPE` keyword text also marks force-quirks mode. Mosaic-era `PUBLIC` and
 `SYSTEM` identifiers are preserved on emitted DOCTYPE tokens, so legacy
 declarations such as `<!DOCTYPE html PUBLIC "...">` keep the information the
 future tree-construction/parser layer will need for compatibility decisions.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4707,6 +4707,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(d)",
   "append_doctype_name(current_lowercase)",
 ]
@@ -4739,6 +4740,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(do)",
   "append_doctype_name(current_lowercase)",
 ]
@@ -4771,6 +4773,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(doc)",
   "append_doctype_name(current_lowercase)",
 ]
@@ -4803,6 +4806,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(doct)",
   "append_doctype_name(current_lowercase)",
 ]
@@ -4835,6 +4839,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(docty)",
   "append_doctype_name(current_lowercase)",
 ]
@@ -4867,6 +4872,7 @@ matcher = { anything = true }
 to = "doctype_name"
 actions = [
   "parse_error(invalid-doctype-keyword)",
+  "mark_force_quirks",
   "append_doctype_name(doctyp)",
   "append_doctype_name(current_lowercase)",
 ]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9984,6 +9984,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(d)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],
@@ -10045,6 +10046,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(do)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],
@@ -10106,6 +10108,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(doc)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],
@@ -10167,6 +10170,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(doct)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],
@@ -10228,6 +10232,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(docty)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],
@@ -10289,6 +10294,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(invalid-doctype-keyword)".to_string(),
+                "mark_force_quirks".to_string(),
                 "append_doctype_name(doctyp)".to_string(),
                 "append_doctype_name(current_lowercase)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 49);
+    assert_eq!(html1.cases.len(), 50);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 48);
+    assert_eq!(file.tests.len(), 49);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -110,35 +110,36 @@ fn html5lib_smoke_fixture_file_parses() {
     assert_eq!(file.tests[4].errors[0].code, "missing-doctype-name");
     assert_eq!(file.tests[5].errors[0].code, "eof-in-doctype");
     assert_eq!(file.tests[6].errors[0].code, "eof-in-doctype");
+    assert_eq!(file.tests[7].errors[0].code, "invalid-doctype-keyword");
     assert_eq!(
-        file.tests[9].errors[0].code,
+        file.tests[10].errors[0].code,
         "missing-doctype-public-identifier"
     );
     assert_eq!(
-        file.tests[11].errors[0].code,
+        file.tests[12].errors[0].code,
         "missing-doctype-system-identifier"
     );
     assert_eq!(
-        file.tests[12].errors[0].code,
+        file.tests[13].errors[0].code,
         "unexpected-character-after-doctype-system-identifier"
     );
-    assert_eq!(file.tests[14].errors[0].code, "eof-in-comment");
-    assert_eq!(file.tests[14].errors[0].line, 1);
-    assert_eq!(file.tests[14].errors[0].col, 9);
+    assert_eq!(file.tests[15].errors[0].code, "eof-in-comment");
+    assert_eq!(file.tests[15].errors[0].line, 1);
+    assert_eq!(file.tests[15].errors[0].col, 9);
     assert_eq!(
-        file.tests[15].errors[0].code,
+        file.tests[16].errors[0].code,
         "abrupt-closing-of-empty-comment"
     );
     assert_eq!(
-        file.tests[17].initial_states,
+        file.tests[18].initial_states,
         vec!["RCDATA state".to_string()]
     );
-    assert_eq!(file.tests[17].last_start_tag.as_deref(), Some("title"));
+    assert_eq!(file.tests[18].last_start_tag.as_deref(), Some("title"));
     assert_eq!(
-        file.tests[19].initial_states,
+        file.tests[20].initial_states,
         vec!["RAWTEXT state".to_string()]
     );
-    assert_eq!(file.tests[19].last_start_tag.as_deref(), Some("style"));
+    assert_eq!(file.tests[20].last_start_tag.as_deref(), Some("style"));
 }
 
 #[test]
@@ -163,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 48);
+    assert_eq!(normalized.cases.len(), 49);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -178,28 +179,24 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
         vec!["eof-in-doctype".to_string()]
     );
     assert_eq!(
-        normalized.cases[9].diagnostics,
+        normalized.cases[7].diagnostics,
+        vec!["invalid-doctype-keyword".to_string()]
+    );
+    assert_eq!(
+        normalized.cases[10].diagnostics,
         vec!["missing-doctype-public-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[11].diagnostics,
+        normalized.cases[12].diagnostics,
         vec!["missing-doctype-system-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[12].diagnostics,
+        normalized.cases[13].diagnostics,
         vec!["unexpected-character-after-doctype-system-identifier".to_string()]
     );
     assert_eq!(
-        normalized.cases[15].diagnostics,
+        normalized.cases[16].diagnostics,
         vec!["abrupt-closing-of-empty-comment".to_string()]
-    );
-    assert_eq!(
-        normalized.cases[17].initial_state.as_deref(),
-        Some("RCDATA state")
-    );
-    assert_eq!(
-        normalized.cases[17].last_start_tag.as_deref(),
-        Some("title")
     );
     assert_eq!(
         normalized.cases[18].initial_state.as_deref(),
@@ -211,10 +208,18 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     );
     assert_eq!(
         normalized.cases[19].initial_state.as_deref(),
-        Some("RAWTEXT state")
+        Some("RCDATA state")
     );
     assert_eq!(
         normalized.cases[19].last_start_tag.as_deref(),
+        Some("title")
+    );
+    assert_eq!(
+        normalized.cases[20].initial_state.as_deref(),
+        Some("RAWTEXT state")
+    );
+    assert_eq!(
+        normalized.cases[20].last_start_tag.as_deref(),
         Some("style")
     );
 }
@@ -258,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 48);
+    assert_eq!(suite.cases.len(), 49);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -91,6 +91,18 @@
       ]
     },
     {
+      "id": "doctype-invalid-keyword-quirks",
+      "description": "Malformed DOCTYPE keyword text marks force-quirks",
+      "input": "<!DOX>",
+      "tokens": [
+        "Doctype(name=dox, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "invalid-doctype-keyword"
+      ]
+    },
+    {
       "id": "doctype-after-name-eof-quirks",
       "description": "DOCTYPE after-name state cut off by EOF marks force-quirks",
       "input": "<!DOCTYPE html ",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -103,6 +103,18 @@
     },
     {
       "id": "html5lib-smoke-8",
+      "description": "doctype invalid keyword force quirks",
+      "input": "<!DOX>",
+      "tokens": [
+        "Doctype(name=dox, force_quirks=true)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "invalid-doctype-keyword"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-9",
       "description": "doctype public identifier",
       "input": "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML//EN\">",
       "tokens": [
@@ -112,7 +124,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-9",
+      "id": "html5lib-smoke-10",
       "description": "doctype public and system identifiers",
       "input": "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01//EN' \"about:legacy-compat\">",
       "tokens": [
@@ -122,7 +134,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-10",
+      "id": "html5lib-smoke-11",
       "description": "doctype missing public identifier",
       "input": "<!DOCTYPE html PUBLIC>",
       "tokens": [
@@ -134,7 +146,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-11",
+      "id": "html5lib-smoke-12",
       "description": "doctype system identifier",
       "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
       "tokens": [
@@ -144,7 +156,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-12",
+      "id": "html5lib-smoke-13",
       "description": "doctype missing system identifier",
       "input": "<!DOCTYPE html SYSTEM>",
       "tokens": [
@@ -156,7 +168,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-13",
+      "id": "html5lib-smoke-14",
       "description": "doctype trailing junk after system identifier",
       "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\" junk>",
       "tokens": [
@@ -168,7 +180,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-14",
+      "id": "html5lib-smoke-15",
       "description": "self closing start tag uses html5lib boolean slot",
       "input": "<br/>",
       "tokens": [
@@ -178,7 +190,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-15",
+      "id": "html5lib-smoke-16",
       "description": "comment eof recovery reports tokenizer error",
       "input": "<!--open",
       "tokens": [
@@ -190,7 +202,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-16",
+      "id": "html5lib-smoke-17",
       "description": "abrupt empty comment close",
       "input": "Before<!-->After",
       "tokens": [
@@ -204,7 +216,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-17",
+      "id": "html5lib-smoke-18",
       "description": "dash prefixed empty comment close",
       "input": "Before<!--->After",
       "tokens": [
@@ -216,7 +228,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-18",
+      "id": "html5lib-smoke-19",
       "description": "rcdata matching end tag emits end tag token",
       "input": "Hello</title>",
       "tokens": [
@@ -229,7 +241,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-19",
+      "id": "html5lib-smoke-20",
       "description": "rcdata non matching end tag stays text",
       "input": "Hello&lt;/title>",
       "tokens": [
@@ -241,7 +253,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-20",
+      "id": "html5lib-smoke-21",
       "description": "rawtext matching end tag emits end tag token",
       "input": "body { color: red; }</style>",
       "tokens": [
@@ -254,7 +266,7 @@
       "last_start_tag": "style"
     },
     {
-      "id": "html5lib-smoke-21",
+      "id": "html5lib-smoke-22",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -265,7 +277,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-22",
+      "id": "html5lib-smoke-23",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -278,7 +290,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-24",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -291,7 +303,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-25",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -301,7 +313,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -311,7 +323,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -323,7 +335,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -333,7 +345,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -343,7 +355,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -356,7 +368,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -366,7 +378,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -376,7 +388,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -389,7 +401,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -403,7 +415,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -417,7 +429,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -434,7 +446,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -444,7 +456,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -454,7 +466,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -464,7 +476,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -474,7 +486,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -486,7 +498,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -499,7 +511,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -512,7 +524,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -527,7 +539,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -540,7 +552,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -554,7 +566,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -567,7 +579,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -581,7 +593,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-49",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -69,6 +69,16 @@
       ]
     },
     {
+      "description": "doctype invalid keyword force quirks",
+      "input": "<!DOX>",
+      "output": [
+        ["DOCTYPE", "dox", null, null, false]
+      ],
+      "errors": [
+        {"code": "invalid-doctype-keyword", "line": 1, "col": 5}
+      ]
+    },
+    {
       "description": "doctype public identifier",
       "input": "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML//EN\">",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -161,6 +161,31 @@ fn default_html_lexer_marks_doctype_keyword_eof_force_quirks() {
 }
 
 #[test]
+fn default_html_lexer_marks_invalid_doctype_keyword_force_quirks() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!DOX>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: Some("dox".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: true,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "invalid-doctype-keyword"));
+}
+
+#[test]
 fn default_html_lexer_marks_after_doctype_name_eof_force_quirks() {
     let tokens = lex_html("<!DOCTYPE html ").unwrap();
 


### PR DESCRIPTION
## Summary
- Mark force-quirks mode when malformed `DOCTYPE` keyword text recovers into a best-effort doctype name.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for `<!DOX>`.
- Regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`
- After rebasing on latest `origin/main`: `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- After rebasing on latest `origin/main`: `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- After rebasing on latest `origin/main`: `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- After rebasing on latest `origin/main`: `git diff --check HEAD~1 HEAD`