### PR TITLE
feat(prolog): parse clpfd infix syntax

### DIFF
--- a/code/grammars/prolog/swi.grammar
+++ b/code/grammars/prolog/swi.grammar
@@ -18,9 +18,10 @@ fact_statement      = callable_term DOT ;
 goal          = disjunction ;
 disjunction   = conjunction { SEMICOLON conjunction } ;
 conjunction   = goal_primary { COMMA goal_primary } ;
-goal_primary  = CUT | grouped_goal | equality_goal | callable_goal ;
+goal_primary  = CUT | grouped_goal | clpfd_goal | equality_goal | callable_goal ;
 grouped_goal  = LPAREN goal RPAREN ;
 equality_goal = term equality_operator term ;
+clpfd_goal    = term clpfd_operator term ;
 callable_goal = callable_term ;
 
 dcg_body          = dcg_disjunction ;
@@ -32,10 +33,17 @@ grouped_dcg_body  = LPAREN dcg_body RPAREN ;
 braced_goal       = LCURLY goal RCURLY ;
 
 equality_operator = "=" | "\=" ;
+clpfd_operator    = "#=" | "#\=" | "#<" | "#=<" | "#>" | "#>="
+                  | "in" | "ins" ;
 
 callable_term = compound_term | atom_term ;
-term          = list_term | compound_term | atom_term | variable_term
-              | anonymous_term | number_term | string_term ;
+term          = range_term ;
+range_term    = additive_term [ range_operator additive_term ] ;
+additive_term = multiplicative_term { additive_operator multiplicative_term } ;
+multiplicative_term = simple_term { multiplicative_operator simple_term } ;
+simple_term   = list_term | compound_term | atom_term | variable_term
+              | anonymous_term | number_term | string_term | grouped_term ;
+grouped_term  = LPAREN term RPAREN ;
 
 compound_term  = atom_token LPAREN [ term_arguments ] RPAREN ;
 term_arguments = term { COMMA term } ;
@@ -49,3 +57,6 @@ variable_term  = VARIABLE ;
 anonymous_term = ANON_VAR ;
 number_term    = FLOAT | INTEGER ;
 string_term    = STRING ;
+range_operator = ".." ;
+additive_operator = "+" | "-" ;
+multiplicative_operator = "*" | "/" | "//" | "mod" ;

--- a/code/grammars/prolog/swi.tokens
+++ b/code/grammars/prolog/swi.tokens
@@ -15,6 +15,7 @@ skip:
 DCG          = "-->"
 QUERY        = "?-"
 RULE         = ":-"
+RANGE        = ".." -> ATOM
 
 # Common dedicated punctuation tokens for the first parser pass.
 LPAREN       = "("

--- a/code/packages/python/prolog-core/CHANGELOG.md
+++ b/code/packages/python/prolog-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add SWI CLP(FD) operator defaults for `#=/2`, `#\=/2`, `#</2`, `#=</2`,
+  `#>/2`, `#>=/2`, `in/2`, `ins/2`, and `../2`.
+
 ## 0.1.0
 
 - Added shared Prolog operator-table and directive IR primitives

--- a/code/packages/python/prolog-core/README.md
+++ b/code/packages/python/prolog-core/README.md
@@ -14,6 +14,7 @@ The first batch includes:
 - `term_expansion_from_directive(...)` and `goal_expansion_from_directive(...)`
 - `expand_dcg_clause(...)` and `expand_dcg_phrase(...)`
 - default ISO/Core and SWI operator tables
+- SWI CLP(FD) operator defaults such as `#=/2`, `in/2`, `ins/2`, and `../2`
 
 Dialect parser packages can share these objects even when they keep separate
 lexer and parser packages.

--- a/code/packages/python/prolog-core/src/prolog_core/runtime.py
+++ b/code/packages/python/prolog-core/src/prolog_core/runtime.py
@@ -985,4 +985,9 @@ def iso_operator_table() -> OperatorTable:
 def swi_operator_table() -> OperatorTable:
     """Return the first shared SWI-Prolog operator defaults."""
 
-    return iso_operator_table().define(600, "xfy", ":")
+    return (
+        iso_operator_table()
+        .define(700, "xfx", "#=", "#\\=", "#<", "#=<", "#>", "#>=", "in", "ins")
+        .define(600, "xfy", ":")
+        .define(450, "xfx", "..")
+    )

