### PR TITLE
feat: PRAGMA user_version + schema_version (mini-sqlite v1.9.0, sql-backend v0.11.0, storage-sqlite v0.18.0)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [1.9.0] - 2026-04-28
+
+### Added
+
+**`PRAGMA user_version` (read/write) and `PRAGMA schema_version` (read)**
+
+Two new PRAGMAs matching real SQLite's behaviour for header-field access:
+
+```sql
+PRAGMA user_version;             -- read: returns one row (user_version,)
+PRAGMA user_version = 7;         -- write: stores 7 in the header
+PRAGMA schema_version;           -- read: returns one row (schema_version,)
+```
+
+- **`PRAGMA user_version`** — application-defined `u32` (0 ≤ v ≤ 2³² − 1).
+  Read returns a one-row, one-column result `(user_version,)`.  Write
+  validates the range and stages the change on the backend; persistent
+  backends (`SqliteFileBackend`) flush via the next `commit`.  An
+  out-of-range value raises `ProgrammingError`.
+- **`PRAGMA schema_version`** — read-only.  Returns the schema cookie,
+  which is bumped automatically on every DDL operation (`CREATE TABLE`,
+  `DROP TABLE`, `CREATE INDEX`, `DROP INDEX`, …).  DML statements
+  (INSERT/UPDATE/DELETE) do *not* bump it.
+- **`_PRAGMA_RE` extension** — the engine's PRAGMA regex now also matches
+  the assignment form `PRAGMA name = <int>` (signed integer), with the
+  value captured into a new `set_value` named group.
+- Backend support: relies on
+  `Backend.get_user_version` / `set_user_version` /
+  `get_schema_version` (added in `sql-backend` 0.11.0 and
+  `storage-sqlite` 0.18.0).  Backends without these methods cause
+  `PRAGMA user_version` writes to raise
+  `ProgrammingError("backend does not support …")` rather than
+  AttributeError.
+
+### Tests added
+
+- `tests/test_tier3_pragma.py::TestUserVersion` — 8 tests: default,
+  description, set+read, overwrite, zero-is-valid, max u32, negative
+  rejected, overflow rejected.
+- `tests/test_tier3_pragma.py::TestSchemaVersion` — 6 tests: default,
+  description, CREATE TABLE bumps, DROP TABLE bumps, CREATE INDEX
+  bumps, DML does not bump.
+
 ## [1.8.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -389,15 +389,21 @@ def _extract_scan_info(plan: LogicalPlan) -> tuple[str, list[str]]:
 # PRAGMA handler — returns backend metadata as a QueryResult.
 # --------------------------------------------------------------------------
 
