### PR TITLE
Add GPU backend plan adapter profiles

### DIFF
--- a/code/packages/rust/paint-vm-gpu-core/src/lib.rs
+++ b/code/packages/rust/paint-vm-gpu-core/src/lib.rs
@@ -124,6 +124,67 @@ pub struct GpuPlanOptions {
     pub curve_segments: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpuApiFamily {
+    Vulkan,
+    OpenGl,
+    Mesa,
+    OpenCl,
+    Wgpu,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpuRenderPath {
+    GraphicsPipeline,
+    ComputeRaster,
+    DriverProfile,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpuReadbackStrategy {
+    TextureCopyToBuffer,
+    FramebufferReadPixels,
+    StorageBufferReadback,
+    DelegatedToProfile,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GpuBackendProfile {
+    pub id: &'static str,
+    pub family: GpuApiFamily,
+    pub render_path: GpuRenderPath,
+    pub shader_model: &'static str,
+    pub readback: GpuReadbackStrategy,
+    pub supports_indexed_meshes: bool,
+    pub supports_scissor_clips: bool,
+    pub supports_texture_sampling: bool,
+    pub supports_glyph_atlas: bool,
+    pub accepts_degraded_solid_gradients: bool,
+}
+
+impl GpuBackendProfile {
+    pub const fn tier1_solid(
+        id: &'static str,
+        family: GpuApiFamily,
+        render_path: GpuRenderPath,
+        shader_model: &'static str,
+        readback: GpuReadbackStrategy,
+    ) -> Self {
+        Self {
+            id,
+            family,
+            render_path,
+            shader_model,
+            readback,
+            supports_indexed_meshes: true,
+            supports_scissor_clips: true,
+            supports_texture_sampling: false,
+            supports_glyph_atlas: false,
+            accepts_degraded_solid_gradients: true,
+        }
+    }
+}
+
 impl Default for GpuPlanOptions {
     fn default() -> Self {
         Self {
@@ -135,6 +196,52 @@ impl Default for GpuPlanOptions {
 
 pub fn plan_scene(scene: &PaintScene) -> GpuPaintPlan {
     plan_scene_with_options(scene, GpuPlanOptions::default())
+}
+
+pub fn unsupported_plan_features(
+    profile: GpuBackendProfile,
+    plan: &GpuPaintPlan,
+) -> Vec<&'static str> {
+    let mut unsupported = Vec::new();
+    for diagnostic in &plan.diagnostics {
+        match diagnostic.severity {
+            GpuPlanSeverity::Unsupported => push_unique(&mut unsupported, diagnostic.feature),
+            GpuPlanSeverity::Degraded if !profile.accepts_degraded_solid_gradients => {
+                push_unique(&mut unsupported, diagnostic.feature)
+            }
+            GpuPlanSeverity::Info | GpuPlanSeverity::Degraded => {}
+        }
+    }
+    for command in &plan.commands {
+        match command {
+            GpuCommand::DrawMesh { .. } if !profile.supports_indexed_meshes => {
+                push_unique(&mut unsupported, "mesh")
+            }
+            GpuCommand::PushClip { .. } | GpuCommand::PopClip
+                if !profile.supports_scissor_clips =>
+            {
+                push_unique(&mut unsupported, "clip")
+            }
+            GpuCommand::DrawText(_) | GpuCommand::DrawGlyphRun(_)
+                if !profile.supports_glyph_atlas =>
+            {
+                push_unique(&mut unsupported, "text")
+            }
+            _ => {}
+        }
+    }
+    if !profile.supports_texture_sampling
+        && (!plan.images.is_empty() || plan.meshes.iter().any(|mesh| mesh.texture_id.is_some()))
+    {
+        push_unique(&mut unsupported, "image")
+    }
+    unsupported
+}
+
+fn push_unique(features: &mut Vec<&'static str>, feature: &'static str) {
+    if !features.contains(&feature) {
+        features.push(feature);
+    }
 }
 
 pub fn plan_scene_with_options(scene: &PaintScene, options: GpuPlanOptions) -> GpuPaintPlan {
@@ -1156,5 +1263,65 @@ mod tests {
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.feature == "gradient"));
+    }
+
+    #[test]
+    fn tier1_solid_profile_accepts_basic_mesh_plan() {
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                1.0, 2.0, 8.0, 4.0, "#ff0000",
+            )));
+        let profile = GpuBackendProfile::tier1_solid(
+            "paint-vm-test-gpu",
+            GpuApiFamily::Wgpu,
+            GpuRenderPath::GraphicsPipeline,
+            "test-shader",
+            GpuReadbackStrategy::TextureCopyToBuffer,
+        );
+
+        let plan = plan_scene(&scene);
+
+        assert!(unsupported_plan_features(profile, &plan).is_empty());
+    }
+
+    #[test]
+    fn tier1_solid_profile_rejects_textures_and_text() {
+        let mut pixels = PixelContainer::new(1, 1);
+        pixels.set_pixel(0, 0, 12, 34, 56, 255);
+        let mut scene = PaintScene::new(20.0, 20.0);
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: None,
+        }));
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: PaintBase::default(),
+            x: 1.0,
+            y: 12.0,
+            text: "GPU".to_string(),
+            font_ref: None,
+            font_size: 12.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+        let profile = GpuBackendProfile::tier1_solid(
+            "paint-vm-test-gpu",
+            GpuApiFamily::Wgpu,
+            GpuRenderPath::GraphicsPipeline,
+            "test-shader",
+            GpuReadbackStrategy::TextureCopyToBuffer,
+        );
+
+        let plan = plan_scene(&scene);
+        let unsupported = unsupported_plan_features(profile, &plan);
+
+        assert!(unsupported.contains(&"image"));
+        assert!(unsupported.contains(&"text"));
     }
 }

