### PR TITLE
feat(twig): twig-clr-compiler — Twig → real dotnet (completes the trilogy)

### DIFF
--- a/code/packages/python/twig-clr-compiler/BUILD
+++ b/code/packages/python/twig-clr-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../interpreter-ir -e ../vm-core -e ../twig -e ../compiler-ir -e ../ir-optimizer -e ../cil-bytecode-builder -e ../ir-to-cil-bytecode -e ../cli-assembly-writer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog — twig-clr-compiler
+
+## 0.1.0 — 2026-04-29
+
+### Added — Twig source → real `dotnet` (completes the Twig trilogy)
+
+- ``compile_to_ir(source) -> IrProgram`` — Twig → compiler-IR for
+  the v1 surface (arithmetic, ``let``, ``begin``, integer
+  literals).
+- ``compile_source(source, *, assembly_name=...)`` — full
+  pipeline: parse → IR → optimise → lower to CIL → write
+  CLR01-conformant ``.exe`` bytes.
+- ``run_source(source)`` — drops the assembly + a
+  ``runtimeconfig.json`` to a temp dir and invokes real
+  ``dotnet <name>.exe``.  Skips when ``dotnet`` is not on PATH.
+- Real-``dotnet`` smoke tests proving end-to-end execution
+  (parity with the JVM and BEAM real-runtime tests):
+  - ``(+ 1 2)`` exits 3
+  - ``(* 6 7)`` exits 42
+  - ``(let ((x 5)) (* x x))`` exits 25
+
+### Out of scope (future iterations)
+
+- ``define``, recursion, ``if`` (needs more IR lowering
+  scaffolding in ``ir-to-cil-bytecode``).
+- Closures, cons cells, lists, symbols (TW02.5 / TW03 work).
+- ``Console.WriteLine`` for explicit I/O — v1 uses the process
+  exit code as the result channel.
+
+### Security
+
+- ``assembly_name`` is interpolated into a tempfile path; we
+  validate it against a strict allowlist regex
+  (``^[A-Za-z][A-Za-z0-9_]{0,63}$``) to block path traversal.
+  Same defense pattern as ``twig-beam-compiler``'s
+  ``module_name`` validation (caught and fixed in BEAM04
+  security review).

