### PR TITLE
feat(rust): LANG10 — code-packager: cross-platform binary packaging

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -346,6 +346,7 @@ members = [
     "ir-to-intel-4004-compiler",
     "intel-4004-assembler",
     "intel-4004-packager",
+    "code-packager",
     "nib-compiler",
     "nib-jvm-compiler",
     "bitset-c",

--- a/code/packages/rust/code-packager/BUILD
+++ b/code/packages/rust/code-packager/BUILD
@@ -1,0 +1,2 @@
+cargo build -p code-packager
+cargo test -p code-packager

--- a/code/packages/rust/code-packager/CHANGELOG.md
+++ b/code/packages/rust/code-packager/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog — code-packager
+
+All notable changes to this crate will be documented here.
+
+## [0.1.0] — 2026-04-28
+
+### Added
+
+- **`Target`** — immutable description of a compilation target with factory methods:
+  - `linux_x64()`, `linux_arm64()` → ELF64 targets
+  - `macos_x64()`, `macos_arm64()` → Mach-O 64-bit targets
+  - `windows_x64()` → PE32+ target
+  - `wasm()` → WebAssembly target
+  - `raw(arch)` → bare binary target (any arch)
+  - `intel_4004()`, `intel_8008()` → Intel HEX ROM targets
+  - `Display` impl: `"arch-os-binary_format"`
+
+- **`CodeArtifact`** — handoff object between a compilation backend and a packager.
+  - `native_bytes: Vec<u8>`, `entry_point: usize`, `target: Target`
+  - `symbol_table: HashMap<String, usize>`, `metadata: HashMap<String, MetadataValue>`
+  - Builder: `with_symbol_table()`, `with_metadata()`
+  - Metadata accessors: `metadata_int()`, `metadata_str()`, `metadata_list()`
+
+- **`MetadataValue`** — untyped metadata union: `Int(i64)`, `Str(String)`, `List(Vec<String>)`
+
+- **`PackagerError`** — error enum:
+  - `UnsupportedTarget(String)` — no packager handles this target
+  - `WasmEncodeError(String)` — WASM module encoding failed
+
+- **`elf64` module** — `Elf64Packager` producing a minimal ELF64 executable.
+  - 64-byte ELF header + 56-byte `PT_LOAD` program header (one segment)
+  - Entry virtual address = `load_address + 120 + entry_point`
+  - `e_machine = 62` (x86_64) or `183` (AArch64) from `target.arch`
+  - Default `load_address = 0x400000`; override via `metadata["load_address"]`
+  - Supported: `linux_x64()`, `linux_arm64()`
+
+- **`macho64` module** — `Macho64Packager` producing a minimal Mach-O 64-bit executable.
+  - `mach_header_64` (32 bytes) + `LC_SEGMENT_64` + `section_64` `__TEXT/__text` + `LC_MAIN`
+  - `cputype = 16777223` (x86_64) or `16777228` (ARM64)
+  - Default `load_address = 0x100000000`; override via metadata
+  - Supported: `macos_x64()`, `macos_arm64()`
+
+- **`pe` module** — `PePackager` producing a minimal PE32+ executable.
+  - 64-byte DOS stub + 4-byte PE signature + 20-byte COFF header + 240-byte optional header
+  - One `.text` section at RVA `0x1000`, file alignment `0x200`
+  - `ImageBase = 0x140000000`, section alignment `0x1000`
+  - `AddressOfEntryPoint = 0x1000 + entry_point`
+  - Supported: `windows_x64()`
+
+- **`raw` module** — pass-through; returns `native_bytes` unchanged.
+  - Any target with `binary_format == "raw"` is accepted.
+
+- **`intel_hex` module** — Intel HEX encoder.
+  - `encode_intel_hex(data: &[u8], origin: u16) -> String`
+  - Data records of up to 16 bytes; two's-complement checksum per record
+  - `origin` from `metadata["origin"]` (default 0)
+  - Supported: `intel_4004()`, `intel_8008()`
+
+- **`wasm` module** — wraps function body bytes in a minimal WASM module.
+  - Type section: `() → i32`; single exported function
+  - Export name from `metadata["exports"][0]` (default `"main"`)
+  - Uses `wasm-module-encoder::encode_module`
+  - Supported: `wasm()`
+
+- **`PackagerRegistry`** — static dispatcher by `binary_format`.
+  - `PackagerRegistry::pack(artifact)` — dispatches to the correct packager
+  - `PackagerRegistry::file_extension(target)` — returns file suffix
+
+- **95 tests**: 86 unit tests across all modules + 9 doc-tests.

--- a/code/packages/rust/code-packager/Cargo.toml
+++ b/code/packages/rust/code-packager/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "code-packager"
+version = "0.1.0"
+edition = "2021"
+description = "Cross-platform binary packaging for compiled code (LANG10)"
+license = "MIT"
+
+[dependencies]
+wasm-types = { path = "../wasm-types" }
+wasm-module-encoder = { path = "../wasm-module-encoder" }
+
+[dev-dependencies]

--- a/code/packages/rust/code-packager/README.md
+++ b/code/packages/rust/code-packager/README.md
@@ -1,0 +1,111 @@
+# code-packager
+
+Cross-platform binary packaging for compiled code (LANG10).
+
+`code-packager` is the **final stage of the ahead-of-time compilation pipeline**.
+It takes a `CodeArtifact` — raw machine code bytes produced by any backend —
+and wraps it in the appropriate OS-specific binary format. Cross-compilation
+is first-class: a Mac can produce a Linux ELF, a CI machine can produce a
+Windows PE, a Pi can produce a WASM module.
+
+## Pipeline position
+
+```text
+aot-core.compile(module)
+  → CodeArtifact(native_bytes, entry_point, target, symbol_table)
+  │
+  └──▶ PackagerRegistry::pack(&artifact)
+         │
+         ├── "elf64"     → Elf64Packager     → Linux ELF64 executable
+         ├── "macho64"   → Macho64Packager   → macOS Mach-O 64 executable
+         ├── "pe"        → PePackager        → Windows PE32+ executable
+         ├── "wasm"      → WasmPackager      → WebAssembly module
+         ├── "raw"       → RawPackager       → bare binary (embedded)
+         └── "intel_hex" → IntelHexPackager  → Intel HEX ROM image
+```
+
+## Quick start
+
+```rust
+use code_packager::{CodeArtifact, PackagerRegistry, Target};
+
+// A tiny x86-64 function: xor rax, rax; ret
+let code = b"\x48\x31\xc0\xc3".to_vec();
+let artifact = CodeArtifact::new(code, 0, Target::linux_x64());
+let elf_bytes = PackagerRegistry::pack(&artifact).unwrap();
+assert_eq!(&elf_bytes[..4], b"\x7fELF");
+```
+
+## Supported targets
+
+| Factory method | `binary_format` | Packager |
+|----------------|----------------|----------|
+| `Target::linux_x64()` | `elf64` | `Elf64Packager` |
+| `Target::linux_arm64()` | `elf64` | `Elf64Packager` |
+| `Target::macos_x64()` | `macho64` | `Macho64Packager` |
+| `Target::macos_arm64()` | `macho64` | `Macho64Packager` |
+| `Target::windows_x64()` | `pe` | `PePackager` |
+| `Target::wasm()` | `wasm` | `WasmPackager` |
+| `Target::raw(arch)` | `raw` | `RawPackager` |
+| `Target::intel_4004()` | `intel_hex` | `IntelHexPackager` |
+| `Target::intel_8008()` | `intel_hex` | `IntelHexPackager` |
+
+## Metadata keys
+
+Packager-specific hints are passed through `CodeArtifact::metadata`:
+
+| Key | Type | Packager | Description |
+|-----|------|----------|-------------|
+| `load_address` | `Int` | ELF64, Mach-O64 | Override virtual load address |
+| `origin` | `Int` | Intel HEX | ROM start address (default 0) |
+| `exports` | `List` | WASM | Function export names (first used) |
+
+## Binary format details
+
+### ELF64 (Linux)
+
+Minimal single-segment ELF64 (`ET_EXEC`):
+- 64-byte ELF header + 56-byte `PT_LOAD` program header + code
+- Entry = `load_address + 120 + entry_point`
+- Default `load_address = 0x400000`
+
+### Mach-O 64-bit (macOS)
+
+Minimal Mach-O executable (`MH_EXECUTE`):
+- 32-byte `mach_header_64` + `LC_SEGMENT_64` + `section_64 __TEXT/__text` + `LC_MAIN`
+- Default `load_address = 0x100000000` (arm64/x86_64 standard)
+
+### PE32+ (Windows)
+
+Minimal PE32+ console executable:
+- 64-byte DOS stub + PE signature + 20-byte COFF header + 240-byte optional header
+- One `.text` section at RVA `0x1000`, file-aligned to 512 bytes
+
+### WASM
+
+Minimal WASM 1.0 module wrapping the function body:
+- Type: `() → i32`; single exported function named `"main"` (or first `exports` entry)
+
+### Intel HEX
+
+Standard Intel HEX records:
+- Data records of up to 16 bytes each, with two's-complement checksum
+- `origin` offset from metadata (default 0)
+
+## Build
+
+```bash
+cargo build -p code-packager
+cargo test -p code-packager
+```
+
+## Dependencies
+
+| Crate | Use |
+|-------|-----|
+| `wasm-types` | `WasmModule`, `FuncType`, etc. |
+| `wasm-module-encoder` | `encode_module` — WASM binary serialization |
+
+## Tests
+
+95 tests: 86 unit tests across all modules + 9 doc-tests.

--- a/code/packages/rust/code-packager/src/artifact.rs
+++ b/code/packages/rust/code-packager/src/artifact.rs
@@ -1,0 +1,281 @@
+//! The `CodeArtifact` — the packager's input.
+//!
+//! A `CodeArtifact` carries everything the packager needs to wrap native bytes
+//! into an OS-specific binary:
+//!
+//! - **`native_bytes`** — the raw machine code produced by a code generator.
+//! - **`entry_point`** — byte offset into `native_bytes` where execution starts.
+//! - **`target`** — which CPU and OS the bytes are meant for.
+//! - **`symbol_table`** — optional map from symbol names to byte offsets.
+//! - **`metadata`** — open-ended key/value store for packager-specific hints
+//!   (e.g. `"load_address"`, `"origin"`, `"exports"`).
+//!
+//! ## Metadata values
+//!
+//! Three value kinds cover the packager's needs:
+//!
+//! ```text
+//! MetadataValue
+//! ├── Int(i64)          — numeric hint, e.g. load_address = 0x400000
+//! ├── Str(String)       — string hint, e.g. subsystem = "console"
+//! └── List(Vec<String>) — list hint, e.g. exports = ["main", "add"]
+//! ```
+//!
+//! ## Builder pattern
+//!
+//! ```rust
+//! use code_packager::{CodeArtifact, MetadataValue, Target};
+//! use std::collections::HashMap;
+//!
+//! let artifact = CodeArtifact::new(vec![0x90], 0, Target::linux_x64())
+//!     .with_metadata({
+//!         let mut m = HashMap::new();
+//!         m.insert("load_address".into(), MetadataValue::Int(0x600000));
+//!         m
+//!     });
+//! assert_eq!(artifact.metadata_int("load_address", 0x400000), 0x600000);
+//! ```
+
+use std::collections::HashMap;
+
+use crate::target::Target;
+
+// ── MetadataValue ─────────────────────────────────────────────────────────────
+
+/// A typed metadata value attached to a `CodeArtifact`.
+///
+/// Metadata is used to pass packager-specific hints that are not part of the
+/// core artifact (e.g. a custom load address, a list of function exports, or
+/// a subsystem identifier for Windows PE files).
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetadataValue {
+    /// A signed 64-bit integer (covers all address-sized values).
+    Int(i64),
+    /// A UTF-8 string value.
+    Str(String),
+    /// A list of UTF-8 strings (e.g. WASM export names).
+    List(Vec<String>),
+}
+
+// ── CodeArtifact ──────────────────────────────────────────────────────────────
+
+/// The input to the packager: native bytes plus everything needed to wrap them.
+///
+/// ```text
+/// CodeArtifact
+/// │
+/// ├── native_bytes  ─ the raw machine code
+/// │                   e.g. [0x55, 0x48, 0x89, 0xE5, ...]  (x86-64 prologue)
+/// │
+/// ├── entry_point   ─ byte offset into native_bytes where execution begins
+/// │                   (0 = first byte is the entry point)
+/// │
+/// ├── target        ─ Target { arch, os, binary_format }
+/// │
+/// ├── symbol_table  ─ { "main" → 0, "add" → 48, ... }
+/// │
+/// └── metadata      ─ { "load_address" → Int(0x400000), "exports" → List([...]) }
+/// ```
+pub struct CodeArtifact {
+    /// Raw machine-code bytes produced by the code generator.
+    pub native_bytes: Vec<u8>,
+    /// Byte offset (0-based) into `native_bytes` where the CPU starts executing.
+    pub entry_point: usize,
+    /// Which CPU and OS this code targets.
+    pub target: Target,
+    /// Maps symbol names to byte offsets within `native_bytes`.
+    pub symbol_table: HashMap<String, usize>,
+    /// Open-ended packager hints, keyed by string.
+    pub metadata: HashMap<String, MetadataValue>,
+}
+
+impl CodeArtifact {
+    // ── Constructors ──────────────────────────────────────────────────────────
+
+    /// Create a minimal artifact with empty `symbol_table` and `metadata`.
+    ///
+    /// # Arguments
+    ///
+    /// * `native_bytes` — the raw machine code.
+    /// * `entry_point` — byte offset of the first instruction.
+    /// * `target` — the compilation target.
+    pub fn new(native_bytes: Vec<u8>, entry_point: usize, target: Target) -> Self {
+        Self {
+            native_bytes,
+            entry_point,
+            target,
+            symbol_table: HashMap::new(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    // ── Builder methods ───────────────────────────────────────────────────────
+
+    /// Attach a symbol table and return `self` (builder style).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use code_packager::{CodeArtifact, Target};
+    /// use std::collections::HashMap;
+    ///
+    /// let mut st = HashMap::new();
+    /// st.insert("main".into(), 0usize);
+    /// let artifact = CodeArtifact::new(vec![], 0, Target::linux_x64())
+    ///     .with_symbol_table(st);
+    /// assert_eq!(artifact.symbol_table["main"], 0);
+    /// ```
+    pub fn with_symbol_table(mut self, st: HashMap<String, usize>) -> Self {
+        self.symbol_table = st;
+        self
+    }
+
+    /// Attach metadata and return `self` (builder style).
+    pub fn with_metadata(mut self, md: HashMap<String, MetadataValue>) -> Self {
+        self.metadata = md;
+        self
+    }
+
+    // ── Metadata accessors ────────────────────────────────────────────────────
+
+    /// Read an `Int` metadata value, falling back to `default` if absent or wrong type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use code_packager::{CodeArtifact, MetadataValue, Target};
+    /// use std::collections::HashMap;
+    ///
+    /// let mut m = HashMap::new();
+    /// m.insert("load_address".into(), MetadataValue::Int(0x600000));
+    /// let artifact = CodeArtifact::new(vec![], 0, Target::raw("x86_64"))
+    ///     .with_metadata(m);
+    ///
+    /// assert_eq!(artifact.metadata_int("load_address", 0), 0x600000);
+    /// assert_eq!(artifact.metadata_int("missing", 42),    42);
+    /// ```
+    pub fn metadata_int(&self, key: &str, default: i64) -> i64 {
+        match self.metadata.get(key) {
+            Some(MetadataValue::Int(n)) => *n,
+            _ => default,
+        }
+    }
+
+    /// Read a `Str` metadata value, falling back to `default` if absent or wrong type.
+    ///
+    /// Returns an owned `String` so callers do not need to worry about lifetimes.
+    pub fn metadata_str(&self, key: &str, default: &str) -> String {
+        match self.metadata.get(key) {
+            Some(MetadataValue::Str(s)) => s.clone(),
+            _ => default.to_string(),
+        }
+    }
+
+    /// Read a `List` metadata value. Returns an empty `Vec` if absent or wrong type.
+    pub fn metadata_list(&self, key: &str) -> Vec<String> {
+        match self.metadata.get(key) {
+            Some(MetadataValue::List(v)) => v.clone(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test 1: new() produces empty symbol_table and metadata
+    #[test]
+    fn new_has_empty_symbol_table_and_metadata() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        assert!(art.symbol_table.is_empty());
+        assert!(art.metadata.is_empty());
+        assert_eq!(art.native_bytes, vec![0x90]);
+        assert_eq!(art.entry_point, 0);
+    }
+
+    // Test 2: with_symbol_table builder
+    #[test]
+    fn with_symbol_table_builder() {
+        let mut st = HashMap::new();
+        st.insert("main".into(), 0usize);
+        st.insert("add".into(), 16usize);
+        let art = CodeArtifact::new(vec![], 0, Target::linux_x64())
+            .with_symbol_table(st);
+        assert_eq!(art.symbol_table["main"], 0);
+        assert_eq!(art.symbol_table["add"], 16);
+    }
+
+    // Test 3: metadata_int default when absent
+    #[test]
+    fn metadata_int_default_when_absent() {
+        let art = CodeArtifact::new(vec![], 0, Target::linux_x64());
+        assert_eq!(art.metadata_int("load_address", 0x400000), 0x400000);
+    }
+
+    // Test 4: metadata_int returns stored value
+    #[test]
+    fn metadata_int_stored_value() {
+        let mut m = HashMap::new();
+        m.insert("load_address".into(), MetadataValue::Int(0x600000));
+        let art = CodeArtifact::new(vec![], 0, Target::linux_x64()).with_metadata(m);
+        assert_eq!(art.metadata_int("load_address", 0), 0x600000);
+    }
+
+    // Test 5: metadata_int falls back when type mismatch
+    #[test]
+    fn metadata_int_type_mismatch_falls_back() {
+        let mut m = HashMap::new();
+        m.insert("key".into(), MetadataValue::Str("not a number".into()));
+        let art = CodeArtifact::new(vec![], 0, Target::linux_x64()).with_metadata(m);
+        assert_eq!(art.metadata_int("key", 99), 99);
+    }
+
+    // Test 6: metadata_str default when absent
+    #[test]
+    fn metadata_str_default_when_absent() {
+        let art = CodeArtifact::new(vec![], 0, Target::linux_x64());
+        assert_eq!(art.metadata_str("subsystem", "console"), "console");
+    }
+
+    // Test 7: metadata_str stored value
+    #[test]
+    fn metadata_str_stored_value() {
+        let mut m = HashMap::new();
+        m.insert("subsystem".into(), MetadataValue::Str("windows".into()));
+        let art = CodeArtifact::new(vec![], 0, Target::windows_x64()).with_metadata(m);
+        assert_eq!(art.metadata_str("subsystem", "console"), "windows");
+    }
+
+    // Test 8: metadata_list default when absent
+    #[test]
+    fn metadata_list_default_when_absent() {
+        let art = CodeArtifact::new(vec![], 0, Target::wasm());
+        assert!(art.metadata_list("exports").is_empty());
+    }
+
+    // Test 9: metadata_list stored value
+    #[test]
+    fn metadata_list_stored_value() {
+        let mut m = HashMap::new();
+        m.insert(
+            "exports".into(),
+            MetadataValue::List(vec!["main".into(), "add".into()]),
+        );
+        let art = CodeArtifact::new(vec![], 0, Target::wasm()).with_metadata(m);
+        let list = art.metadata_list("exports");
+        assert_eq!(list, vec!["main", "add"]);
+    }
+
+    // Test 10: with_metadata replaces all metadata
+    #[test]
+    fn with_metadata_replaces() {
+        let mut m = HashMap::new();
+        m.insert("origin".into(), MetadataValue::Int(0x1000));
+        let art = CodeArtifact::new(vec![], 0, Target::intel_4004()).with_metadata(m);
+        assert_eq!(art.metadata_int("origin", 0), 0x1000);
+        assert_eq!(art.metadata_int("load_address", 42), 42); // absent
+    }
+}

--- a/code/packages/rust/code-packager/src/elf64.rs
+++ b/code/packages/rust/code-packager/src/elf64.rs
@@ -126,7 +126,15 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
 
     // Read the load address from metadata or use the conventional Linux default.
     // 0x400000 is where Linux traditionally maps the first LOAD segment.
-    let load_addr = artifact.metadata_int("load_address", 0x400000) as u64;
+    // Reject negative values: a negative load_address would silently cast to
+    // a huge u64 (two's-complement), embedding a nonsensical virtual address.
+    let load_addr_i = artifact.metadata_int("load_address", 0x400000);
+    if load_addr_i < 0 {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "elf64 packager: load_address must be non-negative, got {load_addr_i}"
+        )));
+    }
+    let load_addr = load_addr_i as u64;
 
     let code_len = artifact.native_bytes.len() as u64;
     let file_size = HEADER_TOTAL + code_len; // p_filesz and p_memsz

--- a/code/packages/rust/code-packager/src/elf64.rs
+++ b/code/packages/rust/code-packager/src/elf64.rs
@@ -1,0 +1,313 @@
+//! ELF64 executable packager.
+//!
+//! Produces a minimal, single-load-segment ELF64 binary that the Linux kernel
+//! can `execve()`. The output has no sections, no dynamic linking, and no debug
+//! info — only the program headers the kernel needs to map and run the code.
+//!
+//! ## ELF64 binary layout
+//!
+//! ```text
+//! Offset │ Size │ Content
+//! ───────┼──────┼────────────────────────────────────────────────────────────
+//!      0 │  64  │ ELF header (e_ident + fields)
+//!     64 │  56  │ Program header #0 (PT_LOAD, the only segment)
+//!    120 │   N  │ native_bytes (the machine code)
+//! ```
+//!
+//! Total file size = 120 + len(native_bytes).
+//!
+//! ## ELF header breakdown (64 bytes)
+//!
+//! ```text
+//! Offset │ Size │ Field          │ Value
+//! ───────┼──────┼────────────────┼───────────────────────────────────────────
+//!      0 │  4   │ e_ident magic  │ 0x7F 0x45 0x4C 0x46  ("\x7FELF")
+//!      4 │  1   │ EI_CLASS       │ 2 = ELFCLASS64 (64-bit)
+//!      5 │  1   │ EI_DATA        │ 1 = ELFDATA2LSB (little-endian)
+//!      6 │  1   │ EI_VERSION     │ 1 = EV_CURRENT
+//!      7 │  8   │ EI_OSABI + pad │ 0 = ELFOSABI_NONE
+//!     15 │  1   │ padding        │ 0
+//!     16 │  2   │ e_type         │ 2 = ET_EXEC (executable)
+//!     18 │  2   │ e_machine      │ 62 = EM_X86_64  |  183 = EM_AARCH64
+//!     20 │  4   │ e_version      │ 1 = EV_CURRENT
+//!     24 │  8   │ e_entry        │ virtual address of first instruction
+//!     32 │  8   │ e_phoff        │ 64 (program header offset)
+//!     40 │  8   │ e_shoff        │ 0 (no section headers)
+//!     48 │  4   │ e_flags        │ 0
+//!     52 │  2   │ e_ehsize       │ 64 (size of this header)
+//!     54 │  2   │ e_phentsize    │ 56 (size of one program header entry)
+//!     56 │  2   │ e_phnum        │ 1 (one program header)
+//!     58 │  2   │ e_shentsize    │ 64 (size of one section header, unused)
+//!     60 │  2   │ e_shnum        │ 0 (no section headers)
+//!     62 │  2   │ e_shstrndx     │ 0 (no section name table)
+//! ```
+//!
+//! ## PT_LOAD program header breakdown (56 bytes, at offset 64)
+//!
+//! ```text
+//! Offset │ Size │ Field   │ Value
+//! ───────┼──────┼─────────┼──────────────────────────────────────────────────
+//!     64 │  4   │ p_type  │ 1 = PT_LOAD (loadable segment)
+//!     68 │  4   │ p_flags │ 5 = PF_R|PF_X (read + execute)
+//!     72 │  8   │ p_offset│ 0 (segment starts at file offset 0)
+//!     80 │  8   │ p_vaddr │ load_address (virtual address in memory)
+//!     88 │  8   │ p_paddr │ load_address (physical address, same as vaddr)
+//!     96 │  8   │ p_filesz│ 120 + len(code) (bytes in file)
+//!    104 │  8   │ p_memsz │ 120 + len(code) (bytes in memory)
+//!    112 │  8   │ p_align │ 0x200000 (2 MiB — standard page-aligned)
+//! ```
+//!
+//! ## Machine type values
+//!
+//! ```text
+//! Architecture │ e_machine value
+//! ─────────────┼────────────────
+//! x86_64       │ 62  (EM_X86_64)
+//! arm64        │ 183 (EM_AARCH64)
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+use crate::target::Target;
+
+// ELF header size = 64 bytes.  Program header size = 56 bytes.
+const ELF_HEADER_SIZE: u64 = 64;
+const PROGRAM_HEADER_SIZE: u64 = 56;
+// The code segment begins immediately after both headers.
+const HEADER_TOTAL: u64 = ELF_HEADER_SIZE + PROGRAM_HEADER_SIZE; // 120
+
+// Machine type constants from the ELF specification.
+const EM_X86_64: u16 = 62;
+const EM_AARCH64: u16 = 183;
+
+/// Determine the ELF `e_machine` value for the given target, or return an error.
+fn machine_type(target: &Target) -> Result<u16, PackagerError> {
+    match target.arch.as_str() {
+        "x86_64" => Ok(EM_X86_64),
+        "arm64" => Ok(EM_AARCH64),
+        _ => Err(PackagerError::UnsupportedTarget(format!(
+            "elf64 packager does not support arch={:?}",
+            target.arch
+        ))),
+    }
+}
+
+/// Validate that the target can be packaged as ELF64.
+///
+/// Only Linux targets with `binary_format == "elf64"` are accepted.
+fn validate(artifact: &CodeArtifact) -> Result<(), PackagerError> {
+    if artifact.target.binary_format != "elf64" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "elf64 packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+    if artifact.target.os != "linux" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "elf64 packager expects os=linux, got {:?}",
+            artifact.target.os
+        )));
+    }
+    Ok(())
+}
+
+/// Pack `artifact` into an ELF64 executable binary.
+///
+/// Returns the raw bytes of the `.elf` file.  All multi-byte fields are
+/// written in little-endian byte order via `.to_le_bytes()`.
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if the artifact's target is not
+/// `linux_x64()` or `linux_arm64()`.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    validate(artifact)?;
+    let e_machine = machine_type(&artifact.target)?;
+
+    // Read the load address from metadata or use the conventional Linux default.
+    // 0x400000 is where Linux traditionally maps the first LOAD segment.
+    let load_addr = artifact.metadata_int("load_address", 0x400000) as u64;
+
+    let code_len = artifact.native_bytes.len() as u64;
+    let file_size = HEADER_TOTAL + code_len; // p_filesz and p_memsz
+
+    // The virtual address of the first instruction = load_addr + headers + entry_point.
+    let entry_vaddr = load_addr + HEADER_TOTAL + artifact.entry_point as u64;
+
+    let mut out: Vec<u8> = Vec::with_capacity(file_size as usize);
+
+    // ── ELF header ────────────────────────────────────────────────────────────
+
+    // e_ident[0..4]: ELF magic bytes.  Every ELF file starts with these four bytes.
+    out.extend_from_slice(&[0x7F, b'E', b'L', b'F']);
+    // e_ident[4]: EI_CLASS = 2 = ELFCLASS64  (64-bit ELF)
+    out.push(2);
+    // e_ident[5]: EI_DATA = 1 = ELFDATA2LSB  (little-endian byte order)
+    out.push(1);
+    // e_ident[6]: EI_VERSION = 1 = EV_CURRENT
+    out.push(1);
+    // e_ident[7..15]: EI_OSABI (0 = ELFOSABI_NONE = System V ABI) + 8 padding bytes
+    out.extend_from_slice(&[0u8; 9]);
+
+    // e_type = 2 = ET_EXEC (executable file, not shared library or relocatable).
+    out.extend_from_slice(&2u16.to_le_bytes());
+    // e_machine: which ISA — EM_X86_64 (62) or EM_AARCH64 (183).
+    out.extend_from_slice(&e_machine.to_le_bytes());
+    // e_version = 1 = EV_CURRENT (the only valid version).
+    out.extend_from_slice(&1u32.to_le_bytes());
+    // e_entry: the virtual address where the OS will jump to start the program.
+    out.extend_from_slice(&entry_vaddr.to_le_bytes());
+    // e_phoff: byte offset of the first program header = right after this header.
+    out.extend_from_slice(&ELF_HEADER_SIZE.to_le_bytes());
+    // e_shoff = 0: no section headers (minimal binary, kernel only needs program headers).
+    out.extend_from_slice(&0u64.to_le_bytes());
+    // e_flags = 0: no processor-specific flags required.
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // e_ehsize = 64: this header is 64 bytes long.
+    out.extend_from_slice(&64u16.to_le_bytes());
+    // e_phentsize = 56: each program header entry is 56 bytes.
+    out.extend_from_slice(&56u16.to_le_bytes());
+    // e_phnum = 1: exactly one program header entry (the PT_LOAD segment).
+    out.extend_from_slice(&1u16.to_le_bytes());
+    // e_shentsize = 64: section header size (irrelevant since e_shnum = 0).
+    out.extend_from_slice(&64u16.to_le_bytes());
+    // e_shnum = 0: no section headers.
+    out.extend_from_slice(&0u16.to_le_bytes());
+    // e_shstrndx = 0: no section name string table.
+    out.extend_from_slice(&0u16.to_le_bytes());
+
+    // Sanity check: we must be at exactly offset 64 after the ELF header.
+    debug_assert_eq!(out.len(), ELF_HEADER_SIZE as usize);
+
+    // ── Program header #0 (PT_LOAD) ───────────────────────────────────────────
+
+    // p_type = 1 = PT_LOAD: the kernel maps this segment into the process's address space.
+    out.extend_from_slice(&1u32.to_le_bytes());
+    // p_flags = 5 = PF_R | PF_X: read + execute (no write — code is immutable at runtime).
+    //   PF_X = 1, PF_W = 2, PF_R = 4.
+    out.extend_from_slice(&5u32.to_le_bytes());
+    // p_offset = 0: this segment starts at the very beginning of the file.
+    //   The kernel reads from file offset 0 and maps it to p_vaddr.
+    out.extend_from_slice(&0u64.to_le_bytes());
+    // p_vaddr: the virtual address where this segment is mapped.
+    out.extend_from_slice(&load_addr.to_le_bytes());
+    // p_paddr: physical address (relevant on embedded; Linux ignores it, uses p_vaddr).
+    out.extend_from_slice(&load_addr.to_le_bytes());
+    // p_filesz: number of bytes to read from the file.
+    out.extend_from_slice(&file_size.to_le_bytes());
+    // p_memsz: number of bytes to reserve in virtual memory (can exceed p_filesz for BSS).
+    //   We keep them equal — no BSS segment.
+    out.extend_from_slice(&file_size.to_le_bytes());
+    // p_align = 0x200000 = 2 MiB: the segment's virtual address must be aligned to this.
+    //   Linux uses huge-page-friendly 2 MiB alignment for the default loader.
+    out.extend_from_slice(&0x200000u64.to_le_bytes());
+
+    // Sanity check: we must be at exactly offset 120 after ELF + program headers.
+    debug_assert_eq!(out.len(), HEADER_TOTAL as usize);
+
+    // ── Machine code ──────────────────────────────────────────────────────────
+
+    // The raw native bytes follow immediately after the headers.
+    out.extend_from_slice(&artifact.native_bytes);
+
+    Ok(out)
+}
+
+/// The conventional file extension for ELF files.
+///
+/// Note: Linux executables typically have no extension at all, but `.elf`
+/// is used in the build system to distinguish packaged files.
+pub fn file_extension() -> &'static str {
+    ".elf"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Minimal x86-64 Linux artifact: NOP (0x90) at offset 0.
+    fn linux_x64_art() -> CodeArtifact {
+        CodeArtifact::new(vec![0x90], 0, Target::linux_x64())
+    }
+
+    // Test 1: ELF magic bytes appear at the start
+    #[test]
+    fn produces_elf_magic() {
+        let bytes = pack(&linux_x64_art()).unwrap();
+        // First 4 bytes must be 0x7F 'E' 'L' 'F'
+        assert_eq!(&bytes[0..4], &[0x7F, b'E', b'L', b'F']);
+    }
+
+    // Test 2: correct file size
+    #[test]
+    fn correct_file_size() {
+        let code = vec![0x90u8; 32]; // 32 NOP bytes
+        let art = CodeArtifact::new(code, 0, Target::linux_x64());
+        let bytes = pack(&art).unwrap();
+        // 64 (ELF header) + 56 (program header) + 32 (code) = 152
+        assert_eq!(bytes.len(), 152);
+    }
+
+    // Test 3: rejects macos_x64
+    #[test]
+    fn rejects_macos_target() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::macos_x64());
+        assert!(
+            matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))),
+            "expected UnsupportedTarget for macos_x64"
+        );
+    }
+
+    // Test 4: rejects windows_x64
+    #[test]
+    fn rejects_windows_target() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::windows_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 5: linux_arm64 produces EM_AARCH64 (183 = 0x00B7)
+    #[test]
+    fn arm64_machine_type() {
+        let art = CodeArtifact::new(vec![0x00], 0, Target::linux_arm64());
+        let bytes = pack(&art).unwrap();
+        // e_machine is at offset 18, little-endian u16 = 183
+        let e_machine = u16::from_le_bytes([bytes[18], bytes[19]]);
+        assert_eq!(e_machine, 183, "expected EM_AARCH64 = 183, got {e_machine}");
+    }
+
+    // Test 6: x86_64 machine type = 62
+    #[test]
+    fn x86_64_machine_type() {
+        let bytes = pack(&linux_x64_art()).unwrap();
+        let e_machine = u16::from_le_bytes([bytes[18], bytes[19]]);
+        assert_eq!(e_machine, 62, "expected EM_X86_64 = 62, got {e_machine}");
+    }
+
+    // Test 7: native_bytes appear at offset 120
+    #[test]
+    fn code_at_offset_120() {
+        let code = vec![0x48, 0x31, 0xC0]; // xor rax, rax
+        let art = CodeArtifact::new(code.clone(), 0, Target::linux_x64());
+        let bytes = pack(&art).unwrap();
+        assert_eq!(&bytes[120..123], code.as_slice());
+    }
+
+    // Test 8: entry point encoded correctly in e_entry
+    #[test]
+    fn entry_point_in_header() {
+        let art = CodeArtifact::new(vec![0x90; 10], 4, Target::linux_x64());
+        let bytes = pack(&art).unwrap();
+        // e_entry is at offset 24, little-endian u64.
+        // Expected = 0x400000 (load_addr) + 120 (header_total) + 4 (entry_point)
+        let e_entry = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+        assert_eq!(e_entry, 0x400000 + 120 + 4);
+    }
+
+    // Test 9: file_extension
+    #[test]
+    fn file_extension_is_elf() {
+        assert_eq!(file_extension(), ".elf");
+    }
+}

