### PR TITLE
feat(rust): dartmouth-basic-ge225-compiler + fix GE-225 branch inhibit semantics

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -229,6 +229,7 @@ members = [
     "dartmouth-basic-lexer",
     "dartmouth-basic-parser",
     "dartmouth-basic-ir-compiler",
+    "dartmouth-basic-ge225-compiler",
     "affine2d",
     "algol-lexer",
     "algol-parser",

--- a/code/packages/rust/dartmouth-basic-ge225-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-ge225-compiler/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog — dartmouth-basic-ge225-compiler
+
+## [0.1.0] — 2026-04-28
+
+### Added
+
+- Initial release: full Dartmouth BASIC → GE-225 four-stage compiled pipeline.
+- `run_basic(source)` — compile and simulate a BASIC program with default options
+  (4 096-word GE-225 memory, 100 000 instruction safety limit).
+- `run_basic_with_options(source, memory_words, max_steps)` — explicit control over
+  memory size and step limit.
+- `RunResult` — structured output containing:
+  - `output` — typewriter characters produced by `PRINT` statements
+    (GE-225 carriage-return codes converted to Unix `\n`).
+  - `var_values` — final 20-bit values of BASIC scalar variables A–Z,
+    sign-extended to `i32`.
+  - `steps` — number of GE-225 instructions executed.
+  - `halt_address` — word address of the halt self-loop stub.
+- `BasicError` — wraps failures from all four pipeline stages (parse, IR compile,
+  GE-225 codegen, simulation) into a single error type.
+- 36 integration tests covering:
+  - `LET` (constant, arithmetic, chained variables, unary minus, complex expressions)
+  - `PRINT` (strings, numbers, leading-zero suppression, negative numbers, mixed)
+  - `FOR … TO [STEP] … NEXT` loops (sequence, sum, stride-2)
+  - `IF … THEN` conditionals (< > = <> <=)
+  - `GOTO`
+  - Classic programs: Fibonacci, countdown, for-loop sum
+  - Error cases: GOSUB unsupported, max-steps exceeded
+  - `RunResult` field checks (steps > 0, halt_address > 0)
+- Pipeline stages:
+  1. `dartmouth-basic-ir-compiler` with `int_bits=20` (GE-225 20-bit word size).
+  2. `ir-to-ge225-compiler` GE-225 backend.
+  3. `coding-adventures-ge225-simulator` behavioural simulator.
+
+### Fixed (discovered during integration testing)
+
+- **GE-225 branch-test "inhibit" semantics** — The GE-225 uses *inhibit* semantics
+  for conditional skip instructions (the named condition **prevents** the skip, not
+  causes it). `ir-to-ge225-compiler` was using the wrong instruction in four places:
+
+  | Site | Old instruction | Correct instruction |
+  |------|-----------------|---------------------|
+  | `BRANCH_Z` (jump when A==0) | `BNZ` | `BZE` |
+  | `BRANCH_NZ` (jump when A≠0) | `BZE` | `BNZ` |
+  | `CMP_EQ` (equal → result 1) | `BNZ` | `BZE` |
+  | `CMP_NE` (not-equal → result 1) | `BZE` | `BNZ` |
+  | `CMP_LT`/`CMP_GT` signed diff | `BPL` (skips when A<0) | `BMI` (skips when A≥0) |
+  | `AND_IMM 1` odd-path layout | LDO at +3, LDZ at +5 | LDZ at +3, LDO at +5 |
+
+  The double-inversion in CMP+BRANCH_NZ accidentally produced correct results for
+  `IF … THEN` tests, masking the bug. BRANCH_Z with arithmetic (leading-zero
+  suppression in `emit_print_number`) and NOT-bool via `AND_IMM` exposed it.

--- a/code/packages/rust/dartmouth-basic-ge225-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-ge225-compiler/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dartmouth-basic-ge225-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "Dartmouth BASIC → GE-225 compiled pipeline: parse → IR compile → GE-225 codegen → simulate"
+
+[dependencies]
+dartmouth-basic-ir-compiler       = { path = "../dartmouth-basic-ir-compiler" }
+ir-to-ge225-compiler              = { path = "../ir-to-ge225-compiler" }
+coding-adventures-ge225-simulator = { path = "../ge225-simulator" }

--- a/code/packages/rust/dartmouth-basic-ge225-compiler/README.md
+++ b/code/packages/rust/dartmouth-basic-ge225-compiler/README.md
@@ -1,0 +1,127 @@
+# dartmouth-basic-ge225-compiler
+
+The full **Dartmouth BASIC → GE-225** compiled pipeline in a single Rust crate.
+
+In 1964, undergraduate students at Dartmouth College typed BASIC programs on
+Teletype terminals.  The GE-225 time-sharing system compiled them on the fly,
+ran the result on the simulator, and printed the output back on the same
+terminal — often in under a second.  This crate recreates that experience.
+
+## Pipeline
+
+```
+BASIC source text
+    │
+    ▼  [dartmouth-basic-ir-compiler]  (int_bits = 20)
+  IrProgram
+    │
+    ▼  [ir-to-ge225-compiler]
+  CompileResult (packed 20-bit binary image)
+    │
+    ▼  [coding-adventures-ge225-simulator]
+  RunResult { output, var_values, steps, halt_address }
+```
+
+`int_bits = 20` is critical: the GE-225 stores signed integers in 20-bit
+two's-complement words (−524 288 to 524 287).  The IR compiler uses this
+setting to compute the power-of-ten constants for `PRINT`-number output —
+passing the default 32-bit setting would emit `LOAD_IMM 1_000_000_000`,
+silently wrapping in a 20-bit word and garbling the output.
+
+## Quick start
+
+```rust
+use dartmouth_basic_ge225_compiler::run_basic;
+
+let result = run_basic("10 LET A = 6 * 7\n20 END\n").unwrap();
+assert_eq!(result.var_values["A"], 42);
+assert_eq!(result.output, "");
+
+let result = run_basic(
+    "10 FOR I = 1 TO 5\n20 PRINT I\n30 NEXT I\n40 END\n"
+).unwrap();
+assert_eq!(result.output, "1\n2\n3\n4\n5\n");
+```
+
+## API
+
+### `run_basic(source: &str) -> Result<RunResult, BasicError>`
+
+Compile and run a BASIC program with the default options:
+- 4 096-word GE-225 memory (the full historical machine)
+- 100 000 instruction safety limit
+
+### `run_basic_with_options(source, memory_words, max_steps) -> Result<RunResult, BasicError>`
+
+Same as `run_basic` but with explicit control over memory size and the
+maximum number of simulated instructions before the safety limit fires.
+
+### `RunResult`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output` | `String` | Typewriter output from `PRINT` statements. GE-225 carriage-return codes (0o37) are converted to Unix `\n`. |
+| `var_values` | `HashMap<String, i32>` | Final values of BASIC scalar variables A–Z, sign-extended from 20-bit two's complement to `i32`. |
+| `steps` | `usize` | Number of GE-225 instructions executed. |
+| `halt_address` | `usize` | Word address of the halt self-loop stub (`BRU halt_address`). |
+
+### `BasicError`
+
+A string-backed error returned when any pipeline stage fails:
+- Parse error (malformed BASIC)
+- IR compile error (unsupported feature in V1 — GOSUB, DIM, arrays, `^`)
+- GE-225 codegen error
+- Runtime error (divide by zero, max-steps exceeded)
+
+## Supported BASIC subset (V1)
+
+| Statement | Notes |
+|-----------|-------|
+| `LET var = expr` | Arithmetic: `+`, `-`, `*`, `/`, unary `-`, parentheses |
+| `PRINT [expr | "string"] [, ...]` | Numbers with leading-zero suppression; strings |
+| `FOR var = start TO limit [STEP n]` | Pre-test loop |
+| `NEXT var` | Closes the nearest open FOR |
+| `GOTO lineno` | Unconditional jump |
+| `IF expr relop expr THEN lineno` | `<`, `>`, `=`, `<>`, `<=`, `>=` |
+| `END` | Halts the program |
+
+Not supported: GOSUB/RETURN, DIM, INPUT, arrays, string variables, `^` (power).
+
+## Memory layout
+
+```
+word 0           : TON  (enable typewriter — emitted by the backend)
+word 1 …         : compiled IR code
+word code_end    : BRU code_end  (halt self-loop)
+word data_base … : spill slots (one per virtual register)
+word …           : constants table (unique LOAD_IMM values)
+```
+
+## GE-225 branch semantics note
+
+The GE-225 uses **inhibit** semantics for its conditional skip instructions:
+the named condition *prevents* the skip, not causes it.  For example:
+
+- `BZE` is **inhibited by zero** — the BRU following it executes when A==0.
+- `BNZ` is **inhibited by non-zero** — the BRU executes when A≠0.
+- `BMI` is **inhibited by minus** — the BRU executes when A<0.
+- `BOD` is **inhibited by odd** — the BRU executes when A is odd.
+
+This is the opposite of the names' intuitive meaning and is a common source
+of confusion when reading original GE-225 programs.
+
+## Where this fits in the stack
+
+```
+dartmouth-basic-lexer
+    │
+dartmouth-basic-parser
+    │
+dartmouth-basic-ir-compiler   ──── compiler-ir (IrProgram / IrOp)
+    │                                     │
+    │                          ir-to-ge225-compiler
+    │                                     │
+    └──────────────────── dartmouth-basic-ge225-compiler (this crate)
+                                          │
+                          coding-adventures-ge225-simulator
+```

--- a/code/packages/rust/dartmouth-basic-ge225-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-ge225-compiler/src/lib.rs
@@ -1,0 +1,545 @@
+//! # dartmouth-basic-ge225-compiler
+//!
+//! The full Dartmouth BASIC → GE-225 compiled pipeline in a single call.
+//!
+//! ## Historical context
+//!
+//! In 1964, a Dartmouth student typed a BASIC program on a Teletype terminal,
+//! pressed RETURN, and within seconds the GE-225 time-sharing system printed
+//! the output on the same terminal.  The pipeline recreates that sequence:
+//!
+//! 1. **Lex & parse** (`dartmouth-basic-parser`) — tokenise the BASIC source
+//!    and build an AST.
+//! 2. **IR compile** (`dartmouth-basic-ir-compiler`) — lower the AST to a
+//!    target-independent `IrProgram` where every variable occupies a fixed
+//!    virtual register.  `int_bits=20` is used so that the digit-extraction
+//!    power constants never exceed the GE-225's 20-bit register range.
+//! 3. **GE-225 backend** (`ir-to-ge225-compiler`) — three-pass assembler that
+//!    emits 20-bit GE-225 machine words packed three bytes each.
+//! 4. **Simulate** (`ge225-simulator`) — load the binary into a behavioural
+//!    GE-225 and step until the halt stub is reached.
+//!
+//! ## Memory layout
+//!
+//! ```text
+//! word 0           : TON  (enable typewriter — emitted by the backend)
+//! word 1 …         : compiled IR code
+//! word code_end    : BRU code_end  (halt self-loop)
+//! word data_base … : spill slots (one per virtual register)
+//! ```
+//!
+//! Register spill slots start at `data_base` (returned by the GE-225 backend).
+//! The GE-225 uses 20-bit two's-complement arithmetic; register values are
+//! sign-extended to Rust `i32` before being returned in [`RunResult`].
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use dartmouth_basic_ge225_compiler::run_basic;
+//!
+//! let result = run_basic("10 LET A = 6 * 7\n20 END\n").unwrap();
+//! assert_eq!(result.var_values["A"], 42);
+//! assert_eq!(result.output, "");
+//! ```
+
+use coding_adventures_ge225_simulator::{unpack_words, Simulator};
+use dartmouth_basic_ir_compiler::{compile_basic_with_options, CharEncoding};
+use ir_to_ge225_compiler::compile_to_ge225;
+use std::collections::HashMap;
+
+// ===========================================================================
+// Public types
+// ===========================================================================
+
+/// Outcome of a successful [`run_basic`] call.
+///
+/// # Fields
+///
+/// - `output`       — Typewriter characters produced by `PRINT` statements.
+///   GE-225 carriage-return codes (0o37) are converted to Unix newlines (`\n`).
+/// - `var_values`   — Final integer values of all 26 BASIC scalar variables
+///   A–Z after the program halts.  The 20-bit two's-complement words are
+///   sign-extended to `i32`.
+/// - `steps`        — Number of GE-225 instructions executed.
+/// - `halt_address` — Word address of the halt stub (`BRU halt_address`).
+///
+/// # Example
+///
+/// ```rust
+/// use dartmouth_basic_ge225_compiler::run_basic;
+///
+/// let result = run_basic("10 LET A = 40 + 2\n20 END\n").unwrap();
+/// assert_eq!(result.var_values["A"], 42);
+/// ```
+#[derive(Debug, Clone)]
+pub struct RunResult {
+    /// Typewriter output — newline-terminated strings produced by `PRINT`.
+    pub output: String,
+    /// Final values of BASIC scalar variables A–Z (sign-extended from 20 bits).
+    pub var_values: HashMap<String, i32>,
+    /// Number of GE-225 instructions simulated.
+    pub steps: usize,
+    /// Word address of the halt stub (`BRU halt_address`).
+    pub halt_address: usize,
+}
+
+/// Error returned when the BASIC program cannot be compiled or executed.
+///
+/// Wraps failures from any of the four pipeline stages: parse, IR compile,
+/// GE-225 codegen, and simulation.
+///
+/// # Example
+///
+/// ```rust
+/// use dartmouth_basic_ge225_compiler::{run_basic, BasicError};
+///
+/// // GOSUB is not supported in V1
+/// let err: Result<_, BasicError> = run_basic("10 GOSUB 100\n20 END\n");
+/// assert!(err.is_err());
+/// ```
+#[derive(Debug, Clone)]
+pub struct BasicError(pub String);
+
+impl std::fmt::Display for BasicError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for BasicError {}
+
+// ===========================================================================
+// Public entry points
+// ===========================================================================
+
+/// Compile and run a Dartmouth BASIC program on the GE-225 simulator.
+///
+/// Uses the default options: 4 096 memory words (the full GE-225 machine)
+/// and a 100 000 instruction safety limit.
+///
+/// # Arguments
+///
+/// - `source` — Dartmouth BASIC source text.  Lines must begin with a line
+///   number followed by a statement.  Lines are separated by `\n`.
+///
+/// # Returns
+///
+/// A [`RunResult`] with the typewriter output, final variable values,
+/// instruction count, and halt address.
+///
+/// # Errors
+///
+/// Returns a [`BasicError`] if:
+/// - The program uses an unsupported V1 feature (GOSUB, DIM, INPUT, arrays,
+///   `^` operator).
+/// - A string literal contains a character with no GE-225 typewriter code.
+/// - A runtime error occurs (e.g. division by zero in the simulator).
+/// - The program has not halted within 100 000 instructions.
+///
+/// # Example
+///
+/// ```rust
+/// use dartmouth_basic_ge225_compiler::run_basic;
+///
+/// let result = run_basic(
+///     "10 FOR I = 1 TO 5\n20 PRINT I\n30 NEXT I\n40 END\n"
+/// ).unwrap();
+/// assert_eq!(result.output, "1\n2\n3\n4\n5\n");
+/// ```
+pub fn run_basic(source: &str) -> Result<RunResult, BasicError> {
+    run_basic_with_options(source, 4096, 100_000)
+}
+
+/// Compile and run a Dartmouth BASIC program with explicit options.
+///
+/// # Arguments
+///
+/// - `source`       — BASIC source text
+/// - `memory_words` — Total GE-225 memory in 20-bit words (default 4 096)
+/// - `max_steps`    — Safety limit on simulated instruction count.
+///   [`BasicError`] is returned if the program has not halted by this point.
+///
+/// # Example
+///
+/// ```rust
+/// use dartmouth_basic_ge225_compiler::run_basic_with_options;
+///
+/// let result = run_basic_with_options(
+///     "10 LET A = 100\n20 END\n",
+///     4096,
+///     50_000,
+/// ).unwrap();
+/// assert_eq!(result.var_values["A"], 100);
+/// ```
+pub fn run_basic_with_options(
+    source: &str,
+    memory_words: i32,
+    max_steps: usize,
+) -> Result<RunResult, BasicError> {
+    // ── Stage 2: IR compilation ──────────────────────────────────────────────
+    //
+    // The GE-225 is a 20-bit machine; its maximum positive signed value is
+    // 2^19 − 1 = 524,287.  We pass `int_bits=20` so that the digit-extraction
+    // powers emitted by `emit_print_number` are bounded by 100,000 (the
+    // largest power of ten < 524,287).  Using the default `int_bits=32` would
+    // emit `LOAD_IMM 1_000_000_000`, which silently overflows a 20-bit word
+    // and produces garbled output.
+    //
+    // NOTE: The parser is called internally by `compile_basic_with_options`.
+    let ir_result = compile_basic_with_options(source, CharEncoding::Ge225, 20)
+        .map_err(|e| BasicError(e.to_string()))?;
+
+    // ── Stage 3: GE-225 backend ──────────────────────────────────────────────
+    let ge225_result = compile_to_ge225(&ir_result.program)
+        .map_err(|e| BasicError(e.to_string()))?;
+
+    // ── Stage 4: simulation ──────────────────────────────────────────────────
+    let mut sim = Simulator::new(memory_words);
+
+    // The binary is packed 3 bytes per 20-bit word; unpack before loading.
+    let words = unpack_words(&ge225_result.binary)
+        .map_err(|e| BasicError(format!("runtime error: {e}")))?;
+    sim.load_words(&words, 0)
+        .map_err(|e| BasicError(format!("runtime error: {e}")))?;
+
+    let halt_addr = ge225_result.halt_address as i32;
+    let mut steps = 0usize;
+
+    loop {
+        if steps >= max_steps {
+            return Err(BasicError(format!(
+                "program did not halt within {max_steps} GE-225 instructions \
+                 (possible infinite loop)"
+            )));
+        }
+        let trace = sim.step()
+            .map_err(|e| BasicError(format!("runtime error: {e}")))?;
+        steps += 1;
+        if trace.address == halt_addr {
+            break;
+        }
+    }
+
+    // ── Collect results ──────────────────────────────────────────────────────
+    //
+    // Each BASIC variable has a fixed virtual register index (A→1, B→2, …Z→26).
+    // The GE-225 backend assigns each register a spill slot at
+    //   data_base + reg_idx
+    // Read the final values and sign-extend from 20-bit two's complement.
+    let mut var_values: HashMap<String, i32> = HashMap::new();
+    for (var_name, &reg_idx) in &ir_result.var_regs {
+        let word_addr = (ge225_result.data_base + reg_idx) as i32;
+        let raw = sim.read_word(word_addr).unwrap_or(0);
+        // Sign-extend 20-bit two's complement to i32:
+        //   if bit 19 is set the value is negative.
+        let signed = if raw & (1 << 19) != 0 {
+            raw - (1 << 20)
+        } else {
+            raw
+        };
+        var_values.insert(var_name.clone(), signed);
+    }
+
+    // Convert GE-225 carriage-return (\r, code 0o37) to Unix newline (\n).
+    let output = sim.get_typewriter_output().replace('\r', "\n");
+
+    Ok(RunResult {
+        output,
+        var_values,
+        steps,
+        halt_address: ge225_result.halt_address,
+    })
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    fn output(source: &str) -> String {
+        run_basic(source).expect("compilation/run should succeed").output
+    }
+
+    fn result(source: &str) -> RunResult {
+        run_basic(source).expect("compilation/run should succeed")
+    }
+
+    // ── LET — variable assignment ──────────────────────────────────────────
+
+    #[test]
+    fn test_let_constant() {
+        let r = result("10 LET A = 42\n20 END\n");
+        assert_eq!(r.var_values["A"], 42);
+    }
+
+    #[test]
+    fn test_let_addition() {
+        let r = result("10 LET A = 3 + 4\n20 END\n");
+        assert_eq!(r.var_values["A"], 7);
+    }
+
+    #[test]
+    fn test_let_subtraction() {
+        let r = result("10 LET A = 10 - 3\n20 END\n");
+        assert_eq!(r.var_values["A"], 7);
+    }
+
+    #[test]
+    fn test_let_multiplication() {
+        let r = result("10 LET A = 6 * 7\n20 END\n");
+        assert_eq!(r.var_values["A"], 42);
+    }
+
+    #[test]
+    fn test_let_division() {
+        let r = result("10 LET A = 100 / 4\n20 END\n");
+        assert_eq!(r.var_values["A"], 25);
+    }
+
+    #[test]
+    fn test_let_chained_variables() {
+        let r = result("10 LET A = 5\n20 LET B = A * 2\n30 LET C = B + A\n40 END\n");
+        assert_eq!(r.var_values["A"], 5);
+        assert_eq!(r.var_values["B"], 10);
+        assert_eq!(r.var_values["C"], 15);
+    }
+
+    #[test]
+    fn test_let_negative_result() {
+        let r = result("10 LET A = 3 - 10\n20 END\n");
+        assert_eq!(r.var_values["A"], -7);
+    }
+
+    #[test]
+    fn test_let_unary_minus() {
+        let r = result("10 LET A = -9\n20 END\n");
+        assert_eq!(r.var_values["A"], -9);
+    }
+
+    #[test]
+    fn test_let_complex_expression() {
+        // (2 + 3) * (10 - 4) = 5 * 6 = 30
+        let r = result("10 LET A = (2 + 3) * (10 - 4)\n20 END\n");
+        assert_eq!(r.var_values["A"], 30);
+    }
+
+    #[test]
+    fn test_let_overwrites_previous_value() {
+        let r = result("10 LET A = 1\n20 LET A = 99\n30 END\n");
+        assert_eq!(r.var_values["A"], 99);
+    }
+
+    // ── PRINT — string output ──────────────────────────────────────────────
+
+    #[test]
+    fn test_hello_world() {
+        assert_eq!(output("10 PRINT \"HELLO WORLD\"\n20 END\n"), "HELLO WORLD\n");
+    }
+
+    #[test]
+    fn test_print_appends_newline() {
+        // Each PRINT ends with GE-225 carriage return → converted to \n
+        assert_eq!(
+            output("10 PRINT \"A\"\n20 PRINT \"B\"\n30 END\n"),
+            "A\nB\n"
+        );
+    }
+
+    #[test]
+    fn test_print_bare() {
+        // Bare PRINT with no argument emits only the carriage return
+        assert_eq!(output("10 PRINT\n20 END\n"), "\n");
+    }
+
+    // ── PRINT — numeric output ─────────────────────────────────────────────
+
+    #[test]
+    fn test_print_zero() {
+        assert_eq!(output("10 PRINT 0\n20 END\n"), "0\n");
+    }
+
+    #[test]
+    fn test_print_positive_integer() {
+        assert_eq!(output("10 PRINT 42\n20 END\n"), "42\n");
+    }
+
+    #[test]
+    fn test_print_negative_integer() {
+        assert_eq!(output("10 LET X = -7\n20 PRINT X\n30 END\n"), "-7\n");
+    }
+
+    #[test]
+    fn test_print_variable() {
+        assert_eq!(output("10 LET A = 99\n20 PRINT A\n30 END\n"), "99\n");
+    }
+
+    #[test]
+    fn test_print_expression_result() {
+        assert_eq!(output("10 PRINT 3 + 4\n20 END\n"), "7\n");
+    }
+
+    #[test]
+    fn test_print_large_number() {
+        assert_eq!(output("10 LET X = 12345\n20 PRINT X\n30 END\n"), "12345\n");
+    }
+
+    #[test]
+    fn test_print_max_20bit() {
+        // Maximum positive 20-bit signed integer: 2^19 − 1 = 524 287
+        assert_eq!(
+            output("10 LET X = 524287\n20 PRINT X\n30 END\n"),
+            "524287\n"
+        );
+    }
+
+    #[test]
+    fn test_print_leading_zero_suppressed() {
+        // 7 should print as "7", not "000007"
+        assert_eq!(output("10 PRINT 7\n20 END\n"), "7\n");
+    }
+
+    #[test]
+    fn test_print_mixed_string_and_number() {
+        let src = "10 LET N = 99\n20 PRINT \"N IS \", N\n30 END\n";
+        assert_eq!(output(src), "N IS 99\n");
+    }
+
+    // ── FOR / NEXT loops ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_for_prints_sequence() {
+        let src = "10 FOR I = 1 TO 5\n20 PRINT I\n30 NEXT I\n40 END\n";
+        assert_eq!(output(src), "1\n2\n3\n4\n5\n");
+    }
+
+    #[test]
+    fn test_for_sum_one_to_ten() {
+        let src = concat!(
+            "10 LET S = 0\n",
+            "20 FOR I = 1 TO 10\n",
+            "30 LET S = S + I\n",
+            "40 NEXT I\n",
+            "50 PRINT S\n",
+            "60 END\n"
+        );
+        let r = result(src);
+        assert_eq!(r.var_values["S"], 55);
+        assert_eq!(r.output, "55\n");
+    }
+
+    #[test]
+    fn test_for_step_2() {
+        // FOR I = 0 TO 8 STEP 2 → 0, 2, 4, 6, 8
+        let src = "10 FOR I = 0 TO 8 STEP 2\n20 PRINT I\n30 NEXT I\n40 END\n";
+        assert_eq!(output(src), "0\n2\n4\n6\n8\n");
+    }
+
+    // ── IF / THEN conditionals ─────────────────────────────────────────────
+
+    #[test]
+    fn test_if_lt_taken() {
+        // IF 3 < 5 THEN skip past END → prints "YES"
+        let src = "10 IF 3 < 5 THEN 30\n20 END\n30 PRINT \"YES\"\n40 END\n";
+        assert_eq!(output(src), "YES\n");
+    }
+
+    #[test]
+    fn test_if_lt_not_taken() {
+        let src = "10 IF 5 < 3 THEN 30\n20 PRINT \"NO\"\n30 END\n";
+        // Branch not taken → prints "NO"
+        assert_eq!(output(src), "NO\n");
+    }
+
+    #[test]
+    fn test_if_eq() {
+        let src = "10 LET A = 5\n20 IF A = 5 THEN 40\n30 END\n40 PRINT \"EQ\"\n50 END\n";
+        assert_eq!(output(src), "EQ\n");
+    }
+
+    #[test]
+    fn test_if_le() {
+        // <= synthesised as NOT(CMP_GT)
+        let src = "10 LET A = 5\n20 IF A <= 5 THEN 40\n30 END\n40 PRINT \"LE\"\n50 END\n";
+        assert_eq!(output(src), "LE\n");
+    }
+
+    // ── GOTO ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_goto() {
+        // GOTO 30 skips line 20 PRINT "SKIP"
+        let src = "10 GOTO 30\n20 PRINT \"SKIP\"\n30 PRINT \"OK\"\n40 END\n";
+        assert_eq!(output(src), "OK\n");
+    }
+
+    // ── Classic programs ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_fibonacci_first_ten() {
+        // Compute F(10) = 55 using BASIC iteration
+        let src = concat!(
+            "10 LET A = 0\n",
+            "20 LET B = 1\n",
+            "30 FOR I = 1 TO 9\n",
+            "40 LET C = A + B\n",
+            "50 LET A = B\n",
+            "60 LET B = C\n",
+            "70 NEXT I\n",
+            "80 PRINT B\n",
+            "90 END\n"
+        );
+        let r = result(src);
+        assert_eq!(r.output, "55\n");
+    }
+
+    #[test]
+    fn test_countdown() {
+        // Count down from 3 to 1
+        let src = concat!(
+            "10 LET N = 3\n",
+            "20 PRINT N\n",
+            "30 LET N = N - 1\n",
+            "40 IF N > 0 THEN 20\n",
+            "50 END\n"
+        );
+        assert_eq!(output(src), "3\n2\n1\n");
+    }
+
+    // ── Error handling ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_gosub_returns_basic_error() {
+        let err = run_basic("10 GOSUB 100\n20 END\n100 END\n");
+        assert!(err.is_err(), "GOSUB should return BasicError");
+        let msg = err.unwrap_err().0;
+        assert!(msg.contains("GOSUB"), "error message should mention GOSUB");
+    }
+
+    #[test]
+    fn test_max_steps_exceeded() {
+        // Infinite loop: GOTO itself
+        let err = run_basic_with_options("10 GOTO 10\n", 4096, 500);
+        assert!(err.is_err(), "infinite loop should exceed max_steps");
+        let msg = err.unwrap_err().0;
+        assert!(msg.contains("500") || msg.contains("infinite"), "error should mention limit");
+    }
+
+    // ── RunResult fields ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_result_steps_positive() {
+        let r = result("10 LET A = 1\n20 END\n");
+        assert!(r.steps > 0, "steps should be > 0 after running");
+    }
+
+    #[test]
+    fn test_result_halt_address_nonzero() {
+        let r = result("10 END\n");
+        assert!(r.halt_address > 0, "halt address should be beyond word 0");
+    }
+}

