### PR TITLE
feat(rust): LANG20 — CodeGenerator adapters for WASM, JVM, Intel 4004 backends

### DIFF
--- a/code/packages/rust/ir-to-intel-4004-compiler/CHANGELOG.md
+++ b/code/packages/rust/ir-to-intel-4004-compiler/CHANGELOG.md
@@ -1,3 +1,20 @@
 # Changelog
 
+## [0.2.0] — 2026-04-29
+
+### Added
+
+- **LANG20 `Intel4004CodeGenerator`** — new `codegen` module implementing
+  `CodeGenerator<IrProgram, String>` from `codegen-core`.
+  - `name()` → `"intel4004"`
+  - `validate(ir)` — runs the `IrToIntel4004Compiler` validator; returns errors as `Vec<String>`
+  - `generate(ir)` → Intel 4004 assembly text string (panics on invalid IR)
+  - 8 unit tests + 1 doc-test
+
+### Changed
+
+- Added `codegen-core` to `[dependencies]` to enable the `CodeGenerator` trait implementation.
+
+## [0.1.0]
+
 - Initial Rust port of the Intel 4004 backend compiler.

--- a/code/packages/rust/ir-to-intel-4004-compiler/Cargo.toml
+++ b/code/packages/rust/ir-to-intel-4004-compiler/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+codegen-core = { path = "../codegen-core" }
 compiler-ir = { path = "../compiler-ir" }
 intel-4004-ir-validator = { path = "../intel-4004-ir-validator" }