--- a/code/packages/rust/code-packager/src/errors.rs
+++ b/code/packages/rust/code-packager/src/errors.rs
@@ -1,0 +1,103 @@
+//! Error types for all packager operations.
+//!
+//! Every function in this crate that can fail returns `Result<_, PackagerError>`.
+//! The variants describe *what* went wrong at a high level; the embedded `String`
+//! carries the human-readable detail.
+//!
+//! ## Design note
+//!
+//! We derive `Clone` and `PartialEq` so that callers can store or compare errors
+//! in tests without needing a reference. `Display` is implemented manually to
+//! produce tidy messages for the end user.
+
+/// The unified error type for the `code-packager` crate.
+///
+/// ```text
+/// Error hierarchy
+///
+///   PackagerError
+///   ├── UnsupportedTarget — the requested binary format has no packager
+///   └── WasmEncodeError   — the WASM module encoder returned an error
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackagerError {
+    /// The target is not supported by the chosen packager.
+    ///
+    /// Example: asking the ELF64 packager to pack a `windows_x64` artifact.
+    /// The embedded string names what was unsupported, e.g.
+    /// `"no packager for binary_format=\"pe\""`.
+    UnsupportedTarget(String),
+
+    /// WASM module encoding failed inside `wasm-module-encoder`.
+    ///
+    /// The embedded string is the `Display` output of the underlying
+    /// `WasmEncodeError`.
+    WasmEncodeError(String),
+}
+
+impl std::fmt::Display for PackagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Forward the detail message verbatim so callers can log it cleanly.
+            PackagerError::UnsupportedTarget(msg) => {
+                write!(f, "unsupported target: {msg}")
+            }
+            PackagerError::WasmEncodeError(msg) => {
+                write!(f, "WASM encode error: {msg}")
+            }
+        }
+    }
+}
+
+// Implement `std::error::Error` with no `source()` override; the detail is
+// already in the `Display` string.
+impl std::error::Error for PackagerError {}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test 1: UnsupportedTarget Display
+    #[test]
+    fn display_unsupported_target() {
+        let err = PackagerError::UnsupportedTarget("no packager for binary_format=\"xyz\"".into());
+        let text = err.to_string();
+        assert!(
+            text.contains("unsupported target"),
+            "expected 'unsupported target' in {text:?}"
+        );
+        assert!(text.contains("xyz"), "expected detail in {text:?}");
+    }
+
+    // Test 2: WasmEncodeError Display
+    #[test]
+    fn display_wasm_encode_error() {
+        let err = PackagerError::WasmEncodeError("invalid function body".into());
+        let text = err.to_string();
+        assert!(
+            text.contains("WASM encode error"),
+            "expected 'WASM encode error' in {text:?}"
+        );
+        assert!(text.contains("invalid function body"), "expected detail in {text:?}");
+    }
+
+    // Test 3: PartialEq
+    #[test]
+    fn equality() {
+        let a = PackagerError::UnsupportedTarget("foo".into());
+        let b = PackagerError::UnsupportedTarget("foo".into());
+        let c = PackagerError::UnsupportedTarget("bar".into());
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    // Test 4: Clone
+    #[test]
+    fn clone_preserves_message() {
+        let orig = PackagerError::WasmEncodeError("some error".into());
+        let cloned = orig.clone();
+        assert_eq!(orig, cloned);
+    }
+}

