### PR TITLE
feat(rust): LANG13+LANG14 — debug-sidecar and native-debug-info

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -164,6 +164,8 @@ members = [
     "verilog-parser",
     "vhdl-lexer",
     "vhdl-parser",
+    "debug-sidecar",
+    "native-debug-info",
     "virtual-machine",
     "vm-core",
     "wasm-simulator",

--- a/code/packages/rust/debug-sidecar/BUILD
+++ b/code/packages/rust/debug-sidecar/BUILD
@@ -1,0 +1,2 @@
+cargo build -p debug-sidecar
+cargo test -p debug-sidecar

--- a/code/packages/rust/debug-sidecar/CHANGELOG.md
+++ b/code/packages/rust/debug-sidecar/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog — debug-sidecar
+
+All notable changes to this crate will be documented here.
+
+## [0.1.0] — 2026-04-28
+
+### Added
+
+- **`DebugSidecarWriter`** — append-only builder that records IIR instruction-to-source-location
+  mappings for a set of named functions.
+  - `new()` — creates an empty writer.
+  - `add_source_file(path, checksum)` — registers a source file; returns a `usize` file ID.
+  - `begin_function(fn_name, start_instr, param_count)` — opens a function entry.
+  - `end_function(fn_name, end_instr)` — closes a function entry with its last instruction index.
+  - `record(fn_name, instr_index, file_id, line, col)` — appends a `(instr_index → location)` row.
+  - `declare_variable(fn_name, reg_index, name, type_hint, live_start, live_end)` — records a
+    variable's live range within a function.
+  - `finish()` — serialises the entire sidecar to `Vec<u8>` (JSON via `serde_json`).
+
+- **`DebugSidecarReader`** — query engine that deserialises and indexes the sidecar.
+  - `new(data: &[u8])` — parses JSON; returns `Err(SidecarError)` on malformed input.
+  - `lookup(fn_name, instr_index)` — DWARF-style "last row ≤ N" bisect via `partition_point`;
+    returns `Option<SourceLocation>`.
+  - `find_instr(file, line)` — reverse lookup; returns `Option<usize>` instruction index.
+  - `live_variables(fn_name, at_instr)` — returns all `Variable`s whose live range covers
+    `at_instr`.
+  - `source_files()` — returns the list of registered source file paths.
+  - `function_names()` — returns all known function names.
+  - `function_range(fn_name)` — returns `(start_instr, end_instr)` for a function.
+  - `raw_line_rows(fn_name)` — returns the pre-sorted `&[LineRow]` slice; used by
+    `native-debug-info` to build `.debug_line` sections.
+
+- **`SourceLocation`** — frozen `(file: String, line: u32, col: u32)` triple.
+  - `Display` prints `"file:line:col"`.
+
+- **`Variable`** — register binding with `name: String`, `type_hint: String`,
+  `reg_index: u32`, `live_start: usize`, `live_end: usize`.
+  - `is_live_at(instr_index: usize) -> bool` convenience predicate.
+
+- **`LineRow`** — `pub struct` with fields `instr_index: usize, file_id: usize,
+  line: u32, col: u32`; exported so `native-debug-info` can pattern-match it.
+
+- **`SidecarError`** — `pub struct SidecarError(pub String)` implementing `Display` and
+  `std::error::Error`.
+
+- 43 tests: 38 unit tests (types × 10, writer × 11, reader × 17) + 5 doc-tests.

--- a/code/packages/rust/debug-sidecar/Cargo.toml
+++ b/code/packages/rust/debug-sidecar/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "debug-sidecar"
+version = "0.1.0"
+edition = "2021"
+description = "Source-location companion for the IIR pipeline — write/read source-location and variable liveness tables for use by debuggers and insight tools (LANG13)."
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/packages/rust/debug-sidecar/README.md
+++ b/code/packages/rust/debug-sidecar/README.md
@@ -1,0 +1,84 @@
+# debug-sidecar
+
+Source-location companion for the IIR pipeline (LANG13).
+
+`debug-sidecar` provides a compact, JSON-backed sidecar that maps IIR instruction
+indices back to their original source locations and tracks variable liveness.
+It is the bridge between the compiler and all downstream debugger/insight tools.
+
+## Pipeline position
+
+```text
+Compiler (emits IIRInstr)
+  │ calls DebugSidecarWriter::record()
+  │
+  ↓ DebugSidecarWriter::finish() → Vec<u8>   (opaque bytes)
+  │
+  ├──→ written to .sidecar file alongside .aot binary
+  │
+Debugger / native-debug-info
+  │ calls DebugSidecarReader::new(bytes)
+  │
+  ├── lookup("fib", 7)            → SourceLocation("fib.tetrad:3:5")
+  ├── find_instr("fib.tetrad", 3) → Some(7)
+  └── live_variables("fib", 7)   → [Variable { name: "n", … }]
+```
+
+## Public API
+
+| Item | Role |
+|------|------|
+| `DebugSidecarWriter` | Append-only builder. Call `finish()` to serialise to `Vec<u8>`. |
+| `DebugSidecarReader` | Query engine: `lookup`, `find_instr`, `live_variables`. |
+| `SourceLocation` | Frozen `(file, line, col)` triple with `Display` as `"file:line:col"`. |
+| `Variable` | Register binding with name, type hint, and live range. |
+| `LineRow` | Raw mapping of `(instr_index, file_id, line, col)` — used by native-debug-info. |
+
+## Quick start
+
+```rust
+use debug_sidecar::{DebugSidecarWriter, DebugSidecarReader};
+
+let mut w = DebugSidecarWriter::new();
+let fid = w.add_source_file("fibonacci.tetrad", b"");
+w.begin_function("fibonacci", 0, 1);
+w.declare_variable("fibonacci", 0, "n", "any", 0, 12);
+w.record("fibonacci", 0, fid, 3, 5);
+w.end_function("fibonacci", 12);
+
+let sidecar = w.finish();
+
+let r = DebugSidecarReader::new(&sidecar).unwrap();
+let loc = r.lookup("fibonacci", 0).unwrap();
+assert_eq!(loc.to_string(), "fibonacci.tetrad:3:5");
+```
+
+## Lookup semantics
+
+`lookup(fn_name, instr_index)` uses a **DWARF-style "last row ≤ N"** bisect
+(`partition_point`), so it correctly handles instruction sequences that span
+multiple source rows. The result is the source location that was in effect at
+the given instruction index.
+
+## Wire format
+
+The sidecar serialises to JSON (via `serde_json`). The schema is internal and
+subject to change; treat the `Vec<u8>` as opaque bytes between writer and reader.
+
+## Build
+
+```bash
+cargo build -p debug-sidecar
+cargo test -p debug-sidecar
+```
+
+## Dependencies
+
+| Crate | Use |
+|-------|-----|
+| `serde` (derive) | Derive `Serialize`/`Deserialize` on all internal structs |
+| `serde_json` | JSON wire format |
+
+## Tests
+
+43 tests: 38 unit tests across `types`, `writer`, `reader`, plus 5 doc-tests.

--- a/code/packages/rust/debug-sidecar/src/lib.rs
+++ b/code/packages/rust/debug-sidecar/src/lib.rs
@@ -1,0 +1,56 @@
+//! `debug-sidecar` — source-location companion for the IIR pipeline (LANG13).
+//!
+//! This crate provides a compact, JSON-backed sidecar that maps IIR instruction
+//! indices back to their original source locations and tracks variable liveness.
+//! It is the bridge between the compiler and all downstream debugger/insight tools:
+//!
+//! ```text
+//! Compiler (emits IIRInstr)
+//!   │ calls DebugSidecarWriter::record()
+//!   │
+//!   ↓ DebugSidecarWriter::finish() → Vec<u8>   (opaque bytes)
+//!   │
+//!   ├──→ written to .sidecar file alongside .aot binary
+//!   │
+//! Debugger / native-debug-info
+//!   │ calls DebugSidecarReader::new(bytes)
+//!   │
+//!   ├── lookup("fib", 7)           → SourceLocation("fib.tetrad:3:5")
+//!   ├── find_instr("fib.tetrad", 3) → Some(7)
+//!   └── live_variables("fib", 7)   → [Variable { name: "n", … }]
+//! ```
+//!
+//! # Public API
+//!
+//! - [`DebugSidecarWriter`] — append-only builder; call [`finish`][DebugSidecarWriter::finish]
+//!   to serialise.
+//! - [`DebugSidecarReader`] — query engine; answers lookup/find_instr/live_variables.
+//! - [`SourceLocation`] — a frozen `(file, line, col)` triple.
+//! - [`Variable`] — a register binding with name, type hint, and live range.
+//!
+//! # Quick start
+//!
+//! ```
+//! use debug_sidecar::{DebugSidecarWriter, DebugSidecarReader};
+//!
+//! let mut w = DebugSidecarWriter::new();
+//! let fid = w.add_source_file("fibonacci.tetrad", b"");
+//! w.begin_function("fibonacci", 0, 1);
+//! w.declare_variable("fibonacci", 0, "n", "any", 0, 12);
+//! w.record("fibonacci", 0, fid, 3, 5);
+//! w.end_function("fibonacci", 12);
+//!
+//! let sidecar = w.finish();
+//!
+//! let r = DebugSidecarReader::new(&sidecar).unwrap();
+//! let loc = r.lookup("fibonacci", 0).unwrap();
+//! assert_eq!(loc.to_string(), "fibonacci.tetrad:3:5");
+//! ```
+
+pub mod reader;
+pub mod types;
+pub mod writer;
+
+pub use reader::{DebugSidecarReader, LineRow};
+pub use types::{SourceLocation, Variable};
+pub use writer::DebugSidecarWriter;

--- a/code/packages/rust/debug-sidecar/src/reader.rs
+++ b/code/packages/rust/debug-sidecar/src/reader.rs
@@ -1,0 +1,489 @@
+//! [`DebugSidecarReader`] — queries source-location data at runtime.
+//!
+//! The reader is the consumer side of the debug sidecar pipeline.  It loads
+//! the bytes produced by [`DebugSidecarWriter::finish`][`crate::DebugSidecarWriter::finish`]
+//! and answers three kinds of questions:
+//!
+//! 1. **Offset → source** (debugger paused):
+//!    [`lookup`][`DebugSidecarReader::lookup`] → `Option<SourceLocation>`
+//!
+//! 2. **Source → offset** (setting a breakpoint):
+//!    [`find_instr`][`DebugSidecarReader::find_instr`] → `Option<usize>`
+//!
+//! 3. **Variable inspection** (Variables panel):
+//!    [`live_variables`][`DebugSidecarReader::live_variables`] → `Vec<Variable>`
+//!
+//! # Example
+//!
+//! ```
+//! use debug_sidecar::{DebugSidecarWriter, DebugSidecarReader};
+//!
+//! let mut w = DebugSidecarWriter::new();
+//! let fid = w.add_source_file("fib.tetrad", b"");
+//! w.begin_function("fib", 0, 1);
+//! w.record("fib", 3, fid, 7, 5);
+//! w.record("fib", 7, fid, 10, 1);
+//! w.end_function("fib", 12);
+//! w.declare_variable("fib", 0, "n", "u8", 0, 12);
+//!
+//! let reader = DebugSidecarReader::new(&w.finish()).unwrap();
+//!
+//! let loc = reader.lookup("fib", 3).unwrap();
+//! assert_eq!(loc.to_string(), "fib.tetrad:7:5");
+//!
+//! let idx = reader.find_instr("fib.tetrad", 7).unwrap();
+//! assert_eq!(idx, 3);
+//!
+//! let vars = reader.live_variables("fib", 5);
+//! assert_eq!(vars.len(), 1);
+//! assert_eq!(vars[0].name, "n");
+//! ```
+
+use serde_json::Value;
+
+use crate::types::{SourceLocation, Variable};
+
+// ---------------------------------------------------------------------------
+// Internal row types (deserialized from JSON)
+// ---------------------------------------------------------------------------
+
+/// A single row in the line number table (exposed for `native-debug-info`).
+#[derive(Debug, Clone)]
+pub struct LineRow {
+    /// 0-based instruction index within the function body.
+    pub instr_index: usize,
+    /// 0-based file ID (index into the source_files list).
+    pub file_id: usize,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number.
+    pub col: u32,
+}
+
+#[derive(Debug, Clone)]
+struct FunctionEntry {
+    start_instr: usize,
+    end_instr: Option<usize>,
+    #[allow(dead_code)]
+    param_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RawVariable {
+    reg_index: u32,
+    name: String,
+    type_hint: String,
+    live_start: usize,
+    live_end: usize,
+}
+
+// ---------------------------------------------------------------------------
+// DebugSidecarReader
+// ---------------------------------------------------------------------------
+
+/// Answers debug queries from a compiled sidecar.
+///
+/// Parse errors are exposed as [`SidecarError`].
+///
+/// The line-number lookup in [`lookup`][`Self::lookup`] uses a binary-search
+/// "last row whose index ≤ N" algorithm identical to the DWARF lookup
+/// semantics — a generated instruction that maps to no explicit row still
+/// gets the location of the nearest preceding recorded instruction.
+#[derive(Debug)]
+pub struct DebugSidecarReader {
+    source_files: Vec<String>,        // path for each file_id
+    line_table: std::collections::HashMap<String, Vec<LineRow>>,
+    functions: std::collections::HashMap<String, FunctionEntry>,
+    variables: std::collections::HashMap<String, Vec<RawVariable>>,
+    /// Pre-sorted instr_index lists for bisect lookups.
+    sorted_indices: std::collections::HashMap<String, Vec<usize>>,
+}
+
+/// Error returned when sidecar bytes cannot be parsed.
+#[derive(Debug)]
+pub struct SidecarError(pub String);
+
+impl std::fmt::Display for SidecarError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SidecarError: {}", self.0)
+    }
+}
+
+impl std::error::Error for SidecarError {}
+
+impl DebugSidecarReader {
+    /// Parse a sidecar produced by [`DebugSidecarWriter::finish`][`crate::DebugSidecarWriter::finish`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SidecarError`] if the bytes are not valid UTF-8 JSON, or if
+    /// the `"version"` field is not `1`.
+    pub fn new(data: &[u8]) -> Result<Self, SidecarError> {
+        let payload: Value = serde_json::from_slice(data)
+            .map_err(|e| SidecarError(format!("invalid sidecar data: {e}")))?;
+
+        match payload.get("version").and_then(|v| v.as_u64()) {
+            Some(1) => {}
+            v => return Err(SidecarError(format!("unsupported sidecar version: {v:?}"))),
+        }
+
+        // Parse source_files.
+        let source_files: Vec<String> = payload
+            .get("source_files")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| e.get("path")?.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Parse line_table.
+        let mut line_table: std::collections::HashMap<String, Vec<LineRow>> =
+            std::collections::HashMap::new();
+        if let Some(lt) = payload.get("line_table").and_then(|v| v.as_object()) {
+            for (fn_name, rows_val) in lt {
+                let rows: Vec<LineRow> = rows_val
+                    .as_array()
+                    .unwrap_or(&vec![])
+                    .iter()
+                    .filter_map(|r| {
+                        Some(LineRow {
+                            instr_index: r.get("instr_index")?.as_u64()? as usize,
+                            file_id: r.get("file_id")?.as_u64()? as usize,
+                            line: r.get("line")?.as_u64()? as u32,
+                            col: r.get("col")?.as_u64()? as u32,
+                        })
+                    })
+                    .collect();
+                line_table.insert(fn_name.clone(), rows);
+            }
+        }
+
+        // Parse functions.
+        let mut functions: std::collections::HashMap<String, FunctionEntry> =
+            std::collections::HashMap::new();
+        if let Some(fns) = payload.get("functions").and_then(|v| v.as_object()) {
+            for (fn_name, fv) in fns {
+                let start_instr = fv.get("start_instr").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                let end_instr = fv.get("end_instr").and_then(|v| v.as_u64()).map(|v| v as usize);
+                let param_count = fv.get("param_count").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                functions.insert(fn_name.clone(), FunctionEntry { start_instr, end_instr, param_count });
+            }
+        }
+
+        // Parse variables.
+        let mut variables: std::collections::HashMap<String, Vec<RawVariable>> =
+            std::collections::HashMap::new();
+        if let Some(vars) = payload.get("variables").and_then(|v| v.as_object()) {
+            for (fn_name, varr) in vars {
+                let vs: Vec<RawVariable> = varr
+                    .as_array()
+                    .unwrap_or(&vec![])
+                    .iter()
+                    .filter_map(|v| {
+                        Some(RawVariable {
+                            reg_index: v.get("reg_index")?.as_u64()? as u32,
+                            name: v.get("name")?.as_str()?.to_string(),
+                            type_hint: v.get("type_hint")?.as_str()?.to_string(),
+                            live_start: v.get("live_start")?.as_u64()? as usize,
+                            live_end: v.get("live_end")?.as_u64()? as usize,
+                        })
+                    })
+                    .collect();
+                variables.insert(fn_name.clone(), vs);
+            }
+        }
+
+        // Pre-build sorted indices for bisect lookups.
+        let sorted_indices: std::collections::HashMap<String, Vec<usize>> = line_table
+            .iter()
+            .map(|(fn_name, rows)| {
+                (fn_name.clone(), rows.iter().map(|r| r.instr_index).collect())
+            })
+            .collect();
+
+        Ok(Self {
+            source_files,
+            line_table,
+            functions,
+            variables,
+            sorted_indices,
+        })
+    }
+
+    // ------------------------------------------------------------------
+    // Source location lookup (offset → source)
+    // ------------------------------------------------------------------
+
+    /// Return the source location of instruction `instr_index` in `fn_name`.
+    ///
+    /// Uses the last row whose index is ≤ `instr_index`, matching the DWARF
+    /// line-number lookup algorithm.  A generated instruction with no explicit
+    /// record still gets the location of the nearest preceding recorded row.
+    ///
+    /// Returns `None` if the function has no debug information or if
+    /// `instr_index` is before the first recorded instruction.
+    pub fn lookup(&self, fn_name: &str, instr_index: usize) -> Option<SourceLocation> {
+        let rows = self.line_table.get(fn_name)?;
+        let indices = self.sorted_indices.get(fn_name)?;
+
+        // Binary search: find the last index ≤ instr_index.
+        // partition_point gives the first index > instr_index, so subtract 1.
+        let pos = indices.partition_point(|&i| i <= instr_index);
+        if pos == 0 {
+            return None;
+        }
+        let row = &rows[pos - 1];
+        let path = self.source_files.get(row.file_id)?.clone();
+        Some(SourceLocation { file: path, line: row.line, col: row.col })
+    }
+
+    // ------------------------------------------------------------------
+    // Reverse lookup (source → offset)
+    // ------------------------------------------------------------------
+
+    /// Return the first instruction index that maps to `(file, line)`.
+    ///
+    /// Scans all functions for a row matching the given file path and line
+    /// number.  Returns the lowest matching instruction index, or `None` if
+    /// the source line is not reachable.
+    pub fn find_instr(&self, file: &str, line: u32) -> Option<usize> {
+        // Resolve file path to file_id.
+        let file_id = self.source_files.iter().position(|p| p == file)?;
+
+        let mut best: Option<usize> = None;
+        for rows in self.line_table.values() {
+            for row in rows {
+                if row.file_id == file_id && row.line == line {
+                    let idx = row.instr_index;
+                    best = Some(best.map_or(idx, |b: usize| b.min(idx)));
+                }
+            }
+        }
+        best
+    }
+
+    // ------------------------------------------------------------------
+    // Variable inspection
+    // ------------------------------------------------------------------
+
+    /// Return all variables live at instruction `at_instr` in `fn_name`.
+    ///
+    /// A variable is live when `live_start <= at_instr < live_end`.
+    /// The result is sorted by `reg_index`.
+    pub fn live_variables(&self, fn_name: &str, at_instr: usize) -> Vec<Variable> {
+        let raw = match self.variables.get(fn_name) {
+            Some(v) => v,
+            None => return Vec::new(),
+        };
+        let mut result: Vec<Variable> = raw
+            .iter()
+            .filter(|v| v.live_start <= at_instr && at_instr < v.live_end)
+            .map(|v| Variable {
+                reg_index: v.reg_index,
+                name: v.name.clone(),
+                type_hint: v.type_hint.clone(),
+                live_start: v.live_start,
+                live_end: v.live_end,
+            })
+            .collect();
+        result.sort_by_key(|v| v.reg_index);
+        result
+    }
+
+    // ------------------------------------------------------------------
+    // Metadata
+    // ------------------------------------------------------------------
+
+    /// Return the list of source file paths registered in this sidecar.
+    pub fn source_files(&self) -> &[String] {
+        &self.source_files
+    }
+
+    /// Return the list of function names that have debug information.
+    pub fn function_names(&self) -> Vec<&str> {
+        self.functions.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Return the `(start_instr, end_instr)` range for `fn_name`.
+    ///
+    /// Returns `None` if the function was not registered or if
+    /// `end_function()` was never called.
+    pub fn function_range(&self, fn_name: &str) -> Option<(usize, usize)> {
+        let entry = self.functions.get(fn_name)?;
+        let end = entry.end_instr?;
+        Some((entry.start_instr, end))
+    }
+
+    /// Return the raw sorted line rows for a function (used by native-debug-info).
+    ///
+    /// Returns an empty slice if the function is not in the line table.
+    pub fn raw_line_rows(&self, fn_name: &str) -> &[LineRow] {
+        self.line_table.get(fn_name).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DebugSidecarWriter;
+
+    fn round_trip_writer() -> (DebugSidecarWriter, usize) {
+        let mut w = DebugSidecarWriter::new();
+        let fid = w.add_source_file("fib.tetrad", b"");
+        w.begin_function("fib", 0, 1);
+        w.record("fib", 3, fid, 7, 5);
+        w.record("fib", 7, fid, 10, 1);
+        w.end_function("fib", 12);
+        w.declare_variable("fib", 0, "n", "u8", 0, 12);
+        (w, fid)
+    }
+
+    fn make_reader() -> DebugSidecarReader {
+        let (w, _) = round_trip_writer();
+        DebugSidecarReader::new(&w.finish()).unwrap()
+    }
+
+    #[test]
+    fn reader_parses_valid_data() {
+        let r = make_reader();
+        assert!(r.source_files.contains(&"fib.tetrad".to_string()));
+    }
+
+    #[test]
+    fn reader_invalid_json_returns_error() {
+        let result = DebugSidecarReader::new(b"not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reader_wrong_version_returns_error() {
+        let json = r#"{"version":2,"source_files":[],"line_table":{},"functions":{},"variables":{}}"#;
+        let result = DebugSidecarReader::new(json.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn lookup_exact_match() {
+        let r = make_reader();
+        let loc = r.lookup("fib", 3).unwrap();
+        assert_eq!(loc.line, 7);
+        assert_eq!(loc.col, 5);
+        assert_eq!(loc.file, "fib.tetrad");
+    }
+
+    #[test]
+    fn lookup_between_rows_returns_preceding() {
+        let r = make_reader();
+        // instr 5 is between rows 3 and 7 — should return row at 3
+        let loc = r.lookup("fib", 5).unwrap();
+        assert_eq!(loc.line, 7);
+    }
+
+    #[test]
+    fn lookup_at_second_row() {
+        let r = make_reader();
+        let loc = r.lookup("fib", 7).unwrap();
+        assert_eq!(loc.line, 10);
+    }
+
+    #[test]
+    fn lookup_before_first_row_returns_none() {
+        let r = make_reader();
+        // instr 0,1,2 are before the first row at 3
+        assert!(r.lookup("fib", 0).is_none());
+        assert!(r.lookup("fib", 2).is_none());
+    }
+
+    #[test]
+    fn lookup_unknown_function_returns_none() {
+        let r = make_reader();
+        assert!(r.lookup("unknown_fn", 0).is_none());
+    }
+
+    #[test]
+    fn find_instr_known_line() {
+        let r = make_reader();
+        let idx = r.find_instr("fib.tetrad", 7).unwrap();
+        assert_eq!(idx, 3);
+    }
+
+    #[test]
+    fn find_instr_unknown_file_returns_none() {
+        let r = make_reader();
+        assert!(r.find_instr("other.t", 7).is_none());
+    }
+
+    #[test]
+    fn find_instr_unknown_line_returns_none() {
+        let r = make_reader();
+        assert!(r.find_instr("fib.tetrad", 999).is_none());
+    }
+
+    #[test]
+    fn live_variables_at_start() {
+        let r = make_reader();
+        let vars = r.live_variables("fib", 0);
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name, "n");
+    }
+
+    #[test]
+    fn live_variables_at_end_exclusive() {
+        let r = make_reader();
+        let vars = r.live_variables("fib", 12); // live_end=12, not live
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn live_variables_unknown_function() {
+        let r = make_reader();
+        let vars = r.live_variables("unknown", 5);
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn live_variables_sorted_by_reg_index() {
+        let mut w = DebugSidecarWriter::new();
+        w.declare_variable("f", 5, "z", "", 0, 10);
+        w.declare_variable("f", 1, "a", "", 0, 10);
+        w.declare_variable("f", 3, "m", "", 0, 10);
+        let r = DebugSidecarReader::new(&w.finish()).unwrap();
+        let vars = r.live_variables("f", 5);
+        assert_eq!(vars[0].reg_index, 1);
+        assert_eq!(vars[1].reg_index, 3);
+        assert_eq!(vars[2].reg_index, 5);
+    }
+
+    #[test]
+    fn source_files_returns_paths() {
+        let r = make_reader();
+        assert!(r.source_files().contains(&"fib.tetrad".to_string()));
+    }
+
+    #[test]
+    fn function_range_returns_start_end() {
+        let r = make_reader();
+        let range = r.function_range("fib").unwrap();
+        assert_eq!(range, (0, 12));
+    }
+
+    #[test]
+    fn function_range_unknown_returns_none() {
+        let r = make_reader();
+        assert!(r.function_range("ghost").is_none());
+    }
+
+    #[test]
+    fn function_names_includes_registered() {
+        let r = make_reader();
+        let names = r.function_names();
+        assert!(names.contains(&"fib"));
+    }
+}

--- a/code/packages/rust/debug-sidecar/src/types.rs
+++ b/code/packages/rust/debug-sidecar/src/types.rs
@@ -1,0 +1,181 @@
+//! Core data types for debug-sidecar.
+//!
+//! Two types are exported:
+//!
+//! - [`SourceLocation`] — a frozen (file, line, col) triple mapping one
+//!   IIR instruction to a position in the original source file.
+//!
+//! - [`Variable`] — a register binding with a human name, type hint, and
+//!   live range expressed as `[live_start, live_end)` instruction indices.
+//!
+//! Both types are cheaply cloneable (`String` fields) and implement `Eq`
+//! and `Hash` so they can be used as `HashMap` keys.
+
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// SourceLocation
+// ---------------------------------------------------------------------------
+
+/// Source position for one IIR instruction.
+///
+/// Lines and columns are 1-based, matching the convention used by editors,
+/// debuggers, and the DWARF standard.
+///
+/// # Example
+///
+/// ```
+/// use debug_sidecar::SourceLocation;
+///
+/// let loc = SourceLocation { file: "fib.tetrad".into(), line: 3, col: 5 };
+/// assert_eq!(loc.to_string(), "fib.tetrad:3:5");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceLocation {
+    /// Source file path as registered with [`crate::DebugSidecarWriter::add_source_file`].
+    pub file: String,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number.
+    pub col: u32,
+}
+
+impl fmt::Display for SourceLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}:{}", self.file, self.line, self.col)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variable
+// ---------------------------------------------------------------------------
+
+/// A named register binding valid over a range of instruction indices.
+///
+/// The live range is expressed as `[live_start, live_end)` — a variable is
+/// live at instruction N when `live_start <= N < live_end`.
+///
+/// # Example
+///
+/// ```
+/// use debug_sidecar::Variable;
+///
+/// let v = Variable {
+///     reg_index: 0,
+///     name: "n".into(),
+///     type_hint: "u8".into(),
+///     live_start: 0,
+///     live_end: 12,
+/// };
+/// assert!(v.is_live_at(0));
+/// assert!(v.is_live_at(11));
+/// assert!(!v.is_live_at(12));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Variable {
+    /// IIR register index (matches the register number in the VM's frame).
+    pub reg_index: u32,
+    /// Human-readable variable name from the source program.
+    pub name: String,
+    /// Declared type string (`"any"`, `"u8"`, `"Int"`, …).
+    /// Empty string if no type annotation was given.
+    pub type_hint: String,
+    /// First instruction index at which this binding is valid (inclusive).
+    pub live_start: usize,
+    /// One-past-last instruction index (exclusive upper bound).
+    pub live_end: usize,
+}
+
+impl Variable {
+    /// Return `true` if this variable is live at `instr_index`.
+    pub fn is_live_at(&self, instr_index: usize) -> bool {
+        self.live_start <= instr_index && instr_index < self.live_end
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_location_display() {
+        let loc = SourceLocation {
+            file: "fibonacci.tetrad".into(),
+            line: 3,
+            col: 5,
+        };
+        assert_eq!(loc.to_string(), "fibonacci.tetrad:3:5");
+    }
+
+    #[test]
+    fn source_location_eq() {
+        let a = SourceLocation { file: "f.t".into(), line: 1, col: 2 };
+        let b = SourceLocation { file: "f.t".into(), line: 1, col: 2 };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn source_location_ne_different_file() {
+        let a = SourceLocation { file: "a.t".into(), line: 1, col: 1 };
+        let b = SourceLocation { file: "b.t".into(), line: 1, col: 1 };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn variable_is_live_at_start() {
+        let v = Variable {
+            reg_index: 0, name: "x".into(), type_hint: "u8".into(),
+            live_start: 5, live_end: 10,
+        };
+        assert!(v.is_live_at(5));
+    }
+
+    #[test]
+    fn variable_is_live_at_before_end() {
+        let v = Variable {
+            reg_index: 0, name: "x".into(), type_hint: "u8".into(),
+            live_start: 5, live_end: 10,
+        };
+        assert!(v.is_live_at(9));
+    }
+
+    #[test]
+    fn variable_not_live_at_end() {
+        let v = Variable {
+            reg_index: 0, name: "x".into(), type_hint: "u8".into(),
+            live_start: 5, live_end: 10,
+        };
+        assert!(!v.is_live_at(10));
+    }
+
+    #[test]
+    fn variable_not_live_before_start() {
+        let v = Variable {
+            reg_index: 0, name: "x".into(), type_hint: "u8".into(),
+            live_start: 5, live_end: 10,
+        };
+        assert!(!v.is_live_at(4));
+    }
+
+    #[test]
+    fn variable_empty_range() {
+        let v = Variable {
+            reg_index: 0, name: "x".into(), type_hint: "any".into(),
+            live_start: 3, live_end: 3,
+        };
+        assert!(!v.is_live_at(3));
+    }
+
+    #[test]
+    fn variable_no_type_hint() {
+        let v = Variable {
+            reg_index: 2, name: "y".into(), type_hint: String::new(),
+            live_start: 0, live_end: 1,
+        };
+        assert!(v.type_hint.is_empty());
+    }
+}

--- a/code/packages/rust/debug-sidecar/src/writer.rs
+++ b/code/packages/rust/debug-sidecar/src/writer.rs
@@ -1,0 +1,413 @@
+//! [`DebugSidecarWriter`] — accumulates source-location data during compilation.
+//!
+//! The compiler calls this once per emitted `IIRInstr` to record the mapping
+//! from instruction index to source location.  After compilation, [`finish`]
+//! serialises the accumulated data to [`bytes::Bytes`] — actually a `Vec<u8>`
+//! — that the reader can load.
+//!
+//! # Design
+//!
+//! The on-disk format is JSON UTF-8.  This is intentionally simpler than a
+//! compact binary format and lets the entire pipeline work end-to-end before
+//! investing in a more efficient encoding.  The [`crate::DebugSidecarReader`]
+//! boundary is the only place that knows the format, so upgrading later is a
+//! single-file change.
+//!
+//! The writer is append-only and **not** `Send` / `Sync` — each compilation
+//! uses its own instance.
+//!
+//! # Example
+//!
+//! ```
+//! use debug_sidecar::DebugSidecarWriter;
+//!
+//! let mut w = DebugSidecarWriter::new();
+//! let file_id = w.add_source_file("fibonacci.tetrad", b"");
+//!
+//! w.begin_function("fibonacci", 0, 1);
+//! w.declare_variable("fibonacci", 0, "n", "any", 0, 12);
+//! w.record("fibonacci", 0, file_id, 3, 5);
+//! w.end_function("fibonacci", 12);
+//!
+//! let sidecar: Vec<u8> = w.finish();
+//! assert!(!sidecar.is_empty());
+//! ```
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// Internal representation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct LineRow {
+    instr_index: usize,
+    file_id: usize,
+    line: u32,
+    col: u32,
+}
+
+#[derive(Debug)]
+struct FunctionEntry {
+    start_instr: usize,
+    end_instr: Option<usize>,
+    param_count: usize,
+}
+
+#[derive(Debug)]
+struct VariableEntry {
+    reg_index: u32,
+    name: String,
+    type_hint: String,
+    live_start: usize,
+    live_end: usize,
+}
+
+// ---------------------------------------------------------------------------
+// DebugSidecarWriter
+// ---------------------------------------------------------------------------
+
+/// Accumulates debug sidecar data during a single compilation.
+///
+/// Create one instance per compilation unit (module / source file), call the
+/// `record*` / `declare_*` / `begin_*` / `end_*` methods as instructions are
+/// emitted, then call [`finish`][`Self::finish`] to serialise.
+#[derive(Debug)]
+pub struct DebugSidecarWriter {
+    source_files: Vec<(String, String)>, // (path, checksum_hex)
+    source_file_index: HashMap<String, usize>,
+    line_table: HashMap<String, Vec<LineRow>>,
+    functions: HashMap<String, FunctionEntry>,
+    variables: HashMap<String, Vec<VariableEntry>>,
+}
+
+impl DebugSidecarWriter {
+    /// Create a new, empty writer.
+    pub fn new() -> Self {
+        Self {
+            source_files: Vec::new(),
+            source_file_index: HashMap::new(),
+            line_table: HashMap::new(),
+            functions: HashMap::new(),
+            variables: HashMap::new(),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Source files
+    // ------------------------------------------------------------------
+
+    /// Register a source file and return its `file_id`.
+    ///
+    /// Calling this multiple times with the same `path` is safe — subsequent
+    /// calls return the same `file_id` without duplicating the entry.
+    ///
+    /// # Parameters
+    ///
+    /// - `path` — source file path (absolute or relative to the build directory).
+    /// - `checksum` — optional SHA-256 bytes of the source at compile time.
+    ///   Pass `b""` to omit.
+    ///
+    /// # Returns
+    ///
+    /// 0-based `file_id` for use in [`record`][`Self::record`].
+    pub fn add_source_file(&mut self, path: &str, checksum: &[u8]) -> usize {
+        if let Some(&id) = self.source_file_index.get(path) {
+            return id;
+        }
+        let id = self.source_files.len();
+        let checksum_hex: String = checksum.iter().map(|b| format!("{b:02x}")).collect();
+        self.source_files.push((path.to_string(), checksum_hex));
+        self.source_file_index.insert(path.to_string(), id);
+        id
+    }
+
+    // ------------------------------------------------------------------
+    // Line table
+    // ------------------------------------------------------------------
+
+    /// Record the source location of one emitted instruction.
+    ///
+    /// May be called out of order by `instr_index` — the reader sorts rows
+    /// by index at load time.
+    ///
+    /// # Parameters
+    ///
+    /// - `fn_name` — function containing this instruction.
+    /// - `instr_index` — 0-based index within the function body.
+    /// - `file_id` — returned by [`add_source_file`][`Self::add_source_file`].
+    /// - `line` — 1-based source line.
+    /// - `col` — 1-based source column.
+    pub fn record(
+        &mut self,
+        fn_name: &str,
+        instr_index: usize,
+        file_id: usize,
+        line: u32,
+        col: u32,
+    ) {
+        self.line_table
+            .entry(fn_name.to_string())
+            .or_default()
+            .push(LineRow { instr_index, file_id, line, col });
+    }
+
+    // ------------------------------------------------------------------
+    // Functions
+    // ------------------------------------------------------------------
+
+    /// Register the start of a function's instruction range.
+    ///
+    /// Must be paired with [`end_function`][`Self::end_function`].
+    ///
+    /// # Parameters
+    ///
+    /// - `fn_name` — function name (must match the `IIRFunction.name`).
+    /// - `start_instr` — index of the first instruction in the function body.
+    /// - `param_count` — number of parameters (for stack frame display).
+    pub fn begin_function(&mut self, fn_name: &str, start_instr: usize, param_count: usize) {
+        self.functions.insert(fn_name.to_string(), FunctionEntry {
+            start_instr,
+            end_instr: None,
+            param_count,
+        });
+    }
+
+    /// Record the end of a function's instruction range.
+    ///
+    /// # Parameters
+    ///
+    /// - `fn_name` — must match a prior [`begin_function`][`Self::begin_function`] call.
+    /// - `end_instr` — one-past-last instruction index (exclusive upper bound).
+    pub fn end_function(&mut self, fn_name: &str, end_instr: usize) {
+        if let Some(entry) = self.functions.get_mut(fn_name) {
+            entry.end_instr = Some(end_instr);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Variables
+    // ------------------------------------------------------------------
+
+    /// Record a named variable binding for a register.
+    ///
+    /// # Parameters
+    ///
+    /// - `fn_name` — function containing this variable.
+    /// - `reg_index` — IIR register index.
+    /// - `name` — human-readable variable name.
+    /// - `type_hint` — declared type (`"any"`, `"u8"`, …), or `""` for none.
+    /// - `live_start` — first instruction index at which this binding is valid.
+    /// - `live_end` — one-past-last instruction index (exclusive).
+    #[allow(clippy::too_many_arguments)]
+    pub fn declare_variable(
+        &mut self,
+        fn_name: &str,
+        reg_index: u32,
+        name: &str,
+        type_hint: &str,
+        live_start: usize,
+        live_end: usize,
+    ) {
+        self.variables
+            .entry(fn_name.to_string())
+            .or_default()
+            .push(VariableEntry {
+                reg_index,
+                name: name.to_string(),
+                type_hint: type_hint.to_string(),
+                live_start,
+                live_end,
+            });
+    }
+
+    // ------------------------------------------------------------------
+    // Serialisation
+    // ------------------------------------------------------------------
+
+    /// Serialise all accumulated data to JSON UTF-8 bytes.
+    ///
+    /// The result is an opaque `Vec<u8>` that can be written to disk or passed
+    /// directly to [`DebugSidecarReader::new`][`crate::DebugSidecarReader::new`].
+    ///
+    /// The format is:
+    ///
+    /// ```json
+    /// {
+    ///   "version": 1,
+    ///   "source_files": [{"path": "...", "checksum": "..."}],
+    ///   "line_table": {"fn": [{"instr_index": N, "file_id": F, "line": L, "col": C}]},
+    ///   "functions": {"fn": {"start_instr": S, "end_instr": E, "param_count": P}},
+    ///   "variables": {"fn": [{"reg_index": R, "name": "...", "type_hint": "...", ...}]}
+    /// }
+    /// ```
+    pub fn finish(&self) -> Vec<u8> {
+        // Build JSON for source_files.
+        let sf_json: Vec<Value> = self.source_files.iter().map(|(path, checksum)| {
+            json!({"path": path, "checksum": checksum})
+        }).collect();
+
+        // Build JSON for line_table — sort each function's rows by instr_index.
+        let mut lt_json = serde_json::Map::new();
+        for (fn_name, rows) in &self.line_table {
+            let mut sorted: Vec<&LineRow> = rows.iter().collect();
+            sorted.sort_by_key(|r| r.instr_index);
+            let rows_json: Vec<Value> = sorted.iter().map(|r| {
+                json!({
+                    "instr_index": r.instr_index,
+                    "file_id": r.file_id,
+                    "line": r.line,
+                    "col": r.col,
+                })
+            }).collect();
+            lt_json.insert(fn_name.clone(), Value::Array(rows_json));
+        }
+
+        // Build JSON for functions.
+        let mut fn_json = serde_json::Map::new();
+        for (fn_name, entry) in &self.functions {
+            fn_json.insert(fn_name.clone(), json!({
+                "start_instr": entry.start_instr,
+                "end_instr": entry.end_instr,
+                "param_count": entry.param_count,
+            }));
+        }
+
+        // Build JSON for variables.
+        let mut var_json = serde_json::Map::new();
+        for (fn_name, vars) in &self.variables {
+            let arr: Vec<Value> = vars.iter().map(|v| {
+                json!({
+                    "reg_index": v.reg_index,
+                    "name": v.name,
+                    "type_hint": v.type_hint,
+                    "live_start": v.live_start,
+                    "live_end": v.live_end,
+                })
+            }).collect();
+            var_json.insert(fn_name.clone(), Value::Array(arr));
+        }
+
+        let payload = json!({
+            "version": 1,
+            "source_files": sf_json,
+            "line_table": Value::Object(lt_json),
+            "functions": Value::Object(fn_json),
+            "variables": Value::Object(var_json),
+        });
+
+        serde_json::to_vec(&payload).expect("sidecar JSON serialisation is infallible")
+    }
+}
+
+impl Default for DebugSidecarWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_source_file_deduplicates() {
+        let mut w = DebugSidecarWriter::new();
+        let id0 = w.add_source_file("fib.tetrad", b"");
+        let id1 = w.add_source_file("fib.tetrad", b"");
+        assert_eq!(id0, id1);
+        assert_eq!(w.source_files.len(), 1);
+    }
+
+    #[test]
+    fn add_two_different_files() {
+        let mut w = DebugSidecarWriter::new();
+        let id0 = w.add_source_file("a.t", b"");
+        let id1 = w.add_source_file("b.t", b"");
+        assert_ne!(id0, id1);
+        assert_eq!(w.source_files.len(), 2);
+    }
+
+    #[test]
+    fn record_stores_row() {
+        let mut w = DebugSidecarWriter::new();
+        w.record("fib", 3, 0, 10, 5);
+        assert_eq!(w.line_table["fib"].len(), 1);
+        assert_eq!(w.line_table["fib"][0].line, 10);
+    }
+
+    #[test]
+    fn begin_end_function() {
+        let mut w = DebugSidecarWriter::new();
+        w.begin_function("fib", 0, 2);
+        w.end_function("fib", 15);
+        let entry = &w.functions["fib"];
+        assert_eq!(entry.start_instr, 0);
+        assert_eq!(entry.end_instr, Some(15));
+        assert_eq!(entry.param_count, 2);
+    }
+
+    #[test]
+    fn end_function_with_no_begin_is_noop() {
+        let mut w = DebugSidecarWriter::new();
+        w.end_function("ghost", 5);
+        assert!(!w.functions.contains_key("ghost"));
+    }
+
+    #[test]
+    fn declare_variable_stored() {
+        let mut w = DebugSidecarWriter::new();
+        w.declare_variable("fib", 0, "n", "u8", 0, 12);
+        assert_eq!(w.variables["fib"].len(), 1);
+        assert_eq!(w.variables["fib"][0].name, "n");
+    }
+
+    #[test]
+    fn finish_produces_non_empty_bytes() {
+        let mut w = DebugSidecarWriter::new();
+        w.add_source_file("f.t", b"");
+        w.begin_function("main", 0, 0);
+        w.end_function("main", 3);
+        let bytes = w.finish();
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn finish_valid_json_with_version_1() {
+        let w = DebugSidecarWriter::new();
+        let bytes = w.finish();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed["version"], 1);
+    }
+
+    #[test]
+    fn finish_line_table_sorted() {
+        let mut w = DebugSidecarWriter::new();
+        w.add_source_file("f.t", b"");
+        // Insert out of order.
+        w.record("fib", 5, 0, 10, 1);
+        w.record("fib", 2, 0, 8, 1);
+        let bytes = w.finish();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let rows = parsed["line_table"]["fib"].as_array().unwrap();
+        let idx0 = rows[0]["instr_index"].as_u64().unwrap();
+        let idx1 = rows[1]["instr_index"].as_u64().unwrap();
+        assert!(idx0 < idx1, "rows must be sorted by instr_index");
+    }
+
+    #[test]
+    fn checksum_stored_as_hex() {
+        let mut w = DebugSidecarWriter::new();
+        w.add_source_file("f.t", &[0xDE, 0xAD]);
+        let bytes = w.finish();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let cs = parsed["source_files"][0]["checksum"].as_str().unwrap();
+        assert_eq!(cs, "dead");
+    }
+}

--- a/code/packages/rust/native-debug-info/BUILD
+++ b/code/packages/rust/native-debug-info/BUILD
@@ -1,0 +1,2 @@
+cargo build -p native-debug-info
+cargo test -p native-debug-info

--- a/code/packages/rust/native-debug-info/CHANGELOG.md
+++ b/code/packages/rust/native-debug-info/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog — native-debug-info
+
+All notable changes to this crate will be documented here.
+
+## [0.1.0] — 2026-04-28
+
+### Added
+
+- **`leb128` module** — ULEB128 and SLEB128 encode/decode used by the DWARF emitter.
+  - `encode_uleb128(value: u64) -> Vec<u8>`
+  - `encode_sleb128(value: i64) -> Vec<u8>`
+  - `decode_uleb128(data: &[u8], offset: usize) -> (u64, usize)`
+  - `decode_sleb128(data: &[u8], offset: usize) -> (i64, usize)`
+  - 14 unit tests + 4 doc-tests.
+
+- **`DwarfEmitter`** — DWARF 4 section builder.
+  - `new(reader, load_address, symbol_table, code_size)` — constructs from a `DebugSidecarReader`.
+  - `build()` — returns a `HashMap<String, Vec<u8>>` with keys `.debug_abbrev`,
+    `.debug_info`, `.debug_line`, `.debug_str`.
+  - `embed_in_elf(elf_bytes)` — parses ELF64 section header table, appends DWARF sections,
+    updates `e_shoff` and section count, returns modified binary.
+  - `embed_in_macho(macho_bytes)` — parses Mach-O 64-bit load commands, appends `__DWARF`
+    segment with DWARF sections, returns modified binary.
+  - 9 unit tests + 1 doc-test.
+
+- **`CodeViewEmitter`** — CodeView 4 section builder.
+  - `new(reader, image_base, symbol_table_u32, code_rva, code_section_index)`.
+  - `build()` — returns `HashMap<String, Vec<u8>>` with keys `.debug$S`, `.debug$T`.
+  - `embed_in_pe(pe_bytes)` — parses PE32+ section table, appends CodeView sections,
+    updates COFF header section count, returns modified binary.
+  - 7 unit tests + 1 doc-test.
+
+- **`ArtifactInfo`** — descriptor struct for `embed_debug_info`.
+  - Fields: `target: String`, `load_address: u64`, `image_base: u64`,
+    `symbol_table_u64: HashMap<String, u64>`, `symbol_table_u32: HashMap<String, u32>`,
+    `code_size: u64`, `code_rva: u32`, `code_section_index: u16`.
+
+- **`embed_debug_info(packed_bytes, artifact, sidecar_bytes)`** — one-call convenience
+  dispatcher that auto-detects the target platform from `artifact.target` (case-insensitive)
+  and calls the correct emitter.
+  - ELF targets: `linux`, `elf`, `freebsd`, `wasm`.
+  - Mach-O targets: `macos`, `darwin`, `macho`.
+  - PE targets: `windows`, `win32`, `pe`.
+  - Returns `Err` for unknown targets or malformed sidecars.
+  - 8 unit tests.
+
+- Exported `encode_uleb128`, `decode_uleb128`, `encode_sleb128`, `decode_sleb128` from
+  crate root for downstream packages that emit their own DWARF streams.
+
+- Total: 42 tests (36 unit + 6 doc-tests).

--- a/code/packages/rust/native-debug-info/Cargo.toml
+++ b/code/packages/rust/native-debug-info/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "native-debug-info"
+version = "0.1.0"
+edition = "2021"
+description = "DWARF 4 and CodeView 4 debug-section emitter for AOT binaries — embed source-level debug info into ELF, Mach-O, and PE binaries (LANG14)."
+license = "MIT"
+
+[dependencies]
+debug-sidecar = { path = "../debug-sidecar" }

--- a/code/packages/rust/native-debug-info/README.md
+++ b/code/packages/rust/native-debug-info/README.md
@@ -1,0 +1,98 @@
+# native-debug-info
+
+DWARF 4 and CodeView 4 debug-section emitter (LANG14).
+
+`native-debug-info` converts source-location data from a [`DebugSidecarReader`] into
+the native debug sections understood by gdb/lldb (DWARF 4) on Linux/macOS and
+WinDbg/Visual Studio (CodeView 4) on Windows.
+
+## Pipeline position
+
+```text
+aot-core.compile(module) → .aot binary + sidecar bytes
+  │
+  ↓ DebugSidecarReader::new(sidecar_bytes)
+  │
+  ├── DwarfEmitter::embed_in_elf(elf_bytes)     → ELF + DWARF
+  ├── DwarfEmitter::embed_in_macho(macho_bytes) → Mach-O + DWARF
+  └── CodeViewEmitter::embed_in_pe(pe_bytes)    → PE + CodeView
+```
+
+## Public API
+
+| Item | Role |
+|------|------|
+| `DwarfEmitter` | Builds `.debug_abbrev`, `.debug_info`, `.debug_line`, `.debug_str`; embeds them into ELF64 or Mach-O 64-bit binaries. |
+| `CodeViewEmitter` | Builds `.debug$S` and `.debug$T`; embeds them into a PE32+ binary. |
+| `embed_debug_info` | Convenience dispatcher — auto-detects target from `ArtifactInfo.target` and calls the correct emitter. |
+| `ArtifactInfo` | Descriptor providing target platform, load address, image base, and symbol tables for both DWARF (u64) and CodeView (u32). |
+| `encode_uleb128` / `decode_uleb128` | ULEB128 encode/decode used by the DWARF emitter; exported for downstream packages. |
+| `encode_sleb128` / `decode_sleb128` | SLEB128 encode/decode; used by DWARF for signed values. |
+
+## Quick start
+
+```rust
+use native_debug_info::{encode_uleb128, decode_uleb128};
+
+let encoded = encode_uleb128(624485);
+let (decoded, _) = decode_uleb128(&encoded, 0);
+assert_eq!(decoded, 624485);
+```
+
+## Target platform dispatch
+
+`embed_debug_info` recognises these target strings (case-insensitive):
+
+| Target strings | Emitter |
+|---------------|---------|
+| `linux`, `elf`, `freebsd`, `wasm` | `DwarfEmitter::embed_in_elf` |
+| `macos`, `darwin`, `macho` | `DwarfEmitter::embed_in_macho` |
+| `windows`, `win32`, `pe` | `CodeViewEmitter::embed_in_pe` |
+
+Unknown targets return `Err("unsupported target platform: ...")`.
+
+## DWARF 4 section layout
+
+| Section | Contents |
+|---------|----------|
+| `.debug_abbrev` | Abbreviation table: one `DW_TAG_compile_unit` + one `DW_TAG_subprogram` entry. |
+| `.debug_str` | Null-terminated strings: compilation directory + source file names. |
+| `.debug_info` | Compile-unit header → `DW_TAG_compile_unit` DIE → one `DW_TAG_subprogram` DIE per function. |
+| `.debug_line` | DWARF 4 line-number program header + `DW_LNS_*` opcodes derived from `raw_line_rows()`. |
+
+## CodeView 4 section layout
+
+| Section | Contents |
+|---------|----------|
+| `.debug$S` | Symbol subsection: `S_GPROC32` records for each function from the symbol table. |
+| `.debug$T` | Type subsection: a single `LF_ARGLIST` + `LF_PROCEDURE` leaf covering the whole module. |
+
+## LEB128 encoding
+
+DWARF uses **LEB128** (Little-Endian Base-128) for compact integer encoding:
+
+- **ULEB128** — unsigned: 7 bits per byte, MSB = continuation flag.
+- **SLEB128** — signed: same layout but sign-extended from the final group of 7 bits.
+
+```rust
+// 624485 encodes as [0xe5, 0x8e, 0x26]
+let bytes = encode_uleb128(624485);
+assert_eq!(bytes, vec![0xe5, 0x8e, 0x26]);
+```
+
+## Build
+
+```bash
+cargo build -p native-debug-info
+cargo test -p native-debug-info
+```
+
+## Dependencies
+
+| Crate | Use |
+|-------|-----|
+| `debug-sidecar` | `DebugSidecarReader` + `LineRow` — source for all debug data |
+
+## Tests
+
+42 tests: 36 unit tests across `leb128`, `dwarf`, `codeview`, `embed`, plus 6 doc-tests.

--- a/code/packages/rust/native-debug-info/src/codeview.rs
+++ b/code/packages/rust/native-debug-info/src/codeview.rs
@@ -1,0 +1,487 @@
+//! [`CodeViewEmitter`] — builds CodeView 4 debug sections for PE/Windows.
+//!
+//! Produces two PE sections:
+//!
+//! - `.debug$S` — symbols + line numbers
+//!   - `DEBUG_S_SYMBOLS` (`0xF1`): `S_GPROC32` records for each function
+//!   - `DEBUG_S_FILECHKSMS` (`0xF4`): file checksum entries
+//!   - `DEBUG_S_LINES` (`0xF2`): source line → code offset mapping
+//!
+//! - `.debug$T` — minimal type section (one `LF_PROCEDURE` entry) so WinDbg
+//!   does not complain about missing type info.
+//!
+//! WinDbg / Visual Studio / dumpbin read this format without a separate `.pdb`.
+
+use std::collections::HashMap;
+
+use debug_sidecar::DebugSidecarReader;
+
+// ---------------------------------------------------------------------------
+// CodeView 4 constants
+// ---------------------------------------------------------------------------
+
+const CV_SIGNATURE: u32 = 4;
+
+// Subsection types
+const DEBUG_S_SYMBOLS: u32 = 0xF1;
+const DEBUG_S_LINES: u32 = 0xF2;
+const DEBUG_S_STRINGTABLE: u32 = 0xF3;
+const DEBUG_S_FILECHKSMS: u32 = 0xF4;
+
+// Symbol record types
+const S_GPROC32: u16 = 0x1110;
+const S_END: u16 = 0x0006;
+
+// PE section characteristics
+const IMAGE_SCN_CNT_INITIALIZED_DATA: u32 = 0x00000040;
+const IMAGE_SCN_MEM_DISCARDABLE: u32 = 0x02000000;
+const IMAGE_SCN_MEM_READ: u32 = 0x40000000;
+const DEBUG_SECTION_CHARACTERISTICS: u32 =
+    IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_DISCARDABLE | IMAGE_SCN_MEM_READ;
+
+fn pad4(buf: &mut Vec<u8>) {
+    while buf.len() % 4 != 0 {
+        buf.push(0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodeViewEmitter
+// ---------------------------------------------------------------------------
+
+/// Builds CodeView 4 sections from a debug sidecar and symbol table.
+///
+/// # Parameters
+///
+/// - `reader` — loaded [`DebugSidecarReader`].
+/// - `image_base` — PE image base address.
+/// - `symbol_table` — maps function name → byte offset from `code_rva`.
+/// - `code_rva` — RVA of the `.text` section in the PE.
+/// - `code_section_index` — 1-based section index for `.text` (default 1).
+pub struct CodeViewEmitter<'a> {
+    reader: &'a DebugSidecarReader,
+    image_base: u64,
+    symbol_table: &'a HashMap<String, u32>,
+    code_rva: u32,
+    code_section_index: u16,
+}
+
+impl<'a> CodeViewEmitter<'a> {
+    /// Create a new emitter.
+    pub fn new(
+        reader: &'a DebugSidecarReader,
+        image_base: u64,
+        symbol_table: &'a HashMap<String, u32>,
+        code_rva: u32,
+        code_section_index: u16,
+    ) -> Self {
+        Self {
+            reader,
+            image_base,
+            symbol_table,
+            code_rva,
+            code_section_index,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /// Build both CodeView sections.
+    ///
+    /// Returns a map with keys `.debug$S` and `.debug$T`.
+    pub fn build(&self) -> HashMap<String, Vec<u8>> {
+        let mut sections = HashMap::new();
+        sections.insert(".debug$S".to_string(), self.build_debug_s());
+        sections.insert(".debug$T".to_string(), self.build_debug_t());
+        sections
+    }
+
+    /// Append `.debug$S` and `.debug$T` sections to a PE32+ file.
+    ///
+    /// Checks that there is space in the section header table for two new
+    /// section headers.  Appends section data at the end of the file,
+    /// aligned to `FileAlignment`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the input is not a valid PE32+ binary or if there
+    /// is insufficient header space.
+    pub fn embed_in_pe(&self, pe_bytes: &[u8]) -> Result<Vec<u8>, String> {
+        let mut data = pe_bytes.to_vec();
+
+        if data.len() < 2 || &data[..2] != b"MZ" {
+            return Err("not a valid PE file".into());
+        }
+        // The DOS stub stores the PE header offset at bytes 60-63.
+        if data.len() < 64 {
+            return Err("PE file too short to contain PE header offset".into());
+        }
+        let pe_off = u32::from_le_bytes(data[60..64].try_into().unwrap()) as usize;
+        if data.len() < pe_off + 4 || &data[pe_off..pe_off + 4] != b"PE\x00\x00" {
+            return Err("not a valid PE file (no PE signature)".into());
+        }
+
+        // COFF header starts 4 bytes past the PE signature (after "PE\x00\x00").
+        let coff_off = pe_off + 4;
+        // COFF header is 20 bytes; optional header starts at coff_off + 20.
+        if data.len() < coff_off + 20 {
+            return Err("PE file too short for COFF header".into());
+        }
+        let num_sections = u16::from_le_bytes(data[coff_off + 2..coff_off + 4].try_into().unwrap()) as usize;
+        let opt_hdr_size = u16::from_le_bytes(data[coff_off + 16..coff_off + 18].try_into().unwrap()) as usize;
+
+        let opt_off = coff_off + 20;
+        // PE32+ optional header needs at least 64 bytes before SizeOfHeaders.
+        if data.len() < opt_off + 64 {
+            return Err("PE file too short for optional header fields".into());
+        }
+        let magic = u16::from_le_bytes(data[opt_off..opt_off + 2].try_into().unwrap());
+        if magic != 0x020B {
+            return Err("only PE32+ (64-bit) supported".into());
+        }
+
+        let file_alignment = u32::from_le_bytes(data[opt_off + 36..opt_off + 40].try_into().unwrap());
+        let section_alignment = u32::from_le_bytes(data[opt_off + 32..opt_off + 36].try_into().unwrap());
+        let size_of_headers = u32::from_le_bytes(data[opt_off + 60..opt_off + 64].try_into().unwrap()) as usize;
+
+        let section_table_off = opt_off + opt_hdr_size;
+        let section_table_size = num_sections
+            .checked_mul(40)
+            .ok_or("PE section table size overflow")?;
+        let section_table_end = section_table_off
+            .checked_add(section_table_size)
+            .ok_or("PE section table end overflow")?;
+        if section_table_end > data.len() {
+            return Err(format!(
+                "PE section table ({num_sections} sections) extends past end of file ({} bytes)",
+                data.len()
+            ));
+        }
+
+        // Guard against size_of_headers being smaller than what we already computed.
+        let available = size_of_headers.saturating_sub(section_table_off + section_table_size);
+        if available < 2 * 40 {
+            return Err(format!(
+                "insufficient PE header space for 2 new debug sections (need 80 bytes, have {available})"
+            ));
+        }
+
+        // Find highest existing section for RVA calculation.
+        let mut last_rva: u32 = 0;
+        let mut last_vsize: u32 = 0;
+        for i in 0..num_sections {
+            let off = section_table_off + i * 40;
+            // Each 40-byte section header entry was already bounds-checked above.
+            let vsize = u32::from_le_bytes(data[off + 8..off + 12].try_into().unwrap());
+            let rva = u32::from_le_bytes(data[off + 12..off + 16].try_into().unwrap());
+            if rva >= last_rva {
+                last_rva = rva;
+                last_vsize = vsize;
+            }
+        }
+
+        fn align_to(x: u32, n: u32) -> u32 { (x + n - 1) & !(n - 1) }
+
+        let cv = self.build();
+        let debug_s = &cv[".debug$S"];
+        let debug_t = &cv[".debug$T"];
+
+        let debug_s_rva = align_to(last_rva + last_vsize, section_alignment);
+        let debug_t_rva = align_to(debug_s_rva + debug_s.len() as u32, section_alignment);
+
+        let file_end = data.len() as u32;
+        let debug_s_raw_start = align_to(file_end, file_alignment) as usize;
+        let debug_s_raw_size = align_to(debug_s.len() as u32, file_alignment);
+        let debug_t_raw_start = debug_s_raw_start + debug_s_raw_size as usize;
+        let debug_t_raw_size = align_to(debug_t.len() as u32, file_alignment);
+
+        let new_size_of_image = align_to(debug_t_rva + debug_t.len() as u32, section_alignment);
+
+        fn make_section_header(
+            name: &[u8],
+            vsize: u32,
+            rva: u32,
+            raw_size: u32,
+            raw_off: u32,
+        ) -> Vec<u8> {
+            let mut h = vec![0u8; 40];
+            let name8 = &name[..8.min(name.len())];
+            h[..name8.len()].copy_from_slice(name8);
+            h[8..12].copy_from_slice(&vsize.to_le_bytes());
+            h[12..16].copy_from_slice(&rva.to_le_bytes());
+            h[16..20].copy_from_slice(&raw_size.to_le_bytes());
+            h[20..24].copy_from_slice(&raw_off.to_le_bytes());
+            h[36..40].copy_from_slice(&DEBUG_SECTION_CHARACTERISTICS.to_le_bytes());
+            h
+        }
+
+        let new_sh_s_off = section_table_off + num_sections * 40;
+        let new_sh_t_off = new_sh_s_off + 40;
+
+        let sh_s = make_section_header(b".debug$S", debug_s.len() as u32, debug_s_rva, debug_s_raw_size, debug_s_raw_start as u32);
+        let sh_t = make_section_header(b".debug$T", debug_t.len() as u32, debug_t_rva, debug_t_raw_size, debug_t_raw_start as u32);
+
+        data[new_sh_s_off..new_sh_s_off + 40].copy_from_slice(&sh_s);
+        data[new_sh_t_off..new_sh_t_off + 40].copy_from_slice(&sh_t);
+
+        // Update COFF header: NumberOfSections += 2
+        data[coff_off + 2..coff_off + 4].copy_from_slice(&((num_sections + 2) as u16).to_le_bytes());
+
+        // Update Optional header: SizeOfImage
+        data[opt_off + 56..opt_off + 60].copy_from_slice(&new_size_of_image.to_le_bytes());
+
+        let mut result = data.clone();
+        result.resize(debug_s_raw_start, 0);
+        result.extend_from_slice(debug_s);
+        result.resize(debug_t_raw_start, 0);
+        result.extend_from_slice(debug_t);
+
+        Ok(result)
+    }
+
+    // ------------------------------------------------------------------
+    // Section builders
+    // ------------------------------------------------------------------
+
+    fn build_debug_s(&self) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&CV_SIGNATURE.to_le_bytes());
+
+        let source_files = self.reader.source_files();
+
+        // Build string name table.
+        let mut name_table: Vec<u8> = Vec::new();
+        let mut name_offsets: Vec<u32> = Vec::new();
+        for path in source_files {
+            name_offsets.push(name_table.len() as u32);
+            name_table.extend_from_slice(path.as_bytes());
+            name_table.push(0);
+        }
+        while name_table.len() % 4 != 0 { name_table.push(0); }
+
+        // DEBUG_S_STRINGTABLE
+        buf.extend_from_slice(&DEBUG_S_STRINGTABLE.to_le_bytes());
+        buf.extend_from_slice(&(name_table.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&name_table);
+        pad4(&mut buf);
+
+        // DEBUG_S_FILECHKSMS
+        let mut chksms_data: Vec<u8> = Vec::new();
+        for off in &name_offsets {
+            chksms_data.extend_from_slice(&off.to_le_bytes());
+            chksms_data.push(0); // checksum_size = 0
+            chksms_data.push(0); // kind = 0
+            chksms_data.extend_from_slice(&0u16.to_le_bytes()); // padding
+        }
+        buf.extend_from_slice(&DEBUG_S_FILECHKSMS.to_le_bytes());
+        buf.extend_from_slice(&(chksms_data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&chksms_data);
+        pad4(&mut buf);
+
+        // DEBUG_S_SYMBOLS: one S_GPROC32 + S_END per function.
+        let mut sym_data: Vec<u8> = Vec::new();
+        for fn_name in self.reader.function_names() {
+            let fn_range = self.reader.function_range(fn_name);
+            let fn_offset = self.symbol_table.get(fn_name).copied().unwrap_or(0);
+            let fn_rva = self.code_rva + fn_offset;
+            let fn_len = fn_range.map(|(s, e)| (e - s) as u32).unwrap_or(0);
+
+            let mut name_bytes = fn_name.as_bytes().to_vec();
+            name_bytes.push(0);
+            while (2 + name_bytes.len()) % 4 != 0 { name_bytes.push(0); }
+
+            // S_GPROC32 fixed payload (35 bytes):
+            // parent(4)+end(4)+next(4)+len(4)+dbg_start(4)+dbg_end(4)+type_idx(4)+offset(4)+segment(2)+flags(1)
+            let mut fixed: Vec<u8> = Vec::new();
+            fixed.extend_from_slice(&0u32.to_le_bytes()); // parent
+            fixed.extend_from_slice(&0u32.to_le_bytes()); // end
+            fixed.extend_from_slice(&0u32.to_le_bytes()); // next
+            fixed.extend_from_slice(&fn_len.to_le_bytes()); // proc_len
+            fixed.extend_from_slice(&0u32.to_le_bytes()); // dbg_start
+            fixed.extend_from_slice(&fn_len.to_le_bytes()); // dbg_end
+            fixed.extend_from_slice(&0u32.to_le_bytes()); // type_index
+            fixed.extend_from_slice(&fn_rva.to_le_bytes()); // offset (RVA)
+            fixed.extend_from_slice(&self.code_section_index.to_le_bytes()); // segment
+            fixed.push(0); // flags
+
+            let record_len = (2 + fixed.len() + name_bytes.len()) as u16;
+            sym_data.extend_from_slice(&record_len.to_le_bytes());
+            sym_data.extend_from_slice(&S_GPROC32.to_le_bytes());
+            sym_data.extend_from_slice(&fixed);
+            sym_data.extend_from_slice(&name_bytes);
+
+            // S_END record
+            sym_data.extend_from_slice(&2u16.to_le_bytes());
+            sym_data.extend_from_slice(&S_END.to_le_bytes());
+        }
+        buf.extend_from_slice(&DEBUG_S_SYMBOLS.to_le_bytes());
+        buf.extend_from_slice(&(sym_data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&sym_data);
+        pad4(&mut buf);
+
+        // DEBUG_S_LINES: per-function line mapping.
+        for fn_name in self.reader.function_names() {
+            let fn_range = self.reader.function_range(fn_name);
+            let fn_offset = self.symbol_table.get(fn_name).copied().unwrap_or(0);
+            let fn_rva = self.code_rva + fn_offset;
+            let fn_len = fn_range.map(|(s, e)| (e - s) as u32).unwrap_or(0);
+
+            let raw_rows = self.reader.raw_line_rows(fn_name);
+            if raw_rows.is_empty() { continue; }
+
+            // Group rows by file_id.
+            let mut by_file: HashMap<usize, Vec<_>> = HashMap::new();
+            for row in raw_rows {
+                by_file.entry(row.file_id).or_default().push(row);
+            }
+
+            let mut lines_data: Vec<u8> = Vec::new();
+            // Header: rva(4) + section_index(2) + flags(2) + code_size(4)
+            lines_data.extend_from_slice(&fn_rva.to_le_bytes());
+            lines_data.extend_from_slice(&self.code_section_index.to_le_bytes());
+            lines_data.extend_from_slice(&0u16.to_le_bytes()); // flags
+            lines_data.extend_from_slice(&fn_len.to_le_bytes());
+
+            for (file_id, rows) in &by_file {
+                let chksm_off = (*file_id as u32) * 8; // 8 bytes per entry
+                let num_lines = rows.len() as u32;
+                let block_size = 12 + num_lines * 8;
+                lines_data.extend_from_slice(&chksm_off.to_le_bytes());
+                lines_data.extend_from_slice(&num_lines.to_le_bytes());
+                lines_data.extend_from_slice(&block_size.to_le_bytes());
+                for row in rows {
+                    let code_offset = row.instr_index as u32;
+                    let line = (row.line & 0xFFFFFF) | (1 << 31); // is_stmt bit
+                    lines_data.extend_from_slice(&code_offset.to_le_bytes());
+                    lines_data.extend_from_slice(&line.to_le_bytes());
+                }
+            }
+
+            buf.extend_from_slice(&DEBUG_S_LINES.to_le_bytes());
+            buf.extend_from_slice(&(lines_data.len() as u32).to_le_bytes());
+            buf.extend_from_slice(&lines_data);
+            pad4(&mut buf);
+        }
+
+        buf
+    }
+
+    fn build_debug_t(&self) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&CV_SIGNATURE.to_le_bytes());
+
+        // LF_PROCEDURE (0x1008): return_type(u32=T_VOID=0x0003) + calling_conv(u8=0)
+        //   + attrs(u8=0) + param_count(u16=0) + arg_list(u32=0)
+        const LF_PROCEDURE: u16 = 0x1008;
+        // record_data: return_type(4) + calling_conv(1) + attrs(1) + param_count(2) + arg_list(4) = 12 bytes
+        let mut record_data: Vec<u8> = Vec::new();
+        record_data.extend_from_slice(&0x0003u32.to_le_bytes()); // T_VOID
+        record_data.push(0x00); // CV_CALL_NEARC
+        record_data.push(0x00); // attrs
+        record_data.extend_from_slice(&0u16.to_le_bytes()); // param_count
+        record_data.extend_from_slice(&0u32.to_le_bytes()); // arg_list
+
+        let record_len = (2 + record_data.len()) as u16;
+        buf.extend_from_slice(&record_len.to_le_bytes());
+        buf.extend_from_slice(&LF_PROCEDURE.to_le_bytes());
+        buf.extend_from_slice(&record_data);
+        pad4(&mut buf);
+
+        buf
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use debug_sidecar::DebugSidecarWriter;
+
+    fn make_reader() -> debug_sidecar::DebugSidecarReader {
+        let mut w = DebugSidecarWriter::new();
+        let fid = w.add_source_file("main.tetrad", b"");
+        w.begin_function("main", 0, 0);
+        w.record("main", 0, fid, 1, 1);
+        w.record("main", 5, fid, 3, 1);
+        w.end_function("main", 10);
+        debug_sidecar::DebugSidecarReader::new(&w.finish()).unwrap()
+    }
+
+    fn empty_symtab() -> HashMap<String, u32> {
+        let mut m = HashMap::new();
+        m.insert("main".to_string(), 0u32);
+        m
+    }
+
+    #[test]
+    fn build_returns_two_sections() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let sections = emitter.build();
+        assert!(sections.contains_key(".debug$S"));
+        assert!(sections.contains_key(".debug$T"));
+    }
+
+    #[test]
+    fn debug_s_starts_with_cv_signature() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let sections = emitter.build();
+        let s = &sections[".debug$S"];
+        assert_eq!(&s[..4], &CV_SIGNATURE.to_le_bytes());
+    }
+
+    #[test]
+    fn debug_t_starts_with_cv_signature() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let sections = emitter.build();
+        let t = &sections[".debug$T"];
+        assert_eq!(&t[..4], &CV_SIGNATURE.to_le_bytes());
+    }
+
+    #[test]
+    fn debug_s_non_empty() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let sections = emitter.build();
+        assert!(sections[".debug$S"].len() > 4);
+    }
+
+    #[test]
+    fn debug_t_non_empty() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let sections = emitter.build();
+        assert!(sections[".debug$T"].len() > 4);
+    }
+
+    #[test]
+    fn embed_in_pe_rejects_non_pe() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = CodeViewEmitter::new(&reader, 0x140000000, &sym, 0x1000, 1);
+        let result = emitter.embed_in_pe(b"not a PE");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_sidecar_build_succeeds() {
+        let w = DebugSidecarWriter::new();
+        let reader = debug_sidecar::DebugSidecarReader::new(&w.finish()).unwrap();
+        let sym = HashMap::new();
+        let emitter = CodeViewEmitter::new(&reader, 0, &sym, 0, 1);
+        let sections = emitter.build();
+        assert_eq!(sections.len(), 2);
+    }
+}

--- a/code/packages/rust/native-debug-info/src/dwarf.rs
+++ b/code/packages/rust/native-debug-info/src/dwarf.rs
@@ -1,0 +1,779 @@
+//! [`DwarfEmitter`] — builds DWARF 4 debug sections from a [`DebugSidecarReader`].
+//!
+//! Produces the minimal DWARF subset that lets gdb/lldb set breakpoints by
+//! source line and show function names in stack traces:
+//!
+//! - `.debug_abbrev` — abbreviation table (defines DIE structure)
+//! - `.debug_info`   — compilation unit + `DW_TAG_subprogram` DIEs
+//! - `.debug_line`   — line number program (instr address → file/line/col)
+//! - `.debug_str`    — deduplicated string pool
+//!
+//! The same four sections work for both ELF (Linux) and Mach-O/macOS — only
+//! the embedding step differs (ELF section names vs `__DWARF` segment).
+
+use std::collections::HashMap;
+
+use debug_sidecar::DebugSidecarReader;
+
+use crate::leb128::{encode_sleb128, encode_uleb128};
+
+// ---------------------------------------------------------------------------
+// DWARF 4 constants
+// ---------------------------------------------------------------------------
+
+const DW_TAG_COMPILE_UNIT: u64 = 0x11;
+const DW_TAG_SUBPROGRAM: u64 = 0x2E;
+
+const DW_CHILDREN_YES: u8 = 0x01;
+const DW_CHILDREN_NO: u8 = 0x00;
+
+const DW_AT_PRODUCER: u64 = 0x25;
+const DW_AT_LANGUAGE: u64 = 0x13;
+const DW_AT_NAME: u64 = 0x03;
+const DW_AT_COMP_DIR: u64 = 0x1B;
+const DW_AT_LOW_PC: u64 = 0x11;
+const DW_AT_HIGH_PC: u64 = 0x12;
+const DW_AT_STMT_LIST: u64 = 0x10;
+const DW_AT_DECL_FILE: u64 = 0x3A;
+const DW_AT_DECL_LINE: u64 = 0x3B;
+const DW_AT_EXTERNAL: u64 = 0x3F;
+
+const DW_FORM_ADDR: u64 = 0x01;
+const DW_FORM_DATA1: u64 = 0x08;
+const DW_FORM_DATA2: u64 = 0x05;
+const DW_FORM_DATA4: u64 = 0x06;
+const DW_FORM_DATA8: u64 = 0x07;
+const DW_FORM_STRP: u64 = 0x0E;
+const DW_FORM_FLAG_PRESENT: u64 = 0x19;
+const DW_FORM_SEC_OFFSET: u64 = 0x17;
+
+const DW_LANG_C99: u16 = 0x0001;
+
+const DW_LNS_COPY: u8 = 0x01;
+const DW_LNS_ADVANCE_PC: u8 = 0x02;
+const DW_LNS_ADVANCE_LINE: u8 = 0x03;
+const DW_LNS_SET_FILE: u8 = 0x04;
+const DW_LNE_SET_ADDRESS: u8 = 0x02;
+const DW_LNE_END_SEQUENCE: u8 = 0x01;
+
+const PRODUCER: &str = "coding-adventures aot-core";
+
+// ---------------------------------------------------------------------------
+// DwarfEmitter
+// ---------------------------------------------------------------------------
+
+/// Builds DWARF 4 sections from a debug sidecar and a symbol table.
+///
+/// # Parameters
+///
+/// - `reader` — a loaded [`DebugSidecarReader`].
+/// - `load_address` — virtual address at which the code is loaded.
+/// - `symbol_table` — maps function name → byte offset from `load_address`.
+/// - `code_size` — total byte size of all code (for `DW_AT_high_pc`).
+pub struct DwarfEmitter<'a> {
+    reader: &'a DebugSidecarReader,
+    load_address: u64,
+    symbol_table: &'a HashMap<String, u64>,
+    code_size: u64,
+}
+
+impl<'a> DwarfEmitter<'a> {
+    /// Create a new emitter.
+    pub fn new(
+        reader: &'a DebugSidecarReader,
+        load_address: u64,
+        symbol_table: &'a HashMap<String, u64>,
+        code_size: u64,
+    ) -> Self {
+        Self { reader, load_address, symbol_table, code_size }
+    }
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /// Build all four DWARF sections.
+    ///
+    /// Returns a map with keys `.debug_abbrev`, `.debug_info`,
+    /// `.debug_line`, `.debug_str`.
+    pub fn build(&self) -> HashMap<String, Vec<u8>> {
+        let (str_table, str_offsets) = self.build_str_table();
+        let debug_abbrev = self.build_abbrev();
+        let debug_line = self.build_line();
+        let debug_info = self.build_info(&str_offsets);
+        let mut sections = HashMap::new();
+        sections.insert(".debug_abbrev".to_string(), debug_abbrev);
+        sections.insert(".debug_info".to_string(), debug_info);
+        sections.insert(".debug_line".to_string(), debug_line);
+        sections.insert(".debug_str".to_string(), str_table);
+        sections
+    }
+
+    /// Append DWARF sections to an ELF64 little-endian binary.
+    ///
+    /// Appends `.debug_abbrev`, `.debug_info`, `.debug_line`, `.debug_str`
+    /// as new ELF sections.  Updates the section header table and string table.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the input is not a valid ELF64 little-endian binary.
+    pub fn embed_in_elf(&self, elf_bytes: &[u8]) -> Result<Vec<u8>, String> {
+        let mut data = elf_bytes.to_vec();
+
+        if data.len() < 4 || &data[..4] != b"\x7fELF" {
+            return Err("not a valid ELF file".into());
+        }
+        if data[4] != 2 {
+            return Err("only ELF64 supported".into());
+        }
+        if data[5] != 1 {
+            return Err("only little-endian ELF supported".into());
+        }
+
+        // The ELF64 header is 64 bytes; we read fields at fixed offsets within it.
+        if data.len() < 64 {
+            return Err("ELF header too short (need at least 64 bytes)".into());
+        }
+        let e_shoff = u64::from_le_bytes(data[40..48].try_into().unwrap());
+        let e_shnum = u16::from_le_bytes(data[60..62].try_into().unwrap()) as usize;
+        let e_shstrndx = u16::from_le_bytes(data[62..64].try_into().unwrap()) as usize;
+
+        const SHDR_SIZE: usize = 64;
+        const SHT_PROGBITS: u32 = 1;
+
+        // Validate section header table bounds before indexing.
+        let shdr_table_start = e_shoff as usize;
+        let shdr_table_end = shdr_table_start
+            .checked_add(e_shnum.checked_mul(SHDR_SIZE).ok_or("ELF e_shnum overflow")?)
+            .ok_or("ELF section header table offset overflow")?;
+        if shdr_table_end > data.len() {
+            return Err(format!(
+                "ELF section header table (offset {shdr_table_start}, {e_shnum} entries) \
+                 extends past end of file ({} bytes)",
+                data.len()
+            ));
+        }
+        if e_shstrndx >= e_shnum {
+            return Err(format!(
+                "ELF e_shstrndx ({e_shstrndx}) out of range (e_shnum = {e_shnum})"
+            ));
+        }
+
+        // Read existing section headers.
+        let mut shdrs: Vec<Vec<u8>> = (0..e_shnum)
+            .map(|i| {
+                let off = shdr_table_start + i * SHDR_SIZE;
+                data[off..off + SHDR_SIZE].to_vec()
+            })
+            .collect();
+
+        // Read the existing section-name string table (.shstrtab).
+        let shstrtab_off = u64::from_le_bytes(shdrs[e_shstrndx][24..32].try_into().unwrap()) as usize;
+        let shstrtab_size = u64::from_le_bytes(shdrs[e_shstrndx][32..40].try_into().unwrap()) as usize;
+        let shstrtab_end = shstrtab_off
+            .checked_add(shstrtab_size)
+            .ok_or("ELF shstrtab offset overflow")?;
+        if shstrtab_end > data.len() {
+            return Err(format!(
+                "ELF shstrtab (offset {shstrtab_off}, size {shstrtab_size}) \
+                 extends past end of file ({} bytes)",
+                data.len()
+            ));
+        }
+        let mut shstrtab = data[shstrtab_off..shstrtab_end].to_vec();
+
+        // Build DWARF sections.
+        let dwarf = self.build();
+        let sec_order = [".debug_abbrev", ".debug_info", ".debug_line", ".debug_str"];
+
+        // Extend .shstrtab with new section names.
+        let mut name_offsets: HashMap<&str, u32> = HashMap::new();
+        for name in &sec_order {
+            name_offsets.insert(name, shstrtab.len() as u32);
+            shstrtab.extend_from_slice(name.as_bytes());
+            shstrtab.push(0);
+        }
+
+        fn align8(x: usize) -> usize { x + (8 - x % 8) % 8 }
+
+        // Append debug section data after current EOF.
+        let mut result = data.clone();
+        let mut debug_file_offsets: HashMap<&str, usize> = HashMap::new();
+        for name in &sec_order {
+            let pos = align8(result.len());
+            result.resize(pos, 0);
+            debug_file_offsets.insert(name, result.len());
+            result.extend_from_slice(&dwarf[*name]);
+        }
+
+        // Append extended .shstrtab.
+        let pos = align8(result.len());
+        result.resize(pos, 0);
+        let new_shstrtab_off = result.len();
+        result.extend_from_slice(&shstrtab);
+
+        // Build new section header table.
+        let pos = align8(result.len());
+        result.resize(pos, 0);
+        let new_shdr_table_off = result.len();
+
+        // Copy existing section headers, updating .shstrtab entry.
+        for (i, shdr) in shdrs.iter().enumerate() {
+            let mut s = shdr.clone();
+            if i == e_shstrndx {
+                s[24..32].copy_from_slice(&(new_shstrtab_off as u64).to_le_bytes());
+                s[32..40].copy_from_slice(&(shstrtab.len() as u64).to_le_bytes());
+            }
+            result.extend_from_slice(&s);
+        }
+
+        // Write four new debug section headers.
+        for name in &sec_order {
+            let sec_data = &dwarf[*name];
+            let mut shdr = vec![0u8; SHDR_SIZE];
+            // sh_name (4), sh_type (4), sh_flags (8), sh_addr (8), sh_offset (8),
+            // sh_size (8), sh_link (4), sh_info (4), sh_addralign (8), sh_entsize (8)
+            shdr[0..4].copy_from_slice(&name_offsets[name].to_le_bytes());
+            shdr[4..8].copy_from_slice(&SHT_PROGBITS.to_le_bytes());
+            // sh_flags = 0, sh_addr = 0
+            shdr[24..32].copy_from_slice(&(debug_file_offsets[name] as u64).to_le_bytes());
+            shdr[32..40].copy_from_slice(&(sec_data.len() as u64).to_le_bytes());
+            // sh_addralign = 1
+            shdr[56..64].copy_from_slice(&1u64.to_le_bytes());
+            result.extend_from_slice(&shdr);
+        }
+
+        // Update ELF header.
+        result[40..48].copy_from_slice(&(new_shdr_table_off as u64).to_le_bytes());
+        result[60..62].copy_from_slice(&((e_shnum + sec_order.len()) as u16).to_le_bytes());
+
+        Ok(result)
+    }
+
+    /// Append a `__DWARF` segment with DWARF sections to a Mach-O 64-bit binary.
+    ///
+    /// Inserts a new `LC_SEGMENT_64` load command.  All existing section file
+    /// offsets are shifted by the size of the new load command.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the input is not a valid 64-bit little-endian Mach-O.
+    pub fn embed_in_macho(&self, macho_bytes: &[u8]) -> Result<Vec<u8>, String> {
+        let mut data = macho_bytes.to_vec();
+        const MH_MAGIC_64: u32 = 0xFEEDFACF;
+        if data.len() < 4 || u32::from_le_bytes(data[0..4].try_into().unwrap()) != MH_MAGIC_64 {
+            return Err("not a valid 64-bit little-endian Mach-O".into());
+        }
+
+        let ncmds = u32::from_le_bytes(data[16..20].try_into().unwrap());
+        let sizeofcmds = u32::from_le_bytes(data[20..24].try_into().unwrap());
+
+        let dwarf = self.build();
+        let sec_order = [".debug_abbrev", ".debug_info", ".debug_line", ".debug_str"];
+
+        const LC_SEGMENT_64: u32 = 0x19;
+        let new_lc_size: u32 = 72 + 4 * 80; // 392 bytes
+
+        // The Mach-O 64-bit header is 32 bytes; load commands start immediately after.
+        if data.len() < 32 {
+            return Err("Mach-O header too short (need at least 32 bytes)".into());
+        }
+
+        // Shift existing segment file offsets.
+        let mut lc_off = 32usize;
+        for _ in 0..ncmds {
+            // Minimum load command size is 8 bytes (cmd + cmdsize).
+            if lc_off + 8 > data.len() {
+                return Err(format!(
+                    "Mach-O load command at offset {lc_off} extends past end of file"
+                ));
+            }
+            let cmd = u32::from_le_bytes(data[lc_off..lc_off + 4].try_into().unwrap());
+            let cmdsize = u32::from_le_bytes(data[lc_off + 4..lc_off + 8].try_into().unwrap()) as usize;
+            // A valid cmdsize must be at least 8 and must not take us past EOF.
+            if cmdsize < 8 {
+                return Err(format!(
+                    "Mach-O load command at offset {lc_off} has invalid cmdsize {cmdsize} (< 8)"
+                ));
+            }
+            if lc_off + cmdsize > data.len() {
+                return Err(format!(
+                    "Mach-O load command at offset {lc_off} (cmdsize {cmdsize}) extends past \
+                     end of file ({} bytes)",
+                    data.len()
+                ));
+            }
+            if cmd == LC_SEGMENT_64 {
+                // LC_SEGMENT_64 header needs 72 bytes minimum before section entries.
+                if lc_off + 72 > data.len() {
+                    return Err("Mach-O LC_SEGMENT_64 too short for segment header".into());
+                }
+                let seg_foff = u64::from_le_bytes(data[lc_off + 40..lc_off + 48].try_into().unwrap());
+                if seg_foff > 0 {
+                    let new_off = seg_foff + new_lc_size as u64;
+                    data[lc_off + 40..lc_off + 48].copy_from_slice(&new_off.to_le_bytes());
+                }
+                let nsects = u32::from_le_bytes(data[lc_off + 64..lc_off + 68].try_into().unwrap()) as usize;
+                // Validate: section entries start at lc_off+72, each 80 bytes.
+                let sect_table_end = lc_off + 72 + nsects * 80;
+                if sect_table_end > data.len() {
+                    return Err(format!(
+                        "Mach-O LC_SEGMENT_64 section table ({nsects} sections) extends past \
+                         end of file ({} bytes)",
+                        data.len()
+                    ));
+                }
+                for s in 0..nsects {
+                    let off_field = lc_off + 72 + s * 80 + 48;
+                    let sec_foff = u32::from_le_bytes(data[off_field..off_field + 4].try_into().unwrap());
+                    if sec_foff > 0 {
+                        let new_foff = sec_foff.checked_add(new_lc_size)
+                            .ok_or("Mach-O section file offset overflow")?;
+                        data[off_field..off_field + 4].copy_from_slice(&new_foff.to_le_bytes());
+                    }
+                    let reloff_field = lc_off + 72 + s * 80 + 56;
+                    let reloff = u32::from_le_bytes(data[reloff_field..reloff_field + 4].try_into().unwrap());
+                    if reloff > 0 {
+                        let new_reloff = reloff.checked_add(new_lc_size)
+                            .ok_or("Mach-O section reloff overflow")?;
+                        data[reloff_field..reloff_field + 4].copy_from_slice(&new_reloff.to_le_bytes());
+                    }
+                }
+            }
+            lc_off += cmdsize;
+        }
+
+        // Debug section data goes after all existing content + new_lc_size shift.
+        let debug_data_start = data.len() + new_lc_size as usize;
+        let mut debug_offsets: HashMap<&str, u32> = HashMap::new();
+        let mut pos = debug_data_start;
+        for name in &sec_order {
+            debug_offsets.insert(name, pos as u32);
+            pos += dwarf[*name].len();
+            pos = (pos + 3) & !3;
+        }
+
+        let new_lc = self.build_dwarf_lc(&debug_offsets, &dwarf, &sec_order);
+        assert_eq!(new_lc.len(), new_lc_size as usize);
+
+        // Update Mach-O header: ncmds + 1, sizeofcmds + new_lc_size.
+        // Use checked arithmetic to detect overflow on malformed inputs.
+        let new_ncmds = ncmds
+            .checked_add(1)
+            .ok_or("Mach-O ncmds overflow")?
+            .to_le_bytes();
+        let new_sizeofcmds = sizeofcmds
+            .checked_add(new_lc_size)
+            .ok_or("Mach-O sizeofcmds overflow")?
+            .to_le_bytes();
+        data[16..20].copy_from_slice(&new_ncmds);
+        data[20..24].copy_from_slice(&new_sizeofcmds);
+
+        // Assemble: [header+existing LCs] + [new LC] + [existing body] + [debug]
+        let existing_data_start = 32 + sizeofcmds as usize;
+        let mut result = Vec::new();
+        result.extend_from_slice(&data[..existing_data_start]);
+        result.extend_from_slice(&new_lc);
+        result.extend_from_slice(&data[existing_data_start..]);
+
+        for name in &sec_order {
+            result.extend_from_slice(&dwarf[*name]);
+            while result.len() % 4 != 0 {
+                result.push(0);
+            }
+        }
+
+        Ok(result)
+    }
+
+    // ------------------------------------------------------------------
+    // Section builders
+    // ------------------------------------------------------------------
+
+    fn build_str_table(&self) -> (Vec<u8>, HashMap<String, u32>) {
+        let mut ordered: Vec<String> = vec![PRODUCER.to_string(), String::new()];
+        let files = self.reader.source_files();
+        if files.is_empty() {
+            ordered.push("<unknown>".to_string());
+        } else {
+            ordered.extend_from_slice(files);
+        }
+        ordered.extend(self.reader.function_names().iter().map(|s| s.to_string()));
+
+        let mut offsets: HashMap<String, u32> = HashMap::new();
+        let mut buf: Vec<u8> = Vec::new();
+        for s in ordered {
+            if !offsets.contains_key(&s) {
+                offsets.insert(s.clone(), buf.len() as u32);
+                buf.extend_from_slice(s.as_bytes());
+                buf.push(0);
+            }
+        }
+        (buf, offsets)
+    }
+
+    fn build_abbrev(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Abbrev 1: DW_TAG_compile_unit, has children
+        buf.extend_from_slice(&encode_uleb128(1));
+        buf.extend_from_slice(&encode_uleb128(DW_TAG_COMPILE_UNIT));
+        buf.push(DW_CHILDREN_YES);
+        for (at, form) in [
+            (DW_AT_PRODUCER,  DW_FORM_STRP),
+            (DW_AT_LANGUAGE,  DW_FORM_DATA2),
+            (DW_AT_NAME,      DW_FORM_STRP),
+            (DW_AT_COMP_DIR,  DW_FORM_STRP),
+            (DW_AT_LOW_PC,    DW_FORM_ADDR),
+            (DW_AT_HIGH_PC,   DW_FORM_DATA8),
+            (DW_AT_STMT_LIST, DW_FORM_SEC_OFFSET),
+        ] {
+            buf.extend_from_slice(&encode_uleb128(at));
+            buf.extend_from_slice(&encode_uleb128(form));
+        }
+        buf.extend_from_slice(&[0x00, 0x00]);
+
+        // Abbrev 2: DW_TAG_subprogram, no children
+        buf.extend_from_slice(&encode_uleb128(2));
+        buf.extend_from_slice(&encode_uleb128(DW_TAG_SUBPROGRAM));
+        buf.push(DW_CHILDREN_NO);
+        for (at, form) in [
+            (DW_AT_NAME,      DW_FORM_STRP),
+            (DW_AT_DECL_FILE, DW_FORM_DATA1),
+            (DW_AT_DECL_LINE, DW_FORM_DATA4),
+            (DW_AT_LOW_PC,    DW_FORM_ADDR),
+            (DW_AT_HIGH_PC,   DW_FORM_DATA8),
+            (DW_AT_EXTERNAL,  DW_FORM_FLAG_PRESENT),
+        ] {
+            buf.extend_from_slice(&encode_uleb128(at));
+            buf.extend_from_slice(&encode_uleb128(form));
+        }
+        buf.extend_from_slice(&[0x00, 0x00]);
+
+        buf.push(0); // end of abbreviation table
+        buf
+    }
+
+    fn build_line(&self) -> Vec<u8> {
+        let source_files = self.reader.source_files();
+        let std_opcode_lengths: &[u8] = &[0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1];
+
+        let mut header_body: Vec<u8> = Vec::new();
+        header_body.push(1);    // minimum_instruction_length
+        header_body.push(1);    // maximum_ops_per_instruction
+        header_body.push(1);    // default_is_stmt
+        header_body.push(0xFB); // line_base = -5 (two's complement)
+        header_body.push(14);   // line_range
+        header_body.push(13);   // opcode_base (13 standard opcodes)
+        header_body.extend_from_slice(std_opcode_lengths);
+        header_body.push(0);    // include_directories: empty
+
+        for path in source_files {
+            header_body.extend_from_slice(path.as_bytes());
+            header_body.push(0);
+            header_body.extend_from_slice(&encode_uleb128(0)); // dir_index
+            header_body.extend_from_slice(&encode_uleb128(0)); // mtime
+            header_body.extend_from_slice(&encode_uleb128(0)); // file size
+        }
+        header_body.push(0); // file names table terminator
+
+        let mut program: Vec<u8> = Vec::new();
+
+        for fn_name in self.reader.function_names() {
+            let fn_range = match self.reader.function_range(fn_name) {
+                Some(r) => r,
+                None => continue,
+            };
+            let fn_offset = self.symbol_table.get(fn_name).copied().unwrap_or(0);
+            let fn_address = self.load_address + fn_offset;
+
+            let raw_rows = self.reader.raw_line_rows(fn_name);
+            if raw_rows.is_empty() {
+                continue;
+            }
+
+            // DW_LNE_set_address
+            program.push(0x00);
+            program.extend_from_slice(&encode_uleb128(1 + 8));
+            program.push(DW_LNE_SET_ADDRESS);
+            program.extend_from_slice(&fn_address.to_le_bytes());
+
+            let mut cur_line: u32 = 1;
+            let mut cur_file_idx: u64 = 1;
+
+            for row in raw_rows {
+                let row_file_idx = row.file_id as u64 + 1;
+
+                let pc_delta = row.instr_index;
+                if pc_delta > 0 {
+                    program.push(DW_LNS_ADVANCE_PC);
+                    program.extend_from_slice(&encode_uleb128(pc_delta as u64));
+                }
+
+                if row_file_idx != cur_file_idx {
+                    program.push(DW_LNS_SET_FILE);
+                    program.extend_from_slice(&encode_uleb128(row_file_idx));
+                    cur_file_idx = row_file_idx;
+                }
+
+                let line_delta = row.line as i64 - cur_line as i64;
+                if line_delta != 0 {
+                    program.push(DW_LNS_ADVANCE_LINE);
+                    program.extend_from_slice(&encode_sleb128(line_delta));
+                    cur_line = row.line;
+                }
+
+                // Reset PC to function start for next row.
+                if pc_delta > 0 {
+                    program.push(DW_LNS_ADVANCE_PC);
+                    let neg_delta = (-(pc_delta as i64)) as u64;
+                    program.extend_from_slice(&encode_uleb128(neg_delta));
+                }
+
+                program.push(DW_LNS_COPY);
+            }
+
+            // DW_LNE_end_sequence
+            program.push(0x00);
+            program.extend_from_slice(&encode_uleb128(1));
+            program.push(DW_LNE_END_SEQUENCE);
+
+            let _ = fn_range; // used for context; fn_address was computed from it above
+        }
+
+        let header_length = header_body.len() as u32;
+        let unit_length = 2 + 4 + header_length + program.len() as u32;
+
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&unit_length.to_le_bytes());
+        buf.extend_from_slice(&4u16.to_le_bytes()); // version
+        buf.extend_from_slice(&header_length.to_le_bytes());
+        buf.extend_from_slice(&header_body);
+        buf.extend_from_slice(&program);
+        buf
+    }
+
+    fn build_info(&self, str_offsets: &HashMap<String, u32>) -> Vec<u8> {
+        let source_files = self.reader.source_files();
+        let primary_file = source_files.first().map(|s| s.as_str()).unwrap_or("<unknown>");
+
+        let mut dies: Vec<u8> = Vec::new();
+
+        // Compile unit DIE (abbrev 1).
+        dies.extend_from_slice(&encode_uleb128(1));
+        dies.extend_from_slice(&str_offsets.get(PRODUCER).copied().unwrap_or(0).to_le_bytes());
+        dies.extend_from_slice(&DW_LANG_C99.to_le_bytes());
+        dies.extend_from_slice(&str_offsets.get(primary_file).copied().unwrap_or(0).to_le_bytes());
+        dies.extend_from_slice(&str_offsets.get("").copied().unwrap_or(0).to_le_bytes());
+        dies.extend_from_slice(&self.load_address.to_le_bytes());
+        dies.extend_from_slice(&self.code_size.to_le_bytes());
+        dies.extend_from_slice(&0u32.to_le_bytes()); // DW_AT_stmt_list → 0
+
+        // One DW_TAG_subprogram per function.
+        for fn_name in self.reader.function_names() {
+            let fn_range = self.reader.function_range(fn_name);
+            let fn_offset = self.symbol_table.get(fn_name).copied().unwrap_or(0);
+            let fn_address = self.load_address + fn_offset;
+
+            let raw_rows = self.reader.raw_line_rows(fn_name);
+            let decl_line = raw_rows.first().map(|r| r.line).unwrap_or(1);
+            let decl_file_idx = raw_rows.first().map(|r| r.file_id as u8 + 1).unwrap_or(1);
+
+            let fn_byte_len = fn_range.map(|(s, e)| (e - s) as u64).unwrap_or(0);
+
+            dies.extend_from_slice(&encode_uleb128(2)); // abbrev 2
+            dies.extend_from_slice(&str_offsets.get(fn_name).copied().unwrap_or(0).to_le_bytes());
+            dies.push(decl_file_idx);
+            dies.extend_from_slice(&decl_line.to_le_bytes());
+            dies.extend_from_slice(&fn_address.to_le_bytes());
+            dies.extend_from_slice(&fn_byte_len.to_le_bytes());
+            // DW_AT_external with DW_FORM_flag_present occupies 0 bytes
+        }
+
+        dies.push(0); // end of children (compile unit)
+
+        // Compile unit header: unit_length(4) + version(2) + abbrev_off(4) + addr_size(1)
+        let unit_length = 2u32 + 4 + 1 + dies.len() as u32;
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&unit_length.to_le_bytes());
+        buf.extend_from_slice(&4u16.to_le_bytes()); // version
+        buf.extend_from_slice(&0u32.to_le_bytes()); // abbrev offset
+        buf.push(8); // address size = 8 bytes
+        buf.extend_from_slice(&dies);
+        buf
+    }
+
+    fn build_dwarf_lc(
+        &self,
+        debug_offsets: &HashMap<&str, u32>,
+        dwarf: &HashMap<String, Vec<u8>>,
+        sec_order: &[&str],
+    ) -> Vec<u8> {
+        const LC_SEGMENT_64: u32 = 0x19;
+        let n_sects = sec_order.len();
+        let cmdsize = (72 + n_sects * 80) as u32;
+        let total_size: u32 = sec_order.iter().map(|n| dwarf[*n].len() as u32).sum();
+        let seg_fileoff = debug_offsets[sec_order[0]];
+
+        let mut buf: Vec<u8> = Vec::new();
+
+        // LC_SEGMENT_64 header (72 bytes)
+        buf.extend_from_slice(&LC_SEGMENT_64.to_le_bytes());
+        buf.extend_from_slice(&cmdsize.to_le_bytes());
+        // segname: "__DWARF\0\0\0\0\0\0\0\0\0" (16 bytes)
+        let segname = b"__DWARF\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+        buf.extend_from_slice(segname);
+        buf.extend_from_slice(&0u64.to_le_bytes());         // vmaddr
+        buf.extend_from_slice(&(total_size as u64).to_le_bytes()); // vmsize
+        buf.extend_from_slice(&(seg_fileoff as u64).to_le_bytes()); // fileoff
+        buf.extend_from_slice(&(total_size as u64).to_le_bytes()); // filesize
+        buf.extend_from_slice(&7u32.to_le_bytes());  // maxprot (RWX)
+        buf.extend_from_slice(&5u32.to_le_bytes());  // initprot (RX)
+        buf.extend_from_slice(&(n_sects as u32).to_le_bytes()); // nsects
+        buf.extend_from_slice(&0u32.to_le_bytes());  // flags
+
+        assert_eq!(buf.len(), 72);
+
+        // section_64 entries (80 bytes each)
+        let macho_name: HashMap<&str, &[u8]> = [
+            (".debug_abbrev", b"__debug_abbrev\x00\x00" as &[u8]),
+            (".debug_info",   b"__debug_info\x00\x00\x00\x00" as &[u8]),
+            (".debug_line",   b"__debug_line\x00\x00\x00\x00" as &[u8]),
+            (".debug_str",    b"__debug_str\x00\x00\x00\x00\x00" as &[u8]),
+        ].into_iter().collect();
+
+        for name in sec_order {
+            let mname = macho_name[name];
+            let sec_data = &dwarf[*name];
+            buf.extend_from_slice(mname);
+            buf.extend_from_slice(segname);
+            buf.extend_from_slice(&0u64.to_le_bytes());  // addr
+            buf.extend_from_slice(&(sec_data.len() as u64).to_le_bytes()); // size
+            buf.extend_from_slice(&debug_offsets[name].to_le_bytes());     // offset
+            buf.extend_from_slice(&0u32.to_le_bytes());  // align
+            buf.extend_from_slice(&0u32.to_le_bytes());  // reloff
+            buf.extend_from_slice(&0u32.to_le_bytes());  // nreloc
+            buf.extend_from_slice(&0x02000000u32.to_le_bytes()); // flags: S_ATTR_DEBUG
+            buf.extend_from_slice(&0u32.to_le_bytes());  // reserved1
+            buf.extend_from_slice(&0u32.to_le_bytes());  // reserved2
+            buf.extend_from_slice(&0u32.to_le_bytes());  // reserved3
+        }
+
+        buf
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use debug_sidecar::DebugSidecarWriter;
+
+    fn make_reader() -> debug_sidecar::DebugSidecarReader {
+        let mut w = DebugSidecarWriter::new();
+        let fid = w.add_source_file("fib.tetrad", b"");
+        w.begin_function("fib", 0, 1);
+        w.record("fib", 0, fid, 3, 1);
+        w.record("fib", 5, fid, 5, 1);
+        w.end_function("fib", 10);
+        debug_sidecar::DebugSidecarReader::new(&w.finish()).unwrap()
+    }
+
+    fn empty_symtab() -> HashMap<String, u64> {
+        let mut m = HashMap::new();
+        m.insert("fib".to_string(), 0);
+        m
+    }
+
+    #[test]
+    fn build_returns_four_sections() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        assert!(sections.contains_key(".debug_abbrev"));
+        assert!(sections.contains_key(".debug_info"));
+        assert!(sections.contains_key(".debug_line"));
+        assert!(sections.contains_key(".debug_str"));
+    }
+
+    #[test]
+    fn debug_abbrev_non_empty() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        assert!(!sections[".debug_abbrev"].is_empty());
+    }
+
+    #[test]
+    fn debug_info_non_empty() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        assert!(!sections[".debug_info"].is_empty());
+    }
+
+    #[test]
+    fn debug_line_non_empty() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        assert!(!sections[".debug_line"].is_empty());
+    }
+
+    #[test]
+    fn debug_str_contains_producer() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        let str_sec = &sections[".debug_str"];
+        assert!(str_sec.windows(PRODUCER.len())
+            .any(|w| w == PRODUCER.as_bytes()));
+    }
+
+    #[test]
+    fn debug_str_contains_function_name() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let sections = emitter.build();
+        let str_sec = &sections[".debug_str"];
+        assert!(str_sec.windows(3).any(|w| w == b"fib"));
+    }
+
+    #[test]
+    fn embed_in_elf_rejects_non_elf() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let result = emitter.embed_in_elf(b"not an elf");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn embed_in_macho_rejects_non_macho() {
+        let reader = make_reader();
+        let sym = empty_symtab();
+        let emitter = DwarfEmitter::new(&reader, 0x400000, &sym, 256);
+        let result = emitter.embed_in_macho(b"not a macho");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_sidecar_build_succeeds() {
+        let w = DebugSidecarWriter::new();
+        let reader = debug_sidecar::DebugSidecarReader::new(&w.finish()).unwrap();
+        let sym = HashMap::new();
+        let emitter = DwarfEmitter::new(&reader, 0, &sym, 0);
+        let sections = emitter.build();
+        // All sections exist even for empty sidecars.
+        assert_eq!(sections.len(), 4);
+    }
+}

