### PR TITLE
feat(twig): twig-clr-compiler — full TW03 Phase 1 surface (define, recursion, if, comparison) on real dotnet

### DIFF
--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -18,25 +18,39 @@ Pipeline
         ↓ dotnet <name>.exe   (real .NET runtime, net9.0)
     process exit code
 
-Why this is intentionally narrow (matches twig-beam-compiler v1)
-================================================================
+Calling convention notes
+========================
 
-The v1 surface is the intersection of what ``ir-to-cil-bytecode``
-already lowers and what makes for a useful smoke test through real
-``dotnet``: integer literals, binary arithmetic (+, -, *, /),
-single-binding ``let``, and ``begin`` for sequencing.
+The CIL backend's natural calling convention is **per-method
+locals**: each callable region (= method) gets a fresh
+``call_register_count``-wide local frame.  At a ``CALL`` site,
+all caller locals get pushed onto the operand stack as args,
+the callee receives them via ``ldarg``, copies them into its own
+locals, runs, and returns via ``ldloc 1; ret``.
 
-The contract: the value of the program's last top-level expression
-becomes the **process exit code** — matching how a C#
-``static int Main()`` returns to the shell.  ``run_source`` reports
-that exit code to the caller as ``ClrRunResult.returncode``.
+Critically, this gives us **automatic caller-saves** — the
+caller's locals (other than local 1, the return slot) are
+inviolate across a call.  The JVM backend needed JVM01's manual
+caller-saves only because it stored "registers" in a class-level
+static int array shared across method invocations; CIL has no
+such issue.
 
-Register / local convention
-===========================
+Register layout
+===============
 
