### PR TITLE
Report incorrectly opened markup declarations

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -87,6 +87,8 @@ documented in this file.
   comment with `unexpected-question-mark-instead-of-tag-name`.
 - EOF in bogus-comment recovery now emits the recovered comment without adding
   an unrelated `eof-in-comment` diagnostic.
+- Malformed markup declarations such as `<!foo>` now report
+  `incorrectly-opened-comment` while recovering as bogus comments.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is
   preserved and malformed end-tag openers recover as bogus comments.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -36,6 +36,9 @@ bogus-comment recovery instead of being mistaken for a start tag, preserving
 legacy document prologs without polluting the tag stream. EOF in that bogus
 comment recovery emits the recovered comment without adding an unrelated
 `eof-in-comment` diagnostic.
+Malformed markup declarations such as `<!foo>` also recover as bogus comments
+and report `incorrectly-opened-comment`, matching the tokenizer error shape the
+future parser will rely on for compatibility diagnostics.
 The tag-open states now only begin normal tags when the next character is an
 ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
 end-tag openers such as `</3>` recover as bogus comments with a tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4280,7 +4280,11 @@ actions = [
 from = "markup_declaration_open"
 matcher = { anything = true }
 to = "bogus_comment"
-actions = ["create_comment", "append_comment(current)"]
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "create_comment",
+  "append_comment(current)",
+]
 
 [[transitions]]
 from = "cdata_open_bracket"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9104,6 +9104,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(incorrectly-opened-comment)".to_string(),
                 "create_comment".to_string(),
                 "append_comment(current)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 54);
+    assert_eq!(html1.cases.len(), 55);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 52);
+    assert_eq!(file.tests.len(), 53);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 52);
+    assert_eq!(normalized.cases.len(), 53);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 52);
+    assert_eq!(suite.cases.len(), 53);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -595,6 +595,20 @@
       ]
     },
     {
+      "id": "incorrectly-opened-markup-declaration",
+      "description": "Malformed markup declarations recover as bogus comments with a diagnostic",
+      "input": "Before<!foo>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=foo)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
       "id": "invalid-tag-open-text-recovery",
       "description": "A less-than sign before non-tag text remains text instead of starting a tag",
       "input": "Before < after",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -635,6 +635,20 @@
     },
     {
       "id": "html5lib-smoke-52",
+      "description": "incorrectly opened markup declaration reports tokenizer error",
+      "input": "Before<!foo>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=foo)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-53",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -553,6 +553,18 @@
       ]
     },
     {
+      "description": "incorrectly opened markup declaration reports tokenizer error",
+      "input": "Before<!foo>After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "foo"],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 9}
+      ]
+    },
+    {
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -383,6 +383,28 @@ fn default_html_lexer_does_not_report_eof_in_bogus_comment_state() {
 }
 
 #[test]
+fn default_html_lexer_reports_incorrectly_opened_markup_declaration() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<!foo>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("foo".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "incorrectly-opened-comment"));
+}
+
+#[test]
 fn default_html_lexer_recovers_invalid_tag_open_as_text() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Report `incorrectly-opened-comment` when malformed markup declarations like `<!foo>` recover as bogus comments.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for that diagnostic path.
- Regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`