### PR TITLE
Add Ruby mini-sqlite facade

### DIFF
--- a/code/packages/ruby/mini_sqlite/BUILD
+++ b/code/packages/ruby/mini_sqlite/BUILD
@@ -1,0 +1,2 @@
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/mini_sqlite/CHANGELOG.md
+++ b/code/packages/ruby/mini_sqlite/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog - coding_adventures_mini_sqlite
+
+## [0.1.0] - 2026-04-29
+
+### Added
+- Initial Ruby Level 0 mini-sqlite facade.
+- In-memory `connect(":memory:")` connections.
+- qmark parameter binding.
+- Basic `CREATE TABLE`, `DROP TABLE`, `INSERT`, `UPDATE`, `DELETE`, and `SELECT`.
+- Cursor fetch helpers and snapshot-backed `commit` / `rollback`.

--- a/code/packages/ruby/mini_sqlite/Gemfile
+++ b/code/packages/ruby/mini_sqlite/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+gem "coding_adventures_grammar_tools", path: "../grammar_tools"
+gem "coding_adventures_lexer", path: "../lexer"
+gem "coding_adventures_graph", path: "../graph"
+gem "coding_adventures_directed_graph", path: "../directed_graph"
+gem "coding_adventures_state_machine", path: "../state_machine"
+gem "coding_adventures_parser", path: "../parser"
+gem "coding_adventures_sql_lexer", path: "../sql_lexer"
+gem "coding_adventures_sql_parser", path: "../sql_parser"
+gem "coding_adventures_sql_execution_engine", path: "../sql_execution_engine"

--- a/code/packages/ruby/mini_sqlite/README.md
+++ b/code/packages/ruby/mini_sqlite/README.md
@@ -1,0 +1,21 @@
+# mini-sqlite (Ruby)
+
+Ruby Level 0 port of the Python `mini-sqlite` facade.
+
+The package provides an in-memory database facade with qmark binding, basic
+DDL/DML, cursors, and transaction snapshots. SELECT queries are delegated to
+the existing Ruby `sql_execution_engine` package.
+
+```ruby
+require "coding_adventures_mini_sqlite"
+
+conn = CodingAdventures::MiniSqlite.connect(":memory:")
+conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+conn.executemany("INSERT INTO users VALUES (?, ?)", [[1, "Alice"], [2, "Bob"]])
+
+rows = conn.execute("SELECT name FROM users WHERE id = ?", [1]).fetchall
+puts rows.inspect # [["Alice"]]
+```
+
+File-backed connections are reserved for a later storage backend port and
+currently raise `NotSupportedError`.