-``ir-to-cil-bytecode``'s ``RET``/``HALT`` lowering reads
-``local 1`` and emits ``ret``.  We mirror that — the last
-expression's value lands in ``IrRegister(1)`` before ``RET``.
+Mirroring twig-jvm-compiler so the two compilers feel identical:
+
+* ``register 0`` — scratch (also CIL's syscall-arg slot).
+* ``register 1`` — function return value / HALT result
+  (the CIL backend's ``RET`` lowering reads ``ldloc 1``).
+* ``registers 2..N`` — function parameter slots (param ``i``
+  lives at register ``_REG_PARAM_BASE + i = 2 + i``).
+* ``registers 10..`` — compiler-allocated holding registers for
+  intermediate values; using a high base keeps them clear of
+  parameter slots, so nested calls don't clobber.
+
+This layout is shared with twig-jvm-compiler because both
+backends drive the same IR; only the lowering differs.
 """
 
 from __future__ import annotations
@@ -50,7 +64,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
-from cil_bytecode_builder import CILBytecodeBuilder
 from cli_assembly_writer import CLIAssemblyConfig, write_cli_assembly
 from compiler_ir import (
     IDGenerator,
@@ -64,9 +77,6 @@ from compiler_ir import (
 from ir_optimizer import IrOptimizer, OptimizationResult
 from ir_to_cil_bytecode import (
     CILBackendConfig,
-    CILMethodArtifact,
-    CILProgramArtifact,
-    SequentialCILTokenProvider,
     lower_ir_to_cil_bytecode,
 )
 from twig import (
@@ -78,11 +88,14 @@ from twig import (
 from twig.ast_nodes import (
     Apply,
     Begin,
+    BoolLit,
     Define,
     Expr,
+    If,
     IntLit,
     Lambda,
     Let,
+    NilLit,
     Program,
     SymLit,
     VarRef,
@@ -133,7 +146,7 @@ class ClrPackageError(TwigError):
 
 
 # ---------------------------------------------------------------------------
-# Builtins recognised in v1
+# Builtins
 # ---------------------------------------------------------------------------
 
 
@@ -142,35 +155,24 @@ _BINARY_OPS: dict[str, IrOp] = {
     "-": IrOp.SUB,
     "*": IrOp.MUL,
     "/": IrOp.DIV,
+    "=": IrOp.CMP_EQ,
+    "<": IrOp.CMP_LT,
+    ">": IrOp.CMP_GT,
 }
 
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {
-        "=",
-        "<",
-        ">",
-        "cons",
-        "car",
-        "cdr",
-        "null?",
-        "pair?",
-        "number?",
-        "symbol?",
-        "print",
-    }
+    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
 )
 
 
-# Register convention.  ``ir-to-cil-bytecode``'s ``RET`` lowering
-# reads ``local 1`` and emits ``ret``, so we land the final result
-# in ``IrRegister(1)``.  Holding registers start above the
-# return-value slot.
-_REG_RETURN: Final = 1
-_REG_HOLDING_BASE: Final = 2
+# Register convention — see module docstring.
+_REG_HALT_RESULT: Final = 1
+_REG_PARAM_BASE: Final = 2
+_REG_HOLDING_BASE: Final = 10
 
-# Strict allowlist for ``assembly_name`` — used as the on-disk
-# ``.exe`` filename and as the CLR module name.  Same defense
-# pattern ``twig-beam-compiler`` uses for ``module_name``.
+
+# Strict allowlist for ``assembly_name``.  Used as both an
+# on-disk filename component and a CLR module/type name.
 _SAFE_ASSEMBLY_NAME_RE: Final = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 
 
@@ -192,15 +194,11 @@ def _validate_assembly_name(name: str) -> None:
 
 @dataclass
 class _FnCtx:
-    """Mutable state during compilation of one IR region.
-
-    ``locals_`` maps Twig names from ``let`` bindings to the IR
-    register holding the bound value.  ``next_holding`` is the
-    next intermediate-value register to allocate.
-    """
+    """Mutable state during compilation of one IR region."""
 
     locals_: dict[str, IrRegister]
     next_holding: int = _REG_HOLDING_BASE
+    next_label: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -209,28 +207,103 @@ class _FnCtx:
 
 
 class _Compiler:
-    """Walk the Twig AST → ``IrProgram`` with a single ``main`` region."""
+    """Walk the typed Twig AST → ``IrProgram`` with one region per
+    top-level function plus a synthesised ``main`` for top-level
+    expressions.
+
+    Mirrors twig-jvm-compiler's structure intentionally — both
+    drive the same IR pipeline; only the lowering target differs.
+    """
 
     def __init__(self) -> None:
         self._program = IrProgram(entry_label="main")
         self._gen = IDGenerator()
+        self._value_consts: dict[str, int] = {}
+        self._fn_params: dict[str, list[str]] = {}
+        # Label counter is **program-wide**, not per-region.  The
+        # CIL backend validates label uniqueness across the entire
+        # IR program (sensible: jumps could in theory cross
+        # regions).  Per-region counters would produce duplicate
+        # ``_else_0`` labels for any program with two functions
+        # that both contain ``if``.
+        self._next_label_id = 0
 
     # ------------------------------------------------------------------
 
     def compile(self, program: Program) -> IrProgram:
+        top_level_exprs: list[Expr] = []
+        function_defs: list[tuple[str, Lambda]] = []
         for form in program.forms:
             if isinstance(form, Define):
-                raise TwigCompileError(
-                    "(define ...) is not yet supported by the CLR backend "
-                    "v1 — only top-level expressions.  See README for the "
-                    "v1 surface and roadmap."
-                )
+                self._classify_define(form)
+                if isinstance(form.expr, Lambda):
+                    function_defs.append((form.name, form.expr))
+            else:
+                top_level_exprs.append(form)
 
+        for name, lam in function_defs:
+            self._emit_function(name, lam)
+
+        self._emit_main(top_level_exprs)
+        return self._program
+
+    # ------------------------------------------------------------------
+
+    def _classify_define(self, form: Define) -> None:
+        if isinstance(form.expr, Lambda):
+            self._fn_params[form.name] = list(form.expr.params)
+            return
+
+        if isinstance(form.expr, IntLit):
+            self._value_consts[form.name] = int(form.expr.value)
+            return
+        if isinstance(form.expr, BoolLit):
+            self._value_consts[form.name] = 1 if form.expr.value else 0
+            return
+
+        raise TwigCompileError(
+            f"(define {form.name} ...) — v1 only supports literal "
+            "RHS for value defines.  Use a top-level function for "
+            "computed values."
+        )
+
+    # ------------------------------------------------------------------
+    # Function emission
+    # ------------------------------------------------------------------
+
+    def _emit_function(self, name: str, lam: Lambda) -> None:
+        self._emit(IrOp.LABEL, IrLabel(name=name), id=-1)
+
+        # Copy each parameter out of its arrival register
+        # (``_REG_PARAM_BASE + i``) into a fresh body-local
+        # holding register.  Mirrors the JVM01 paired fix in
+        # twig-jvm-compiler — keeps the IR shape uniform across
+        # both compilers.  CIL itself has automatic caller-saves
+        # so this isn't strictly necessary on CLR, but keeping
+        # the IR identical means downstream tooling treats both
+        # the same.
+        ctx = _FnCtx(locals_={})
+        for i, param in enumerate(lam.params):
+            arrival = IrRegister(index=_REG_PARAM_BASE + i)
+            body_local = self._fresh_holding(ctx)
+            self._emit_move(body_local, arrival)
+            ctx.locals_[param] = body_local
+
+        last: IrRegister | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            raise TwigCompileError(f"function {name!r} has empty body")
+
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.RET)
+
+    def _emit_main(self, exprs: list[Expr]) -> None:
         self._emit(IrOp.LABEL, IrLabel(name="main"), id=-1)
         ctx = _FnCtx(locals_={})
 
         last: IrRegister | None = None
-        for expr in program.forms:
+        for expr in exprs:
             last = self._compile_expr(expr, ctx)
 
         if last is None:
@@ -238,12 +311,8 @@ class _Compiler:
             self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
             last = zero
 
-        # Move the final result into the return register and close
-        # the region with RET.  The CIL backend's RET lowering
-        # reads ``local 1`` and emits ``ret``.
-        self._emit_move(IrRegister(_REG_RETURN), last)
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
         self._emit(IrOp.RET)
-        return self._program
 
     # ------------------------------------------------------------------
     # Expression compilation
@@ -255,13 +324,31 @@ class _Compiler:
             self._emit(IrOp.LOAD_IMM, reg, IrImmediate(int(expr.value)))
             return reg
 
+        if isinstance(expr, BoolLit):
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(1 if expr.value else 0))
+            return reg
+
+        if isinstance(expr, NilLit):
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(0))
+            return reg
+
         if isinstance(expr, VarRef):
-            try:
+            if expr.name in ctx.locals_:
                 return ctx.locals_[expr.name]
-            except KeyError as exc:
-                raise TwigCompileError(
-                    f"unbound name: {expr.name!r}"
-                ) from exc
+            if expr.name in self._value_consts:
+                reg = self._fresh_holding(ctx)
+                self._emit(
+                    IrOp.LOAD_IMM,
+                    reg,
+                    IrImmediate(self._value_consts[expr.name]),
+                )
+                return reg
+            raise TwigCompileError(f"unbound name: {expr.name!r}")
+
+        if isinstance(expr, If):
+            return self._compile_if(expr, ctx)
 
         if isinstance(expr, Let):
             return self._compile_let(expr, ctx)
@@ -274,41 +361,61 @@ class _Compiler:
 
         if isinstance(expr, Lambda):
             raise TwigCompileError(
-                "lambdas are not yet supported by the CLR backend v1 — "
-                "needs the multi-method / closure-class lowering planned "
-                "for TW02.5."
+                "anonymous lambdas are not yet supported by the CLR "
+                "backend — see TW03 Phase 2 for closures."
             )
 
         if isinstance(expr, SymLit):
             raise TwigCompileError(
-                "quoted symbols are not yet supported by the CLR backend "
-                "v1 — atoms-as-values needs heap support across backends."
+                "quoted symbols are not yet supported by the CLR "
+                "backend — see TW03 Phase 3."
             )
 
         msg = f"unsupported Twig form for CLR v1: {type(expr).__name__}"
         raise TwigCompileError(msg)
 
-    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
-        if len(expr.bindings) != 1:
-            raise TwigCompileError(
-                "(let ((name expr) ...) body) with multiple bindings is "
-                "not yet supported — v1 only handles a single binding"
-            )
-        name, value_expr = expr.bindings[0]
-        bound_reg = self._compile_expr(value_expr, ctx)
+    def _compile_if(self, expr: If, ctx: _FnCtx) -> IrRegister:
+        cond = self._compile_expr(expr.cond, ctx)
+        else_label = self._fresh_label(ctx, "else")
+        end_label = self._fresh_label(ctx, "endif")
+        result = self._fresh_holding(ctx)
 
-        previous = ctx.locals_.get(name)
-        ctx.locals_[name] = bound_reg
-        try:
-            last = self._compile_expr(expr.body[0], ctx)
-            for body_expr in expr.body[1:]:
-                last = self._compile_expr(body_expr, ctx)
-            return last
-        finally:
-            if previous is None:
+        self._emit(IrOp.BRANCH_Z, cond, IrLabel(else_label))
+
+        then_v = self._compile_expr(expr.then_branch, ctx)
+        self._emit_move(result, then_v)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+
+        self._emit(IrOp.LABEL, IrLabel(else_label), id=-1)
+        else_v = self._compile_expr(expr.else_branch, ctx)
+        self._emit_move(result, else_v)
+
+        self._emit(IrOp.LABEL, IrLabel(end_label), id=-1)
+        return result
+
+    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
+        binding_regs: list[tuple[str, IrRegister]] = []
+        for name, rhs in expr.bindings:
+            v = self._compile_expr(rhs, ctx)
+            binding_regs.append((name, v))
+
+        saved: dict[str, IrRegister | None] = {}
+        for name, reg in binding_regs:
+            saved[name] = ctx.locals_.get(name)
+            ctx.locals_[name] = reg
+
+        last: IrRegister | None = None
+        for e in expr.body:
+            last = self._compile_expr(e, ctx)
+        assert last is not None
+
+        for name, prior in saved.items():
+            if prior is None:
                 del ctx.locals_[name]
             else:
-                ctx.locals_[name] = previous
+                ctx.locals_[name] = prior
+
+        return last
 
     def _compile_begin(self, expr: Begin, ctx: _FnCtx) -> IrRegister:
         last: IrRegister | None = None
@@ -323,58 +430,86 @@ class _Compiler:
     def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
         if not isinstance(expr.fn, VarRef):
             raise TwigCompileError(
-                "v1 only supports calls to named builtins (no first-class "
-                "function values yet)"
+                "v1 only supports direct calls of top-level names"
             )
         name = expr.fn.name
+
         if name in _V1_REJECTED_BUILTINS:
             raise TwigCompileError(
-                f"builtin {name!r} is not yet supported by the CLR backend "
-                "v1 — needs branching / heap / I/O support"
+                f"builtin {name!r} is not yet supported by the CLR "
+                "backend — see TW03 Phase 3 for heap primitives."
             )
-        if name not in _BINARY_OPS:
-            raise TwigCompileError(f"unknown builtin: {name!r}")
-        if len(expr.args) != 2:
-            raise TwigCompileError(
-                f"{name!r} expects exactly 2 arguments, got {len(expr.args)}"
-            )
-        lhs = self._compile_expr(expr.args[0], ctx)
-        rhs = self._compile_expr(expr.args[1], ctx)
-        result = self._fresh_holding(ctx)
-        self._emit(_BINARY_OPS[name], result, lhs, rhs)
-        return result
+
+        if name in _BINARY_OPS:
+            if len(expr.args) != 2:
+                raise TwigCompileError(
+                    f"{name!r} expects 2 arguments, got {len(expr.args)}"
+                )
+            left = self._compile_expr(expr.args[0], ctx)
+            right = self._compile_expr(expr.args[1], ctx)
+            dest = self._fresh_holding(ctx)
+            self._emit(_BINARY_OPS[name], dest, left, right)
+            return dest
+
+        if name in self._fn_params:
+            params = self._fn_params[name]
+            if len(expr.args) != len(params):
+                raise TwigCompileError(
+                    f"function {name!r} takes {len(params)} arguments, "
+                    f"got {len(expr.args)}"
+                )
+
+            arg_regs: list[IrRegister] = [
+                self._compile_expr(a, ctx) for a in expr.args
+            ]
+
+            for i, src in enumerate(arg_regs):
+                self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+
+            self._emit(IrOp.CALL, IrLabel(name))
+
+            dest = self._fresh_holding(ctx)
+            self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+            return dest
+
+        raise TwigCompileError(
+            f"unknown function {name!r}.  v1 supports binary builtins "
+            "(+, -, *, /, =, <, >) and top-level (define (f ...) ...)."
+        )
 
     # ------------------------------------------------------------------
-    # Low-level emit helpers
+    # IR-emission helpers
     # ------------------------------------------------------------------
 
     def _emit(
         self,
-        op: IrOp,
+        opcode: IrOp,
         *operands: object,
         id: int | None = None,
     ) -> None:
         self._program.add_instruction(
             IrInstruction(
-                op,
-                list(operands),
+                opcode=opcode,
+                operands=list(operands),
                 id=self._gen.next() if id is None else id,
             )
         )
 
     def _emit_move(self, dst: IrRegister, src: IrRegister) -> None:
-        if dst.index == src.index:
+        if dst == src:
             return
-        # No MOVE op in compiler-ir; lower as ADD with a freshly
-        # zeroed register.  Same idiom ``twig-beam-compiler`` uses.
-        zero = IrRegister(index=1000)
-        self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
-        self._emit(IrOp.ADD, dst, src, zero)
+        self._emit(IrOp.ADD_IMM, dst, src, IrImmediate(0))
 
     def _fresh_holding(self, ctx: _FnCtx) -> IrRegister:
-        reg = IrRegister(index=ctx.next_holding)
+        idx = ctx.next_holding
         ctx.next_holding += 1
-        return reg
+        return IrRegister(index=idx)
+
+    def _fresh_label(self, ctx: _FnCtx, prefix: str) -> str:
+        # Program-wide counter (see ``__init__`` doc).
+        idx = self._next_label_id
+        self._next_label_id += 1
+        return f"_{prefix}_{idx}"
 
 
 # ---------------------------------------------------------------------------
@@ -418,8 +553,17 @@ def compile_source(
         optimized_ir = raw_ir
 
     try:
+        # ``call_register_count=None`` tells the CIL backend to
+        # auto-derive the call-arg count from ``plan.local_count``.
+        # The default of ``0`` would emit 0-parameter callable
+        # methods — which means arg-passing breaks silently:
+        # callee reads ldloc 2 expecting the arg but finds 0
+        # because no parameters were declared and no entry-copy
+        # ran.  ``None`` is the only correct setting for any
+        # program that calls user-defined functions with args.
         cil_program = lower_ir_to_cil_bytecode(
-            optimized_ir, CILBackendConfig()
+            optimized_ir,
+            CILBackendConfig(call_register_count=None),
         )
     except Exception as exc:
         raise ClrPackageError("lower-cil", str(exc), exc) from exc
@@ -464,11 +608,6 @@ def dotnet_available() -> bool:
 
 
 def _runtimeconfig_for_net9() -> str:
-    """Minimal ``<name>.runtimeconfig.json`` real .NET expects.
-
-    Without this file alongside the assembly, ``dotnet <name>.exe``
-    fails before even loading the PE because it can't pick a runtime.
-    """
     return json.dumps(
         {
             "runtimeOptions": {
@@ -491,10 +630,8 @@ def run_source(
 ) -> ClrRunResult:
     """Compile and execute on the **real** ``dotnet`` runtime.
 
-    Drops the ``.exe`` plus a ``runtimeconfig.json`` to a temp dir
-    and invokes ``dotnet <name>.exe``.  The process exit code IS
-    the program's result for v1 — same convention as a C#
-    ``static int Main()``.
+    The process exit code IS the program's result for v1 — same
+    convention as a C# ``static int Main()``.
     """
     compilation = compile_source(
         source, assembly_name=assembly_name, optimize=optimize

--- a/code/packages/python/twig-clr-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_compile.py
@@ -1,8 +1,8 @@
-"""Compile-time tests — no ``dotnet`` required.
+"""Compile-time tests for the upgraded twig-clr-compiler.
 
-Verifies the Twig → IR lowering produces sensible IR and rejects
-out-of-scope forms with clear error messages.  Real-``dotnet``
-end-to-end tests live in ``test_real_dotnet.py``.
+Verifies the Twig → IR lowering produces sensible IR for the
+TW03 Phase 1 surface (define, recursion, if, comparison) and
+rejects the still-out-of-scope forms with clear errors.
 """
 
 from __future__ import annotations
@@ -51,45 +51,115 @@ class TestSupportedSurface:
         ops = [ins.opcode for ins in ir.instructions]
         assert IrOp.MUL in ops
 
+    def test_if_emits_branch(self) -> None:
+        ir = compile_to_ir("(if (= 1 1) 100 200)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.BRANCH_Z in ops
+        assert IrOp.JUMP in ops
+        assert IrOp.CMP_EQ in ops
+
+    @pytest.mark.parametrize(
+        ("src", "op"),
+        [
+            ("(= 1 1)", IrOp.CMP_EQ),
+            ("(< 1 2)", IrOp.CMP_LT),
+            ("(> 2 1)", IrOp.CMP_GT),
+        ],
+    )
+    def test_comparison_emits_cmp(self, src: str, op: IrOp) -> None:
+        ir = compile_to_ir(src)
+        ops = [ins.opcode for ins in ir.instructions]
+        assert op in ops
+
+    def test_define_function_emits_call(self) -> None:
+        ir = compile_to_ir("(define (square x) (* x x)) (square 7)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.CALL in ops
+        # Two LABELs: one for square, one for main.
+        assert ops.count(IrOp.LABEL) >= 2
+
+    def test_recursive_function_compiles(self) -> None:
+        ir = compile_to_ir(
+            "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))"
+            "(fact 5)"
+        )
+        ops = [ins.opcode for ins in ir.instructions]
+        # At least 2 CALLs: the inner ``fact`` recursive call and
+        # the outer ``(fact 5)``.
+        assert ops.count(IrOp.CALL) >= 2
+        assert IrOp.BRANCH_Z in ops
+
+    def test_value_define_inlined(self) -> None:
+        ir = compile_to_ir("(define x 42) x")
+        ops = [ins.opcode for ins in ir.instructions]
+        # Value defines fold to compile-time constants — no extra
+        # callable region.  Just one LABEL for main.
+        assert ops.count(IrOp.LABEL) == 1
+
+    def test_mutual_recursion_compiles(self) -> None:
+        ir = compile_to_ir(
+            """
+            (define (even? n) (if (= n 0) 1 (odd? (- n 1))))
+            (define (odd? n) (if (= n 0) 0 (even? (- n 1))))
+            (even? 4)
+            """
+        )
+        # Confirm three callable regions (even?, odd?, main) by
+        # filtering for region-entry labels (no underscore prefix).
+        # Every ``if`` adds two synthetic ``_else_*`` / ``_endif_*``
+        # labels, so the raw LABEL count is much higher.
+        from compiler_ir import IrLabel
+        region_labels = [
+            ins.operands[0].name
+            for ins in ir.instructions
+            if ins.opcode is IrOp.LABEL
+            and isinstance(ins.operands[0], IrLabel)
+            and not ins.operands[0].name.startswith("_")
+        ]
+        assert region_labels == ["even?", "odd?", "main"]
+
 
 class TestRejectedSurface:
-    def test_define_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(define x 1)")
-
     def test_lambda_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="not yet supported"):
             compile_to_ir("(lambda (x) x)")
-
-    def test_comparison_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(= 1 1)")
 
     def test_unbound_name_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="unbound name"):
             compile_to_ir("foo")
 
-    def test_unknown_builtin_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="unknown builtin"):
+    def test_unknown_function_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="unknown function"):
             compile_to_ir("(weirdop 1 2)")
 
     def test_arity_mismatch_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="expects exactly 2"):