--- a/code/packages/rust/paint-vm-mesa/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-mesa/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added an explicit Mesa GPU backend profile.
+- Added shared `paint-vm-gpu-core` plan validation for the Tier 1 solid-vector
+  slice.
+- Kept runtime rendering unavailable until Mesa profile routing lands.

--- a/code/packages/rust/paint-vm-mesa/Cargo.toml
+++ b/code/packages/rust/paint-vm-mesa/Cargo.toml
@@ -2,8 +2,9 @@
 name = "paint-vm-mesa"
 version = "0.1.0"
 edition = "2021"
-description = "Mesa software/native GPU profile scaffold for the Paint VM runtime"
+description = "Mesa software/native GPU profile adapter for the Paint VM runtime"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+paint-vm-gpu-core = { path = "../paint-vm-gpu-core" }
 paint-vm-runtime = { path = "../paint-vm-runtime" }

--- a/code/packages/rust/paint-vm-mesa/README.md
+++ b/code/packages/rust/paint-vm-mesa/README.md
@@ -1,0 +1,32 @@
+# paint-vm-mesa
+
+Mesa backend profile and shared GPU-plan adapter for the Paint VM runtime.
+
+## Status
+
+Mesa is a driver stack rather than one drawing API. This crate models Mesa as a
+first-class runtime profile for software and driver-backed execution paths such
+as llvmpipe and lavapipe. It now consumes `paint-vm-gpu-core` plans for the Tier
+1 solid-vector slice while keeping runtime rendering unavailable until routing
+to an OpenGL or Vulkan Mesa profile exists.
+
+The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
+selection does not pick Mesa before it can execute pixels. Use `profile()` and
+`plan()` to validate the shared contract.
+
+## Planned Execution Path
+
+```text
+PaintScene
+  -> paint-vm-gpu-core::GpuPaintPlan
+  -> Mesa profile router (llvmpipe/lavapipe)
+  -> OpenGL or Vulkan execution path
+  -> PixelContainer
+```
+
+## Next Steps
+
+- Detect available Mesa profiles on Linux/WSL.
+- Route llvmpipe through the OpenGL backend or lavapipe through Vulkan.
+- Keep deterministic software execution selectable when native GPU drivers are
+  unavailable.

--- a/code/packages/rust/paint-vm-mesa/src/lib.rs
+++ b/code/packages/rust/paint-vm-mesa/src/lib.rs
@@ -1,10 +1,15 @@
-//! Mesa backend profile scaffold for the Paint VM runtime.
+//! Mesa backend profile and plan adapter for the Paint VM runtime.
 //!
 //! Mesa is not a single drawing API; it supplies software and driver-backed
 //! implementations for OpenGL and Vulkan. This crate gives the runtime a
