### PR TITLE
Add Go mini-sqlite facade

### DIFF
--- a/code/packages/go/mini-sqlite/BUILD
+++ b/code/packages/go/mini-sqlite/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/mini-sqlite/CHANGELOG.md
+++ b/code/packages/go/mini-sqlite/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog - mini-sqlite (Go)
+
+## [0.1.0] - 2026-04-29
+
+### Added
+- Initial Go Level 0 mini-sqlite facade.
+- In-memory `Connect(":memory:")` connections.
+- qmark parameter binding.
+- Basic `CREATE TABLE`, `DROP TABLE`, `INSERT`, `UPDATE`, `DELETE`, and `SELECT`.
+- Cursor fetch helpers and snapshot-backed `Commit` / `Rollback`.

--- a/code/packages/go/mini-sqlite/README.md
+++ b/code/packages/go/mini-sqlite/README.md
@@ -1,0 +1,27 @@
+# mini-sqlite (Go)
+
+Go Level 0 port of the Python `mini-sqlite` facade.
+
+The package provides an in-memory database facade with qmark binding, basic
+DDL/DML, cursors, and transaction snapshots. SELECT queries are delegated to
+the existing Go `sql-execution-engine` package.
+
+```go
+conn, err := minisqlite.Connect(":memory:")
+if err != nil {
+    panic(err)
+}
+
+_, _ = conn.Execute("CREATE TABLE users (id INTEGER, name TEXT)")
+_, _ = conn.Executemany("INSERT INTO users VALUES (?, ?)", [][]any{
+    {int64(1), "Alice"},
+    {int64(2), "Bob"},
+})
+
+cur, _ := conn.Execute("SELECT name FROM users WHERE id = ?", int64(1))
+rows := cur.Fetchall()
+fmt.Println(rows) // [[Alice]]
+```
+
+File-backed connections are reserved for a later storage backend port and
+currently return `NotSupportedError`.