+        with pytest.raises(TwigCompileError, match="expects 2 arguments"):
             compile_to_ir("(+ 1 2 3)")
 
-    def test_multi_binding_let_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="multiple bindings"):
-            compile_to_ir("(let ((x 1) (y 2)) (+ x y))")
+    def test_function_arity_mismatch_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="takes 1 arguments"):
+            compile_to_ir("(define (id x) x) (id 1 2)")
 
     def test_quoted_symbol_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="quoted symbols"):
             compile_to_ir("'foo")
 
+    def test_cons_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(cons 1 2)")
+
+    def test_print_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(print 42)")
+
+    def test_non_literal_value_define_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="literal RHS"):
+            compile_to_ir("(define x (+ 1 2))")
+
 
 class TestCompileSourceShape:
     def test_returns_pe_bytes(self) -> None:
         result = compile_source("(+ 1 2)")
-        # PE/CLI files start with the MS-DOS ``MZ`` signature.
         assert result.assembly_bytes[:2] == b"MZ"
         assert result.assembly_name == "TwigProgram"
 
@@ -107,9 +177,7 @@ class TestCompileSourceShape:
 
 
 class TestAssemblyNameSecurity:
-    """Defends against path-traversal and CLR-name violations via
-    ``assembly_name``.  Same allowlist pattern as
-    ``twig-beam-compiler``'s ``module_name`` validation."""
+    """Defends against path-traversal and CLR-name violations."""
 
     def test_legal_name_accepted(self) -> None:
         result = compile_source("(+ 1 2)", assembly_name="Answer42")