--- a/code/packages/rust/native-debug-info/src/embed.rs
+++ b/code/packages/rust/native-debug-info/src/embed.rs
@@ -1,0 +1,238 @@
+//! `embed_debug_info` — one-call convenience dispatcher.
+//!
+//! Reads the target platform from an artifact descriptor and dispatches to
+//! either [`DwarfEmitter`] (ELF/Mach-O) or [`CodeViewEmitter`] (PE).
+//!
+//! # Example
+//!
+//! ```no_run
+//! use native_debug_info::{embed_debug_info, ArtifactInfo};
+//! use debug_sidecar::DebugSidecarWriter;
+//! use std::collections::HashMap;
+//!
+//! let mut w = DebugSidecarWriter::new();
+//! let sidecar = w.finish();
+//!
+//! let artifact = ArtifactInfo {
+//!     target: "linux".to_string(),
+//!     load_address: 0x400000,
+//!     image_base: 0x140000000,
+//!     symbol_table_u64: HashMap::new(),
+//!     symbol_table_u32: HashMap::new(),
+//!     code_size: 0,
+//!     code_rva: 0x1000,
+//!     code_section_index: 1,
+//! };
+//!
+//! // Provide a full ELF binary here; a truncated buffer will cause
+//! // an out-of-bounds error when the emitter reads the section header table.
+//! let elf_bytes: Vec<u8> = std::fs::read("my_program").unwrap();
+//! let result = embed_debug_info(&elf_bytes, &artifact, &sidecar);
+//! assert!(result.is_ok());
+//! ```
+
+use std::collections::HashMap;
+
+use debug_sidecar::DebugSidecarReader;
+
+use crate::codeview::CodeViewEmitter;
+use crate::dwarf::DwarfEmitter;
+
+// ---------------------------------------------------------------------------
+// Target sets
+// ---------------------------------------------------------------------------
+
+const ELF_TARGETS: &[&str] = &["linux", "elf", "freebsd", "wasm"];
+const MACHO_TARGETS: &[&str] = &["macos", "darwin", "macho"];
+const PE_TARGETS: &[&str] = &["windows", "win32", "pe"];
+
+// ---------------------------------------------------------------------------
+// ArtifactInfo
+// ---------------------------------------------------------------------------
+
+/// Descriptor that provides target platform metadata for debug embedding.
+///
+/// Passed to [`embed_debug_info`].  Both symbol table variants are present
+/// so the struct covers both DWARF (u64 offsets) and CodeView (u32 offsets)
+/// without separate generics.
+pub struct ArtifactInfo {
+    /// Target platform string, e.g. `"linux"`, `"macos"`, `"windows"`.
+    pub target: String,
+    /// Virtual address at which code is loaded (ELF / Mach-O).
+    pub load_address: u64,
+    /// PE image base address.
+    pub image_base: u64,
+    /// Function name → byte offset (u64) for DWARF emitter.
+    pub symbol_table_u64: HashMap<String, u64>,
+    /// Function name → byte offset (u32) for CodeView emitter.
+    pub symbol_table_u32: HashMap<String, u32>,
+    /// Total code size in bytes (DWARF emitter).
+    pub code_size: u64,
+    /// RVA of the `.text` section (CodeView emitter).
+    pub code_rva: u32,
+    /// 1-based section index for `.text` (CodeView emitter, default 1).
+    pub code_section_index: u16,
+}
+
+// ---------------------------------------------------------------------------
+// Public function
+// ---------------------------------------------------------------------------
+
+/// Embed native debug info into a packed binary.
+///
+/// Dispatches to:
+/// - [`DwarfEmitter::embed_in_elf`] for `"linux"`, `"elf"`, `"freebsd"`, `"wasm"`
+/// - [`DwarfEmitter::embed_in_macho`] for `"macos"`, `"darwin"`, `"macho"`
+/// - [`CodeViewEmitter::embed_in_pe`] for `"windows"`, `"win32"`, `"pe"`
+///
+/// # Parameters
+///
+/// - `packed_bytes` — raw binary (ELF, Mach-O, or PE).
+/// - `artifact` — metadata descriptor.
+/// - `sidecar_bytes` — raw sidecar from `DebugSidecarWriter::finish()`.
+///
+/// # Errors
+///
+/// Returns `Err` if:
+/// - `sidecar_bytes` is not a valid sidecar.
+/// - `artifact.target` is not a recognised platform.
+/// - The underlying emitter returns an error.
+pub fn embed_debug_info(
+    packed_bytes: &[u8],
+    artifact: &ArtifactInfo,
+    sidecar_bytes: &[u8],
+) -> Result<Vec<u8>, String> {
+    let reader = DebugSidecarReader::new(sidecar_bytes)
+        .map_err(|e| e.to_string())?;
+
+    let target = artifact.target.to_lowercase();
+
+    if ELF_TARGETS.contains(&target.as_str()) {
+        let emitter = DwarfEmitter::new(
+            &reader,
+            artifact.load_address,
+            &artifact.symbol_table_u64,
+            artifact.code_size,
+        );
+        return emitter.embed_in_elf(packed_bytes);
+    }
+
+    if MACHO_TARGETS.contains(&target.as_str()) {
+        let emitter = DwarfEmitter::new(
+            &reader,
+            artifact.load_address,
+            &artifact.symbol_table_u64,
+            artifact.code_size,
+        );
+        return emitter.embed_in_macho(packed_bytes);
+    }
+
+    if PE_TARGETS.contains(&target.as_str()) {
+        let emitter = CodeViewEmitter::new(
+            &reader,
+            artifact.image_base,
+            &artifact.symbol_table_u32,
+            artifact.code_rva,
+            artifact.code_section_index,
+        );
+        return emitter.embed_in_pe(packed_bytes);
+    }
+
+    Err(format!("unsupported target platform: {:?}", artifact.target))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use debug_sidecar::DebugSidecarWriter;
+
+    fn empty_sidecar() -> Vec<u8> {
+        DebugSidecarWriter::new().finish()
+    }
+
+    fn make_artifact(target: &str) -> ArtifactInfo {
+        ArtifactInfo {
+            target: target.to_string(),
+            load_address: 0x400000,
+            image_base: 0x140000000,
+            symbol_table_u64: HashMap::new(),
+            symbol_table_u32: HashMap::new(),
+            code_size: 0,
+            code_rva: 0x1000,
+            code_section_index: 1,
+        }
+    }
+
+    #[test]
+    fn unknown_target_returns_error() {
+        let artifact = make_artifact("amiga");
+        let result = embed_debug_info(b"data", &artifact, &empty_sidecar());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("unsupported target platform"));
+    }
+
+    #[test]
+    fn invalid_sidecar_returns_error() {
+        let artifact = make_artifact("linux");
+        let result = embed_debug_info(b"data", &artifact, b"not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn linux_target_dispatches_to_elf() {
+        let artifact = make_artifact("linux");
+        // Real ELF data would succeed; invalid data triggers embed_in_elf error.
+        let result = embed_debug_info(b"BADELF", &artifact, &empty_sidecar());
+        assert!(result.is_err()); // "not a valid ELF" — correct path taken
+        let err = result.unwrap_err();
+        assert!(err.contains("ELF") || err.contains("elf"));
+    }
+
+    #[test]
+    fn macos_target_dispatches_to_macho() {
+        let artifact = make_artifact("macos");
+        let result = embed_debug_info(b"BADMACHO", &artifact, &empty_sidecar());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Mach-O") || err.contains("mach"));
+    }
+
+    #[test]
+    fn windows_target_dispatches_to_pe() {
+        let artifact = make_artifact("windows");
+        let result = embed_debug_info(b"BADPE", &artifact, &empty_sidecar());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("PE") || err.contains("pe") || err.contains("valid"));
+    }
+
+    #[test]
+    fn target_case_insensitive_elf() {
+        let artifact = make_artifact("LINUX");
+        let result = embed_debug_info(b"x", &artifact, &empty_sidecar());
+        // Should dispatch to ELF, not return "unsupported platform"
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().contains("unsupported"));
+    }
+
+    #[test]
+    fn darwin_alias_dispatches_to_macho() {
+        let artifact = make_artifact("darwin");
+        let result = embed_debug_info(b"x", &artifact, &empty_sidecar());
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().contains("unsupported"));
+    }
+
+    #[test]
+    fn pe_alias_dispatches_to_pe() {
+        let artifact = make_artifact("pe");
+        let result = embed_debug_info(b"x", &artifact, &empty_sidecar());
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().contains("unsupported"));
+    }
+}