--- a/code/packages/go/mini-sqlite/binding.go
+++ b/code/packages/go/mini-sqlite/binding.go
@@ -1,0 +1,134 @@
+package minisqlite
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+func bindParameters(sql string, params []any) (string, error) {
+	var out strings.Builder
+	index := 0
+
+	for i := 0; i < len(sql); {
+		ch := sql[i]
+		if ch == '\'' || ch == '"' {
+			lit, next := readQuoted(sql, i, ch)
+			out.WriteString(lit)
+			i = next
+			continue
+		}
+		if ch == '-' && i+1 < len(sql) && sql[i+1] == '-' {
+			next := readLineComment(sql, i)
+			out.WriteString(sql[i:next])
+			i = next
+			continue
+		}
+		if ch == '/' && i+1 < len(sql) && sql[i+1] == '*' {
+			next := readBlockComment(sql, i)
+			out.WriteString(sql[i:next])
+			i = next
+			continue
+		}
+		if ch == '?' {
+			if index >= len(params) {
+				return "", &ProgrammingError{Message: "not enough parameters for SQL statement"}
+			}
+			lit, err := toSQLLiteral(params[index])
+			if err != nil {
+				return "", err
+			}
+			out.WriteString(lit)
+			index++
+			i++
+			continue
+		}
+		out.WriteByte(ch)
+		i++
+	}
+
+	if index != len(params) {
+		return "", &ProgrammingError{Message: "too many parameters for SQL statement"}
+	}
+	return out.String(), nil
+}
+
+func readQuoted(sql string, start int, quote byte) (string, int) {
+	for i := start + 1; i < len(sql); i++ {
+		if sql[i] == quote {
+			if i+1 < len(sql) && sql[i+1] == quote {
+				i++
+				continue
+			}
+			return sql[start : i+1], i + 1
+		}
+	}
+	return sql[start:], len(sql)
+}
+
+func readLineComment(sql string, start int) int {
+	i := start + 2
+	for i < len(sql) && sql[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+func readBlockComment(sql string, start int) int {
+	i := start + 2
+	for i+1 < len(sql) {
+		if sql[i] == '*' && sql[i+1] == '/' {
+			return i + 2
+		}
+		i++
+	}
+	return len(sql)
+}
+
+func toSQLLiteral(value any) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "NULL", nil
+	case bool:
+		if v {
+			return "TRUE", nil
+		}
+		return "FALSE", nil
+	case int:
+		return strconv.FormatInt(int64(v), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(v), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(v), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(v), 10), nil
+	case int64:
+		return strconv.FormatInt(v, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(v), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10), nil
+	case uint64:
+		return strconv.FormatUint(v, 10), nil
+	case float32:
+		f := float64(v)
+		if math.IsInf(f, 0) || math.IsNaN(f) {
+			return "", &ProgrammingError{Message: "non-finite numeric parameter is not supported"}
+		}
+		return strconv.FormatFloat(f, 'f', -1, 64), nil
+	case float64:
+		if math.IsInf(v, 0) || math.IsNaN(v) {
+			return "", &ProgrammingError{Message: "non-finite numeric parameter is not supported"}
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
+	case string:
+		return "'" + strings.ReplaceAll(v, "'", "''") + "'", nil
+	default:
+		return "", &ProgrammingError{Message: fmt.Sprintf("unsupported parameter type: %T", value)}
+	}
+}

--- a/code/packages/go/mini-sqlite/connection.go
+++ b/code/packages/go/mini-sqlite/connection.go
@@ -1,0 +1,157 @@
+package minisqlite
+
+const (
+	APILevel     = "2.0"
+	ThreadSafety = 1
+	ParamStyle   = "qmark"
+)
+
+type Options struct {
+	Autocommit bool
+}
+
+type Connection struct {
+	db         *inMemoryDatabase
+	autocommit bool
+	snapshot   snapshot
+	closed     bool
+}
+
+func Connect(database string, options ...Options) (*Connection, error) {
+	if database != ":memory:" {
+		return nil, &NotSupportedError{Message: "Go mini-sqlite supports only :memory: in Level 0"}
+	}
+	opts := Options{}
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	return &Connection{
+		db:         newInMemoryDatabase(),
+		autocommit: opts.Autocommit,
+	}, nil
+}
+
+func (c *Connection) Cursor() (*Cursor, error) {
+	if err := c.assertOpen(); err != nil {
+		return nil, err
+	}
+	return &Cursor{conn: c, rowcount: -1}, nil
+}
+
+func (c *Connection) Execute(sql string, params ...any) (*Cursor, error) {
+	cur, err := c.Cursor()
+	if err != nil {
+		return nil, err
+	}
+	return cur.Execute(sql, params...)
+}
+
+func (c *Connection) Executemany(sql string, seq [][]any) (*Cursor, error) {
+	cur, err := c.Cursor()
+	if err != nil {
+		return nil, err
+	}
+	return cur.Executemany(sql, seq)
+}
+
+func (c *Connection) Commit() error {
+	if err := c.assertOpen(); err != nil {
+		return err
+	}
+	c.snapshot = nil
+	return nil
+}
+
+func (c *Connection) Rollback() error {
+	if err := c.assertOpen(); err != nil {
+		return err
+	}
+	if c.snapshot != nil {
+		c.db.restore(c.snapshot)
+		c.snapshot = nil
+	}
+	return nil
+}
+
+func (c *Connection) Close() error {
+	if c.closed {
+		return nil
+	}
+	if c.snapshot != nil {
+		c.db.restore(c.snapshot)
+	}
+	c.snapshot = nil
+	c.closed = true
+	return nil
+}
+
+func (c *Connection) executeBound(sql string, params []any) (*statementResult, error) {
+	if err := c.assertOpen(); err != nil {
+		return nil, err
+	}
+	bound, err := bindParameters(sql, params)
+	if err != nil {
+		return nil, err
+	}
+	switch firstKeyword(bound) {
+	case "BEGIN":
+		c.ensureSnapshot()
+		return emptyStatementResult(), nil
+	case "COMMIT":
+		return emptyStatementResult(), c.Commit()
+	case "ROLLBACK":
+		return emptyStatementResult(), c.Rollback()
+	case "SELECT":
+		return c.db.selectSQL(bound)
+	case "CREATE":
+		c.ensureSnapshot()
+		stmt, err := parseCreate(bound)
+		if err != nil {
+			return nil, err
+		}
+		return c.db.create(stmt)
+	case "DROP":
+		c.ensureSnapshot()
+		stmt, err := parseDrop(bound)
+		if err != nil {
+			return nil, err
+		}
+		return c.db.drop(stmt)
+	case "INSERT":
+		c.ensureSnapshot()
+		stmt, err := parseInsert(bound)
+		if err != nil {
+			return nil, err
+		}
+		return c.db.insert(stmt)
+	case "UPDATE":
+		c.ensureSnapshot()
+		stmt, err := parseUpdate(bound)
+		if err != nil {
+			return nil, err
+		}
+		return c.db.update(stmt)
+	case "DELETE":
+		c.ensureSnapshot()
+		stmt, err := parseDelete(bound)
+		if err != nil {
+			return nil, err
+		}
+		return c.db.delete(stmt)
+	default:
+		return nil, &ProgrammingError{Message: "unsupported SQL statement"}
+	}
+}
+
+func (c *Connection) ensureSnapshot() {
+	if !c.autocommit && c.snapshot == nil {
+		c.snapshot = c.db.snapshot()
+	}
+}
+
+func (c *Connection) assertOpen() error {
+	if c.closed {
+		return &ProgrammingError{Message: "connection is closed"}
+	}
+	return nil
+}

--- a/code/packages/go/mini-sqlite/cursor.go
+++ b/code/packages/go/mini-sqlite/cursor.go
@@ -1,0 +1,121 @@
+package minisqlite
+
+type ColumnDescription struct {
+	Name string
+}
+
+type Cursor struct {
+	conn        *Connection
+	Description []ColumnDescription
+	rowcount    int
+	lastrowid   any
+	arraysize   int
+	rows        [][]any
+	offset      int
+	closed      bool
+}
+
+func (c *Cursor) Rowcount() int {
+	return c.rowcount
+}
+
+func (c *Cursor) Lastrowid() any {
+	return c.lastrowid
+}
+
+func (c *Cursor) Arraysize() int {
+	if c.arraysize == 0 {
+		return 1
+	}
+	return c.arraysize
+}
+
+func (c *Cursor) SetArraysize(size int) {
+	if size > 0 {
+		c.arraysize = size
+	}
+}
+
+func (c *Cursor) Execute(sql string, params ...any) (*Cursor, error) {
+	if err := c.assertOpen(); err != nil {
+		return nil, err
+	}
+	result, err := c.conn.executeBound(sql, params)
+	if err != nil {
+		return nil, err
+	}
+	c.rows = result.rows
+	c.offset = 0
+	c.rowcount = result.rowsAffected
+	c.Description = make([]ColumnDescription, len(result.columns))
+	for i, column := range result.columns {
+		c.Description[i] = ColumnDescription{Name: column}
+	}
+	return c, nil
+}
+
+func (c *Cursor) Executemany(sql string, seq [][]any) (*Cursor, error) {
+	if err := c.assertOpen(); err != nil {
+		return nil, err
+	}
+	total := 0
+	for _, params := range seq {
+		if _, err := c.Execute(sql, params...); err != nil {
+			return nil, err
+		}
+		if c.rowcount > 0 {
+			total += c.rowcount
+		}
+	}
+	if len(seq) > 0 {
+		c.rowcount = total
+	}
+	return c, nil
+}
+
+func (c *Cursor) Fetchone() ([]any, bool) {
+	if c.closed || c.offset >= len(c.rows) {
+		return nil, false
+	}
+	row := c.rows[c.offset]
+	c.offset++
+	return row, true
+}
+
+func (c *Cursor) Fetchmany(size int) [][]any {
+	if c.closed {
+		return nil
+	}
+	if size < 0 {
+		size = c.Arraysize()
+	}
+	end := c.offset + size
+	if end > len(c.rows) {
+		end = len(c.rows)
+	}
+	rows := c.rows[c.offset:end]
+	c.offset = end
+	return rows
+}
+
+func (c *Cursor) Fetchall() [][]any {
+	if c.closed {
+		return nil
+	}
+	rows := c.rows[c.offset:]
+	c.offset = len(c.rows)
+	return rows
+}
+
+func (c *Cursor) Close() {
+	c.closed = true
+	c.rows = nil
+	c.Description = nil
+}
+
+func (c *Cursor) assertOpen() error {
+	if c.closed {
+		return &ProgrammingError{Message: "cursor is closed"}
+	}
+	return nil
+}

--- a/code/packages/go/mini-sqlite/database.go
+++ b/code/packages/go/mini-sqlite/database.go
@@ -1,0 +1,297 @@
+package minisqlite
+
+import (
+	"fmt"
+	"strings"
+
+	sqlengine "github.com/adhithyan15/coding-adventures/code/packages/go/sql-execution-engine"
+)
+
+const rowIDColumn = "__mini_sqlite_rowid"
+
+type statementResult struct {
+	columns      []string
+	rows         [][]any
+	rowsAffected int
+}
+
+type tableData struct {
+	columns []string
+	rows    []map[string]any
+}
+
+type snapshot map[string]tableData
+
+type inMemoryDatabase struct {
+	tables map[string]tableData
+}
+
+func newInMemoryDatabase() *inMemoryDatabase {
+	return &inMemoryDatabase{tables: map[string]tableData{}}
+}
+
+func (db *inMemoryDatabase) Schema(tableName string) ([]string, error) {
+	table, err := db.table(tableName)
+	if err != nil {
+		return nil, err
+	}
+	return append([]string{}, table.columns...), nil
+}
+
+func (db *inMemoryDatabase) Scan(tableName string) ([]map[string]any, error) {
+	table, err := db.table(tableName)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]map[string]any, len(table.rows))
+	for i, row := range table.rows {
+		rows[i] = copyRow(row)
+	}
+	return rows, nil
+}
+
+func (db *inMemoryDatabase) snapshot() snapshot {
+	out := snapshot{}
+	for name, table := range db.tables {
+		rows := make([]map[string]any, len(table.rows))
+		for i, row := range table.rows {
+			rows[i] = copyRow(row)
+		}
+		out[name] = tableData{
+			columns: append([]string{}, table.columns...),
+			rows:    rows,
+		}
+	}
+	return out
+}
+
+func (db *inMemoryDatabase) restore(s snapshot) {
+	db.tables = map[string]tableData{}
+	for name, table := range s {
+		rows := make([]map[string]any, len(table.rows))
+		for i, row := range table.rows {
+			rows[i] = copyRow(row)
+		}
+		db.tables[name] = tableData{
+			columns: append([]string{}, table.columns...),
+			rows:    rows,
+		}
+	}
+}
+
+func (db *inMemoryDatabase) create(stmt *createTableStatement) (*statementResult, error) {
+	key := normalizeName(stmt.table)
+	if _, ok := db.tables[key]; ok {
+		if stmt.ifNotExists {
+			return emptyStatementResult(), nil
+		}
+		return nil, &OperationalError{Message: "table already exists: " + stmt.table}
+	}
+	seen := map[string]bool{}
+	for _, column := range stmt.columns {
+		k := normalizeName(column)
+		if seen[k] {
+			return nil, &ProgrammingError{Message: "duplicate column: " + column}
+		}
+		seen[k] = true
+	}
+	db.tables[key] = tableData{columns: append([]string{}, stmt.columns...), rows: []map[string]any{}}
+	return emptyStatementResult(), nil
+}
+
+func (db *inMemoryDatabase) drop(stmt *dropTableStatement) (*statementResult, error) {
+	key := normalizeName(stmt.table)
+	if _, ok := db.tables[key]; !ok {
+		if stmt.ifExists {
+			return emptyStatementResult(), nil
+		}
+		return nil, &OperationalError{Message: "no such table: " + stmt.table}
+	}
+	delete(db.tables, key)
+	return emptyStatementResult(), nil
+}
+
+func (db *inMemoryDatabase) insert(stmt *insertStatement) (*statementResult, error) {
+	table, err := db.table(stmt.table)
+	if err != nil {
+		return nil, err
+	}
+	columns := stmt.columns
+	if len(columns) == 0 {
+		columns = table.columns
+	}
+	if err := assertKnownColumns(table, columns); err != nil {
+		return nil, err
+	}
+	for _, values := range stmt.rows {
+		if len(values) != len(columns) {
+			return nil, &IntegrityError{Message: fmt.Sprintf("INSERT expected %d values, got %d", len(columns), len(values))}
+		}
+		row := map[string]any{}
+		for _, column := range table.columns {
+			row[column] = nil
+		}
+		for i, column := range columns {
+			row[column] = values[i]
+		}
+		table.rows = append(table.rows, row)
+	}
+	db.tables[normalizeName(stmt.table)] = table
+	return &statementResult{rowsAffected: len(stmt.rows)}, nil
+}
+
+func (db *inMemoryDatabase) update(stmt *updateStatement) (*statementResult, error) {
+	table, err := db.table(stmt.table)
+	if err != nil {
+		return nil, err
+	}
+	var columns []string
+	for column := range stmt.assignments {
+		columns = append(columns, column)
+	}
+	if err := assertKnownColumns(table, columns); err != nil {
+		return nil, err
+	}
+	rowIDs, err := db.matchingRowIDs(stmt.table, stmt.where)
+	if err != nil {
+		return nil, err
+	}
+	for _, rowID := range rowIDs {
+		for column, value := range stmt.assignments {
+			table.rows[rowID][column] = value
+		}
+	}
+	db.tables[normalizeName(stmt.table)] = table
+	return &statementResult{rowsAffected: len(rowIDs)}, nil
+}
+
+func (db *inMemoryDatabase) delete(stmt *deleteStatement) (*statementResult, error) {
+	table, err := db.table(stmt.table)
+	if err != nil {
+		return nil, err
+	}
+	rowIDs, err := db.matchingRowIDs(stmt.table, stmt.where)
+	if err != nil {
+		return nil, err
+	}
+	remove := map[int]bool{}
+	for _, rowID := range rowIDs {
+		remove[rowID] = true
+	}
+	var rows []map[string]any
+	for i, row := range table.rows {
+		if !remove[i] {
+			rows = append(rows, row)
+		}
+	}
+	table.rows = rows
+	db.tables[normalizeName(stmt.table)] = table
+	return &statementResult{rowsAffected: len(rowIDs)}, nil
+}
+
+func (db *inMemoryDatabase) selectSQL(sql string) (*statementResult, error) {
+	result, err := sqlengine.Execute(sql, db)
+	if err != nil {
+		return nil, translateError(err)
+	}
+	return &statementResult{
+		columns:      result.Columns,
+		rows:         result.Rows,
+		rowsAffected: -1,
+	}, nil
+}
+
+func (db *inMemoryDatabase) matchingRowIDs(tableName, whereSQL string) ([]int, error) {
+	table, err := db.table(tableName)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(whereSQL) == "" {
+		ids := make([]int, len(table.rows))
+		for i := range table.rows {
+			ids[i] = i
+		}
+		return ids, nil
+	}
+	source := &rowIDSource{tableName: tableName, table: table}
+	result, err := sqlengine.Execute(fmt.Sprintf("SELECT %s FROM %s WHERE %s", rowIDColumn, tableName, whereSQL), source)
+	if err != nil {
+		return nil, translateError(err)
+	}
+	ids := make([]int, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		if len(row) == 0 {
+			continue
+		}
+		switch v := row[0].(type) {
+		case int:
+			ids = append(ids, v)
+		case int64:
+			ids = append(ids, int(v))
+		}
+	}
+	return ids, nil
+}
+
+func (db *inMemoryDatabase) table(tableName string) (tableData, error) {
+	table, ok := db.tables[normalizeName(tableName)]
+	if !ok {
+		return tableData{}, &OperationalError{Message: "no such table: " + tableName}
+	}
+	return table, nil
+}
+
+type rowIDSource struct {
+	tableName string
+	table     tableData
+}
+
+func (s *rowIDSource) Schema(tableName string) ([]string, error) {
+	if normalizeName(tableName) != normalizeName(s.tableName) {
+		return nil, &sqlengine.TableNotFoundError{TableName: tableName}
+	}
+	columns := append([]string{}, s.table.columns...)
+	return append(columns, rowIDColumn), nil
+}
+
+func (s *rowIDSource) Scan(tableName string) ([]map[string]any, error) {
+	if normalizeName(tableName) != normalizeName(s.tableName) {
+		return nil, &sqlengine.TableNotFoundError{TableName: tableName}
+	}
+	rows := make([]map[string]any, len(s.table.rows))
+	for i, row := range s.table.rows {
+		copy := copyRow(row)
+		copy[rowIDColumn] = int64(i)
+		rows[i] = copy
+	}
+	return rows, nil
+}
+
+func assertKnownColumns(table tableData, columns []string) error {
+	known := map[string]bool{}
+	for _, column := range table.columns {
+		known[normalizeName(column)] = true
+	}
+	for _, column := range columns {
+		if !known[normalizeName(column)] {
+			return &OperationalError{Message: "no such column: " + column}
+		}
+	}
+	return nil
+}
+
+func copyRow(row map[string]any) map[string]any {
+	out := map[string]any{}
+	for k, v := range row {
+		out[k] = v
+	}
+	return out
+}
+
+func normalizeName(name string) string {
+	return strings.ToLower(name)
+}
+
+func emptyStatementResult() *statementResult {
+	return &statementResult{rowsAffected: 0}
+}