-//! first-class place to model Mesa profiles such as llvmpipe and lavapipe.
+//! first-class place to model Mesa profiles such as llvmpipe and lavapipe while
+//! sharing the same GPU render plan as WGPU, Vulkan, OpenGL, and OpenCL.
 
 use paint_instructions::{PaintScene, PixelContainer};
+use paint_vm_gpu_core::{
+    plan_scene, unsupported_plan_features, GpuApiFamily, GpuBackendProfile, GpuPaintPlan,
+    GpuReadbackStrategy, GpuRenderPath,
+};
 use paint_vm_runtime::{
     PaintAcceleration, PaintBackendDescriptor, PaintBackendFamily, PaintPlatformSupport,
     PaintRenderError, PaintRenderer,
@@ -25,8 +30,24 @@ pub fn descriptor() -> PaintBackendDescriptor {
     )
 }
 
+pub fn profile() -> GpuBackendProfile {
+    GpuBackendProfile::tier1_solid(
+        "paint-vm-mesa",
+        GpuApiFamily::Mesa,
+        GpuRenderPath::DriverProfile,
+        "Mesa llvmpipe/lavapipe profile",
+        GpuReadbackStrategy::DelegatedToProfile,
+    )
+}
+
 pub fn renderer() -> MesaPaintBackend {
     MesaPaintBackend
+}
+
+pub fn plan(scene: &PaintScene) -> Result<GpuPaintPlan, PaintRenderError> {
+    let plan = plan_scene(scene);
+    reject_unsupported_plan(&plan)?;
+    Ok(plan)
 }
 
 pub fn render(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
@@ -38,10 +59,26 @@ impl PaintRenderer for MesaPaintBackend {
         descriptor()
     }
 
-    fn render(&self, _scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        let _plan = plan(scene)?;
         Err(PaintRenderError::BackendUnavailable {
             backend: "paint-vm-mesa",
-            reason: "Mesa profile routing is scaffolded but not implemented yet",
+            reason: "Mesa profile routing to llvmpipe/lavapipe execution is not implemented yet",
+        })
+    }
+}
+
+fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> {
+    let unsupported = unsupported_plan_features(profile(), plan);
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(PaintRenderError::RenderFailed {
+            backend: "paint-vm-mesa",
+            message: format!(
+                "Mesa Tier 1 plan adapter does not support: {}",
+                unsupported.join(", ")
+            ),
         })
     }
 }
@@ -49,11 +86,58 @@ impl PaintRenderer for MesaPaintBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_vm_runtime::PaintBackendTier;
 
     #[test]
-    fn exposes_scaffold_descriptor() {
+    fn exposes_scaffold_descriptor_until_profile_execution_lands() {
         let descriptor = descriptor();
         assert_eq!(descriptor.id, "paint-vm-mesa");
         assert_eq!(descriptor.family, PaintBackendFamily::Mesa);
+        assert_eq!(descriptor.tier, PaintBackendTier::Tier0Scaffold);
+    }
+
+    #[test]
+    fn exposes_mesa_gpu_profile() {
+        let profile = profile();
+        assert_eq!(profile.id, "paint-vm-mesa");
+        assert_eq!(profile.family, GpuApiFamily::Mesa);
+        assert_eq!(profile.render_path, GpuRenderPath::DriverProfile);
+        assert_eq!(profile.readback, GpuReadbackStrategy::DelegatedToProfile);
+    }
+
+    #[test]
+    fn plans_solid_rects_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(16.0, 16.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                2.0, 2.0, 8.0, 8.0, "#ff0000",
+            )));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!((plan.width, plan.height), (16, 16));
+        assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn rejects_text_until_glyph_atlas_lands() {
+        let mut scene = PaintScene::new(80.0, 40.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: Default::default(),
+            x: 4.0,
+            y: 20.0,
+            text: "glyphs later".to_string(),
+            font_ref: None,
+            font_size: 16.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+
+        let err = plan(&scene).unwrap_err();
+
+        assert!(matches!(err, PaintRenderError::RenderFailed { .. }));
     }
 }

