### PR TITLE
Add GDI Paint VM runtime adapter

### DIFF
--- a/code/packages/rust/paint-vm-gdi/Cargo.toml
+++ b/code/packages/rust/paint-vm-gdi/Cargo.toml
@@ -7,6 +7,7 @@ description = "GDI renderer for the paint-instructions scene model (P2D07)"
 [dependencies]
 arc2d = { path = "../arc2d" }
 paint-instructions = { path = "../paint-instructions" }
+paint-vm-runtime = { path = "../paint-vm-runtime" }
 point2d = { path = "../point2d" }
 
 [dependencies.windows]

--- a/code/packages/rust/paint-vm-gdi/src/lib.rs
+++ b/code/packages/rust/paint-vm-gdi/src/lib.rs
@@ -69,6 +69,11 @@ use paint_instructions::{
     PaintInstruction, PaintLayer, PaintLine, PaintPath, PaintRect, PaintScene, PaintText,
     PathCommand, PixelContainer, TextAlign, Transform2D,
 };
+#[cfg(target_os = "windows")]
+use paint_vm_runtime::{
+    PaintAcceleration, PaintBackendCapabilities, PaintBackendDescriptor, PaintBackendFamily,
+    PaintBackendTier, PaintPlatformSupport, PaintRenderError, PaintRenderer, SupportLevel,
+};
 use point2d::Point as Point2D;
 
 // ---------------------------------------------------------------------------
@@ -1464,6 +1469,61 @@ pub fn render(scene: &PaintScene) -> PixelContainer {
     unsafe { render_unsafe(scene, width, height) }
 }
 
