### PR TITLE
Add native Cairo Paint VM backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,12 @@ jobs:
         if: needs.detect.outputs.needs_rust == 'true'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install native Paint VM dependencies
+        if: needs.detect.outputs.needs_rust == 'true' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev
+
       - name: Install cargo-tarpaulin
         if: needs.detect.outputs.needs_rust == 'true' && runner.os == 'Linux'
         run: cargo install cargo-tarpaulin

--- a/code/packages/rust/paint-vm-cairo/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-cairo/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added native Linux/BSD Cairo image-surface rendering through `cairo-rs`.
+- Added deterministic non-Cairo fallback rendering for non-Linux/BSD targets.
+- Added runtime descriptor capabilities and selection tests.
+- Added smoke coverage for rects, clipping, text visibility, and runtime
+  degraded-text opt-in.

--- a/code/packages/rust/paint-vm-cairo/Cargo.toml
+++ b/code/packages/rust/paint-vm-cairo/Cargo.toml
@@ -2,8 +2,11 @@
 name = "paint-vm-cairo"
 version = "0.1.0"
 edition = "2021"
-description = "Cairo backend scaffold for the Paint VM runtime"
+description = "Cairo backend for the Paint VM runtime"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
 paint-vm-runtime = { path = "../paint-vm-runtime" }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+cairo-rs = { version = "0.20.12", default-features = false }

--- a/code/packages/rust/paint-vm-cairo/README.md
+++ b/code/packages/rust/paint-vm-cairo/README.md
@@ -1,0 +1,43 @@
+# paint-vm-cairo
+
+Cairo backend for the Paint VM runtime.
+
+This crate renders `paint-instructions::PaintScene` values through native
+Cairo on Linux and BSD targets. Other desktop targets keep a deterministic
+software smoke renderer so the runtime can still compile and exercise Cairo
+selection behavior without requiring Cairo DLL/framework installation.
+
+## Status
+
+| Area | Status |
+|------|--------|
+| Native Cairo image surface | Implemented on Linux/BSD via `cairo-rs` |
+| Rect, line, ellipse, path | Implemented, except SVG `ArcTo` lowering |
+| Clip, group transform, layer opacity | Implemented natively |
+| Image pixels | Implemented for `ImageSrc::Pixels` |
+| Text | Degraded, uses Cairo toy text API |
+| Glyph runs | Degraded, uses Cairo glyph APIs without full shaping integration |
+| Gradients | Not implemented |
+| Layer filters / blend modes | Not implemented |
+
+## Linux Dependencies
+
+Native builds require Cairo development headers:
+
+```bash
+sudo apt-get install -y libcairo2-dev
+```
+
+Pango/HarfBuzz integration is intentionally not part of this first slice. Text
+is visible for smoke tests, but full text parity should come through the shared
+font/shaping pipeline and `pangocairo`.
+
+## Runtime Use
+
+```rust
+let backend = paint_vm_cairo::renderer();
+let pixels = backend.render(&scene)?;
+```
+
+For backend selection, register this renderer with `paint-vm-runtime`. Exact
+text selection will reject Cairo for now unless degraded text is allowed.

--- a/code/packages/rust/paint-vm-cairo/src/lib.rs
+++ b/code/packages/rust/paint-vm-cairo/src/lib.rs
@@ -1,24 +1,187 @@
-//! Cairo backend scaffold for the Paint VM runtime.
+//! Cairo backend adapter for the Paint VM runtime.
+//!
+//! Linux and BSD targets render through native `cairo-rs` image surfaces.
+//! Other desktop targets keep a deterministic software smoke path so pipeline
+//! selection and compatibility fixtures can still exercise the Cairo-family
+//! backend without requiring Cairo DLLs/frameworks everywhere.
 
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+use paint_instructions::{
+    GlyphPosition, ImageSrc, PaintClip, PaintEllipse, PaintGlyphRun, PaintGroup, PaintImage,
+    PaintInstruction, PaintLayer, PaintPath, PaintRect, PaintText, PathCommand, TextAlign,
+};
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_runtime::{
-    PaintAcceleration, PaintBackendDescriptor, PaintBackendFamily, PaintPlatformSupport,
-    PaintRenderError, PaintRenderer,
+    PaintAcceleration, PaintBackendCapabilities, PaintBackendDescriptor, PaintBackendFamily,
+    PaintBackendTier, PaintPlatformSupport, PaintRenderError, PaintRenderer, SupportLevel,
 };
 
 pub const VERSION: &str = "0.1.0";
 