--- a/code/packages/rust/paint-vm-opencl/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-opencl/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added an explicit OpenCL compute backend profile.
+- Added shared `paint-vm-gpu-core` plan validation for the Tier 1 solid-vector
+  slice.
+- Kept runtime rendering unavailable until an OpenCL compute raster execution
+  path exists.

--- a/code/packages/rust/paint-vm-opencl/Cargo.toml
+++ b/code/packages/rust/paint-vm-opencl/Cargo.toml
@@ -2,8 +2,9 @@
 name = "paint-vm-opencl"
 version = "0.1.0"
 edition = "2021"
-description = "OpenCL compute backend scaffold for the Paint VM runtime"
+description = "OpenCL compute backend profile and plan adapter for the Paint VM runtime"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+paint-vm-gpu-core = { path = "../paint-vm-gpu-core" }
 paint-vm-runtime = { path = "../paint-vm-runtime" }

--- a/code/packages/rust/paint-vm-opencl/README.md
+++ b/code/packages/rust/paint-vm-opencl/README.md
@@ -1,0 +1,32 @@
+# paint-vm-opencl
+
+OpenCL compute backend profile and shared GPU-plan adapter for the Paint VM
+runtime.
+
+## Status
+
+OpenCL is modeled as a compute raster path rather than a native vector API. This
+crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector slice
+while keeping runtime rendering unavailable until an OpenCL context, kernels,
+buffers, and readback path lands.
+
+The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
+selection does not pick OpenCL before it can execute pixels. Use `profile()` and
+`plan()` to validate the backend contract while compute kernels are being built.
+
+## Planned Execution Path
+
+```text
+PaintScene
+  -> paint-vm-gpu-core::GpuPaintPlan
+  -> OpenCL C raster kernels
+  -> RGBA8 storage buffer
+  -> PixelContainer
+```
+
+## Next Steps
+
+- Build a kernel-side triangle coverage rasterizer for solid meshes.
+- Add buffer upload/readback and device fallback selection.
+- Add texture sampling for `PaintImage`.
+- Add glyph atlas buffers once the shared text shaping path is ready.

--- a/code/packages/rust/paint-vm-opencl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opencl/src/lib.rs
@@ -1,8 +1,12 @@
-//! OpenCL compute backend scaffold for the Paint VM runtime.
+//! OpenCL compute backend profile and plan adapter for the Paint VM runtime.
 //!
 //! OpenCL is treated as a compute raster path rather than a native vector API.
 
 use paint_instructions::{PaintScene, PixelContainer};
+use paint_vm_gpu_core::{
+    plan_scene, unsupported_plan_features, GpuApiFamily, GpuBackendProfile, GpuPaintPlan,
+    GpuReadbackStrategy, GpuRenderPath,
+};
 use paint_vm_runtime::{
     PaintAcceleration, PaintBackendDescriptor, PaintBackendFamily, PaintPlatformSupport,
     PaintRenderError, PaintRenderer,
@@ -23,8 +27,24 @@ pub fn descriptor() -> PaintBackendDescriptor {
     )
 }
 
+pub fn profile() -> GpuBackendProfile {
+    GpuBackendProfile::tier1_solid(
+        "paint-vm-opencl",
+        GpuApiFamily::OpenCl,
+        GpuRenderPath::ComputeRaster,
+        "OpenCL C 1.2 kernels",
+        GpuReadbackStrategy::StorageBufferReadback,
+    )
+}
+
 pub fn renderer() -> OpenClPaintBackend {
     OpenClPaintBackend
+}
+
+pub fn plan(scene: &PaintScene) -> Result<GpuPaintPlan, PaintRenderError> {
+    let plan = plan_scene(scene);
+    reject_unsupported_plan(&plan)?;
+    Ok(plan)
 }
 
 pub fn render(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
@@ -36,10 +56,27 @@ impl PaintRenderer for OpenClPaintBackend {
         descriptor()
     }
 
-    fn render(&self, _scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        let _plan = plan(scene)?;
         Err(PaintRenderError::BackendUnavailable {
             backend: "paint-vm-opencl",
-            reason: "OpenCL compute raster pipeline is scaffolded but not implemented yet",
+            reason:
+                "OpenCL context, kernels, buffers, and readback execution are not implemented yet",
+        })
+    }
+}
+
+fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> {
+    let unsupported = unsupported_plan_features(profile(), plan);
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(PaintRenderError::RenderFailed {
+            backend: "paint-vm-opencl",
+            message: format!(
+                "OpenCL Tier 1 plan adapter does not support: {}",
+                unsupported.join(", ")
+            ),
         })
     }
 }