@@ -118,12 +186,12 @@ class TestAssemblyNameSecurity:
     @pytest.mark.parametrize(
         "bad",
         [
-            "../etc_passwd",      # path-traversal style
-            "1Bad",                # digit start
-            "Has Space",           # space
-            "with;semicolon",      # punctuation
-            "",                     # empty
-            "a" * 65,              # too long
+            "../etc_passwd",
+            "1Bad",
+            "Has Space",
+            "with;semicolon",
+            "",
+            "a" * 65,
         ],
     )
     def test_unsafe_names_rejected(self, bad: str) -> None:

--- a/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
@@ -1,20 +1,8 @@
 """End-to-end Twig source → real ``dotnet`` execution tests.
 
-These tests require ``dotnet`` on PATH.  They are the headline
-proof that the Twig → CLR pipeline works end-to-end on real
-.NET 9.0+ — completing the Twig real-runtime trilogy alongside
-JVM and BEAM.
-
-Note on the result channel
-==========================
-
-For v1 the program's last expression value flows to the **process
-exit code** (matching how a C# ``static int Main()`` program works).
-That keeps the v1 surface tiny — no stdout / Console.WriteLine
-needed.  v2 adds explicit I/O.
-
-Exit codes are 32-bit signed integers, so we limit our v1 tests to
-small positive results.
+Headline TW03 Phase 1 proof: ``define``, ``if``, comparison,
+recursion all work on real .NET 9.0 — completing CLR parity
+with JVM01's factorial test on real ``java``.
 """
 
 from __future__ import annotations