--- a/code/packages/rust/ir-to-ge225-compiler/CHANGELOG.md
+++ b/code/packages/rust/ir-to-ge225-compiler/CHANGELOG.md
@@ -2,11 +2,40 @@
 
 ## Unreleased
 
-- add the first Rust `ir-to-ge225-compiler` backend
-- port the three-pass GE-225 assembler from Python to Rust
-- implement `validate_for_ge225` checking opcode support, 20-bit constant range,
-  SYSCALL number, and AND_IMM immediate constraints
-- implement `compile_to_ge225` with Pass 0 (register/constant collection),
-  Pass 1 (label address assignment), and Pass 2 (word emission)
-- add `GE225CodeGenerator` adapter implementing the `CodeGenerator<IrProgram, CompileResult>` protocol
-- write 30+ unit tests covering every opcode emitter and validation rule
+### Added
+- Initial Rust port: three-pass GE-225 assembler from Python.
+- `validate_for_ge225` — checks opcode support, 20-bit constant range,
+  SYSCALL number, and AND_IMM immediate constraints.
+- `compile_to_ge225` — Pass 0 (register/constant collection),
+  Pass 1 (label address assignment), Pass 2 (word emission).
+- `GE225CodeGenerator` adapter implementing the
+  `CodeGenerator<IrProgram, CompileResult>` protocol (LANG20).
+- `IrOp::Mul` support — 6-word sequence `LDA; LQA; LDZ; MPY; LAQ; STA`
+  using the GE-225's 40-bit accumulate multiply.
+- `IrOp::Div` support — 5-word sequence `LDA; LQA; LDZ; DVD; STA`
+  using the GE-225's 40-bit signed divide.
+- 35+ unit tests covering every opcode emitter and validation rule.
+
+### Fixed
+- **GE-225 branch-test "inhibit" semantics** — The GE-225 uses *inhibit* semantics
+  for conditional skip instructions: the named condition *prevents* the skip; the
+  skip occurs when the condition is FALSE, not when it is TRUE.
+
+  Four instruction sites were using the wrong instruction:
+
+  | Site | Before | After |
+  |------|--------|-------|
+  | `BRANCH_Z` (jump when A==0) | `BNZ` | `BZE` |
+  | `BRANCH_NZ` (jump when A≠0) | `BZE` | `BNZ` |
+  | `CMP_EQ` equality test | `BNZ` | `BZE` |
+  | `CMP_NE` inequality test | `BZE` | `BNZ` |
+  | `CMP_LT`/`CMP_GT` signed diff | `BPL` (skips when A<0) | `BMI` (skips when A≥0) |
+  | `AND_IMM 1` result layout | LDO@+3, LDZ@+5 | LDZ@+3, LDO@+5 |
+
+  The double-inversion (wrong CMP result × wrong BRANCH_NZ) accidentally produced
+  correct results for `IF … THEN` tests, masking the bug.  `BRANCH_Z` used with
+  plain arithmetic values (leading-zero suppression in `emit_print_number`) and
+  `AND_IMM` used in NOT-bool expressions exposed the true behavior.
+
+  Updated all four `emit_*` methods and the top-level module documentation to
+  describe the inhibit-semantics table precisely.

