### PR TITLE
Recover PI-like markup as bogus comments

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -83,6 +83,8 @@ documented in this file.
   inside open comments, preserving the text while reporting `nested-comment`.
 - HTML comment end-bang handling for `--!>` recovery and non-closing `--!`
   text preservation.
+- Processing-instruction-looking `<?...?>` markup now recovers as a bogus
+  comment with `unexpected-question-mark-instead-of-tag-name`.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`
   and whitespace-only DOCTYPE names.
 - DOCTYPE declarations cut off by EOF after a name now emit the current name

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -31,6 +31,9 @@ Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an
 open comment remain literal comment data and surface a recoverable
 `nested-comment` diagnostic. Comment endings also recover from `--!>` with an
 `incorrectly-closed-comment` diagnostic while preserving non-closing `--!` text.
+Processing-instruction-looking markup such as `<?xml ...?>` now follows HTML
+bogus-comment recovery instead of being mistaken for a start tag, preserving
+legacy document prologs without polluting the tag stream.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
 inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
 or inside the `DOCTYPE` keyword emits a force-quirks token. Malformed

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -63,6 +63,7 @@ alphabet = [
   "s",
   "X",
   "x",
+  "?",
 ]
 
 [[tokens]]
@@ -2412,6 +2413,13 @@ to = "end_tag_open"
 from = "tag_open"
 matcher = { literal = "!" }
 to = "markup_declaration_open"
+
+[[transitions]]
+from = "tag_open"
+matcher = { literal = "?" }
+to = "bogus_comment"
+consume = false
+actions = ["parse_error(unexpected-question-mark-instead-of-tag-name)", "create_comment"]
 
 [[transitions]]
 from = "tag_open"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -33,6 +33,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         "<".to_string(),
         "=".to_string(),
         ">".to_string(),
+        "?".to_string(),
         "A".to_string(),
         "B".to_string(),
         "C".to_string(),
@@ -5457,6 +5458,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: Vec::new(),
             consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_open".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("?".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-question-mark-instead-of-tag-name)".to_string(),
+                "create_comment".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "tag_open".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 50);
+    assert_eq!(html1.cases.len(), 51);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 49);
+    assert_eq!(file.tests.len(), 50);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 49);
+    assert_eq!(normalized.cases.len(), 50);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 49);
+    assert_eq!(suite.cases.len(), 50);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -566,6 +566,20 @@
         "Text(data=<not-markup> &amp; After)",
         "EOF"
       ]
+    },
+    {
+      "id": "question-mark-tag-open-bogus-comment",
+      "description": "Processing-instruction-looking markup recovers as a bogus comment",
+      "input": "Before<?xml version=\"1.0\"?>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=?xml version=\"1.0\"?)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -605,6 +605,20 @@
       "diagnostics": [
         "incorrectly-closed-comment"
       ]
+    },
+    {
+      "id": "html5lib-smoke-50",
+      "description": "question mark after tag open recovers as bogus comment",
+      "input": "Before<?xml version=\"1.0\"?>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=?xml version=\"1.0\"?)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ]
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -528,6 +528,18 @@
       "errors": [
         {"code": "incorrectly-closed-comment", "line": 1, "col": 15}
       ]
+    },
+    {
+      "description": "question mark after tag open recovers as bogus comment",
+      "input": "Before<?xml version=\"1.0\"?>After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "?xml version=\"1.0\"?"],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "unexpected-question-mark-instead-of-tag-name", "line": 1, "col": 8}
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -336,6 +336,28 @@ fn default_html_lexer_marks_trailing_junk_after_system_identifier_force_quirks()
 }
 
 #[test]
+fn default_html_lexer_recovers_question_mark_tag_open_as_bogus_comment() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<?xml version=\"1.0\"?>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("?xml version=\"1.0\"?".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-question-mark-instead-of-tag-name"));
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Add `?` handling in the HTML1 `tag_open` state so `<?...?>` recovers as a bogus comment instead of a start tag.
- Cover the behavior in the Rust wrapper test, Venture fixture suite, and html5lib-style smoke corpus.
- Regenerate the static HTML1 Rust state machine and normalized smoke fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`