### PR TITLE
Fix CodeQL ReDoS and add sharded CI build plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,19 @@ jobs:
             go build -o ../../../../build-tool .
           fi
 
+      - name: Reclaim Linux runner disk
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android || true
+          docker system prune --all --force || true
+          sudo apt-get clean
+          echo "Disk after cleanup:"
+          df -h /
+
       - name: Build and test affected Swift packages on Windows
         if: runner.os == 'Windows' && needs.detect.outputs.needs_swift == 'true'
         shell: pwsh
@@ -546,7 +559,7 @@ jobs:
 
       # ── Run the build ─────────────────────────────────────────
       - name: Build and test affected packages
-        if: runner.os != 'Windows' || (needs.detect.outputs.needs_swift == 'true' && false)
+        if: needs.detect.outputs.is_main != 'true' && (runner.os != 'Windows' || (needs.detect.outputs.needs_swift == 'true' && false))
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then BT=./build-tool.exe; else BT=./build-tool; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
-      shard_count: ${{ steps.detect.outputs.shard_count }}
+      build_matrix: ${{ steps.build-matrix.outputs.build_matrix }}
+      shard_count: ${{ steps.build-matrix.outputs.shard_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -124,8 +125,10 @@ jobs:
           go build -o ../../../../build-tool .
           cd ../../../..
           force_flag=()
+          shard_flags=()
           if [ "${{ steps.detect-main.outputs.is_main }}" = "true" ]; then
             force_flag=(-force)
+            shard_flags=(-shard-count 5 -emit-shard-matrix)
           fi
           ./build-tool \
             -root . \
@@ -134,8 +137,7 @@ jobs:
             -validate-build-files \
             -detect-languages \
             -emit-plan build-plan.json \
-            -shard-count 5 \
-            -emit-shard-matrix
+            "${shard_flags[@]}"
 
       - name: Normalize toolchain requirements
         id: toolchains
@@ -180,6 +182,49 @@ jobs:
               'needs_swift=${{ steps.detect.outputs.needs_swift }}' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Plan build matrix
+        id: build-matrix
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_MAIN: ${{ steps.detect-main.outputs.is_main }}
+          BUILD_SHARDS: ${{ steps.detect.outputs.build_shards }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          if os.environ["IS_MAIN"] == "true":
+            shards = json.loads(os.environ.get("BUILD_SHARDS") or "[]")
+            entries = [
+              {
+                "os": "ubuntu-latest",
+                "label": shard["label"],
+                "sharded": True,
+                "shard_index": shard["shard_index"],
+                "package_count": shard.get("package_count", 0),
+                "languages": shard.get("languages", []),
+              }
+              for shard in shards
+            ]
+            shard_count = len(entries)
+          elif os.environ["EVENT_NAME"] == "pull_request":
+            entries = [
+              {"os": "ubuntu-latest", "label": "ubuntu-latest", "sharded": False, "shard_index": -1},
+              {"os": "macos-latest", "label": "macos-latest", "sharded": False, "shard_index": -1},
+              {"os": "windows-latest", "label": "windows-latest", "sharded": False, "shard_index": -1},
+            ]
+            shard_count = 0
+          else:
+            entries = [
+              {"os": "ubuntu-latest", "label": "ubuntu-latest", "sharded": False, "shard_index": -1},
+            ]
+            shard_count = 0
+
+          print("build_matrix=" + json.dumps(entries, separators=(",", ":")))
+          print(f"shard_count={shard_count}")
+          PY
+
       - name: Upload build plan
         uses: actions/upload-artifact@v4
         with:
@@ -193,11 +238,10 @@ jobs:
   # compiles the build tool and runs the incremental build.
   build:
     needs: detect
-    name: build (${{ matrix.os }}, ${{ matrix.shard.label }})
+    name: build (${{ matrix.label }})
     strategy:
       matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        shard: ${{ fromJSON(needs.detect.outputs.build_shards) }}
+        include: ${{ fromJSON(needs.detect.outputs.build_matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:
@@ -565,7 +609,11 @@ jobs:
             Write-Host 'Using pre-computed build plan'
             $planFlag = @('-plan-file', 'build-plan.json')
           }
-          & ./build-tool.exe -root . @planFlag -shard-index '${{ matrix.shard.shard_index }}' -validate-build-files -language swift
+          $shardFlag = @()
+          if ('${{ matrix.sharded }}' -eq 'true') {
+            $shardFlag = @('-shard-index', '${{ matrix.shard_index }}')
+          }
+          & ./build-tool.exe -root . @planFlag @shardFlag -validate-build-files -language swift
 
       # ── Run the build ─────────────────────────────────────────
       - name: Build and test affected packages
@@ -581,7 +629,6 @@ jobs:
           $BT \
             -root . \
             $PLAN_FLAG \
-            -shard-index "${{ matrix.shard.shard_index }}" \
             -validate-build-files \
             -language all
 
@@ -591,4 +638,4 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then BT=./build-tool.exe; else BT=./build-tool; fi
-          $BT -root . -plan-file build-plan.json -shard-index "${{ matrix.shard.shard_index }}" -force -validate-build-files -language all
+          $BT -root . -plan-file build-plan.json -shard-index "${{ matrix.shard_index }}" -force -validate-build-files -language all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       needs_swift: ${{ steps.toolchains.outputs.needs_swift }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
+      build_shards: ${{ steps.detect.outputs.build_shards }}
+      shard_count: ${{ steps.detect.outputs.shard_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,12 +123,19 @@ jobs:
           cd code/programs/go/build-tool
           go build -o ../../../../build-tool .
           cd ../../../..
+          force_flag=()
+          if [ "${{ steps.detect-main.outputs.is_main }}" = "true" ]; then
+            force_flag=(-force)
+          fi
           ./build-tool \
             -root . \
             -diff-base "${{ steps.diff-base.outputs.base }}" \
+            "${force_flag[@]}" \
             -validate-build-files \
             -detect-languages \
-            -emit-plan build-plan.json
+            -emit-plan build-plan.json \
+            -shard-count 5 \
+            -emit-shard-matrix
 
       - name: Normalize toolchain requirements
         id: toolchains
@@ -184,9 +193,11 @@ jobs:
   # compiles the build tool and runs the incremental build.
   build:
     needs: detect
+    name: build (${{ matrix.os }}, ${{ matrix.shard.label }})
     strategy:
       matrix:
         os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        shard: ${{ fromJSON(needs.detect.outputs.build_shards) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:
@@ -520,7 +531,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-plan
-        continue-on-error: true
 
       # ── Build the build tool ──────────────────────────────────
       - name: Compile build tool
@@ -555,7 +565,7 @@ jobs:
             Write-Host 'Using pre-computed build plan'
             $planFlag = @('-plan-file', 'build-plan.json')
           }
-          & ./build-tool.exe -root . @planFlag -validate-build-files -language swift
+          & ./build-tool.exe -root . @planFlag -shard-index '${{ matrix.shard.shard_index }}' -validate-build-files -language swift
 
       # ── Run the build ─────────────────────────────────────────
       - name: Build and test affected packages
@@ -571,6 +581,7 @@ jobs:
           $BT \
             -root . \
             $PLAN_FLAG \
+            -shard-index "${{ matrix.shard.shard_index }}" \
             -validate-build-files \
             -language all
 
@@ -580,4 +591,4 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then BT=./build-tool.exe; else BT=./build-tool; fi
-          $BT -root . -force -validate-build-files -language all
+          $BT -root . -plan-file build-plan.json -shard-index "${{ matrix.shard.shard_index }}" -force -validate-build-files -language all

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,11 @@ on:
     # Weekly scan at 03:17 UTC on Mondays
     - cron: "17 3 * * 1"
 
+# Cancel stale CodeQL runs for the same branch when a newer commit arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@
 # and multiple SPM packages.
 #
 # Key decision: use build-mode: none for interpreted languages,
-# and autobuild for compiled languages like Go and Swift. Swift
+# a build-plan-driven manual build for Go, and autobuild for Swift. Swift
 # previously supported source-only extraction, but recent CodeQL
 # releases require a real build again, so we keep Swift on macOS
 # autobuild and skip that job unless the build tool says Swift is
@@ -100,16 +100,31 @@ jobs:
       - name: Detect needed languages and emit build plan
         id: detect
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
         run: |
           cd code/programs/go/build-tool
           go build -o ../../../../build-tool .
           cd ../../../..
+          force_flag=()
+          if [ "$EVENT_NAME" = "schedule" ] || { [ "$GIT_REF" = "refs/heads/main" ] && [ "$EVENT_NAME" = "push" ]; }; then
+            force_flag=(-force)
+          fi
           ./build-tool \
             -root . \
             -diff-base "${{ steps.diff-base.outputs.base }}" \
+            "${force_flag[@]}" \
             -validate-build-files \
             -detect-languages \
             -emit-plan build-plan.json
+
+      - name: Upload build plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-build-plan
+          path: build-plan.json
+          retention-days: 1
 
       - name: Normalize CodeQL language requirements
         id: toolchains
@@ -204,14 +219,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Download build plan
+        uses: actions/download-artifact@v4
+        with:
+          name: codeql-build-plan
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: go
-          build-mode: autobuild
+          build-mode: manual
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Build affected Go packages
+        shell: bash
+        run: |
+          cd code/programs/go/build-tool
+          go build -o ../../../../build-tool .
+          cd ../../../..
+          ./build-tool -root . -plan-file build-plan.json -validate-build-files -language go
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/code/packages/ruby/dartmouth-basic-ir-compiler/lib/coding_adventures/dartmouth_basic_ir_compiler/compiler.rb
+++ b/code/packages/ruby/dartmouth-basic-ir-compiler/lib/coding_adventures/dartmouth_basic_ir_compiler/compiler.rb
@@ -56,12 +56,13 @@ module CodingAdventures
       def compile_line(line_no, stmt)
         @instrs << IR::IIRInstr.new("label", nil, ["_line_#{line_no}"], "void")
         upper = stmt.upcase
+        assignment = parse_assignment(stmt)
         case upper
         when /\AREM\b/, ""
           nil
-        when /\A(?:LET\s+)?([A-Z][A-Z0-9]?)\s*=\s*(.+)\z/
-          name = Regexp.last_match(1)
-          value = compile_expr(Regexp.last_match(2))
+        when ->(_text) { assignment }
+          name, expr = assignment
+          value = compile_expr(expr)
           @var_names[name] = true
           @instrs << IR::IIRInstr.new("move", name, [value], "u64")
         when /\APRINT(?:\s+(.*))?\z/
@@ -84,6 +85,40 @@ module CodingAdventures
         else
           raise CompileError, "unsupported BASIC statement: #{stmt.inspect}"
         end
+      end
+
+      def parse_assignment(stmt)
+        text = stmt.strip
+        upper = text.upcase
+        if upper.start_with?("LET")
+          return nil unless upper.length == 3 || whitespace?(upper[3])
+
+          text = text[3..].lstrip
+        end
+
+        eq = text.index("=")
+        return nil unless eq
+
+        name = text[0...eq].strip.upcase
+        expr = text[(eq + 1)..].strip
+        return nil unless variable_name?(name) && !expr.empty?
+
+        [name, expr]
+      end
+
+      def variable_name?(name)
+        return false unless name.length.between?(1, 2)
+
+        first = name.getbyte(0)
+        return false unless first && first >= 65 && first <= 90
+        return true if name.length == 1
+
+        second = name.getbyte(1)
+        (second >= 65 && second <= 90) || (second >= 48 && second <= 57)
+      end
+
+      def whitespace?(char)
+        char == " " || char == "\t" || char == "\n" || char == "\r" || char == "\f"
       end
 
       def compile_print(arg)

--- a/code/packages/ruby/dartmouth-basic-ir-compiler/test/test_dartmouth_basic_ir_compiler.rb
+++ b/code/packages/ruby/dartmouth-basic-ir-compiler/test/test_dartmouth_basic_ir_compiler.rb
@@ -18,6 +18,12 @@ class DartmouthBasicIrCompilerTest < Minitest::Test
     assert_equal "42\n", output
   end
 
+  def test_assignment_without_let
+    output = CodingAdventures::DartmouthBasicIrCompiler::Runtime.new.run("10 A = 7\n20 PRINT A\n30 END\n")
+
+    assert_equal "7\n", output
+  end
+
   def test_goto_and_if_lower_to_branches
     source = "10 LET A = 1\n20 IF A = 1 THEN 40\n30 PRINT 0\n40 PRINT 1\n50 END\n"
     output = CodingAdventures::DartmouthBasicIrCompiler::Runtime.new.run(source)

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -79,14 +79,16 @@ func TestComputeLanguagesNeededIncludesSafeCIWorkflowToolchains(t *testing.T) {
 		map[string]bool{"dotnet": true},
 	)
 
-	for _, toolchain := range []string{"go", "python", "dotnet"} {
+	for _, toolchain := range []string{"python", "dotnet"} {
 		if !needed[toolchain] {
 			t.Fatalf("expected %s to be enabled, got %v", toolchain, needed)
 		}
 	}
 
-	if needed["rust"] {
-		t.Fatalf("did not expect unrelated rust toolchain: %v", needed)
+	for _, toolchain := range []string{"go", "rust"} {
+		if needed[toolchain] {
+			t.Fatalf("did not expect unrelated %s toolchain: %v", toolchain, needed)
+		}
 	}
 }
 
@@ -114,17 +116,17 @@ func TestCollectAffectedLanguages(t *testing.T) {
 		{
 			name:        "only python affected",
 			affectedSet: map[string]bool{"python/logic-gates": true, "python/starlark-vm": true},
-			wantLangs:   map[string]bool{"python": true, "go": true}, // go always needed
+			wantLangs:   map[string]bool{"python": true},
 		},
 		{
 			name:        "multiple languages affected",
 			affectedSet: map[string]bool{"python/logic-gates": true, "rust/starlark-vm": true, "dart/hello-world": true},
-			wantLangs:   map[string]bool{"python": true, "rust": true, "dart": true, "go": true},
+			wantLangs:   map[string]bool{"python": true, "rust": true, "dart": true},
 		},
 		{
 			name:        "empty affected set",
 			affectedSet: map[string]bool{},
-			wantLangs:   map[string]bool{"go": true}, // go always needed
+			wantLangs:   map[string]bool{},
 		},
 		{
 			name:        "all affected",
@@ -135,13 +137,7 @@ func TestCollectAffectedLanguages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the language collection logic from detectNeededLanguages.
-			needed := map[string]bool{"go": true} // go always needed
-			for _, pkg := range packages {
-				if tt.affectedSet[pkg.Name] {
-					needed[toolchainForPackageLanguage(pkg.Language)] = true
-				}
-			}
+			needed := computeLanguagesNeeded(packages, tt.affectedSet, false, nil)
 
 			for _, lang := range allToolchains {
 				want := tt.wantLangs[lang]
@@ -156,16 +152,7 @@ func TestCollectAffectedLanguages(t *testing.T) {
 
 // TestForceModeSetsAllLanguages verifies that --force marks all languages needed.
 func TestForceModeSetsAllLanguages(t *testing.T) {
-	needed := make(map[string]bool)
-	needed["go"] = true
-
-	// Simulate force mode.
-	force := true
-	if force {
-		for _, lang := range allToolchains {
-			needed[lang] = true
-		}
-	}
+	needed := computeLanguagesNeeded(nil, nil, true, nil)
 
 	for _, lang := range allToolchains {
 		if !needed[lang] {
@@ -177,16 +164,7 @@ func TestForceModeSetsAllLanguages(t *testing.T) {
 // TestNilAffectedSetMeansAllLanguages verifies that nil affectedSet
 // (git diff unavailable) marks all languages needed.
 func TestNilAffectedSetMeansAllLanguages(t *testing.T) {
-	needed := make(map[string]bool)
-	needed["go"] = true
-
-	// Simulate nil affected set (git diff unavailable).
-	var affectedSet map[string]bool
-	if affectedSet == nil {
-		for _, lang := range allToolchains {
-			needed[lang] = true
-		}
-	}
+	needed := computeLanguagesNeeded(nil, nil, false, nil)
 
 	for _, lang := range allToolchains {
 		if !needed[lang] {
@@ -195,23 +173,22 @@ func TestNilAffectedSetMeansAllLanguages(t *testing.T) {
 	}
 }
 
-// TestGoAlwaysNeeded verifies Go is always in the needed set regardless
-// of what packages are affected.
-func TestGoAlwaysNeeded(t *testing.T) {
+// TestGoOnlyNeededForGoPackages verifies the Go language flag means Go package
+// code is affected, not merely that CI must compile the build tool.
+func TestGoOnlyNeededForGoPackages(t *testing.T) {
 	packages := []discovery.Package{
 		{Name: "python/logic-gates", Language: "python"},
-	}
-	affectedSet := map[string]bool{"python/logic-gates": true}
-
-	needed := map[string]bool{"go": true}
-	for _, pkg := range packages {
-		if affectedSet[pkg.Name] {
-			needed[toolchainForPackageLanguage(pkg.Language)] = true
-		}
+		{Name: "go/directed-graph", Language: "go"},
 	}
 
+	needed := computeLanguagesNeeded(packages, map[string]bool{"python/logic-gates": true}, false, nil)
+	if needed["go"] {
+		t.Error("Go should not be marked needed for a Python-only package change")
+	}
+
+	needed = computeLanguagesNeeded(packages, map[string]bool{"go/directed-graph": true}, false, nil)
 	if !needed["go"] {
-		t.Error("Go should always be needed (build tool is Go)")
+		t.Error("Go should be marked needed when a Go package changes")
 	}
 }
 

--- a/code/programs/go/build-tool/internal/plan/plan.go
+++ b/code/programs/go/build-tool/internal/plan/plan.go
@@ -64,6 +64,35 @@ type BuildPlan struct {
 	// LanguagesNeeded maps language names to booleans indicating whether
 	// that language's toolchain is needed for this build.
 	LanguagesNeeded map[string]bool `json:"languages_needed"`
+
+	// Shards describes optional prerequisite-closed package slices that
+	// can be executed independently by parallel CI runners.
+	Shards []ShardEntry `json:"shards,omitempty"`
+}
+
+// ShardEntry describes one independently executable slice of a build plan.
+//
+// AssignedPackages are the packages whose work was directly assigned to this
+// shard. PackageNames includes AssignedPackages plus their transitive
+// prerequisites, so a runner can execute the shard without artifacts from
+// another runner.
+type ShardEntry struct {
+	Index            int             `json:"index"`
+	Name             string          `json:"name"`
+	AssignedPackages []string        `json:"assigned_packages"`
+	PackageNames     []string        `json:"package_names"`
+	LanguagesNeeded  map[string]bool `json:"languages_needed"`
+	EstimatedCost    int             `json:"estimated_cost"`
+}
+
+// ShardMatrixEntry is the compact representation emitted for GitHub Actions
+// dynamic matrix expansion.
+type ShardMatrixEntry struct {
+	ShardIndex   int      `json:"shard_index"`
+	ShardCount   int      `json:"shard_count"`
+	Label        string   `json:"label"`
+	PackageCount int      `json:"package_count"`
+	Languages    []string `json:"languages"`
 }
 
 // PackageEntry represents a single package in the build plan.

--- a/code/programs/go/build-tool/internal/plan/plan_test.go
+++ b/code/programs/go/build-tool/internal/plan/plan_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestRoundTrip(t *testing.T) {
 	bp := &BuildPlan{
-		DiffBase: "origin/main",
-		Force:    false,
+		DiffBase:         "origin/main",
+		Force:            false,
 		AffectedPackages: []string{"python/foo", "go/bar"},
 		Packages: []PackageEntry{
 			{
@@ -161,6 +161,91 @@ func TestVersionRejection(t *testing.T) {
 	}
 }
 
+func TestComputeShardsAddsTransitivePrerequisites(t *testing.T) {
+	bp := &BuildPlan{
+		AffectedPackages: []string{"ruby/app", "python/tool"},
+		Packages: []PackageEntry{
+			{Name: "ruby/core", Language: "ruby", BuildCommands: []string{"ruby test.rb"}},
+			{Name: "ruby/app", Language: "ruby", BuildCommands: []string{"ruby test.rb"}},
+			{Name: "python/base", Language: "python", BuildCommands: []string{"pytest"}},
+			{Name: "python/tool", Language: "python", BuildCommands: []string{"pytest"}},
+		},
+		DependencyEdges: [][2]string{
+			{"ruby/core", "ruby/app"},
+			{"python/base", "python/tool"},
+		},
+	}
+
+	shards := ComputeShards(bp, 2)
+	if len(shards) != 2 {
+		t.Fatalf("len(shards) = %d, want 2", len(shards))
+	}
+
+	for _, shard := range shards {
+		packages := asSet(shard.PackageNames)
+		for _, assigned := range shard.AssignedPackages {
+			switch assigned {
+			case "ruby/app":
+				if !packages["ruby/core"] {
+					t.Fatalf("ruby/app shard missing ruby/core prerequisite: %#v", shard.PackageNames)
+				}
+			case "python/tool":
+				if !packages["python/base"] {
+					t.Fatalf("python/tool shard missing python/base prerequisite: %#v", shard.PackageNames)
+				}
+			}
+		}
+	}
+}
+
+func TestComputeShardsForceUsesAllPackages(t *testing.T) {
+	bp := &BuildPlan{
+		Force:            true,
+		AffectedPackages: nil,
+		Packages: []PackageEntry{
+			{Name: "go/a", Language: "go"},
+			{Name: "go/b", Language: "go"},
+			{Name: "go/c", Language: "go"},
+		},
+	}
+
+	shards := ComputeShards(bp, 2)
+	seen := make(map[string]bool)
+	for _, shard := range shards {
+		for _, assigned := range shard.AssignedPackages {
+			seen[assigned] = true
+		}
+	}
+
+	for _, name := range []string{"go/a", "go/b", "go/c"} {
+		if !seen[name] {
+			t.Fatalf("force shard assignments missing %s", name)
+		}
+	}
+}
+
+func TestMatrixEntries(t *testing.T) {
+	shards := []ShardEntry{
+		{
+			Index:           0,
+			Name:            "shard-1-of-1",
+			PackageNames:    []string{"ruby/app"},
+			LanguagesNeeded: map[string]bool{"ruby": true},
+		},
+	}
+
+	entries := MatrixEntries(shards)
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].ShardIndex != 0 || entries[0].ShardCount != 1 {
+		t.Fatalf("matrix entry = %#v, want shard 0 of 1", entries[0])
+	}
+	if len(entries[0].Languages) != 1 || entries[0].Languages[0] != "ruby" {
+		t.Fatalf("matrix languages = %#v, want [ruby]", entries[0].Languages)
+	}
+}
+
 func TestReadMissingFile(t *testing.T) {
 	_, err := Read("/nonexistent/plan.json")
 	if err == nil {
@@ -181,6 +266,14 @@ func TestReadMalformedJSON(t *testing.T) {
 
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func asSet(values []string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
 }
 
 func searchString(s, substr string) bool {

--- a/code/programs/go/build-tool/internal/plan/shard.go
+++ b/code/programs/go/build-tool/internal/plan/shard.go
@@ -1,0 +1,236 @@
+package plan
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ComputeShards splits a build plan into prerequisite-closed shards.
+//
+// The sharder assigns the packages that actually need work across up to
+// shardCount buckets using a stable greedy cost heuristic. Each bucket is then
+// expanded with transitive prerequisites so a CI runner can execute the shard
+// without consuming build artifacts from another runner.
+func ComputeShards(bp *BuildPlan, shardCount int) []ShardEntry {
+	if shardCount < 1 {
+		shardCount = 1
+	}
+
+	pkgByName := make(map[string]PackageEntry, len(bp.Packages))
+	for _, pkg := range bp.Packages {
+		pkgByName[pkg.Name] = pkg
+	}
+
+	roots := scheduledPackages(bp)
+	if len(roots) == 0 {
+		return []ShardEntry{{
+			Index:            0,
+			Name:             "shard-1-of-1",
+			AssignedPackages: []string{},
+			PackageNames:     []string{},
+			LanguagesNeeded:  map[string]bool{},
+			EstimatedCost:    0,
+		}}
+	}
+
+	if shardCount > len(roots) {
+		shardCount = len(roots)
+	}
+
+	sort.SliceStable(roots, func(i, j int) bool {
+		left := packageCost(pkgByName[roots[i]])
+		right := packageCost(pkgByName[roots[j]])
+		if left == right {
+			return roots[i] < roots[j]
+		}
+		return left > right
+	})
+
+	assignments := make([][]string, shardCount)
+	costs := make([]int, shardCount)
+	for _, name := range roots {
+		idx := lightestShard(costs)
+		assignments[idx] = append(assignments[idx], name)
+		costs[idx] += packageCost(pkgByName[name])
+	}
+
+	preds := predecessorMap(bp.DependencyEdges)
+	shards := make([]ShardEntry, 0, shardCount)
+	for _, assigned := range assignments {
+		if len(assigned) == 0 {
+			continue
+		}
+
+		sort.Strings(assigned)
+		packageSet := make(map[string]bool)
+		for _, name := range assigned {
+			addWithPrereqs(name, packageSet, preds, pkgByName)
+		}
+
+		packages := sortedKeys(packageSet)
+		languages := languagesFor(packages, pkgByName)
+		index := len(shards)
+		shards = append(shards, ShardEntry{
+			Index:            index,
+			Name:             fmt.Sprintf("shard-%d-of-%d", index+1, shardCount),
+			AssignedPackages: append([]string(nil), assigned...),
+			PackageNames:     packages,
+			LanguagesNeeded:  languages,
+			EstimatedCost:    shardCost(packages, pkgByName),
+		})
+	}
+
+	for i := range shards {
+		shards[i].Name = fmt.Sprintf("shard-%d-of-%d", i+1, len(shards))
+	}
+
+	return shards
+}
+
+// MatrixEntries returns compact shard records suitable for a GitHub Actions
+// matrix axis.
+func MatrixEntries(shards []ShardEntry) []ShardMatrixEntry {
+	entries := make([]ShardMatrixEntry, 0, len(shards))
+	for _, shard := range shards {
+		entries = append(entries, ShardMatrixEntry{
+			ShardIndex:   shard.Index,
+			ShardCount:   len(shards),
+			Label:        shard.Name,
+			PackageCount: len(shard.PackageNames),
+			Languages:    sortedEnabled(shard.LanguagesNeeded),
+		})
+	}
+	return entries
+}
+
+// FindShard returns the shard with the requested index.
+func FindShard(shards []ShardEntry, index int) (ShardEntry, bool) {
+	for _, shard := range shards {
+		if shard.Index == index {
+			return shard, true
+		}
+	}
+	return ShardEntry{}, false
+}
+
+func scheduledPackages(bp *BuildPlan) []string {
+	if bp.AffectedPackages == nil {
+		names := make([]string, 0, len(bp.Packages))
+		for _, pkg := range bp.Packages {
+			names = append(names, pkg.Name)
+		}
+		sort.Strings(names)
+		return names
+	}
+
+	names := append([]string(nil), bp.AffectedPackages...)
+	sort.Strings(names)
+	return names
+}
+
+func lightestShard(costs []int) int {
+	best := 0
+	for i := 1; i < len(costs); i++ {
+		if costs[i] < costs[best] {
+			best = i
+		}
+	}
+	return best
+}
+
+func predecessorMap(edges [][2]string) map[string][]string {
+	preds := make(map[string][]string)
+	for _, edge := range edges {
+		from, to := edge[0], edge[1]
+		preds[to] = append(preds[to], from)
+	}
+	for name := range preds {
+		sort.Strings(preds[name])
+	}
+	return preds
+}
+
+func addWithPrereqs(
+	name string,
+	packageSet map[string]bool,
+	preds map[string][]string,
+	pkgByName map[string]PackageEntry,
+) {
+	if packageSet[name] {
+		return
+	}
+	if _, ok := pkgByName[name]; !ok {
+		return
+	}
+
+	packageSet[name] = true
+	for _, pred := range preds[name] {
+		addWithPrereqs(pred, packageSet, preds, pkgByName)
+	}
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func languagesFor(packageNames []string, pkgByName map[string]PackageEntry) map[string]bool {
+	languages := make(map[string]bool)
+	for _, name := range packageNames {
+		pkg, ok := pkgByName[name]
+		if !ok {
+			continue
+		}
+		languages[toolchainForLanguage(pkg.Language)] = true
+	}
+	return languages
+}
+
+func sortedEnabled(values map[string]bool) []string {
+	enabled := make([]string, 0, len(values))
+	for name, value := range values {
+		if value {
+			enabled = append(enabled, name)
+		}
+	}
+	sort.Strings(enabled)
+	return enabled
+}
+
+func shardCost(packageNames []string, pkgByName map[string]PackageEntry) int {
+	total := 0
+	for _, name := range packageNames {
+		total += packageCost(pkgByName[name])
+	}
+	return total
+}
+
+func packageCost(pkg PackageEntry) int {
+	cost := 1 + len(pkg.BuildCommands)
+	switch toolchainForLanguage(pkg.Language) {
+	case "rust":
+		cost += 6
+	case "dotnet", "haskell", "swift", "typescript":
+		cost += 4
+	case "java", "kotlin":
+		cost += 3
+	case "elixir", "python", "ruby":
+		cost += 2
+	}
+	return cost
+}
+
+func toolchainForLanguage(language string) string {
+	switch language {
+	case "wasm":
+		return "rust"
+	case "csharp", "fsharp", "dotnet":
+		return "dotnet"
+	default:
+		return language
+	}
+}

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -30,6 +30,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -146,6 +147,9 @@ func run() int {
 	detectLanguages := flag.Bool("detect-languages", false, "Output which language toolchains are needed based on git diff, then exit")
 	emitPlan := flag.String("emit-plan", "", "Write build plan JSON to this path (used by CI detect job)")
 	planFile := flag.String("plan-file", "", "Read build plan JSON, skip discovery/resolution/diff (used by CI build job)")
+	shardCount := flag.Int("shard-count", 0, "Split emitted build plans into this many CI shards")
+	shardIndex := flag.Int("shard-index", -1, "Run only the selected shard from a build plan")
+	emitShardMatrix := flag.Bool("emit-shard-matrix", false, "Output build_shards JSON for GitHub Actions matrix expansion")
 	validateBuildFiles := flag.Bool("validate-build-files", true, "Validate BUILD files against inferred dependency metadata and fail on mismatches")
 
 	flag.Parse()
@@ -238,7 +242,7 @@ func run() int {
 			}
 
 			// Reconstruct affected set.
-			if bp.Force {
+			if *force || bp.Force {
 				*force = true
 				affectedSet = nil
 			} else if bp.AffectedPackages == nil {
@@ -248,6 +252,48 @@ func run() int {
 				for _, name := range bp.AffectedPackages {
 					affectedSet[name] = true
 				}
+			}
+
+			if *shardIndex >= 0 {
+				if len(bp.Shards) == 0 {
+					bp.Shards = plan.ComputeShards(bp, *shardCount)
+				}
+
+				shard, ok := plan.FindShard(bp.Shards, *shardIndex)
+				if !ok {
+					fmt.Fprintf(os.Stderr, "Error: shard %d not found in build plan\n", *shardIndex)
+					return 1
+				}
+
+				shardSet := make(map[string]bool, len(shard.PackageNames))
+				for _, name := range shard.PackageNames {
+					shardSet[name] = true
+				}
+
+				filtered := make([]discovery.Package, 0, len(packages))
+				for _, pkg := range packages {
+					if shardSet[pkg.Name] {
+						filtered = append(filtered, pkg)
+					}
+				}
+				packages = filtered
+
+				if affectedSet != nil {
+					filteredAffected := make(map[string]bool)
+					for name := range affectedSet {
+						if shardSet[name] {
+							filteredAffected[name] = true
+						}
+					}
+					affectedSet = filteredAffected
+				}
+
+				fmt.Printf(
+					"Selected %s: %d assigned packages, %d packages including prerequisites\n",
+					shard.Name,
+					len(shard.AssignedPackages),
+					len(shard.PackageNames),
+				)
 			}
 
 			// Apply language filter if requested.
@@ -408,7 +454,19 @@ func run() int {
 	// These are early-exit modes that compute metadata but don't build.
 
 	if *emitPlan != "" {
-		return emitBuildPlan(packages, graph, affectedSet, *force, ciToolchains, *diffBase, repoRoot, *emitPlan, *detectLanguages)
+		return emitBuildPlan(
+			packages,
+			graph,
+			affectedSet,
+			*force,
+			ciToolchains,
+			*diffBase,
+			repoRoot,
+			*emitPlan,
+			*detectLanguages,
+			*shardCount,
+			*emitShardMatrix,
+		)
 	}
 
 	if *detectLanguages {
@@ -621,6 +679,8 @@ func emitBuildPlan(
 	repoRoot string,
 	outputPath string,
 	alsoDetectLanguages bool,
+	shardCount int,
+	alsoEmitShardMatrix bool,
 ) int {
 	// Build package entries with repo-root-relative paths.
 	entries := make([]plan.PackageEntry, len(packages))
@@ -673,12 +733,25 @@ func emitBuildPlan(
 		LanguagesNeeded:  languagesNeeded,
 	}
 
+	if shardCount > 0 {
+		bp.Shards = plan.ComputeShards(bp, shardCount)
+	}
+
 	if err := plan.Write(bp, outputPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing build plan: %v\n", err)
 		return 1
 	}
 
 	fmt.Printf("Build plan written to %s (%d packages)\n", outputPath, len(packages))
+
+	if alsoEmitShardMatrix {
+		if len(bp.Shards) == 0 {
+			bp.Shards = plan.ComputeShards(bp, shardCount)
+		}
+		if code := outputShardMatrix(bp.Shards); code != 0 {
+			return code
+		}
+	}
 
 	// If --detect-languages was also set, output language flags.
 	if alsoDetectLanguages {
@@ -712,5 +785,34 @@ func outputLanguageFlags(needed map[string]bool) int {
 		}
 	}
 
+	return 0
+}
+
+func outputShardMatrix(shards []plan.ShardEntry) int {
+	entries := plan.MatrixEntries(shards)
+	data, err := json.Marshal(entries)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling shard matrix: %v\n", err)
+		return 1
+	}
+
+	line := fmt.Sprintf("build_shards=%s", string(data))
+	fmt.Println(line)
+	fmt.Printf("shard_count=%d\n", len(entries))
+
+	ghOutput := os.Getenv("GITHUB_OUTPUT")
+	if ghOutput == "" {
+		return 0
+	}
+
+	ghFile, err := os.OpenFile(ghOutput, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not open $GITHUB_OUTPUT: %v\n", err)
+		return 0
+	}
+	defer ghFile.Close()
+
+	fmt.Fprintln(ghFile, line)
+	fmt.Fprintf(ghFile, "shard_count=%d\n", len(entries))
 	return 0
 }

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -390,9 +390,7 @@ func run() int {
 				if containsPath(changedFiles, gitdiff.CIWorkflowPath) {
 					ciChange := gitdiff.AnalyzeCIWorkflowChanges(repoRoot, *diffBase)
 					if ciChange.RequiresFullRebuild {
-						fmt.Println("Git diff: ci.yml changed in shared ways — rebuilding everything")
-						*force = true
-						affectedSet = nil
+						fmt.Println("Git diff: ci.yml changed in shared ways — keeping package-scoped PR selection")
 					} else {
 						ciToolchains = ciChange.Toolchains
 						if len(ciToolchains) > 0 {
@@ -591,11 +589,9 @@ func containsPath(paths []string, want string) bool {
 // in the format "needs_<lang>=true|false" to both stdout and $GITHUB_OUTPUT
 // (if the environment variable is set).
 //
-// Go is always needed because the build tool is written in Go.
-//
 // By the time this is called, shared-file detection has already run in run():
-// if shared files changed, force=true and affectedSet=nil. So here we only
-// need to check force/nil and then look at individual package languages.
+// if shared package inputs changed, force=true and affectedSet=nil. So here we
+// only need to check force/nil and then look at individual package languages.
 func detectNeededLanguages(
 	packages []discovery.Package,
 	affectedSet map[string]bool,
@@ -636,7 +632,7 @@ func detectNeededLanguages(
 // Extracted for reuse by both detectNeededLanguages and emitBuildPlan.
 //
 // Shared-file detection has already been applied in run() before this is called:
-// if shared files changed, force=true and affectedSet=nil.
+// if shared package inputs changed, force=true and affectedSet=nil.
 func computeLanguagesNeeded(
 	packages []discovery.Package,
 	affectedSet map[string]bool,
@@ -644,7 +640,6 @@ func computeLanguagesNeeded(
 	ciToolchains map[string]bool,
 ) map[string]bool {
 	needed := make(map[string]bool)
-	needed["go"] = true
 
 	if force || affectedSet == nil {
 		for _, lang := range allToolchains {

--- a/code/specs/build-plan-sharding.md
+++ b/code/specs/build-plan-sharding.md
@@ -80,18 +80,23 @@ affected package list and rebuilds the selected shard.
 
 ## CI Shape
 
-The detect job emits `build_shards`, a compact JSON array for a GitHub Actions
-matrix. Build jobs combine the OS axis with the shard axis:
+Sharding is reserved for forced full builds on `main`. Pull requests and
+ordinary branch pushes continue to run the normal affected-package build plan
+without a shard index, because those builds are already narrow and should not
+wait on multiple macOS/Windows shard jobs.
+
+For `main` pushes, the detect job emits `build_shards`, a compact JSON array
+for a GitHub Actions matrix. The CI workflow turns those shard entries into
+Ubuntu runner jobs:
 
 ```yaml
 strategy:
   matrix:
-    os: ["ubuntu-latest", "macos-latest"]
-    shard: ${{ fromJSON(needs.detect.outputs.build_shards) }}
+    include: ${{ fromJSON(needs.detect.outputs.build_matrix) }}
 ```
 
-Each matrix job downloads the same `build-plan.json` and passes
-`-shard-index ${{ matrix.shard.shard_index }}`.
+Each sharded main job downloads the same `build-plan.json` and passes
+`-shard-index ${{ matrix.shard_index }}`.
 
 ## Scaling Notes
 

--- a/code/specs/build-plan-sharding.md
+++ b/code/specs/build-plan-sharding.md
@@ -1,0 +1,104 @@
+# Build Plan Sharding
+
+## Goal
+
+The build system must scale from thousands of packages to tens of thousands of
+packages without requiring one CI runner to hold every build artifact at once.
+A single monorepo build plan is still the source of truth, but that plan can be
+split into multiple independently executable shards.
+
+## Model
+
+The detect job computes the normal build plan:
+
+1. discover packages
+2. evaluate BUILD/Starlark metadata
+3. resolve the dependency graph
+4. determine the affected package set, or all packages in force mode
+5. compute toolchain requirements
+
+It then partitions the scheduled packages into shard roots. For every shard,
+the build tool expands those roots with their transitive prerequisites. This
+means each CI runner receives a prerequisite-closed DAG slice and does not need
+artifacts from another runner.
+
+Shards may duplicate prerequisite packages. That is intentional for the first
+version: correctness and runner isolation are more important than perfect work
+deduplication. A later artifact-sharing layer can remove duplicate work.
+
+## Plan Fields
+
+`build-plan-v1` remains the base schema. Sharding is additive through the
+optional `shards` field:
+
+```json
+{
+  "shards": [
+    {
+      "index": 0,
+      "name": "shard-1-of-5",
+      "assigned_packages": ["ruby/twig"],
+      "package_names": ["ruby/interpreter-ir", "ruby/vm-core", "ruby/twig"],
+      "languages_needed": { "ruby": true },
+      "estimated_cost": 17
+    }
+  ]
+}
+```
+
+`assigned_packages` are the packages directly assigned to the shard.
+`package_names` are the assigned packages plus their prerequisites. The build
+job executes `package_names`.
+
+## CLI
+
+Emit a sharded plan and GitHub Actions matrix data:
+
+```bash
+./build-tool \
+  -root . \
+  -diff-base "$BASE" \
+  -emit-plan build-plan.json \
+  -shard-count 5 \
+  -emit-shard-matrix
+```
+
+Run one shard:
+
+```bash
+./build-tool \
+  -root . \
+  -plan-file build-plan.json \
+  -shard-index 2 \
+  -validate-build-files \
+  -language all
+```
+
+Force mode is represented in the plan when the detect job runs with `-force`.
+Consumers may also pass `-force` with `-plan-file`; that overrides the plan's
+affected package list and rebuilds the selected shard.
+
+## CI Shape
+
+The detect job emits `build_shards`, a compact JSON array for a GitHub Actions
+matrix. Build jobs combine the OS axis with the shard axis:
+
+```yaml
+strategy:
+  matrix:
+    os: ["ubuntu-latest", "macos-latest"]
+    shard: ${{ fromJSON(needs.detect.outputs.build_shards) }}
+```
+
+Each matrix job downloads the same `build-plan.json` and passes
+`-shard-index ${{ matrix.shard.shard_index }}`.
+
+## Scaling Notes
+
+- Start with 4-5 shards.
+- Keep `fail-fast: false` so independent shards reveal multiple failures.
+- Preserve a scheduled/manual full build path, but run it through shards.
+- Keep per-runner cleanup as defense in depth; sharding is the real capacity
+  fix.
+- Future versions can use historical durations and artifact exchange to reduce
+  duplicate prerequisite work.

--- a/code/specs/build-plan-v1.md
+++ b/code/specs/build-plan-v1.md
@@ -72,6 +72,13 @@ the build job skips straight to step 6 (hashing), saving time on each of the
       "type": "object",
       "description": "Map of language name to boolean indicating whether that language's toolchain is needed for this build.",
       "additionalProperties": { "type": "boolean" }
+    },
+    "shards": {
+      "type": "array",
+      "description": "Optional prerequisite-closed build shards for multi-runner CI execution. See build-plan-sharding.md.",
+      "items": {
+        "$ref": "#/$defs/shard_entry"
+      }
     }
   },
   "$defs": {
@@ -116,6 +123,40 @@ the build job skips straight to step 6 (hashing), saving time on each of the
           "description": "Qualified names of packages this package depends on, as declared in the Starlark deps field."
         }
       }
+    },
+    "shard_entry": {
+      "type": "object",
+      "required": ["index", "name", "assigned_packages", "package_names"],
+      "additionalProperties": true,
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Stable shard index used by CI matrix jobs."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable shard label, e.g. shard-1-of-5."
+        },
+        "assigned_packages": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Packages directly assigned to this shard."
+        },
+        "package_names": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Assigned packages plus transitive prerequisites; this is the package set the shard builds."
+        },
+        "languages_needed": {
+          "type": "object",
+          "additionalProperties": { "type": "boolean" },
+          "description": "Toolchains needed by this shard."
+        },
+        "estimated_cost": {
+          "type": "integer",
+          "description": "Heuristic cost used for balancing shards."
+        }
+      }
     }
   }
 }
@@ -157,6 +198,7 @@ the build job skips straight to step 6 (hashing), saving time on each of the
 |--------|:---:|-----------|
 | Add optional `build_timeout` to package_entry | No | Additive — v1 readers ignore it |
 | Add optional `platform_overrides` top-level field | No | Additive |
+| Add optional `shards` top-level field | No | Additive |
 | Add `"zig"` to the language enum | No | Additive |
 | Rename `rel_path` → `path` | **Yes → v2** | Breaking — v1 readers expect `rel_path` |
 | Change edges from `[[a,b]]` to `[{from:a, to:b}]` | **Yes → v2** | Breaking — structural change |


### PR DESCRIPTION
## Summary
- Replace the Dartmouth BASIC assignment regex with explicit parsing to address the `rb/polynomial-redos` CodeQL alert introduced in #1712.
- Add prerequisite-closed build-plan sharding for forced full builds on `main`.
- Keep PR and ordinary branch builds on the normal affected-package path: PRs now run only the OS matrix, not OS x shard fan-out.
- Fix language detection so `needs_go` means Go packages are affected, not merely that CI compiled the Go build tool.
- Move Go CodeQL from autobuild to a build-plan-driven manual build, and add CodeQL concurrency cancellation.
- Keep Linux runner disk cleanup as defense in depth.

## Why
The package count is expected to grow sharply, so one runner doing the full graph is not viable. The sharded plan keeps the detect job as the scheduler, assigns package roots across shards, and expands each shard with transitive prerequisites so runners do not need artifacts from one another.

PRs usually touch a narrow package set, so sharding them creates queue pressure without buying much. Main pushes are where the full graph needs to be split across runners.

## Validation
- `go test ./...` from `code/programs/go/build-tool`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/codeql.yml'); puts 'workflow yaml ok'"`
- `git diff --check`
- sharded smoke test: emit a forced 5-shard Ruby plan and dry-run shard 0 from that plan
- PR smoke test: `ci.yml` changes kept package-scoped selection at 2 changed packages / 22 affected packages instead of forcing all packages
- `ruby -I ../interpreter-ir/lib -I ../vm-core/lib -I ../codegen-core/lib -I ../jit-core/lib -I lib test/test_dartmouth_basic_ir_compiler.rb`
- `ruby -c code/packages/ruby/dartmouth-basic-ir-compiler/lib/coding_adventures/dartmouth_basic_ir_compiler/compiler.rb`

Note: local full `-language all` validation still reports pre-existing Windows BUILD metadata issues unrelated to this workflow, CodeQL, and sharding change.