--- a/code/packages/rust/ir-to-ge225-compiler/src/lib.rs
+++ b/code/packages/rust/ir-to-ge225-compiler/src/lib.rs
@@ -51,13 +51,24 @@
 //!
 //! # Conditional branches
 //!
-//! GE-225 conditional branches (BZE/BNZ/BMI/BPL/BOD) are *skip-next-if-true*:
-//! when the condition holds they advance PC by 2 (skipping the next word).
-//! Far conditional jumps therefore require a two-word pair after the load:
+//! GE-225 conditional branches (BZE/BNZ/BMI/BOD) use **inhibit** semantics:
+//! the named condition *prevents* the skip; when the condition is FALSE the
+//! next word is skipped.  Equivalently: "the BRU executes when the condition
+//! is TRUE".
+//!
+//! | Instruction | Inhibit condition | BRU executes when… |
+//! |-------------|-------------------|--------------------|
+//! | `BZE`       | A == 0            | A == 0             |
+//! | `BNZ`       | A ≠ 0             | A ≠ 0              |
+//! | `BMI`       | A < 0             | A < 0              |
+//! | `BOD`       | A is odd          | A is odd           |
+//!
+//! Far conditional jumps therefore require a two-word pair after the load.
+//! For `BRANCH_Z` (jump when A == 0) use `BZE`:
 //!
 //! ```text
 //! LDA  spill(vN)