--- a/code/packages/rust/code-packager/src/intel_hex.rs
+++ b/code/packages/rust/code-packager/src/intel_hex.rs
@@ -1,0 +1,324 @@
+//! Intel HEX packager.
+//!
+//! Encodes binary data as Intel HEX — a text format that represents binary
+//! data as ASCII hexadecimal records. It was invented by Intel in 1973 for
+//! programming early microprocessors like the 4004 and 8008, and is still
+//! widely used for programming microcontrollers, EPROMs, and FPGAs today.
+//!
+//! ## Why text, not binary?
+//!
+//! In 1973, the tools for transferring binary data between computers were
+//! unreliable. ASCII text could be transferred over serial links (RS-232),
+//! printed on paper tape, and punched onto cards without corruption. Intel
+//! HEX encodes binary data as printable hex digits, making it completely
+//! safe for these channels.
+//!
+//! ## Record format
+//!
+//! Each record (line) has this structure:
+//!
+//! ```text
+//! :LLAAAATTDD...CC\n
+//!  │ │   │ │      └─ Checksum (2 hex digits)
+//!  │ │   │ └──────── Data bytes (2 hex digits each)
+//!  │ │   └────────── Record type (2 hex digits)
+//!  │ └────────────── Start address (4 hex digits, big-endian)
+//!  └──────────────── Byte count (2 hex digits)
+//! ^ Colon: record start marker
+//! ```
+//!
+//! ## Record types
+//!
+//! ```text
+//! Type │ Meaning
+//! ─────┼────────────────────────────────────────────────────────────────────
+//!  00  │ Data record (the actual bytes)
+//!  01  │ End-of-file record (terminates the file)
+//!  02  │ Extended segment address (for 80286 real-mode segmentation)
+//!  03  │ Start segment address (CS:IP for 8086)
+//!  04  │ Extended linear address (high 16 bits of 32-bit address)
+//!  05  │ Start linear address (32-bit EIP for 80386)
+//! ```
+//!
+//! This packager emits only types 00 (data) and 01 (EOF).
+//!
+//! ## Checksum algorithm
+//!
+//! The checksum is the **two's complement** of the sum of all bytes in the
+//! record from `:LL` through the last data byte.
+//!
+//! ```text
+//! record bytes = [LL, AAAA_hi, AAAA_lo, TT, DD...]
+//! sum = sum of all record bytes mod 256
+//! checksum = (256 - sum) mod 256  =  (!sum + 1) & 0xFF
+//! ```
+//!
+//! A reader can verify a record by summing all bytes including the checksum;
+//! the result must be 0 (mod 256).
+//!
+//! ## Data record layout (16 bytes per record)
+//!
+//! ```text
+//! :10 0000 00 AABBCCDD EEFFGGHH IIJJKKLL MMNNOOPP XX\n
+//!  │  │    │  └─ 16 data bytes                    └─ checksum
+//!  │  │    └──── record type 00
+//!  │  └─────────  address (big-endian, 16-bit)
+//!  └────────────  byte count = 0x10 = 16
+//! ```
+//!
+//! ## EOF record
+//!
+//! ```text
+//! :00 0000 01 FF\n
+//!  │  │    │   └─ checksum of [00, 00, 00, 01] = 0xFF
+//!  │  │    └──── record type 01
+//!  │  └─────────  address = 0 (unused in EOF)
+//!  └────────────  byte count = 0 (no data)
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+
+/// Maximum data bytes per record.
+/// 16 is the de-facto standard; some tools use 32, but 16 is safest.
+const BYTES_PER_RECORD: usize = 16;
+
+/// Record type 00: data.
+const RECORD_DATA: u8 = 0x00;
+/// Record type 01: end of file.
+const RECORD_EOF: u8 = 0x01;
+
+// ── Core encoder ──────────────────────────────────────────────────────────────
+
+/// Compute the Intel HEX checksum for one record's worth of bytes.
+///
+/// The checksum is appended to each record so that readers can detect
+/// transmission errors.
+///
+/// ## Algorithm
+///
+/// ```text
+/// Step 1: sum all bytes (byte count, address hi, address lo, type, data…)
+/// Step 2: take the two's complement = (256 - sum) mod 256
+/// ```
+///
+/// A reader sums all bytes *including* the checksum; the result is 0 if valid.
+fn checksum(byte_count: u8, addr: u16, record_type: u8, data: &[u8]) -> u8 {
+    let mut sum: u32 = 0;
+    sum += byte_count as u32;
+    sum += (addr >> 8) as u32;   // high byte of the address
+    sum += (addr & 0xFF) as u32; // low byte of the address
+    sum += record_type as u32;
+    for b in data {
+        sum += *b as u32;
+    }
+    // Two's complement (mod 256): negate the sum.
+    ((!sum).wrapping_add(1) & 0xFF) as u8
+}
+
+/// Encode a single Intel HEX record as an ASCII string (including trailing `\n`).
+///
+/// # Arguments
+///
+/// * `addr` — 16-bit start address for this record.
+/// * `record_type` — 0x00 for data, 0x01 for EOF.
+/// * `data` — the bytes to encode (may be empty for EOF).
+fn encode_record(addr: u16, record_type: u8, data: &[u8]) -> String {
+    let byte_count = data.len() as u8;
+    let cc = checksum(byte_count, addr, record_type, data);
+
+    // Format: ":LLAAAATTDD...CC\n"
+    // Pre-build the hex string piece by piece.
+    let mut record = String::with_capacity(1 + 2 + 4 + 2 + data.len() * 2 + 2 + 1);
+    record.push(':');
+    record.push_str(&format!("{byte_count:02X}"));
+    record.push_str(&format!("{addr:04X}"));
+    record.push_str(&format!("{record_type:02X}"));
+    for b in data {
+        record.push_str(&format!("{b:02X}"));
+    }
+    record.push_str(&format!("{cc:02X}"));
+    record.push('\n');
+    record
+}
+
+/// Encode binary `data` as a complete Intel HEX file.
+///
+/// # Arguments
+///
+/// * `data` — the raw bytes to encode.
+/// * `origin` — the 16-bit start address.  Each record's address is
+///   `origin + byte_offset_into_data`.  If `origin + data.len() > 0xFFFF`
+///   the addresses wrap around (Intel HEX 8-bit mode behaviour).
+///
+/// # Returns
+///
+/// A `String` containing the complete Intel HEX file, ready to write to disk.
+///
+/// # Example
+///
+/// ```text
+/// encode_intel_hex(&[0x01, 0x02, 0x03], 0x0000)
+///
+/// :03000000010203F9\n
+/// :00000001FF\n
+/// ```
+pub fn encode_intel_hex(data: &[u8], origin: u16) -> String {
+    let mut output = String::new();
+
+    // Split data into chunks of up to BYTES_PER_RECORD bytes.
+    for (chunk_idx, chunk) in data.chunks(BYTES_PER_RECORD).enumerate() {
+        // Address = origin + number of bytes already emitted.
+        let addr = origin.wrapping_add((chunk_idx * BYTES_PER_RECORD) as u16);
+        output.push_str(&encode_record(addr, RECORD_DATA, chunk));
+    }
+
+    // Emit the EOF record.
+    output.push_str(&encode_record(0x0000, RECORD_EOF, &[]));
+
+    output
+}
+
+/// Pack `artifact` into an Intel HEX file.
+///
+/// The `origin` address is read from `artifact.metadata_int("origin", 0)`
+/// and cast to a `u16`.
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if `binary_format != "intel_hex"`.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    if artifact.target.binary_format != "intel_hex" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "intel_hex packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+
+    let origin = artifact.metadata_int("origin", 0) as u16;
+    let hex = encode_intel_hex(&artifact.native_bytes, origin);
+    Ok(hex.into_bytes())
+}
+
+/// The conventional file extension for Intel HEX files.
+pub fn file_extension() -> &'static str {
+    ".hex"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target::Target;
+
+    // Test 1: Known short input — 3 bytes at origin 0
+    //
+    // Record analysis:
+    //   LL = 03 (3 data bytes)
+    //   AAAA = 0000 (address = 0)
+    //   TT = 00 (data record)
+    //   DD = 01 02 03
+    //   sum = 03 + 00 + 00 + 00 + 01 + 02 + 03 = 09
+    //   checksum = (256 - 9) & 0xFF = 247 = 0xF7
+    #[test]
+    fn known_short_input() {
+        let hex = encode_intel_hex(&[0x01, 0x02, 0x03], 0x0000);
+        assert_eq!(hex, ":03000000010203F7\n:00000001FF\n");
+    }
+
+    // Test 2: EOF checksum is always 0xFF when data is empty
+    #[test]
+    fn eof_record_checksum() {
+        // :00 0000 01 FF
+        // sum = 0 + 0 + 0 + 1 = 1 → checksum = 256 - 1 = 255 = 0xFF
+        let eof = encode_record(0x0000, RECORD_EOF, &[]);
+        assert_eq!(eof, ":00000001FF\n");
+    }
+
+    // Test 3: Checksum verification — sum of all record bytes (including checksum) = 0
+    #[test]
+    fn checksum_verifies_to_zero() {
+        let data = [0xAA, 0xBB, 0xCC];
+        let cc = checksum(3, 0x0010, RECORD_DATA, &data);
+        // Sum all record bytes including the checksum byte:
+        let sum: u32 = 3 + 0 + 0x10 + 0 + 0xAA + 0xBB + 0xCC + cc as u32;
+        assert_eq!(sum & 0xFF, 0, "checksum verification failed: sum mod 256 = {}", sum & 0xFF);
+    }
+
+    // Test 4: Each record header starts with ':' and ends with '\n'
+    #[test]
+    fn record_format_delimiters() {
+        let hex = encode_intel_hex(&[0xFF], 0x0000);
+        for line in hex.lines() {
+            assert!(line.starts_with(':'), "line does not start with ':': {line:?}");
+        }
+        // Original string ends with '\n'
+        assert!(hex.ends_with('\n'));
+    }
+
+    // Test 5: 16 bytes fit in a single data record (+ EOF)
+    #[test]
+    fn sixteen_bytes_one_record() {
+        let data: Vec<u8> = (0..16).collect();
+        let hex = encode_intel_hex(&data, 0x0000);
+        let lines: Vec<&str> = hex.lines().collect();
+        // 1 data record + 1 EOF record = 2 lines
+        assert_eq!(lines.len(), 2);
+        // First line: byte count = 10 (hex for 16)
+        assert!(lines[0].starts_with(":10"), "expected :10... got {}", lines[0]);
+    }
+
+    // Test 6: 17 bytes produce two data records + EOF
+    #[test]
+    fn seventeen_bytes_two_records() {
+        let data: Vec<u8> = (0..17).collect();
+        let hex = encode_intel_hex(&data, 0x0000);
+        let lines: Vec<&str> = hex.lines().collect();
+        // 2 data records + 1 EOF
+        assert_eq!(lines.len(), 3);
+    }
+
+    // Test 7: Origin address is encoded correctly in the second record
+    #[test]
+    fn origin_address_in_second_record() {
+        // 17 bytes → 2 data records: first at origin, second at origin + 16
+        let data: Vec<u8> = vec![0x00; 17];
+        let hex = encode_intel_hex(&data, 0x0100);
+        let lines: Vec<&str> = hex.lines().collect();
+        // First record address = 0100
+        assert!(lines[0].starts_with(":100100"), "got: {}", lines[0]);
+        // Second record address = 0110 (0x0100 + 16)
+        assert!(lines[1].starts_with(":010110"), "got: {}", lines[1]);
+    }
+
+    // Test 8: pack() with intel_4004 target succeeds
+    #[test]
+    fn pack_intel_4004_succeeds() {
+        let art = CodeArtifact::new(vec![0x00, 0xFF], 0, Target::intel_4004());
+        let bytes = pack(&art).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains(':'));
+        assert!(text.ends_with('\n'));
+    }
+
+    // Test 9: pack() rejects elf64 target
+    #[test]
+    fn pack_rejects_elf64() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 10: empty input produces only EOF record
+    #[test]
+    fn empty_input_eof_only() {
+        let hex = encode_intel_hex(&[], 0x0000);
+        assert_eq!(hex, ":00000001FF\n");
+    }
+
+    // Test 11: file_extension
+    #[test]
+    fn file_extension_is_hex() {
+        assert_eq!(file_extension(), ".hex");
+    }
+}

