### PR TITLE
feat(rust): LANG19/20 — codegen-core crate

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -402,4 +402,5 @@ members = [
     "cas-number-theory",
     "cas-complex",
     "cas-trig",
+    "codegen-core",
 ]

--- a/code/packages/rust/codegen-core/BUILD
+++ b/code/packages/rust/codegen-core/BUILD
@@ -1,0 +1,2 @@
+cargo build -p codegen-core
+cargo test -p codegen-core

--- a/code/packages/rust/codegen-core/CHANGELOG.md
+++ b/code/packages/rust/codegen-core/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog — codegen-core (Rust)
+
+## [0.1.0] — 2026-04-28
+
+### Added
+
+Initial Rust port of the Python `codegen-core` package (LANG19 / LANG20).
+
+#### `optimizer` module
+- `Optimizer<IR>` trait — generic IR → IR transformation protocol
+  (`fn optimize(&self, ir: IR) -> IR`).
+- `impl Optimizer<Vec<CIRInstr>> for CIROptimizer` — blanket adapter so
+  `jit_core`'s constant-folding + DCE optimizer can be used in a
+  `CodegenPipeline<Vec<CIRInstr>>`.
+- `IrProgramOptimizer` — thin wrapper around `ir_optimizer::IrOptimizer`
+  that implements `Optimizer<IrProgram>` (strips `IrOp::Nop` instructions).
+
+#### `codegen` module (LANG20 protocol)
+- `CodeGenerator<IR, Assembly>` trait — validate + generate assembly
+  (`fn name()`, `fn validate(&IR)`, `fn generate(&IR)`).
+- `CodeGeneratorRegistry` — name-to-generator map backed by
+  `HashMap<String, Box<dyn Any + Send + Sync>>` with `register`, `get`,
+  `names`, `len`, `is_empty`, and `Default`.
+
+#### `pipeline` module
+- `Compile<IR>` trait — generic compilation backend (`name + compile`).
+- Blanket `impl<B: Backend> Compile<Vec<CIRInstr>> for B` so any
+  `jit_core::backend::Backend` works with `CodegenPipeline<Vec<CIRInstr>>`
+  without adapter boilerplate.
+- `CodegenResult<IR>` — compilation output struct with `binary`,
+  `ir_snapshot`, `backend_name`, `compilation_time_ns`, `optimizer_applied`,
+  plus `success()` and `binary_size()` derived helpers.
+- `CodegenPipeline<IR>` — composes `Option<Box<dyn Optimizer<IR>>>` +
+  `Box<dyn Compile<IR>>`; exposes `compile(ir)` (fast path) and
+  `compile_with_stats(ir)` (diagnostics path with timing + IR snapshot).
+
+#### `registry` module
+- `BackendRegistry` — name-to-backend map backed by
+  `HashMap<String, Box<dyn Any + Send + Sync>>` with `register`, `get`,
+  `get_or_raise`, `names`, `len`, `is_empty`, and `Default`.
+
+#### Crate root re-exports
+- From `jit-core`: `Backend`, `CIRInstr`, `CIROperand`, `CIROptimizer`.
+- From own modules: `CodeGenerator`, `CodeGeneratorRegistry`,
+  `IrProgramOptimizer`, `Compile`, `CodegenPipeline`, `CodegenResult`,
+  `Optimizer`, `BackendRegistry`.
+
+### Tests
+- 41 unit tests across all four modules.
+- 17 doc tests embedded in rustdoc examples.
+- 58 total tests; all green.

--- a/code/packages/rust/codegen-core/Cargo.toml
+++ b/code/packages/rust/codegen-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "codegen-core"
+version = "0.1.0"
+edition = "2021"
+description = "Universal IR-to-native compilation layer (LANG19/LANG20)"
+license = "MIT"
+
+[dependencies]
+jit-core = { path = "../jit-core" }
+compiler-ir = { path = "../compiler-ir" }
+ir-optimizer = { path = "../ir-optimizer" }
+
+[dev-dependencies]

--- a/code/packages/rust/codegen-core/README.md
+++ b/code/packages/rust/codegen-core/README.md
@@ -1,0 +1,120 @@
+# codegen-core (Rust)
+
+Universal IR-to-native compilation layer — LANG19 / LANG20.
+
+`codegen-core` is the single shared layer that defines what *code generation*
+means across every compilation path in this repository.  It provides three
+composable abstractions:
+
+```text
+IR
+  │
+  ▼
+[Optimizer<IR>]        ← optional IR → IR transformation
+  │
+  ▼
+[Compile<IR>]          ← translate IR → Option<Vec<u8>>
+  │  (CodegenPipeline wraps both)
+  ▼
+Option<Vec<u8>>        ← opaque native binary
+```
+
+---
+
+## Compilation paths
+
+```text
+JIT / AOT path
+  Vec<CIRInstr>
+    → CIROptimizer::optimize()      (constant fold + DCE)
+    → any Compile<Vec<CIRInstr>>    (Intel 4004 backend, …)
+    → Option<Vec<u8>>
+
+Compiled-language path  (Nib, Brainfuck, Algol-60)
+  IrProgram
+    → IrProgramOptimizer::optimize()  (NOP stripping)
+    → any Compile<IrProgram>          (WASM, JVM, …)
+    → Option<Vec<u8>>
+```
+
+---
+
+## Module overview
+
+| Module | Key items |
+|--------|-----------|
+| [`optimizer`] | `Optimizer<IR>` trait, `CIROptimizer` impl, `IrProgramOptimizer` |
+| [`codegen`]   | `CodeGenerator<IR, Assembly>` trait (LANG20), `CodeGeneratorRegistry` |
+| [`pipeline`]  | `Compile<IR>` trait, `CodegenPipeline<IR>`, `CodegenResult<IR>` |
+| [`registry`]  | `BackendRegistry` |
+
+---
+
+## Quick start
+
+### JIT pipeline
+
+```rust
+use codegen_core::{CIRInstr, CodegenPipeline, CIROptimizer};
+use codegen_core::pipeline::Compile;
+use jit_core::backend::NullBackend;
+
+// NullBackend auto-implements Compile<Vec<CIRInstr>> via the blanket impl.
+let pipeline: CodegenPipeline<Vec<CIRInstr>> = CodegenPipeline::new(
+    Box::new(NullBackend),
+    Some(Box::new(CIROptimizer)),
+);
+
+let cir: Vec<CIRInstr> = vec![ /* ... */ ];
+let result = pipeline.compile_with_stats(cir);
+println!("backend: {}, time: {}ns", result.backend_name, result.compilation_time_ns);
+```
+
+### LANG20 CodeGenerator
+
+```rust
+use codegen_core::codegen::{CodeGenerator, CodeGeneratorRegistry};
+
+struct EchoGenerator;
+
+impl CodeGenerator<String, String> for EchoGenerator {
+    fn name(&self) -> &str { "echo" }
+    fn validate(&self, _ir: &String) -> Vec<String> { vec![] }
+    fn generate(&self, ir: &String) -> String { ir.clone() }
+}
+
+let mut registry = CodeGeneratorRegistry::new();
+registry.register("echo", Box::new(EchoGenerator));
+assert_eq!(registry.len(), 1);
+```
+
+---
+
+## Re-exports from `jit-core`
+
+`CIRInstr`, `CIROperand`, `CIROptimizer`, and `Backend` are already defined in
+`jit-core` and re-exported here so callers can import everything from one place:
+
+```rust
+use codegen_core::{CIRInstr, CIROperand, CIROptimizer, Backend};
+```
+
+---
+
+## Dependencies
+
+| Crate | Role |
+|-------|------|
+| `jit-core` | `CIRInstr`, `Backend`, `CIROptimizer` |
+| `compiler-ir` | `IrProgram`, `IrInstruction`, `IrOp` |
+| `ir-optimizer` | `IrOptimizer` (NOP stripping) |
+
+---
+
+## Tests
+
+```sh
+cargo test -p codegen-core
+```
+
+41 unit tests + 17 doc tests = **58 total**, all green.