--- a/code/packages/go/mini-sqlite/errors.go
+++ b/code/packages/go/mini-sqlite/errors.go
@@ -1,0 +1,47 @@
+package minisqlite
+
+import "fmt"
+
+type InterfaceError struct{ Message string }
+
+func (e *InterfaceError) Error() string { return e.Message }
+
+type DatabaseError struct{ Message string }
+
+func (e *DatabaseError) Error() string { return e.Message }
+
+type DataError struct{ Message string }
+
+func (e *DataError) Error() string { return e.Message }
+
+type OperationalError struct{ Message string }
+
+func (e *OperationalError) Error() string { return e.Message }
+
+type IntegrityError struct{ Message string }
+
+func (e *IntegrityError) Error() string { return e.Message }
+
+type InternalError struct{ Message string }
+
+func (e *InternalError) Error() string { return e.Message }
+
+type ProgrammingError struct{ Message string }
+
+func (e *ProgrammingError) Error() string { return e.Message }
+
+type NotSupportedError struct{ Message string }
+
+func (e *NotSupportedError) Error() string { return e.Message }
+
+func translateError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch err.(type) {
+	case *InterfaceError, *DatabaseError, *DataError, *OperationalError,
+		*IntegrityError, *InternalError, *ProgrammingError, *NotSupportedError:
+		return err
+	}
+	return &ProgrammingError{Message: fmt.Sprintf("%v", err)}
+}