@@ -47,11 +84,58 @@ impl PaintRenderer for OpenClPaintBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_vm_runtime::PaintBackendTier;
 
     #[test]
-    fn exposes_scaffold_descriptor() {
+    fn exposes_scaffold_descriptor_until_compute_raster_lands() {
         let descriptor = descriptor();
         assert_eq!(descriptor.id, "paint-vm-opencl");
         assert_eq!(descriptor.family, PaintBackendFamily::OpenCl);
+        assert_eq!(descriptor.tier, PaintBackendTier::Tier0Scaffold);
+    }
+
+    #[test]
+    fn exposes_opencl_gpu_profile() {
+        let profile = profile();
+        assert_eq!(profile.id, "paint-vm-opencl");
+        assert_eq!(profile.family, GpuApiFamily::OpenCl);
+        assert_eq!(profile.render_path, GpuRenderPath::ComputeRaster);
+        assert_eq!(profile.readback, GpuReadbackStrategy::StorageBufferReadback);
+    }
+
+    #[test]
+    fn plans_solid_rects_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(16.0, 16.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                2.0, 2.0, 8.0, 8.0, "#ff0000",
+            )));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!((plan.width, plan.height), (16, 16));
+        assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn rejects_text_until_glyph_atlas_lands() {
+        let mut scene = PaintScene::new(80.0, 40.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: Default::default(),
+            x: 4.0,
+            y: 20.0,
+            text: "glyphs later".to_string(),
+            font_ref: None,
+            font_size: 16.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+
+        let err = plan(&scene).unwrap_err();
+
+        assert!(matches!(err, PaintRenderError::RenderFailed { .. }));
     }
 }

--- a/code/packages/rust/paint-vm-opengl/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-opengl/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added an explicit OpenGL GPU backend profile.
+- Added shared `paint-vm-gpu-core` plan validation for the Tier 1 solid-vector
+  slice.
+- Kept runtime rendering unavailable until an OpenGL framebuffer execution path
+  exists.

--- a/code/packages/rust/paint-vm-opengl/Cargo.toml
+++ b/code/packages/rust/paint-vm-opengl/Cargo.toml
@@ -2,8 +2,9 @@
 name = "paint-vm-opengl"
 version = "0.1.0"
 edition = "2021"
-description = "OpenGL backend scaffold for the Paint VM runtime"
+description = "OpenGL backend profile and plan adapter for the Paint VM runtime"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+paint-vm-gpu-core = { path = "../paint-vm-gpu-core" }
 paint-vm-runtime = { path = "../paint-vm-runtime" }

--- a/code/packages/rust/paint-vm-opengl/README.md
+++ b/code/packages/rust/paint-vm-opengl/README.md
@@ -1,0 +1,34 @@
+# paint-vm-opengl
+
+OpenGL backend profile and shared GPU-plan adapter for the Paint VM runtime.
+
+## Status
+
+This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector
+slice: indexed meshes, scissor clips, group/layer transform lowering, opacity
+folding, and degraded solid-gradient fallback. The runtime renderer still
+returns `BackendUnavailable` until a real OpenGL context, framebuffer, shader,
+and readback path lands.
+
+The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
+selection does not pick OpenGL before it can execute pixels. Use `profile()` and
+`plan()` to validate the backend contract while the native execution path is
+being implemented.
+
+## Planned Execution Path
+
+```text
+PaintScene
+  -> paint-vm-gpu-core::GpuPaintPlan
+  -> GLSL vertex/fragment shaders
+  -> offscreen framebuffer
+  -> glReadPixels RGBA8 readback
+  -> PixelContainer
+```
+
+## Next Steps
+
+- Create platform-specific headless GL contexts.
+- Upload shared meshes to VBO/IBO buffers and draw them with GLSL.
+- Add texture upload/sampling for `PaintImage`.
+- Add glyph atlas sampling once the shared text shaping path is ready.