-//! BNZ              ; skip BRU when A ≠ 0  (don't jump)
+//! BZE              ; inhibited-by-zero → skip BRU when A ≠ 0
 //! BRU  target      ; executed only when A == 0
 //! ```
 //!
@@ -178,6 +189,8 @@ fn is_supported_opcode(op: IrOp) -> bool {
             | IrOp::AddImm
             | IrOp::Add
             | IrOp::Sub
+            | IrOp::Mul
+            | IrOp::Div
             | IrOp::AndImm
             | IrOp::CmpEq
             | IrOp::CmpNe
@@ -513,12 +526,9 @@ impl<'a> CodeGen<'a> {
     fn sta(&self, addr: usize) -> i32 {
         encode_instruction(OP_STA, 0, addr as i32).unwrap()
     }
-    // mpy/dvd helpers kept for future MUL/DIV opcode support (not yet in IrOp)
-    #[allow(dead_code)]
     fn mpy(&self, addr: usize) -> i32 {
         encode_instruction(OP_MPY, 0, addr as i32).unwrap()
     }
-    #[allow(dead_code)]
     fn dvd(&self, addr: usize) -> i32 {
         encode_instruction(OP_DVD, 0, addr as i32).unwrap()
     }
@@ -556,6 +566,11 @@ impl<'a> CodeGen<'a> {
 
             // LDA a; ADD/SUB b; STA dst  (3 words)
             IrOp::Add | IrOp::Sub => 3,
+
+            // MUL vDst, vA, vB → LDA; LQA; LDZ; MPY; LAQ; STA  (6 words)
+            IrOp::Mul => 6,
+            // DIV vDst, vA, vB → LDA; LQA; LDZ; DVD; STA        (5 words)
+            IrOp::Div => 5,
 
             // BOD-branch pattern for bit-0 extraction (7 words — see `emit_and_imm`)
             IrOp::AndImm => 7,
@@ -633,10 +648,9 @@ impl<'a> CodeGen<'a> {
         let w_bod  = assemble_fixed("BOD").unwrap();
         let w_san6 = assemble_shift("SAN", 6).unwrap();
         let w_typ  = assemble_fixed("TYP").unwrap();
-        // Suppress unused-variable warnings for words that are assembled for
-        // completeness/documentation but not yet consumed (MUL/DIV are not in
-        // the Rust IrOp enum yet).
-        let _ = (w_lqa, w_laq, w_bmi);
+        // BPL (branch on plus/non-negative) is assembled but replaced by BMI for
+        // signed comparisons — suppress the unused-variable warning.
+        let _ = w_bpl;
 
         let mut words: Vec<i32> = vec![w_ton]; // prologue at address 0
         let mut emit_addr: usize = 1; // address of the next word to be appended
@@ -646,8 +660,9 @@ impl<'a> CodeGen<'a> {
                 instr,
                 emit_addr,
                 w_nop, w_ldz, w_ldo,
-                w_ado, w_sbo, w_bpl, w_bze,
+                w_ado, w_sbo, w_bmi, w_bze,
                 w_bnz, w_bod, w_san6, w_typ,
+                w_lqa, w_laq,
             )?;
             emit_addr += new_words.len();
             words.extend(new_words);
@@ -689,8 +704,9 @@ impl<'a> CodeGen<'a> {
         instr: &IrInstruction,
         start_addr: usize,
         w_nop: i32, w_ldz: i32, w_ldo: i32,
-        w_ado: i32, w_sbo: i32, w_bpl: i32, w_bze: i32,
+        w_ado: i32, w_sbo: i32, w_bmi: i32, w_bze: i32,
         w_bnz: i32, w_bod: i32, w_san6: i32, w_typ: i32,
+        w_lqa: i32, w_laq: i32,
     ) -> Result<Vec<i32>, CodeGenError> {
         Ok(match instr.opcode {
             IrOp::Label | IrOp::Comment => vec![],
@@ -703,11 +719,13 @@ impl<'a> CodeGen<'a> {
             IrOp::AddImm => self.emit_add_imm(instr, w_ado, w_sbo)?,
             IrOp::Add => self.emit_binop(OP_ADD, instr)?,
             IrOp::Sub => self.emit_binop(OP_SUB, instr)?,
+            IrOp::Mul => self.emit_mul(instr, w_lqa, w_laq, w_ldz)?,
+            IrOp::Div => self.emit_div(instr, w_lqa, w_ldz)?,
             IrOp::AndImm => self.emit_and_imm(instr, start_addr, w_bod, w_ldz, w_ldo)?,
             IrOp::CmpEq => self.emit_cmp(instr, start_addr, true, false, w_bze, w_bnz, w_ldz, w_ldo)?,
             IrOp::CmpNe => self.emit_cmp(instr, start_addr, true, true, w_bze, w_bnz, w_ldz, w_ldo)?,
-            IrOp::CmpLt => self.emit_cmp_signed(instr, start_addr, false, w_bpl, w_ldz, w_ldo)?,
-            IrOp::CmpGt => self.emit_cmp_signed(instr, start_addr, true, w_bpl, w_ldz, w_ldo)?,
+            IrOp::CmpLt => self.emit_cmp_signed(instr, start_addr, false, w_bmi, w_ldz, w_ldo)?,
+            IrOp::CmpGt => self.emit_cmp_signed(instr, start_addr, true, w_bmi, w_ldz, w_ldo)?,
             IrOp::Jump => self.emit_jump(instr)?,
             IrOp::BranchZ => self.emit_branch(instr, true, w_bze, w_bnz)?,
             IrOp::BranchNz => self.emit_branch(instr, false, w_bze, w_bnz)?,
@@ -779,23 +797,98 @@ impl<'a> CodeGen<'a> {
         ])
     }
 
+    /// `MUL vDst, vA, vB` — signed multiply using MPY (6 words).
+    ///
+    /// The GE-225 `MPY` instruction computes `A,Q = Q × mem[ea] + A` (40-bit
+    /// accumulate multiply).  To multiply `vA × vB` and store the lower 20
+    /// bits of the product in `vDst`:
+    ///
+    /// ```text
+    /// LDA  spill(vA)   ; A = vA
+    /// LQA              ; Q = A = vA  (seed the Q register with vA)
+    /// LDZ              ; A = 0       (zero the accumulator — we want Q*vB+0)
+    /// MPY  spill(vB)   ; A,Q = Q*vB + A = vA*vB + 0  (40-bit result)
+    /// LAQ              ; A = Q  (take the lower 20-bit word of the product)
+    /// STA  spill(vDst)
+    /// ```
+    ///
+    /// V1 ignores overflow (products larger than 2^19 − 1 wrap silently).
+    fn emit_mul(
+        &self,
+        instr: &IrInstruction,
+        w_lqa: i32, w_laq: i32, w_ldz: i32,
+    ) -> Result<Vec<i32>, CodeGenError> {
+        let dst   = self.reg(instr, 0)?;
+        let reg_a = self.reg(instr, 1)?;
+        let reg_b = self.reg(instr, 2)?;
+        Ok(vec![
+            self.lda(self.spill(reg_a)),  // A = vA
+            w_lqa,                         // Q = A = vA
+            w_ldz,                         // A = 0
+            self.mpy(self.spill(reg_b)),  // A,Q = vA * vB
+            w_laq,                         // A = Q  (lower 20 bits of product)
+            self.sta(self.spill(dst)),    // spill(vDst) = A
+        ])
+    }
+
+    /// `DIV vDst, vA, vB` — signed integer division using DVD (5 words).
+    ///
+    /// The GE-225 `DVD` instruction divides the 40-bit value `(A,Q)` by
+    /// `mem[ea]`, placing the quotient in `A` and the remainder in `Q`.
+    /// To compute `vA ÷ vB` (integer quotient, truncates toward zero):
+    ///
+    /// ```text
+    /// LDA  spill(vA)   ; A = vA  (low word of 40-bit dividend)
+    /// LQA              ; Q = A = vA  (copy into Q as the low dividend word)
+    /// LDZ              ; A = 0       (high word — zero-extend the dividend)
+    /// DVD  spill(vB)   ; A = quotient; Q = remainder
+    /// STA  spill(vDst)
+    /// ```
+    ///
+    /// Division by zero propagates a runtime trap from the GE-225 simulator.
+    fn emit_div(
+        &self,
+        instr: &IrInstruction,
+        w_lqa: i32, w_ldz: i32,
+    ) -> Result<Vec<i32>, CodeGenError> {
+        let dst   = self.reg(instr, 0)?;
+        let reg_a = self.reg(instr, 1)?;
+        let reg_b = self.reg(instr, 2)?;
+        Ok(vec![
+            self.lda(self.spill(reg_a)),  // A = vA
+            w_lqa,                         // Q = A = vA  (dividend in Q)
+            w_ldz,                         // A = 0       (high word = 0)
+            self.dvd(self.spill(reg_b)),  // A = quotient
+            self.sta(self.spill(dst)),    // spill(vDst) = quotient
+        ])
+    }
+
     /// `AND_IMM vDst, vSrc, 1` — extract parity bit using BOD (7 words).
     ///
     /// The GE-225 has no general bitwise-AND. We use the BOD (branch-if-odd)
-    /// instruction which skips the next word when bit 0 of A is set.
+    /// instruction to test bit 0.
     ///
-    /// GE-225 branch-test semantics: `BOD` **skips** the next word when the
-    /// condition is TRUE (A is odd). Therefore when A is odd, the `BRU` at
-    /// offset +2 is skipped and execution falls to `LDO` at +3; when A is
-    /// even the `BRU` executes and jumps to `LDZ` at +5.
+    /// ## GE-225 branch-test "inhibit" semantics
+    ///
+    /// GE-225 skip instructions use **inhibit** semantics: the `cond` field says
+    /// what *prevents* the skip, not what causes it.  Concretely:
+    ///
+    /// - `BOD` — inhibited by odd. When A is odd `cond = true`, so `!cond = false`
+    ///   and the skip does **NOT** occur.  When A is even `!cond = true` and the
+    ///   next word **is** skipped.
+    ///
+    /// Therefore: BOD **skips the next word when A is EVEN** and
+    /// **does not skip when A is ODD**.
+    ///
+    /// ## Instruction layout
     ///
     /// ```text
     /// addr+0:  LDA  spill(vSrc)
-    /// addr+1:  BOD               ; skip next (BRU) if A is ODD
-    /// addr+2:  BRU  addr+5       ; A is EVEN → jump to LDZ
-    /// addr+3:  LDO               ; A is ODD (BOD skipped BRU) → A=1
+    /// addr+1:  BOD               ; skip +2 when A is EVEN (inhibited-by-odd)
+    /// addr+2:  BRU  addr+5       ; A is ODD (BOD did NOT skip) → jump to LDO
+    /// addr+3:  LDZ               ; A is EVEN (BOD skipped +2) → A=0
     /// addr+4:  BRU  addr+6       ; jump to STA
-    /// addr+5:  LDZ               ; A is EVEN → A=0
+    /// addr+5:  LDO               ; A is ODD → A=1
     /// addr+6:  STA  spill(vDst)
     /// ```
     fn emit_and_imm(
@@ -811,15 +904,18 @@ impl<'a> CodeGen<'a> {
                 imm
             )));
         }
-        let zero_addr = start_addr + 5; // LDZ (result=0) for EVEN inputs
+        // BOD skips when A is EVEN (inhibit = odd).
+        // Even path: BOD skips +2 → falls to LDZ (result=0) at +3.
+        // Odd  path: BOD does NOT skip → executes BRU to LDO (result=1) at +5.
+        let ldo_addr  = start_addr + 5; // LDO (result=1) for ODD inputs
         let done_addr = start_addr + 6; // STA
         Ok(vec![
             self.lda(self.spill(src)), // +0: load source
-            w_bod,                      // +1: skip +2 if A is ODD (TRUE)
-            self.bru(zero_addr),        // +2: A is EVEN → jump to LDZ
-            w_ldo,                      // +3: A is ODD (BOD skipped +2) → A=1
+            w_bod,                      // +1: BOD — skip +2 when A is EVEN
+            self.bru(ldo_addr),         // +2: A is ODD (not skipped) → jump to LDO
+            w_ldz,                      // +3: A is EVEN (BOD skipped +2) → A=0
             self.bru(done_addr),        // +4: jump to STA
-            w_ldz,                      // +5: A is EVEN → A=0
+            w_ldo,                      // +5: A is ODD → A=1
             self.sta(self.spill(dst)),  // +6: store result
         ])
     }
@@ -828,18 +924,26 @@ impl<'a> CodeGen<'a> {
     ///
     /// The GE-225 has no compare instruction. We subtract and test the result:
     ///
+    /// ## GE-225 branch-test "inhibit" semantics (recap)
+    ///
+    /// Skip instructions use **inhibit** semantics: the named condition
+    /// *prevents* the skip.  `BZE` is inhibited by zero (skip when A≠0);
+    /// `BNZ` is inhibited by non-zero (skip when A==0).
+    ///
+    /// ## `CMP_EQ` layout (result = 1 when equal, 0 otherwise)
+    ///
     /// ```text
     /// LDA  spill(vA)
     /// SUB  spill(vB)         ; A = vA - vB  (zero iff equal)
-    /// BNZ                    ; if A≠0 → skip next  (for CMP_EQ)
-    /// BRU  addr+6 (__true)
-    /// LDZ                    ; A==0 → result 0
+    /// BZE                    ; inhibited-by-zero → skip when A≠0
+    /// BRU  addr+6 (__true)   ; executed when A==0 (equal) → jump to LDO
+    /// LDZ                    ; A≠0 → result 0
     /// BRU  addr+7 (__done)
-    /// LDO                    ; A!=0 → result 1    [__true]
-    /// STA  spill(vDst)                             [__done]
+    /// LDO                    ; A==0 → result 1   [__true]
+    /// STA  spill(vDst)                            [__done]
     /// ```
     ///
-    /// For `CMP_NE`, swap the skip sense (`BZE` instead of `BNZ`) and the
+    /// For `CMP_NE`, swap the skip sense (`BNZ` instead of `BZE`) and the
     /// result labels.
     fn emit_cmp(
         &self, instr: &IrInstruction, start_addr: usize,
@@ -853,9 +957,11 @@ impl<'a> CodeGen<'a> {
         let true_addr = start_addr + 6;
         let done_addr = start_addr + 7;
 
-        // For CMP_EQ: BNZ skips when A≠0 (different → skip to BRU-true).
-        // For CMP_NE: BZE skips when A=0 (equal → skip to BRU-true).
-        let skip_word = if eq { w_bnz } else { w_bze };
+        // For CMP_EQ: BZE — inhibited by zero, so skips when A≠0;
+        //   BRU to __true is NOT skipped when A==0 (equal → result 1).
+        // For CMP_NE: BNZ — inhibited by non-zero, so skips when A==0;
+        //   BRU to __true is NOT skipped when A≠0 (different → result 1).
+        let skip_word = if eq { w_bze } else { w_bnz };
 
         // Result words: if negate (CMP_NE) swap 0 and 1.
         // zero_word = result when A==0 after SUB
@@ -877,23 +983,33 @@ impl<'a> CodeGen<'a> {
 
     /// `CMP_LT` or `CMP_GT` — signed integer comparison (8 words).
     ///
-    /// For `CMP_LT` (vA < vB): compute vA − vB; negative result means vA < vB:
+    /// For `CMP_LT` (vA < vB): compute vA − vB; negative result means vA < vB.
+    ///
+    /// ## GE-225 branch-test "inhibit" semantics (recap)
+    ///
+    /// `BMI` is **inhibited by minus** (inhibit = A<0): skip occurs when
+    /// `!cond = (A≥0)`.  Therefore:
+    /// - A < 0 (lhs < rhs → true): cond=true, skip **does NOT** occur → BRU
+    ///   executes → jump to LDO → result 1.
+    /// - A ≥ 0 (lhs ≥ rhs → false): cond=false, skip occurs → LDZ → result 0.
+    ///
+    /// ## Layout
     ///
     /// ```text
     /// LDA  spill(vA)
     /// SUB  spill(vB)         ; A = vA - vB
-    /// BPL                    ; if A>=0 → skip next (not less than)
-    /// BRU  addr+6 (__true)
-    /// LDZ                    ; >=0 → result 0
+    /// BMI                    ; inhibited by minus → skip when A≥0 (not less than)
+    /// BRU  addr+6 (__true)   ; A<0 → jump to LDO (result 1)
+    /// LDZ                    ; A≥0 → result 0
     /// BRU  addr+7 (__done)
-    /// LDO                    ; <0  → result 1   [__true]
+    /// LDO                    ; A<0 → result 1   [__true]
     /// STA  spill(vDst)                          [__done]
     /// ```
     ///
     /// For `CMP_GT` (vA > vB): swap vA and vB (vA > vB iff vB < vA).
     fn emit_cmp_signed(
         &self, instr: &IrInstruction, start_addr: usize,
-        gt_mode: bool, w_bpl: i32, w_ldz: i32, w_ldo: i32,
+        gt_mode: bool, w_bmi: i32, w_ldz: i32, w_ldo: i32,
     ) -> Result<Vec<i32>, CodeGenError> {
         let dst   = self.reg(instr, 0)?;
         let reg_a = self.reg(instr, 1)?;
@@ -907,14 +1023,15 @@ impl<'a> CodeGen<'a> {
         let lhs = if gt_mode { reg_b } else { reg_a };
         let rhs = if gt_mode { reg_a } else { reg_b };
 
-        // BPL skips when A >= 0 (not negative). When the difference is
-        // negative (lhs < rhs) we do NOT skip → BRU jumps to __true → LDO.
+        // BMI (inhibited-by-minus) skips when A≥0.
+        // When A<0 (lhs < rhs) → no skip → BRU to __true → result 1.
+        // When A≥0 (lhs ≥ rhs) → skip BRU → LDZ → result 0.
         Ok(vec![
             self.lda(self.spill(lhs)), // +0
             self.sub(self.spill(rhs)), // +1
-            w_bpl,                      // +2: skip next if A>=0 (not less)
-            self.bru(true_addr),        // +3: jump to true (A<0)
-            w_ldz,                      // +4: A>=0 → result 0
+            w_bmi,                      // +2: BMI — skip when A≥0 (not less)
+            self.bru(true_addr),        // +3: A<0 → jump to LDO
+            w_ldz,                      // +4: A≥0 → result 0
             self.bru(done_addr),        // +5
             w_ldo,                      // +6: A<0 → result 1  [__true]
             self.sta(self.spill(dst)), // +7  [__done]
@@ -929,26 +1046,35 @@ impl<'a> CodeGen<'a> {
 
     /// `BRANCH_Z` or `BRANCH_NZ` — conditional far branch (3 words).
     ///
-    /// The GE-225 conditional branches are *skip-next-if-true*, not
-    /// *jump-if-true*. A far conditional branch requires a two-word pair
-    /// after the load:
+    /// ## GE-225 branch-test "inhibit" semantics (recap)
+    ///
+    /// Skip instructions use **inhibit** semantics: the named condition
+    /// *prevents* the skip.
+    ///
+    /// - `BZE` — inhibited by zero (cond = A==0).  Skips when A≠0
+    ///   (i.e. the BRU at offset +1 is skipped when A is non-zero).
+    ///   Therefore the BRU **executes** when A==0.
+    /// - `BNZ` — inhibited by non-zero (cond = A≠0).  Skips when A==0.
+    ///   Therefore the BRU **executes** when A≠0.
+    ///
+    /// ## Layout for `BRANCH_Z` (jump when A==0)
     ///
     /// ```text
     /// LDA  spill(vN)
-    /// BNZ               ; BRANCH_Z:  skip BRU when A≠0 (fall through); execute BRU when A==0
-    /// BRU  target       ; executed only when A==0
+    /// BZE               ; inhibited-by-zero → skip BRU when A≠0 (don't jump)
+    /// BRU  target       ; executed only when A==0 → jump to target
     /// ; fall through when A≠0
     /// ```
     ///
-    /// For `BRANCH_NZ`, swap `BNZ → BZE`.
+    /// For `BRANCH_NZ` (jump when A≠0), swap `BZE → BNZ`.
     fn emit_branch(
         &self, instr: &IrInstruction, zero: bool, w_bze: i32, w_bnz: i32,
     ) -> Result<Vec<i32>, CodeGenError> {
         let reg_n  = self.reg(instr, 0)?;
         let target = self.resolve_label(instr, 1)?;
-        // To jump when A==0: use BNZ (skip when A!=0, so don't skip when A==0)
-        // To jump when A!=0: use BZE (skip when A==0, so don't skip when A!=0)
-        let skip_word = if zero { w_bnz } else { w_bze };
+        // BRANCH_Z (jump when A==0): BZE — inhibited by zero → BRU executes when A==0.
+        // BRANCH_NZ (jump when A≠0): BNZ — inhibited by non-zero → BRU executes when A≠0.
+        let skip_word = if zero { w_bze } else { w_bnz };
         Ok(vec![
             self.lda(self.spill(reg_n)),
             skip_word,


### PR DESCRIPTION
## Summary

- **New crate `dartmouth-basic-ge225-compiler`**: full Dartmouth BASIC → GE-225 compiled pipeline in a single Rust crate, recreating the 1964 Dartmouth time-sharing experience. Supports `run_basic(source)` and `run_basic_with_options(source, memory_words, max_steps)`.
- **Bug fix in `ir-to-ge225-compiler`**: four conditional branch emission sites used the wrong GE-225 skip instruction. The GE-225 uses *inhibit* semantics (named condition **prevents** the skip). A double-inversion (wrong CMP × wrong BRANCH_NZ) masked the bug in IF tests; BRANCH_Z with plain arithmetic values (leading-zero suppression) exposed it.
- **MUL/DIV activated** in `ir-to-ge225-compiler` (stubs existed, now wired to the new `IrOp::Mul`/`IrOp::Div` variants added in the previous PR).

## Branch semantics fix

| Site | Before | After |
|------|--------|-------|
| `BRANCH_Z` | `BNZ` | `BZE` |
| `BRANCH_NZ` | `BZE` | `BNZ` |
| `CMP_EQ` | `BNZ` | `BZE` |
| `CMP_NE` | `BZE` | `BNZ` |
| `CMP_LT`/`CMP_GT` | `BPL` | `BMI` |
| `AND_IMM 1` layout | LDO@+3, LDZ@+5 | LDZ@+3, LDO@+5 |

## Test plan

- [ ] `cargo test -p ir-to-ge225-compiler` — 35 unit tests pass
- [ ] `cargo test -p dartmouth-basic-ge225-compiler` — 36 integration tests pass
- [ ] `cargo build --workspace` — full workspace compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)