@@ -29,49 +17,148 @@ requires_dotnet = pytest.mark.skipif(
 )
 
 
+# ── Arithmetic ─────────────────────────────────────────────────────────────
+
+
 @requires_dotnet
 def test_addition() -> None:
-    """``(+ 1 2)`` exits 3 from real dotnet."""
     result = run_source("(+ 1 2)", assembly_name="ClrAdd")
-    assert result.returncode == 3, (
-        f"dotnet rejected the assembly or returned wrong code:\n"
-        f"  exit={result.returncode}\n"
-        f"  stderr={result.stderr!r}"
-    )
+    assert result.returncode == 3, result.stderr
 
 
 @requires_dotnet
 def test_multiplication() -> None:
-    """``(* 6 7)`` exits 42."""
     result = run_source("(* 6 7)", assembly_name="ClrMul")
     assert result.returncode == 42, result.stderr
 
 
 @requires_dotnet
 def test_subtraction() -> None:
-    """``(- 10 3)`` exits 7."""
     result = run_source("(- 10 3)", assembly_name="ClrSub")
     assert result.returncode == 7, result.stderr
 
 
 @requires_dotnet
 def test_division() -> None:
-    """``(/ 10 2)`` exits 5."""
     result = run_source("(/ 10 2)", assembly_name="ClrDiv")
     assert result.returncode == 5, result.stderr
 
 
 @requires_dotnet
 def test_let_binding() -> None:
-    """``(let ((x 5)) (* x x))`` exits 25."""
     result = run_source("(let ((x 5)) (* x x))", assembly_name="ClrLet")
     assert result.returncode == 25, result.stderr
 
 
 @requires_dotnet
 def test_nested_arithmetic() -> None:
-    """``(+ (* 6 7) (* 2 3))`` exits 48."""
     result = run_source(
         "(+ (* 6 7) (* 2 3))", assembly_name="ClrNested"
     )
     assert result.returncode == 48, result.stderr
+
+
+# ── if / comparison ────────────────────────────────────────────────────────
+
+
+@requires_dotnet
+def test_if_taken_branch() -> None:
+    result = run_source("(if (= 1 1) 100 200)", assembly_name="ClrIfT")
+    assert result.returncode == 100, result.stderr
+
+
+@requires_dotnet
+def test_if_not_taken_branch() -> None:
+    result = run_source("(if (= 1 2) 100 200)", assembly_name="ClrIfF")
+    assert result.returncode == 200, result.stderr
+
+
+@requires_dotnet
+def test_comparison_lt() -> None:
+    result = run_source("(if (< 3 5) 1 0)", assembly_name="ClrLt")
+    assert result.returncode == 1, result.stderr
+
+
+@requires_dotnet
+def test_comparison_gt() -> None:
+    result = run_source("(if (> 3 5) 1 0)", assembly_name="ClrGt")
+    assert result.returncode == 0, result.stderr
+
+
+# ── define + function calls ────────────────────────────────────────────────
+
+
+@requires_dotnet
+def test_top_level_function() -> None:
+    """``(define (square x) (* x x)) (square 7) → 49``."""
+    result = run_source(
+        "(define (square x) (* x x)) (square 7)",
+        assembly_name="ClrSquare",
+    )
+    assert result.returncode == 49, result.stderr
+
+
+@requires_dotnet
+def test_two_param_function() -> None:
+    result = run_source(
+        "(define (add3 a b) (+ a (+ b 3))) (add3 10 20)",
+        assembly_name="ClrAdd3",
+    )
+    assert result.returncode == 33, result.stderr
+
+
+@requires_dotnet
+def test_top_level_value_define_inlined() -> None:
+    result = run_source("(define x 42) x", assembly_name="ClrVal")
+    assert result.returncode == 42, result.stderr
+
+
+@requires_dotnet
+def test_nested_function_calls() -> None:
+    result = run_source(
+        """
+        (define (inc x) (+ x 1))
+        (define (dbl x) (* x 2))
+        (inc (dbl 5))
+        """,
+        assembly_name="ClrNestedFn",
+    )
+    assert result.returncode == 11, result.stderr
+
+
+# ── recursion ──────────────────────────────────────────────────────────────
+
+
+@requires_dotnet
+def test_recursion_factorial() -> None:
+    """``(fact 5) → 120`` — the headline TW03 Phase 1 test.
+
+    Proves recursion works on real ``dotnet``, completing parity
+    with JVM01's ``test_recursion_factorial`` on real ``java``.
+    """
+    result = run_source(
+        """
+        (define (fact n)
+          (if (= n 0) 1 (* n (fact (- n 1)))))
+        (fact 5)
+        """,
+        assembly_name="ClrFact",
+    )
+    assert result.returncode == 120, (
+        f"factorial mismatch — exit {result.returncode}, "
+        f"stderr={result.stderr!r}"
+    )
+
+
+@requires_dotnet
+def test_mutual_recursion_even_odd() -> None:
+    """``(even? 4) → 1``."""
+    result = run_source(
+        """
+        (define (even? n) (if (= n 0) 1 (odd? (- n 1))))
+        (define (odd? n) (if (= n 0) 0 (even? (- n 1))))
+        (even? 4)
+        """,
+        assembly_name="ClrEvenOdd",
+    )
+    assert result.returncode == 1, result.stderr