--- a/code/packages/rust/native-debug-info/src/leb128.rs
+++ b/code/packages/rust/native-debug-info/src/leb128.rs
@@ -1,0 +1,258 @@
+//! LEB128 variable-length integer encoding used throughout DWARF.
+//!
+//! ULEB128 encodes unsigned integers; SLEB128 encodes signed integers.
+//! Both use 7 bits per byte, with the high bit set on all bytes except the last.
+//!
+//! # ULEB128 example
+//!
+//! ```text
+//! 624485 = 0x98765
+//! Bytes: 0xe5, 0x8e, 0x26  (3 bytes)
+//! ```
+//!
+//! # SLEB128 example
+//!
+//! ```text
+//! -123456 → Bytes: 0xc0, 0xbb, 0x78  (3 bytes)
+//! ```
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+/// Encode a non-negative integer as ULEB128.
+///
+/// # Panics
+///
+/// Panics if `value < 0`.  Use [`encode_sleb128`] for signed values.
+///
+/// # Example
+///
+/// ```
+/// use native_debug_info::{encode_uleb128, encode_sleb128};
+///
+/// assert_eq!(encode_uleb128(0), vec![0x00]);
+/// assert_eq!(encode_uleb128(127), vec![0x7F]);
+/// assert_eq!(encode_uleb128(128), vec![0x80, 0x01]);
+/// assert_eq!(encode_uleb128(624485), vec![0xe5, 0x8e, 0x26]);
+/// ```
+pub fn encode_uleb128(mut value: u64) -> Vec<u8> {
+    let mut result = Vec::new();
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value != 0 {
+            result.push(byte | 0x80); // more bytes follow
+        } else {
+            result.push(byte);
+            break;
+        }
+    }
+    result
+}
+
+/// Encode a signed integer as SLEB128.
+///
+/// # Example
+///
+/// ```
+/// use native_debug_info::encode_sleb128;
+///
+/// assert_eq!(encode_sleb128(0), vec![0x00]);
+/// assert_eq!(encode_sleb128(-1), vec![0x7F]);
+/// assert_eq!(encode_sleb128(63), vec![0x3F]);
+/// assert_eq!(encode_sleb128(-123456), vec![0xc0, 0xbb, 0x78]);
+/// ```
+pub fn encode_sleb128(mut value: i64) -> Vec<u8> {
+    let mut result = Vec::new();
+    let mut more = true;
+    while more {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        // We are done when:
+        // - value is 0 and the sign bit (bit 6) of byte is NOT set (positive done)
+        // - value is -1 and the sign bit (bit 6) of byte IS set (negative done)
+        if (value == 0 && (byte & 0x40) == 0) || (value == -1 && (byte & 0x40) != 0) {
+            more = false;
+            result.push(byte);
+        } else {
+            result.push(byte | 0x80);
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+/// Decode ULEB128 from `data` at `offset`.
+///
+/// Returns `(value, bytes_consumed)`.
+///
+/// Decoding stops safely at the end of `data`: if no terminating byte is
+/// found before the buffer ends, the function returns the partial value
+/// decoded so far together with `data.len() - offset` consumed bytes.
+/// Shift values beyond 63 bits are clamped so that bits are silently dropped
+/// rather than causing an arithmetic overflow.
+///
+/// # Example
+///
+/// ```
+/// use native_debug_info::decode_uleb128;
+///
+/// let (v, n) = decode_uleb128(&[0xe5, 0x8e, 0x26, 0xFF], 0);
+/// assert_eq!(v, 624485);
+/// assert_eq!(n, 3);
+/// ```
+pub fn decode_uleb128(data: &[u8], offset: usize) -> (u64, usize) {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    let mut consumed = 0usize;
+    loop {
+        // Bounds guard: stop if we have consumed all available bytes.
+        if offset + consumed >= data.len() {
+            break;
+        }
+        let byte = data[offset + consumed];
+        consumed += 1;
+        // Shift guard: a valid u64 ULEB128 is at most 10 bytes (70 bits).
+        // If shift would exceed 63, the remaining bits are outside the u64
+        // range and are silently dropped to prevent arithmetic overflow.
+        if shift < 64 {
+            result |= ((byte & 0x7F) as u64) << shift;
+        }
+        shift += 7;
+        if (byte & 0x80) == 0 {
+            break;
+        }
+    }
+    (result, consumed)
+}
+
+/// Decode SLEB128 from `data` at `offset`.
+///
+/// Returns `(value, bytes_consumed)`.
+///
+/// Like [`decode_uleb128`], decoding stops safely at end-of-buffer without
+/// panicking.  Shift values beyond 63 bits are clamped.
+///
+/// # Example
+///
+/// ```
+/// use native_debug_info::decode_sleb128;
+///
+/// let (v, n) = decode_sleb128(&[0xc0, 0xbb, 0x78], 0);
+/// assert_eq!(v, -123456);
+/// assert_eq!(n, 3);
+/// ```
+pub fn decode_sleb128(data: &[u8], offset: usize) -> (i64, usize) {
+    let mut result: i64 = 0;
+    let mut shift = 0u32;
+    let mut consumed = 0usize;
+    let mut last_byte = 0u8;
+    loop {
+        // Bounds guard: stop if we have consumed all available bytes.
+        if offset + consumed >= data.len() {
+            break;
+        }
+        let byte = data[offset + consumed];
+        consumed += 1;
+        last_byte = byte;
+        // Shift guard: silently drop bits beyond the i64 range.
+        if shift < 64 {
+            result |= ((byte & 0x7F) as i64) << shift;
+        }
+        shift += 7;
+        if (byte & 0x80) == 0 {
+            break;
+        }
+    }
+    // Sign-extend if the sign bit of the last byte is set.
+    if shift < 64 && (last_byte & 0x40) != 0 {
+        result |= -(1i64 << shift);
+    }
+    (result, consumed)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uleb128_zero() {
+        assert_eq!(encode_uleb128(0), [0x00]);
+    }
+
+    #[test]
+    fn uleb128_single_byte_max() {
+        assert_eq!(encode_uleb128(127), [0x7F]);
+    }
+
+    #[test]
+    fn uleb128_two_bytes_128() {
+        assert_eq!(encode_uleb128(128), [0x80, 0x01]);
+    }
+
+    #[test]
+    fn uleb128_624485() {
+        assert_eq!(encode_uleb128(624485), [0xe5, 0x8e, 0x26]);
+    }
+
+    #[test]
+    fn sleb128_zero() {
+        assert_eq!(encode_sleb128(0), [0x00]);
+    }
+
+    #[test]
+    fn sleb128_negative_one() {
+        assert_eq!(encode_sleb128(-1), [0x7F]);
+    }
+
+    #[test]
+    fn sleb128_positive_63() {
+        assert_eq!(encode_sleb128(63), [0x3F]);
+    }
+
+    #[test]
+    fn sleb128_negative_123456() {
+        assert_eq!(encode_sleb128(-123456), [0xc0, 0xbb, 0x78]);
+    }
+
+    #[test]
+    fn decode_uleb128_roundtrip() {
+        for val in [0u64, 1, 127, 128, 255, 624485, u32::MAX as u64] {
+            let encoded = encode_uleb128(val);
+            let (decoded, _) = decode_uleb128(&encoded, 0);
+            assert_eq!(decoded, val, "roundtrip failed for {val}");
+        }
+    }
+
+    #[test]
+    fn decode_uleb128_with_offset() {
+        let data = [0xFF, 0xe5, 0x8e, 0x26, 0xFF];
+        let (v, n) = decode_uleb128(&data, 1);
+        assert_eq!(v, 624485);
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn decode_sleb128_roundtrip() {
+        for val in [0i64, -1, 63, -64, 127, -128, -123456, i32::MAX as i64, i32::MIN as i64] {
+            let encoded = encode_sleb128(val);
+            let (decoded, _) = decode_sleb128(&encoded, 0);
+            assert_eq!(decoded, val, "roundtrip failed for {val}");
+        }
+    }
+
+    #[test]
+    fn decode_sleb128_negative_123456() {
+        let (v, n) = decode_sleb128(&[0xc0, 0xbb, 0x78], 0);
+        assert_eq!(v, -123456);
+        assert_eq!(n, 3);
+    }
+}

--- a/code/packages/rust/native-debug-info/src/lib.rs
+++ b/code/packages/rust/native-debug-info/src/lib.rs
@@ -1,0 +1,52 @@
+//! `native-debug-info` — DWARF 4 and CodeView 4 debug-section emitter (LANG14).
+//!
+//! This crate converts source-location data from a [`DebugSidecarReader`] into
+//! the native debug sections understood by gdb/lldb (DWARF 4) on Linux/macOS
+//! and WinDbg/Visual Studio (CodeView 4) on Windows.
+//!
+//! # Public API
+//!
+//! - [`DwarfEmitter`] — builds `.debug_abbrev`, `.debug_info`, `.debug_line`,
+//!   `.debug_str` and embeds them into an ELF64 or Mach-O 64-bit binary.
+//!
+//! - [`CodeViewEmitter`] — builds `.debug$S` and `.debug$T` and embeds them
+//!   into a PE32+ binary.
+//!
+//! - [`embed_debug_info`] — convenience dispatcher that auto-detects the target
+//!   platform and calls the correct emitter.
+//!
+//! - [`encode_uleb128`], [`encode_sleb128`], [`decode_uleb128`], [`decode_sleb128`]
+//!   — ULEB128 / SLEB128 encode/decode used by the DWARF emitter (also exported
+//!   for downstream packages that emit their own DWARF streams).
+//!
+//! # Pipeline position
+//!
+//! ```text
+//! aot-core.compile(module) → .aot binary + sidecar bytes
+//!   │
+//!   ↓ DebugSidecarReader::new(sidecar_bytes)
+//!   │
+//!   ├── DwarfEmitter::embed_in_elf(elf_bytes)     → ELF + DWARF
+//!   ├── DwarfEmitter::embed_in_macho(macho_bytes) → Mach-O + DWARF
+//!   └── CodeViewEmitter::embed_in_pe(pe_bytes)    → PE + CodeView
+//! ```
+//!
+//! # Quick start
+//!
+//! ```
+//! use native_debug_info::{encode_uleb128, decode_uleb128};
+//!
+//! let encoded = encode_uleb128(624485);
+//! let (decoded, _) = decode_uleb128(&encoded, 0);
+//! assert_eq!(decoded, 624485);
+//! ```
+
+pub mod codeview;
+pub mod dwarf;
+pub mod embed;
+pub mod leb128;
+
+pub use codeview::CodeViewEmitter;
+pub use dwarf::DwarfEmitter;
+pub use embed::{embed_debug_info, ArtifactInfo};
+pub use leb128::{decode_sleb128, decode_uleb128, encode_sleb128, encode_uleb128};


### PR DESCRIPTION
## Summary

- **LANG13 `debug-sidecar`** — compact JSON sidecar that maps IIR instruction indices to source locations and tracks variable liveness. Bridge between the AOT compiler and debugger/native-debug-info consumers.
  - `DebugSidecarWriter`: append-only builder with `add_source_file`, `begin/end_function`, `declare_variable`, `record`, `finish`
  - `DebugSidecarReader`: query engine with DWARF-style "last row ≤ N" bisect (`partition_point`), `find_instr`, `live_variables`, `raw_line_rows`
  - `SourceLocation` / `Variable` / `LineRow` public types; `SidecarError` with `Display + Error`
  - **43 tests** (38 unit + 5 doc-tests)

- **LANG14 `native-debug-info`** — DWARF 4 and CodeView 4 debug-section emitter.
  - `DwarfEmitter`: builds `.debug_abbrev` / `.debug_info` / `.debug_line` / `.debug_str`; embeds into ELF64 and Mach-O 64-bit
  - `CodeViewEmitter`: builds `.debug$S` / `.debug$T`; embeds into PE32+
  - `embed_debug_info`: one-call dispatcher, auto-detects target from `ArtifactInfo.target`
  - ULEB128/SLEB128 encode+decode exported for downstream packages
  - **42 tests** (36 unit + 6 doc-tests)

## Security hardening (4 MEDIUM issues found and fixed in review)

- **leb128 decoders**: explicit end-of-buffer guard (no panic on truncated stream) + shift-overflow guard (bits beyond 63 silently dropped instead of wrapping in release builds)
- **`embed_in_elf`**: ELF header length check (≥64 bytes), section header table bounds, `e_shstrndx < e_shnum`, and shstrtab extent — all using checked arithmetic before any slice index
- **`embed_in_pe`**: DOS stub length (≥64 bytes), COFF header length, optional header length, section table bounds via `checked_mul`/`checked_add`; `saturating_sub` for available-space calculation
- **`embed_in_macho`**: `cmdsize ≥ 8` and `lc_off + cmdsize ≤ data.len()` before advancing; section table extent check; `checked_add` for file offsets, reloff, ncmds, sizeofcmds

## Test plan

- [x] `cargo test -p debug-sidecar` — 43 tests pass
- [x] `cargo test -p native-debug-info` — 42 tests pass
- [x] Security review completed; all MEDIUM findings fixed
- [x] Low findings noted: `writer::finish()` uses `.expect()` on truly-infallible JSON serialisation (in-memory `Value` → `Vec<u8>`); no change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)