--- a/code/packages/python/twig-clr-compiler/README.md
+++ b/code/packages/python/twig-clr-compiler/README.md
@@ -1,0 +1,83 @@
+# twig-clr-compiler
+
+End-to-end Twig source → PE/CLI assembly (a real `.exe`) → real
+`dotnet` execution.  The CLR-side counterpart to
+[`twig-jvm-compiler`](../twig-jvm-compiler/) and
+[`twig-beam-compiler`](../twig-beam-compiler/) — **completing the
+Twig real-runtime trilogy across JVM, CLR, and BEAM.**
+
+## Pipeline
+
+```
+Twig source
+    ↓ parse + extract       (twig package)
+typed AST
+    ↓ Compiler.compile()    (this module — Twig → compiler-IR)
+IrProgram
+    ↓ ir-optimizer          (constant folding, DCE)
+IrProgram (optimised)
+    ↓ lower_ir_to_cil_bytecode  (ir-to-cil-bytecode)
+CILProgramArtifact
+    ↓ write_cli_assembly        (cli-assembly-writer, CLR01-conformant)
+.exe bytes
+    ↓ dotnet <name>.exe         (real .NET runtime, net9.0)
+program output
+```
+
+## V1 surface
+
+The first iteration is intentionally narrow — exactly what
+`ir-to-cil-bytecode` supports plus the ``main()`` boilerplate
+the CLR runtime expects:
+
+- Integer literals (positive integers in v1)
+- Binary arithmetic: `+`, `-`, `*`, `/`
+- Single-binding `let`
+- `begin` for sequencing
+
+The value of the program's last top-level expression becomes the
+process exit code (matching how a `static int Main()` C# program
+returns to the shell).
+
+## Quick start
+
+```python
+from twig_clr_compiler import run_source
+
+result = run_source("(* 6 7)", assembly_name="Answer42")
+print(result.returncode)   # 42 — value flows through Main's return
+```
+
+## Out of scope for v1
+
+- **Top-level `define`**: requires multi-method lowering on top
+  of `ir-to-cil-bytecode`'s entry-point assumption.  v2.
+- **Recursion**: requires the `CALL` IR-op to plumb through
+  `ir-to-cil-bytecode` end-to-end with a real-`dotnet`-loadable
+  entry shape.  v2.
+- **`if` outside trivial cases**: needs branching in the lowering
+  + verifier-friendly stack discipline.  v2.
+- **Closures, cons, lists, symbols**: cross-backend heap work
+  (TW02.5 / TW03 spec coordination).
+- **`SYSCALL` / `Console.WriteLine`**: process exit code is the
+  v1 result channel; explicit I/O is v2.
+
+## Sister packages
+
+- [`twig-jvm-compiler`](../twig-jvm-compiler/) — JVM target.
+- [`twig-beam-compiler`](../twig-beam-compiler/) — BEAM target.
+- [`twig`](../twig/) — frontend + `vm-core` interpreter.
+- [`cli-assembly-writer`](../cli-assembly-writer/) — emits
+  CLR01-conformant `.exe` bytes.
+- [`ir-to-cil-bytecode`](../ir-to-cil-bytecode/) — IR → CIL
+  method bodies.
+
+## Why this matters
+
+Per the Twig vision: "compile Twig to JVM, CLR and BEAM VM
+bytecode such that those engines can also run them."  This
+package is the third leg of that trilogy.  The shape of the
+public API (`compile_to_ir`, `compile_source`, `run_source`,
+`dotnet_available`) deliberately mirrors `twig-jvm-compiler` and
+`twig-beam-compiler` so all three real-runtime targets feel
+identical to drive.