### PR DESCRIPTION
## Summary

**Supersedes #1693** with the full TW03 Phase 1 surface in a single PR rather than v1 (arithmetic only) + follow-up.

Closes the language-surface gap on the CLR backend so Twig source has the same expressive power on real `dotnet` as it does on real `java` (post-JVM01):

- Top-level `define` for both functions and value constants
- Recursion (incl. mutual recursion)
- `if` / `else`
- Comparison: `=`, `<`, `>`
- Plus everything from the v1: arithmetic, `let`, `begin`

## Headline test

```python
>>> from twig_clr_compiler import run_source
>>> run_source(
...   "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) (fact 5)",
...   assembly_name="ClrFact",
... ).returncode
120
```

This matches JVM01's `test_recursion_factorial` on real `java` — **byte-for-byte parity between the JVM and CLR Twig real-runtime tracks**.

## What this advances

- Closes [TW03](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/TW03-lisp-primitives-and-gc.md) **Phase 1** for CLR.
- Phase 1 for BEAM is the next follow-up PR.

## Notable fix in the CIL backend usage

`CILBackendConfig.call_register_count` defaults to `0`, which silently emits 0-parameter callable methods — arg passing dies, callees read uninitialised locals, programs return 0 with no error. Fix is one line: pass `call_register_count=None` to derive the count from `plan.local_count`. Documented inline so future twig-* compilers don't fall into the same trap.

## Test coverage

**50 tests, 88% line coverage**:

- `test_compile.py` — full Phase 1 surface compiles to expected IR (BRANCH_Z, JUMP, CMP_*, CALL, multi-region). Rejected forms (lambda, cons, print, symbols) raise clear errors. Security: 7 parametrised tests for `assembly_name` allowlist.
- `test_real_dotnet.py` (skipped without `dotnet`) — **16 end-to-end smokes** including:
  - 6 arithmetic + let
  - 4 if / comparison
  - 4 define + multi-arg + nested calls + value-define inlining
  - **2 recursion**: `(fact 5) → 120` and `(even? 4) → 1` (mutual)

All confirmed passing on local `dotnet 9.0.313`.

## Test plan

- [x] 50/50 tests pass locally (incl. 16 real-`dotnet` smokes)
- [x] `build-tool -validate-build-files` — clean
- [x] `/security-review` — passed
- [ ] CI confirmation across runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)