--- a/code/packages/rust/codegen-core/src/codegen.rs
+++ b/code/packages/rust/codegen-core/src/codegen.rs
@@ -1,0 +1,301 @@
+//! `CodeGenerator<IR, Assembly>` — the LANG20 protocol.
+//!
+//! A `CodeGenerator` separates the *code generation* concern from assembly,
+//! packaging, and execution.  It takes a typed IR, validates it for the target
+//! architecture, and produces "assembly" — whatever the backend naturally
+//! emits before the packaging step.
+//!
+//! ## Why a separate protocol?
+//!
+//! LANG19's `Backend<IR>` bundled validate + generate + assemble + run into
+//! one interface.  That works for single-stage backends but prevents:
+//!
+//! - Inspecting assembly before it is assembled into bytes.
+//! - Sharing a validate-then-generate loop across the AOT and JIT pipelines.
+//! - A clean seam between "IR → Assembly" and "Assembly → binary".
+//!
+//! LANG20 splits at the assembly boundary:
+//!
+//! ```text
+//! [CodeGenerator] — validate + generate assembly    ← this module
+//!     ↓ Assembly (str | Vec<u8> | WasmModule | …)
+//!     ├──▶ [Assembler → Packager] → binary  (AOT path)
+//!     ├──▶ [JIT runner]           → run     (JIT path)
+//!     └──▶ [Simulator]            → run     (orthogonal)
+//! ```
+//!
+//! ## Assembly type
+//!
+//! The `Assembly` type parameter is whatever the backend naturally produces
+//! before packaging:
+//!
+//! - `String` — for text-assembly backends (Intel 4004, Intel 8008)
+//! - `Vec<u8>` — for backends that emit binary directly (GE-225, JVM)
+//! - Structured objects — WASM (`WasmModule`), CIL (`CILProgramArtifact`)
+//!
+//! ## Example
+//!
+//! ```rust
+//! use codegen_core::codegen::{CodeGenerator, CodeGeneratorRegistry};
+//!
+//! // A mock generator for illustration.
+//! struct EchoGenerator;
+//!
+//! impl CodeGenerator<String, String> for EchoGenerator {
+//!     fn name(&self) -> &str { "echo" }
+//!
+//!     fn validate(&self, _ir: &String) -> Vec<String> { vec![] }
+//!
+//!     fn generate(&self, ir: &String) -> String {
+//!         ir.clone()
+//!     }
+//! }
+//!
+//! let mut registry = CodeGeneratorRegistry::new();
+//! registry.register("echo", Box::new(EchoGenerator) as Box<dyn std::any::Any + Send + Sync>);
+//! // Registry stores type-erased generators keyed by name.
+//! assert_eq!(registry.len(), 1);
+//! ```
+
+use std::any::Any;
+use std::collections::HashMap;
+
+// ── CodeGenerator trait ───────────────────────────────────────────────────────
+
+/// Validates IR for a target architecture and generates target assembly.
+///
+/// Does NOT assemble (text → binary), package, link, or execute.
+///
+/// ## Type parameters
+///
+/// - `IR` — the typed intermediate representation consumed by this generator.
+/// - `Assembly` — the output: text, bytes, or a structured object.
+///
+/// ## Contract
+///
+/// 1. `validate(ir)` returns an empty `Vec` if `ir` is valid for this target.
+/// 2. `generate(ir)` MAY panic or return a wrong result if `validate(ir)` was
+///    non-empty.  Well-behaved callers always validate first.
+/// 3. `generate(ir)` implicitly calls `validate(ir)` and panics on the first
+///    error — callers that do not need to inspect errors can skip the explicit
+///    `validate` call.
+pub trait CodeGenerator<IR, Assembly>: Send + Sync {
+    /// A unique, stable name for this code generator (e.g. `"intel4004"`).
+    fn name(&self) -> &str;
+
+    /// Return validation errors for this target; empty list = valid.
+    ///
+    /// This is a *pre-flight check* — it reports issues before any code is
+    /// generated, so the caller can produce a useful error message.
+    fn validate(&self, ir: &IR) -> Vec<String>;
+
+    /// Generate assembly from `ir`.
+    ///
+    /// # Panics
+    ///
+    /// May panic if `validate(ir)` would have returned errors.  Always call
+    /// `validate` first in production code.
+    fn generate(&self, ir: &IR) -> Assembly;
+}
+
+// ── CodeGeneratorRegistry ─────────────────────────────────────────────────────
+
+/// Name-to-generator mapping.
+///
+/// The registry holds type-erased (`Box<dyn Any + Send + Sync>`) generators
+/// because Rust does not support generic trait objects with multiple type
+/// parameters directly.  Callers must downcast after retrieval.
+///
+/// ## Usage pattern
+///
+/// ```rust
+/// use codegen_core::codegen::CodeGeneratorRegistry;
+/// use std::any::Any;
+///
+/// let mut registry = CodeGeneratorRegistry::new();
+/// assert!(registry.get("missing").is_none());
+/// assert_eq!(registry.names(), Vec::<String>::new());
+/// ```
+pub struct CodeGeneratorRegistry {
+    generators: HashMap<String, Box<dyn Any + Send + Sync>>,
+}
+
+impl CodeGeneratorRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            generators: HashMap::new(),
+        }
+    }
+
+    /// Register a code generator.
+    ///
+    /// The generator is stored under its `name()`.  If a generator with the
+    /// same name was previously registered, it is silently replaced.
+    ///
+    /// The generator must implement `Any + Send + Sync` so it can be stored
+    /// and later downcast.  In practice, pass a `Box<dyn CodeGenerator<IR, Assembly>>`
+    /// wrapped in a newtype that derives `Any`, or use `register_named`.
+    pub fn register(&mut self, name: impl Into<String>, generator: Box<dyn Any + Send + Sync>) {
+        self.generators.insert(name.into(), generator);
+    }
+
+    /// Retrieve a generator by name, as an opaque `Any` reference.
+    ///
+    /// The caller must downcast to the concrete `CodeGenerator` type.
+    pub fn get(&self, name: &str) -> Option<&(dyn Any + Send + Sync)> {
+        self.generators.get(name).map(|b| b.as_ref())
+    }
+
+    /// Return all registered generator names, sorted alphabetically.
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.generators.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Return the number of registered generators.
+    pub fn len(&self) -> usize {
+        self.generators.len()
+    }
+
+    /// Return `true` if no generators are registered.
+    pub fn is_empty(&self) -> bool {
+        self.generators.is_empty()
+    }
+}
+
+impl Default for CodeGeneratorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A minimal mock code generator for tests.
+    struct MockGen {
+        name: String,
+        fail: bool,
+    }
+
+    impl MockGen {
+        fn new(name: &str) -> Self {
+            Self { name: name.into(), fail: false }
+        }
+        fn failing(name: &str) -> Self {
+            Self { name: name.into(), fail: true }
+        }
+    }
+
+    impl CodeGenerator<String, String> for MockGen {
+        fn name(&self) -> &str { &self.name }
+
+        fn validate(&self, _ir: &String) -> Vec<String> {
+            if self.fail {
+                vec!["mock validation error".into()]
+            } else {
+                vec![]
+            }
+        }
+
+        fn generate(&self, ir: &String) -> String {
+            format!("[{}] {}", self.name, ir)
+        }
+    }
+
+    // Test 1: validate() returns empty on valid IR
+    #[test]
+    fn mock_validate_valid() {
+        let gen = MockGen::new("echo");
+        assert!(gen.validate(&"hello".to_string()).is_empty());
+    }
+
+    // Test 2: validate() returns errors when generator is set to fail
+    #[test]
+    fn mock_validate_failing() {
+        let gen = MockGen::failing("bad");
+        let errors = gen.validate(&"x".to_string());
+        assert!(!errors.is_empty());
+    }
+
+    // Test 3: generate() produces output
+    #[test]
+    fn mock_generate() {
+        let gen = MockGen::new("myarch");
+        let out = gen.generate(&"add r0, r1".to_string());
+        assert!(out.contains("myarch"));
+        assert!(out.contains("add r0, r1"));
+    }
+
+    // Test 4: name() returns the generator name
+    #[test]
+    fn mock_name() {
+        let gen = MockGen::new("intel4004");
+        assert_eq!(gen.name(), "intel4004");
+    }
+
+    // Test 5: registry starts empty
+    #[test]
+    fn registry_starts_empty() {
+        let reg = CodeGeneratorRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.names().is_empty());
+    }
+
+    // Test 6: register + get
+    #[test]
+    fn registry_register_and_get() {
+        let mut reg = CodeGeneratorRegistry::new();
+        reg.register("echo", Box::new(MockGen::new("echo")));
+        assert!(!reg.is_empty());
+        assert_eq!(reg.len(), 1);
+        assert!(reg.get("echo").is_some());
+        assert!(reg.get("missing").is_none());
+    }
+
+    // Test 7: names() returns sorted names
+    #[test]
+    fn registry_names_sorted() {
+        let mut reg = CodeGeneratorRegistry::new();
+        reg.register("zzz", Box::new(MockGen::new("zzz")));
+        reg.register("aaa", Box::new(MockGen::new("aaa")));
+        reg.register("mmm", Box::new(MockGen::new("mmm")));
+        assert_eq!(reg.names(), vec!["aaa", "mmm", "zzz"]);
+    }
+
+    // Test 8: register replaces existing generator with same name
+    #[test]
+    fn registry_register_replaces() {
+        let mut reg = CodeGeneratorRegistry::new();
+        reg.register("gen", Box::new(MockGen::new("gen")));
+        reg.register("gen", Box::new(MockGen::failing("gen")));
+        assert_eq!(reg.len(), 1); // still one entry
+        // The new entry should be the failing one.
+        let stored = reg.get("gen").unwrap();
+        let downcast = stored.downcast_ref::<MockGen>().unwrap();
+        assert!(downcast.fail);
+    }
+
+    // Test 9: default() is the same as new()
+    #[test]
+    fn registry_default() {
+        let reg: CodeGeneratorRegistry = Default::default();
+        assert!(reg.is_empty());
+    }
+
+    // Test 10: downcast after retrieval
+    #[test]
+    fn registry_downcast() {
+        let mut reg = CodeGeneratorRegistry::new();
+        reg.register("echo", Box::new(MockGen::new("echo")));
+        let any = reg.get("echo").unwrap();
+        let gen = any.downcast_ref::<MockGen>().unwrap();
+        assert_eq!(gen.name(), "echo");
+    }
+}