-# Matches: PRAGMA name  or  PRAGMA name('arg')  or  PRAGMA name("arg")
+# Matches one of these PRAGMA forms:
+#   PRAGMA name                       — read query
+#   PRAGMA name('arg')                — read with table-name argument
+#   PRAGMA name("arg")                — same, double-quoted
+#   PRAGMA name = <int>               — write (non-negative integer literal)
 _PRAGMA_RE = re.compile(
     r"""
     \s* PRAGMA \s+
     (?P<name>[A-Za-z_][A-Za-z0-9_]*)   # pragma name
-    (?:                                  # optional argument
+    (?:                                  # optional argument or assignment
         \s* \(
             \s* ["']? (?P<arg>[A-Za-z_][A-Za-z0-9_]*) ["']? \s*
         \)
+        |
+        \s* = \s* (?P<set_value>-?\d+)
     )?
     \s* ;? \s* $
     """,
@@ -422,12 +428,26 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
 
     ``PRAGMA table_list``
         One row per table in the schema: ``(schema, name, type)``.
+
+    ``PRAGMA user_version``
+        Read the user-defined integer at byte offset 60 of the database
+        header.  Returns one row ``(user_version,)`` of an int.  A fresh
+        database returns 0.
+
+    ``PRAGMA user_version = <int>``
+        Write *<int>* into the user_version field.  Must fit in u32
+        (0 ≤ v ≤ 2³² − 1).  Produces an empty result.
+
+    ``PRAGMA schema_version``
+        Read-only — returns one row ``(schema_version,)`` of an int.
+        The schema cookie is bumped automatically on every DDL operation.
     """
     m = _PRAGMA_RE.match(sql)
     if m is None:
         raise ProgrammingError(f"invalid PRAGMA syntax: {sql!r}")
     name = m.group("name").lower()
     arg = m.group("arg")  # may be None
+    set_value = m.group("set_value")  # may be None — assignment form
 
     if name == "table_info":
         if not arg:
@@ -492,6 +512,34 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             columns=("schema", "name", "type"),
             rows=tuple(("main", t, "table") for t in tables),
         )
+
+    if name == "user_version":
+        if set_value is not None:
+            try:
+                backend.set_user_version(int(set_value))
+            except AttributeError as e:
+                # Backend without u32-header support (e.g. InMemoryBackend
+                # in some configurations) — surface as Unsupported rather
+                # than the bare AttributeError.
+                raise ProgrammingError(
+                    "backend does not support PRAGMA user_version write"
+                ) from e
+            except ValueError as e:
+                raise ProgrammingError(str(e)) from e
+            return QueryResult(rows_affected=0)
+        try:
+            v = backend.get_user_version()
+        except AttributeError:
+            v = 0  # backend has no header — return 0 by convention
+        return QueryResult(columns=("user_version",), rows=((v,),))
+
+    if name == "schema_version":
+        # Read-only.  Ignores any "= value" form (matches sqlite3 silently).
+        try:
+            v = backend.get_schema_version()
+        except AttributeError:
+            v = 0
+        return QueryResult(columns=("schema_version",), rows=((v,),))
 
     # Unknown PRAGMA — return empty result rather than error, matching SQLite.
     return QueryResult(columns=(), rows=())

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma.py
@@ -105,3 +105,108 @@ def test_pragma_table_info_order_by_cid(conn):
     rows = conn.execute("PRAGMA table_info(products)").fetchall()
     cids = [r[0] for r in rows]
     assert cids == list(range(len(rows)))
+
+
+# ---------------------------------------------------------------------------
+# PRAGMA user_version (read/write) and PRAGMA schema_version (read-only)
+# ---------------------------------------------------------------------------
+
+
+class TestUserVersion:
+    """``PRAGMA user_version`` — application-defined u32 in the header."""
+
+    def test_default_is_zero(self):
+        c = mini_sqlite.connect(":memory:")
+        rows = c.execute("PRAGMA user_version").fetchall()
+        assert rows == [(0,)]
+
+    def test_columns_label(self):
+        c = mini_sqlite.connect(":memory:")
+        cur = c.execute("PRAGMA user_version")
+        assert cur.description == (("user_version", None, None, None, None, None, None),)
+
+    def test_set_then_read(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA user_version = 7")
+        rows = c.execute("PRAGMA user_version").fetchall()
+        assert rows == [(7,)]
+
+    def test_overwrite(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA user_version = 1")
+        c.execute("PRAGMA user_version = 99")
+        rows = c.execute("PRAGMA user_version").fetchall()
+        assert rows == [(99,)]
+
+    def test_zero_is_a_valid_value(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA user_version = 5")
+        c.execute("PRAGMA user_version = 0")
+        rows = c.execute("PRAGMA user_version").fetchall()
+        assert rows == [(0,)]
+
+    def test_max_u32(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA user_version = 4294967295")  # 2^32 - 1
+        rows = c.execute("PRAGMA user_version").fetchall()
+        assert rows == [(4294967295,)]
+
+    def test_negative_value_rejected(self):
+        c = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_sqlite.ProgrammingError, match="u32"):
+            c.execute("PRAGMA user_version = -1")
+
+    def test_overflow_value_rejected(self):
+        c = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_sqlite.ProgrammingError, match="u32"):
+            c.execute("PRAGMA user_version = 4294967296")  # 2^32
+
+
+class TestSchemaVersion:
+    """``PRAGMA schema_version`` — read-only, bumps on every DDL."""
+
+    def test_default_is_zero(self):
+        c = mini_sqlite.connect(":memory:")
+        rows = c.execute("PRAGMA schema_version").fetchall()
+        assert rows == [(0,)]
+
+    def test_columns_label(self):
+        c = mini_sqlite.connect(":memory:")
+        cur = c.execute("PRAGMA schema_version")
+        assert cur.description == (
+            ("schema_version", None, None, None, None, None, None),
+        )
+
+    def test_create_table_bumps_schema_version(self):
+        c = mini_sqlite.connect(":memory:")
+        v0 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        c.execute("CREATE TABLE t (x INTEGER)")
+        v1 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        assert v1 == v0 + 1
+
+    def test_drop_table_bumps_schema_version(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        v1 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        c.execute("DROP TABLE t")
+        v2 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        assert v2 == v1 + 1
+
+    def test_create_index_bumps_schema_version(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER, y INTEGER)")
+        v1 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        c.execute("CREATE INDEX idx_x ON t (x)")
+        v2 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        assert v2 == v1 + 1
+
+    def test_dml_does_not_bump_schema_version(self):
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        v1 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        c.execute("INSERT INTO t VALUES (1)")
+        c.execute("INSERT INTO t VALUES (2)")
+        c.execute("UPDATE t SET x = 99 WHERE x = 1")
+        c.execute("DELETE FROM t WHERE x = 2")
+        v2 = c.execute("PRAGMA schema_version").fetchall()[0][0]
+        assert v2 == v1  # DML must not bump it

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-04-28
+
+### Added
+
+- **`InMemoryBackend.get_user_version` / `set_user_version` /
+  `get_schema_version`** — three new methods exposing the SQLite header
+  fields used by `PRAGMA user_version` / `PRAGMA schema_version`.
+  - `_user_version`: a `u32` opaque to the engine (defaults to 0).
+  - `_schema_version`: a counter the backend bumps automatically on every
+    successful `create_table` / `drop_table` / `create_index` / `drop_index`.
+  - `set_user_version` validates `0 ≤ v ≤ 2³² − 1` and raises
+    `ValueError` otherwise.
+
 ## [0.10.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/sql-backend/src/sql_backend/in_memory.py
+++ b/code/packages/python/sql-backend/src/sql_backend/in_memory.py
@@ -168,6 +168,12 @@ class InMemoryBackend(Backend):
         # Each SAVEPOINT pushes a deep-copy; RELEASE pops; ROLLBACK TO
         # restores from a snapshot but keeps the entry so it can be reused.
         self._savepoint_stack: list[tuple[str, dict[str, _Table], dict[str, IndexDef]]] = []
+        # PRAGMA user_version / schema_version backing fields (real SQLite
+        # stores these in the file header; for the in-memory backend we
+        # just hold ints).  ``_schema_version`` increments on every
+        # successful create_table / drop_table / create_index / drop_index.
+        self._user_version: int = 0
+        self._schema_version: int = 0
 
     # --- Construction helpers ---------------------------------------------
 
@@ -197,6 +203,29 @@ class InMemoryBackend(Backend):
 
     def columns(self, table: str) -> list[ColumnDef]:
         return list(self._require_table(table).columns)
+
+    # --- Header fields (PRAGMA user_version / schema_version) -------------
+
+    def get_user_version(self) -> int:
+        """Return the user_version field (a u32 with no engine semantics).
+
+        Defaults to 0 on a fresh backend.  Persistent backends (e.g.
+        ``SqliteFileBackend``) read this from byte 60 of the page-1
+        header; in-memory just holds it as an attribute.
+        """
+        return self._user_version
+
+    def set_user_version(self, value: int) -> None:
+        """Write *value* into ``user_version``; must fit in u32."""
+        if not (0 <= value <= 0xFFFFFFFF):
+            raise ValueError(
+                f"user_version must fit in u32 (0 ≤ v ≤ {0xFFFFFFFF}), got {value}"
+            )
+        self._user_version = value
+
+    def get_schema_version(self) -> int:
+        """Return the schema cookie — bumped on every DDL operation."""
+        return self._schema_version
 
     # --- Read -------------------------------------------------------------
 
@@ -291,6 +320,7 @@ class InMemoryBackend(Backend):
                 return
             raise TableAlreadyExists(table=table)
         self._tables[table] = _Table(columns)
+        self._schema_version += 1
 
     def drop_table(self, table: str, if_exists: bool) -> None:
         if table not in self._tables:
@@ -298,6 +328,7 @@ class InMemoryBackend(Backend):
                 return
             raise TableNotFound(table=table)
         del self._tables[table]
+        self._schema_version += 1
 
     def add_column(self, table: str, column: ColumnDef) -> None:
         if table not in self._tables:
@@ -483,6 +514,7 @@ class InMemoryBackend(Backend):
             if col not in col_names:
                 raise ColumnNotFound(table=index.table, column=col)
         self._indexes[index.name] = index
+        self._schema_version += 1
 
     def drop_index(self, name: str, *, if_exists: bool = False) -> None:
         """Remove an index definition.
@@ -495,6 +527,7 @@ class InMemoryBackend(Backend):
                 return
             raise IndexNotFound(index=name)
         del self._indexes[name]
+        self._schema_version += 1
 
     def list_indexes(self, table: str | None = None) -> list[IndexDef]:
         """Return all stored index definitions, optionally filtered by table.

--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.18.0] - 2026-04-28
+
+### Added
+
+**Database header field accessors (PRAGMA user_version / schema_version)**
+
+- **`Schema.get_user_version()` / `set_user_version(value)`** — read/write
+  the `user_version` field at byte offset 60 of the page-1 header
+  (`u32` BE).  Range-checked to `0 ≤ v ≤ 2³² − 1`.  The write is staged
+  via the pager and persisted on the next `commit`.
+- **`SqliteFileBackend.get_user_version()` / `set_user_version(value)` /
+  `get_schema_version()`** — backend-level wrappers that delegate to the
+  `Schema` object.  `get_schema_version()` returns the schema cookie
+  (offset 40), which is bumped automatically by every DDL operation.
+- New private constant `_USER_VERSION_OFFSET = 60` in `schema.py`.
+
+These methods are used by mini-sqlite's `PRAGMA user_version` /
+`PRAGMA schema_version` dispatch (added in mini-sqlite 1.9.0).
+
 ## [0.17.0] - 2026-04-28
 
 ### Added

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -966,6 +966,39 @@ class SqliteFileBackend(Backend):
         _, cols = self._require_table(table)
         return cols
 
+    # ── Header field accessors (PRAGMA user_version / schema_version) ────────
+
+    def get_user_version(self) -> int:
+        """Read the ``user_version`` field from the database header.
+
+        ``user_version`` is a 32-bit unsigned integer at byte offset 60
+        of the page-1 header.  It is opaque to the engine — applications
+        typically use it for schema-migration version tracking.  A fresh
+        database returns 0.
+        """
+        return self._schema.get_user_version()
+
+    def set_user_version(self, value: int) -> None:
+        """Write *value* into the ``user_version`` field.
+
+        *value* must fit in an unsigned 32-bit integer; otherwise raises
+        ``ValueError``.  The change is staged in the pager and persists
+        on the next ``commit``.  No transaction is auto-committed here —
+        the caller (typically the SQL VM) wraps the PRAGMA in its usual
+        transaction lifecycle.
+        """
+        self._schema.set_user_version(value)
+
+    def get_schema_version(self) -> int:
+        """Read the schema cookie from the database header.
+
+        The schema cookie (a 32-bit unsigned integer at byte offset 40)
+        is incremented automatically on every DDL operation
+        (``CREATE TABLE``, ``DROP TABLE``, ``ALTER TABLE``, etc.).
+        Read-only — applications cannot set it directly.
+        """
+        return self._schema.get_schema_cookie()
+
     # ── Backend interface: Read ───────────────────────────────────────────────
 
     def scan(self, table: str) -> RowIterator:

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/schema.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/schema.py
@@ -112,6 +112,13 @@ _SCHEMA_COOKIE_OFFSET: int = 40
 """Byte offset of the schema cookie (u32 BE) inside the 100-byte database
 header, which lives at the start of page 1."""
 
+_USER_VERSION_OFFSET: int = 60
+"""Byte offset of the user_version field (u32 BE) inside the page-1 header.
+
+Opaque to the engine — applications use it for schema-migration tracking
+or feature-version flags.  Read/written via
+:meth:`Schema.get_user_version` / :meth:`Schema.set_user_version`."""
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -260,6 +267,38 @@ class Schema:
         page1 = self._pager.read(1)
         (cookie,) = struct.unpack_from(">I", page1, _SCHEMA_COOKIE_OFFSET)
         return cookie
+
+    def get_user_version(self) -> int:
+        """Read the user_version field from the page-1 header.
+
+        ``user_version`` is a u32 at byte offset 60 of the database header.
+        It is opaque to the engine — applications use it for whatever
+        versioning semantics they like (typically: schema-migration
+        version tracking).  Returns 0 on a fresh database.
+        """
+        page1 = self._pager.read(1)
+        (version,) = struct.unpack_from(">I", page1, _USER_VERSION_OFFSET)
+        return version
+
+    def set_user_version(self, value: int) -> None:
+        """Write *value* into the user_version field of the page-1 header.
+
+        *value* must fit in an unsigned 32-bit integer (0 ≤ v ≤ 2³² − 1);
+        anything else raises :class:`ValueError`.  The change is staged
+        in the pager's dirty-page table and persisted on the next
+        :meth:`~storage_sqlite.pager.Pager.commit`.
+
+        Unlike the schema cookie, ``user_version`` is *not* bumped
+        automatically — applications set it explicitly to mark schema
+        migrations or feature versions.
+        """
+        if not (0 <= value <= 0xFFFFFFFF):
+            raise ValueError(
+                f"user_version must fit in u32 (0 ≤ v ≤ {0xFFFFFFFF}), got {value}"
+            )
+        buf = bytearray(self._pager.read(1))
+        struct.pack_into(">I", buf, _USER_VERSION_OFFSET, value)
+        self._pager.write(1, bytes(buf))
 
     # ── Write operations ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two new PRAGMAs matching real SQLite header-field accessors:

- \`PRAGMA user_version\` — read/write application-defined u32 (offset 60 of page-1 header). Range-checked to \`0 ≤ v ≤ 2^32 − 1\`; out-of-range raises \`ProgrammingError\`
- \`PRAGMA schema_version\` — read-only schema cookie (offset 40); bumped automatically on every DDL operation, **not** on DML

```sql
PRAGMA user_version;          -- read: returns (user_version,)
PRAGMA user_version = 7;      -- write: stores 7 in the header
PRAGMA schema_version;        -- read: returns (schema_version,)
```

## Cross-package changes

- **sql-backend (v0.11.0)** — \`InMemoryBackend\` gains \`get_user_version\`/\`set_user_version\`/\`get_schema_version\`. \`_schema_version\` bumps on every \`create_table\`/\`drop_table\`/\`create_index\`/\`drop_index\`
- **storage-sqlite (v0.18.0)** — \`Schema.get_user_version\`/\`set_user_version\` (offset 60 of page-1 header). \`SqliteFileBackend\` exposes the three header accessors via thin wrappers
- **mini-sqlite (v1.9.0)** — \`_PRAGMA_RE\` extended with assignment form \`PRAGMA name = <int>\`. Two new dispatch branches in \`_run_pragma\`. AttributeError fallback for backends that don't implement these methods

## Test plan

- [x] All 132 sql-backend, 646 storage-sqlite, 595 mini-sqlite tests pass after rebase onto post-#1676 main
- [x] \`ruff check src/ tests/\` clean across all three packages
- [x] Security review passed in one round (regex/ReDoS analysis, range check, struct-pack-into safety, AttributeError fallback semantics, semicolon-injection guard via \`$\` anchor)
- [x] Tested: 8 user_version cases (default, description, set+read, overwrite, zero, max u32, negative rejected, overflow rejected) + 6 schema_version cases (default, description, CREATE TABLE / DROP TABLE / CREATE INDEX bump, DML does not bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)