+/// Runtime adapter for selecting GDI through `paint-vm-runtime`.
+#[cfg(target_os = "windows")]
+pub struct GdiPaintBackend;
+
+#[cfg(target_os = "windows")]
+pub fn descriptor() -> PaintBackendDescriptor {
+    PaintBackendDescriptor {
+        id: "paint-vm-gdi",
+        display_name: "Paint VM GDI",
+        family: PaintBackendFamily::Gdi,
+        acceleration: PaintAcceleration::Cpu,
+        tier: PaintBackendTier::Tier2NativeScenes,
+        platforms: PaintPlatformSupport::windows(),
+        capabilities: PaintBackendCapabilities {
+            rect: SupportLevel::Supported,
+            line: SupportLevel::Supported,
+            ellipse: SupportLevel::Supported,
+            path: SupportLevel::Supported,
+            path_arc_to: SupportLevel::Supported,
+            glyph_run: SupportLevel::Supported,
+            text: SupportLevel::Supported,
+            image: SupportLevel::Supported,
+            clip: SupportLevel::Supported,
+            group: SupportLevel::Supported,
+            group_transform: SupportLevel::Supported,
+            group_opacity: SupportLevel::Supported,
+            layer: SupportLevel::Supported,
+            layer_opacity: SupportLevel::Supported,
+            layer_filters: SupportLevel::Unsupported,
+            layer_blend_modes: SupportLevel::Unsupported,
+            linear_gradient: SupportLevel::Unsupported,
+            radial_gradient: SupportLevel::Unsupported,
+            antialiasing: SupportLevel::Unsupported,
+            offscreen_pixels: SupportLevel::Supported,
+        },
+        priority: 100,
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn renderer() -> GdiPaintBackend {
+    GdiPaintBackend
+}
+
+#[cfg(target_os = "windows")]
+impl PaintRenderer for GdiPaintBackend {
+    fn descriptor(&self) -> PaintBackendDescriptor {
+        descriptor()
+    }
+
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        Ok(crate::render(scene))
+    }
+}
+
 /// The actual rendering logic, wrapped in `unsafe` for GDI FFI calls.
 ///
 /// ## DIBSection memory layout
@@ -1573,6 +1633,10 @@ mod tests {
         ImageSrc, PaintBase, PaintEllipse, PaintGroup, PaintImage, PaintInstruction, PaintLayer,
         PaintPath, PaintRect, PaintScene, PaintText, PathCommand, TextAlign,
     };
+    #[cfg(target_os = "windows")]
+    use paint_vm_runtime::{
+        PaintBackendPreference, PaintBackendRegistry, PaintRenderOptions, SupportLevel,
+    };
 
     #[cfg(target_os = "windows")]
     fn dark_pixel_bounds(pixels: &PixelContainer) -> Option<(u32, u32, u32, u32)> {
@@ -1599,6 +1663,48 @@ mod tests {
     #[test]
     fn version_exists() {
         assert_eq!(VERSION, "0.1.0");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn descriptor_reports_gdi_runtime_capabilities() {
+        let descriptor = descriptor();
+        assert_eq!(descriptor.id, "paint-vm-gdi");
+        assert_eq!(descriptor.capabilities.text, SupportLevel::Supported);
+        assert_eq!(descriptor.capabilities.glyph_run, SupportLevel::Supported);
+        assert_eq!(descriptor.capabilities.path_arc_to, SupportLevel::Supported);
+        assert_eq!(
+            descriptor.capabilities.linear_gradient,
+            SupportLevel::Unsupported
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn runtime_registry_can_render_with_gdi_backend() {
+        let backend = renderer();
+        let mut registry = PaintBackendRegistry::new();
+        registry.register(&backend);
+
+        let mut scene = PaintScene::new(32.0, 32.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                4.0, 4.0, 20.0, 20.0, "#000000",
+            )));
+
+        let pixels = registry
+            .render_auto(
+                &scene,
+                PaintRenderOptions {
+                    preference: PaintBackendPreference::Named("paint-vm-gdi".to_string()),
+                    ..PaintRenderOptions::default()
+                },
+            )
+            .expect("GDI should satisfy a rect-only scene");
+
+        let (r, g, b, a) = pixels.pixel_at(8, 8);
+        assert_eq!((r, g, b, a), (0, 0, 0, 255));
     }
 
     // ─── Colour parser tests ────────────────────────────────────────────────

--- a/code/specs/P2D09-paint-vm-backend-convergence.md
+++ b/code/specs/P2D09-paint-vm-backend-convergence.md
@@ -140,23 +140,24 @@ pub struct PaintBackendCapabilities {
     pub text: SupportLevel,
     pub image: SupportLevel,
     pub clip: SupportLevel,
+    pub group: SupportLevel,
     pub group_transform: SupportLevel,
     pub group_opacity: SupportLevel,
+    pub layer: SupportLevel,
     pub layer_opacity: SupportLevel,
     pub layer_filters: SupportLevel,
     pub layer_blend_modes: SupportLevel,
     pub linear_gradient: SupportLevel,
     pub radial_gradient: SupportLevel,
-    pub subpixel_geometry: SupportLevel,
     pub antialiasing: SupportLevel,
+    pub offscreen_pixels: SupportLevel,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SupportLevel {
-    Native,
-    Emulated,
-    Degraded,
     Unsupported,
+    Degraded,
+    Supported,
 }
 ```
 
@@ -164,10 +165,9 @@ Definitions:
 
 | Level | Meaning |
 |-------|---------|
-| `Native` | The platform API directly supports the feature. |
-| `Emulated` | The backend implements correct output through helper code, offscreen buffers, tessellation, or shaders. |
-| `Degraded` | The backend produces approximate output and documents the difference. |
 | `Unsupported` | The backend must reject the scene when strict rendering is requested. |
+| `Degraded` | The backend produces approximate output and may be selected only when the caller allows degradation. |
+| `Supported` | The backend should render the feature faithfully within its documented tolerances, whether natively or through correct emulation. |
 
 Development builds should prefer loud failures for `Unsupported`. Production
 callers may opt into degraded rendering, but that choice belongs to the caller
@@ -185,13 +185,15 @@ pub struct PaintSceneRequirements {
     pub uses_line: bool,
     pub uses_ellipse: bool,
     pub uses_path: bool,
-    pub uses_arc_to: bool,
+    pub uses_path_arc_to: bool,
     pub uses_glyph_run: bool,
     pub uses_text: bool,
     pub uses_image: bool,
     pub uses_clip: bool,
+    pub uses_group: bool,
     pub uses_group_transform: bool,
     pub uses_group_opacity: bool,
+    pub uses_layer: bool,
     pub uses_layer_opacity: bool,
     pub uses_layer_filters: bool,
     pub uses_layer_blend_modes: bool,
@@ -502,10 +504,11 @@ Only Tier 2 and above should be candidates for automatic pipeline selection.
 
 ## Current Gaps to Close
 
-Known gaps after the GDI arc convergence work:
+Known gaps after the GDI runtime adapter work:
 
 | Area | Status |
 |------|--------|
+| GDI runtime adapter | Implemented; `paint-vm-gdi` now exposes a `PaintRenderer` adapter, descriptor, capabilities, and runtime registry smoke test. |
 | GDI `PathCommand::ArcTo` | Implemented by converting SVG arcs to cubic Beziers and rendering them through the existing GDI path pipeline. |
 | GDI gradients | Not implemented. |
 | GDI layer filters and blend modes | Layer opacity/transform works; filters/blend modes are not implemented. |
@@ -513,19 +516,21 @@ Known gaps after the GDI arc convergence work:
 | Direct2D gradients | Not implemented. |
 | Direct2D layer filters and blend modes | Layer opacity works; full effects/blend modes are not implemented. |
 | Metal text | Still partial. Glyph/text convergence remains a larger font-system project. |
-| Cairo/Skia/Vulkan/OpenGL/WGPU/CoreGraphics | Crates not implemented yet. |
+| Cairo/Skia/Vulkan/OpenGL/WGPU/OpenCL/Mesa/CoreGraphics | Scaffold crates exist for all except CoreGraphics; drawing implementations are not yet wired. |
 
 Recommended immediate order:
 
 1. Direct2D `PaintText`, to restore symmetry with GDI for the string-text path.
-2. Direct2D and GDI gradients.
-3. Cairo Tier 1.
-4. Skia Tier 1, then Tier 2.
-5. Shared `paint-vm-gpu-core`.
-6. WGPU Tier 1.
-7. Vulkan Tier 1.
-8. OpenGL Tier 1.
-9. Filters and advanced blend modes across GPU-capable backends.
+2. Direct2D runtime adapter once `PaintText` lands.
+3. Direct2D and GDI gradients.
+4. Cairo Tier 1.
+5. Skia Tier 1, then Tier 2.
+6. Shared `paint-vm-gpu-core`.
+7. WGPU Tier 1.
+8. Vulkan Tier 1.
+9. OpenGL and Mesa-backed Tier 1.
+10. OpenCL compute raster experiments for filters/software paths.
+11. Filters and advanced blend modes across GPU-capable backends.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a `PaintRenderer` adapter for `paint-vm-gdi` so the runtime registry can select and render through the existing GDI backend
- publish GDI backend descriptors/capabilities, including text, glyph runs, image, groups, layers, and ArcTo support while keeping gradients/filters/blends unsupported
- add focused tests that verify GDI capability reporting and runtime registry rendering
- align P2D09 with the implemented runtime support-level model and record GDI as a pluggable backend

## Verification
- `cargo test --manifest-path code/packages/rust/paint-vm-gdi/Cargo.toml -- --nocapture`
- `cargo test --manifest-path code/packages/rust/paint-vm-runtime/Cargo.toml -- --nocapture`