--- a/code/packages/rust/paint-vm-opengl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opengl/src/lib.rs
@@ -1,6 +1,15 @@
-//! OpenGL backend scaffold for the Paint VM runtime.
+//! OpenGL backend profile and plan adapter for the Paint VM runtime.
+//!
+//! This crate still needs an actual context/framebuffer implementation before
+//! it can render pixels. The shared GPU-plan adapter is present now so OpenGL
+//! converges with WGPU, Vulkan, Mesa, and OpenCL on the same PaintScene
+//! lowering contract.
 
 use paint_instructions::{PaintScene, PixelContainer};
+use paint_vm_gpu_core::{
+    plan_scene, unsupported_plan_features, GpuApiFamily, GpuBackendProfile, GpuPaintPlan,
+    GpuReadbackStrategy, GpuRenderPath,
+};
 use paint_vm_runtime::{
     PaintAcceleration, PaintBackendDescriptor, PaintBackendFamily, PaintPlatformSupport,
     PaintRenderError, PaintRenderer,
@@ -21,8 +30,24 @@ pub fn descriptor() -> PaintBackendDescriptor {
     )
 }
 
+pub fn profile() -> GpuBackendProfile {
+    GpuBackendProfile::tier1_solid(
+        "paint-vm-opengl",
+        GpuApiFamily::OpenGl,
+        GpuRenderPath::GraphicsPipeline,
+        "GLSL 330 core",
+        GpuReadbackStrategy::FramebufferReadPixels,
+    )
+}
+
 pub fn renderer() -> OpenGlPaintBackend {
     OpenGlPaintBackend
+}
+
+pub fn plan(scene: &PaintScene) -> Result<GpuPaintPlan, PaintRenderError> {
+    let plan = plan_scene(scene);
+    reject_unsupported_plan(&plan)?;
+    Ok(plan)
 }
 
 pub fn render(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
@@ -34,10 +59,26 @@ impl PaintRenderer for OpenGlPaintBackend {
         descriptor()
     }
 
-    fn render(&self, _scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        let _plan = plan(scene)?;
         Err(PaintRenderError::BackendUnavailable {
             backend: "paint-vm-opengl",
-            reason: "OpenGL framebuffer pipeline is scaffolded but not implemented yet",
+            reason: "OpenGL context, framebuffer, shader, and readback execution are not implemented yet",
+        })
+    }
+}
+
+fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> {
+    let unsupported = unsupported_plan_features(profile(), plan);
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(PaintRenderError::RenderFailed {
+            backend: "paint-vm-opengl",
+            message: format!(
+                "OpenGL Tier 1 plan adapter does not support: {}",
+                unsupported.join(", ")
+            ),
         })
     }
 }
@@ -45,11 +86,58 @@ impl PaintRenderer for OpenGlPaintBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_vm_runtime::PaintBackendTier;
 
     #[test]
-    fn exposes_scaffold_descriptor() {
+    fn exposes_scaffold_descriptor_until_framebuffer_lands() {
         let descriptor = descriptor();
         assert_eq!(descriptor.id, "paint-vm-opengl");
         assert_eq!(descriptor.family, PaintBackendFamily::OpenGl);
+        assert_eq!(descriptor.tier, PaintBackendTier::Tier0Scaffold);
+    }
+
+    #[test]
+    fn exposes_opengl_gpu_profile() {
+        let profile = profile();
+        assert_eq!(profile.id, "paint-vm-opengl");
+        assert_eq!(profile.family, GpuApiFamily::OpenGl);
+        assert_eq!(profile.render_path, GpuRenderPath::GraphicsPipeline);
+        assert_eq!(profile.readback, GpuReadbackStrategy::FramebufferReadPixels);
+    }
+
+    #[test]
+    fn plans_solid_rects_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(16.0, 16.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                2.0, 2.0, 8.0, 8.0, "#ff0000",
+            )));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!((plan.width, plan.height), (16, 16));
+        assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn rejects_text_until_glyph_atlas_lands() {
+        let mut scene = PaintScene::new(80.0, 40.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: Default::default(),
+            x: 4.0,
+            y: 20.0,
+            text: "glyphs later".to_string(),
+            font_ref: None,
+            font_size: 16.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+
+        let err = plan(&scene).unwrap_err();
+
+        assert!(matches!(err, PaintRenderError::RenderFailed { .. }));
     }
 }