--- a/code/packages/rust/code-packager/src/intel_hex.rs
+++ b/code/packages/rust/code-packager/src/intel_hex.rs
@@ -195,7 +195,16 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
         )));
     }
 
-    let origin = artifact.metadata_int("origin", 0) as u16;
+    // Validate origin range: Intel HEX 8-bit mode uses 16-bit addresses [0, 65535].
+    // A negative or out-of-range value would silently truncate via `as u16`, producing
+    // records with a wrong start address that looks plausible but is incorrect.
+    let origin_i = artifact.metadata_int("origin", 0);
+    if !(0..=0xFFFF).contains(&origin_i) {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "intel_hex packager: origin {origin_i} is out of range [0, 65535]"
+        )));
+    }
+    let origin = origin_i as u16;
     let hex = encode_intel_hex(&artifact.native_bytes, origin);
     Ok(hex.into_bytes())
 }

--- a/code/packages/rust/code-packager/src/lib.rs
+++ b/code/packages/rust/code-packager/src/lib.rs
@@ -1,0 +1,93 @@
+//! # code-packager
+//!
+//! Cross-platform binary packaging for compiled machine code (LANG10).
+//!
+//! This crate wraps raw native bytes in OS-specific binary container formats
+//! so that operating systems, runtimes, and embedded programmers can load and
+//! execute the code.
+//!
+//! ## Supported output formats
+//!
+//! ```text
+//! Format      │ Platform          │ File ext │ Factory method
+//! ────────────┼───────────────────┼──────────┼─────────────────────────
+//! ELF64       │ Linux (x64/arm64) │ .elf     │ Target::linux_x64()
+//! Mach-O 64   │ macOS (x64/arm64) │ .macho   │ Target::macos_arm64()
+//! PE32+       │ Windows x64       │ .exe     │ Target::windows_x64()
+//! WebAssembly │ Browser/Wasmtime  │ .wasm    │ Target::wasm()
+//! Raw binary  │ Bare-metal/BIOS   │ .bin     │ Target::raw("x86_64")
+//! Intel HEX   │ Microcontrollers  │ .hex     │ Target::intel_4004()
+//! ```
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use code_packager::{CodeArtifact, PackagerRegistry, Target};
+//!
+//! // 1. Describe the target platform.
+//! let target = Target::linux_x64();
+//!
+//! // 2. Wrap the native bytes in a CodeArtifact.
+//! //    `entry_point` is the byte offset of the first instruction.
+//! let artifact = CodeArtifact::new(
+//!     vec![0x48, 0x31, 0xC0, // xor rax, rax  (return 0)
+//!          0xC3],            // ret
+//!     0, // entry_point
+//!     target,
+//! );
+//!
+//! // 3. Pack into the target binary format.
+//! let bytes: Vec<u8> = PackagerRegistry::pack(&artifact).unwrap();
+//!
+//! // 4. `bytes` is now a valid Linux ELF64 executable.
+//! assert_eq!(&bytes[0..4], &[0x7F, b'E', b'L', b'F']);
+//! ```
+//!
+//! ## Architecture
+//!
+//! ```text
+//! CodeArtifact ──► PackagerRegistry::pack
+//!                        │
+//!          ┌─────────────┼──────────────────┐
+//!          ▼             ▼                  ▼
+//!       elf64::pack  macho64::pack      pe::pack
+//!       raw::pack    intel_hex::pack    wasm::pack
+//! ```
+//!
+//! Each packager module is independent: they only import `artifact`, `errors`,
+//! and `target`. The registry dispatches by `artifact.target.binary_format`.
+//!
+//! ## Metadata hints
+//!
+//! Some packagers accept metadata for fine-grained control:
+//!
+//! ```text
+//! Key            │ Type │ Packagers          │ Meaning
+//! ───────────────┼──────┼────────────────────┼────────────────────────────
+//! "load_address" │ Int  │ elf64, macho64     │ Virtual address of segment
+//! "origin"       │ Int  │ intel_hex          │ Start address (16-bit)
+//! "exports"      │ List │ wasm               │ WASM export function names
+//! ```
+//!
+//! Use `CodeArtifact::with_metadata(...)` to pass these hints.
+//!
+//! ## No unsafe code
+//!
+//! All binary construction uses `.to_le_bytes()` and `extend_from_slice` on
+//! `Vec<u8>`. There is no `unsafe` anywhere in this crate.
+
+pub mod artifact;
+pub mod elf64;
+pub mod errors;
+pub mod intel_hex;
+pub mod macho64;
+pub mod pe;
+pub mod raw;
+pub mod registry;
+pub mod target;
+pub mod wasm;
+
+pub use artifact::{CodeArtifact, MetadataValue};
+pub use errors::PackagerError;
+pub use registry::PackagerRegistry;
+pub use target::Target;

--- a/code/packages/rust/code-packager/src/macho64.rs
+++ b/code/packages/rust/code-packager/src/macho64.rs
@@ -187,7 +187,15 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
     let (cputype, cpusubtype) = cpu_type(&artifact.target)?;
 
     // Default load address for macOS 64-bit = 0x100000000 (above 4 GiB boundary).
-    let load_addr = artifact.metadata_int("load_address", 0x100000000) as u64;
+    // Reject negative values: a negative load_address casts to an enormous u64,
+    // producing a nonsensical vmaddr in the LC_SEGMENT_64 header.
+    let load_addr_i = artifact.metadata_int("load_address", 0x100000000);
+    if load_addr_i < 0 {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "macho64 packager: load_address must be non-negative, got {load_addr_i}"
+        )));
+    }
+    let load_addr = load_addr_i as u64;
     let code_len = artifact.native_bytes.len() as u64;
     let vmsize = HEADER_TOTAL + code_len;
 

--- a/code/packages/rust/code-packager/src/macho64.rs
+++ b/code/packages/rust/code-packager/src/macho64.rs
@@ -1,0 +1,387 @@
+//! Mach-O 64-bit executable packager.
+//!
+//! Produces a minimal, single-section Mach-O 64-bit binary that macOS can
+//! execute directly. The output uses `LC_MAIN` (the modern load command
+//! introduced in macOS 10.8 Mountain Lion) to specify the entry point.
+//!
+//! ## Mach-O file layout
+//!
+//! ```text
+//! Offset │ Size │ Content
+//! ───────┼──────┼────────────────────────────────────────────────────────────
+//!      0 │  32  │ mach_header_64
+//!     32 │  72  │ LC_SEGMENT_64 header (for the __TEXT segment)
+//!    104 │  80  │ section_64 (for the __text section)
+//!    184 │  24  │ LC_MAIN (entry point specification)
+//!    208 │   N  │ native_bytes (the machine code)
+//! ```
+//!
+//! Total header = 32 + 72 + 80 + 24 = **208 bytes** (`HEADER_TOTAL`).
+//!
+//! ## mach_header_64 (32 bytes, at offset 0)
+//!
+//! ```text
+//! Field      │ Size │ Value
+//! ───────────┼──────┼───────────────────────────────────────────────────────
+//! magic      │  4   │ 0xCFFAEDFE (MH_MAGIC_64, reversed for LE)
+//! cputype    │  4   │ 0x01000007 (x86_64) | 0x0100000C (arm64)
+//! cpusubtype │  4   │ 3 (x86_64 all) | 0 (arm64 all)
+//! filetype   │  4   │ 2 = MH_EXECUTE
+//! ncmds      │  4   │ 2 (two load commands: LC_SEGMENT_64 + LC_MAIN)
+//! sizeofcmds │  4   │ 256 (72 + 80 + 24 = 176 … but we compute dynamically)
+//! flags      │  4   │ 0
+//! reserved   │  4   │ 0 (only in 64-bit header)
+//! ```
+//!
+//! ## LC_SEGMENT_64 (72 bytes, at offset 32)
+//!
+//! ```text
+//! Field    │ Size │ Value
+//! ─────────┼──────┼─────────────────────────────────────────────────────────
+//! cmd      │  4   │ 0x19 = LC_SEGMENT_64
+//! cmdsize  │  4   │ 152 (72 header + 80 section_64)
+//! segname  │ 16   │ "__TEXT\0\0\0\0\0\0\0\0\0\0"
+//! vmaddr   │  8   │ load_address (default 0x100000000)
+//! vmsize   │  8   │ HEADER_TOTAL + len(code)
+//! fileoff  │  8   │ 0 (segment starts at file beginning)
+//! filesize │  8   │ HEADER_TOTAL + len(code)
+//! maxprot  │  4   │ 7 (rwx — maximum allowed protection)
+//! initprot │  4   │ 5 (r+x — initial protection at load time)
+//! nsects   │  4   │ 1 (one section: __text)
+//! flags    │  4   │ 0
+//! ```
+//!
+//! ## section_64 (80 bytes, at offset 104)
+//!
+//! ```text
+//! Field     │ Size │ Value
+//! ──────────┼──────┼────────────────────────────────────────────────────────
+//! sectname  │ 16   │ "__text\0\0\0\0\0\0\0\0\0\0"
+//! segname   │ 16   │ "__TEXT\0\0\0\0\0\0\0\0\0\0"
+//! addr      │  8   │ load_address + HEADER_TOTAL
+//! size      │  8   │ len(code)
+//! offset    │  4   │ HEADER_TOTAL (file offset of the code)
+//! align     │  4   │ 4 (2^4 = 16-byte alignment)
+//! reloff    │  4   │ 0 (no relocations)
+//! nreloc    │  4   │ 0
+//! flags     │  4   │ 0x80000400 (S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS)
+//! reserved1 │  4   │ 0
+//! reserved2 │  4   │ 0
+//! reserved3 │  4   │ 0
+//! ```
+//!
+//! ## LC_MAIN (24 bytes, at offset 184)
+//!
+//! LC_MAIN replaced LC_UNIXTHREAD in macOS 10.8 and is required by the
+//! dynamic linker on newer macOS versions. It specifies the entry point as an
+//! *offset from the start of the __TEXT segment*, not an absolute address.
+//!
+//! ```text
+//! Field     │ Size │ Value
+//! ──────────┼──────┼────────────────────────────────────────────────────────
+//! cmd       │  4   │ 0x80000028 = LC_MAIN
+//! cmdsize   │  4   │ 24
+//! entryoff  │  8   │ HEADER_TOTAL + entry_point
+//! stacksize │  8   │ 0 (use default stack)
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+use crate::target::Target;
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+// mach_header_64 size.
+const MACH_HEADER_SIZE: u64 = 32;
+// LC_SEGMENT_64 header (without sections) = 72 bytes.
+const LC_SEGMENT_SIZE: u64 = 72;
+// section_64 struct = 80 bytes.
+const SECTION_SIZE: u64 = 80;
+// LC_MAIN = 24 bytes.
+const LC_MAIN_SIZE: u64 = 24;
+
+// cmdsize of the LC_SEGMENT_64 command = header + one section_64.
+const LC_SEGMENT_CMDSIZE: u32 = (LC_SEGMENT_SIZE + SECTION_SIZE) as u32; // 152
+
+// Total size of all load commands (LC_SEGMENT_64 with section + LC_MAIN).
+const SIZEOFCMDS: u32 = LC_SEGMENT_CMDSIZE + LC_MAIN_SIZE as u32; // 176
+
+// Total header size before native code begins.
+const HEADER_TOTAL: u64 = MACH_HEADER_SIZE + LC_SEGMENT_SIZE + SECTION_SIZE + LC_MAIN_SIZE; // 208
+
+// ── CPU type/subtype constants ────────────────────────────────────────────────
+
+// CPU_TYPE_X86_64 = CPU_TYPE_I386 | CPU_ARCH_ABI64 = 7 | 0x01000000.
+const CPU_TYPE_X86_64: u32 = 0x01000007;
+// CPU_TYPE_ARM64 = CPU_TYPE_ARM | CPU_ARCH_ABI64 = 12 | 0x01000000.
+const CPU_TYPE_ARM64: u32 = 0x0100000C;
+
+// CPU_SUBTYPE_X86_ALL = 3.
+const CPU_SUBTYPE_X86_ALL: u32 = 3;
+// CPU_SUBTYPE_ARM_ALL = 0.
+const CPU_SUBTYPE_ARM_ALL: u32 = 0;
+
+// ── Load command identifiers ──────────────────────────────────────────────────
+
+// LC_SEGMENT_64 = 0x19.
+const LC_SEGMENT_64: u32 = 0x19;
+// LC_MAIN = 0x80000028 (flagged with LC_REQ_DYLD = 0x80000000).
+const LC_MAIN: u32 = 0x80000028;
+
+// ── Section flags ─────────────────────────────────────────────────────────────
+
+// S_ATTR_PURE_INSTRUCTIONS (0x80000000) | S_ATTR_SOME_INSTRUCTIONS (0x00000400).
+const SECTION_FLAGS_CODE: u32 = 0x80000400;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Determine CPU type and subtype for the given target.
+fn cpu_type(target: &Target) -> Result<(u32, u32), PackagerError> {
+    match target.arch.as_str() {
+        "x86_64" => Ok((CPU_TYPE_X86_64, CPU_SUBTYPE_X86_ALL)),
+        "arm64" => Ok((CPU_TYPE_ARM64, CPU_SUBTYPE_ARM_ALL)),
+        _ => Err(PackagerError::UnsupportedTarget(format!(
+            "macho64 packager does not support arch={:?}",
+            target.arch
+        ))),
+    }
+}
+
+/// Validate that the artifact is destined for a macOS Mach-O target.
+fn validate(artifact: &CodeArtifact) -> Result<(), PackagerError> {
+    if artifact.target.binary_format != "macho64" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "macho64 packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+    if artifact.target.os != "macos" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "macho64 packager expects os=macos, got {:?}",
+            artifact.target.os
+        )));
+    }
+    Ok(())
+}
+
+/// Write a fixed-length segment or section name field (always 16 bytes, NUL-padded).
+fn write_name(out: &mut Vec<u8>, name: &[u8]) {
+    // The Mach-O spec requires exactly 16 bytes for segname/sectname fields.
+    let mut buf = [0u8; 16];
+    let n = name.len().min(16);
+    buf[..n].copy_from_slice(&name[..n]);
+    out.extend_from_slice(&buf);
+}
+
+/// Pack `artifact` into a Mach-O 64-bit executable binary.
+///
+/// Returns the raw bytes of the `.macho` file.  All multi-byte fields are
+/// written in little-endian byte order.
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if the artifact's target is not
+/// `macos_x64()` or `macos_arm64()`.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    validate(artifact)?;
+    let (cputype, cpusubtype) = cpu_type(&artifact.target)?;
+
+    // Default load address for macOS 64-bit = 0x100000000 (above 4 GiB boundary).
+    let load_addr = artifact.metadata_int("load_address", 0x100000000) as u64;
+    let code_len = artifact.native_bytes.len() as u64;
+    let vmsize = HEADER_TOTAL + code_len;
+
+    let mut out: Vec<u8> = Vec::with_capacity(vmsize as usize);
+
+    // ── mach_header_64 ────────────────────────────────────────────────────────
+
+    // magic = 0xFEEDFACF (MH_MAGIC_64).
+    // In little-endian memory this is stored as [CF EA FE DE] = 0xCFFAEDFE.
+    // We write the *value* 0xFEEDFACF; to_le_bytes() gives [CF FA ED FE].
+    // Wait — let's be precise: MH_MAGIC_64 in the Mach-O spec is 0xFEEDFACF
+    // (host-endian). On a little-endian host, the on-disk bytes are
+    // [0xCF, 0xFA, 0xED, 0xFE], which is what a hex editor shows.
+    out.extend_from_slice(&0xFEEDFACFu32.to_le_bytes());
+    // cputype: CPU_TYPE_X86_64 or CPU_TYPE_ARM64.
+    out.extend_from_slice(&cputype.to_le_bytes());
+    // cpusubtype: CPU_SUBTYPE_X86_ALL or CPU_SUBTYPE_ARM_ALL.
+    out.extend_from_slice(&cpusubtype.to_le_bytes());
+    // filetype = 2 = MH_EXECUTE (executable binary).
+    out.extend_from_slice(&2u32.to_le_bytes());
+    // ncmds = 2: one LC_SEGMENT_64 command + one LC_MAIN command.
+    out.extend_from_slice(&2u32.to_le_bytes());
+    // sizeofcmds: total byte size of all load commands.
+    out.extend_from_slice(&SIZEOFCMDS.to_le_bytes());
+    // flags = 0: no special flags needed for a minimal binary.
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // reserved (64-bit header only): must be 0.
+    out.extend_from_slice(&0u32.to_le_bytes());
+
+    debug_assert_eq!(out.len(), MACH_HEADER_SIZE as usize);
+
+    // ── LC_SEGMENT_64 ─────────────────────────────────────────────────────────
+
+    // cmd = LC_SEGMENT_64 = 0x19.
+    out.extend_from_slice(&LC_SEGMENT_64.to_le_bytes());
+    // cmdsize = 152: the size of this load command including all section_64 structs.
+    out.extend_from_slice(&LC_SEGMENT_CMDSIZE.to_le_bytes());
+    // segname: "__TEXT" padded to 16 bytes.
+    write_name(&mut out, b"__TEXT");
+    // vmaddr: virtual address of the segment's start.
+    out.extend_from_slice(&load_addr.to_le_bytes());
+    // vmsize: size of the segment in virtual memory.
+    out.extend_from_slice(&vmsize.to_le_bytes());
+    // fileoff = 0: segment contents start at byte 0 of the file.
+    out.extend_from_slice(&0u64.to_le_bytes());
+    // filesize: number of bytes from the file that back this segment.
+    out.extend_from_slice(&vmsize.to_le_bytes());
+    // maxprot = 7 = VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE (maximum allowed).
+    out.extend_from_slice(&7u32.to_le_bytes());
+    // initprot = 5 = VM_PROT_READ | VM_PROT_EXECUTE (initial protection at load).
+    out.extend_from_slice(&5u32.to_le_bytes());
+    // nsects = 1: this segment contains one section (__text).
+    out.extend_from_slice(&1u32.to_le_bytes());
+    // flags = 0: no special segment flags.
+    out.extend_from_slice(&0u32.to_le_bytes());
+
+    debug_assert_eq!(out.len(), (MACH_HEADER_SIZE + LC_SEGMENT_SIZE) as usize);
+
+    // ── section_64 for __text ─────────────────────────────────────────────────
+
+    // sectname: "__text" padded to 16 bytes.
+    write_name(&mut out, b"__text");
+    // segname: "__TEXT" padded to 16 bytes.
+    write_name(&mut out, b"__TEXT");
+    // addr: virtual address of the section = segment start + header size.
+    let text_addr = load_addr + HEADER_TOTAL;
+    out.extend_from_slice(&text_addr.to_le_bytes());
+    // size: byte length of the section's content.
+    out.extend_from_slice(&code_len.to_le_bytes());
+    // offset: file offset of the section's content (right after all headers).
+    out.extend_from_slice(&(HEADER_TOTAL as u32).to_le_bytes());
+    // align = 4: the section is aligned to 2^4 = 16 bytes (standard code alignment).
+    out.extend_from_slice(&4u32.to_le_bytes());
+    // reloff = 0: no relocations.
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // nreloc = 0: no relocation entries.
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // flags = S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS.
+    //   S_ATTR_PURE_INSTRUCTIONS (0x80000000): all bytes are machine instructions.
+    //   S_ATTR_SOME_INSTRUCTIONS (0x00000400): contains at least one instruction.
+    out.extend_from_slice(&SECTION_FLAGS_CODE.to_le_bytes());
+    // reserved1 = 0 (unused for code sections).
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // reserved2 = 0 (unused for code sections).
+    out.extend_from_slice(&0u32.to_le_bytes());
+    // reserved3 = 0 (only in 64-bit section_64 struct).
+    out.extend_from_slice(&0u32.to_le_bytes());
+
+    debug_assert_eq!(
+        out.len(),
+        (MACH_HEADER_SIZE + LC_SEGMENT_SIZE + SECTION_SIZE) as usize
+    );
+
+    // ── LC_MAIN ───────────────────────────────────────────────────────────────
+
+    // cmd = LC_MAIN = 0x80000028.
+    // The 0x80000000 bit marks it as "required for dynamic linking" (LC_REQ_DYLD).
+    out.extend_from_slice(&LC_MAIN.to_le_bytes());
+    // cmdsize = 24: this command is exactly 24 bytes.
+    out.extend_from_slice(&24u32.to_le_bytes());
+    // entryoff: byte offset from the beginning of the __TEXT segment to the
+    // first instruction. The __TEXT segment starts at file offset 0, so
+    // entryoff = HEADER_TOTAL + entry_point.
+    let entryoff = HEADER_TOTAL + artifact.entry_point as u64;
+    out.extend_from_slice(&entryoff.to_le_bytes());
+    // stacksize = 0: use the system default stack size.
+    out.extend_from_slice(&0u64.to_le_bytes());
+
+    debug_assert_eq!(out.len(), HEADER_TOTAL as usize);
+
+    // ── Machine code ──────────────────────────────────────────────────────────
+
+    out.extend_from_slice(&artifact.native_bytes);
+
+    Ok(out)
+}
+
+/// The conventional file extension for Mach-O files.
+pub fn file_extension() -> &'static str {
+    ".macho"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn macos_arm64_art() -> CodeArtifact {
+        CodeArtifact::new(vec![0x1F, 0x20, 0x03, 0xD5], 0, Target::macos_arm64())
+    }
+
+    // Test 1: Mach-O magic bytes (little-endian stored as [CF FA ED FE])
+    #[test]
+    fn produces_macho_magic() {
+        let bytes = pack(&macos_arm64_art()).unwrap();
+        // 0xFEEDFACF.to_le_bytes() = [0xCF, 0xFA, 0xED, 0xFE]
+        assert_eq!(&bytes[0..4], &[0xCF, 0xFA, 0xED, 0xFE]);
+    }
+
+    // Test 2: rejects linux_x64
+    #[test]
+    fn rejects_linux_target() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 3: correct file size
+    #[test]
+    fn correct_file_size() {
+        let code = vec![0x00u8; 16];
+        let art = CodeArtifact::new(code, 0, Target::macos_arm64());
+        let bytes = pack(&art).unwrap();
+        // 208 header + 16 code = 224
+        assert_eq!(bytes.len(), 224);
+    }
+
+    // Test 4: ncmds = 2 at offset 16
+    #[test]
+    fn ncmds_is_two() {
+        let bytes = pack(&macos_arm64_art()).unwrap();
+        let ncmds = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
+        assert_eq!(ncmds, 2);
+    }
+
+    // Test 5: ARM64 CPU type at offset 4
+    #[test]
+    fn arm64_cpu_type() {
+        let bytes = pack(&macos_arm64_art()).unwrap();
+        let cputype = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(cputype, CPU_TYPE_ARM64);
+    }
+
+    // Test 6: x86_64 CPU type
+    #[test]
+    fn x86_64_cpu_type() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::macos_x64());
+        let bytes = pack(&art).unwrap();
+        let cputype = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(cputype, CPU_TYPE_X86_64);
+    }
+
+    // Test 7: native bytes appear at offset 208
+    #[test]
+    fn code_at_header_total() {
+        let code = vec![0xAA, 0xBB, 0xCC];
+        let art = CodeArtifact::new(code.clone(), 0, Target::macos_arm64());
+        let bytes = pack(&art).unwrap();
+        assert_eq!(&bytes[208..211], code.as_slice());
+    }
+
+    // Test 8: file_extension
+    #[test]
+    fn file_extension_is_macho() {
+        assert_eq!(file_extension(), ".macho");
+    }
+}