--- a/code/packages/python/prolog-core/tests/test_prolog_core.py
+++ b/code/packages/python/prolog-core/tests/test_prolog_core.py
@@ -51,6 +51,11 @@ class TestOperatorTable:
         assert iso.get(":-", "xfx") is not None
         assert iso.get(":", "xfy") is None
         assert swi.get(":", "xfy") is not None
+        assert iso.get("#=", "xfx") is None
+        assert swi.get("#=", "xfx") is not None
+        assert swi.get("in", "xfx") is not None
+        assert swi.get("ins", "xfx") is not None
+        assert swi.get("..", "xfx") is not None
 
     def test_apply_op_directive_adds_and_removes_operator(self) -> None:
         table = empty_operator_table()

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -21,6 +21,8 @@
   checks and successor relations.
 - Run callable CLP(FD) forms through the VM path, including finite domains,
   arithmetic equality constraints, all-different, and labeling.
+- Run natural SWI CLP(FD) infix syntax through the VM path, including `1..N`
+  range domains and arithmetic equality constraints.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -129,7 +129,7 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
-- callable CLP(FD) forms for finite-domain puzzles
+- callable and natural infix CLP(FD) forms for finite-domain puzzles
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -206,6 +206,26 @@ class TestPrologVMStress:
             {"X": num(2), "Y": num(3), "Z": num(5)},
         ]
 
+    def test_clpfd_infix_forms_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- [X,Y] ins 1..3,
+               Z in 1..6,
+               X #< Y,
+               Z #= X + Y,
+               all_different([X,Y]),
+               labeling([], [X,Y,Z]).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"X": num(1), "Y": num(2), "Z": num(3)},
+            {"X": num(1), "Y": num(3), "Z": num(4)},
+            {"X": num(2), "Y": num(3), "Z": num(5)},
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/packages/python/swi-prolog-lexer/CHANGELOG.md
+++ b/code/packages/python/swi-prolog-lexer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Tokenize SWI CLP(FD) range syntax (`..`) as one symbolic atom so
+  finite-domain expressions such as `1..4` can parse as operator terms.
+
 ## 0.1.0
 
 - Added the first SWI-Prolog lexer package backed by `code/grammars/prolog/swi.tokens`

--- a/code/packages/python/swi-prolog-lexer/README.md
+++ b/code/packages/python/swi-prolog-lexer/README.md
@@ -9,6 +9,9 @@ code/grammars/prolog/swi.tokens
 This package is separate from `iso-prolog-lexer` and `prolog-lexer` so SWI
 lexical behavior can evolve independently.
 
+It also keeps SWI-specific symbolic forms owned by the dialect, including
+CLP(FD) range syntax such as `1..4`.
+
 ## Quick Start
 
 ```python

--- a/code/packages/python/swi-prolog-lexer/tests/test_swi_prolog_lexer.py
+++ b/code/packages/python/swi-prolog-lexer/tests/test_swi_prolog_lexer.py
@@ -108,6 +108,24 @@ class TestSwiTokenization:
             "EOF",
         ]
 
+    def test_clpfd_range_operator_is_one_symbolic_atom(self) -> None:
+        tokens = tokenize_swi_prolog("?- X in 1..4, X #=< 3.\n")
+
+        assert [(token.type_name, token.value) for token in tokens] == [
+            ("QUERY", "?-"),
+            ("VARIABLE", "X"),
+            ("ATOM", "in"),
+            ("INTEGER", "1"),
+            ("ATOM", ".."),
+            ("INTEGER", "4"),
+            ("COMMA", ","),
+            ("VARIABLE", "X"),
+            ("ATOM", "#=<"),
+            ("INTEGER", "3"),
+            ("DOT", "."),
+            ("EOF", ""),
+        ]
+
     def test_create_swi_prolog_lexer(self) -> None:
         lexer = create_swi_prolog_lexer("likes(marge, donuts).\n")
 

--- a/code/packages/python/swi-prolog-parser/CHANGELOG.md
+++ b/code/packages/python/swi-prolog-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Parse natural SWI CLP(FD) infix syntax such as `X in 1..4`,
+  `[X,Y] ins 1..4`, and `Z #= X + Y`.
+
 ## 0.1.0
 
 - Added the first SWI-Prolog parser package backed by `code/grammars/prolog/swi.grammar`