--- a/code/packages/rust/codegen-core/src/lib.rs
+++ b/code/packages/rust/codegen-core/src/lib.rs
@@ -1,0 +1,56 @@
+//! # codegen-core — Universal IR-to-native compilation layer (LANG19/LANG20)
+//!
+//! `codegen-core` is the single shared layer that defines what code generation
+//! means across every compilation path in this repository:
+//!
+//! ## Compilation paths
+//!
+//! ```text
+//! JIT path (jit-core → codegen-core)
+//!   IIRFunction
+//!     → jit_core::specialise()   → Vec<CIRInstr>
+//!     → CIROptimizer::run()      → Vec<CIRInstr>  (constant fold + DCE)
+//!     → Backend::compile()       → bytes
+//!
+//! AOT path (aot-core → codegen-core)
+//!   IIRFunction
+//!     → aot_core::aot_specialise() → Vec<CIRInstr>
+//!     → CIROptimizer::run()         → Vec<CIRInstr>
+//!     → Backend::compile()          → bytes
+//!
+//! Compiled-language path (Nib, BF, Algol-60 → codegen-core)
+//!   IrProgram
+//!     → IrProgramOptimizer::optimize() → IrProgram
+//!     → CodeGenerator::generate()      → Assembly  (LANG20)
+//!     → Backend::compile()             → bytes
+//! ```
+//!
+//! ## Module structure
+//!
+//! | Module | Contents |
+//! |--------|----------|
+//! | [`optimizer`] | `Optimizer<IR>` trait, `CIROptimizer`, `IrProgramOptimizer` |
+//! | [`codegen`]   | `CodeGenerator<IR, Assembly>` trait, `CodeGeneratorRegistry` |
+//! | [`pipeline`]  | `CodegenPipeline<IR>`, `CodegenResult<IR>` |
+//! | [`registry`]  | `BackendRegistry` |
+//!
+//! ## Re-exports from jit-core
+//!
+//! `CIRInstr`, `CIROperand`, `Backend` are already defined in `jit-core`
+//! and re-exported here so callers can import everything from one place.
+
+pub mod codegen;
+pub mod optimizer;
+pub mod pipeline;
+pub mod registry;
+
+// Re-export from jit-core so callers can use codegen-core as a one-stop shop.
+pub use jit_core::backend::Backend;
+pub use jit_core::cir::{CIRInstr, CIROperand};
+pub use jit_core::optimizer::CIROptimizer;
+
+// Re-export the new types.
+pub use codegen::{CodeGenerator, CodeGeneratorRegistry};
+pub use optimizer::IrProgramOptimizer;
+pub use pipeline::{Compile, CodegenPipeline, CodegenResult, Optimizer};
+pub use registry::BackendRegistry;