--- a/code/packages/rust/paint-vm-vulkan/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-vulkan/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added an explicit Vulkan GPU backend profile.
+- Added shared `paint-vm-gpu-core` plan validation for the Tier 1 solid-vector
+  slice.
+- Kept runtime rendering unavailable until a Vulkan render-pass execution path
+  exists.

--- a/code/packages/rust/paint-vm-vulkan/Cargo.toml
+++ b/code/packages/rust/paint-vm-vulkan/Cargo.toml
@@ -2,8 +2,9 @@
 name = "paint-vm-vulkan"
 version = "0.1.0"
 edition = "2021"
-description = "Vulkan backend scaffold for the Paint VM runtime"
+description = "Vulkan backend profile and plan adapter for the Paint VM runtime"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+paint-vm-gpu-core = { path = "../paint-vm-gpu-core" }
 paint-vm-runtime = { path = "../paint-vm-runtime" }

--- a/code/packages/rust/paint-vm-vulkan/README.md
+++ b/code/packages/rust/paint-vm-vulkan/README.md
@@ -1,0 +1,34 @@
+# paint-vm-vulkan
+
+Vulkan backend profile and shared GPU-plan adapter for the Paint VM runtime.
+
+## Status
+
+This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector
+slice: indexed meshes, scissor clips, group/layer transform lowering, opacity
+folding, and degraded solid-gradient fallback. The runtime renderer still
+returns `BackendUnavailable` until a Vulkan instance, device, render pass,
+pipeline, and readback path lands.
+
+The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
+selection does not pick Vulkan before it can execute pixels. Use `profile()` and
+`plan()` to validate the backend contract while the native execution path is
+being implemented.
+
+## Planned Execution Path
+
+```text
+PaintScene
+  -> paint-vm-gpu-core::GpuPaintPlan
+  -> SPIR-V graphics pipeline
+  -> offscreen color attachment
+  -> transfer to host-visible buffer
+  -> PixelContainer
+```
+
+## Next Steps
+
+- Create instance/device/queue selection with headless surfaces avoided.
+- Upload shared meshes to vertex/index buffers.
+- Add render-pass and pipeline creation for solid-color meshes.
+- Add sampled image textures and glyph atlas textures.

--- a/code/packages/rust/paint-vm-vulkan/src/lib.rs
+++ b/code/packages/rust/paint-vm-vulkan/src/lib.rs
@@ -1,6 +1,15 @@
-//! Vulkan backend scaffold for the Paint VM runtime.
+//! Vulkan backend profile and plan adapter for the Paint VM runtime.
+//!
+//! This crate still needs a native Vulkan instance/device/render-pass
+//! implementation before it can render pixels. The shared GPU-plan adapter is
+//! present now so Vulkan converges with WGPU, OpenGL, Mesa, and OpenCL on the
+//! same PaintScene lowering contract.
 
 use paint_instructions::{PaintScene, PixelContainer};
+use paint_vm_gpu_core::{
+    plan_scene, unsupported_plan_features, GpuApiFamily, GpuBackendProfile, GpuPaintPlan,
+    GpuReadbackStrategy, GpuRenderPath,
+};
 use paint_vm_runtime::{
     PaintAcceleration, PaintBackendDescriptor, PaintBackendFamily, PaintPlatformSupport,
     PaintRenderError, PaintRenderer,
@@ -21,8 +30,24 @@ pub fn descriptor() -> PaintBackendDescriptor {
     )
 }
 