--- a/code/packages/rust/code-packager/src/pe.rs
+++ b/code/packages/rust/code-packager/src/pe.rs
@@ -165,6 +165,16 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
             "pe packager: native_bytes length exceeds u32::MAX (4 GiB)".into(),
         )
     })?;
+    // Guard: align_to(code_len, FILE_ALIGNMENT) computes `code_len + FILE_ALIGNMENT - 1`
+    // in u32. If code_len is within FILE_ALIGNMENT-1 bytes of u32::MAX, this addition
+    // overflows u32 — panicking in debug, wrapping silently in release.  The wrap produces
+    // a far-too-small raw_code_size, which in turn makes the output buffer too small and
+    // causes the copy_from_slice below to panic.  Reject the pathological range early.
+    if code_len > u32::MAX - (FILE_ALIGNMENT - 1) {
+        return Err(PackagerError::UnsupportedTarget(
+            "pe packager: native_bytes too large to align to file boundary (within 511 bytes of 4 GiB)".into(),
+        ));
+    }
     // Validate that entry_point fits in u32.  On a 64-bit host, usize can exceed u32::MAX;
     // truncating would silently embed a wrong AddressOfEntryPoint in the header.
     let entry_u32 = u32::try_from(artifact.entry_point).map_err(|_| {
@@ -173,6 +183,7 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
         )
     })?;
     // On-disk size of the code section, rounded up to the next file-alignment boundary.
+    // Safe: code_len <= u32::MAX - (FILE_ALIGNMENT - 1) checked above.
     let raw_code_size = align_to(code_len, FILE_ALIGNMENT);
     // In-memory image size: headers occupy [0, 0x1000), code occupies [0x1000, ...).
     let size_of_image = align_to(
@@ -191,7 +202,15 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
     })?;
 
     // Pre-allocate the full output buffer.
-    let total_size = (TEXT_FILE_OFFSET + raw_code_size) as usize;
+    // Use checked_add so that a near-u32::MAX raw_code_size cannot silently produce
+    // an underflowed total_size that is too small for the copy_from_slice below.
+    let total_size = TEXT_FILE_OFFSET
+        .checked_add(raw_code_size)
+        .ok_or_else(|| {
+            PackagerError::UnsupportedTarget(
+                "pe packager: total output size (headers + code) overflows u32".into(),
+            )
+        })? as usize;
     let mut out: Vec<u8> = vec![0u8; total_size];
 
     // ── DOS stub (64 bytes) ───────────────────────────────────────────────────