--- a/code/packages/go/mini-sqlite/go.mod
+++ b/code/packages/go/mini-sqlite/go.mod
@@ -1,0 +1,28 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/mini-sqlite
+
+go 1.23
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/sql-execution-engine v0.0.0
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/capability-cage v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/sql-lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/sql-parser v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace (
+	github.com/adhithyan15/coding-adventures/code/packages/go/capability-cage => ../capability-cage
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/sql-execution-engine => ../sql-execution-engine
+	github.com/adhithyan15/coding-adventures/code/packages/go/sql-lexer => ../sql-lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/sql-parser => ../sql-parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+)

--- a/code/packages/go/mini-sqlite/mini_sqlite_test.go
+++ b/code/packages/go/mini-sqlite/mini_sqlite_test.go
@@ -1,0 +1,181 @@
+package minisqlite
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func mustConnect(t *testing.T) *Connection {
+	t.Helper()
+	conn, err := Connect(":memory:")
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	return conn
+}
+
+func mustExecute(t *testing.T, conn *Connection, sql string, params ...any) *Cursor {
+	t.Helper()
+	cur, err := conn.Execute(sql, params...)
+	if err != nil {
+		t.Fatalf("Execute(%q) failed: %v", sql, err)
+	}
+	return cur
+}
+
+func TestModuleConstants(t *testing.T) {
+	if APILevel != "2.0" {
+		t.Fatalf("APILevel = %q", APILevel)
+	}
+	if ThreadSafety != 1 {
+		t.Fatalf("ThreadSafety = %d", ThreadSafety)
+	}
+	if ParamStyle != "qmark" {
+		t.Fatalf("ParamStyle = %q", ParamStyle)
+	}
+}
+
+func TestCreateInsertSelect(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER, name TEXT, active BOOLEAN)")
+	_, err := conn.Executemany("INSERT INTO users VALUES (?, ?, ?)", [][]any{
+		{int64(1), "Alice", true},
+		{int64(2), "Bob", false},
+		{int64(3), "Carol", true},
+	})
+	if err != nil {
+		t.Fatalf("Executemany failed: %v", err)
+	}
+
+	cur := mustExecute(t, conn, "SELECT name FROM users WHERE active = ? ORDER BY id ASC", true)
+	if len(cur.Description) != 1 || cur.Description[0].Name != "name" {
+		t.Fatalf("description = %#v", cur.Description)
+	}
+	want := [][]any{{"Alice"}, {"Carol"}}
+	if got := cur.Fetchall(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows = %#v, want %#v", got, want)
+	}
+}
+
+func TestFetchoneFetchmany(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE nums (n INTEGER)")
+	_, err := conn.Executemany("INSERT INTO nums VALUES (?)", [][]any{{int64(1)}, {int64(2)}, {int64(3)}})
+	if err != nil {
+		t.Fatalf("Executemany failed: %v", err)
+	}
+	cur := mustExecute(t, conn, "SELECT n FROM nums ORDER BY n ASC")
+
+	row, ok := cur.Fetchone()
+	if !ok || !reflect.DeepEqual(row, []any{int64(1)}) {
+		t.Fatalf("Fetchone = %#v, %v", row, ok)
+	}
+	if got := cur.Fetchmany(1); !reflect.DeepEqual(got, [][]any{{int64(2)}}) {
+		t.Fatalf("Fetchmany = %#v", got)
+	}
+	if got := cur.Fetchall(); !reflect.DeepEqual(got, [][]any{{int64(3)}}) {
+		t.Fatalf("Fetchall = %#v", got)
+	}
+	if _, ok := cur.Fetchone(); ok {
+		t.Fatal("Fetchone after exhaustion returned a row")
+	}
+}
+
+func TestUpdateRows(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+	_, _ = conn.Executemany("INSERT INTO users VALUES (?, ?)", [][]any{{int64(1), "Alice"}, {int64(2), "Bob"}})
+
+	cur := mustExecute(t, conn, "UPDATE users SET name = ? WHERE id = ?", "Bobby", int64(2))
+	if cur.Rowcount() != 1 {
+		t.Fatalf("rowcount = %d", cur.Rowcount())
+	}
+	want := [][]any{{"Alice"}, {"Bobby"}}
+	if got := mustExecute(t, conn, "SELECT name FROM users ORDER BY id").Fetchall(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows = %#v, want %#v", got, want)
+	}
+}
+
+func TestDeleteRows(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+	_, _ = conn.Executemany("INSERT INTO users VALUES (?, ?)", [][]any{
+		{int64(1), "Alice"},
+		{int64(2), "Bob"},
+		{int64(3), "Carol"},
+	})
+
+	cur := mustExecute(t, conn, "DELETE FROM users WHERE id IN (?, ?)", int64(1), int64(3))
+	if cur.Rowcount() != 2 {
+		t.Fatalf("rowcount = %d", cur.Rowcount())
+	}
+	want := [][]any{{int64(2), "Bob"}}
+	if got := mustExecute(t, conn, "SELECT id, name FROM users").Fetchall(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows = %#v, want %#v", got, want)
+	}
+}
+
+func TestRollbackRestoresSnapshot(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+	if err := conn.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	mustExecute(t, conn, "INSERT INTO users VALUES (?, ?)", int64(1), "Alice")
+	if err := conn.Rollback(); err != nil {
+		t.Fatalf("Rollback failed: %v", err)
+	}
+	if got := mustExecute(t, conn, "SELECT * FROM users").Fetchall(); len(got) != 0 {
+		t.Fatalf("rows after rollback = %#v", got)
+	}
+}
+
+func TestCommitKeepsChanges(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+	mustExecute(t, conn, "INSERT INTO users VALUES (?, ?)", int64(1), "Alice")
+	if err := conn.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if err := conn.Rollback(); err != nil {
+		t.Fatalf("Rollback failed: %v", err)
+	}
+	want := [][]any{{"Alice"}}
+	if got := mustExecute(t, conn, "SELECT name FROM users").Fetchall(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows = %#v, want %#v", got, want)
+	}
+}
+
+func TestDropTable(t *testing.T) {
+	conn := mustConnect(t)
+	mustExecute(t, conn, "CREATE TABLE users (id INTEGER)")
+	mustExecute(t, conn, "DROP TABLE users")
+
+	_, err := conn.Execute("SELECT * FROM users")
+	var opErr *OperationalError
+	if !errors.As(err, &opErr) {
+		t.Fatalf("error = %T %v, want OperationalError", err, err)
+	}
+}
+
+func TestWrongParameterCounts(t *testing.T) {
+	conn := mustConnect(t)
+	_, err := conn.Execute("SELECT ? FROM t")
+	var progErr *ProgrammingError
+	if !errors.As(err, &progErr) {
+		t.Fatalf("not enough params error = %T %v", err, err)
+	}
+	_, err = conn.Execute("SELECT 1 FROM t", int64(1))
+	if !errors.As(err, &progErr) {
+		t.Fatalf("too many params error = %T %v", err, err)
+	}
+}
+
+func TestUnsupportedFileConnection(t *testing.T) {
+	_, err := Connect("app.db")
+	var notSupported *NotSupportedError
+	if !errors.As(err, &notSupported) {
+		t.Fatalf("error = %T %v, want NotSupportedError", err, err)
+	}
+}