--- a/code/packages/rust/codegen-core/src/optimizer.rs
+++ b/code/packages/rust/codegen-core/src/optimizer.rs
@@ -1,0 +1,186 @@
+//! Optimizer traits and concrete implementations.
+//!
+//! An `Optimizer<IR>` transforms an IR value into a (hopefully smaller or
+//! faster) equivalent IR value without changing the program's observable
+//! semantics.
+//!
+//! ## Two concrete optimizers
+//!
+//! ```text
+//! CIROptimizer        — re-exported from jit-core
+//!   Input:  Vec<CIRInstr>
+//!   Output: Vec<CIRInstr>
+//!   Passes: constant folding + dead-code elimination
+//!
+//! IrProgramOptimizer  — defined here, wraps ir-optimizer::IrOptimizer
+//!   Input:  IrProgram
+//!   Output: IrProgram
+//!   Passes: NOP stripping (IrOp::Nop removal)
+//! ```
+//!
+//! ## The `Optimizer<IR>` trait
+//!
+//! The trait is generic over IR so that `CodegenPipeline<IR>` can hold
+//! an `Option<Box<dyn Optimizer<IR>>>` without knowing the concrete type.
+//!
+//! ```rust
+//! use codegen_core::optimizer::{Optimizer, IrProgramOptimizer};
+//! use compiler_ir::{IrProgram, IrInstruction};
+//! use compiler_ir::opcodes::IrOp;
+//!
+//! let mut prog = IrProgram::new("_start");
+//! prog.add_instruction(IrInstruction::new(IrOp::Nop, vec![], 0));
+//! prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 1));
+//!
+//! let opt = IrProgramOptimizer;
+//! let result = opt.optimize(prog);
+//! // Nop was removed; only Halt remains.
+//! assert_eq!(result.instructions.len(), 1);
+//! ```
+
+use compiler_ir::IrProgram;
+use ir_optimizer::IrOptimizer;
+
+// ── Optimizer trait ───────────────────────────────────────────────────────────
+
+/// A pass that transforms `IR` → `IR` without changing observable semantics.
+///
+/// Implementors must be `Send + Sync` so they can be used inside
+/// `Arc<dyn Optimizer<IR>>` in a multi-threaded compilation pipeline.
+pub trait Optimizer<IR>: Send + Sync {
+    /// Transform `ir` and return the optimized result.
+    ///
+    /// The input is taken by value because optimization often rewrites the
+    /// entire IR rather than mutating it in place.  The output has the same
+    /// type as the input.
+    fn optimize(&self, ir: IR) -> IR;
+}
+
+// ── CIROptimizer is already in jit-core ──────────────────────────────────────
+//
+// We re-export it at the crate root (see lib.rs) so callers can write
+// `use codegen_core::CIROptimizer` instead of `use jit_core::optimizer::CIROptimizer`.
+//
+// We also implement the Optimizer<Vec<CIRInstr>> trait for it here.
+
+use jit_core::cir::CIRInstr;
+use jit_core::optimizer::CIROptimizer;
+
+/// `CIROptimizer` implements `Optimizer<Vec<CIRInstr>>` so it can be used
+/// inside a `CodegenPipeline<Vec<CIRInstr>>`.
+///
+/// The implementation delegates to `CIROptimizer::run()`, which performs
+/// constant folding and dead-code elimination.
+///
+/// ```rust
+/// use codegen_core::optimizer::Optimizer;
+/// use codegen_core::{CIRInstr, CIROptimizer};
+///
+/// let opt = CIROptimizer;
+/// // Use ret_void — it has no destination so DCE never eliminates it.
+/// let instrs = vec![CIRInstr::new("ret_void", None::<&str>, vec![], "void")];
+/// let out = opt.optimize(instrs);
+/// assert!(!out.is_empty());
+/// ```
+impl Optimizer<Vec<CIRInstr>> for CIROptimizer {
+    fn optimize(&self, ir: Vec<CIRInstr>) -> Vec<CIRInstr> {
+        self.run(ir)
+    }
+}
+
+// ── IrProgramOptimizer ────────────────────────────────────────────────────────
+
+/// A thin wrapper around `ir_optimizer::IrOptimizer` that implements
+/// `Optimizer<IrProgram>`.
+///
+/// This is the compiled-language path optimizer (Nib, Brainfuck, Algol-60).
+/// It currently strips `IrOp::Nop` instructions; future passes will add
+/// constant folding and peephole optimizations.
+///
+/// ## Why wrap instead of using `IrOptimizer` directly?
+///
+/// `IrOptimizer` does not implement the `Optimizer<IrProgram>` trait from
+/// this crate.  The wrapper provides the glue without modifying the
+/// `ir-optimizer` crate.
+pub struct IrProgramOptimizer;
+
+impl Optimizer<IrProgram> for IrProgramOptimizer {
+    /// Optimize `ir` by removing `Nop` instructions.
+    ///
+    /// ```rust
+    /// use codegen_core::optimizer::{Optimizer, IrProgramOptimizer};
+    /// use compiler_ir::{IrProgram, IrInstruction};
+    /// use compiler_ir::opcodes::IrOp;
+    ///
+    /// let mut prog = IrProgram::new("_start");
+    /// prog.add_instruction(IrInstruction::new(IrOp::Nop, vec![], 0));
+    /// prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 1));
+    ///
+    /// let result = IrProgramOptimizer.optimize(prog);
+    /// assert_eq!(result.instructions.len(), 1);
+    /// assert_eq!(result.instructions[0].opcode, IrOp::Halt);
+    /// ```
+    fn optimize(&self, ir: IrProgram) -> IrProgram {
+        IrOptimizer.optimize(&ir)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use compiler_ir::{IrInstruction, IrProgram};
+    use compiler_ir::opcodes::IrOp;
+    use jit_core::cir::CIROperand;
+
+    // Test 1: CIROptimizer implements Optimizer<Vec<CIRInstr>>
+    // Use ret_void so DCE doesn't eliminate it (void instructions are always "live").
+    #[test]
+    fn cir_optimizer_trait() {
+        let opt = CIROptimizer;
+        let instrs = vec![CIRInstr::new("ret_void", None::<&str>, vec![], "void")];
+        let out: Vec<CIRInstr> = opt.optimize(instrs);
+        assert!(!out.is_empty());
+    }
+
+    // Test 2: CIROptimizer is identity on non-reducible instructions
+    #[test]
+    fn cir_optimizer_passthrough() {
+        let opt = CIROptimizer;
+        let instrs = vec![
+            CIRInstr::new("label", None::<&str>, vec![CIROperand::Var("loop".into())], "void"),
+            CIRInstr::new("ret_void", None::<&str>, vec![], "void"),
+        ];
+        let out = opt.optimize(instrs);
+        assert_eq!(out.len(), 2);
+    }
+
+    // Test 3: IrProgramOptimizer strips NOPs
+    #[test]
+    fn ir_optimizer_strips_nops() {
+        let mut prog = IrProgram::new("_start");
+        prog.add_instruction(IrInstruction::new(IrOp::Nop, vec![], 0));
+        prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 1));
+        let result = IrProgramOptimizer.optimize(prog);
+        assert_eq!(result.instructions.len(), 1);
+        assert_eq!(result.instructions[0].opcode, IrOp::Halt);
+    }
+
+    // Test 4: IrProgramOptimizer is identity on programs with no NOPs
+    #[test]
+    fn ir_optimizer_passthrough_no_nops() {
+        let mut prog = IrProgram::new("main");
+        prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 0));
+        let result = IrProgramOptimizer.optimize(prog);
+        assert_eq!(result.instructions.len(), 1);
+    }
+
+    // Test 5: IrProgramOptimizer preserves entry_label
+    #[test]
+    fn ir_optimizer_preserves_entry() {
+        let prog = IrProgram::new("my_entry");
+        let result = IrProgramOptimizer.optimize(prog);
+        assert_eq!(result.entry_label, "my_entry");
+    }
+}