--- a/code/packages/ruby/mini_sqlite/Rakefile
+++ b/code/packages/ruby/mini_sqlite/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/mini_sqlite/coding_adventures_mini_sqlite.gemspec
+++ b/code/packages/ruby/mini_sqlite/coding_adventures_mini_sqlite.gemspec
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/mini_sqlite/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "coding_adventures_mini_sqlite"
+  spec.version = CodingAdventures::MiniSqlite::VERSION
+  spec.authors = ["Adhithya Rajasekaran"]
+  spec.summary = "Mini-SQLite facade for Ruby"
+  spec.description = "An in-memory mini-sqlite facade built on the Ruby SQL execution engine."
+  spec.homepage = "https://github.com/adhithyan15/coding-adventures"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+  spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+  spec.add_dependency "coding_adventures_sql_execution_engine", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "mini_sqlite/version"
+require_relative "mini_sqlite/errors"
+require_relative "mini_sqlite/binding"
+require_relative "mini_sqlite/sql"
+require_relative "mini_sqlite/database"
+require_relative "mini_sqlite/connection"
+require_relative "mini_sqlite/cursor"
+
+module CodingAdventures
+  module MiniSqlite
+    APILEVEL = "2.0"
+    THREADSAFETY = 1
+    PARAMSTYLE = "qmark"
+
+    module_function
+
+    def connect(database = ":memory:", autocommit: false)
+      raise NotSupportedError, "Ruby mini-sqlite supports only :memory: in Level 0" unless database == ":memory:"
+
+      Connection.new(autocommit:)
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/binding.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/binding.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    module Binding
+      module_function
+
+      def substitute(sql, params = [])
+        index = 0
+        out = +""
+        i = 0
+        while i < sql.length
+          ch = sql[i]
+          nxt = sql[i + 1]
+          if ch == "'" || ch == '"'
+            literal, i = read_quoted(sql, i, ch)
+            out << literal
+            next
+          end
+          if ch == "-" && nxt == "-"
+            j = sql.index("\n", i) || sql.length
+            out << sql[i...j]
+            i = j
+            next
+          end
+          if ch == "/" && nxt == "*"
+            j = sql.index("*/", i + 2)
+            j = j ? j + 2 : sql.length
+            out << sql[i...j]
+            i = j
+            next
+          end
+          if ch == "?"
+            raise ProgrammingError, "not enough parameters for SQL statement" if index >= params.length
+
+            out << to_sql_literal(params[index])
+            index += 1
+            i += 1
+            next
+          end
+          out << ch
+          i += 1
+        end
+        raise ProgrammingError, "too many parameters for SQL statement" unless index == params.length
+
+        out
+      end
+
+      def read_quoted(sql, start, quote)
+        i = start + 1
+        while i < sql.length
+          if sql[i] == quote
+            if sql[i + 1] == quote
+              i += 2
+              next
+            end
+            return [sql[start..i], i + 1]
+          end
+          i += 1
+        end
+        [sql[start..], sql.length]
+      end
+
+      def to_sql_literal(value)
+        case value
+        when nil then "NULL"
+        when true then "TRUE"
+        when false then "FALSE"
+        when Integer, Float
+          raise ProgrammingError, "non-finite numeric parameter is not supported" unless value.finite?
+
+          value.to_s
+        when String
+          "'#{value.gsub("'", "''")}'"
+        else
+          raise ProgrammingError, "unsupported parameter type: #{value.class}"
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/connection.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/connection.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    class Connection
+      def initialize(autocommit: false)
+        @database = InMemoryDatabase.new
+        @autocommit = autocommit
+        @snapshot = nil
+        @closed = false
+      end
+
+      def cursor
+        assert_open!
+        Cursor.new(self)
+      end
+
+      def execute(sql, params = [])
+        cursor.execute(sql, params)
+      end
+
+      def executemany(sql, sequence_of_params)
+        cursor.executemany(sql, sequence_of_params)
+      end
+
+      def commit
+        assert_open!
+        @snapshot = nil
+        nil
+      end
+
+      def rollback
+        assert_open!
+        if @snapshot
+          @database.restore(@snapshot)
+          @snapshot = nil
+        end
+        nil
+      end
+
+      def close
+        return nil if @closed
+
+        @database.restore(@snapshot) if @snapshot
+        @snapshot = nil
+        @closed = true
+        nil
+      end
+
+      def execute_bound(sql, params)
+        assert_open!
+        bound = Binding.substitute(sql, params)
+        case SQL.first_keyword(bound)
+        when "BEGIN"
+          ensure_snapshot
+          {columns: [], rows: [], rows_affected: 0}
+        when "COMMIT"
+          commit
+          {columns: [], rows: [], rows_affected: 0}
+        when "ROLLBACK"
+          rollback
+          {columns: [], rows: [], rows_affected: 0}
+        when "SELECT"
+          @database.select(bound)
+        when "CREATE"
+          ensure_snapshot
+          @database.create(SQL.parse_create(bound))
+        when "DROP"
+          ensure_snapshot
+          @database.drop(SQL.parse_drop(bound))
+        when "INSERT"
+          ensure_snapshot
+          @database.insert(SQL.parse_insert(bound))
+        when "UPDATE"
+          ensure_snapshot
+          @database.update(SQL.parse_update(bound))
+        when "DELETE"
+          ensure_snapshot
+          @database.delete(SQL.parse_delete(bound))
+        else
+          raise ProgrammingError, "unsupported SQL statement"
+        end
+      end
+
+      private
+
+      def ensure_snapshot
+        @snapshot = @database.snapshot if !@autocommit && @snapshot.nil?
+      end
+
+      def assert_open!
+        raise ProgrammingError, "connection is closed" if @closed
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/cursor.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/cursor.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    class Cursor
+      attr_reader :description, :rowcount, :lastrowid
+      attr_accessor :arraysize
+
+      def initialize(connection)
+        @connection = connection
+        @description = nil
+        @rowcount = -1
+        @lastrowid = nil
+        @arraysize = 1
+        @rows = []
+        @offset = 0
+        @closed = false
+      end
+
+      def execute(sql, params = [])
+        assert_open!
+        result = @connection.execute_bound(sql, params)
+        @rows = result[:rows]
+        @offset = 0
+        @rowcount = result[:rows_affected]
+        @description = result[:columns].empty? ? nil : result[:columns].map { |name| [name, nil, nil, nil, nil, nil, nil] }
+        self
+      end
+
+      def executemany(sql, sequence_of_params)
+        assert_open!
+        total = 0
+        sequence_of_params.each do |params|
+          execute(sql, params)
+          total += @rowcount if @rowcount.positive?
+        end
+        @rowcount = total unless sequence_of_params.empty?
+        self
+      end
+
+      def fetchone
+        assert_open!
+        return nil if @offset >= @rows.length
+
+        row = @rows[@offset]
+        @offset += 1
+        row
+      end
+
+      def fetchmany(size = nil)
+        assert_open!
+        size = @arraysize if size.nil? || size.negative?
+        rows = @rows[@offset, size] || []
+        @offset += rows.length
+        rows
+      end
+
+      def fetchall
+        assert_open!
+        rows = @rows[@offset..] || []
+        @offset = @rows.length
+        rows
+      end
+
+      def close
+        @closed = true
+        @rows = []
+        @description = nil
+        nil
+      end
+
+      def each
+        return enum_for(:each) unless block_given?
+
+        while (row = fetchone)
+          yield row
+        end
+      end
+
+      private
+
+      def assert_open!
+        raise ProgrammingError, "cursor is closed" if @closed
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/database.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/database.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "coding_adventures_sql_execution_engine"
+
+module CodingAdventures
+  module MiniSqlite
+    ROW_ID = "__mini_sqlite_rowid"
+
+    class InMemoryDatabase
+      include CodingAdventures::SqlExecutionEngine::DataSource
+
+      def initialize
+        @tables = {}
+      end
+
+      def schema(table_name)
+        table(table_name)[:columns].dup
+      end
+
+      def scan(table_name)
+        table(table_name)[:rows].map(&:dup)
+      end
+
+      def snapshot
+        @tables.transform_values do |table|
+          {columns: table[:columns].dup, rows: table[:rows].map(&:dup)}
+        end
+      end
+
+      def restore(snapshot)
+        @tables = snapshot.transform_values do |table|
+          {columns: table[:columns].dup, rows: table[:rows].map(&:dup)}
+        end
+      end
+
+      def create(stmt)
+        key = normalize(stmt[:table])
+        if @tables.key?(key)
+          return empty_result if stmt[:if_not_exists]
+
+          raise OperationalError, "table already exists: #{stmt[:table]}"
+        end
+        seen = {}
+        stmt[:columns].each do |column|
+          normalized = normalize(column)
+          raise ProgrammingError, "duplicate column: #{column}" if seen[normalized]
+
+          seen[normalized] = true
+        end
+        @tables[key] = {columns: stmt[:columns].dup, rows: []}
+        empty_result
+      end
+
+      def drop(stmt)
+        key = normalize(stmt[:table])
+        unless @tables.key?(key)
+          return empty_result if stmt[:if_exists]
+
+          raise OperationalError, "no such table: #{stmt[:table]}"
+        end
+        @tables.delete(key)
+        empty_result
+      end
+
+      def insert(stmt)
+        table_data = table(stmt[:table])
+        columns = stmt[:columns] || table_data[:columns]
+        assert_known_columns(table_data, columns)
+        stmt[:rows].each do |values|
+          if values.length != columns.length
+            raise IntegrityError, "INSERT expected #{columns.length} values, got #{values.length}"
+          end
+          row = table_data[:columns].to_h { |column| [column, nil] }
+          columns.each_with_index { |column, index| row[column] = values[index] }
+          table_data[:rows] << row
+        end
+        {columns: [], rows: [], rows_affected: stmt[:rows].length}
+      end
+
+      def update(stmt)
+        table_data = table(stmt[:table])
+        assert_known_columns(table_data, stmt[:assignments].keys)
+        row_ids = matching_row_ids(stmt[:table], stmt[:where])
+        row_ids.each do |row_id|
+          stmt[:assignments].each { |column, value| table_data[:rows][row_id][column] = value }
+        end
+        {columns: [], rows: [], rows_affected: row_ids.length}
+      end
+
+      def delete(stmt)
+        table_data = table(stmt[:table])
+        row_ids = matching_row_ids(stmt[:table], stmt[:where])
+        remove = row_ids.to_h { |row_id| [row_id, true] }
+        table_data[:rows] = table_data[:rows].each_with_index.reject { |_row, index| remove[index] }.map(&:first)
+        {columns: [], rows: [], rows_affected: row_ids.length}
+      end
+
+      def select(sql)
+        result = CodingAdventures::SqlExecutionEngine.execute(sql, self)
+        {
+          columns: result.columns,
+          rows: result.rows.map { |row| result.columns.map { |column| row[column] } },
+          rows_affected: -1
+        }
+      rescue StandardError => e
+        raise MiniSqlite.translate_error(e)
+      end
+
+      private
+
+      def matching_row_ids(table_name, where_sql)
+        table_data = table(table_name)
+        return table_data[:rows].each_index.to_a if where_sql.to_s.strip.empty?
+
+        source = RowIdSource.new(table_name, table_data)
+        result = CodingAdventures::SqlExecutionEngine.execute(
+          "SELECT #{ROW_ID} FROM #{table_name} WHERE #{where_sql}",
+          source
+        )
+        result.rows.map { |row| row[ROW_ID].to_i }
+      rescue StandardError => e
+        raise MiniSqlite.translate_error(e)
+      end
+
+      def table(table_name)
+        @tables.fetch(normalize(table_name)) { raise OperationalError, "no such table: #{table_name}" }
+      end
+
+      def assert_known_columns(table_data, columns)
+        known = table_data[:columns].map { |column| normalize(column) }.to_h { |column| [column, true] }
+        columns.each do |column|
+          raise OperationalError, "no such column: #{column}" unless known[normalize(column)]
+        end
+      end
+
+      def normalize(name)
+        name.to_s.downcase
+      end
+
+      def empty_result
+        {columns: [], rows: [], rows_affected: 0}
+      end
+    end
+
+    class RowIdSource
+      include CodingAdventures::SqlExecutionEngine::DataSource
+
+      def initialize(table_name, table_data)
+        @table_name = table_name
+        @table_data = table_data
+      end
+
+      def schema(table_name)
+        assert_table(table_name)
+        @table_data[:columns] + [ROW_ID]
+      end
+
+      def scan(table_name)
+        assert_table(table_name)
+        @table_data[:rows].each_with_index.map do |row, index|
+          row.merge(ROW_ID => index)
+        end
+      end
+
+      private
+
+      def assert_table(table_name)
+        return if table_name.to_s.downcase == @table_name.to_s.downcase
+
+        raise CodingAdventures::SqlExecutionEngine::TableNotFoundError, table_name
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/errors.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/errors.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    class Warning < StandardError; end
+    class Error < StandardError; end
+    class InterfaceError < Error; end
+    class DatabaseError < Error; end
+    class DataError < DatabaseError; end
+    class OperationalError < DatabaseError; end
+    class IntegrityError < DatabaseError; end
+    class InternalError < DatabaseError; end
+    class ProgrammingError < DatabaseError; end
+    class NotSupportedError < DatabaseError; end
+
+    def self.translate_error(error)
+      return error if error.is_a?(Error)
+
+      message = error.message
+      case error.class.name
+      when /TableNotFound|ColumnNotFound/
+        OperationalError.new(message)
+      else
+        ProgrammingError.new(message)
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/sql.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/sql.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    module SQL
+      module_function
+
+      def first_keyword(sql)
+        sql.lstrip[/\A[A-Za-z]+/].to_s.upcase
+      end
+
+      def parse_create(sql)
+        match = /\A\s*CREATE\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?([A-Za-z_]\w*)\s*\((.*)\)\s*;?\s*\z/im.match(sql)
+        raise ProgrammingError, "invalid CREATE TABLE statement" unless match
+
+        columns = split_top_level(match[3], ",").map { |part| part.strip[/\A[A-Za-z_]\w*/] }.compact
+        raise ProgrammingError, "CREATE TABLE requires at least one column" if columns.empty?
+
+        {kind: :create, table: match[2], columns:, if_not_exists: !match[1].nil?}
+      end
+
+      def parse_drop(sql)
+        match = /\A\s*DROP\s+TABLE\s+(IF\s+EXISTS\s+)?([A-Za-z_]\w*)\s*;?\s*\z/im.match(sql)
+        raise ProgrammingError, "invalid DROP TABLE statement" unless match
+
+        {kind: :drop, table: match[2], if_exists: !match[1].nil?}
+      end
+
+      def parse_insert(sql)
+        match = /\A\s*INSERT\s+INTO\s+([A-Za-z_]\w*)(?:\s*\(([^)]*)\))?\s+VALUES\s+(.*?)\s*;?\s*\z/im.match(sql)
+        raise ProgrammingError, "invalid INSERT statement" unless match
+
+        columns = match[2] ? split_top_level(match[2], ",").map { |part| identifier(part.strip) } : nil
+        {kind: :insert, table: match[1], columns:, rows: parse_value_rows(match[3])}
+      end
+
+      def parse_update(sql)
+        text = sql.strip.delete_suffix(";").strip
+        match = /\A\s*UPDATE\s+([A-Za-z_]\w*)\s+SET\s+(.*)\z/im.match(text)
+        raise ProgrammingError, "invalid UPDATE statement" unless match
+
+        assignment_sql, where_sql = split_top_level_keyword(match[2], "WHERE")
+        assignments = {}
+        split_top_level(assignment_sql, ",").each do |assignment|
+          parts = split_top_level(assignment, "=")
+          raise ProgrammingError, "invalid assignment: #{assignment.strip}" unless parts.length == 2
+
+          assignments[identifier(parts[0].strip)] = parse_literal(parts[1].strip)
+        end
+        raise ProgrammingError, "UPDATE requires at least one assignment" if assignments.empty?
+
+        {kind: :update, table: match[1], assignments:, where: where_sql}
+      end
+
+      def parse_delete(sql)
+        match = /\A\s*DELETE\s+FROM\s+([A-Za-z_]\w*)(?:\s+WHERE\s+(.*?))?\s*;?\s*\z/im.match(sql)
+        raise ProgrammingError, "invalid DELETE statement" unless match
+
+        {kind: :delete, table: match[1], where: match[2].to_s.strip}
+      end
+
+      def parse_value_rows(sql)
+        rest = sql.strip
+        rows = []
+        until rest.empty?
+          raise ProgrammingError, "INSERT VALUES rows must be parenthesized" unless rest.start_with?("(")
+
+          ending = matching_paren(rest, 0)
+          raise ProgrammingError, "unterminated INSERT VALUES row" unless ending
+
+          rows << split_top_level(rest[1...ending], ",").map { |part| parse_literal(part.strip) }
+          rest = rest[(ending + 1)..].to_s.strip
+          rest = rest[1..].strip if rest.start_with?(",")
+        end
+        raise ProgrammingError, "INSERT requires at least one row" if rows.empty?
+
+        rows
+      end
+
+      def parse_literal(text)
+        value = text.strip
+        return nil if value.match?(/\ANULL\z/i)
+        return true if value.match?(/\ATRUE\z/i)
+        return false if value.match?(/\AFALSE\z/i)
+        return value.to_f if value.match?(/\A-?\d+\.\d+\z/)
+        return value.to_i if value.match?(/\A-?\d+\z/)
+        return value[1...-1].gsub("''", "'") if value.start_with?("'") && value.end_with?("'")
+
+        raise ProgrammingError, "expected literal value, got: #{text}"
+      end
+
+      def split_top_level(text, delimiter)
+        parts = []
+        start = 0
+        depth = 0
+        quote = nil
+        i = 0
+        while i < text.length
+          ch = text[i]
+          if quote
+            if ch == quote && text[i + 1] == quote
+              i += 2
+              next
+            elsif ch == quote
+              quote = nil
+            end
+          elsif ch == "'" || ch == '"'
+            quote = ch
+          elsif ch == "("
+            depth += 1
+          elsif ch == ")"
+            depth -= 1
+          elsif depth.zero? && text[i, delimiter.length] == delimiter
+            part = text[start...i].strip
+            parts << part unless part.empty?
+            i += delimiter.length
+            start = i
+            next
+          end
+          i += 1
+        end
+        part = text[start..].to_s.strip
+        parts << part unless part.empty?
+        parts
+      end
+
+      def split_top_level_keyword(text, keyword)
+        depth = 0
+        quote = nil
+        upper = text.upcase
+        needle = keyword.upcase
+        i = 0
+        while i < text.length
+          ch = text[i]
+          if quote
+            if ch == quote && text[i + 1] == quote
+              i += 2
+              next
+            elsif ch == quote
+              quote = nil
+            end
+          elsif ch == "'" || ch == '"'
+            quote = ch
+          elsif ch == "("
+            depth += 1
+          elsif ch == ")"
+            depth -= 1
+          elsif depth.zero? && upper[i, needle.length] == needle && boundary?(text[i - 1]) && boundary?(text[i + needle.length])
+            return [text[0...i].strip, text[(i + needle.length)..].to_s.strip]
+          end
+          i += 1
+        end
+        [text.strip, ""]
+      end
+
+      def matching_paren(text, open_index)
+        depth = 0
+        quote = nil
+        i = open_index
+        while i < text.length
+          ch = text[i]
+          if quote
+            if ch == quote && text[i + 1] == quote
+              i += 2
+              next
+            elsif ch == quote
+              quote = nil
+            end
+          elsif ch == "'" || ch == '"'
+            quote = ch
+          elsif ch == "("
+            depth += 1
+          elsif ch == ")"
+            depth -= 1
+            return i if depth.zero?
+          end
+          i += 1
+        end
+        nil
+      end
+
+      def identifier(text)
+        raise ProgrammingError, "invalid identifier: #{text}" unless text.match?(/\A[A-Za-z_]\w*\z/)
+
+        text
+      end
+
+      def boundary?(char)
+        char.nil? || !char.match?(/[A-Za-z0-9_]/)
+      end
+    end
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/version.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module MiniSqlite
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures_mini_sqlite.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures_mini_sqlite.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/mini_sqlite"