--- a/code/packages/rust/code-packager/src/pe.rs
+++ b/code/packages/rust/code-packager/src/pe.rs
@@ -1,0 +1,411 @@
+//! PE32+ executable packager for Windows x86-64.
+//!
+//! Produces a minimal Portable Executable (PE32+) file — the binary format
+//! used by all Windows NT-family operating systems (Windows XP through 11,
+//! Windows Server). The "32+" suffix means this is the 64-bit variant of the
+//! PE format (magic = 0x020B), as opposed to PE32 (magic = 0x010B) for 32-bit.
+//!
+//! ## PE file layout
+//!
+//! ```text
+//! Offset  │ Size │ Content
+//! ────────┼──────┼─────────────────────────────────────────────────────────
+//!       0 │  64  │ DOS stub (MZ header + minimal stub program)
+//!      64 │   4  │ PE signature ("PE\x00\x00")
+//!      68 │  20  │ COFF file header
+//!      88 │ 240  │ Optional header (PE32+ variant)
+//!     328 │  40  │ Section table (one .text entry)
+//!     368 │ …    │ Padding to 0x200 (FileAlignment boundary)
+//!    0x200 │   N  │ .text section (native_bytes + padding to FileAlignment)
+//! ```
+//!
+//! ## DOS stub (64 bytes)
+//!
+//! The very start of every PE file must be an MS-DOS compatible header so
+//! that old DOS programs print "This program cannot be run in DOS mode."
+//! Modern Windows loaders look only at the `e_magic` ("MZ") and `e_lfanew`
+//! fields and jump straight to the PE signature.
+//!
+//! ```text
+//! Offset │ Field    │ Value
+//! ───────┼──────────┼──────────────────────────────────────────────────────
+//!      0 │ e_magic  │ 0x5A4D = "MZ" (Mark Zbikowski, the DOS header designer)
+//!     60 │ e_lfanew │ 64 (byte offset of the PE signature)
+//!   rest  │ padding  │ 0
+//! ```
+//!
+//! ## COFF header (20 bytes, at offset 68)
+//!
+//! ```text
+//! Field                │ Size │ Value
+//! ─────────────────────┼──────┼──────────────────────────────────────────────
+//! Machine              │  2   │ 0x8664 = IMAGE_FILE_MACHINE_AMD64
+//! NumberOfSections     │  2   │ 1 (just .text)
+//! TimeDateStamp        │  4   │ 0 (reproducible builds)
+//! PointerToSymbolTable │  4   │ 0 (no COFF symbols)
+//! NumberOfSymbols      │  4   │ 0
+//! SizeOfOptionalHeader │  2   │ 240 (PE32+ optional header size)
+//! Characteristics      │  2   │ 0x0022 = EXECUTABLE_IMAGE | NO_RELOCATIONS
+//! ```
+//!
+//! ## Optional header PE32+ (240 bytes, at offset 88)
+//!
+//! Despite the name, this header is *mandatory* for executable images.
+//! "Optional" refers to the fact that it's absent in object files (.obj).
+//!
+//! Key fields:
+//! ```text
+//! Field                      │ Value
+//! ───────────────────────────┼──────────────────────────────────────────────
+//! Magic                      │ 0x020B (PE32+, 64-bit)
+//! SizeOfCode                 │ aligned(len(native_bytes), 0x200)
+//! AddressOfEntryPoint        │ 0x1000 + entry_point (RVA)
+//! BaseOfCode                 │ 0x1000 (first section starts at RVA 0x1000)
+//! ImageBase                  │ 0x140000000 (default for 64-bit Windows EXEs)
+//! SectionAlignment           │ 0x1000 (4 KiB page alignment in memory)
+//! FileAlignment              │ 0x200 (512-byte alignment on disk)
+//! SizeOfImage                │ aligned(0x1000 + len(native_bytes), 0x1000)
+//! SizeOfHeaders              │ 0x200 (all headers fit in first 512-byte block)
+//! Subsystem                  │ 3 = IMAGE_SUBSYSTEM_WINDOWS_CUI (console)
+//! NumberOfRvaAndSizes        │ 16 (standard data directory count)
+//! DataDirectory[16]          │ all zeros (no exports, imports, resources, etc.)
+//! ```
+//!
+//! ## Section table (.text, 40 bytes)
+//!
+//! ```text
+//! Field                │ Value
+//! ─────────────────────┼───────────────────────────────────────────────────
+//! Name                 │ ".text\0\0\0" (8 bytes, NUL-padded)
+//! VirtualSize          │ len(native_bytes)
+//! VirtualAddress       │ 0x1000 (RVA — relative virtual address)
+//! SizeOfRawData        │ aligned(len(native_bytes), 0x200)
+//! PointerToRawData     │ 0x200 (file offset of the .text section)
+//! Characteristics      │ 0x60000020 = code | execute | read
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+// The PE signature ("PE\x00\x00") is at the offset stored in e_lfanew.
+const PE_HEADER_OFFSET: u32 = 64;
+
+// SectionAlignment: sections are aligned to 4 KiB pages in virtual memory.
+const SECTION_ALIGNMENT: u32 = 0x1000;
+
+// FileAlignment: sections are aligned to 512-byte blocks on disk.
+const FILE_ALIGNMENT: u32 = 0x200;
+
+// All headers (DOS stub + PE sig + COFF + optional + section table) fit in 0x200.
+const SIZE_OF_HEADERS: u32 = 0x200;
+
+// The virtual address (RVA) where the .text section is mapped.
+const TEXT_RVA: u32 = 0x1000;
+
+// The .text section is at file offset 0x200 (first FileAlignment-aligned block
+// after all headers).
+const TEXT_FILE_OFFSET: u32 = 0x200;
+
+// Default image base for PE32+ executables.
+// The Windows loader prefers this address; ASLR may override it.
+const IMAGE_BASE: u64 = 0x140000000;
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// Round `x` up to the next multiple of `n`.
+///
+/// `n` must be a power of two.  Equivalent to `ceil(x / n) * n`.
+///
+/// ```text
+/// align_to(3,  512) = 512
+/// align_to(512, 512) = 512
+/// align_to(513, 512) = 1024
+/// ```
+fn align_to(x: u32, n: u32) -> u32 {
+    // Bit-twiddling trick: `!(n-1)` is a mask that zeros the low bits.
+    // Adding `n-1` first ensures we round *up* rather than down.
+    (x + n - 1) & !(n - 1)
+}
+
+/// Validate that the artifact targets Windows x86-64 PE format.
+fn validate(artifact: &CodeArtifact) -> Result<(), PackagerError> {
+    if artifact.target.binary_format != "pe" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pe packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+    if artifact.target.os != "windows" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pe packager expects os=windows, got {:?}",
+            artifact.target.os
+        )));
+    }
+    Ok(())
+}
+
+/// Pack `artifact` into a PE32+ executable binary.
+///
+/// Returns the raw bytes of the `.exe` file.  All fields are little-endian.
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if the artifact's target is not
+/// `windows_x64()`.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    validate(artifact)?;
+
+    let code_len = artifact.native_bytes.len() as u32;
+    // On-disk size of the code section, rounded up to the next file-alignment boundary.
+    let raw_code_size = align_to(code_len, FILE_ALIGNMENT);
+    // In-memory image size: headers occupy [0, 0x1000), code occupies [0x1000, ...).
+    let size_of_image = align_to(TEXT_RVA + code_len, SECTION_ALIGNMENT);
+    // RVA of the entry point = start of .text + entry_point offset.
+    let address_of_entry_point = TEXT_RVA + artifact.entry_point as u32;
+
+    // Pre-allocate the full output buffer.
+    let total_size = (TEXT_FILE_OFFSET + raw_code_size) as usize;
+    let mut out: Vec<u8> = vec![0u8; total_size];
+
+    // ── DOS stub (64 bytes) ───────────────────────────────────────────────────
+
+    // e_magic = "MZ" — the DOS magic number.
+    out[0] = b'M';
+    out[1] = b'Z';
+    // e_lfanew at offset 60 — tells the loader where the PE signature is.
+    out[60..64].copy_from_slice(&PE_HEADER_OFFSET.to_le_bytes());
+
+    // ── PE signature (4 bytes, at offset 64) ──────────────────────────────────
+
+    out[64] = b'P';
+    out[65] = b'E';
+    out[66] = 0x00;
+    out[67] = 0x00;
+
+    // ── COFF header (20 bytes, at offset 68) ──────────────────────────────────
+
+    let mut pos = 68usize;
+
+    // Machine = 0x8664 = IMAGE_FILE_MACHINE_AMD64 (x86-64).
+    out[pos..pos + 2].copy_from_slice(&0x8664u16.to_le_bytes()); pos += 2;
+    // NumberOfSections = 1 (just .text).
+    out[pos..pos + 2].copy_from_slice(&1u16.to_le_bytes()); pos += 2;
+    // TimeDateStamp = 0 for reproducible builds.
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // PointerToSymbolTable = 0 (no COFF symbol table).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // NumberOfSymbols = 0.
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // SizeOfOptionalHeader = 240 (fixed size for PE32+).
+    out[pos..pos + 2].copy_from_slice(&240u16.to_le_bytes()); pos += 2;
+    // Characteristics = 0x0022:
+    //   IMAGE_FILE_EXECUTABLE_IMAGE (0x0002) — this is a runnable executable.
+    //   IMAGE_FILE_RELOCS_STRIPPED  (0x0001) — no base relocations needed.
+    out[pos..pos + 2].copy_from_slice(&0x0022u16.to_le_bytes()); pos += 2;
+
+    // pos is now 88. ── Optional header (240 bytes) ───────────────────────────
+
+    // Magic = 0x020B = PE32+ (64-bit image).
+    out[pos..pos + 2].copy_from_slice(&0x020Bu16.to_le_bytes()); pos += 2;
+    // MajorLinkerVersion = 0.
+    out[pos] = 0; pos += 1;
+    // MinorLinkerVersion = 0.
+    out[pos] = 0; pos += 1;
+    // SizeOfCode: total size of all code sections on disk (aligned).
+    out[pos..pos + 4].copy_from_slice(&raw_code_size.to_le_bytes()); pos += 4;
+    // SizeOfInitializedData = 0 (no .data section).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // SizeOfUninitializedData = 0 (no .bss section).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // AddressOfEntryPoint: RVA of the first instruction.
+    out[pos..pos + 4].copy_from_slice(&address_of_entry_point.to_le_bytes()); pos += 4;
+    // BaseOfCode: RVA where the code sections start (0x1000).
+    out[pos..pos + 4].copy_from_slice(&TEXT_RVA.to_le_bytes()); pos += 4;
+    // ImageBase: preferred load address in virtual memory.
+    out[pos..pos + 8].copy_from_slice(&IMAGE_BASE.to_le_bytes()); pos += 8;
+    // SectionAlignment: sections align to 4 KiB in virtual memory.
+    out[pos..pos + 4].copy_from_slice(&SECTION_ALIGNMENT.to_le_bytes()); pos += 4;
+    // FileAlignment: sections align to 512 bytes on disk.
+    out[pos..pos + 4].copy_from_slice(&FILE_ALIGNMENT.to_le_bytes()); pos += 4;
+    // MajorOperatingSystemVersion = 6 (Windows Vista/2008 baseline).
+    out[pos..pos + 2].copy_from_slice(&6u16.to_le_bytes()); pos += 2;
+    // MinorOperatingSystemVersion = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // MajorImageVersion = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // MinorImageVersion = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // MajorSubsystemVersion = 6 (Windows Vista minimum).
+    out[pos..pos + 2].copy_from_slice(&6u16.to_le_bytes()); pos += 2;
+    // MinorSubsystemVersion = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // Win32VersionValue = 0 (must be zero per spec).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // SizeOfImage: total size of the image in memory, page-aligned.
+    out[pos..pos + 4].copy_from_slice(&size_of_image.to_le_bytes()); pos += 4;
+    // SizeOfHeaders: size of all headers on disk, aligned to FileAlignment.
+    out[pos..pos + 4].copy_from_slice(&SIZE_OF_HEADERS.to_le_bytes()); pos += 4;
+    // CheckSum = 0 (loader verifies only for kernel-mode drivers; ignored for EXE).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // Subsystem = 3 = IMAGE_SUBSYSTEM_WINDOWS_CUI (console application).
+    //   1 = native (no subsystem), 2 = Windows GUI, 3 = Windows CUI (console),
+    //   9 = WinCE GUI, 14 = EFI application, etc.
+    out[pos..pos + 2].copy_from_slice(&3u16.to_le_bytes()); pos += 2;
+    // DllCharacteristics = 0 (no ASLR, no DEP, etc. for minimal binary).
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // SizeOfStackReserve: amount of virtual address space reserved for the stack.
+    out[pos..pos + 8].copy_from_slice(&0x100000u64.to_le_bytes()); pos += 8;
+    // SizeOfStackCommit: initial committed (physically backed) stack size.
+    out[pos..pos + 8].copy_from_slice(&0x1000u64.to_le_bytes()); pos += 8;
+    // SizeOfHeapReserve: reserved heap space (managed by process heap).
+    out[pos..pos + 8].copy_from_slice(&0x100000u64.to_le_bytes()); pos += 8;
+    // SizeOfHeapCommit: initial committed heap size.
+    out[pos..pos + 8].copy_from_slice(&0x1000u64.to_le_bytes()); pos += 8;
+    // LoaderFlags = 0 (obsolete field, must be zero).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // NumberOfRvaAndSizes = 16: the loader will parse 16 data directory entries.
+    out[pos..pos + 4].copy_from_slice(&16u32.to_le_bytes()); pos += 4;
+    // DataDirectory[16]: 16 entries × 8 bytes each = 128 bytes, all zero.
+    // (No exports, imports, resources, exceptions, security, base relocs, etc.)
+    for _ in 0..16 {
+        out[pos..pos + 8].copy_from_slice(&0u64.to_le_bytes());
+        pos += 8;
+    }
+
+    // pos should now be 88 + 240 = 328. ── Section table ───────────────────────
+
+    // Section name: ".text\0\0\0" — exactly 8 bytes.
+    out[pos..pos + 8].copy_from_slice(b".text\x00\x00\x00"); pos += 8;
+    // VirtualSize: the actual byte count of the section's content (unpadded).
+    out[pos..pos + 4].copy_from_slice(&code_len.to_le_bytes()); pos += 4;
+    // VirtualAddress: RVA where the section is mapped in memory.
+    out[pos..pos + 4].copy_from_slice(&TEXT_RVA.to_le_bytes()); pos += 4;
+    // SizeOfRawData: disk size, rounded up to FileAlignment.
+    out[pos..pos + 4].copy_from_slice(&raw_code_size.to_le_bytes()); pos += 4;
+    // PointerToRawData: file offset of the section's raw bytes.
+    out[pos..pos + 4].copy_from_slice(&TEXT_FILE_OFFSET.to_le_bytes()); pos += 4;
+    // PointerToRelocations = 0 (no COFF relocations).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // PointerToLinenumbers = 0 (deprecated).
+    out[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()); pos += 4;
+    // NumberOfRelocations = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // NumberOfLinenumbers = 0.
+    out[pos..pos + 2].copy_from_slice(&0u16.to_le_bytes()); pos += 2;
+    // Characteristics = 0x60000020:
+    //   IMAGE_SCN_CNT_CODE        (0x00000020) — section contains executable code.
+    //   IMAGE_SCN_MEM_EXECUTE     (0x20000000) — section is executable.
+    //   IMAGE_SCN_MEM_READ        (0x40000000) — section is readable.
+    out[pos..pos + 4].copy_from_slice(&0x60000020u32.to_le_bytes());
+    pos += 4;
+
+    // The section table ends at 328 + 40 = 368.
+    // The output buffer was pre-filled with zeros, so the gap from 368 to 0x200
+    // is already zero-padded — no extra work needed.
+
+    // ── .text section (at file offset 0x200) ─────────────────────────────────
+
+    // Copy native bytes. Any remaining bytes up to raw_code_size are already 0.
+    let text_start = TEXT_FILE_OFFSET as usize;
+    out[text_start..text_start + artifact.native_bytes.len()]
+        .copy_from_slice(&artifact.native_bytes);
+
+    let _ = pos; // suppress unused-variable warning
+    Ok(out)
+}
+
+/// The conventional file extension for PE executables.
+pub fn file_extension() -> &'static str {
+    ".exe"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target::Target;
+
+    fn win64_art() -> CodeArtifact {
+        CodeArtifact::new(vec![0xC3], 0, Target::windows_x64()) // single RET instruction
+    }
+
+    // Test 1: MZ magic at offset 0
+    #[test]
+    fn produces_mz_magic() {
+        let bytes = pack(&win64_art()).unwrap();
+        assert_eq!(&bytes[0..2], b"MZ");
+    }
+
+    // Test 2: PE signature at offset 64
+    #[test]
+    fn pe_signature_at_64() {
+        let bytes = pack(&win64_art()).unwrap();
+        assert_eq!(&bytes[64..68], b"PE\x00\x00");
+    }
+
+    // Test 3: rejects linux_x64
+    #[test]
+    fn rejects_linux_target() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 4: rejects macos_x64
+    #[test]
+    fn rejects_macos_target() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::macos_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 5: file size is 0x200 + aligned code
+    #[test]
+    fn file_size_correct() {
+        // 1 byte of code → aligned to 512 → total 0x200 + 0x200 = 0x400
+        let bytes = pack(&win64_art()).unwrap();
+        assert_eq!(bytes.len(), 0x400);
+    }
+
+    // Test 6: native bytes at 0x200
+    #[test]
+    fn code_at_0x200() {
+        let bytes = pack(&win64_art()).unwrap();
+        assert_eq!(bytes[0x200], 0xC3); // RET
+    }
+
+    // Test 7: Machine field in COFF header = 0x8664
+    #[test]
+    fn coff_machine_amd64() {
+        let bytes = pack(&win64_art()).unwrap();
+        // COFF header starts at offset 68. Machine is the first field (2 bytes).
+        let machine = u16::from_le_bytes([bytes[68], bytes[69]]);
+        assert_eq!(machine, 0x8664);
+    }
+
+    // Test 8: align_to helper
+    #[test]
+    fn align_to_helper() {
+        assert_eq!(align_to(0, 512), 0);
+        assert_eq!(align_to(1, 512), 512);
+        assert_eq!(align_to(512, 512), 512);
+        assert_eq!(align_to(513, 512), 1024);
+        assert_eq!(align_to(1000, 4096), 4096);
+    }
+
+    // Test 9: file_extension
+    #[test]
+    fn file_extension_is_exe() {
+        assert_eq!(file_extension(), ".exe");
+    }
+
+    // Test 10: optional header magic = 0x020B (PE32+)
+    #[test]
+    fn optional_header_magic_pe32plus() {
+        let bytes = pack(&win64_art()).unwrap();
+        // Optional header starts at 68 + 20 = 88. First 2 bytes = magic.
+        let magic = u16::from_le_bytes([bytes[88], bytes[89]]);
+        assert_eq!(magic, 0x020B, "expected PE32+ magic 0x020B, got {magic:#06X}");
+    }
+}

--- a/code/packages/rust/code-packager/src/pe.rs
+++ b/code/packages/rust/code-packager/src/pe.rs
@@ -157,13 +157,38 @@ fn validate(artifact: &CodeArtifact) -> Result<(), PackagerError> {
 pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
     validate(artifact)?;
 
-    let code_len = artifact.native_bytes.len() as u32;
+    // Validate that native_bytes fits in a PE32+ file (max ~4 GiB, constrained by u32 RVA
+    // and file-offset arithmetic).  Silently truncating via `as u32` would produce an
+    // undersized output buffer that panics on the copy_from_slice below.
+    let code_len = u32::try_from(artifact.native_bytes.len()).map_err(|_| {
+        PackagerError::UnsupportedTarget(
+            "pe packager: native_bytes length exceeds u32::MAX (4 GiB)".into(),
+        )
+    })?;
+    // Validate that entry_point fits in u32.  On a 64-bit host, usize can exceed u32::MAX;
+    // truncating would silently embed a wrong AddressOfEntryPoint in the header.
+    let entry_u32 = u32::try_from(artifact.entry_point).map_err(|_| {
+        PackagerError::UnsupportedTarget(
+            "pe packager: entry_point exceeds u32::MAX".into(),
+        )
+    })?;
     // On-disk size of the code section, rounded up to the next file-alignment boundary.
     let raw_code_size = align_to(code_len, FILE_ALIGNMENT);
     // In-memory image size: headers occupy [0, 0x1000), code occupies [0x1000, ...).
-    let size_of_image = align_to(TEXT_RVA + code_len, SECTION_ALIGNMENT);
+    let size_of_image = align_to(
+        TEXT_RVA.checked_add(code_len).ok_or_else(|| {
+            PackagerError::UnsupportedTarget(
+                "pe packager: TEXT_RVA + code_len overflows u32".into(),
+            )
+        })?,
+        SECTION_ALIGNMENT,
+    );
     // RVA of the entry point = start of .text + entry_point offset.
-    let address_of_entry_point = TEXT_RVA + artifact.entry_point as u32;
+    let address_of_entry_point = TEXT_RVA.checked_add(entry_u32).ok_or_else(|| {
+        PackagerError::UnsupportedTarget(
+            "pe packager: TEXT_RVA + entry_point overflows u32".into(),
+        )
+    })?;
 
     // Pre-allocate the full output buffer.
     let total_size = (TEXT_FILE_OFFSET + raw_code_size) as usize;

--- a/code/packages/rust/code-packager/src/pe.rs
+++ b/code/packages/rust/code-packager/src/pe.rs
@@ -165,15 +165,28 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
             "pe packager: native_bytes length exceeds u32::MAX (4 GiB)".into(),
         )
     })?;
-    // Guard: align_to(code_len, FILE_ALIGNMENT) computes `code_len + FILE_ALIGNMENT - 1`
-    // in u32. If code_len is within FILE_ALIGNMENT-1 bytes of u32::MAX, this addition
-    // overflows u32 — panicking in debug, wrapping silently in release.  The wrap produces
-    // a far-too-small raw_code_size, which in turn makes the output buffer too small and
-    // causes the copy_from_slice below to panic.  Reject the pathological range early.
-    if code_len > u32::MAX - (FILE_ALIGNMENT - 1) {
-        return Err(PackagerError::UnsupportedTarget(
-            "pe packager: native_bytes too large to align to file boundary (within 511 bytes of 4 GiB)".into(),
-        ));
+    // Guard: both align_to calls below compute `val + alignment - 1` in u32.  We need
+    // to reject any code_len that would cause either of these additions to overflow:
+    //
+    //   1. raw_code_size  = align_to(code_len,            FILE_ALIGNMENT)
+    //      → requires code_len + FILE_ALIGNMENT - 1 ≤ u32::MAX
+    //      → code_len ≤ u32::MAX - (FILE_ALIGNMENT - 1)
+    //
+    //   2. size_of_image  = align_to(TEXT_RVA + code_len, SECTION_ALIGNMENT)
+    //      → requires TEXT_RVA + code_len + SECTION_ALIGNMENT - 1 ≤ u32::MAX
+    //      → code_len ≤ u32::MAX - TEXT_RVA - (SECTION_ALIGNMENT - 1)
+    //
+    // The second bound is tighter (0xFFFFE000 vs 0xFFFFFE00), so it subsumes the first.
+    // Using a single check here keeps the subsequent align_to calls unconditionally safe.
+    //
+    // Practical impact: the effective code limit is ~3.99 GiB — far larger than any
+    // reasonable compiled binary.
+    const MAX_CODE_LEN: u32 = u32::MAX - TEXT_RVA - (SECTION_ALIGNMENT - 1);
+    if code_len > MAX_CODE_LEN {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pe packager: native_bytes length {code_len} exceeds maximum \
+             safe size {MAX_CODE_LEN} (required for 4 KiB section alignment)"
+        )));
     }
     // Validate that entry_point fits in u32.  On a 64-bit host, usize can exceed u32::MAX;
     // truncating would silently embed a wrong AddressOfEntryPoint in the header.
