### PR TITLE
Recover invalid tag open sequences

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -85,6 +85,8 @@ documented in this file.
   text preservation.
 - Processing-instruction-looking `<?...?>` markup now recovers as a bogus
   comment with `unexpected-question-mark-instead-of-tag-name`.
+- Invalid tag-open characters now follow HTML recovery: stray `<` text is
+  preserved and malformed end-tag openers recover as bogus comments.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`
   and whitespace-only DOCTYPE names.
 - DOCTYPE declarations cut off by EOF after a name now emit the current name

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -34,6 +34,10 @@ open comment remain literal comment data and surface a recoverable
 Processing-instruction-looking markup such as `<?xml ...?>` now follows HTML
 bogus-comment recovery instead of being mistaken for a start tag, preserving
 legacy document prologs without polluting the tag stream.
+The tag-open states now only begin normal tags when the next character is an
+ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
+end-tag openers such as `</3>` recover as bogus comments with a tokenizer
+diagnostic.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
 inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
 or inside the `DOCTYPE` keyword emits a force-quirks token. Malformed

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -2423,6 +2423,18 @@ actions = ["parse_error(unexpected-question-mark-instead-of-tag-name)", "create_
 
 [[transitions]]
 from = "tag_open"
+matcher = { range = ["A", "Z"] }
+to = "tag_name"
+actions = ["create_start_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "tag_open"
+matcher = { range = ["a", "z"] }
+to = "tag_name"
+actions = ["create_start_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "tag_open"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -2436,8 +2448,9 @@ actions = [
 [[transitions]]
 from = "tag_open"
 matcher = { anything = true }
-to = "tag_name"
-actions = ["create_start_tag", "append_tag_name(current_lowercase)"]
+to = "data"
+consume = false
+actions = ["parse_error(invalid-first-character-of-tag-name)", "append_text(<)"]
 
 [[transitions]]
 from = "end_tag_open"
@@ -2459,9 +2472,22 @@ actions = [
 
 [[transitions]]
 from = "end_tag_open"
-matcher = { anything = true }
+matcher = { range = ["A", "Z"] }
 to = "end_tag_name"
 actions = ["create_end_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "end_tag_open"
+matcher = { range = ["a", "z"] }
+to = "end_tag_name"
+actions = ["create_end_tag", "append_tag_name(current_lowercase)"]
+
+[[transitions]]
+from = "end_tag_open"
+matcher = { anything = true }
+to = "bogus_comment"
+consume = false
+actions = ["parse_error(invalid-first-character-of-tag-name)", "create_comment"]
 
 [[transitions]]
 from = "tag_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -5478,6 +5478,38 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "tag_open".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
+            to: vec![
+                "tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "create_start_tag".to_string(),
+                "append_tag_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_open".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "create_start_tag".to_string(),
+                "append_tag_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_open".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -5498,16 +5530,16 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "tag_name".to_string(),
+                "data".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "create_start_tag".to_string(),
-                "append_tag_name(current_lowercase)".to_string(),
+                "parse_error(invalid-first-character-of-tag-name)".to_string(),
+                "append_text(<)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "end_tag_open".to_string(),
@@ -5545,7 +5577,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "end_tag_open".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Anything),
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
             to: vec![
                 "end_tag_name".to_string(),
             ],
@@ -5557,6 +5589,38 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_tag_name(current_lowercase)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_open".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "create_end_tag".to_string(),
+                "append_tag_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_open".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(invalid-first-character-of-tag-name)".to_string(),
+                "create_comment".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "tag_name".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 51);
+    assert_eq!(html1.cases.len(), 53);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 50);
+    assert_eq!(file.tests.len(), 51);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 50);
+    assert_eq!(normalized.cases.len(), 51);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 50);
+    assert_eq!(suite.cases.len(), 51);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -580,6 +580,33 @@
       "diagnostics": [
         "unexpected-question-mark-instead-of-tag-name"
       ]
+    },
+    {
+      "id": "invalid-tag-open-text-recovery",
+      "description": "A less-than sign before non-tag text remains text instead of starting a tag",
+      "input": "Before < after",
+      "tokens": [
+        "Text(data=Before )",
+        "Text(data=< after)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ]
+    },
+    {
+      "id": "invalid-end-tag-open-bogus-comment",
+      "description": "An end-tag opener followed by a non-letter recovers as a bogus comment",
+      "input": "Before</3>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=3)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -619,6 +619,20 @@
       "diagnostics": [
         "unexpected-question-mark-instead-of-tag-name"
       ]
+    },
+    {
+      "id": "html5lib-smoke-51",
+      "description": "invalid end tag opener recovers as bogus comment",
+      "input": "Before</3>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=3)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ]
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -540,6 +540,18 @@
       "errors": [
         {"code": "unexpected-question-mark-instead-of-tag-name", "line": 1, "col": 8}
       ]
+    },
+    {
+      "description": "invalid end tag opener recovers as bogus comment",
+      "input": "Before</3>After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "3"],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "invalid-first-character-of-tag-name", "line": 1, "col": 9}
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -358,6 +358,49 @@ fn default_html_lexer_recovers_question_mark_tag_open_as_bogus_comment() {
 }
 
 #[test]
+fn default_html_lexer_recovers_invalid_tag_open_as_text() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before < after").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before ".to_string()),
+            Token::Text("< after".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "invalid-first-character-of-tag-name"));
+}
+
+#[test]
+fn default_html_lexer_recovers_invalid_end_tag_open_as_bogus_comment() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before</3>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("3".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "invalid-first-character-of-tag-name"));
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Restrict normal start/end tag creation in the HTML1 `tag_open` states to ASCII letters.
- Recover stray less-than text like `Before < after` as text with `invalid-first-character-of-tag-name`.
- Recover malformed end-tag openers like `</3>` as bogus comments, and refresh generated source plus fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`