--- a/code/packages/ruby/mini_sqlite/required_capabilities.json
+++ b/code/packages/ruby/mini_sqlite/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}

--- a/code/packages/ruby/mini_sqlite/test/test_helper.rb
+++ b/code/packages/ruby/mini_sqlite/test/test_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 60
+end
+
+require "minitest/autorun"
+require "coding_adventures_mini_sqlite"

--- a/code/packages/ruby/mini_sqlite/test/test_mini_sqlite.rb
+++ b/code/packages/ruby/mini_sqlite/test/test_mini_sqlite.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+MS = CodingAdventures::MiniSqlite
+
+class TestMiniSqlite < Minitest::Test
+  def setup
+    @conn = MS.connect(":memory:")
+  end
+
+  def test_module_constants
+    assert_equal "2.0", MS::APILEVEL
+    assert_equal 1, MS::THREADSAFETY
+    assert_equal "qmark", MS::PARAMSTYLE
+  end
+
+  def test_create_insert_select
+    @conn.execute("CREATE TABLE users (id INTEGER, name TEXT, active BOOLEAN)")
+    @conn.executemany("INSERT INTO users VALUES (?, ?, ?)", [
+      [1, "Alice", true],
+      [2, "Bob", false],
+      [3, "Carol", true]
+    ])
+
+    cur = @conn.execute("SELECT name FROM users WHERE active = ? ORDER BY id ASC", [true])
+
+    assert_equal "name", cur.description[0][0]
+    assert_equal [["Alice"], ["Carol"]], cur.fetchall
+  end
+
+  def test_fetchone_fetchmany_fetchall
+    @conn.execute("CREATE TABLE nums (n INTEGER)")
+    @conn.executemany("INSERT INTO nums VALUES (?)", [[1], [2], [3]])
+    cur = @conn.execute("SELECT n FROM nums ORDER BY n ASC")
+
+    assert_equal [1], cur.fetchone
+    assert_equal [[2]], cur.fetchmany(1)
+    assert_equal [[3]], cur.fetchall
+    assert_nil cur.fetchone
+  end
+
+  def test_update_rows
+    @conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+    @conn.executemany("INSERT INTO users VALUES (?, ?)", [[1, "Alice"], [2, "Bob"]])
+
+    cur = @conn.execute("UPDATE users SET name = ? WHERE id = ?", ["Bobby", 2])
+
+    assert_equal 1, cur.rowcount
+    assert_equal [["Alice"], ["Bobby"]], @conn.execute("SELECT name FROM users ORDER BY id").fetchall
+  end
+
+  def test_delete_rows
+    @conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+    @conn.executemany("INSERT INTO users VALUES (?, ?)", [
+      [1, "Alice"],
+      [2, "Bob"],
+      [3, "Carol"]
+    ])
+
+    cur = @conn.execute("DELETE FROM users WHERE id IN (?, ?)", [1, 3])
+
+    assert_equal 2, cur.rowcount
+    assert_equal [[2, "Bob"]], @conn.execute("SELECT id, name FROM users").fetchall
+  end
+
+  def test_rollback_restores_snapshot
+    @conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+    @conn.commit
+    @conn.execute("INSERT INTO users VALUES (?, ?)", [1, "Alice"])
+    @conn.rollback
+
+    assert_empty @conn.execute("SELECT * FROM users").fetchall
+  end
+
+  def test_commit_keeps_changes
+    @conn.execute("CREATE TABLE users (id INTEGER, name TEXT)")
+    @conn.execute("INSERT INTO users VALUES (?, ?)", [1, "Alice"])
+    @conn.commit
+    @conn.rollback
+
+    assert_equal [["Alice"]], @conn.execute("SELECT name FROM users").fetchall
+  end
+
+  def test_drop_table
+    @conn.execute("CREATE TABLE users (id INTEGER)")
+    @conn.execute("DROP TABLE users")
+
+    assert_raises(MS::OperationalError) { @conn.execute("SELECT * FROM users") }
+  end
+
+  def test_wrong_parameter_counts
+    assert_raises(MS::ProgrammingError) { @conn.execute("SELECT ? FROM t") }
+    assert_raises(MS::ProgrammingError) { @conn.execute("SELECT 1 FROM t", [1]) }
+  end
+
+  def test_unknown_table
+    assert_raises(MS::OperationalError) { @conn.execute("SELECT * FROM missing") }
+  end
+
+  def test_unsupported_file_connection
+    assert_raises(MS::NotSupportedError) { MS.connect("app.db") }
+  end
+end


### PR DESCRIPTION
## Summary
- add a Ruby Level 0 `coding_adventures_mini_sqlite` package with in-memory connections, cursor fetch helpers, qmark binding, and snapshot commit/rollback
- support basic create/drop/insert/update/delete and SELECT delegation through the Ruby SQL execution engine
- add package docs, gemspec, BUILD, capabilities, and minitest coverage

## Validation
- `ruby -c` over all Ruby files in `code/packages/ruby/mini_sqlite`

## Local validation note
- `bundle install --quiet` is blocked in this local shell because the available Ruby is 3.3.8 while the repo `mise.toml` and shared Ruby grammar-tools dependency require Ruby 3.4.0+. The package gemspec is set to `>= 3.4.0` to match that toolchain.