--- a/code/packages/rust/codegen-core/src/pipeline.rs
+++ b/code/packages/rust/codegen-core/src/pipeline.rs
@@ -1,0 +1,566 @@
+//! `CodegenPipeline<IR>` — the universal optimize-then-compile pipeline.
+//!
+//! `CodegenPipeline<IR>` is the single place that defines what *code generation*
+//! means in this repository:
+//!
+//! ```text
+//! IR  →  [Optimizer<IR>]  →  [Compile<IR>]  →  Option<Vec<u8>>
+//! ```
+//!
+//! ## Two concrete instantiations
+//!
+//! ```text
+//! CodegenPipeline<Vec<CIRInstr>>
+//!   Optimizer: CIROptimizer (constant folding + DCE)
+//!   Compile:   any CIR backend (Intel 4004, interp, …)
+//!
+//! CodegenPipeline<IrProgram>
+//!   Optimizer: IrProgramOptimizer (NOP stripping)
+//!   Compile:   any IrProgram backend (WASM, JVM, …)
+//! ```
+//!
+//! ## Optimizer protocol
+//!
+//! The `Optimizer<IR>` trait (defined in [`crate::optimizer`]) requires only
+//! `fn optimize(&self, ir: IR) -> IR`.  Passing `optimizer: None` skips the
+//! optimization step entirely; `optimizer_applied` is `false` in the result.
+//!
+//! ## The `Compile<IR>` trait
+//!
+//! `Compile<IR>` abstracts over *compilation* — the step that turns IR into
+//! an opaque binary blob.  It parallels `jit_core::backend::Backend` but is
+//! generic over the IR type so that `CodegenPipeline<IrProgram>` is also
+//! expressible.
+//!
+//! A blanket `impl<B: Backend> Compile<Vec<CIRInstr>> for B` lets callers
+//! wrap any existing `jit_core` backend with zero boilerplate.
+//!
+//! ## Example: JIT pipeline
+//!
+//! ```rust
+//! use codegen_core::pipeline::{Compile, CodegenPipeline};
+//! use codegen_core::CIRInstr;
+//!
+//! // A trivial mock backend for illustration.
+//! struct NullCompile;
+//!
+//! impl Compile<Vec<CIRInstr>> for NullCompile {
+//!     fn name(&self) -> &str { "null" }
+//!     fn compile(&self, _ir: &Vec<CIRInstr>) -> Option<Vec<u8>> {
+//!         Some(vec![0u8])
+//!     }
+//! }
+//!
+//! let pipeline: CodegenPipeline<Vec<CIRInstr>> = CodegenPipeline::new(
+//!     Box::new(NullCompile),
+//!     None,  // no optimizer
+//! );
+//! assert!(pipeline.compile(vec![]).is_some());
+//! assert_eq!(pipeline.backend_name(), "null");
+//! ```
+
+use std::time::Instant;
+
+// Re-export `Optimizer` from the optimizer module so callers can write
+// `use codegen_core::pipeline::Optimizer` and also so the crate root
+// re-export `pub use pipeline::Optimizer` works.
+pub use crate::optimizer::Optimizer;
+
+// ── Compile<IR> trait ─────────────────────────────────────────────────────────
+
+/// A generic compilation backend: translates `IR` into an opaque binary.
+///
+/// This trait mirrors `jit_core::backend::Backend` but is parameterised over
+/// the IR type so it can be used inside `CodegenPipeline<IrProgram>` as well
+/// as `CodegenPipeline<Vec<CIRInstr>>`.
+///
+/// ## Contract
+///
+/// - `compile` is **pure**: the same IR must produce semantically equivalent
+///   binaries on every call.
+/// - Returns `None` when compilation is not possible (unsupported opcodes,
+///   register count too large, etc.).  `CodegenPipeline` propagates the `None`
+///   to its caller unchanged.
+///
+/// ## Implementing
+///
+/// ```rust
+/// use codegen_core::pipeline::Compile;
+///
+/// struct EchoCompile;
+///
+/// impl Compile<Vec<u8>> for EchoCompile {
+///     fn name(&self) -> &str { "echo" }
+///     fn compile(&self, ir: &Vec<u8>) -> Option<Vec<u8>> {
+///         Some(ir.clone())
+///     }
+/// }
+/// ```
+pub trait Compile<IR>: Send + Sync {
+    /// A short human-readable identifier (e.g. `"intel4004"`, `"wasm"`).
+    ///
+    /// Stored in `CodegenResult.backend_name` for diagnostics.
+    fn name(&self) -> &str;
+
+    /// Compile `ir` into an opaque binary, or return `None` on failure.
+    fn compile(&self, ir: &IR) -> Option<Vec<u8>>;
+}
+
+// ── Blanket impl: jit_core::Backend → Compile<Vec<CIRInstr>> ─────────────────
+
+// Any type that implements the CIR-specific `jit_core::backend::Backend` trait
+// automatically satisfies `Compile<Vec<CIRInstr>>`.  This lets callers pass
+// a `NullBackend` or `EchoBackend` directly to `CodegenPipeline::new()` without
+// writing adapter code.
+
+use crate::CIRInstr;
+use jit_core::backend::Backend;
+
+impl<B: Backend> Compile<Vec<CIRInstr>> for B {
+    fn name(&self) -> &str {
+        Backend::name(self)
+    }
+
+    fn compile(&self, ir: &Vec<CIRInstr>) -> Option<Vec<u8>> {
+        Backend::compile(self, ir)
+    }
+}
+
+// ── CodegenResult<IR> ─────────────────────────────────────────────────────────
+
+/// The output of one `CodegenPipeline::compile_with_stats()` call.
+///
+/// Bundles the native binary with enough metadata for diagnostics, profiling,
+/// and cache-key decisions.
+///
+/// ## Fields
+///
+/// | Field | Description |
+/// |-------|-------------|
+/// | `binary` | Opaque native bytes, or `None` if the backend declined. |
+/// | `ir_snapshot` | Post-optimization IR snapshot for dumps and tests. |
+/// | `backend_name` | Identifies which backend produced the binary. |
+/// | `compilation_time_ns` | Wall-clock nanoseconds from IR-in to binary-out. |
+/// | `optimizer_applied` | Whether an optimizer pass ran. |
+///
+/// ## Example
+///
+/// ```rust
+/// use codegen_core::pipeline::CodegenResult;
+///
+/// let r = CodegenResult {
+///     binary: Some(vec![0u8]),
+///     ir_snapshot: "add r0, r1".to_string(),
+///     backend_name: "test".to_string(),
+///     compilation_time_ns: 42_000,
+///     optimizer_applied: false,
+/// };
+/// assert!(r.success());
+/// assert_eq!(r.binary_size(), 1);
+/// ```
+pub struct CodegenResult<IR> {
+    /// Opaque native binary, or `None` if the backend declined.
+    pub binary: Option<Vec<u8>>,
+
+    /// Post-optimization IR snapshot (what was handed to the backend).
+    pub ir_snapshot: IR,
+
+    /// Short name of the backend that produced the binary.
+    pub backend_name: String,
+
+    /// Wall-clock nanoseconds from IR-in to binary-out.
+    pub compilation_time_ns: u64,
+
+    /// `true` when an `Optimizer` was present in the pipeline and ran.
+    pub optimizer_applied: bool,
+}
+
+impl<IR> CodegenResult<IR> {
+    /// `true` when the backend produced a non-`None` binary.
+    ///
+    /// ```rust
+    /// use codegen_core::pipeline::CodegenResult;
+    ///
+    /// let ok = CodegenResult {
+    ///     binary: Some(vec![1, 2, 3]),
+    ///     ir_snapshot: (),
+    ///     backend_name: "t".into(),
+    ///     compilation_time_ns: 0,
+    ///     optimizer_applied: false,
+    /// };
+    /// assert!(ok.success());
+    ///
+    /// let fail = CodegenResult {
+    ///     binary: None,
+    ///     ir_snapshot: (),
+    ///     backend_name: "t".into(),
+    ///     compilation_time_ns: 0,
+    ///     optimizer_applied: false,
+    /// };
+    /// assert!(!fail.success());
+    /// ```
+    pub fn success(&self) -> bool {
+        self.binary.is_some()
+    }
+
+    /// Byte length of the compiled binary, or `0` if compilation failed.
+    ///
+    /// ```rust
+    /// use codegen_core::pipeline::CodegenResult;
+    ///
+    /// let r = CodegenResult {
+    ///     binary: Some(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+    ///     ir_snapshot: (),
+    ///     backend_name: "t".into(),
+    ///     compilation_time_ns: 0,
+    ///     optimizer_applied: false,
+    /// };
+    /// assert_eq!(r.binary_size(), 4);
+    /// ```
+    pub fn binary_size(&self) -> usize {
+        self.binary.as_ref().map(|b| b.len()).unwrap_or(0)
+    }
+}
+
+// ── CodegenPipeline<IR> ───────────────────────────────────────────────────────
+
+/// Universal IR → native binary pipeline.
+///
+/// `CodegenPipeline<IR>` composes an optional optimizer with a compilation
+/// backend:
+///
+/// ```text
+/// IR  →  optimizer.optimize(IR)  →  backend.compile(&IR)  →  Option<Vec<u8>>
+/// ```
+///
+/// ## Type parameter
+///
+/// `IR` — the IR type flowing through this pipeline.  Common values:
+/// - `Vec<CIRInstr>` — the JIT/AOT path
+/// - `IrProgram` — the compiled-language path (Nib, Brainfuck, Algol-60)
+///
+/// ## Thread safety
+///
+/// `CodegenPipeline` is not `Sync` (it holds `Box<dyn …>` trait objects).
+/// Each concurrent compilation should use its own instance.
+///
+/// ## Example
+///
+/// ```rust
+/// use codegen_core::pipeline::{Compile, CodegenPipeline};
+///
+/// struct AlwaysOk;
+/// impl Compile<String> for AlwaysOk {
+///     fn name(&self) -> &str { "ok" }
+///     fn compile(&self, ir: &String) -> Option<Vec<u8>> {
+///         Some(ir.as_bytes().to_vec())
+///     }
+/// }
+///
+/// let pipeline: CodegenPipeline<String> = CodegenPipeline::new(
+///     Box::new(AlwaysOk),
+///     None,
+/// );
+/// let result = pipeline.compile_with_stats("hello world".to_string());
+/// assert!(result.success());
+/// assert!(!result.optimizer_applied);
+/// ```
+pub struct CodegenPipeline<IR> {
+    /// The compilation backend.
+    backend: Box<dyn Compile<IR>>,
+
+    /// An optional optimizer that runs before the backend.
+    optimizer: Option<Box<dyn Optimizer<IR>>>,
+}
+
+impl<IR> CodegenPipeline<IR> {
+    /// Create a new pipeline.
+    ///
+    /// # Parameters
+    ///
+    /// - `backend` — implements `Compile<IR>`.  Called last; its `compile()`
+    ///   method receives the (possibly optimized) IR.
+    /// - `optimizer` — implements `Optimizer<IR>`, or `None` to skip
+    ///   optimization.
+    pub fn new(backend: Box<dyn Compile<IR>>, optimizer: Option<Box<dyn Optimizer<IR>>>) -> Self {
+        Self { backend, optimizer }
+    }
+
+    /// Short identifier of the backend used by this pipeline.
+    ///
+    /// ```rust
+    /// use codegen_core::pipeline::{Compile, CodegenPipeline};
+    ///
+    /// struct MyBackend;
+    /// impl Compile<()> for MyBackend {
+    ///     fn name(&self) -> &str { "my-backend" }
+    ///     fn compile(&self, _ir: &()) -> Option<Vec<u8>> { Some(vec![]) }
+    /// }
+    ///
+    /// let p = CodegenPipeline::new(Box::new(MyBackend), None);
+    /// assert_eq!(p.backend_name(), "my-backend");
+    /// ```
+    pub fn backend_name(&self) -> &str {
+        self.backend.name()
+    }
+
+    /// Compile `ir` to a native binary.
+    ///
+    /// This is the **fast path** — no timing or IR snapshot is taken.
+    ///
+    /// # Returns
+    ///
+    /// `Some(bytes)` — opaque native binary ready for `Backend::run()`.
+    /// `None` — if the backend declined to compile the IR.
+    pub fn compile(&self, ir: IR) -> Option<Vec<u8>> {
+        let optimized = self.run_optimizer(ir);
+        self.backend.compile(&optimized)
+    }
+
+    /// Compile `ir` and return a `CodegenResult` with diagnostics.
+    ///
+    /// Unlike the plain `compile()` method, this path:
+    /// - Captures wall-clock compilation time in nanoseconds.
+    /// - Stores the post-optimization IR snapshot in the result.
+    /// - Records whether an optimizer was applied.
+    ///
+    /// Use this path when you need to store or display the post-optimization
+    /// IR (e.g., for a JIT cache entry or an IR dump tool).
+    pub fn compile_with_stats(&self, ir: IR) -> CodegenResult<IR> {
+        let t0 = Instant::now();
+        let optimizer_applied = self.optimizer.is_some();
+        let optimized = self.run_optimizer(ir);
+        let binary = self.backend.compile(&optimized);
+        let compilation_time_ns = t0.elapsed().as_nanos() as u64;
+
+        CodegenResult {
+            binary,
+            ir_snapshot: optimized,
+            backend_name: self.backend.name().to_string(),
+            compilation_time_ns,
+            optimizer_applied,
+        }
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    /// Apply the optimizer if one is present; otherwise return `ir` unchanged.
+    fn run_optimizer(&self, ir: IR) -> IR {
+        match &self.optimizer {
+            Some(opt) => opt.optimize(ir),
+            None => ir,
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /// A backend that always succeeds, returning the IR length as a single byte.
+    struct LenBackend;
+
+    impl Compile<String> for LenBackend {
+        fn name(&self) -> &str {
+            "len"
+        }
+        fn compile(&self, ir: &String) -> Option<Vec<u8>> {
+            Some(vec![ir.len() as u8])
+        }
+    }
+
+    /// A backend that always fails.
+    struct FailBackend;
+
+    impl Compile<String> for FailBackend {
+        fn name(&self) -> &str {
+            "fail"
+        }
+        fn compile(&self, _ir: &String) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    /// An optimizer that uppercases the string IR.
+    struct UpperOptimizer;
+
+    impl Optimizer<String> for UpperOptimizer {
+        fn optimize(&self, ir: String) -> String {
+            ir.to_uppercase()
+        }
+    }
+
+    // ── CodegenResult tests ────────────────────────────────────────────────
+
+    // Test 1: success() returns true when binary is Some
+    #[test]
+    fn result_success_when_some() {
+        let r = CodegenResult {
+            binary: Some(vec![0u8]),
+            ir_snapshot: (),
+            backend_name: "t".into(),
+            compilation_time_ns: 0,
+            optimizer_applied: false,
+        };
+        assert!(r.success());
+    }
+
+    // Test 2: success() returns false when binary is None
+    #[test]
+    fn result_success_false_when_none() {
+        let r: CodegenResult<()> = CodegenResult {
+            binary: None,
+            ir_snapshot: (),
+            backend_name: "t".into(),
+            compilation_time_ns: 0,
+            optimizer_applied: false,
+        };
+        assert!(!r.success());
+    }
+
+    // Test 3: binary_size() returns the byte length
+    #[test]
+    fn result_binary_size() {
+        let r = CodegenResult {
+            binary: Some(vec![1, 2, 3, 4]),
+            ir_snapshot: (),
+            backend_name: "t".into(),
+            compilation_time_ns: 0,
+            optimizer_applied: false,
+        };
+        assert_eq!(r.binary_size(), 4);
+    }
+
+    // Test 4: binary_size() returns 0 when binary is None
+    #[test]
+    fn result_binary_size_none() {
+        let r: CodegenResult<()> = CodegenResult {
+            binary: None,
+            ir_snapshot: (),
+            backend_name: "t".into(),
+            compilation_time_ns: 0,
+            optimizer_applied: false,
+        };
+        assert_eq!(r.binary_size(), 0);
+    }
+
+    // ── CodegenPipeline tests ──────────────────────────────────────────────
+
+    // Test 5: backend_name() returns the backend's name
+    #[test]
+    fn pipeline_backend_name() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(LenBackend), None);
+        assert_eq!(p.backend_name(), "len");
+    }
+
+    // Test 6: compile() returns Some when backend succeeds
+    #[test]
+    fn pipeline_compile_success() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(LenBackend), None);
+        let result = p.compile("abc".to_string());
+        assert_eq!(result, Some(vec![3u8]));
+    }
+
+    // Test 7: compile() returns None when backend fails
+    #[test]
+    fn pipeline_compile_failure() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(FailBackend), None);
+        assert!(p.compile("anything".to_string()).is_none());
+    }
+
+    // Test 8: compile() runs the optimizer before the backend
+    #[test]
+    fn pipeline_compile_with_optimizer() {
+        // LenBackend returns the length of the string.
+        // UpperOptimizer uppercases — doesn't change len, but proves it ran.
+        // Use a different optimizer that changes length.
+        struct DupOptimizer; // doubles the string
+        impl Optimizer<String> for DupOptimizer {
+            fn optimize(&self, ir: String) -> String {
+                format!("{ir}{ir}")
+            }
+        }
+
+        let p: CodegenPipeline<String> = CodegenPipeline::new(
+            Box::new(LenBackend),
+            Some(Box::new(DupOptimizer)),
+        );
+        // "ab" → "abab" (len 4) → backend returns [4]
+        let result = p.compile("ab".to_string());
+        assert_eq!(result, Some(vec![4u8]));
+    }
+
+    // Test 9: compile_with_stats() has optimizer_applied=false when no optimizer
+    #[test]
+    fn pipeline_stats_no_optimizer() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(LenBackend), None);
+        let result = p.compile_with_stats("x".to_string());
+        assert!(!result.optimizer_applied);
+        assert!(result.success());
+    }
+
+    // Test 10: compile_with_stats() has optimizer_applied=true when optimizer present
+    #[test]
+    fn pipeline_stats_with_optimizer() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(
+            Box::new(LenBackend),
+            Some(Box::new(UpperOptimizer)),
+        );
+        let result = p.compile_with_stats("hello".to_string());
+        assert!(result.optimizer_applied);
+    }
+
+    // Test 11: compile_with_stats() stores the post-optimization IR snapshot
+    #[test]
+    fn pipeline_stats_ir_snapshot() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(
+            Box::new(LenBackend),
+            Some(Box::new(UpperOptimizer)),
+        );
+        let result = p.compile_with_stats("hello".to_string());
+        // UpperOptimizer turns "hello" into "HELLO"
+        assert_eq!(result.ir_snapshot, "HELLO");
+    }
+
+    // Test 12: compile_with_stats() stores backend_name
+    #[test]
+    fn pipeline_stats_backend_name() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(LenBackend), None);
+        let result = p.compile_with_stats("x".to_string());
+        assert_eq!(result.backend_name, "len");
+    }
+
+    // Test 13: compile_with_stats() records compilation_time_ns > 0
+    #[test]
+    fn pipeline_stats_timing() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(LenBackend), None);
+        let result = p.compile_with_stats("x".to_string());
+        // Timing may be 0 on very fast machines; just verify it's a non-negative u64
+        let _ = result.compilation_time_ns; // type check passes
+    }
+
+    // Test 14: compile_with_stats() binary is None when backend fails
+    #[test]
+    fn pipeline_stats_fail_backend() {
+        let p: CodegenPipeline<String> = CodegenPipeline::new(Box::new(FailBackend), None);
+        let result = p.compile_with_stats("x".to_string());
+        assert!(!result.success());
+        assert_eq!(result.binary_size(), 0);
+    }
+
+    // Test 15: blanket impl works — jit_core::NullBackend via Compile<Vec<CIRInstr>>
+    #[test]
+    fn blanket_impl_null_backend() {
+        use jit_core::backend::NullBackend;
+
+        let p: CodegenPipeline<Vec<CIRInstr>> =
+            CodegenPipeline::new(Box::new(NullBackend), None);
+        let result = p.compile(vec![]);
+        assert_eq!(result, Some(vec![0u8]));
+        assert_eq!(p.backend_name(), "null");
+    }
+}