+const BACKEND_ID: &str = "paint-vm-cairo";
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Rgba {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+impl Rgba {
+    const TRANSPARENT: Self = Self {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    };
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    )))]
+    fn with_alpha(self, opacity: f64) -> Self {
+        Self {
+            a: ((self.a as f64 * opacity.clamp(0.0, 1.0)).round() as u8),
+            ..self
+        }
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ClipRect {
+    x0: i32,
+    y0: i32,
+    x1: i32,
+    y1: i32,
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+impl ClipRect {
+    fn full(width: u32, height: u32) -> Self {
+        Self {
+            x0: 0,
+            y0: 0,
+            x1: width as i32,
+            y1: height as i32,
+        }
+    }
+
+    fn intersect(self, other: Self) -> Self {
+        Self {
+            x0: self.x0.max(other.x0),
+            y0: self.y0.max(other.y0),
+            x1: self.x1.min(other.x1),
+            y1: self.y1.min(other.y1),
+        }
+    }
+
+    fn contains(self, x: i32, y: i32) -> bool {
+        x >= self.x0 && x < self.x1 && y >= self.y0 && y < self.y1
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RenderState {
+    clip: ClipRect,
+    opacity: f64,
+}
+
 pub struct CairoPaintBackend;
 
 pub fn descriptor() -> PaintBackendDescriptor {
-    PaintBackendDescriptor::scaffold(
-        "paint-vm-cairo",
-        "Paint VM Cairo",
-        PaintBackendFamily::Cairo,
-        PaintAcceleration::Cpu,
-        PaintPlatformSupport::all_desktop(),
-        40,
-    )
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    let capabilities = PaintBackendCapabilities {
+        rect: SupportLevel::Supported,
+        line: SupportLevel::Supported,
+        ellipse: SupportLevel::Supported,
+        path: SupportLevel::Supported,
+        path_arc_to: SupportLevel::Unsupported,
+        glyph_run: SupportLevel::Degraded,
+        text: SupportLevel::Degraded,
+        image: SupportLevel::Supported,
+        clip: SupportLevel::Supported,
+        group: SupportLevel::Supported,
+        group_transform: SupportLevel::Supported,
+        group_opacity: SupportLevel::Supported,
+        layer: SupportLevel::Supported,
+        layer_opacity: SupportLevel::Supported,
+        layer_filters: SupportLevel::Unsupported,
+        layer_blend_modes: SupportLevel::Unsupported,
+        linear_gradient: SupportLevel::Unsupported,
+        radial_gradient: SupportLevel::Unsupported,
+        antialiasing: SupportLevel::Supported,
+        offscreen_pixels: SupportLevel::Supported,
+    };
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    )))]
+    let capabilities = PaintBackendCapabilities {
+        rect: SupportLevel::Supported,
+        line: SupportLevel::Supported,
+        ellipse: SupportLevel::Supported,
+        path: SupportLevel::Degraded,
+        path_arc_to: SupportLevel::Unsupported,
+        glyph_run: SupportLevel::Degraded,
+        text: SupportLevel::Degraded,
+        image: SupportLevel::Degraded,
+        clip: SupportLevel::Supported,
+        group: SupportLevel::Supported,
+        group_transform: SupportLevel::Unsupported,
+        group_opacity: SupportLevel::Degraded,
+        layer: SupportLevel::Degraded,
+        layer_opacity: SupportLevel::Degraded,
+        layer_filters: SupportLevel::Unsupported,
+        layer_blend_modes: SupportLevel::Unsupported,
+        linear_gradient: SupportLevel::Unsupported,
+        radial_gradient: SupportLevel::Unsupported,
+        antialiasing: SupportLevel::Degraded,
+        offscreen_pixels: SupportLevel::Supported,
+    };
+
+    PaintBackendDescriptor {
+        id: BACKEND_ID,
+        display_name: "Paint VM Cairo",
+        family: PaintBackendFamily::Cairo,
+        acceleration: PaintAcceleration::Cpu,
+        tier: PaintBackendTier::Tier1Smoke,
+        platforms: PaintPlatformSupport::all_desktop(),
+        capabilities,
+        priority: 40,
+    }
 }
 
 pub fn renderer() -> CairoPaintBackend {
@@ -34,22 +197,1359 @@ impl PaintRenderer for CairoPaintBackend {
         descriptor()
     }
 
-    fn render(&self, _scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
-        Err(PaintRenderError::BackendUnavailable {
-            backend: "paint-vm-cairo",
-            reason: "Cairo drawing pipeline is scaffolded but not implemented yet",
-        })
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        ))]
+        {
+            native_cairo::render(scene)
+        }
+
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )))]
+        {
+            render_software(scene)
+        }
     }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+fn render_software(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+    let width = scene.width.ceil().max(0.0) as u32;
+    let height = scene.height.ceil().max(0.0) as u32;
+    let mut surface = SoftwareSurface::new(width, height);
+    surface.clear(parse_css_color(&scene.background));
+
+    let state = RenderState {
+        clip: ClipRect::full(width, height),
+        opacity: 1.0,
+    };
+    for instruction in &scene.instructions {
+        surface.render_instruction(instruction, state)?;
+    }
+
+    Ok(surface.into_pixels())
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+mod native_cairo {
+    use super::{parse_css_color, render_failed, Rgba, BACKEND_ID};
+    use cairo::{
+        Context, FillRule as CairoFillRule, FontSlant, FontWeight, Format, Glyph, ImageSurface,
+        LineCap, LineJoin, Matrix, Operator,
+    };
+    use paint_instructions::{
+        FillRule as PaintFillRule, GlyphPosition, ImageSrc, PaintClip, PaintEllipse, PaintGlyphRun,
+        PaintGroup, PaintImage, PaintInstruction, PaintLayer, PaintLine, PaintPath, PaintRect,
+        PaintScene, PaintText, PathCommand, PixelContainer, StrokeCap, StrokeJoin, TextAlign,
+        Transform2D,
+    };
+    use paint_vm_runtime::{PaintRenderError, SupportLevel};
+
+    pub fn render(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        let width = scene.width.ceil().max(0.0) as i32;
+        let height = scene.height.ceil().max(0.0) as i32;
+        let surface = ImageSurface::create(Format::ARgb32, width, height).map_err(cairo_error)?;
+
+        {
+            let cr = Context::new(&surface).map_err(cairo_error)?;
+            clear(&cr, parse_css_color(&scene.background))?;
+            for instruction in &scene.instructions {
+                render_instruction(&cr, instruction, 1.0)?;
+            }
+        }
+
+        surface.flush();
+        surface_to_pixels(surface, width as u32, height as u32)
+    }
+
+    fn clear(cr: &Context, color: Rgba) -> Result<(), PaintRenderError> {
+        cr.save().map_err(cairo_error)?;
+        cr.set_operator(Operator::Source);
+        set_source(cr, color, 1.0);
+        cr.paint().map_err(cairo_error)?;
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_instruction(
+        cr: &Context,
+        instruction: &PaintInstruction,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        match instruction {
+            PaintInstruction::Rect(rect) => render_rect(cr, rect, opacity),
+            PaintInstruction::Line(line) => render_line(cr, line, opacity),
+            PaintInstruction::Ellipse(ellipse) => render_ellipse(cr, ellipse, opacity),
+            PaintInstruction::Path(path) => render_path(cr, path, opacity),
+            PaintInstruction::Text(text) => render_text(cr, text, opacity),
+            PaintInstruction::GlyphRun(run) => render_glyph_run(cr, run, opacity),
+            PaintInstruction::Group(group) => render_group(cr, group, opacity),
+            PaintInstruction::Layer(layer) => render_layer(cr, layer, opacity),
+            PaintInstruction::Clip(clip) => render_clip(cr, clip, opacity),
+            PaintInstruction::Gradient(_) => Err(render_failed(
+                "native Cairo renderer does not implement gradients yet",
+            )),
+            PaintInstruction::Image(image) => render_image(cr, image, opacity),
+        }
+    }
+
+    fn render_rect(cr: &Context, rect: &PaintRect, opacity: f64) -> Result<(), PaintRenderError> {
+        append_rounded_rect(
+            cr,
+            rect.x,
+            rect.y,
+            rect.width,
+            rect.height,
+            rect.corner_radius,
+        );
+        if let Some(fill) = &rect.fill {
+            set_source(cr, parse_css_color(fill), opacity);
+            if rect.stroke.is_some() {
+                cr.fill_preserve().map_err(cairo_error)?;
+            } else {
+                cr.fill().map_err(cairo_error)?;
+            }
+        }
+        if let Some(stroke) = &rect.stroke {
+            apply_stroke(
+                cr,
+                rect.stroke_width,
+                None,
+                rect.stroke_dash.as_deref(),
+                rect.stroke_dash_offset,
+            );
+            set_source(cr, parse_css_color(stroke), opacity);
+            cr.stroke().map_err(cairo_error)?;
+        } else {
+            cr.new_path();
+        }
+        Ok(())
+    }
+
+    fn render_line(cr: &Context, line: &PaintLine, opacity: f64) -> Result<(), PaintRenderError> {
+        cr.new_path();
+        cr.move_to(line.x1, line.y1);
+        cr.line_to(line.x2, line.y2);
+        apply_stroke(
+            cr,
+            line.stroke_width,
+            line.stroke_cap.as_ref(),
+            line.stroke_dash.as_deref(),
+            line.stroke_dash_offset,
+        );
+        set_source(cr, parse_css_color(&line.stroke), opacity);
+        cr.stroke().map_err(cairo_error)
+    }
+
+    fn render_ellipse(
+        cr: &Context,
+        ellipse: &PaintEllipse,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        if ellipse.rx <= 0.0 || ellipse.ry <= 0.0 {
+            return Ok(());
+        }
+
+        cr.save().map_err(cairo_error)?;
+        cr.translate(ellipse.cx, ellipse.cy);
+        cr.scale(ellipse.rx, ellipse.ry);
+        cr.arc(0.0, 0.0, 1.0, 0.0, std::f64::consts::TAU);
+        cr.restore().map_err(cairo_error)?;
+
+        if let Some(fill) = &ellipse.fill {
+            set_source(cr, parse_css_color(fill), opacity);
+            if ellipse.stroke.is_some() {
+                cr.fill_preserve().map_err(cairo_error)?;
+            } else {
+                cr.fill().map_err(cairo_error)?;
+            }
+        }
+        if let Some(stroke) = &ellipse.stroke {
+            apply_stroke(
+                cr,
+                ellipse.stroke_width,
+                None,
+                ellipse.stroke_dash.as_deref(),
+                ellipse.stroke_dash_offset,
+            );
+            set_source(cr, parse_css_color(stroke), opacity);
+            cr.stroke().map_err(cairo_error)?;
+        } else {
+            cr.new_path();
+        }
+        Ok(())
+    }
+
+    fn render_path(cr: &Context, path: &PaintPath, opacity: f64) -> Result<(), PaintRenderError> {
+        if path
+            .commands
+            .iter()
+            .any(|command| matches!(command, PathCommand::ArcTo { .. }))
+        {
+            return Err(render_failed(
+                "native Cairo renderer does not lower SVG ArcTo commands yet",
+            ));
+        }
+
+        cr.new_path();
+        let mut first = None::<(f64, f64)>;
+        let mut cursor = None::<(f64, f64)>;
+        for command in &path.commands {
+            match *command {
+                PathCommand::MoveTo { x, y } => {
+                    first = Some((x, y));
+                    cursor = Some((x, y));
+                    cr.move_to(x, y);
+                }
+                PathCommand::LineTo { x, y } => {
+                    cursor = Some((x, y));
+                    cr.line_to(x, y);
+                }
+                PathCommand::QuadTo { cx, cy, x, y } => {
+                    if let Some((x0, y0)) = cursor {
+                        let c1x = x0 + (2.0 / 3.0) * (cx - x0);
+                        let c1y = y0 + (2.0 / 3.0) * (cy - y0);
+                        let c2x = x + (2.0 / 3.0) * (cx - x);
+                        let c2y = y + (2.0 / 3.0) * (cy - y);
+                        cr.curve_to(c1x, c1y, c2x, c2y, x, y);
+                    }
+                    cursor = Some((x, y));
+                }
+                PathCommand::CubicTo {
+                    cx1,
+                    cy1,
+                    cx2,
+                    cy2,
+                    x,
+                    y,
+                } => {
+                    cursor = Some((x, y));
+                    cr.curve_to(cx1, cy1, cx2, cy2, x, y);
+                }
+                PathCommand::Close => {
+                    if first.is_some() {
+                        cr.close_path();
+                        cursor = first;
+                    }
+                }
+                PathCommand::ArcTo { .. } => unreachable!("ArcTo rejected before path lowering"),
+            }
+        }
+
+        cr.set_fill_rule(
+            match path.fill_rule.as_ref().unwrap_or(&PaintFillRule::NonZero) {
+                PaintFillRule::NonZero => CairoFillRule::Winding,
+                PaintFillRule::EvenOdd => CairoFillRule::EvenOdd,
+            },
+        );
+
+        if let Some(fill) = &path.fill {
+            set_source(cr, parse_css_color(fill), opacity);
+            if path.stroke.is_some() {
+                cr.fill_preserve().map_err(cairo_error)?;
+            } else {
+                cr.fill().map_err(cairo_error)?;
+            }
+        }
+        if let Some(stroke) = &path.stroke {
+            apply_stroke(
+                cr,
+                path.stroke_width,
+                path.stroke_cap.as_ref(),
+                path.stroke_dash.as_deref(),
+                path.stroke_dash_offset,
+            );
+            if let Some(join) = &path.stroke_join {
+                cr.set_line_join(match join {
+                    StrokeJoin::Miter => LineJoin::Miter,
+                    StrokeJoin::Round => LineJoin::Round,
+                    StrokeJoin::Bevel => LineJoin::Bevel,
+                });
+            }
+            set_source(cr, parse_css_color(stroke), opacity);
+            cr.stroke().map_err(cairo_error)?;
+        } else {
+            cr.new_path();
+        }
+
+        Ok(())
+    }
+
+    fn render_text(cr: &Context, text: &PaintText, opacity: f64) -> Result<(), PaintRenderError> {
+        cr.save().map_err(cairo_error)?;
+        cr.select_font_face(
+            font_family(text.font_ref.as_deref()).as_str(),
+            FontSlant::Normal,
+            FontWeight::Normal,
+        );
+        cr.set_font_size(text.font_size);
+        set_source(
+            cr,
+            parse_css_color(text.fill.as_deref().unwrap_or("#000000")),
+            opacity,
+        );
+
+        let extents = cr.text_extents(&text.text).map_err(cairo_error)?;
+        let x = match text.text_align.as_ref().unwrap_or(&TextAlign::Left) {
+            TextAlign::Left => text.x,
+            TextAlign::Center => text.x - extents.width() / 2.0,
+            TextAlign::Right => text.x - extents.width(),
+        };
+        cr.move_to(x, text.y);
+        cr.show_text(&text.text).map_err(cairo_error)?;
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_glyph_run(
+        cr: &Context,
+        run: &PaintGlyphRun,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        cr.save().map_err(cairo_error)?;
+        cr.select_font_face(
+            font_family(Some(&run.font_ref)).as_str(),
+            FontSlant::Normal,
+            FontWeight::Normal,
+        );
+        cr.set_font_size(run.font_size);
+        set_source(
+            cr,
+            parse_css_color(run.fill.as_deref().unwrap_or("#000000")),
+            opacity,
+        );
+        let glyphs: Vec<Glyph> = run
+            .glyphs
+            .iter()
+            .map(|GlyphPosition { glyph_id, x, y }| Glyph::new(*glyph_id as u64, *x, *y))
+            .collect();
+        cr.show_glyphs(&glyphs).map_err(cairo_error)?;
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_group(
+        cr: &Context,
+        group: &PaintGroup,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        let opacity = opacity * group.opacity.unwrap_or(1.0).clamp(0.0, 1.0);
+        cr.save().map_err(cairo_error)?;
+        if let Some(transform) = group.transform {
+            apply_transform(cr, transform);
+        }
+        for child in &group.children {
+            render_instruction(cr, child, opacity)?;
+        }
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_layer(
+        cr: &Context,
+        layer: &PaintLayer,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        if layer
+            .filters
+            .as_ref()
+            .is_some_and(|filters| !filters.is_empty())
+        {
+            return Err(render_failed(
+                "native Cairo renderer does not implement layer filters yet",
+            ));
+        }
+        if layer.blend_mode.is_some() {
+            return Err(render_failed(
+                "native Cairo renderer does not implement layer blend modes yet",
+            ));
+        }
+
+        cr.save().map_err(cairo_error)?;
+        if let Some(transform) = layer.transform {
+            apply_transform(cr, transform);
+        }
+        cr.push_group();
+        for child in &layer.children {
+            render_instruction(cr, child, 1.0)?;
+        }
+        cr.pop_group_to_source().map_err(cairo_error)?;
+        cr.paint_with_alpha(opacity * layer.opacity.unwrap_or(1.0).clamp(0.0, 1.0))
+            .map_err(cairo_error)?;
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_clip(cr: &Context, clip: &PaintClip, opacity: f64) -> Result<(), PaintRenderError> {
+        cr.save().map_err(cairo_error)?;
+        cr.rectangle(clip.x, clip.y, clip.width, clip.height);
+        cr.clip();
+        for child in &clip.children {
+            render_instruction(cr, child, opacity)?;
+        }
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn render_image(
+        cr: &Context,
+        image: &PaintImage,
+        opacity: f64,
+    ) -> Result<(), PaintRenderError> {
+        let ImageSrc::Pixels(src) = &image.src else {
+            return Err(render_failed(
+                "native Cairo renderer only supports ImageSrc::Pixels",
+            ));
+        };
+        if image.width <= 0.0 || image.height <= 0.0 || src.width == 0 || src.height == 0 {
+            return Ok(());
+        }
+
+        let source = image_surface_from_pixels(src)?;
+        cr.save().map_err(cairo_error)?;
+        cr.translate(image.x, image.y);
+        cr.scale(
+            image.width / src.width as f64,
+            image.height / src.height as f64,
+        );
+        cr.set_source_surface(&source, 0.0, 0.0)
+            .map_err(cairo_error)?;
+        cr.paint_with_alpha(opacity * image.opacity.unwrap_or(1.0).clamp(0.0, 1.0))
+            .map_err(cairo_error)?;
+        cr.restore().map_err(cairo_error)
+    }
+
+    fn append_rounded_rect(
+        cr: &Context,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        radius: Option<f64>,
+    ) {
+        let radius = radius
+            .unwrap_or(0.0)
+            .max(0.0)
+            .min(width / 2.0)
+            .min(height / 2.0);
+        cr.new_path();
+        if radius <= f64::EPSILON {
+            cr.rectangle(x, y, width, height);
+            return;
+        }
+
+        cr.new_sub_path();
+        cr.arc(
+            x + width - radius,
+            y + radius,
+            radius,
+            -std::f64::consts::FRAC_PI_2,
+            0.0,
+        );
+        cr.arc(
+            x + width - radius,
+            y + height - radius,
+            radius,
+            0.0,
+            std::f64::consts::FRAC_PI_2,
+        );
+        cr.arc(
+            x + radius,
+            y + height - radius,
+            radius,
+            std::f64::consts::FRAC_PI_2,
+            std::f64::consts::PI,
+        );
+        cr.arc(
+            x + radius,
+            y + radius,
+            radius,
+            std::f64::consts::PI,
+            std::f64::consts::PI * 1.5,
+        );
+        cr.close_path();
+    }
+
+    fn apply_stroke(
+        cr: &Context,
+        width: Option<f64>,
+        cap: Option<&StrokeCap>,
+        dash: Option<&[f64]>,
+        dash_offset: Option<f64>,
+    ) {
+        cr.set_line_width(width.unwrap_or(1.0).max(1.0));
+        cr.set_line_cap(match cap.unwrap_or(&StrokeCap::Butt) {
+            StrokeCap::Butt => LineCap::Butt,
+            StrokeCap::Round => LineCap::Round,
+            StrokeCap::Square => LineCap::Square,
+        });
+        if let Some(dash) = dash {
+            cr.set_dash(dash, dash_offset.unwrap_or(0.0));
+        } else {
+            cr.set_dash(&[], 0.0);
+        }
+    }
+
+    fn apply_transform(cr: &Context, transform: Transform2D) {
+        let [a, b, c, d, e, f] = transform;
+        cr.transform(Matrix::new(a, b, c, d, e, f));
+    }
+
+    fn set_source(cr: &Context, color: Rgba, opacity: f64) {
+        let alpha = (color.a as f64 / 255.0) * opacity.clamp(0.0, 1.0);
+        cr.set_source_rgba(
+            color.r as f64 / 255.0,
+            color.g as f64 / 255.0,
+            color.b as f64 / 255.0,
+            alpha,
+        );
+    }
+
+    fn font_family(font_ref: Option<&str>) -> String {
+        let Some(font_ref) = font_ref else {
+            return "Sans".to_string();
+        };
+        let spec = font_ref
+            .strip_prefix("canvas:")
+            .or_else(|| font_ref.strip_prefix("directwrite:"))
+            .unwrap_or(font_ref);
+        spec.split('@')
+            .next()
+            .filter(|family| !family.is_empty())
+            .unwrap_or("Sans")
+            .to_string()
+    }
+
+    fn image_surface_from_pixels(src: &PixelContainer) -> Result<ImageSurface, PaintRenderError> {
+        let stride = src.width as usize * 4;
+        let mut data = vec![0u8; stride * src.height as usize];
+        for y in 0..src.height {
+            for x in 0..src.width {
+                let (r, g, b, a) = src.pixel_at(x, y);
+                let i = (y as usize * stride) + x as usize * 4;
+                data[i] = premultiply(b, a);
+                data[i + 1] = premultiply(g, a);
+                data[i + 2] = premultiply(r, a);
+                data[i + 3] = a;
+            }
+        }
+        ImageSurface::create_for_data(
+            data,
+            Format::ARgb32,
+            src.width as i32,
+            src.height as i32,
+            stride as i32,
+        )
+        .map_err(cairo_error)
+    }
+
+    fn surface_to_pixels(
+        mut surface: ImageSurface,
+        width: u32,
+        height: u32,
+    ) -> Result<PixelContainer, PaintRenderError> {
+        let stride = surface.stride() as usize;
+        let data = surface.data().map_err(cairo_error)?;
+        let mut pixels = PixelContainer::new(width, height);
+        for y in 0..height {
+            for x in 0..width {
+                let i = y as usize * stride + x as usize * 4;
+                let b = data[i];
+                let g = data[i + 1];
+                let r = data[i + 2];
+                let a = data[i + 3];
+                pixels.set_pixel(
+                    x,
+                    y,
+                    unpremultiply(r, a),
+                    unpremultiply(g, a),
+                    unpremultiply(b, a),
+                    a,
+                );
+            }
+        }
+        Ok(pixels)
+    }
+
+    fn premultiply(channel: u8, alpha: u8) -> u8 {
+        ((channel as u16 * alpha as u16 + 127) / 255) as u8
+    }
+
+    fn unpremultiply(channel: u8, alpha: u8) -> u8 {
+        if alpha == 0 {
+            return 0;
+        }
+        ((channel as u16 * 255 + alpha as u16 / 2) / alpha as u16).min(255) as u8
+    }
+
+    fn cairo_error(error: impl std::fmt::Display) -> PaintRenderError {
+        PaintRenderError::RenderFailed {
+            backend: BACKEND_ID,
+            message: error.to_string(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn _assert_text_is_degraded(level: SupportLevel) {
+        debug_assert_eq!(level, SupportLevel::Degraded);
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+struct SoftwareSurface {
+    pixels: PixelContainer,
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+impl SoftwareSurface {
+    fn new(width: u32, height: u32) -> Self {
+        Self {
+            pixels: PixelContainer::new(width, height),
+        }
+    }
+
+    fn clear(&mut self, color: Rgba) {
+        self.pixels.fill(color.r, color.g, color.b, color.a);
+    }
+
+    fn into_pixels(self) -> PixelContainer {
+        self.pixels
+    }
+
+    fn render_instruction(
+        &mut self,
+        instruction: &PaintInstruction,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        match instruction {
+            PaintInstruction::Rect(rect) => self.render_rect(rect, state),
+            PaintInstruction::Line(line) => {
+                self.render_line(
+                    line.x1,
+                    line.y1,
+                    line.x2,
+                    line.y2,
+                    parse_css_color(&line.stroke).with_alpha(state.opacity),
+                    line.stroke_width.unwrap_or(1.0),
+                    state,
+                );
+                Ok(())
+            }
+            PaintInstruction::Ellipse(ellipse) => self.render_ellipse(ellipse, state),
+            PaintInstruction::Path(path) => self.render_path(path, state),
+            PaintInstruction::Text(text) => self.render_text(text, state),
+            PaintInstruction::GlyphRun(run) => self.render_glyph_run(run, state),
+            PaintInstruction::Group(group) => self.render_group(group, state),
+            PaintInstruction::Layer(layer) => self.render_layer(layer, state),
+            PaintInstruction::Clip(clip) => self.render_clip(clip, state),
+            PaintInstruction::Gradient(_) => Err(render_failed(
+                "Cairo smoke renderer does not implement gradients yet",
+            )),
+            PaintInstruction::Image(image) => self.render_image(image, state),
+        }
+    }
+
+    fn render_rect(
+        &mut self,
+        rect: &PaintRect,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        if let Some(fill) = &rect.fill {
+            self.fill_rect(
+                rect.x,
+                rect.y,
+                rect.width,
+                rect.height,
+                parse_css_color(fill).with_alpha(state.opacity),
+                state.clip,
+            );
+        }
+
+        if let Some(stroke) = &rect.stroke {
+            let color = parse_css_color(stroke).with_alpha(state.opacity);
+            let width = rect.stroke_width.unwrap_or(1.0);
+            self.stroke_rect(rect.x, rect.y, rect.width, rect.height, width, color, state);
+        }
+
+        Ok(())
+    }
+
+    fn render_ellipse(
+        &mut self,
+        ellipse: &PaintEllipse,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        if ellipse.rx <= 0.0 || ellipse.ry <= 0.0 {
+            return Ok(());
+        }
+
+        let x0 = (ellipse.cx - ellipse.rx).floor() as i32;
+        let y0 = (ellipse.cy - ellipse.ry).floor() as i32;
+        let x1 = (ellipse.cx + ellipse.rx).ceil() as i32;
+        let y1 = (ellipse.cy + ellipse.ry).ceil() as i32;
+        let stroke_width = ellipse.stroke_width.unwrap_or(1.0).max(1.0);
+        let stroke_band = (stroke_width / ellipse.rx.max(ellipse.ry)).max(0.01);
+
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let nx = (x as f64 + 0.5 - ellipse.cx) / ellipse.rx;
+                let ny = (y as f64 + 0.5 - ellipse.cy) / ellipse.ry;
+                let distance = nx * nx + ny * ny;
+                if let Some(fill) = &ellipse.fill {
+                    if distance <= 1.0 {
+                        self.blend_pixel(
+                            x,
+                            y,
+                            parse_css_color(fill).with_alpha(state.opacity),
+                            state.clip,
+                        );
+                    }
+                }
+                if let Some(stroke) = &ellipse.stroke {
+                    if (1.0 - stroke_band..=1.0 + stroke_band).contains(&distance) {
+                        self.blend_pixel(
+                            x,
+                            y,
+                            parse_css_color(stroke).with_alpha(state.opacity),
+                            state.clip,
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn render_path(
+        &mut self,
+        path: &PaintPath,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        if path
+            .commands
+            .iter()
+            .any(|command| matches!(command, PathCommand::ArcTo { .. }))
+        {
+            return Err(render_failed(
+                "Cairo smoke renderer cannot lower SVG ArcTo commands yet",
+            ));
+        }
+
+        let stroke = path
+            .stroke
+            .as_ref()
+            .map(|stroke| parse_css_color(stroke).with_alpha(state.opacity));
+        let fill = path
+            .fill
+            .as_ref()
+            .map(|fill| parse_css_color(fill).with_alpha(state.opacity));
+
+        let mut first = None::<(f64, f64)>;
+        let mut cursor = None::<(f64, f64)>;
+        let mut points = Vec::new();
+
+        for command in &path.commands {
+            match *command {
+                PathCommand::MoveTo { x, y } => {
+                    first = Some((x, y));
+                    cursor = Some((x, y));
+                    points.push((x, y));
+                }
+                PathCommand::LineTo { x, y } => {
+                    if let Some((x0, y0)) = cursor {
+                        if let Some(color) = stroke {
+                            self.render_line(
+                                x0,
+                                y0,
+                                x,
+                                y,
+                                color,
+                                path.stroke_width.unwrap_or(1.0),
+                                state,
+                            );
+                        }
+                    }
+                    cursor = Some((x, y));
+                    points.push((x, y));
+                }
+                PathCommand::Close => {
+                    if let (Some((x0, y0)), Some((x1, y1))) = (cursor, first) {
+                        if let Some(color) = stroke {
+                            self.render_line(
+                                x0,
+                                y0,
+                                x1,
+                                y1,
+                                color,
+                                path.stroke_width.unwrap_or(1.0),
+                                state,
+                            );
+                        }
+                    }
+                }
+                PathCommand::QuadTo { x, y, .. } | PathCommand::CubicTo { x, y, .. } => {
+                    if let Some((x0, y0)) = cursor {
+                        if let Some(color) = stroke {
+                            self.render_line(
+                                x0,
+                                y0,
+                                x,
+                                y,
+                                color,
+                                path.stroke_width.unwrap_or(1.0),
+                                state,
+                            );
+                        }
+                    }
+                    cursor = Some((x, y));
+                    points.push((x, y));
+                }
+                PathCommand::ArcTo { .. } => unreachable!("ArcTo rejected before path lowering"),
+            }
+        }
+
+        if let Some(color) = fill {
+            self.fill_polygon_bounds(&points, color, state.clip);
+        }
+
+        Ok(())
+    }
+
+    fn render_text(
+        &mut self,
+        text: &PaintText,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        let color =
+            parse_css_color(text.fill.as_deref().unwrap_or("#000000")).with_alpha(state.opacity);
+        let char_width = (text.font_size * 0.56).max(1.0);
+        let text_width = char_width * text.text.chars().count() as f64;
+        let x = match text.text_align.as_ref().unwrap_or(&TextAlign::Left) {
+            TextAlign::Left => text.x,
+            TextAlign::Center => text.x - text_width / 2.0,
+            TextAlign::Right => text.x - text_width,
+        };
+        let top = text.y - text.font_size;
+        for (index, ch) in text.text.chars().enumerate() {
+            if !ch.is_whitespace() {
+                self.fill_rect(
+                    x + index as f64 * char_width,
+                    top,
+                    (char_width * 0.7).max(1.0),
+                    text.font_size.max(1.0),
+                    color,
+                    state.clip,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn render_glyph_run(
+        &mut self,
+        run: &PaintGlyphRun,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        let color =
+            parse_css_color(run.fill.as_deref().unwrap_or("#000000")).with_alpha(state.opacity);
+        for GlyphPosition { glyph_id, x, y } in &run.glyphs {
+            if *glyph_id != 0 {
+                self.fill_rect(
+                    *x,
+                    *y - run.font_size,
+                    (run.font_size * 0.55).max(1.0),
+                    run.font_size.max(1.0),
+                    color,
+                    state.clip,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn render_group(
+        &mut self,
+        group: &PaintGroup,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        if group.transform.is_some() {
+            return Err(render_failed(
+                "Cairo smoke renderer does not implement group transforms yet",
+            ));
+        }
+        let state = RenderState {
+            opacity: state.opacity * group.opacity.unwrap_or(1.0).clamp(0.0, 1.0),
+            ..state
+        };
+        for child in &group.children {
+            self.render_instruction(child, state)?;
+        }
+        Ok(())
+    }
+
+    fn render_layer(
+        &mut self,
+        layer: &PaintLayer,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        if layer.transform.is_some() {
+            return Err(render_failed(
+                "Cairo smoke renderer does not implement layer transforms yet",
+            ));
+        }
+        if layer
+            .filters
+            .as_ref()
+            .is_some_and(|filters| !filters.is_empty())
+        {
+            return Err(render_failed(
+                "Cairo smoke renderer does not implement layer filters yet",
+            ));
+        }
+        if layer.blend_mode.is_some() {
+            return Err(render_failed(
+                "Cairo smoke renderer does not implement layer blend modes yet",
+            ));
+        }
+        let state = RenderState {
+            opacity: state.opacity * layer.opacity.unwrap_or(1.0).clamp(0.0, 1.0),
+            ..state
+        };
+        for child in &layer.children {
+            self.render_instruction(child, state)?;
+        }
+        Ok(())
+    }
+
+    fn render_clip(
+        &mut self,
+        clip: &PaintClip,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        let clip_rect = ClipRect {
+            x0: clip.x.floor() as i32,
+            y0: clip.y.floor() as i32,
+            x1: (clip.x + clip.width).ceil() as i32,
+            y1: (clip.y + clip.height).ceil() as i32,
+        };
+        let state = RenderState {
+            clip: state.clip.intersect(clip_rect),
+            ..state
+        };
+        for child in &clip.children {
+            self.render_instruction(child, state)?;
+        }
+        Ok(())
+    }
+
+    fn render_image(
+        &mut self,
+        image: &PaintImage,
+        state: RenderState,
+    ) -> Result<(), PaintRenderError> {
+        let ImageSrc::Pixels(src) = &image.src else {
+            return Err(render_failed(
+                "Cairo smoke renderer only supports ImageSrc::Pixels",
+            ));
+        };
+        if image.width <= 0.0 || image.height <= 0.0 || src.width == 0 || src.height == 0 {
+            return Ok(());
+        }
+
+        let opacity = state.opacity * image.opacity.unwrap_or(1.0).clamp(0.0, 1.0);
+        let x0 = image.x.floor() as i32;
+        let y0 = image.y.floor() as i32;
+        let x1 = (image.x + image.width).ceil() as i32;
+        let y1 = (image.y + image.height).ceil() as i32;
+
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let u = ((x as f64 - image.x) / image.width).clamp(0.0, 1.0);
+                let v = ((y as f64 - image.y) / image.height).clamp(0.0, 1.0);
+                let sx = (u * (src.width.saturating_sub(1)) as f64).round() as u32;
+                let sy = (v * (src.height.saturating_sub(1)) as f64).round() as u32;
+                let (r, g, b, a) = src.pixel_at(sx, sy);
+                self.blend_pixel(x, y, Rgba { r, g, b, a }.with_alpha(opacity), state.clip);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fill_rect(&mut self, x: f64, y: f64, width: f64, height: f64, color: Rgba, clip: ClipRect) {
+        if color.a == 0 || width <= 0.0 || height <= 0.0 {
+            return;
+        }
+        let x0 = x.floor() as i32;
+        let y0 = y.floor() as i32;
+        let x1 = (x + width).ceil() as i32;
+        let y1 = (y + height).ceil() as i32;
+        for py in y0..y1 {
+            for px in x0..x1 {
+                self.blend_pixel(px, py, color, clip);
+            }
+        }
+    }
+
+    fn stroke_rect(
+        &mut self,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        stroke_width: f64,
+        color: Rgba,
+        state: RenderState,
+    ) {
+        let stroke_width = stroke_width.max(1.0);
+        self.fill_rect(x, y, width, stroke_width, color, state.clip);
+        self.fill_rect(
+            x,
+            y + height - stroke_width,
+            width,
+            stroke_width,
+            color,
+            state.clip,
+        );
+        self.fill_rect(x, y, stroke_width, height, color, state.clip);
+        self.fill_rect(
+            x + width - stroke_width,
+            y,
+            stroke_width,
+            height,
+            color,
+            state.clip,
+        );
+    }
+
+    fn render_line(
+        &mut self,
+        x0: f64,
+        y0: f64,
+        x1: f64,
+        y1: f64,
+        color: Rgba,
+        stroke_width: f64,
+        state: RenderState,
+    ) {
+        if color.a == 0 {
+            return;
+        }
+        let dx = x1 - x0;
+        let dy = y1 - y0;
+        let steps = dx.abs().max(dy.abs()).ceil().max(1.0) as i32;
+        let radius = (stroke_width.max(1.0) / 2.0).ceil() as i32;
+        for step in 0..=steps {
+            let t = step as f64 / steps as f64;
+            let x = (x0 + dx * t).round() as i32;
+            let y = (y0 + dy * t).round() as i32;
+            for oy in -radius..=radius {
+                for ox in -radius..=radius {
+                    self.blend_pixel(x + ox, y + oy, color, state.clip);
+                }
+            }
+        }
+    }
+
+    fn fill_polygon_bounds(&mut self, points: &[(f64, f64)], color: Rgba, clip: ClipRect) {
+        if points.len() < 3 || color.a == 0 {
+            return;
+        }
+        let (mut x0, mut y0) = (f64::MAX, f64::MAX);
+        let (mut x1, mut y1) = (f64::MIN, f64::MIN);
+        for (x, y) in points {
+            x0 = x0.min(*x);
+            y0 = y0.min(*y);
+            x1 = x1.max(*x);
+            y1 = y1.max(*y);
+        }
+        self.fill_rect(x0, y0, x1 - x0, y1 - y0, color, clip);
+    }
+
+    fn blend_pixel(&mut self, x: i32, y: i32, color: Rgba, clip: ClipRect) {
+        if color.a == 0 || !clip.contains(x, y) || x < 0 || y < 0 {
+            return;
+        }
+        let x = x as u32;
+        let y = y as u32;
+        if x >= self.pixels.width || y >= self.pixels.height {
+            return;
+        }
+
+        let (dr, dg, db, da) = self.pixels.pixel_at(x, y);
+        let sa = color.a as f64 / 255.0;
+        let da = da as f64 / 255.0;
+        let out_a = sa + da * (1.0 - sa);
+        if out_a <= f64::EPSILON {
+            self.pixels.set_pixel(x, y, 0, 0, 0, 0);
+            return;
+        }
+
+        let blend_channel = |src: u8, dst: u8| -> u8 {
+            (((src as f64 * sa) + (dst as f64 * da * (1.0 - sa))) / out_a)
+                .round()
+                .clamp(0.0, 255.0) as u8
+        };
+
+        self.pixels.set_pixel(
+            x,
+            y,
+            blend_channel(color.r, dr),
+            blend_channel(color.g, dg),
+            blend_channel(color.b, db),
+            (out_a * 255.0).round().clamp(0.0, 255.0) as u8,
+        );
+    }
+}
+
+fn render_failed(message: impl Into<String>) -> PaintRenderError {
+    PaintRenderError::RenderFailed {
+        backend: BACKEND_ID,
+        message: message.into(),
+    }
+}
+
+fn parse_css_color(s: &str) -> Rgba {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("transparent") || s.eq_ignore_ascii_case("none") {
+        return Rgba::TRANSPARENT;
+    }
+    if let Some(inner) = s
+        .strip_prefix("rgba(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+        if parts.len() == 4 {
+            return Rgba {
+                r: parse_css_channel(parts[0]),
+                g: parse_css_channel(parts[1]),
+                b: parse_css_channel(parts[2]),
+                a: (parts[3].parse::<f64>().unwrap_or(1.0).clamp(0.0, 1.0) * 255.0).round() as u8,
+            };
+        }
+    }
+    if let Some(inner) = s
+        .strip_prefix("rgb(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+        if parts.len() == 3 {
+            return Rgba {
+                r: parse_css_channel(parts[0]),
+                g: parse_css_channel(parts[1]),
+                b: parse_css_channel(parts[2]),
+                a: 255,
+            };
+        }
+    }
+
+    let hex = s.trim_start_matches('#');
+    let expanded = if hex.len() == 3 {
+        let mut expanded = String::with_capacity(6);
+        for c in hex.chars() {
+            expanded.push(c);
+            expanded.push(c);
+        }
+        expanded
+    } else {
+        hex.to_string()
+    };
+    if expanded.len() < 6 {
+        return Rgba {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 255,
+        };
+    }
+
+    Rgba {
+        r: u8::from_str_radix(&expanded[0..2], 16).unwrap_or(0),
+        g: u8::from_str_radix(&expanded[2..4], 16).unwrap_or(0),
+        b: u8::from_str_radix(&expanded[4..6], 16).unwrap_or(0),
+        a: if expanded.len() >= 8 {
+            u8::from_str_radix(&expanded[6..8], 16).unwrap_or(255)
+        } else {
+            255
+        },
+    }
+}
+
+fn parse_css_channel(s: &str) -> u8 {
+    s.parse::<f64>().unwrap_or(0.0).round().clamp(0.0, 255.0) as u8
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use paint_instructions::{
+        PaintBase, PaintClip, PaintInstruction, PaintRect, PaintText, TextAlign,
+    };
+    use paint_vm_runtime::{
+        PaintBackendPreference, PaintBackendRegistry, PaintFeature, PaintRenderOptions,
+    };
+
+    fn transparent_scene(width: f64, height: f64) -> PaintScene {
+        PaintScene {
+            width,
+            height,
+            background: "transparent".to_string(),
+            instructions: Vec::new(),
+            id: None,
+            metadata: None,
+        }
+    }
 
     #[test]
-    fn exposes_scaffold_descriptor() {
+    fn exposes_tier_one_descriptor() {
         let descriptor = descriptor();
-        assert_eq!(descriptor.id, "paint-vm-cairo");
+        assert_eq!(descriptor.id, BACKEND_ID);
         assert_eq!(descriptor.family, PaintBackendFamily::Cairo);
+        assert_eq!(descriptor.tier, PaintBackendTier::Tier1Smoke);
+        assert_eq!(descriptor.capabilities.rect, SupportLevel::Supported);
+        assert_eq!(descriptor.capabilities.text, SupportLevel::Degraded);
+    }
+
+    #[test]
+    fn renders_filled_rectangles_to_pixels() {
+        let mut scene = transparent_scene(8.0, 8.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                2.0, 2.0, 3.0, 3.0, "#ff0000",
+            )));
+
+        let pixels = render(&scene).expect("rect scene renders");
+
+        assert_eq!(pixels.pixel_at(3, 3), (255, 0, 0, 255));
+        assert_eq!(pixels.pixel_at(0, 0), (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn clips_child_instructions() {
+        let mut scene = transparent_scene(6.0, 6.0);
+        scene.instructions.push(PaintInstruction::Clip(PaintClip {
+            base: PaintBase::default(),
+            x: 2.0,
+            y: 2.0,
+            width: 2.0,
+            height: 2.0,
+            children: vec![PaintInstruction::Rect(PaintRect::filled(
+                0.0, 0.0, 6.0, 6.0, "#00ff00",
+            ))],
+        }));
+
+        let pixels = render(&scene).expect("clip scene renders");
+
+        assert_eq!(pixels.pixel_at(2, 2), (0, 255, 0, 255));
+        assert_eq!(pixels.pixel_at(1, 1), (0, 0, 0, 0));
+        assert_eq!(pixels.pixel_at(4, 4), (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn renders_text_as_degraded_visible_glyph_blocks() {
+        let mut scene = transparent_scene(64.0, 24.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: PaintBase::default(),
+            x: 32.0,
+            y: 18.0,
+            text: "Hi".to_string(),
+            font_ref: None,
+            font_size: 12.0,
+            fill: Some("#0000ff".to_string()),
+            text_align: Some(TextAlign::Center),
+        }));
+
+        let pixels = render(&scene).expect("text smoke scene renders");
+
+        assert!(pixels
+            .data
+            .chunks_exact(4)
+            .any(|pixel| pixel[2] > pixel[0] && pixel[2] > pixel[1] && pixel[3] > 0));
+    }
+
+    #[test]
+    fn runtime_selects_cairo_for_exact_rect_scenes() {
+        let backend = renderer();
+        let mut registry = PaintBackendRegistry::new();
+        registry.register(&backend);
+
+        let mut scene = transparent_scene(4.0, 4.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                0.0, 0.0, 4.0, 4.0, "#111111",
+            )));
+
+        let pixels = registry
+            .render_auto(&scene, PaintRenderOptions::default())
+            .expect("runtime should select Cairo for rect scenes");
+
+        assert_eq!(pixels.pixel_at(1, 1), (17, 17, 17, 255));
+    }
+
+    #[test]
+    fn runtime_requires_degraded_text_opt_in() {
+        let backend = renderer();
+        let mut registry = PaintBackendRegistry::new();
+        registry.register(&backend);
+
+        let mut scene = transparent_scene(32.0, 16.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 12.0,
+            text: "A".to_string(),
+            font_ref: None,
+            font_size: 10.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+
+        let err = match registry.select(&scene, PaintRenderOptions::default()) {
+            Ok(_) => panic!("exact text should reject degraded Cairo text"),
+            Err(err) => err,
+        };
+        assert!(matches!(
+            err,
+            PaintRenderError::NoCompatibleBackend { missing, .. }
+                if missing.contains(&PaintFeature::Text)
+        ));
+
+        let pixels = registry
+            .render_auto(
+                &scene,
+                PaintRenderOptions {
+                    preference: PaintBackendPreference::Named(BACKEND_ID.to_string()),
+                    allow_degraded: true,
+                    require_antialiasing: false,
+                    require_exact_text: false,
+                },
+            )
+            .expect("degraded text opt-in should render");
+        assert!(pixels.data.chunks_exact(4).any(|pixel| pixel[3] != 0));
     }
 }

--- a/code/specs/P2D06-paint-vm-native-backends.md
+++ b/code/specs/P2D06-paint-vm-native-backends.md
@@ -367,14 +367,25 @@ significant limitations:
 | Layer opacity        | Native          | Manual (offscreen blit)   |
 | Rounded rectangles   | Native geometry | Manual (RoundRect or arcs)|
 
-### P2D08 — paint-vm-cairo (Design Only)
+### P2D08 — paint-vm-cairo
 
 **Crate:** `paint-vm-cairo`
-**Platform:** Linux (GTK), BSDs, macOS (via Homebrew)
-**Dependencies:** `cairo-rs` crate, `pango` crate (for text)
-**Status:** Design only. Implementation deferred until Linux platform support begins.
+**Native platform:** Linux (GTK/headless), BSDs.
+
+**Portable fallback:** deterministic software smoke path on Windows/macOS.
+**Current dependencies:** `cairo-rs` crate on Linux/BSD.
+
+**Planned text dependencies:** `pango` / `pangocairo` once full native shaping
+is connected.
+**Status:** Tier 1 native image-surface renderer implemented for Linux/BSD.
 
 **Context type:** `cairo::Context` (wraps `*mut cairo_t`)
+
+The Rust crate now has a Tier 1 native Cairo image-surface renderer for
+Linux/BSD. It supports the core vector smoke path plus `ImageSrc::Pixels`,
+clips, group transforms, and layer opacity. `PaintText` and `PaintGlyphRun`
+are intentionally marked degraded because they use Cairo toy/glyph APIs rather
+than the final Pango/HarfBuzz shaping path.
 
 #### Handler Mapping
 

--- a/code/specs/P2D09-paint-vm-backend-convergence.md
+++ b/code/specs/P2D09-paint-vm-backend-convergence.md
@@ -515,21 +515,21 @@ Known gaps after the GDI runtime adapter work:
 | Direct2D gradients | Not implemented. |
 | Direct2D layer filters and blend modes | Layer opacity works; full effects/blend modes are not implemented. |
 | Metal text | Still partial. Glyph/text convergence remains a larger font-system project. |
-| Cairo/Skia/Vulkan/OpenGL/WGPU/OpenCL/Mesa/CoreGraphics | Scaffold crates exist for all except CoreGraphics; drawing implementations are not yet wired. |
+| Cairo | Tier 1 native path implemented on Linux/BSD via `cairo-rs`; text/glyphs are degraded until Pango/HarfBuzz shaping is connected; gradients and SVG `ArcTo` lowering remain open. |
+| Skia/Vulkan/OpenGL/WGPU/OpenCL/Mesa/CoreGraphics | Scaffold crates exist for all except CoreGraphics; drawing implementations are not yet wired. |
 
 Recommended immediate order:
 
-1. Direct2D `PaintText`, to restore symmetry with GDI for the string-text path.
-2. Direct2D runtime adapter once `PaintText` lands.
-3. Direct2D and GDI gradients.
-4. Cairo Tier 1.
-5. Skia Tier 1, then Tier 2.
-6. Shared `paint-vm-gpu-core`.
-7. WGPU Tier 1.
-8. Vulkan Tier 1.
-9. OpenGL and Mesa-backed Tier 1.
-10. OpenCL compute raster experiments for filters/software paths.
-11. Filters and advanced blend modes across GPU-capable backends.
+1. Direct2D runtime adapter now that `PaintText` has landed.
+2. Direct2D and GDI gradients.
+3. Cairo Pango/HarfBuzz text and SVG `ArcTo` lowering.
+4. Skia Tier 1, then Tier 2.
+5. Shared `paint-vm-gpu-core`.
+6. WGPU Tier 1.
+7. Vulkan Tier 1.
+8. OpenGL and Mesa-backed Tier 1.
+9. OpenCL compute raster experiments for filters/software paths.
+10. Filters and advanced blend modes across GPU-capable backends.
 
 ---
 
@@ -573,7 +573,7 @@ Backends should be isolated so CI can build what the machine supports:
 |---------|----------------|
 | Direct2D | Build and test on Windows runners. |
 | GDI | Build and test on Windows runners. |
-| Cairo | Build and test on Linux runners with Cairo/Pango packages installed. |
+| Cairo | Build and test on Linux runners with Cairo headers installed; add Pango packages when text shaping lands. |
 | Skia | Build on all major OSes if cache/build time is acceptable; otherwise nightly or opt-in CI. |
 | Vulkan | Build everywhere with loader headers; hardware tests opt-in. |
 | OpenGL | Build everywhere; pixel tests require software GL or platform context setup. |


### PR DESCRIPTION
﻿## Summary
- add a native Linux/BSD Cairo renderer for PaintScene via cairo-rs image surfaces
- keep a deterministic non-Cairo fallback path for Windows/macOS runtime smoke coverage
- document Cairo Tier 1 status and install Cairo headers in Linux CI

## Tests
- cargo test --manifest-path code/packages/rust/paint-vm-cairo/Cargo.toml -- --nocapture
- wsl -d Ubuntu bash -lc "cd /mnt/c/Users/adhit/Downloads/Codex/coding-adventures && COLUMNS=120 LINES=40 CARGO_TERM_COLOR=never CARGO_TARGET_DIR=/tmp/codex-cairo-target ~/.cargo/bin/cargo test --manifest-path code/packages/rust/paint-vm-cairo/Cargo.toml -- --nocapture"