--- a/code/packages/python/swi-prolog-parser/README.md
+++ b/code/packages/python/swi-prolog-parser/README.md
@@ -14,6 +14,10 @@ the directive list as metadata, and file-scoped `op/3` directives are applied
 while parsing so later clauses use the updated operator table. DCG rules
 (`-->`) are also expanded into ordinary executable clauses during parsing.
 
+The SWI parser accepts natural CLP(FD) infix forms such as `X in 1..4`,
+`[X,Y] ins 1..4`, and `Z #= X + Y`; the loader/VM layers can then adapt those
+operator-shaped goals into finite-domain builtin constraints.
+
 ## Quick Start
 
 ```python

--- a/code/packages/python/swi-prolog-parser/tests/test_swi_prolog_parser.py
+++ b/code/packages/python/swi-prolog-parser/tests/test_swi_prolog_parser.py
@@ -155,6 +155,19 @@ class TestSwiParser:
 
         assert str(goal_as_term(query.goal)) == "is(X, +(1, *(2, 3)))"
 
+    def test_parse_swi_query_understands_clpfd_infix_forms(self) -> None:
+        query = parse_swi_query("?- [X,Y] ins 1..4, Z #= X + Y, X #< Y.\n")
+
+        assert str(goal_as_term(query.goal)) == (
+            ",(ins(.(X, .(Y, [])), ..(1, 4)), ,(#=(Z, +(X, Y)), #<(X, Y)))"
+        )
+
+    def test_parse_swi_ast_accepts_clpfd_infix_forms(self) -> None:
+        ast = parse_swi_ast("?- X in 1..4, Y #= X + 1, Y #=< 4.\n")
+
+        assert ast.rule_name == "program"
+        assert len(ast.children) == 1
+
     def test_parse_swi_program_rejects_queries(self) -> None:
         with pytest.raises(PrologParseError, match="expected only clauses"):
             parse_swi_program("?- true.\n")

--- a/code/specs/PR31-prolog-clpfd-infix-syntax.md
+++ b/code/specs/PR31-prolog-clpfd-infix-syntax.md
@@ -1,0 +1,43 @@
+# PR31: Prolog CLP(FD) Infix Syntax
+
+## Summary
+
+This batch makes the SWI-Prolog frontend accept the natural CLP(FD) syntax that
+users expect to write on top of the Logic VM finite-domain layer. The previous
+batch adapted callable forms such as `#=(Z, +(X,Y))`; this one parses operator
+forms such as `Z #= X + Y`.
+
+## Goals
+
+- tokenize `..` as one SWI symbolic atom rather than two statement dots
+- add SWI operator defaults for CLP(FD) comparisons, `in/2`, `ins/2`, and
+  range terms
+- keep the dialect grammar file aware of CLP(FD) infix forms
+- verify parser lowering for `[X,Y] ins 1..4`, `X in 1..4`, and arithmetic
+  constraints such as `Z #= X + Y`
+- run an end-to-end Prolog VM stress query using natural CLP(FD) syntax
+
+## Example
+
+```prolog
+?- [X,Y] ins 1..3,
+   Z in 1..6,
+   X #< Y,
+   Z #= X + Y,
+   all_different([X,Y]),
+   labeling([], [X,Y,Z]).
+```
+
+Expected answers:
+
+```prolog
+X = 1, Y = 2, Z = 3 ;
+X = 1, Y = 3, Z = 4 ;
+X = 2, Y = 3, Z = 5.
+```
+
+## Non-Goals
+
+- parsing every CLP(FD) reification/connective operator
+- implementing labeling option semantics
+- importing SWI's full `library(clpfd)` module surface


### PR DESCRIPTION
## Summary

- tokenize SWI CLP(FD) range syntax (`..`) as one symbolic atom
- add SWI operator defaults for CLP(FD) comparisons, `in/2`, `ins/2`, and `../2`
- extend the SWI grammar/parser tests and add an end-to-end VM stress query using natural CLP(FD) syntax

## Verification

- `bash BUILD` in `code/packages/python/swi-prolog-lexer`
- `bash BUILD` in `code/packages/python/prolog-core`
- `bash BUILD` in `code/packages/python/swi-prolog-parser`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/swi-prolog-lexer`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-core`
- `.venv/bin/ruff check .` in `code/packages/python/swi-prolog-parser`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `go build -o /tmp/ca-build-tool-prolog-clpfd-infix .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-clpfd-infix -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-clpfd-infix-build-plan.json`