--- a/code/packages/python/twig-clr-compiler/pyproject.toml
+++ b/code/packages/python/twig-clr-compiler/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-twig-clr-compiler"
+version = "0.1.0"
+description = "Twig source → PE/CLI assembly (real dotnet target) — completes the Twig real-runtime trilogy alongside JVM and BEAM"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["twig", "lisp", "clr", "dotnet", "compiler", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+dependencies = [
+    "coding-adventures-twig",
+    "coding-adventures-compiler-ir",
+    "coding-adventures-ir-optimizer",
+    "coding-adventures-ir-to-cil-bytecode",
+    "coding-adventures-cli-assembly-writer",
+    "coding-adventures-cil-bytecode-builder",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/twig_clr_compiler"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=twig_clr_compiler --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/twig_clr_compiler"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/__init__.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/__init__.py
@@ -1,0 +1,26 @@
+"""``twig-clr-compiler`` — Twig source → real ``dotnet``.
+
+Completes the Twig real-runtime trilogy alongside JVM and BEAM.
+"""
+
+from __future__ import annotations
+
+from twig_clr_compiler.compiler import (
+    ClrPackageError,
+    ClrPackageResult,
+    ClrRunResult,
+    compile_source,
+    compile_to_ir,
+    dotnet_available,
+    run_source,
+)
+
+__all__ = [
+    "ClrPackageError",
+    "ClrPackageResult",
+    "ClrRunResult",
+    "compile_source",
+    "compile_to_ir",
+    "dotnet_available",
+    "run_source",
+]

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -1,0 +1,520 @@
+"""Twig source → real ``dotnet`` end-to-end compiler.
+
+Pipeline
+========
+::
+
+    Twig source
+        ↓ parse + extract     (twig package)
+    typed AST
+        ↓ Compiler.compile()  (this module — Twig → compiler-IR)
+    IrProgram
+        ↓ ir-optimizer        (constant folding, DCE)
+    IrProgram (optimised)
+        ↓ ir-to-cil-bytecode  (CIL method bodies)
+    CILProgramArtifact
+        ↓ cli-assembly-writer (CLR01-conformant PE/CLI .exe)
+    .exe bytes
+        ↓ dotnet <name>.exe   (real .NET runtime, net9.0)
+    process exit code
+
+Why this is intentionally narrow (matches twig-beam-compiler v1)
+================================================================
+
+The v1 surface is the intersection of what ``ir-to-cil-bytecode``
+already lowers and what makes for a useful smoke test through real
+``dotnet``: integer literals, binary arithmetic (+, -, *, /),
+single-binding ``let``, and ``begin`` for sequencing.
+
+The contract: the value of the program's last top-level expression
+becomes the **process exit code** — matching how a C#
+``static int Main()`` returns to the shell.  ``run_source`` reports
+that exit code to the caller as ``ClrRunResult.returncode``.
+
+Register / local convention
+===========================
+
+``ir-to-cil-bytecode``'s ``RET``/``HALT`` lowering reads
+``local 1`` and emits ``ret``.  We mirror that — the last
+expression's value lands in ``IrRegister(1)`` before ``RET``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from cil_bytecode_builder import CILBytecodeBuilder
+from cli_assembly_writer import CLIAssemblyConfig, write_cli_assembly
+from compiler_ir import (
+    IDGenerator,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+from ir_optimizer import IrOptimizer, OptimizationResult
+from ir_to_cil_bytecode import (
+    CILBackendConfig,
+    CILMethodArtifact,
+    CILProgramArtifact,
+    SequentialCILTokenProvider,
+    lower_ir_to_cil_bytecode,
+)
+from twig import (
+    TwigCompileError,
+    TwigError,
+    extract_program,
+    parse_twig,
+)
+from twig.ast_nodes import (
+    Apply,
+    Begin,
+    Define,
+    Expr,
+    IntLit,
+    Lambda,
+    Let,
+    Program,
+    SymLit,
+    VarRef,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClrPackageResult:
+    """Aggregated artefacts from one compile run."""
+
+    source: str
+    assembly_name: str
+    ast: Program
+    raw_ir: IrProgram
+    optimization: OptimizationResult
+    optimized_ir: IrProgram
+    assembly_bytes: bytes
+
+
+@dataclass(frozen=True)
+class ClrRunResult:
+    """Compilation result + real-``dotnet`` invocation output."""
+
+    compilation: ClrPackageResult
+    stdout: bytes
+    stderr: bytes
+    returncode: int
+
+
+class ClrPackageError(TwigError):
+    """Stage-tagged failure during compile or run."""
+
+    def __init__(
+        self,
+        stage: str,
+        message: str,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(f"[{stage}] {message}")
+        self.stage = stage
+        self.message = message
+        self.cause = cause
+
+
+# ---------------------------------------------------------------------------
+# Builtins recognised in v1
+# ---------------------------------------------------------------------------
+
+
+_BINARY_OPS: dict[str, IrOp] = {
+    "+": IrOp.ADD,
+    "-": IrOp.SUB,
+    "*": IrOp.MUL,
+    "/": IrOp.DIV,
+}
+
+_V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
+    {
+        "=",
+        "<",
+        ">",
+        "cons",
+        "car",
+        "cdr",
+        "null?",
+        "pair?",
+        "number?",
+        "symbol?",
+        "print",
+    }
+)
+
+
+# Register convention.  ``ir-to-cil-bytecode``'s ``RET`` lowering
+# reads ``local 1`` and emits ``ret``, so we land the final result
+# in ``IrRegister(1)``.  Holding registers start above the
+# return-value slot.
+_REG_RETURN: Final = 1
+_REG_HOLDING_BASE: Final = 2
+
+# Strict allowlist for ``assembly_name`` — used as the on-disk
+# ``.exe`` filename and as the CLR module name.  Same defense
+# pattern ``twig-beam-compiler`` uses for ``module_name``.
+_SAFE_ASSEMBLY_NAME_RE: Final = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+
+
+def _validate_assembly_name(name: str) -> None:
+    if not _SAFE_ASSEMBLY_NAME_RE.match(name):
+        msg = (
+            f"assembly_name must match {_SAFE_ASSEMBLY_NAME_RE.pattern!r} "
+            f"(letter-start, alnum + underscore, ≤64 chars); got {name!r}.  "
+            "Strict rules block path traversal in the on-disk filename and "
+            "follow CLR module-naming conventions."
+        )
+        raise ClrPackageError("validate", msg)
+
+
+# ---------------------------------------------------------------------------
+# Per-region compilation context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FnCtx:
+    """Mutable state during compilation of one IR region.
+
+    ``locals_`` maps Twig names from ``let`` bindings to the IR
+    register holding the bound value.  ``next_holding`` is the
+    next intermediate-value register to allocate.
+    """
+
+    locals_: dict[str, IrRegister]
+    next_holding: int = _REG_HOLDING_BASE
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+class _Compiler:
+    """Walk the Twig AST → ``IrProgram`` with a single ``main`` region."""
+
+    def __init__(self) -> None:
+        self._program = IrProgram(entry_label="main")
+        self._gen = IDGenerator()
+
+    # ------------------------------------------------------------------
+
+    def compile(self, program: Program) -> IrProgram:
+        for form in program.forms:
+            if isinstance(form, Define):
+                raise TwigCompileError(
+                    "(define ...) is not yet supported by the CLR backend "
+                    "v1 — only top-level expressions.  See README for the "
+                    "v1 surface and roadmap."
+                )
+
+        self._emit(IrOp.LABEL, IrLabel(name="main"), id=-1)
+        ctx = _FnCtx(locals_={})
+
+        last: IrRegister | None = None
+        for expr in program.forms:
+            last = self._compile_expr(expr, ctx)
+
+        if last is None:
+            zero = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
+            last = zero
+
+        # Move the final result into the return register and close
+        # the region with RET.  The CIL backend's RET lowering
+        # reads ``local 1`` and emits ``ret``.
+        self._emit_move(IrRegister(_REG_RETURN), last)
+        self._emit(IrOp.RET)
+        return self._program
+
+    # ------------------------------------------------------------------
+    # Expression compilation
+    # ------------------------------------------------------------------
+
+    def _compile_expr(self, expr: Expr, ctx: _FnCtx) -> IrRegister:
+        if isinstance(expr, IntLit):
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(int(expr.value)))
+            return reg
+
+        if isinstance(expr, VarRef):
+            try:
+                return ctx.locals_[expr.name]
+            except KeyError as exc:
+                raise TwigCompileError(
+                    f"unbound name: {expr.name!r}"
+                ) from exc
+
+        if isinstance(expr, Let):
+            return self._compile_let(expr, ctx)
+
+        if isinstance(expr, Begin):
+            return self._compile_begin(expr, ctx)
+
+        if isinstance(expr, Apply):
+            return self._compile_apply(expr, ctx)
+
+        if isinstance(expr, Lambda):
+            raise TwigCompileError(
+                "lambdas are not yet supported by the CLR backend v1 — "
+                "needs the multi-method / closure-class lowering planned "
+                "for TW02.5."
+            )
+
+        if isinstance(expr, SymLit):
+            raise TwigCompileError(
+                "quoted symbols are not yet supported by the CLR backend "
+                "v1 — atoms-as-values needs heap support across backends."
+            )
+
+        msg = f"unsupported Twig form for CLR v1: {type(expr).__name__}"
+        raise TwigCompileError(msg)
+
+    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
+        if len(expr.bindings) != 1:
+            raise TwigCompileError(
+                "(let ((name expr) ...) body) with multiple bindings is "
+                "not yet supported — v1 only handles a single binding"
+            )
+        name, value_expr = expr.bindings[0]
+        bound_reg = self._compile_expr(value_expr, ctx)
+
+        previous = ctx.locals_.get(name)
+        ctx.locals_[name] = bound_reg
+        try:
+            last = self._compile_expr(expr.body[0], ctx)
+            for body_expr in expr.body[1:]:
+                last = self._compile_expr(body_expr, ctx)
+            return last
+        finally:
+            if previous is None:
+                del ctx.locals_[name]
+            else:
+                ctx.locals_[name] = previous
+
+    def _compile_begin(self, expr: Begin, ctx: _FnCtx) -> IrRegister:
+        last: IrRegister | None = None
+        for sub in expr.exprs:
+            last = self._compile_expr(sub, ctx)
+        if last is None:
+            zero = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
+            return zero
+        return last
+
+    def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
+        if not isinstance(expr.fn, VarRef):
+            raise TwigCompileError(
+                "v1 only supports calls to named builtins (no first-class "
+                "function values yet)"
+            )
+        name = expr.fn.name
+        if name in _V1_REJECTED_BUILTINS:
+            raise TwigCompileError(
+                f"builtin {name!r} is not yet supported by the CLR backend "
+                "v1 — needs branching / heap / I/O support"
+            )
+        if name not in _BINARY_OPS:
+            raise TwigCompileError(f"unknown builtin: {name!r}")
+        if len(expr.args) != 2:
+            raise TwigCompileError(
+                f"{name!r} expects exactly 2 arguments, got {len(expr.args)}"
+            )
+        lhs = self._compile_expr(expr.args[0], ctx)
+        rhs = self._compile_expr(expr.args[1], ctx)
+        result = self._fresh_holding(ctx)
+        self._emit(_BINARY_OPS[name], result, lhs, rhs)
+        return result
+
+    # ------------------------------------------------------------------
+    # Low-level emit helpers
+    # ------------------------------------------------------------------
+
+    def _emit(
+        self,
+        op: IrOp,
+        *operands: object,
+        id: int | None = None,
+    ) -> None:
+        self._program.add_instruction(
+            IrInstruction(
+                op,
+                list(operands),
+                id=self._gen.next() if id is None else id,
+            )
+        )
+
+    def _emit_move(self, dst: IrRegister, src: IrRegister) -> None:
+        if dst.index == src.index:
+            return
+        # No MOVE op in compiler-ir; lower as ADD with a freshly
+        # zeroed register.  Same idiom ``twig-beam-compiler`` uses.
+        zero = IrRegister(index=1000)
+        self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
+        self._emit(IrOp.ADD, dst, src, zero)
+
+    def _fresh_holding(self, ctx: _FnCtx) -> IrRegister:
+        reg = IrRegister(index=ctx.next_holding)
+        ctx.next_holding += 1
+        return reg
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def compile_to_ir(source: str) -> IrProgram:
+    """Compile Twig source into an unoptimised :class:`IrProgram`."""
+    ast = parse_twig(source)
+    program = extract_program(ast)
+    return _Compiler().compile(program)
+
+
+def compile_source(
+    source: str,
+    *,
+    assembly_name: str = "TwigProgram",
+    optimize: bool = True,
+) -> ClrPackageResult:
+    """Run the full Twig → ``.exe`` pipeline end-to-end."""
+    _validate_assembly_name(assembly_name)
+    try:
+        ast = parse_twig(source)
+        twig_program = extract_program(ast)
+    except Exception as exc:
+        raise ClrPackageError("parse", str(exc), exc) from exc
+
+    try:
+        raw_ir = _Compiler().compile(twig_program)
+    except TwigCompileError:
+        raise
+    except Exception as exc:  # pragma: no cover
+        raise ClrPackageError("ir-emit", str(exc), exc) from exc
+
+    if optimize:
+        optimization = IrOptimizer.default_passes().optimize(raw_ir)
+        optimized_ir = optimization.program
+    else:
+        optimization = OptimizationResult(program=raw_ir)
+        optimized_ir = raw_ir
+
+    try:
+        cil_program = lower_ir_to_cil_bytecode(
+            optimized_ir, CILBackendConfig()
+        )
+    except Exception as exc:
+        raise ClrPackageError("lower-cil", str(exc), exc) from exc
+
+    try:
+        artifact = write_cli_assembly(
+            cil_program,
+            CLIAssemblyConfig(
+                assembly_name=assembly_name,
+                module_name=f"{assembly_name}.exe",
+                type_name=assembly_name,
+            ),
+        )
+    except Exception as exc:
+        raise ClrPackageError("write-pe", str(exc), exc) from exc
+
+    return ClrPackageResult(
+        source=source,
+        assembly_name=assembly_name,
+        ast=twig_program,
+        raw_ir=raw_ir,
+        optimization=optimization,
+        optimized_ir=optimized_ir,
+        assembly_bytes=artifact.assembly_bytes,
+    )
+
+
+def dotnet_available() -> bool:
+    """Return ``True`` iff a working ``dotnet`` binary is on PATH."""
+    if shutil.which("dotnet") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["dotnet", "--version"],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _runtimeconfig_for_net9() -> str:
+    """Minimal ``<name>.runtimeconfig.json`` real .NET expects.
+
+    Without this file alongside the assembly, ``dotnet <name>.exe``
+    fails before even loading the PE because it can't pick a runtime.
+    """
+    return json.dumps(
+        {
+            "runtimeOptions": {
+                "tfm": "net9.0",
+                "framework": {
+                    "name": "Microsoft.NETCore.App",
+                    "version": "9.0.0",
+                },
+            },
+        }
+    )
+
+
+def run_source(
+    source: str,
+    *,
+    assembly_name: str = "TwigProgram",
+    optimize: bool = True,
+    timeout_seconds: int = 30,
+) -> ClrRunResult:
+    """Compile and execute on the **real** ``dotnet`` runtime.
+
+    Drops the ``.exe`` plus a ``runtimeconfig.json`` to a temp dir
+    and invokes ``dotnet <name>.exe``.  The process exit code IS
+    the program's result for v1 — same convention as a C#
+    ``static int Main()``.
+    """
+    compilation = compile_source(
+        source, assembly_name=assembly_name, optimize=optimize
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        exe_path = tmp_path / f"{assembly_name}.exe"
+        cfg_path = tmp_path / f"{assembly_name}.runtimeconfig.json"
+        exe_path.write_bytes(compilation.assembly_bytes)
+        cfg_path.write_text(_runtimeconfig_for_net9())
+
+        proc = subprocess.run(
+            ["dotnet", str(exe_path)],
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    return ClrRunResult(
+        compilation=compilation,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        returncode=proc.returncode,
+    )

--- a/code/packages/python/twig-clr-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_compile.py
@@ -1,0 +1,131 @@
+"""Compile-time tests — no ``dotnet`` required.
+
+Verifies the Twig → IR lowering produces sensible IR and rejects
+out-of-scope forms with clear error messages.  Real-``dotnet``
+end-to-end tests live in ``test_real_dotnet.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from compiler_ir import IrOp
+from twig.errors import TwigCompileError
+
+from twig_clr_compiler import (
+    ClrPackageError,
+    compile_source,
+    compile_to_ir,
+)
+
+
+class TestSupportedSurface:
+    def test_int_literal_compiles(self) -> None:
+        ir = compile_to_ir("42")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.LABEL in ops
+        assert IrOp.LOAD_IMM in ops
+        assert IrOp.RET in ops
+
+    def test_addition_emits_add(self) -> None:
+        ir = compile_to_ir("(+ 1 2)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.ADD in ops
+
+    def test_subtraction_emits_sub(self) -> None:
+        ir = compile_to_ir("(- 10 3)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.SUB in ops
+
+    def test_multiplication_emits_mul(self) -> None:
+        ir = compile_to_ir("(* 6 7)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.MUL in ops
+
+    def test_division_emits_div(self) -> None:
+        ir = compile_to_ir("(/ 10 2)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.DIV in ops
+
+    def test_let_compiles(self) -> None:
+        ir = compile_to_ir("(let ((x 5)) (* x x))")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.MUL in ops
+
+
+class TestRejectedSurface:
+    def test_define_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(define x 1)")
+
+    def test_lambda_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(lambda (x) x)")
+
+    def test_comparison_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(= 1 1)")
+
+    def test_unbound_name_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="unbound name"):
+            compile_to_ir("foo")
+
+    def test_unknown_builtin_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="unknown builtin"):
+            compile_to_ir("(weirdop 1 2)")
+
+    def test_arity_mismatch_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="expects exactly 2"):
+            compile_to_ir("(+ 1 2 3)")
+
+    def test_multi_binding_let_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="multiple bindings"):
+            compile_to_ir("(let ((x 1) (y 2)) (+ x y))")
+
+    def test_quoted_symbol_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="quoted symbols"):
+            compile_to_ir("'foo")
+
+
+class TestCompileSourceShape:
+    def test_returns_pe_bytes(self) -> None:
+        result = compile_source("(+ 1 2)")
+        # PE/CLI files start with the MS-DOS ``MZ`` signature.
+        assert result.assembly_bytes[:2] == b"MZ"
+        assert result.assembly_name == "TwigProgram"
+
+    def test_custom_assembly_name(self) -> None:
+        result = compile_source("(+ 1 2)", assembly_name="Adder")
+        assert result.assembly_name == "Adder"
+
+    def test_compile_without_optimizer(self) -> None:
+        result = compile_source("(+ 1 2)", optimize=False)
+        assert result.assembly_bytes[:2] == b"MZ"
+
+    def test_empty_program_returns_zero(self) -> None:
+        result = compile_source("")
+        assert result.assembly_bytes[:2] == b"MZ"
+
+
+class TestAssemblyNameSecurity:
+    """Defends against path-traversal and CLR-name violations via
+    ``assembly_name``.  Same allowlist pattern as
+    ``twig-beam-compiler``'s ``module_name`` validation."""
+
+    def test_legal_name_accepted(self) -> None:
+        result = compile_source("(+ 1 2)", assembly_name="Answer42")
+        assert result.assembly_name == "Answer42"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../etc_passwd",      # path-traversal style
+            "1Bad",                # digit start
+            "Has Space",           # space
+            "with;semicolon",      # punctuation
+            "",                     # empty
+            "a" * 65,              # too long
+        ],
+    )
+    def test_unsafe_names_rejected(self, bad: str) -> None:
+        with pytest.raises(ClrPackageError, match="assembly_name must match"):
+            compile_source("(+ 1 2)", assembly_name=bad)