@@ -183,17 +196,12 @@ pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
         )
     })?;
     // On-disk size of the code section, rounded up to the next file-alignment boundary.
-    // Safe: code_len <= u32::MAX - (FILE_ALIGNMENT - 1) checked above.
+    // Safe: code_len ≤ MAX_CODE_LEN ≤ u32::MAX - (FILE_ALIGNMENT - 1).
     let raw_code_size = align_to(code_len, FILE_ALIGNMENT);
     // In-memory image size: headers occupy [0, 0x1000), code occupies [0x1000, ...).
-    let size_of_image = align_to(
-        TEXT_RVA.checked_add(code_len).ok_or_else(|| {
-            PackagerError::UnsupportedTarget(
-                "pe packager: TEXT_RVA + code_len overflows u32".into(),
-            )
-        })?,
-        SECTION_ALIGNMENT,
-    );
+    // Safe: TEXT_RVA + code_len ≤ TEXT_RVA + MAX_CODE_LEN = u32::MAX - (SECTION_ALIGNMENT-1),
+    // so align_to(TEXT_RVA + code_len, SECTION_ALIGNMENT) cannot overflow.
+    let size_of_image = align_to(TEXT_RVA + code_len, SECTION_ALIGNMENT);
     // RVA of the entry point = start of .text + entry_point offset.
     let address_of_entry_point = TEXT_RVA.checked_add(entry_u32).ok_or_else(|| {
         PackagerError::UnsupportedTarget(

--- a/code/packages/rust/code-packager/src/raw.rs
+++ b/code/packages/rust/code-packager/src/raw.rs
@@ -1,0 +1,110 @@
+//! Raw binary packager — pass-through with no container format.
+//!
+//! The "raw" packager is the simplest possible packager: it returns the native
+//! bytes unmodified, with no ELF header, no Mach-O header, and no PE stub.
+//!
+//! ## Use cases
+//!
+//! Raw binaries are used in situations where there is no operating system to
+//! parse a binary format:
+//!
+//! - **Bootloaders**: the BIOS/UEFI loads the first 512 bytes of a disk sector
+//!   directly into memory and jumps to it. The bytes must start with
+//!   executable code, not an OS-specific header.
+//! - **Firmware images**: microcontrollers like the ATmega328 (Arduino Uno)
+//!   have their flash memory programmed with a flat binary image.
+//! - **ROM dumps**: retro computer emulators need the exact bytes that were
+//!   in the original ROM chip.
+//! - **Unit testing**: testing a code generator is easier with raw output
+//!   because there are no headers to strip before comparing bytes.
+//!
+//! ## Accepted targets
+//!
+//! Any target with `binary_format == "raw"` is accepted, regardless of `arch`
+//! or `os`. Use `Target::raw(arch)` to construct such a target.
+//!
+//! ```rust
+//! use code_packager::{CodeArtifact, PackagerRegistry, Target};
+//!
+//! let art = CodeArtifact::new(vec![0x90, 0xC3], 0, Target::raw("x86_64"));
+//! let bytes = PackagerRegistry::pack(&art).unwrap();
+//! assert_eq!(bytes, vec![0x90, 0xC3]);
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+
+/// Pack `artifact` by returning its native bytes unchanged.
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if `binary_format != "raw"`.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    if artifact.target.binary_format != "raw" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "raw packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+    // Nothing to do — just clone the bytes.
+    Ok(artifact.native_bytes.clone())
+}
+
+/// The conventional file extension for raw binaries.
+pub fn file_extension() -> &'static str {
+    ".bin"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target::Target;
+
+    // Test 1: raw target returns bytes unchanged
+    #[test]
+    fn pass_through_bytes() {
+        let code = vec![0x90, 0x48, 0x31, 0xC0, 0xC3];
+        let art = CodeArtifact::new(code.clone(), 0, Target::raw("x86_64"));
+        let out = pack(&art).unwrap();
+        assert_eq!(out, code);
+    }
+
+    // Test 2: empty bytes round-trip
+    #[test]
+    fn empty_bytes() {
+        let art = CodeArtifact::new(vec![], 0, Target::raw("avr"));
+        let out = pack(&art).unwrap();
+        assert!(out.is_empty());
+    }
+
+    // Test 3: rejects elf64 target
+    #[test]
+    fn rejects_elf64() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 4: rejects wasm target
+    #[test]
+    fn rejects_wasm() {
+        let art = CodeArtifact::new(vec![0x0B], 0, Target::wasm());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 5: output is a clone (not the same allocation)
+    #[test]
+    fn output_is_independent_clone() {
+        let code = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let art = CodeArtifact::new(code.clone(), 0, Target::raw("mips"));
+        let out = pack(&art).unwrap();
+        assert_eq!(out, code);
+    }
+
+    // Test 6: file_extension
+    #[test]
+    fn file_extension_is_bin() {
+        assert_eq!(file_extension(), ".bin");
+    }
+}

--- a/code/packages/rust/code-packager/src/registry.rs
+++ b/code/packages/rust/code-packager/src/registry.rs
@@ -1,0 +1,206 @@
+//! Packager registry — dispatches artifacts to the right packager by format.
+//!
+//! The `PackagerRegistry` is the single entry point for packaging. Callers
+//! create a `CodeArtifact`, call `PackagerRegistry::pack`, and receive the
+//! binary bytes — without knowing which specific packager was invoked.
+//!
+//! ## Dispatch table
+//!
+//! ```text
+//! binary_format  │  packager module  │  output file
+//! ───────────────┼───────────────────┼─────────────────────────────────────
+//! "elf64"        │  elf64::pack      │  Linux ELF64 executable (.elf)
+//! "macho64"      │  macho64::pack    │  macOS Mach-O 64-bit executable (.macho)
+//! "pe"           │  pe::pack         │  Windows PE32+ executable (.exe)
+//! "wasm"         │  wasm::pack       │  WebAssembly module (.wasm)
+//! "raw"          │  raw::pack        │  Raw binary blob (.bin)
+//! "intel_hex"    │  intel_hex::pack  │  Intel HEX text file (.hex)
+//! ```
+//!
+//! Any other `binary_format` value returns `PackagerError::UnsupportedTarget`.
+//!
+//! ## Design note
+//!
+//! The registry is a zero-size struct with only associated functions. There is
+//! no state to maintain — the dispatch is purely a function of the artifact's
+//! target.
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use code_packager::{CodeArtifact, PackagerRegistry, Target};
+//!
+//! let art = CodeArtifact::new(
+//!     vec![0x90, 0xC3], // NOP; RET
+//!     0,
+//!     Target::linux_x64(),
+//! );
+//! let bytes = PackagerRegistry::pack(&art).unwrap();
+//! assert_eq!(&bytes[0..4], &[0x7F, b'E', b'L', b'F']);
+//! ```
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+use crate::target::Target;
+use crate::{elf64, intel_hex, macho64, pe, raw, wasm};
+
+/// Stateless packager dispatcher.
+///
+/// All methods are `pub fn` (not `pub fn self`); you never need to construct
+/// an instance.
+pub struct PackagerRegistry;
+
+impl PackagerRegistry {
+    /// Pack `artifact` using the packager that matches its `binary_format`.
+    ///
+    /// # Errors
+    ///
+    /// - `PackagerError::UnsupportedTarget` if no packager handles the format.
+    /// - Any error returned by the specific packager (also `UnsupportedTarget`
+    ///   or `WasmEncodeError`).
+    pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+        match artifact.target.binary_format.as_str() {
+            // Linux/BSD ELF64 executable.
+            "elf64" => elf64::pack(artifact),
+            // macOS Mach-O 64-bit executable.
+            "macho64" => macho64::pack(artifact),
+            // Windows PE32+ executable.
+            "pe" => pe::pack(artifact),
+            // WebAssembly 1.0 module.
+            "wasm" => wasm::pack(artifact),
+            // Flat binary blob (no container).
+            "raw" => raw::pack(artifact),
+            // Intel HEX ASCII text format.
+            "intel_hex" => intel_hex::pack(artifact),
+            // Unknown format.
+            fmt => Err(PackagerError::UnsupportedTarget(format!(
+                "no packager for binary_format={fmt:?}"
+            ))),
+        }
+    }
+
+    /// Return the conventional file extension for the given `target`.
+    ///
+    /// The extension includes the leading dot (e.g. `".elf"`, `".exe"`).
+    /// For unknown formats, returns `".bin"` as a safe fallback.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use code_packager::{PackagerRegistry, Target};
+    ///
+    /// assert_eq!(PackagerRegistry::file_extension(&Target::linux_x64()),   ".elf");
+    /// assert_eq!(PackagerRegistry::file_extension(&Target::windows_x64()), ".exe");
+    /// assert_eq!(PackagerRegistry::file_extension(&Target::wasm()),        ".wasm");
+    /// ```
+    pub fn file_extension(target: &Target) -> &'static str {
+        match target.binary_format.as_str() {
+            "elf64" => ".elf",
+            "macho64" => ".macho",
+            "pe" => ".exe",
+            "wasm" => ".wasm",
+            "raw" => ".bin",
+            "intel_hex" => ".hex",
+            // Unknown formats get a safe generic extension.
+            _ => ".bin",
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test 1: dispatch to ELF64 — output starts with ELF magic
+    #[test]
+    fn dispatch_elf64() {
+        let art = CodeArtifact::new(vec![0x90], 0, Target::linux_x64());
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        assert_eq!(&bytes[0..4], &[0x7F, b'E', b'L', b'F']);
+    }
+
+    // Test 2: dispatch to Mach-O — output starts with Mach-O magic
+    #[test]
+    fn dispatch_macho64() {
+        let art = CodeArtifact::new(vec![0x1F, 0x20, 0x03, 0xD5], 0, Target::macos_arm64());
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        // 0xFEEDFACF in little-endian = [0xCF, 0xFA, 0xED, 0xFE]
+        assert_eq!(&bytes[0..4], &[0xCF, 0xFA, 0xED, 0xFE]);
+    }
+
+    // Test 3: dispatch to PE — output starts with "MZ"
+    #[test]
+    fn dispatch_pe() {
+        let art = CodeArtifact::new(vec![0xC3], 0, Target::windows_x64());
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        assert_eq!(&bytes[0..2], b"MZ");
+    }
+
+    // Test 4: dispatch to raw — output equals input
+    #[test]
+    fn dispatch_raw() {
+        let code = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let art = CodeArtifact::new(code.clone(), 0, Target::raw("x86_64"));
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        assert_eq!(bytes, code);
+    }
+
+    // Test 5: dispatch to intel_hex — output is ASCII text
+    #[test]
+    fn dispatch_intel_hex() {
+        let art = CodeArtifact::new(vec![0xFF], 0, Target::intel_4004());
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains(':'));
+        assert!(text.ends_with('\n'));
+    }
+
+    // Test 6: dispatch to WASM — output starts with WASM magic
+    #[test]
+    fn dispatch_wasm() {
+        // Minimal valid function body: i32.const 0; end
+        let art = CodeArtifact::new(vec![0x41, 0x00, 0x0B], 0, Target::wasm());
+        let bytes = PackagerRegistry::pack(&art).unwrap();
+        assert_eq!(&bytes[0..4], &[0x00, 0x61, 0x73, 0x6D]);
+    }
+
+    // Test 7: unknown format returns UnsupportedTarget error
+    #[test]
+    fn unknown_format_returns_error() {
+        use crate::target::Target;
+        let art = CodeArtifact::new(
+            vec![0x00],
+            0,
+            Target { arch: "x86_64".into(), os: "haiku".into(), binary_format: "elf32".into() },
+        );
+        let err = PackagerRegistry::pack(&art).unwrap_err();
+        assert!(
+            matches!(err, PackagerError::UnsupportedTarget(_)),
+            "expected UnsupportedTarget, got {err:?}"
+        );
+    }
+
+    // Test 8: file_extension for each known format
+    #[test]
+    fn file_extension_all_formats() {
+        assert_eq!(PackagerRegistry::file_extension(&Target::linux_x64()),   ".elf");
+        assert_eq!(PackagerRegistry::file_extension(&Target::macos_arm64()), ".macho");
+        assert_eq!(PackagerRegistry::file_extension(&Target::windows_x64()), ".exe");
+        assert_eq!(PackagerRegistry::file_extension(&Target::wasm()),        ".wasm");
+        assert_eq!(PackagerRegistry::file_extension(&Target::raw("avr")),    ".bin");
+        assert_eq!(PackagerRegistry::file_extension(&Target::intel_4004()),  ".hex");
+    }
+
+    // Test 9: file_extension for unknown format returns ".bin"
+    #[test]
+    fn file_extension_unknown_returns_bin() {
+        let t = Target {
+            arch: "riscv64".into(),
+            os: "none".into(),
+            binary_format: "elf32".into(), // not in dispatch table
+        };
+        assert_eq!(PackagerRegistry::file_extension(&t), ".bin");
+    }
+}

--- a/code/packages/rust/code-packager/src/target.rs
+++ b/code/packages/rust/code-packager/src/target.rs
@@ -1,0 +1,271 @@
+//! Compilation target descriptor.
+//!
+//! A `Target` is an immutable triple of `(arch, os, binary_format)` that tells
+//! the packager how to wrap native bytes into the correct binary container.
+//!
+//! ## Analogy
+//!
+//! Think of the `Target` as the *address label* on a package:
+//!
+//! - `arch` says what CPU the code runs on (the language of the bytes inside).
+//! - `os`   says what operating system loads the file (who opens the package).
+//! - `binary_format` says the *container format* (ELF box, Mach-O box, PE box…).
+//!
+//! ## Supported triples
+//!
+//! ```text
+//! arch      │ os      │ binary_format │ factory method
+//! ──────────┼─────────┼───────────────┼───────────────────
+//! x86_64    │ linux   │ elf64         │ linux_x64()
+//! arm64     │ linux   │ elf64         │ linux_arm64()
+//! x86_64    │ macos   │ macho64       │ macos_x64()
+//! arm64     │ macos   │ macho64       │ macos_arm64()
+//! x86_64    │ windows │ pe            │ windows_x64()
+//! wasm32    │ none    │ wasm          │ wasm()
+//! <arch>    │ none    │ raw           │ raw(arch)
+//! i4004     │ none    │ intel_hex     │ intel_4004()
+//! i8008     │ none    │ intel_hex     │ intel_8008()
+//! ```
+
+/// Immutable description of a compilation target.
+///
+/// All three fields are plain `String` values so that callers can construct
+/// custom targets without needing an exhaustive enum.
+///
+/// # Examples
+///
+/// ```rust
+/// use code_packager::Target;
+///
+/// let t = Target::linux_x64();
+/// assert_eq!(t.arch, "x86_64");
+/// assert_eq!(t.os, "linux");
+/// assert_eq!(t.binary_format, "elf64");
+/// println!("{t}"); // "x86_64-linux-elf64"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Target {
+    /// The instruction-set architecture, e.g. `"x86_64"`, `"arm64"`, `"wasm32"`.
+    pub arch: String,
+    /// The operating system (or `"none"` for bare-metal / WASM targets).
+    pub os: String,
+    /// The binary container format: `"elf64"`, `"macho64"`, `"pe"`, `"wasm"`,
+    /// `"raw"`, or `"intel_hex"`.
+    pub binary_format: String,
+}
+
+impl Target {
+    // ── Private constructor ────────────────────────────────────────────────────
+
+    /// Internal helper: construct from string slices.
+    fn new(arch: &str, os: &str, binary_format: &str) -> Self {
+        Self {
+            arch: arch.to_string(),
+            os: os.to_string(),
+            binary_format: binary_format.to_string(),
+        }
+    }
+
+    // ── Linux targets (ELF64) ─────────────────────────────────────────────────
+
+    /// Linux on AMD64 / x86-64. Produces an ELF64 executable.
+    ///
+    /// This is the most common server target (EC2, GCP, Azure).
+    pub fn linux_x64() -> Self {
+        Self::new("x86_64", "linux", "elf64")
+    }
+
+    /// Linux on AArch64 / ARM64. Produces an ELF64 executable.
+    ///
+    /// Covers Raspberry Pi 4 (64-bit), AWS Graviton, Apple M1 running Linux.
+    pub fn linux_arm64() -> Self {
+        Self::new("arm64", "linux", "elf64")
+    }
+
+    // ── macOS targets (Mach-O 64) ─────────────────────────────────────────────
+
+    /// macOS on Intel x86-64. Produces a Mach-O 64-bit executable.
+    pub fn macos_x64() -> Self {
+        Self::new("x86_64", "macos", "macho64")
+    }
+
+    /// macOS on Apple Silicon (arm64). Produces a Mach-O 64-bit executable.
+    ///
+    /// Apple calls this architecture "arm64" in its toolchain even though the
+    /// ISA is technically AArch64.
+    pub fn macos_arm64() -> Self {
+        Self::new("arm64", "macos", "macho64")
+    }
+
+    // ── Windows target (PE32+) ────────────────────────────────────────────────
+
+    /// Windows on x86-64. Produces a PE32+ executable (`.exe`).
+    ///
+    /// PE32+ is the 64-bit variant of the Portable Executable format used by
+    /// Windows NT and all its descendants (XP, 7, 10, 11, Server).
+    pub fn windows_x64() -> Self {
+        Self::new("x86_64", "windows", "pe")
+    }
+
+    // ── WebAssembly target ────────────────────────────────────────────────────
+
+    /// WebAssembly (wasm32). Produces a `.wasm` module.
+    ///
+    /// The WASM target has no OS: it runs inside a host runtime (browser,
+    /// Wasmtime, Wasmer, Node.js, etc.).
+    pub fn wasm() -> Self {
+        Self::new("wasm32", "none", "wasm")
+    }
+
+    // ── Raw binary target ─────────────────────────────────────────────────────
+
+    /// Bare-metal raw binary for the given architecture.
+    ///
+    /// No container format is applied; the bytes are written verbatim.
+    /// Useful for bootloaders, firmware images, and ROM dumps.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use code_packager::Target;
+    /// let t = Target::raw("x86_64");
+    /// assert_eq!(t.binary_format, "raw");
+    /// ```
+    pub fn raw(arch: &str) -> Self {
+        Self::new(arch, "none", "raw")
+    }
+
+    // ── Intel HEX targets ─────────────────────────────────────────────────────
+
+    /// Intel 4004 (4-bit CPU, 1971). Produces an Intel HEX file.
+    ///
+    /// The i4004 was Intel's first microprocessor. Its 4-bit ALU and 12-bit
+    /// address space make it suitable for simple calculators and controllers.
+    /// Intel HEX is a text format that encodes binary data as ASCII records,
+    /// making it easy to transfer over serial links and program into EPROMs.
+    pub fn intel_4004() -> Self {
+        Self::new("i4004", "none", "intel_hex")
+    }
+
+    /// Intel 8008 (8-bit CPU, 1972). Produces an Intel HEX file.
+    ///
+    /// The i8008 was Intel's first 8-bit processor, a direct ancestor of the
+    /// 8080 and the x86 family. It addressed 16 KiB of memory.
+    pub fn intel_8008() -> Self {
+        Self::new("i8008", "none", "intel_hex")
+    }
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+impl std::fmt::Display for Target {
+    /// Formats as `"arch-os-binary_format"`, e.g. `"x86_64-linux-elf64"`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}-{}", self.arch, self.os, self.binary_format)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test 1: linux_x64 fields
+    #[test]
+    fn linux_x64_fields() {
+        let t = Target::linux_x64();
+        assert_eq!(t.arch, "x86_64");
+        assert_eq!(t.os, "linux");
+        assert_eq!(t.binary_format, "elf64");
+    }
+
+    // Test 2: linux_arm64 fields
+    #[test]
+    fn linux_arm64_fields() {
+        let t = Target::linux_arm64();
+        assert_eq!(t.arch, "arm64");
+        assert_eq!(t.os, "linux");
+        assert_eq!(t.binary_format, "elf64");
+    }
+
+    // Test 3: macos_x64 fields
+    #[test]
+    fn macos_x64_fields() {
+        let t = Target::macos_x64();
+        assert_eq!(t.arch, "x86_64");
+        assert_eq!(t.os, "macos");
+        assert_eq!(t.binary_format, "macho64");
+    }
+
+    // Test 4: macos_arm64 fields
+    #[test]
+    fn macos_arm64_fields() {
+        let t = Target::macos_arm64();
+        assert_eq!(t.arch, "arm64");
+        assert_eq!(t.os, "macos");
+        assert_eq!(t.binary_format, "macho64");
+    }
+
+    // Test 5: windows_x64 fields
+    #[test]
+    fn windows_x64_fields() {
+        let t = Target::windows_x64();
+        assert_eq!(t.arch, "x86_64");
+        assert_eq!(t.os, "windows");
+        assert_eq!(t.binary_format, "pe");
+    }
+
+    // Test 6: wasm fields
+    #[test]
+    fn wasm_fields() {
+        let t = Target::wasm();
+        assert_eq!(t.arch, "wasm32");
+        assert_eq!(t.os, "none");
+        assert_eq!(t.binary_format, "wasm");
+    }
+
+    // Test 7: raw(arch) sets binary_format to "raw"
+    #[test]
+    fn raw_target() {
+        let t = Target::raw("avr");
+        assert_eq!(t.arch, "avr");
+        assert_eq!(t.os, "none");
+        assert_eq!(t.binary_format, "raw");
+    }
+
+    // Test 8: intel_4004 fields
+    #[test]
+    fn intel_4004_fields() {
+        let t = Target::intel_4004();
+        assert_eq!(t.arch, "i4004");
+        assert_eq!(t.os, "none");
+        assert_eq!(t.binary_format, "intel_hex");
+    }
+
+    // Test 9: intel_8008 fields
+    #[test]
+    fn intel_8008_fields() {
+        let t = Target::intel_8008();
+        assert_eq!(t.arch, "i8008");
+        assert_eq!(t.binary_format, "intel_hex");
+    }
+
+    // Test 10: Display format
+    #[test]
+    fn display_format() {
+        assert_eq!(Target::linux_x64().to_string(), "x86_64-linux-elf64");
+        assert_eq!(Target::wasm().to_string(), "wasm32-none-wasm");
+        assert_eq!(Target::intel_4004().to_string(), "i4004-none-intel_hex");
+        assert_eq!(Target::windows_x64().to_string(), "x86_64-windows-pe");
+    }
+
+    // Test 11: Clone and PartialEq
+    #[test]
+    fn clone_and_eq() {
+        let a = Target::macos_arm64();
+        let b = a.clone();
+        assert_eq!(a, b);
+        assert_ne!(a, Target::macos_x64());
+    }
+}

--- a/code/packages/rust/code-packager/src/wasm.rs
+++ b/code/packages/rust/code-packager/src/wasm.rs
@@ -1,0 +1,231 @@
+//! WebAssembly module packager.
+//!
+//! Wraps native WebAssembly bytecode inside a minimal, well-formed WASM 1.0
+//! module using the `wasm-types` and `wasm-module-encoder` crates.
+//!
+//! ## What is a WASM module?
+//!
+//! A WebAssembly module is a binary container format (`.wasm`) that bundles:
+//!
+//! - **Type definitions** — function signatures (param types → result types).
+//! - **Function declarations** — references to type entries.
+//! - **Exports** — which functions (and memories, tables, globals) are visible
+//!   to the host (browser, Wasmtime, Node.js, etc.).
+//! - **Code** — the actual function bodies (WASM bytecode).
+//!
+//! The packager creates the *minimal* module that makes the native bytes
+//! callable from the host.
+//!
+//! ## Module structure produced
+//!
+//! ```text
+//! WasmModule {
+//!   types:     [FuncType { params: [], results: [i32] }]
+//!   functions: [0]   ← function 0 has type 0
+//!   exports:   [Export { name: "main", kind: Function, index: 0 }]
+//!   code:      [FunctionBody { locals: [], code: <native_bytes> }]
+//! }
+//! ```
+//!
+//! The function signature `() -> i32` is a reasonable convention for a "main"
+//! function: no arguments, returns an exit code.
+//!
+//! ## Export name
+//!
+//! The export name is taken from `artifact.metadata_list("exports")`.
+//! If the list is empty or absent, the name defaults to `"main"`.
+//!
+//! ```text
+//! metadata_list("exports") = []            → export name = "main"
+//! metadata_list("exports") = ["run"]       → export name = "run"
+//! metadata_list("exports") = ["add", "sub"] → export name = "add" (first)
+//! ```
+//!
+//! ## WASM binary magic
+//!
+//! Every `.wasm` file starts with the 4-byte magic `\x00asm` (= `[0x00, 0x61, 0x73, 0x6D]`)
+//! followed by the version `\x01\x00\x00\x00`. The `wasm-module-encoder` crate
+//! always emits these correctly.
+//!
+//! ## Accepted targets
+//!
+//! Only `Target::wasm()` (binary_format = "wasm") is accepted.
+
+use wasm_module_encoder::encode_module;
+use wasm_types::{Export, ExternalKind, FuncType, FunctionBody, ValueType, WasmModule};
+
+use crate::artifact::CodeArtifact;
+use crate::errors::PackagerError;
+
+/// Validate that the artifact targets the WASM format.
+fn validate(artifact: &CodeArtifact) -> Result<(), PackagerError> {
+    if artifact.target.binary_format != "wasm" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "wasm packager does not handle binary_format={:?}",
+            artifact.target.binary_format
+        )));
+    }
+    Ok(())
+}
+
+/// Pack `artifact` into a minimal WASM 1.0 module.
+///
+/// The native bytes are placed verbatim into the function body's `code` field.
+/// It is the caller's responsibility to ensure the bytes are valid WASM
+/// bytecode (including the mandatory trailing `end` opcode 0x0B).
+///
+/// # Errors
+///
+/// Returns `PackagerError::UnsupportedTarget` if `binary_format != "wasm"`.
+/// Returns `PackagerError::WasmEncodeError` if the WASM encoder fails.
+pub fn pack(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
+    validate(artifact)?;
+
+    // ── Determine the export name ─────────────────────────────────────────────
+
+    // Pull the first element of the "exports" metadata list, or fall back to "main".
+    let exports_list = artifact.metadata_list("exports");
+    let export_name = exports_list
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "main".to_string());
+
+    // ── Build the WASM module ─────────────────────────────────────────────────
+
+    let module = WasmModule {
+        // Type section: define one function type: () -> i32.
+        // This is the conventional signature for a "main" or "run" function
+        // that returns an integer exit code (0 = success, non-zero = error).
+        types: vec![FuncType {
+            params: vec![],
+            results: vec![ValueType::I32],
+        }],
+
+        // Function section: function 0 uses type 0.
+        // The parallel array of (functions, code) means functions[0] is
+        // implemented by code[0].
+        functions: vec![0],
+
+        // Export section: make function 0 visible to the host under export_name.
+        exports: vec![Export {
+            name: export_name,
+            kind: ExternalKind::Function,
+            index: 0,
+        }],
+
+        // Code section: function 0's body.
+        // locals: no local variables beyond the parameters (there are none).
+        // code: the raw WASM bytecode bytes from the artifact.
+        code: vec![FunctionBody {
+            locals: vec![],
+            code: artifact.native_bytes.clone(),
+        }],
+
+        // All other sections are empty for this minimal module.
+        ..WasmModule::default()
+    };
+
+    // ── Encode to bytes ───────────────────────────────────────────────────────
+
+    // `encode_module` writes the WASM magic, version, and all sections.
+    encode_module(&module)
+        .map_err(|e| PackagerError::WasmEncodeError(e.to_string()))
+}
+
+/// The conventional file extension for WebAssembly modules.
+pub fn file_extension() -> &'static str {
+    ".wasm"
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::{CodeArtifact, MetadataValue};
+    use crate::target::Target;
+    use std::collections::HashMap;
+
+    // Minimal WASM function body: `i32.const 42; end` = [0x41, 0x2A, 0x0B]
+    fn minimal_wasm_code() -> Vec<u8> {
+        vec![0x41, 0x2A, 0x0B] // i32.const 42; end
+    }
+
+    // Test 1: output starts with WASM magic [0x00, 0x61, 0x73, 0x6D]
+    #[test]
+    fn produces_wasm_magic() {
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::wasm());
+        let bytes = pack(&art).unwrap();
+        assert_eq!(
+            &bytes[0..4],
+            &[0x00, 0x61, 0x73, 0x6D],
+            "expected WASM magic \\x00asm, got {:02X?}", &bytes[0..4]
+        );
+    }
+
+    // Test 2: WASM version = [0x01, 0x00, 0x00, 0x00]
+    #[test]
+    fn produces_wasm_version() {
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::wasm());
+        let bytes = pack(&art).unwrap();
+        assert_eq!(&bytes[4..8], &[0x01, 0x00, 0x00, 0x00]);
+    }
+
+    // Test 3: rejects linux_x64
+    #[test]
+    fn rejects_linux_target() {
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::linux_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 4: rejects pe target
+    #[test]
+    fn rejects_pe_target() {
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::windows_x64());
+        assert!(matches!(pack(&art), Err(PackagerError::UnsupportedTarget(_))));
+    }
+
+    // Test 5: export name defaults to "main" when no metadata
+    #[test]
+    fn default_export_name_is_main() {
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::wasm());
+        let bytes = pack(&art).unwrap();
+        // "main" in UTF-8 is [0x6D, 0x61, 0x69, 0x6E].
+        // It will appear somewhere in the binary (in the export section).
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("main"), "expected 'main' in WASM binary");
+    }
+
+    // Test 6: custom export name from metadata
+    #[test]
+    fn custom_export_name() {
+        let mut m = HashMap::new();
+        m.insert(
+            "exports".into(),
+            MetadataValue::List(vec!["run".into()]),
+        );
+        let art = CodeArtifact::new(minimal_wasm_code(), 0, Target::wasm())
+            .with_metadata(m);
+        let bytes = pack(&art).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("run"), "expected 'run' in WASM binary");
+    }
+
+    // Test 7: file_extension
+    #[test]
+    fn file_extension_is_wasm() {
+        assert_eq!(file_extension(), ".wasm");
+    }
+
+    // Test 8: output is non-empty for empty native_bytes
+    // (a valid WASM module with an empty function body is: [end] = [0x0B])
+    #[test]
+    fn empty_native_bytes_produces_module() {
+        // A WASM function body must end with 0x0B (end opcode).
+        let art = CodeArtifact::new(vec![0x0B], 0, Target::wasm());
+        let result = pack(&art);
+        // This should succeed and produce a non-empty byte slice.
+        assert!(result.is_ok());
+        assert!(!result.unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the `code-packager` Rust crate (LANG10): the final stage of the AOT compilation pipeline
- Takes a `CodeArtifact` (raw machine-code bytes + metadata) and wraps it in the correct binary format
- **6 packagers**: ELF64 (Linux), Mach-O 64 (macOS), PE32+ (Windows), WASM, Raw, Intel HEX
- **95 tests**: 86 unit tests across all modules + 9 doc-tests
- **4 security fixes** applied proactively during implementation

## Packagers

| Format | Target | Factory |
|--------|--------|---------|
| ELF64 | Linux x64/arm64 | `Target::linux_x64()` |
| Mach-O 64 | macOS x64/arm64 | `Target::macos_arm64()` |
| PE32+ | Windows x64 | `Target::windows_x64()` |
| WASM 1.0 | wasm32 | `Target::wasm()` |
| Raw binary | bare-metal | `Target::raw(arch)` |
| Intel HEX | Intel 4004/8008 | `Target::intel_4004()` |

## Security hardening

- **ELF64/Mach-O**: reject negative `load_address` metadata before `as u64` cast (silent huge address)
- **Intel HEX**: validate `origin` in [0, 65535] before `as u16` cast (silent wrong address)
- **PE32+**: `u32::try_from()` for `code_len` + `entry_point`; `checked_add` for `total_size`
- **PE32+**: tight `MAX_CODE_LEN` bound prevents `align_to` u32 overflow in both `raw_code_size` and `size_of_image` computations

## Test plan

- [x] `cargo build -p code-packager` passes
- [x] `cargo test -p code-packager` — 95 tests pass
- [x] Security review: 3 passes, all findings resolved
- [x] No `unsafe` code anywhere in the crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)