--- a/code/packages/rust/codegen-core/src/registry.rs
+++ b/code/packages/rust/codegen-core/src/registry.rs
@@ -1,0 +1,285 @@
+//! `BackendRegistry` — look up backends by name.
+//!
+//! A `BackendRegistry` is a simple name-to-backend mapping.  Its purpose is to
+//! decouple the *selection* of a backend from the *construction* of a
+//! `CodegenPipeline`:
+//!
+//! ```rust
+//! use codegen_core::registry::BackendRegistry;
+//! use jit_core::backend::NullBackend;
+//!
+//! let mut registry = BackendRegistry::new();
+//! registry.register("null", Box::new(NullBackend));
+//!
+//! assert!(registry.get("null").is_some());
+//! assert!(registry.get("missing").is_none());
+//! ```
+//!
+//! ## Why a registry?
+//!
+//! Without a registry, every call site that selects a backend must import and
+//! instantiate the concrete backend type directly, coupling the call site to a
+//! specific backend package.  The registry moves backend selection to
+//! configuration time and makes it easy to enumerate available backends in
+//! diagnostics or help output.
+//!
+//! ## Type erasure
+//!
+//! Because Rust does not support generic trait objects with multiple type
+//! parameters directly, the registry stores backends as
+//! `Box<dyn Any + Send + Sync>`.  Callers must downcast after retrieval.
+//!
+//! This is the same pattern used by `CodeGeneratorRegistry` (see
+//! [`crate::codegen`]).
+
+use std::any::Any;
+use std::collections::HashMap;
+
+// ── BackendRegistry ───────────────────────────────────────────────────────────
+
+/// Name-to-backend mapping.
+///
+/// Backends are stored type-erased (`Box<dyn Any + Send + Sync>`) because
+/// backends can be generic over different IR types.  Callers must downcast
+/// after retrieval.
+///
+/// Registering a second backend with the same name silently replaces the first.
+///
+/// ## Example
+///
+/// ```rust
+/// use codegen_core::registry::BackendRegistry;
+/// use jit_core::backend::NullBackend;
+///
+/// let mut reg = BackendRegistry::new();
+/// reg.register("null", Box::new(NullBackend));
+/// assert_eq!(reg.len(), 1);
+/// assert_eq!(reg.names(), vec!["null"]);
+/// ```
+pub struct BackendRegistry {
+    backends: HashMap<String, Box<dyn Any + Send + Sync>>,
+}
+
+impl BackendRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            backends: HashMap::new(),
+        }
+    }
+
+    /// Register a backend under `name`.
+    ///
+    /// If a backend with the same name already exists it is silently replaced.
+    ///
+    /// # Parameters
+    ///
+    /// - `name` — the lookup key (typically matches `Backend::name()`).
+    /// - `backend` — type-erased backend; must implement `Any + Send + Sync`.
+    pub fn register(&mut self, name: impl Into<String>, backend: Box<dyn Any + Send + Sync>) {
+        self.backends.insert(name.into(), backend);
+    }
+
+    /// Return the backend registered under `name`, as an opaque `Any` reference.
+    ///
+    /// Returns `None` if no backend with that name has been registered.
+    ///
+    /// The caller must downcast to the concrete backend type:
+    ///
+    /// ```rust
+    /// use codegen_core::registry::BackendRegistry;
+    /// use jit_core::backend::NullBackend;
+    ///
+    /// let mut reg = BackendRegistry::new();
+    /// reg.register("null", Box::new(NullBackend));
+    ///
+    /// let backend = reg.get("null").unwrap();
+    /// let _concrete = backend.downcast_ref::<NullBackend>().unwrap();
+    /// ```
+    pub fn get(&self, name: &str) -> Option<&(dyn Any + Send + Sync)> {
+        self.backends.get(name).map(|b| b.as_ref())
+    }
+
+    /// Return the backend registered under `name`, or an error message.
+    ///
+    /// Mirrors the Python `get_or_raise` method, adapted to return a `Result`
+    /// rather than raising an exception.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` listing the available backend names when `name`
+    /// is not found.
+    ///
+    /// ```rust
+    /// use codegen_core::registry::BackendRegistry;
+    /// use jit_core::backend::NullBackend;
+    ///
+    /// let mut reg = BackendRegistry::new();
+    /// reg.register("null", Box::new(NullBackend));
+    ///
+    /// assert!(reg.get_or_raise("null").is_ok());
+    /// assert!(reg.get_or_raise("missing").is_err());
+    /// ```
+    pub fn get_or_raise(&self, name: &str) -> Result<&(dyn Any + Send + Sync), String> {
+        self.backends.get(name).map(|b| b.as_ref()).ok_or_else(|| {
+            let available = if self.backends.is_empty() {
+                "<none>".to_string()
+            } else {
+                self.names().join(", ")
+            };
+            format!(
+                "No backend named {:?} in registry. Available: {}",
+                name, available
+            )
+        })
+    }
+
+    /// Return all registered backend names, sorted alphabetically.
+    ///
+    /// ```rust
+    /// use codegen_core::registry::BackendRegistry;
+    /// use jit_core::backend::{NullBackend, EchoBackend};
+    ///
+    /// let mut reg = BackendRegistry::new();
+    /// reg.register("zzz", Box::new(NullBackend));
+    /// reg.register("aaa", Box::new(EchoBackend));
+    /// assert_eq!(reg.names(), vec!["aaa", "zzz"]);
+    /// ```
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.backends.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Return the number of registered backends.
+    pub fn len(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Return `true` if no backends are registered.
+    pub fn is_empty(&self) -> bool {
+        self.backends.is_empty()
+    }
+}
+
+impl Default for BackendRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jit_core::backend::{EchoBackend, NullBackend};
+
+    // Test 1: registry starts empty
+    #[test]
+    fn registry_starts_empty() {
+        let reg = BackendRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.names().is_empty());
+    }
+
+    // Test 2: default() == new()
+    #[test]
+    fn registry_default() {
+        let reg: BackendRegistry = Default::default();
+        assert!(reg.is_empty());
+    }
+
+    // Test 3: register + get by name
+    #[test]
+    fn registry_register_and_get() {
+        let mut reg = BackendRegistry::new();
+        reg.register("null", Box::new(NullBackend));
+        assert!(!reg.is_empty());
+        assert_eq!(reg.len(), 1);
+        assert!(reg.get("null").is_some());
+        assert!(reg.get("missing").is_none());
+    }
+
+    // Test 4: get() returns None for unknown names
+    #[test]
+    fn registry_get_unknown_returns_none() {
+        let reg = BackendRegistry::new();
+        assert!(reg.get("no-such-backend").is_none());
+    }
+
+    // Test 5: names() returns sorted names
+    #[test]
+    fn registry_names_sorted() {
+        let mut reg = BackendRegistry::new();
+        reg.register("zzz", Box::new(NullBackend));
+        reg.register("aaa", Box::new(EchoBackend));
+        reg.register("mmm", Box::new(NullBackend));
+        assert_eq!(reg.names(), vec!["aaa", "mmm", "zzz"]);
+    }
+
+    // Test 6: registering the same name replaces the previous entry
+    #[test]
+    fn registry_register_replaces() {
+        let mut reg = BackendRegistry::new();
+        reg.register("b", Box::new(NullBackend));
+        reg.register("b", Box::new(EchoBackend));
+        assert_eq!(reg.len(), 1); // still one entry
+
+        // Downcast confirms it's now the EchoBackend
+        let stored = reg.get("b").unwrap();
+        assert!(stored.downcast_ref::<EchoBackend>().is_some());
+        assert!(stored.downcast_ref::<NullBackend>().is_none());
+    }
+
+    // Test 7: downcast_ref works after get()
+    #[test]
+    fn registry_downcast_after_get() {
+        let mut reg = BackendRegistry::new();
+        reg.register("null", Box::new(NullBackend));
+        let any = reg.get("null").unwrap();
+        let concrete = any.downcast_ref::<NullBackend>();
+        assert!(concrete.is_some());
+    }
+
+    // Test 8: get_or_raise() returns Ok for a registered backend
+    #[test]
+    fn registry_get_or_raise_ok() {
+        let mut reg = BackendRegistry::new();
+        reg.register("null", Box::new(NullBackend));
+        let result = reg.get_or_raise("null");
+        assert!(result.is_ok());
+    }
+
+    // Test 9: get_or_raise() returns Err for an unregistered name
+    #[test]
+    fn registry_get_or_raise_err() {
+        let mut reg = BackendRegistry::new();
+        reg.register("null", Box::new(NullBackend));
+        let result = reg.get_or_raise("unknown");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("unknown"));
+        assert!(msg.contains("null")); // lists the available backends
+    }
+
+    // Test 10: get_or_raise() error message says "<none>" when registry is empty
+    #[test]
+    fn registry_get_or_raise_empty_registry() {
+        let reg = BackendRegistry::new();
+        let result = reg.get_or_raise("anything");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("<none>"));
+    }
+
+    // Test 11: multiple backends, len() tracks correctly
+    #[test]
+    fn registry_len_multiple() {
+        let mut reg = BackendRegistry::new();
+        reg.register("a", Box::new(NullBackend));
+        reg.register("b", Box::new(EchoBackend));
+        reg.register("c", Box::new(NullBackend));
+        assert_eq!(reg.len(), 3);
+    }
+}