--- a/code/packages/rust/ir-to-intel-4004-compiler/src/codegen.rs
+++ b/code/packages/rust/ir-to-intel-4004-compiler/src/codegen.rs
@@ -1,0 +1,211 @@
+//! `Intel4004CodeGenerator` — LANG20 `CodeGenerator<IrProgram, String>` adapter.
+//!
+//! This module wraps `IrToIntel4004Compiler` in the `CodeGenerator` protocol
+//! defined by `codegen-core`.  It is the Rust equivalent of the Python
+//! `Intel4004CodeGenerator` adapter described in LANG20.
+//!
+//! ## Assembly type
+//!
+//! The "assembly" returned is a `String` — human-readable Intel 4004 assembly
+//! text.  Each line is either a label definition (`LOOP_0:`) or a single
+//! 4004 mnemonic (`LDM 5`, `XCH R2`, `JUN LOOP_0`, etc.).
+//!
+//! The text can be fed to the `intel-4004-assembler` crate to produce a binary
+//! ROM image, or passed directly to the `intel4004-simulator` for execution.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use codegen_core::codegen::CodeGenerator;
+//! use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+//! use ir_to_intel_4004_compiler::codegen::Intel4004CodeGenerator;
+//!
+//! let prog = IrProgram {
+//!     instructions: vec![
+//!         IrInstruction::new(IrOp::Label,   vec![IrOperand::Label("_start".into())], -1),
+//!         IrInstruction::new(IrOp::LoadImm, vec![IrOperand::Register(0), IrOperand::Immediate(5)], 0),
+//!         IrInstruction::new(IrOp::Halt,    vec![], 1),
+//!     ],
+//!     data: vec![],
+//!     entry_label: "_start".into(),
+//!     version: 1,
+//! };
+//!
+//! let gen = Intel4004CodeGenerator::default();
+//! assert!(gen.validate(&prog).is_empty());
+//! let asm = gen.generate(&prog);
+//! assert!(asm.contains("LDM"));   // LOAD_IMM lowers to LDM + XCH
+//! ```
+
+use codegen_core::codegen::CodeGenerator;
+use compiler_ir::IrProgram;
+
+use crate::IrToIntel4004Compiler;
+
+// ── Intel4004CodeGenerator ────────────────────────────────────────────────────
+
+/// `CodeGenerator<IrProgram, String>` adapter for the Intel 4004 backend.
+///
+/// Wraps `IrToIntel4004Compiler` in the `codegen_core::codegen::CodeGenerator`
+/// protocol so it can be registered in a `CodeGeneratorRegistry` alongside the
+/// WASM and JVM backends.
+///
+/// ## Assembly text format
+///
+/// The generated text starts with `    ORG 0x000` and then one or more lines
+/// per IR instruction.  Labels are un-indented (`_start:`), instructions are
+/// indented with four spaces.
+#[derive(Debug, Clone, Default)]
+pub struct Intel4004CodeGenerator;
+
+impl CodeGenerator<IrProgram, String> for Intel4004CodeGenerator {
+    /// Returns `"intel4004"` — the canonical backend identifier.
+    fn name(&self) -> &str {
+        "intel4004"
+    }
+
+    /// Validate `ir` for Intel 4004 assembly generation.
+    ///
+    /// Returns an empty `Vec` when every IR instruction in `ir` maps to a
+    /// known Intel 4004 opcode sequence, or a `Vec` of error strings for any
+    /// instruction that the backend cannot lower.
+    fn validate(&self, ir: &IrProgram) -> Vec<String> {
+        match IrToIntel4004Compiler::default().compile(ir) {
+            Ok(_) => vec![],
+            Err(errs) => errs.iter().map(|d| d.to_string()).collect(),
+        }
+    }
+
+    /// Compile `IrProgram → Intel 4004 assembly text`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `validate(ir)` would have returned errors.  Always call
+    /// `validate` first in production code.
+    fn generate(&self, ir: &IrProgram) -> String {
+        IrToIntel4004Compiler::default()
+            .compile(ir)
+            .expect("Intel4004CodeGenerator::generate called on invalid IrProgram; call validate() first")
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+
+    use super::*;
+
+    /// Minimal valid program: `_start: LOAD_IMM v0, 5; HALT`
+    ///
+    /// Intel 4004 supports LOAD_IMM for values 0–15 (fits in a nibble) and HALT
+    /// via the BRU mnemonic pointing at itself.  This program exercises the
+    /// simplest possible compile path.
+    fn minimal_prog() -> IrProgram {
+        IrProgram {
+            instructions: vec![
+                IrInstruction::new(
+                    IrOp::Label,
+                    vec![IrOperand::Label("_start".into())],
+                    -1,
+                ),
+                IrInstruction::new(
+                    IrOp::LoadImm,
+                    vec![IrOperand::Register(0), IrOperand::Immediate(5)],
+                    0,
+                ),
+                IrInstruction::new(IrOp::Halt, vec![], 1),
+            ],
+            data: vec![],
+            entry_label: "_start".into(),
+            version: 1,
+        }
+    }
+
+    // Test 1: name() returns "intel4004"
+    #[test]
+    fn name_is_intel4004() {
+        let gen = Intel4004CodeGenerator::default();
+        assert_eq!(gen.name(), "intel4004");
+    }
+
+    // Test 2: validate() returns empty Vec on a valid program
+    #[test]
+    fn validate_empty_on_valid() {
+        let gen = Intel4004CodeGenerator::default();
+        let errors = gen.validate(&minimal_prog());
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    // Test 3: validate() returns errors on a program with unsupported opcodes
+    //         STORE_BYTE is not supported on the 4004 (no memory-write instruction)
+    #[test]
+    fn validate_fails_on_unsupported_opcode() {
+        let gen = Intel4004CodeGenerator::default();
+        let bad = IrProgram {
+            instructions: vec![
+                IrInstruction::new(
+                    IrOp::Label,
+                    vec![IrOperand::Label("_start".into())],
+                    -1,
+                ),
+                IrInstruction::new(
+                    IrOp::StoreByte,
+                    vec![
+                        IrOperand::Register(0),
+                        IrOperand::Register(1),
+                        IrOperand::Register(2),
+                    ],
+                    0,
+                ),
+            ],
+            data: vec![],
+            entry_label: "_start".into(),
+            version: 1,
+        };
+        let errors = gen.validate(&bad);
+        assert!(!errors.is_empty(), "expected errors for STORE_BYTE on 4004");
+    }
+
+    // Test 4: generate() returns non-empty assembly text
+    #[test]
+    fn generate_returns_text() {
+        let gen = Intel4004CodeGenerator::default();
+        let asm = gen.generate(&minimal_prog());
+        assert!(!asm.is_empty(), "expected non-empty assembly text");
+    }
+
+    // Test 5: generated text starts with ORG directive
+    #[test]
+    fn generate_starts_with_org() {
+        let gen = Intel4004CodeGenerator::default();
+        let asm = gen.generate(&minimal_prog());
+        assert!(asm.contains("ORG"), "expected ORG directive in assembly: {asm}");
+    }
+
+    // Test 6: LOAD_IMM lowers to LDM (load immediate data) mnemonic
+    #[test]
+    fn load_imm_lowers_to_ldm() {
+        let gen = Intel4004CodeGenerator::default();
+        let asm = gen.generate(&minimal_prog());
+        assert!(asm.contains("LDM"), "expected LDM in assembly: {asm}");
+    }
+
+    // Test 7: validate() then generate() succeeds end-to-end
+    #[test]
+    fn validate_then_generate() {
+        let gen = Intel4004CodeGenerator::default();
+        let prog = minimal_prog();
+        assert!(gen.validate(&prog).is_empty());
+        let asm = gen.generate(&prog);
+        assert!(asm.contains("_start"), "expected _start label in asm: {asm}");
+    }
+
+    // Test 8: Intel4004CodeGenerator is Send + Sync
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Intel4004CodeGenerator>();
+    }
+}

--- a/code/packages/rust/ir-to-intel-4004-compiler/src/lib.rs
+++ b/code/packages/rust/ir-to-intel-4004-compiler/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod codegen;
+
 use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
 use intel_4004_ir_validator::{IrValidator, ValidationDiagnostic};
 

--- a/code/packages/rust/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## Unreleased
+## [0.2.0] — 2026-04-29
+
+### Added
+
+- **LANG20 `JvmCodeGenerator`** — new `codegen` module implementing
+  `CodeGenerator<IrProgram, JvmClassArtifact>` from `codegen-core`.
+  - `name()` → `"jvm"`
+  - `class_name()` — returns the configured JVM class name
+  - `validate(ir)` — dry-run compile; returns errors as `Vec<String>`
+  - `generate(ir)` → `JvmClassArtifact` (panics on invalid IR)
+  - Default class name: `"Main"`; customise with `JvmCodeGenerator::new("MyClass")`
+  - 8 unit tests + 1 doc-test
+
+### Changed
+
+- Added `codegen-core` to `[dependencies]` to enable the `CodeGenerator` trait implementation.
+
+## [0.1.0] — Unreleased
 
 - add the first Rust `ir-to-jvm-class-file` backend
 - lower the current Brainfuck and Nib IR subset into verifier-friendly JVM bytecode

--- a/code/packages/rust/ir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/ir-to-jvm-class-file/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Lower compiler-ir programs into conservative JVM class files"
 
 [dependencies]
+codegen-core = { path = "../codegen-core" }
 compiler-ir = { path = "../compiler-ir" }
 jvm-class-file = { path = "../jvm-class-file" }
 libc = "0.2"

--- a/code/packages/rust/ir-to-jvm-class-file/src/codegen.rs
+++ b/code/packages/rust/ir-to-jvm-class-file/src/codegen.rs
@@ -1,0 +1,223 @@
+//! `JvmCodeGenerator` — LANG20 `CodeGenerator<IrProgram, JvmClassArtifact>` adapter.
+//!
+//! This module wraps `lower_ir_to_jvm_class_file` in the `CodeGenerator` protocol
+//! defined by `codegen-core`, making the JVM backend interchangeable with all
+//! other LANG20 backends (WASM, Intel 4004, etc.).
+//!
+//! ## Assembly type
+//!
+//! The assembly returned is a `JvmClassArtifact` — a structured object that
+//! carries the class name, the raw JVM `.class` bytes, callable label indices,
+//! and data offsets.  Pass `artifact.class_bytes` to a JVM simulator for
+//! execution, or call `write_class_file(&artifact, out_dir)` to write a `.class`
+//! file to disk.
+//!
+//! ## Class name
+//!
+//! By default `JvmCodeGenerator` uses `"Main"` as the JVM class name.  Provide
+//! a custom name at construction time:
+//!
+//! ```rust
+//! use ir_to_jvm_class_file::codegen::JvmCodeGenerator;
+//!
+//! let gen = JvmCodeGenerator::new("MyClass");
+//! assert_eq!(gen.class_name(), "MyClass");
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use codegen_core::codegen::CodeGenerator;
+//! use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+//! use ir_to_jvm_class_file::codegen::JvmCodeGenerator;
+//!
+//! let prog = IrProgram {
+//!     instructions: vec![
+//!         IrInstruction::new(IrOp::Label, vec![IrOperand::Label("_start".into())], -1),
+//!         IrInstruction::new(IrOp::Halt,  vec![], 0),
+//!     ],
+//!     data: vec![],
+//!     entry_label: "_start".into(),
+//!     version: 1,
+//! };
+//!
+//! let gen = JvmCodeGenerator::default();
+//! assert!(gen.validate(&prog).is_empty());
+//! let artifact = gen.generate(&prog);
+//! assert!(!artifact.class_bytes.is_empty());
+//! ```
+
+use codegen_core::codegen::CodeGenerator;
+use compiler_ir::IrProgram;
+
+use crate::{lower_ir_to_jvm_class_file, JvmBackendConfig, JvmClassArtifact};
+
+// ── JvmCodeGenerator ─────────────────────────────────────────────────────────
+
+/// `CodeGenerator<IrProgram, JvmClassArtifact>` adapter for the JVM backend.
+///
+/// Wraps `lower_ir_to_jvm_class_file` in the `codegen_core::codegen::CodeGenerator`
+/// protocol.  The returned `JvmClassArtifact` contains the raw `.class` bytes
+/// in `artifact.class_bytes`.
+///
+/// ## Default class name
+///
+/// When constructed via `JvmCodeGenerator::default()` the JVM class name is
+/// `"Main"`.  Change it with `JvmCodeGenerator::new("YourClass")`.
+pub struct JvmCodeGenerator {
+    class_name: String,
+}
+
+impl JvmCodeGenerator {
+    /// Construct a JVM code generator with an explicit class name.
+    ///
+    /// # Arguments
+    ///
+    /// * `class_name` — The JVM class name (e.g. `"Main"`, `"BrainfuckProgram"`).
+    ///   Must be a valid JVM binary class name.
+    pub fn new(class_name: impl Into<String>) -> Self {
+        Self { class_name: class_name.into() }
+    }
+
+    /// Return the JVM class name this generator uses.
+    pub fn class_name(&self) -> &str {
+        &self.class_name
+    }
+
+    fn config(&self) -> JvmBackendConfig {
+        JvmBackendConfig::new(&self.class_name)
+    }
+}
+
+impl Default for JvmCodeGenerator {
+    fn default() -> Self {
+        Self::new("Main")
+    }
+}
+
+impl CodeGenerator<IrProgram, JvmClassArtifact> for JvmCodeGenerator {
+    /// Returns `"jvm"` — the canonical backend identifier.
+    fn name(&self) -> &str {
+        "jvm"
+    }
+
+    /// Validate `ir` for JVM lowering.
+    ///
+    /// Returns an empty `Vec` if the program can be lowered without errors, or a
+    /// single-element `Vec` containing the backend error message when the program
+    /// is invalid for this target.
+    fn validate(&self, ir: &IrProgram) -> Vec<String> {
+        match lower_ir_to_jvm_class_file(ir, self.config()) {
+            Ok(_) => vec![],
+            Err(e) => vec![e.to_string()],
+        }
+    }
+
+    /// Compile `IrProgram → JvmClassArtifact`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `validate(ir)` would have returned errors.  Always call
+    /// `validate` first in production code.
+    fn generate(&self, ir: &IrProgram) -> JvmClassArtifact {
+        lower_ir_to_jvm_class_file(ir, self.config())
+            .expect("JvmCodeGenerator::generate called on invalid IrProgram; call validate() first")
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+
+    use super::*;
+
+    /// Minimal valid program: `_start: LOAD_IMM v0, 99; HALT`
+    ///
+    /// This exercises the entire JVM lowering pipeline from a single entry
+    /// function through to raw `.class` bytes.
+    fn minimal_prog() -> IrProgram {
+        IrProgram {
+            instructions: vec![
+                IrInstruction::new(
+                    IrOp::Label,
+                    vec![IrOperand::Label("_start".into())],
+                    -1,
+                ),
+                IrInstruction::new(
+                    IrOp::LoadImm,
+                    vec![IrOperand::Register(0), IrOperand::Immediate(99)],
+                    0,
+                ),
+                IrInstruction::new(IrOp::Halt, vec![], 1),
+            ],
+            data: vec![],
+            entry_label: "_start".into(),
+            version: 1,
+        }
+    }
+
+    // Test 1: name() returns "jvm"
+    #[test]
+    fn name_is_jvm() {
+        let gen = JvmCodeGenerator::default();
+        assert_eq!(gen.name(), "jvm");
+    }
+
+    // Test 2: default class name is "Main"
+    #[test]
+    fn default_class_name() {
+        let gen = JvmCodeGenerator::default();
+        assert_eq!(gen.class_name(), "Main");
+    }
+
+    // Test 3: custom class name is preserved
+    #[test]
+    fn custom_class_name() {
+        let gen = JvmCodeGenerator::new("BrainfuckProgram");
+        assert_eq!(gen.class_name(), "BrainfuckProgram");
+    }
+
+    // Test 4: validate() returns empty Vec on a valid program
+    #[test]
+    fn validate_empty_on_valid() {
+        let gen = JvmCodeGenerator::default();
+        let errors = gen.validate(&minimal_prog());
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    // Test 5: generate() produces a non-empty class artifact
+    #[test]
+    fn generate_produces_artifact() {
+        let gen = JvmCodeGenerator::default();
+        let artifact = gen.generate(&minimal_prog());
+        assert!(!artifact.class_bytes.is_empty(), "expected non-empty class bytes");
+    }
+
+    // Test 6: artifact class name matches the configured class name
+    #[test]
+    fn artifact_class_name_matches_config() {
+        let gen = JvmCodeGenerator::new("MyApp");
+        let artifact = gen.generate(&minimal_prog());
+        assert_eq!(artifact.class_name, "MyApp");
+    }
+
+    // Test 7: validate() then generate() succeeds end-to-end
+    #[test]
+    fn validate_then_generate() {
+        let gen = JvmCodeGenerator::default();
+        let prog = minimal_prog();
+        assert!(gen.validate(&prog).is_empty());
+        let artifact = gen.generate(&prog);
+        // JVM class magic number: 0xCAFEBABE at bytes 0-3
+        assert_eq!(&artifact.class_bytes[..4], &[0xCA, 0xFE, 0xBA, 0xBE]);
+    }
+
+    // Test 8: JvmCodeGenerator is Send + Sync
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<JvmCodeGenerator>();
+    }
+}

--- a/code/packages/rust/ir-to-jvm-class-file/src/lib.rs
+++ b/code/packages/rust/ir-to-jvm-class-file/src/lib.rs
@@ -8,6 +8,8 @@
 //! is a feature, because boring bytecode is easy for both the JVM verifier and
 //! GraalVM Native Image to accept.
 
+pub mod codegen;
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::CString;
 use std::fmt;

--- a/code/packages/rust/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/rust/ir-to-wasm-compiler/CHANGELOG.md
@@ -1,3 +1,21 @@
 # Changelog
 
-- 0.1.0: Initial release.
+## [0.2.0] — 2026-04-29
+
+### Added
+
+- **LANG20 `WasmCodeGenerator`** — new `codegen` module implementing
+  `CodeGenerator<IrProgram, WasmModule>` from `codegen-core`.
+  - `name()` → `"wasm"`
+  - `validate(ir)` — dry-run compile; returns errors as `Vec<String>`
+  - `generate(ir)` → `WasmModule` (panics on invalid IR — always call `validate` first)
+  - 8 unit tests + 1 doc-test
+
+### Changed
+
+- Added `codegen-core` to `[dependencies]` to enable the `CodeGenerator` trait implementation.
+
+## [0.1.0] — Initial release
+
+- `IrToWasmCompiler::compile(program, signatures)` — lower `IrProgram` to `WasmModule`
+- `infer_function_signatures_from_comments` — infer `FunctionSignature` from `COMMENT` IR instructions

--- a/code/packages/rust/ir-to-wasm-compiler/Cargo.toml
+++ b/code/packages/rust/ir-to-wasm-compiler/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Lower the generic compiler IR into WebAssembly 1.0 modules"
 
 [dependencies]
+codegen-core = { path = "../codegen-core" }
 compiler-ir = { path = "../compiler-ir" }
 wasm-leb128 = { path = "../wasm-leb128" }
 wasm-opcodes = { path = "../wasm-opcodes" }

--- a/code/packages/rust/ir-to-wasm-compiler/src/codegen.rs
+++ b/code/packages/rust/ir-to-wasm-compiler/src/codegen.rs
@@ -1,0 +1,234 @@
+//! `WasmCodeGenerator` — LANG20 `CodeGenerator<IrProgram, WasmModule>` adapter.
+//!
+//! This module wraps `IrToWasmCompiler` in the `CodeGenerator` protocol defined
+//! by `codegen-core`.  It is the Rust equivalent of the Python `WASMCodeGenerator`
+//! adapter described in LANG20.
+//!
+//! ## Responsibilities
+//!
+//! - **Validate**: Attempt a dry-run compilation; map any `WasmLoweringError` to
+//!   a `Vec<String>` of human-readable errors.
+//! - **Generate**: Compile `IrProgram → WasmModule` using the default
+//!   `IrToWasmCompiler` with an empty function-signature list (letting the
+//!   compiler infer signatures from `COMMENT` instructions in the IR).
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use codegen_core::codegen::CodeGenerator;
+//! use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+//! use ir_to_wasm_compiler::codegen::WasmCodeGenerator;
+//!
+//! let prog = IrProgram {
+//!     instructions: vec![
+//!         IrInstruction::new(IrOp::Label, vec![IrOperand::Label("_start".into())], -1),
+//!         IrInstruction::new(IrOp::Halt,  vec![], 0),
+//!     ],
+//!     data: vec![],
+//!     entry_label: "_start".into(),
+//!     version: 1,
+//! };
+//!
+//! let gen = WasmCodeGenerator::default();
+//! assert!(gen.validate(&prog).is_empty());
+//! let module = gen.generate(&prog);
+//! // module is a valid WasmModule with an exported "_start" function.
+//! ```
+
+use codegen_core::codegen::CodeGenerator;
+use compiler_ir::IrProgram;
+use wasm_types::WasmModule;
+
+use crate::IrToWasmCompiler;
+
+// ── WasmCodeGenerator ────────────────────────────────────────────────────────
+
+/// `CodeGenerator<IrProgram, WasmModule>` adapter for the WASM backend.
+///
+/// Wraps `IrToWasmCompiler` in the `codegen_core::codegen::CodeGenerator`
+/// protocol so it can be registered in a `CodeGeneratorRegistry` and used
+/// uniformly alongside other backends.
+///
+/// ## Assembly type
+///
+/// Returns a `WasmModule` — the structured WebAssembly 1.0 module object
+/// produced by the lowering pass.  Pass the result to `encode_module` from
+/// `wasm-module-encoder` to obtain a binary `Vec<u8>`.
+///
+/// ## Function signatures
+///
+/// The `generate()` / `validate()` methods call the compiler with an *empty*
+/// function-signature list, relying on the WASM compiler's built-in heuristic
+/// that infers signatures from `COMMENT` instructions in the IR.  If you need
+/// to supply explicit signatures, use `IrToWasmCompiler::compile()` directly.
+#[derive(Debug, Clone, Default)]
+pub struct WasmCodeGenerator;
+
+impl CodeGenerator<IrProgram, WasmModule> for WasmCodeGenerator {
+    /// Returns `"wasm"` — the canonical backend identifier.
+    fn name(&self) -> &str {
+        "wasm"
+    }
+
+    /// Attempt a dry-run compilation.
+    ///
+    /// Returns an empty `Vec` when the program is valid for WASM lowering,
+    /// or a single-element `Vec` containing the lowering error message
+    /// when something goes wrong.
+    fn validate(&self, ir: &IrProgram) -> Vec<String> {
+        match IrToWasmCompiler::default().compile(ir, &[]) {
+            Ok(_) => vec![],
+            Err(e) => vec![e.to_string()],
+        }
+    }
+
+    /// Compile `IrProgram → WasmModule`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `validate(ir)` would have returned errors.  Always call
+    /// `validate` first in production code.
+    fn generate(&self, ir: &IrProgram) -> WasmModule {
+        IrToWasmCompiler::default()
+            .compile(ir, &[])
+            .expect("WasmCodeGenerator::generate called on invalid IrProgram; call validate() first")
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use compiler_ir::{IrInstruction, IrOp, IrOperand, IrProgram};
+
+    use super::*;
+
+    /// Helper: a minimal valid IrProgram with a single entry function.
+    /// Emits:  `_start: LOAD_IMM r0, 42; HALT`
+    ///
+    /// This is the canonical smoke-test program used throughout the LANG20 test
+    /// suite.  `LOAD_IMM v0, 42; HALT` is the simplest program that exercises
+    /// the full compile path without requiring any WASI imports.
+    fn minimal_prog() -> IrProgram {
+        IrProgram {
+            instructions: vec![
+                IrInstruction::new(
+                    IrOp::Label,
+                    vec![IrOperand::Label("_start".into())],
+                    -1,
+                ),
+                IrInstruction::new(
+                    IrOp::LoadImm,
+                    vec![IrOperand::Register(0), IrOperand::Immediate(42)],
+                    0,
+                ),
+                IrInstruction::new(IrOp::Halt, vec![], 1),
+            ],
+            data: vec![],
+            entry_label: "_start".into(),
+            version: 1,
+        }
+    }
+
+    // Test 1: name() returns "wasm"
+    #[test]
+    fn name_is_wasm() {
+        let gen = WasmCodeGenerator::default();
+        assert_eq!(gen.name(), "wasm");
+    }
+
+    // Test 2: validate() returns empty Vec on a valid program
+    #[test]
+    fn validate_empty_on_valid() {
+        let gen = WasmCodeGenerator::default();
+        let errors = gen.validate(&minimal_prog());
+        assert!(
+            errors.is_empty(),
+            "expected no errors, got: {:?}",
+            errors
+        );
+    }
+
+    // Test 3: validate() returns non-empty Vec on an unsupported SYSCALL number.
+    //         SYSCALL 99 is not a recognised WASI syscall, so the compiler rejects it.
+    //         This ensures validate() surfaces lowering errors as strings.
+    #[test]
+    fn validate_fails_on_bad_syscall() {
+        let gen = WasmCodeGenerator::default();
+        let bad = IrProgram {
+            instructions: vec![
+                IrInstruction::new(
+                    IrOp::Label,
+                    vec![IrOperand::Label("_start".into())],
+                    -1,
+                ),
+                IrInstruction::new(
+                    IrOp::Syscall,
+                    vec![IrOperand::Immediate(99)],
+                    0,
+                ),
+            ],
+            data: vec![],
+            entry_label: "_start".into(),
+            version: 1,
+        };
+        let errors = gen.validate(&bad);
+        assert!(!errors.is_empty(), "expected validation errors for SYSCALL 99");
+        assert!(
+            errors[0].contains("SYSCALL"),
+            "expected SYSCALL mention in error: {:?}",
+            errors
+        );
+    }
+
+    // Test 4: generate() returns a WasmModule for a valid program
+    #[test]
+    fn generate_produces_wasm_module() {
+        let gen = WasmCodeGenerator::default();
+        let module = gen.generate(&minimal_prog());
+        // A compiled WASM module must have at least one function type and one export
+        assert!(!module.exports.is_empty(), "expected at least one export");
+    }
+
+    // Test 5: generate() WasmModule exports the _start function
+    #[test]
+    fn generate_exports_start() {
+        let gen = WasmCodeGenerator::default();
+        let module = gen.generate(&minimal_prog());
+        let export_names: Vec<&str> = module.exports.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            export_names.contains(&"_start"),
+            "_start not found in exports: {:?}",
+            export_names
+        );
+    }
+
+    // Test 6: validate() then generate() on the same program succeeds end-to-end
+    #[test]
+    fn validate_then_generate() {
+        let gen = WasmCodeGenerator::default();
+        let prog = minimal_prog();
+        let errors = gen.validate(&prog);
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        let module = gen.generate(&prog);
+        // A well-formed WASM module produced by the lowering has at least one type entry
+        assert!(!module.types.is_empty(), "expected non-empty type section");
+    }
+
+    // Test 7: WasmCodeGenerator is Send + Sync (required by CodeGenerator bound)
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WasmCodeGenerator>();
+    }
+
+    // Test 8: validate() is idempotent — calling it twice gives the same result
+    #[test]
+    fn validate_idempotent() {
+        let gen = WasmCodeGenerator::default();
+        let prog = minimal_prog();
+        let e1 = gen.validate(&prog);
+        let e2 = gen.validate(&prog);
+        assert_eq!(e1, e2);
+    }
+}

--- a/code/packages/rust/ir-to-wasm-compiler/src/lib.rs
+++ b/code/packages/rust/ir-to-wasm-compiler/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod codegen;
+
 use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 


### PR DESCRIPTION
## Summary

- **`WasmCodeGenerator`** in `ir-to-wasm-compiler` — `CodeGenerator<IrProgram, WasmModule>`
- **`JvmCodeGenerator`** in `ir-to-jvm-class-file` — `CodeGenerator<IrProgram, JvmClassArtifact>`
- **`Intel4004CodeGenerator`** in `ir-to-intel-4004-compiler` — `CodeGenerator<IrProgram, String>`

These complete the Rust-side LANG20 CodeGenerator protocol, making all three backends interchangeable via the `CodeGenerator` trait from `codegen-core` (merged in PR #1700).

Each adapter is ~60 lines and wraps the existing compiler:
- `name()` — stable backend identifier (`"wasm"`, `"jvm"`, `"intel4004"`)
- `validate(ir)` — dry-run compile; returns `Vec<String>` of errors
- `generate(ir)` — full compile; panics if called on invalid IR (documented contract)

27 new tests (8 unit + 1 doc-test per adapter); all pass.

## Test plan

- [x] `cargo test -p ir-to-wasm-compiler` — 11 pass (8 new codegen tests)
- [x] `cargo test -p ir-to-jvm-class-file` — 15 pass (8 new codegen tests)
- [x] `cargo test -p ir-to-intel-4004-compiler` — 9 pass (8 new codegen tests)
- [x] Security review passed (1 round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)