### PR TITLE
feat(prolog): flatten clpfd sum equality

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -16,6 +16,8 @@
 - adapt callable CLP(FD) forms (`in/2`, `ins/2`, `#=/2`, `#\=/2`, `#</2`,
   `#=</2`, `#>/2`, `#>=/2`, `all_different/1`, `all_distinct/1`, `label/1`,
   and `labeling/2`) into the finite-domain builtin layer
+- flatten nested additive CLP(FD) equality expressions such as
+  `Z #= X + Y + 1` into n-ary finite-domain sum constraints
 - adapt common Prolog list predicates (`member/2`, `append/3`, `select/3`,
   `permutation/2`, `reverse/2`, `last/2`, `length/2`, `sort/2`, `msort/2`,
   `nth0/3`, `nth1/3`, `nth0/4`, `nth1/4`, and `is_list/1`) into the

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -15,6 +15,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - adapt finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
 - adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
   `all_different/1`, and `labeling/2`
+- flatten nested additive CLP(FD) equality expressions such as
+  `Z #= X + Y + 1`
 - adapt `phrase/2` and `phrase/3` into executable DCG runtime calls
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -34,6 +34,7 @@ from logic_builtins import (
     fd_mulo,
     fd_neqo,
     fd_subo,
+    fd_sumo,
     findallo,
     forallo,
     functoro,
@@ -332,6 +333,10 @@ def _adapt_fd_arithmetic_expression(expression: Term, result: Term) -> GoalExpr 
     if expression.functor.namespace is not None:
         return None
 
+    sum_terms = _fd_sum_terms(expression)
+    if sum_terms is not None and len(sum_terms) > 2:
+        return fd_sumo(sum_terms, result)
+
     left, right = expression.args
     if expression.functor.name == "+":
         return fd_addo(left, right, result)
@@ -339,6 +344,30 @@ def _adapt_fd_arithmetic_expression(expression: Term, result: Term) -> GoalExpr 
         return fd_subo(left, right, result)
     if expression.functor.name == "*":
         return fd_mulo(left, right, result)
+    return None
+
+
+def _fd_sum_terms(expression: Term) -> tuple[Term, ...] | None:
+    if not isinstance(expression, Compound) or len(expression.args) != 2:
+        return (expression,)
+    if expression.functor.namespace is not None:
+        return None
+
+    left, right = expression.args
+    if expression.functor.name == "+":
+        left_terms = _fd_sum_terms(left)
+        right_terms = _fd_sum_terms(right)
+        if left_terms is None or right_terms is None:
+            return None
+        return (*left_terms, *right_terms)
+
+    if expression.functor.name == "-":
+        left_terms = _fd_sum_terms(left)
+        if left_terms is None:
+            return None
+        if isinstance(right, int):
+            return (*left_terms, -right)
+
     return None
 
 

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -991,6 +991,27 @@ class TestPrologGoalAdapter:
             (num(2), num(3), num(5)),
         ]
 
+    def test_adapt_prolog_goal_flattens_clpfd_sum_equality(self) -> None:
+        parsed = parse_swi_query(
+            "?- [X,Y] ins 1..3, "
+            "Z in 4..6, "
+            "X #< Y, "
+            "Z #= X + Y + 1, "
+            "labeling([], [X,Y,Z]).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            (parsed.variables["X"], parsed.variables["Y"], parsed.variables["Z"]),
+            adapted,
+        ) == [
+            (num(1), num(2), num(4)),
+            (num(1), num(3), num(5)),
+            (num(2), num(3), num(6)),
+        ]
+
     def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:
         parsed = parse_swi_query(
             "?- member(Item, [tea, cake]), "

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -23,6 +23,8 @@
   arithmetic equality constraints, all-different, and labeling.
 - Run natural SWI CLP(FD) infix syntax through the VM path, including `1..N`
   range domains and arithmetic equality constraints.
+- Run nested additive CLP(FD) equality expressions through the VM path by
+  lowering them to finite-domain sum constraints.
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -129,7 +129,8 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
-- callable and natural infix CLP(FD) forms for finite-domain puzzles
+- callable, natural infix, and nested additive CLP(FD) forms for finite-domain
+  puzzles
 - collection predicates such as `findall/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -226,6 +226,25 @@ class TestPrologVMStress:
             {"X": num(2), "Y": num(3), "Z": num(5)},
         ]
 
+    def test_clpfd_nested_sum_equality_runs_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- [X,Y] ins 1..3,
+               Z in 4..6,
+               X #< Y,
+               Z #= X + Y + 1,
+               labeling([], [X,Y,Z]).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"X": num(1), "Y": num(2), "Z": num(4)},
+            {"X": num(1), "Y": num(3), "Z": num(5)},
+            {"X": num(2), "Y": num(3), "Z": num(6)},
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR32-prolog-clpfd-nested-arithmetic.md
+++ b/code/specs/PR32-prolog-clpfd-nested-arithmetic.md
@@ -1,0 +1,41 @@
+# PR32: Prolog CLP(FD) Nested Additive Arithmetic
+
+## Summary
+
+This batch expands the Prolog loader's CLP(FD) adapter from single binary
+arithmetic equality expressions to nested additive expressions. It lets natural
+source queries like `Z #= X + Y + 1` run through the same Logic VM finite-domain
+path as simpler `Z #= X + Y` constraints.
+
+## Goals
+
+- flatten nested `+/2` equality expressions into `fd_sumo(...)`
+- support integer offsets in nested additive expressions, including forms such
+  as `Z #= X + Y - 1`
+- keep simple binary `+`, `-`, and `*` equality lowering on the existing
+  `fd_addo`, `fd_subo`, and `fd_mulo` constraints
+- verify parser-to-loader and full Prolog VM execution
+
+## Example
+
+```prolog
+?- [X,Y] ins 1..3,
+   Z in 4..6,
+   X #< Y,
+   Z #= X + Y + 1,
+   labeling([], [X,Y,Z]).
+```
+
+Expected answers:
+
+```prolog
+X = 1, Y = 2, Z = 4 ;
+X = 1, Y = 3, Z = 5 ;
+X = 2, Y = 3, Z = 6.
+```
+
+## Non-Goals
+
+- hidden temporary-variable domains for arbitrary nested multiplication
+- symbolic linear coefficients such as `Z #= X - Y`
+- full CLP(FD) expression compilation for every SWI arithmetic form


### PR DESCRIPTION
## Summary

- flatten nested additive CLP(FD) equality expressions such as `Z #= X + Y + 1`
- lower larger additive forms to `fd_sumo(...)` while preserving existing simple `fd_addo`, `fd_subo`, and `fd_mulo` lowering
- add loader and end-to-end Prolog VM stress coverage plus PR32 spec notes

## Verification

- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `go build -o /tmp/ca-build-tool-prolog-clpfd-nested .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-clpfd-nested -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-clpfd-nested-build-plan.json`