--- a/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
@@ -1,0 +1,77 @@
+"""End-to-end Twig source → real ``dotnet`` execution tests.
+
+These tests require ``dotnet`` on PATH.  They are the headline
+proof that the Twig → CLR pipeline works end-to-end on real
+.NET 9.0+ — completing the Twig real-runtime trilogy alongside
+JVM and BEAM.
+
+Note on the result channel
+==========================
+
+For v1 the program's last expression value flows to the **process
+exit code** (matching how a C# ``static int Main()`` program works).
+That keeps the v1 surface tiny — no stdout / Console.WriteLine
+needed.  v2 adds explicit I/O.
+
+Exit codes are 32-bit signed integers, so we limit our v1 tests to
+small positive results.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from twig_clr_compiler import dotnet_available, run_source
+
+requires_dotnet = pytest.mark.skipif(
+    not dotnet_available(),
+    reason="dotnet not on PATH",
+)
+
+
+@requires_dotnet
+def test_addition() -> None:
+    """``(+ 1 2)`` exits 3 from real dotnet."""
+    result = run_source("(+ 1 2)", assembly_name="ClrAdd")
+    assert result.returncode == 3, (
+        f"dotnet rejected the assembly or returned wrong code:\n"
+        f"  exit={result.returncode}\n"
+        f"  stderr={result.stderr!r}"
+    )
+
+
+@requires_dotnet
+def test_multiplication() -> None:
+    """``(* 6 7)`` exits 42."""
+    result = run_source("(* 6 7)", assembly_name="ClrMul")
+    assert result.returncode == 42, result.stderr
+
+
+@requires_dotnet
+def test_subtraction() -> None:
+    """``(- 10 3)`` exits 7."""
+    result = run_source("(- 10 3)", assembly_name="ClrSub")
+    assert result.returncode == 7, result.stderr
+
+
+@requires_dotnet
+def test_division() -> None:
+    """``(/ 10 2)`` exits 5."""
+    result = run_source("(/ 10 2)", assembly_name="ClrDiv")
+    assert result.returncode == 5, result.stderr
+
+
+@requires_dotnet
+def test_let_binding() -> None:
+    """``(let ((x 5)) (* x x))`` exits 25."""
+    result = run_source("(let ((x 5)) (* x x))", assembly_name="ClrLet")
+    assert result.returncode == 25, result.stderr
+
+
+@requires_dotnet
+def test_nested_arithmetic() -> None:
+    """``(+ (* 6 7) (* 2 3))`` exits 48."""
+    result = run_source(
+        "(+ (* 6 7) (* 2 3))", assembly_name="ClrNested"
+    )
+    assert result.returncode == 48, result.stderr


### PR DESCRIPTION
## Summary

- **Closes the third leg of the Twig real-runtime trilogy**: Twig now runs on JVM ✅ + CLR ✅ + BEAM ✅ (+ WASM via JIT ✅).
- New package `twig-clr-compiler` mirrors `twig-jvm-compiler` and `twig-beam-compiler` exactly so all three real-runtime targets feel identical to drive.
- **31 tests, 87% coverage.** Includes 6 real-`dotnet` smoke tests proving Twig source executes on real .NET 9.0:

```python
>>> from twig_clr_compiler import run_source
>>> run_source("(* 6 7)", assembly_name="Answer42").returncode
42
>>> run_source("(let ((x 5)) (* x x))", assembly_name="Square5").returncode
25
```

## Pipeline

```
Twig source
    ↓ parse + extract       (twig package)
typed AST
    ↓ Compiler.compile()
IrProgram
    ↓ ir-optimizer + ir-to-cil-bytecode
CILProgramArtifact
    ↓ cli-assembly-writer (CLR01-conformant .exe)
.exe bytes
    ↓ dotnet <name>.exe
process exit code
```

The result channel for v1 is the **process exit code** (matching how a C# `static int Main()` returns to the shell). Future v2 adds explicit `Console.WriteLine` I/O.

## V1 surface

Same as `twig-beam-compiler` v1: integer literals, binary `+`/`-`/`*`/`/`, single-binding `let`, `begin`. Recursion, `define`, `if`, closures, lists, symbols are out of scope until the broader cross-backend heap work.

## Security

`assembly_name` is validated via `^[A-Za-z][A-Za-z0-9_]{0,63}$` allowlist — same defense pattern caught + fixed during BEAM04's security review.

## Test plan

- [x] 31/31 tests pass locally (incl. 6 real-`dotnet` smokes)
- [x] `build-tool -validate-build-files` — clean
- [x] `/security-review` — passed in one round
- [ ] CI confirmation across runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)