+pub fn profile() -> GpuBackendProfile {
+    GpuBackendProfile::tier1_solid(
+        "paint-vm-vulkan",
+        GpuApiFamily::Vulkan,
+        GpuRenderPath::GraphicsPipeline,
+        "SPIR-V 1.0",
+        GpuReadbackStrategy::TextureCopyToBuffer,
+    )
+}
+
 pub fn renderer() -> VulkanPaintBackend {
     VulkanPaintBackend
+}
+
+pub fn plan(scene: &PaintScene) -> Result<GpuPaintPlan, PaintRenderError> {
+    let plan = plan_scene(scene);
+    reject_unsupported_plan(&plan)?;
+    Ok(plan)
 }
 
 pub fn render(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
@@ -34,10 +59,26 @@ impl PaintRenderer for VulkanPaintBackend {
         descriptor()
     }
 
-    fn render(&self, _scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+    fn render(&self, scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
+        let _plan = plan(scene)?;
         Err(PaintRenderError::BackendUnavailable {
             backend: "paint-vm-vulkan",
-            reason: "Vulkan render-pass pipeline is scaffolded but not implemented yet",
+            reason: "Vulkan instance, device, render pass, and readback execution are not implemented yet",
+        })
+    }
+}
+
+fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> {
+    let unsupported = unsupported_plan_features(profile(), plan);
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(PaintRenderError::RenderFailed {
+            backend: "paint-vm-vulkan",
+            message: format!(
+                "Vulkan Tier 1 plan adapter does not support: {}",
+                unsupported.join(", ")
+            ),
         })
     }
 }
@@ -45,11 +86,58 @@ impl PaintRenderer for VulkanPaintBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_vm_runtime::PaintBackendTier;
 
     #[test]
-    fn exposes_scaffold_descriptor() {
+    fn exposes_scaffold_descriptor_until_render_pass_lands() {
         let descriptor = descriptor();
         assert_eq!(descriptor.id, "paint-vm-vulkan");
         assert_eq!(descriptor.family, PaintBackendFamily::Vulkan);
+        assert_eq!(descriptor.tier, PaintBackendTier::Tier0Scaffold);
+    }
+
+    #[test]
+    fn exposes_vulkan_gpu_profile() {
+        let profile = profile();
+        assert_eq!(profile.id, "paint-vm-vulkan");
+        assert_eq!(profile.family, GpuApiFamily::Vulkan);
+        assert_eq!(profile.render_path, GpuRenderPath::GraphicsPipeline);
+        assert_eq!(profile.readback, GpuReadbackStrategy::TextureCopyToBuffer);
+    }
+
+    #[test]
+    fn plans_solid_rects_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(16.0, 16.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                2.0, 2.0, 8.0, 8.0, "#ff0000",
+            )));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!((plan.width, plan.height), (16, 16));
+        assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn rejects_text_until_glyph_atlas_lands() {
+        let mut scene = PaintScene::new(80.0, 40.0);
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: Default::default(),
+            x: 4.0,
+            y: 20.0,
+            text: "glyphs later".to_string(),
+            font_ref: None,
+            font_size: 16.0,
+            fill: Some("#000000".to_string()),
+            text_align: None,
+        }));
+
+        let err = plan(&scene).unwrap_err();
+
+        assert!(matches!(err, PaintRenderError::RenderFailed { .. }));
     }
 }


### PR DESCRIPTION
## Summary
- Adds shared GPU backend profile metadata and Tier 1 plan compatibility checks in `paint-vm-gpu-core`.
- Converts the OpenGL, Vulkan, Mesa, and OpenCL crates from vague scaffolds into explicit profile + `GpuPaintPlan` adapters while keeping runtime descriptors Tier 0 until native execution exists.
- Adds README/changelog specs for each remaining GPU-family backend with concrete execution-path next steps.

## Verification
- `cargo fmt -p paint-vm-gpu-core -p paint-vm-opengl -p paint-vm-vulkan -p paint-vm-mesa -p paint-vm-opencl`
- `cargo test -p paint-vm-gpu-core -p paint-vm-opengl -p paint-vm-vulkan -p paint-vm-mesa -p paint-vm-opencl -- --nocapture` on Windows.
- `wsl -d Ubuntu bash -lc "cd /mnt/c/Users/adhit/Downloads/Codex/coding-adventures/.codex-worktrees/gpu-backend-plan-adapters/code/packages/rust && CARGO_TARGET_DIR=/tmp/codex-gpu-profiles-target ~/.cargo/bin/cargo test -p paint-vm-gpu-core -p paint-vm-opengl -p paint-vm-vulkan -p paint-vm-mesa -p paint-vm-opencl -- --nocapture"` on WSL/Linux.