### PR DESCRIPTION
## Summary

- Ports the Python `codegen-core` package (LANG19/LANG20) to Rust
- New crate at `code/packages/rust/codegen-core/`
- Four modules: `optimizer`, `codegen`, `pipeline`, `registry`

### Key new types

| Module | Type | Purpose |
|--------|------|---------|
| `optimizer` | `Optimizer<IR>` trait | Generic IR → IR transformation |
| `optimizer` | `IrProgramOptimizer` | Strips `IrOp::Nop` (wraps `ir_optimizer::IrOptimizer`) |
| `codegen` | `CodeGenerator<IR, Assembly>` | LANG20 validate + generate protocol |
| `codegen` | `CodeGeneratorRegistry` | Type-erased name → generator map |
| `pipeline` | `Compile<IR>` | Generic compilation backend trait |
| `pipeline` | `CodegenPipeline<IR>` | Composes Optimizer + Compile |
| `pipeline` | `CodegenResult<IR>` | Binary + diagnostics output |
| `registry` | `BackendRegistry` | Type-erased name → backend map |

### Notable design decisions

- Blanket `impl<B: Backend> Compile<Vec<CIRInstr>> for B` lets any existing `jit_core` backend plug directly into `CodegenPipeline<Vec<CIRInstr>>` with zero boilerplate
- Type erasure via `Box<dyn Any + Send + Sync>` follows the same pattern used in `CodeGeneratorRegistry` and `BackendRegistry` (Rust can't do heterogeneous generic trait objects)
- `Optimizer<IR>` is re-exported from both `pipeline` and the crate root for convenience

### Tests

58 tests total: 41 unit tests + 17 doc tests — all green.

## Test plan

- [x] `cargo test -p codegen-core` passes (41 unit + 17 doc tests)
- [x] `cargo build --workspace` passes
- [x] Security review passed (no vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)