--- a/code/packages/go/mini-sqlite/required_capabilities.json
+++ b/code/packages/go/mini-sqlite/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}

--- a/code/packages/go/mini-sqlite/sql.go
+++ b/code/packages/go/mini-sqlite/sql.go
@@ -1,0 +1,334 @@
+package minisqlite
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type createTableStatement struct {
+	table       string
+	columns     []string
+	ifNotExists bool
+}
+
+type dropTableStatement struct {
+	table    string
+	ifExists bool
+}
+
+type insertStatement struct {
+	table   string
+	columns []string
+	rows    [][]any
+}
+
+type updateStatement struct {
+	table       string
+	assignments map[string]any
+	where       string
+}
+
+type deleteStatement struct {
+	table string
+	where string
+}
+
+var (
+	createRe = regexp.MustCompile(`(?is)^\s*CREATE\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*;?\s*$`)
+	dropRe   = regexp.MustCompile(`(?is)^\s*DROP\s+TABLE\s+(IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*;?\s*$`)
+	insertRe = regexp.MustCompile(`(?is)^\s*INSERT\s+INTO\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*\(([^)]*)\))?\s+VALUES\s+(.*?)\s*;?\s*$`)
+	deleteRe = regexp.MustCompile(`(?is)^\s*DELETE\s+FROM\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s+WHERE\s+(.*?))?\s*;?\s*$`)
+)
+
+func firstKeyword(sql string) string {
+	trimmed := strings.TrimLeftFunc(sql, unicode.IsSpace)
+	end := 0
+	for end < len(trimmed) && unicode.IsLetter(rune(trimmed[end])) {
+		end++
+	}
+	return strings.ToUpper(trimmed[:end])
+}
+
+func parseCreate(sql string) (*createTableStatement, error) {
+	m := createRe.FindStringSubmatch(sql)
+	if m == nil {
+		return nil, &ProgrammingError{Message: "invalid CREATE TABLE statement"}
+	}
+	var columns []string
+	for _, part := range splitTopLevel(m[3], ",") {
+		name := identifierAtStart(strings.TrimSpace(part))
+		if name != "" {
+			columns = append(columns, name)
+		}
+	}
+	if len(columns) == 0 {
+		return nil, &ProgrammingError{Message: "CREATE TABLE requires at least one column"}
+	}
+	return &createTableStatement{
+		table:       m[2],
+		columns:     columns,
+		ifNotExists: m[1] != "",
+	}, nil
+}
+
+func parseDrop(sql string) (*dropTableStatement, error) {
+	m := dropRe.FindStringSubmatch(sql)
+	if m == nil {
+		return nil, &ProgrammingError{Message: "invalid DROP TABLE statement"}
+	}
+	return &dropTableStatement{table: m[2], ifExists: m[1] != ""}, nil
+}
+
+func parseInsert(sql string) (*insertStatement, error) {
+	m := insertRe.FindStringSubmatch(sql)
+	if m == nil {
+		return nil, &ProgrammingError{Message: "invalid INSERT statement"}
+	}
+	var columns []string
+	if strings.TrimSpace(m[2]) != "" {
+		for _, part := range splitTopLevel(m[2], ",") {
+			name, err := normalizeIdentifier(strings.TrimSpace(part))
+			if err != nil {
+				return nil, err
+			}
+			columns = append(columns, name)
+		}
+	}
+	rows, err := parseValueRows(m[3])
+	if err != nil {
+		return nil, err
+	}
+	return &insertStatement{table: m[1], columns: columns, rows: rows}, nil
+}
+
+func parseUpdate(sql string) (*updateStatement, error) {
+	trimmed := strings.TrimSpace(sql)
+	if strings.HasSuffix(trimmed, ";") {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
+	}
+	re := regexp.MustCompile(`(?is)^\s*UPDATE\s+([A-Za-z_][A-Za-z0-9_]*)\s+SET\s+(.*)$`)
+	m := re.FindStringSubmatch(trimmed)
+	if m == nil {
+		return nil, &ProgrammingError{Message: "invalid UPDATE statement"}
+	}
+	assignSQL, whereSQL := splitTopLevelKeyword(m[2], "WHERE")
+	assignments := map[string]any{}
+	for _, assignment := range splitTopLevel(assignSQL, ",") {
+		parts := splitTopLevel(assignment, "=")
+		if len(parts) != 2 {
+			return nil, &ProgrammingError{Message: "invalid assignment: " + strings.TrimSpace(assignment)}
+		}
+		name, err := normalizeIdentifier(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, err
+		}
+		value, err := parseLiteral(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, err
+		}
+		assignments[name] = value
+	}
+	if len(assignments) == 0 {
+		return nil, &ProgrammingError{Message: "UPDATE requires at least one assignment"}
+	}
+	return &updateStatement{table: m[1], assignments: assignments, where: whereSQL}, nil
+}
+
+func parseDelete(sql string) (*deleteStatement, error) {
+	m := deleteRe.FindStringSubmatch(sql)
+	if m == nil {
+		return nil, &ProgrammingError{Message: "invalid DELETE statement"}
+	}
+	return &deleteStatement{table: m[1], where: strings.TrimSpace(m[2])}, nil
+}
+
+func parseValueRows(sql string) ([][]any, error) {
+	rest := strings.TrimSpace(sql)
+	var rows [][]any
+	for rest != "" {
+		if rest[0] != '(' {
+			return nil, &ProgrammingError{Message: "INSERT VALUES rows must be parenthesized"}
+		}
+		end := findMatchingParen(rest, 0)
+		if end < 0 {
+			return nil, &ProgrammingError{Message: "unterminated INSERT VALUES row"}
+		}
+		var row []any
+		for _, part := range splitTopLevel(rest[1:end], ",") {
+			value, err := parseLiteral(strings.TrimSpace(part))
+			if err != nil {
+				return nil, err
+			}
+			row = append(row, value)
+		}
+		rows = append(rows, row)
+		rest = strings.TrimSpace(rest[end+1:])
+		if strings.HasPrefix(rest, ",") {
+			rest = strings.TrimSpace(rest[1:])
+		} else if rest != "" {
+			return nil, &ProgrammingError{Message: "invalid text after INSERT row"}
+		}
+	}
+	if len(rows) == 0 {
+		return nil, &ProgrammingError{Message: "INSERT requires at least one row"}
+	}
+	return rows, nil
+}
+
+func parseLiteral(text string) (any, error) {
+	value := strings.TrimSpace(text)
+	upper := strings.ToUpper(value)
+	switch upper {
+	case "NULL":
+		return nil, nil
+	case "TRUE":
+		return true, nil
+	case "FALSE":
+		return false, nil
+	}
+	if strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
+		return strings.ReplaceAll(value[1:len(value)-1], "''", "'"), nil
+	}
+	if strings.Contains(value, ".") {
+		f, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			return f, nil
+		}
+	} else {
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			return i, nil
+		}
+	}
+	return nil, &ProgrammingError{Message: "expected literal value, got: " + text}
+}
+
+func splitTopLevel(text, delimiter string) []string {
+	var parts []string
+	start, depth := 0, 0
+	var quote byte
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+		if quote != 0 {
+			if ch == quote && i+1 < len(text) && text[i+1] == quote {
+				i++
+			} else if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		if ch == '\'' || ch == '"' {
+			quote = ch
+			continue
+		}
+		if ch == '(' {
+			depth++
+		} else if ch == ')' {
+			depth--
+		} else if depth == 0 && strings.HasPrefix(text[i:], delimiter) {
+			part := strings.TrimSpace(text[start:i])
+			if part != "" {
+				parts = append(parts, part)
+			}
+			i += len(delimiter) - 1
+			start = i + 1
+		}
+	}
+	part := strings.TrimSpace(text[start:])
+	if part != "" {
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func splitTopLevelKeyword(text, keyword string) (string, string) {
+	depth := 0
+	var quote byte
+	upper := strings.ToUpper(text)
+	needle := strings.ToUpper(keyword)
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+		if quote != 0 {
+			if ch == quote && i+1 < len(text) && text[i+1] == quote {
+				i++
+			} else if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		if ch == '\'' || ch == '"' {
+			quote = ch
+			continue
+		}
+		if ch == '(' {
+			depth++
+		} else if ch == ')' {
+			depth--
+		} else if depth == 0 && strings.HasPrefix(upper[i:], needle) && boundary(text, i-1) && boundary(text, i+len(needle)) {
+			return strings.TrimSpace(text[:i]), strings.TrimSpace(text[i+len(needle):])
+		}
+	}
+	return strings.TrimSpace(text), ""
+}
+
+func findMatchingParen(text string, open int) int {
+	depth := 0
+	var quote byte
+	for i := open; i < len(text); i++ {
+		ch := text[i]
+		if quote != 0 {
+			if ch == quote && i+1 < len(text) && text[i+1] == quote {
+				i++
+			} else if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		if ch == '\'' || ch == '"' {
+			quote = ch
+			continue
+		}
+		if ch == '(' {
+			depth++
+		}
+		if ch == ')' {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func identifierAtStart(text string) string {
+	for i, r := range text {
+		if i == 0 {
+			if !(unicode.IsLetter(r) || r == '_') {
+				return ""
+			}
+			continue
+		}
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
+			return text[:i]
+		}
+	}
+	return text
+}
+
+func normalizeIdentifier(text string) (string, error) {
+	if text == "" || identifierAtStart(text) != text {
+		return "", &ProgrammingError{Message: "invalid identifier: " + text}
+	}
+	return text, nil
+}
+
+func boundary(text string, index int) bool {
+	if index < 0 || index >= len(text) {
+		return true
+	}
+	r := rune(text[index])
+	return !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_')
+}

--- a/code/packages/go/sql-execution-engine/engine.go
+++ b/code/packages/go/sql-execution-engine/engine.go
@@ -128,41 +128,43 @@ func ExecuteAll(sql string, source DataSource) ([]*QueryResult, error) {
 // findSelectNode navigates from a "program" root to the first "select_stmt"
 // node. Returns UnsupportedStatementError if the first statement is not SELECT.
 func findSelectNode(program *parser.ASTNode) (*parser.ASTNode, error) {
-	// program → statement → select_stmt
-	for _, child := range program.Children {
-		stmtNode, ok := child.(*parser.ASTNode)
-		if !ok {
-			continue
-		}
-		if stmtNode.RuleName == "statement" {
-			return findSelectInStatement(stmtNode)
-		}
-	}
-	return nil, fmt.Errorf("no statements found in program")
+	return findSelectInStatement(program)
 }
 
 // findSelectInStatement extracts the select_stmt from a statement node.
 // Returns UnsupportedStatementError for any non-SELECT statement type.
 func findSelectInStatement(stmt *parser.ASTNode) (*parser.ASTNode, error) {
-	for _, child := range stmt.Children {
-		node, ok := child.(*parser.ASTNode)
+	kind, node := findFirstConcreteStatement(stmt)
+	switch kind {
+	case "select_stmt":
+		return node, nil
+	case "insert_stmt":
+		return nil, &UnsupportedStatementError{StatementType: "INSERT"}
+	case "update_stmt":
+		return nil, &UnsupportedStatementError{StatementType: "UPDATE"}
+	case "delete_stmt":
+		return nil, &UnsupportedStatementError{StatementType: "DELETE"}
+	case "create_table_stmt":
+		return nil, &UnsupportedStatementError{StatementType: "CREATE TABLE"}
+	case "drop_table_stmt":
+		return nil, &UnsupportedStatementError{StatementType: "DROP TABLE"}
+	}
+	return nil, fmt.Errorf("could not find statement type in AST node %q", stmt.RuleName)
+}
+
+func findFirstConcreteStatement(node *parser.ASTNode) (string, *parser.ASTNode) {
+	switch node.RuleName {
+	case "select_stmt", "insert_stmt", "update_stmt", "delete_stmt", "create_table_stmt", "drop_table_stmt":
+		return node.RuleName, node
+	}
+	for _, child := range node.Children {
+		childNode, ok := child.(*parser.ASTNode)
 		if !ok {
 			continue
 		}
-		switch node.RuleName {
-		case "select_stmt":
-			return node, nil
-		case "insert_stmt":
-			return nil, &UnsupportedStatementError{StatementType: "INSERT"}
-		case "update_stmt":
-			return nil, &UnsupportedStatementError{StatementType: "UPDATE"}
-		case "delete_stmt":
-			return nil, &UnsupportedStatementError{StatementType: "DELETE"}
-		case "create_table_stmt":
-			return nil, &UnsupportedStatementError{StatementType: "CREATE TABLE"}
-		case "drop_table_stmt":
-			return nil, &UnsupportedStatementError{StatementType: "DROP TABLE"}
+		if kind, found := findFirstConcreteStatement(childNode); found != nil {
+			return kind, found
 		}
 	}
-	return nil, fmt.Errorf("could not find statement type in AST node %q", stmt.RuleName)
+	return "", nil
 }

--- a/code/packages/go/sql-execution-engine/expression.go
+++ b/code/packages/go/sql-execution-engine/expression.go
@@ -365,28 +365,24 @@ func evalComparisonKeywordOp(lhs interface{}, nodes []*parser.ASTNode, tokens []
 
 	case firstTok == "IN":
 		// IN (value_list): true if lhs equals any value in the list
-		for _, n := range nodes[1:] {
-			if n.RuleName == "value_list" {
-				vals := evalValueList(n, rowCtx)
-				return evalIn(lhs, vals)
-			}
+		if valueList := findRuleInNodes(nodes[1:], "value_list"); valueList != nil {
+			vals := evalValueList(valueList, rowCtx)
+			return evalIn(lhs, vals)
 		}
 		return nil
 
 	case firstTok == "NOT" && len(tokens) >= 2 && strings.ToUpper(tokens[1].Value) == "IN":
 		// NOT IN (value_list)
-		for _, n := range nodes[1:] {
-			if n.RuleName == "value_list" {
-				vals := evalValueList(n, rowCtx)
-				result := evalIn(lhs, vals)
-				if result == nil {
-					return nil
-				}
-				if b, ok := result.(bool); ok {
-					return !b
-				}
+		if valueList := findRuleInNodes(nodes[1:], "value_list"); valueList != nil {
+			vals := evalValueList(valueList, rowCtx)
+			result := evalIn(lhs, vals)
+			if result == nil {
 				return nil
 			}
+			if b, ok := result.(bool); ok {
+				return !b
+			}
+			return nil
 		}
 		return nil
 
@@ -484,14 +480,22 @@ func evalBetween(val, low, high interface{}) interface{} {
 // value_list = expr { "," expr }
 func evalValueList(node *parser.ASTNode, rowCtx map[string]interface{}) []interface{} {
 	var vals []interface{}
+	collectValueListValues(node, rowCtx, &vals)
+	return vals
+}
+
+func collectValueListValues(node *parser.ASTNode, rowCtx map[string]interface{}, vals *[]interface{}) {
 	for _, child := range node.Children {
 		childNode, ok := child.(*parser.ASTNode)
 		if !ok {
-			continue // skip comma tokens
+			continue
 		}
-		vals = append(vals, evalExpr(childNode, rowCtx))
+		if childNode.RuleName == "expr" {
+			*vals = append(*vals, evalExpr(childNode, rowCtx))
+			continue
+		}
+		collectValueListValues(childNode, rowCtx, vals)
 	}
-	return vals
 }
 
 // evalIn implements the IN predicate.
@@ -858,7 +862,8 @@ func parseNumber(s string) interface{} {
 //
 // For single-table queries: "salary" → rowCtx["salary"]
 // For multi-table queries: "e.salary" → rowCtx["employees.salary"] (if "e" is
-//   the alias for "employees"), or rowCtx["e.salary"]
+//
+//	the alias for "employees"), or rowCtx["e.salary"]
 //
 // Resolution order:
 //  1. Qualified name exactly as written: "dept.name" → rowCtx["dept.name"]
@@ -1013,7 +1018,9 @@ func isTruthy(v interface{}) bool {
 
 // collectRuleChildren returns all child ASTNodes with the given rule name.
 // This is used to collect operands in binary operator chains like:
-//   or_expr = and_expr { "OR" and_expr }
+//
+//	or_expr = and_expr { "OR" and_expr }
+//
 // where we need just the and_expr children, skipping "OR" tokens.
 func collectRuleChildren(node *parser.ASTNode, ruleName string) []*parser.ASTNode {
 	var result []*parser.ASTNode
@@ -1027,6 +1034,15 @@ func collectRuleChildren(node *parser.ASTNode, ruleName string) []*parser.ASTNod
 		}
 	}
 	return result
+}
+
+func findRuleInNodes(nodes []*parser.ASTNode, ruleName string) *parser.ASTNode {
+	for _, node := range nodes {
+		if found := findChildDeep(node, ruleName); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 // findChild searches the direct children of node for an ASTNode with the


### PR DESCRIPTION
## Summary
- add a Go Level 0 `mini-sqlite` package with in-memory connections, cursor fetch helpers, qmark binding, and snapshot commit/rollback
- support basic create/drop/insert/update/delete and SELECT delegation through the Go SQL execution engine
- make the Go SQL execution engine resilient to the current parser wrapper shape and fix nested `IN` / `NOT IN` value-list discovery

## Validation
- `go test ./... -v -cover` in `code/packages/go/sql-execution-engine`
- `go test ./... -v -cover` in `code/packages/go/mini-sqlite`