### PR TITLE
Add Elixir mini-sqlite facade

### DIFF
--- a/code/packages/elixir/mini_sqlite/BUILD
+++ b/code/packages/elixir/mini_sqlite/BUILD
@@ -1,0 +1,1 @@
+mix test

--- a/code/packages/elixir/mini_sqlite/CHANGELOG.md
+++ b/code/packages/elixir/mini_sqlite/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a Level 0 Elixir mini-sqlite facade backed by an Agent-managed in-memory table store.
+- Support qmark binding, DB-API-inspired connection/cursor helpers, snapshot commit/rollback, and SELECT delegation through the Elixir SQL execution engine.

--- a/code/packages/elixir/mini_sqlite/README.md
+++ b/code/packages/elixir/mini_sqlite/README.md
@@ -1,0 +1,27 @@
+# coding_adventures_mini_sqlite
+
+`coding_adventures_mini_sqlite` is the Elixir Level 0 port of the mini-sqlite facade. It exposes an in-memory SQL connection and cursor API, while reusing `CodingAdventures.SqlExecutionEngine` for `SELECT`.
+
+## Scope
+
+- `CodingAdventures.MiniSqlite.connect(":memory:")`
+- `CREATE TABLE`, `DROP TABLE`, `INSERT`, `UPDATE`, `DELETE`
+- `SELECT` queries supported by the Elixir SQL execution engine
+- qmark parameter binding
+- `commit`, `rollback`, and close-time rollback snapshots when autocommit is disabled
+
+Opening anything other than `:memory:` returns `{:error, %NotSupportedError{}}` in Level 0.
+
+## Example
+
+```elixir
+alias CodingAdventures.MiniSqlite
+alias CodingAdventures.MiniSqlite.Cursor
+
+{:ok, conn} = MiniSqlite.connect(":memory:")
+{:ok, _} = MiniSqlite.execute(conn, "CREATE TABLE users (id INTEGER, name TEXT)", [])
+{:ok, _} = MiniSqlite.execute(conn, "INSERT INTO users VALUES (?, ?)", [1, "Alice"])
+{:ok, cursor} = MiniSqlite.execute(conn, "SELECT name FROM users", [])
+{rows, _cursor} = Cursor.fetchall(cursor)
+rows == [["Alice"]]
+```

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite.ex
@@ -1,0 +1,38 @@
+defmodule CodingAdventures.MiniSqlite do
+  @moduledoc """
+  Level 0 mini-sqlite facade for Elixir.
+
+  The package is intentionally small: it provides an in-memory database,
+  qmark parameter binding, DB-API-inspired connection/cursor helpers, and
+  delegates `SELECT` statements to `CodingAdventures.SqlExecutionEngine`.
+  """
+
+  alias CodingAdventures.MiniSqlite.Connection
+  alias CodingAdventures.MiniSqlite.Errors.NotSupportedError
+
+  @apilevel "2.0"
+  @threadsafety 1
+  @paramstyle "qmark"
+
+  def apilevel, do: @apilevel
+  def threadsafety, do: @threadsafety
+  def paramstyle, do: @paramstyle
+
+  @spec connect(String.t(), keyword()) :: {:ok, Connection.t()} | {:error, Exception.t()}
+  def connect(database, opts \\ [])
+
+  def connect(":memory:", opts) do
+    Connection.open(opts)
+  end
+
+  def connect(_database, _opts) do
+    {:error, %NotSupportedError{message: "Elixir mini-sqlite supports only :memory: in Level 0"}}
+  end
+
+  defdelegate cursor(connection), to: Connection
+  defdelegate execute(connection, sql, params \\ []), to: Connection
+  defdelegate executemany(connection, sql, params_seq), to: Connection
+  defdelegate commit(connection), to: Connection
+  defdelegate rollback(connection), to: Connection
+  defdelegate close(connection), to: Connection
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/binding.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/binding.ex
@@ -1,0 +1,113 @@
+defmodule CodingAdventures.MiniSqlite.Binding do
+  @moduledoc false
+
+  alias CodingAdventures.MiniSqlite.Errors.ProgrammingError
+
+  def bind(sql, params) when is_binary(sql) and is_list(params) do
+    scan(sql, params, 0, [])
+  end
+
+  defp scan(sql, params, pos, acc) when pos >= byte_size(sql) do
+    case params do
+      [] ->
+        {:ok, acc |> Enum.reverse() |> IO.iodata_to_binary()}
+
+      _ ->
+        {:error, %ProgrammingError{message: "too many parameters for SQL statement"}}
+    end
+  end
+
+  defp scan(sql, params, pos, acc) do
+    ch = binary_part(sql, pos, 1)
+
+    cond do
+      ch in ["'", "\""] ->
+        next = read_quoted(sql, pos, ch)
+        scan(sql, params, next, [binary_part(sql, pos, next - pos) | acc])
+
+      ch == "-" and pos + 1 < byte_size(sql) and binary_part(sql, pos + 1, 1) == "-" ->
+        next = read_line_comment(sql, pos)
+        scan(sql, params, next, [binary_part(sql, pos, next - pos) | acc])
+
+      ch == "/" and pos + 1 < byte_size(sql) and binary_part(sql, pos + 1, 1) == "*" ->
+        next = read_block_comment(sql, pos)
+        scan(sql, params, next, [binary_part(sql, pos, next - pos) | acc])
+
+      ch == "?" ->
+        case params do
+          [] ->
+            {:error, %ProgrammingError{message: "not enough parameters for SQL statement"}}
+
+          [param | rest] ->
+            scan(sql, rest, pos + 1, [to_sql_literal(param) | acc])
+        end
+
+      true ->
+        scan(sql, params, pos + 1, [ch | acc])
+    end
+  end
+
+  defp read_quoted(sql, pos, quote) do
+    do_read_quoted(sql, pos + 1, quote)
+  end
+
+  defp do_read_quoted(sql, pos, _quote) when pos >= byte_size(sql), do: byte_size(sql)
+
+  defp do_read_quoted(sql, pos, quote) do
+    ch = binary_part(sql, pos, 1)
+
+    cond do
+      ch == "\\" ->
+        do_read_quoted(sql, min(pos + 2, byte_size(sql)), quote)
+
+      ch == quote ->
+        pos + 1
+
+      true ->
+        do_read_quoted(sql, pos + 1, quote)
+    end
+  end
+
+  defp read_line_comment(sql, pos) do
+    do_read_line_comment(sql, pos + 2)
+  end
+
+  defp do_read_line_comment(sql, pos) when pos >= byte_size(sql), do: byte_size(sql)
+
+  defp do_read_line_comment(sql, pos) do
+    if binary_part(sql, pos, 1) == "\n" do
+      pos
+    else
+      do_read_line_comment(sql, pos + 1)
+    end
+  end
+
+  defp read_block_comment(sql, pos) do
+    do_read_block_comment(sql, pos + 2)
+  end
+
+  defp do_read_block_comment(sql, pos) when pos + 1 >= byte_size(sql), do: byte_size(sql)
+
+  defp do_read_block_comment(sql, pos) do
+    if binary_part(sql, pos, 2) == "*/" do
+      pos + 2
+    else
+      do_read_block_comment(sql, pos + 1)
+    end
+  end
+
+  defp to_sql_literal(nil), do: "NULL"
+  defp to_sql_literal(true), do: "TRUE"
+  defp to_sql_literal(false), do: "FALSE"
+  defp to_sql_literal(value) when is_integer(value), do: Integer.to_string(value)
+  defp to_sql_literal(value) when is_float(value), do: Float.to_string(value)
+
+  defp to_sql_literal(value) when is_binary(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("'", "\\'")
+    |> String.replace("\n", "\\n")
+    |> String.replace("\t", "\\t")
+    |> then(&"'#{&1}'")
+  end
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/connection.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/connection.ex
@@ -1,0 +1,122 @@
+defmodule CodingAdventures.MiniSqlite.Connection do
+  @moduledoc "Connection handle for an Agent-backed in-memory mini-sqlite database."
+
+  alias CodingAdventures.MiniSqlite.{Binding, Cursor, Database, Sql}
+  alias CodingAdventures.MiniSqlite.Errors.{OperationalError, ProgrammingError}
+  alias CodingAdventures.SqlExecutionEngine
+
+  defstruct [:agent, :source]
+
+  @type t :: %__MODULE__{}
+
+  def open(opts) do
+    autocommit = Keyword.get(opts, :autocommit, false)
+
+    with {:ok, agent} <- Database.start_link(autocommit: autocommit),
+         {:ok, source} <- Database.data_source(agent) do
+      {:ok, %__MODULE__{agent: agent, source: source}}
+    end
+  end
+
+  def cursor(%__MODULE__{} = connection) do
+    with :ok <- Database.assert_open(connection.agent) do
+      {:ok, %Cursor{connection: connection}}
+    end
+  end
+
+  def execute(%__MODULE__{} = connection, sql, params \\ []) do
+    with {:ok, cursor} <- cursor(connection) do
+      Cursor.execute(cursor, sql, params)
+    end
+  end
+
+  def executemany(%__MODULE__{} = connection, sql, params_seq) do
+    with {:ok, cursor} <- cursor(connection) do
+      Cursor.executemany(cursor, sql, params_seq)
+    end
+  end
+
+  def commit(%__MODULE__{} = connection), do: Database.commit(connection.agent)
+  def rollback(%__MODULE__{} = connection), do: Database.rollback(connection.agent)
+  def close(%__MODULE__{} = connection), do: Database.close(connection.agent)
+
+  @doc false
+  def execute_bound(%__MODULE__{} = connection, sql, params) do
+    with :ok <- Database.assert_open(connection.agent),
+         {:ok, bound} <- Binding.bind(sql, params) do
+      dispatch(connection, bound)
+    end
+  end
+
+  defp dispatch(connection, sql) do
+    case first_keyword(sql) do
+      "BEGIN" ->
+        Database.begin(connection.agent)
+
+      "COMMIT" ->
+        Database.commit_result(connection.agent)
+
+      "ROLLBACK" ->
+        Database.rollback_result(connection.agent)
+
+      "SELECT" ->
+        select(connection, sql)
+
+      "CREATE" ->
+        with {:ok, statement} <- Sql.parse_create(sql),
+             do: Database.create(connection.agent, statement)
+
+      "DROP" ->
+        with {:ok, statement} <- Sql.parse_drop(sql),
+             do: Database.drop(connection.agent, statement)
+
+      "INSERT" ->
+        with {:ok, statement} <- Sql.parse_insert(sql),
+             do: Database.insert(connection.agent, statement)
+
+      "UPDATE" ->
+        with {:ok, statement} <- Sql.parse_update(sql),
+             {:ok, row_ids} <-
+               Database.matching_row_ids(connection.agent, statement.table, statement.where_sql) do
+          Database.update(connection.agent, statement, row_ids)
+        end
+
+      "DELETE" ->
+        with {:ok, statement} <- Sql.parse_delete(sql),
+             {:ok, row_ids} <-
+               Database.matching_row_ids(connection.agent, statement.table, statement.where_sql) do
+          Database.delete(connection.agent, statement, row_ids)
+        end
+
+      _ ->
+        {:error, %ProgrammingError{message: "unsupported SQL statement"}}
+    end
+  end
+
+  defp select(connection, sql) do
+    case SqlExecutionEngine.execute(sql, connection.source) do
+      {:ok, result} ->
+        {:ok,
+         %{
+           columns: result.columns,
+           rows: result.rows,
+           rows_affected: -1,
+           lastrowid: nil
+         }}
+
+      {:error, "Parse error:" <> _ = message} ->
+        {:error, %ProgrammingError{message: message}}
+
+      {:error, message} ->
+        {:error, %OperationalError{message: message}}
+    end
+  end
+
+  defp first_keyword(sql) do
+    sql
+    |> String.trim_leading()
+    |> String.split(~r/\s+/, parts: 2)
+    |> hd()
+    |> String.upcase()
+  end
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/cursor.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/cursor.ex
@@ -1,0 +1,94 @@
+defmodule CodingAdventures.MiniSqlite.Cursor do
+  @moduledoc "Immutable cursor state for mini-sqlite query results."
+
+  alias CodingAdventures.MiniSqlite.Connection
+  alias CodingAdventures.MiniSqlite.Errors.ProgrammingError
+
+  defstruct connection: nil,
+            description: [],
+            rowcount: -1,
+            lastrowid: nil,
+            arraysize: 1,
+            rows: [],
+            offset: 0,
+            closed: false
+
+  @type t :: %__MODULE__{}
+
+  def execute(cursor, sql, params \\ [])
+
+  def execute(%__MODULE__{closed: true}, _sql, _params) do
+    {:error, %ProgrammingError{message: "cursor is closed"}}
+  end
+
+  def execute(%__MODULE__{} = cursor, sql, params) do
+    case Connection.execute_bound(cursor.connection, sql, params) do
+      {:ok, result} ->
+        {:ok,
+         %{
+           cursor
+           | description: Enum.map(result.columns, &%{name: &1}),
+             rowcount: result.rows_affected,
+             lastrowid: result.lastrowid,
+             rows: result.rows,
+             offset: 0
+         }}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  def executemany(%__MODULE__{closed: true}, _sql, _params_seq) do
+    {:error, %ProgrammingError{message: "cursor is closed"}}
+  end
+
+  def executemany(%__MODULE__{} = cursor, sql, params_seq) do
+    Enum.reduce_while(params_seq, {:ok, cursor, 0}, fn params, {:ok, cur, total} ->
+      case execute(cur, sql, params) do
+        {:ok, next} ->
+          total = if next.rowcount > 0, do: total + next.rowcount, else: total
+          {:cont, {:ok, next, total}}
+
+        {:error, error} ->
+          {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, cur, total} when params_seq != [] -> {:ok, %{cur | rowcount: total}}
+      {:ok, cur, _total} -> {:ok, cur}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def fetchone(%__MODULE__{closed: true} = cursor), do: {nil, cursor}
+
+  def fetchone(%__MODULE__{} = cursor) do
+    if cursor.offset >= length(cursor.rows) do
+      {nil, cursor}
+    else
+      {Enum.at(cursor.rows, cursor.offset), %{cursor | offset: cursor.offset + 1}}
+    end
+  end
+
+  def fetchmany(cursor, size \\ nil)
+
+  def fetchmany(%__MODULE__{closed: true} = cursor, _size), do: {[], cursor}
+
+  def fetchmany(%__MODULE__{} = cursor, size) do
+    count = size || cursor.arraysize
+    rows = cursor.rows |> Enum.drop(cursor.offset) |> Enum.take(count)
+    {rows, %{cursor | offset: min(cursor.offset + count, length(cursor.rows))}}
+  end
+
+  def fetchall(%__MODULE__{closed: true} = cursor), do: {[], cursor}
+
+  def fetchall(%__MODULE__{} = cursor) do
+    rows = Enum.drop(cursor.rows, cursor.offset)
+    {rows, %{cursor | offset: length(cursor.rows)}}
+  end
+
+  def close(%__MODULE__{} = cursor) do
+    %{cursor | closed: true, rows: [], description: []}
+  end
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/database.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/database.ex
@@ -1,0 +1,451 @@
+defmodule CodingAdventures.MiniSqlite.Database do
+  @moduledoc false
+
+  alias CodingAdventures.MiniSqlite.Errors.{IntegrityError, OperationalError, ProgrammingError}
+  alias CodingAdventures.SqlExecutionEngine
+  alias CodingAdventures.SqlExecutionEngine.Errors.TableNotFoundError
+
+  @row_id_column "__mini_sqlite_rowid"
+
+  def start_link(opts) do
+    autocommit = Keyword.get(opts, :autocommit, false)
+
+    Agent.start_link(fn ->
+      %{tables: %{}, snapshot: nil, autocommit: autocommit, closed: false}
+    end)
+  end
+
+  def data_source(agent) do
+    module_name = unique_module("DataSource")
+    :persistent_term.put({__MODULE__, module_name, :agent}, agent)
+
+    body =
+      quote do
+        @behaviour CodingAdventures.SqlExecutionEngine.DataSource
+
+        @impl true
+        def schema(table_name) do
+          CodingAdventures.MiniSqlite.Database.schema_for_source(__MODULE__, table_name)
+        end
+
+        @impl true
+        def scan(table_name) do
+          CodingAdventures.MiniSqlite.Database.scan_for_source(__MODULE__, table_name)
+        end
+      end
+
+    {:module, mod, _binary, _exports} =
+      Module.create(module_name, body, Macro.Env.location(__ENV__))
+
+    {:ok, mod}
+  end
+
+  def row_id_source(agent, table_name) do
+    module_name = unique_module("RowIdSource")
+    :persistent_term.put({__MODULE__, module_name, :agent}, agent)
+    :persistent_term.put({__MODULE__, module_name, :table}, table_name)
+
+    body =
+      quote do
+        @behaviour CodingAdventures.SqlExecutionEngine.DataSource
+
+        @impl true
+        def schema(table_name) do
+          CodingAdventures.MiniSqlite.Database.schema_for_row_id_source(__MODULE__, table_name)
+        end
+
+        @impl true
+        def scan(table_name) do
+          CodingAdventures.MiniSqlite.Database.scan_for_row_id_source(__MODULE__, table_name)
+        end
+      end
+
+    {:module, mod, _binary, _exports} =
+      Module.create(module_name, body, Macro.Env.location(__ENV__))
+
+    mod
+  end
+
+  def schema_for_source(source, table_name) do
+    source
+    |> source_agent()
+    |> schema(table_name)
+  end
+
+  def scan_for_source(source, table_name) do
+    source
+    |> source_agent()
+    |> scan(table_name)
+  end
+
+  def schema_for_row_id_source(source, table_name) do
+    agent = source_agent(source)
+    expected = :persistent_term.get({__MODULE__, source, :table})
+
+    if normalize(table_name) != normalize(expected) do
+      raise TableNotFoundError, table_name
+    end
+
+    schema(agent, table_name) ++ [@row_id_column]
+  end
+
+  def scan_for_row_id_source(source, table_name) do
+    agent = source_agent(source)
+    expected = :persistent_term.get({__MODULE__, source, :table})
+
+    if normalize(table_name) != normalize(expected) do
+      raise TableNotFoundError, table_name
+    end
+
+    agent
+    |> scan(table_name)
+    |> Enum.with_index()
+    |> Enum.map(fn {row, index} -> Map.put(row, @row_id_column, index) end)
+  end
+
+  def schema(agent, table_name) do
+    case Agent.get(agent, &schema_result(&1, table_name)) do
+      {:ok, columns} -> columns
+      {:error, :closed} -> raise ProgrammingError, "connection is closed"
+      {:error, :missing} -> raise TableNotFoundError, table_name
+    end
+  end
+
+  def scan(agent, table_name) do
+    case Agent.get(agent, &scan_result(&1, table_name)) do
+      {:ok, rows} -> rows
+      {:error, :closed} -> raise ProgrammingError, "connection is closed"
+      {:error, :missing} -> raise TableNotFoundError, table_name
+    end
+  end
+
+  def assert_open(agent) do
+    Agent.get(agent, fn state ->
+      if state.closed do
+        {:error, %ProgrammingError{message: "connection is closed"}}
+      else
+        :ok
+      end
+    end)
+  end
+
+  def begin(agent) do
+    mutate(agent, fn state ->
+      {empty_result(), ensure_snapshot(state)}
+    end)
+  end
+
+  def commit(agent) do
+    update_state(agent, fn state -> %{state | snapshot: nil} end)
+  end
+
+  def commit_result(agent) do
+    mutate(agent, fn state -> {empty_result(), %{state | snapshot: nil}} end)
+  end
+
+  def rollback(agent) do
+    update_state(agent, &restore_snapshot/1)
+  end
+
+  def rollback_result(agent) do
+    mutate(agent, fn state -> {empty_result(), restore_snapshot(state)} end)
+  end
+
+  def close(agent) do
+    update_state(agent, fn state ->
+      state
+      |> restore_snapshot()
+      |> Map.put(:closed, true)
+    end)
+  end
+
+  def create(agent, statement) do
+    mutate(agent, fn state ->
+      state = ensure_snapshot(state)
+      key = normalize(statement.table)
+
+      cond do
+        Map.has_key?(state.tables, key) and statement.if_not_exists ->
+          {empty_result(), state}
+
+        Map.has_key?(state.tables, key) ->
+          {%OperationalError{message: "table already exists: #{statement.table}"}, state}
+
+        statement.columns == [] ->
+          {%ProgrammingError{message: "CREATE TABLE requires at least one column"}, state}
+
+        duplicate_column?(statement.columns) ->
+          {%ProgrammingError{message: "duplicate column in CREATE TABLE"}, state}
+
+        true ->
+          table = %{columns: statement.columns, rows: []}
+          {empty_result(), put_in(state.tables[key], table)}
+      end
+    end)
+  end
+
+  def drop(agent, statement) do
+    mutate(agent, fn state ->
+      state = ensure_snapshot(state)
+      key = normalize(statement.table)
+
+      cond do
+        Map.has_key?(state.tables, key) ->
+          {empty_result(), %{state | tables: Map.delete(state.tables, key)}}
+
+        statement.if_exists ->
+          {empty_result(), state}
+
+        true ->
+          {%OperationalError{message: "no such table: #{statement.table}"}, state}
+      end
+    end)
+  end
+
+  def insert(agent, statement) do
+    mutate(agent, fn state ->
+      state = ensure_snapshot(state)
+      key = normalize(statement.table)
+
+      case Map.get(state.tables, key) do
+        nil ->
+          {%OperationalError{message: "no such table: #{statement.table}"}, state}
+
+        table ->
+          with {:ok, columns} <- insert_columns(table, statement.columns),
+               :ok <- validate_row_widths(statement.rows, columns) do
+            rows =
+              Enum.map(statement.rows, fn values ->
+                base = Map.new(table.columns, &{&1, nil})
+
+                columns
+                |> Enum.zip(values)
+                |> Enum.reduce(base, fn {col, val}, row -> Map.put(row, col, val) end)
+              end)
+
+            table = %{table | rows: table.rows ++ rows}
+            {%{empty_result() | rows_affected: length(rows)}, put_in(state.tables[key], table)}
+          else
+            {:error, error} -> {error, state}
+          end
+      end
+    end)
+  end
+
+  def update(agent, statement, row_ids) do
+    mutate(agent, fn state ->
+      state = ensure_snapshot(state)
+      key = normalize(statement.table)
+
+      case Map.get(state.tables, key) do
+        nil ->
+          {%OperationalError{message: "no such table: #{statement.table}"}, state}
+
+        table ->
+          with {:ok, assignments} <- canonical_assignments(table, statement.assignments) do
+            id_set = MapSet.new(row_ids)
+
+            rows =
+              table.rows
+              |> Enum.with_index()
+              |> Enum.map(fn {row, index} ->
+                if MapSet.member?(id_set, index) do
+                  Enum.reduce(assignments, row, fn {col, val}, acc -> Map.put(acc, col, val) end)
+                else
+                  row
+                end
+              end)
+
+            table = %{table | rows: rows}
+
+            {%{empty_result() | rows_affected: MapSet.size(id_set)},
+             put_in(state.tables[key], table)}
+          else
+            {:error, error} -> {error, state}
+          end
+      end
+    end)
+  end
+
+  def delete(agent, statement, row_ids) do
+    mutate(agent, fn state ->
+      state = ensure_snapshot(state)
+      key = normalize(statement.table)
+
+      case Map.get(state.tables, key) do
+        nil ->
+          {%OperationalError{message: "no such table: #{statement.table}"}, state}
+
+        table ->
+          id_set = MapSet.new(row_ids)
+
+          rows =
+            table.rows
+            |> Enum.with_index()
+            |> Enum.reject(fn {_row, index} -> MapSet.member?(id_set, index) end)
+            |> Enum.map(fn {row, _index} -> row end)
+
+          table = %{table | rows: rows}
+
+          {%{empty_result() | rows_affected: MapSet.size(id_set)},
+           put_in(state.tables[key], table)}
+      end
+    end)
+  end
+
+  def matching_row_ids(agent, table_name, where_sql) do
+    if String.trim(where_sql) == "" do
+      Agent.get(agent, fn state ->
+        case Map.get(state.tables, normalize(table_name)) do
+          nil -> {:error, %OperationalError{message: "no such table: #{table_name}"}}
+          table -> {:ok, Enum.to_list(0..(length(table.rows) - 1)) |> Enum.reject(&(&1 < 0))}
+        end
+      end)
+    else
+      source = row_id_source(agent, table_name)
+
+      case SqlExecutionEngine.execute(
+             "SELECT #{@row_id_column} FROM #{table_name} WHERE #{where_sql}",
+             source
+           ) do
+        {:ok, result} ->
+          {:ok, Enum.map(result.rows, &hd/1)}
+
+        {:error, "Parse error:" <> _ = message} ->
+          {:error, %ProgrammingError{message: message}}
+
+        {:error, message} ->
+          {:error, %OperationalError{message: message}}
+      end
+    end
+  end
+
+  defp mutate(agent, fun) do
+    Agent.get_and_update(agent, fn state ->
+      if state.closed do
+        error = %ProgrammingError{message: "connection is closed"}
+        {{:error, error}, state}
+      else
+        case fun.(state) do
+          {%_{} = error, next_state} -> {{:error, error}, next_state}
+          {result, next_state} -> {{:ok, result}, next_state}
+        end
+      end
+    end)
+  end
+
+  defp update_state(agent, fun) do
+    Agent.get_and_update(agent, fn state ->
+      if state.closed do
+        error = %ProgrammingError{message: "connection is closed"}
+        {{:error, error}, state}
+      else
+        {:ok, fun.(state)}
+      end
+    end)
+  end
+
+  defp ensure_snapshot(%{autocommit: false, snapshot: nil} = state) do
+    %{state | snapshot: %{tables: state.tables}}
+  end
+
+  defp ensure_snapshot(state), do: state
+
+  defp restore_snapshot(%{snapshot: %{tables: tables}} = state) do
+    %{state | tables: tables, snapshot: nil}
+  end
+
+  defp restore_snapshot(state), do: state
+
+  defp empty_result do
+    %{columns: [], rows: [], rows_affected: 0, lastrowid: nil}
+  end
+
+  defp insert_columns(table, []) do
+    {:ok, table.columns}
+  end
+
+  defp insert_columns(table, columns) do
+    canonical_columns(table, columns)
+  end
+
+  defp validate_row_widths(rows, columns) do
+    case Enum.find(rows, &(length(&1) != length(columns))) do
+      nil ->
+        :ok
+
+      row ->
+        {:error,
+         %IntegrityError{message: "INSERT expected #{length(columns)} values, got #{length(row)}"}}
+    end
+  end
+
+  defp canonical_assignments(table, assignments) do
+    Enum.reduce_while(assignments, {:ok, []}, fn {column, value}, {:ok, acc} ->
+      case canonical_column(table, column) do
+        {:ok, canonical} -> {:cont, {:ok, [{canonical, value} | acc]}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, assignments} -> {:ok, Enum.reverse(assignments)}
+      error -> error
+    end
+  end
+
+  defp canonical_columns(table, columns) do
+    Enum.reduce_while(columns, {:ok, []}, fn column, {:ok, acc} ->
+      case canonical_column(table, column) do
+        {:ok, canonical} -> {:cont, {:ok, [canonical | acc]}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, columns} -> {:ok, Enum.reverse(columns)}
+      error -> error
+    end
+  end
+
+  defp canonical_column(table, column) do
+    normalized = normalize(column)
+
+    case Enum.find(table.columns, &(normalize(&1) == normalized)) do
+      nil -> {:error, %OperationalError{message: "no such column: #{column}"}}
+      column -> {:ok, column}
+    end
+  end
+
+  defp duplicate_column?(columns) do
+    normalized = Enum.map(columns, &normalize/1)
+    length(normalized) != length(Enum.uniq(normalized))
+  end
+
+  defp schema_result(%{closed: true}, _table_name), do: {:error, :closed}
+
+  defp schema_result(state, table_name) do
+    case Map.get(state.tables, normalize(table_name)) do
+      nil -> {:error, :missing}
+      table -> {:ok, table.columns}
+    end
+  end
+
+  defp scan_result(%{closed: true}, _table_name), do: {:error, :closed}
+
+  defp scan_result(state, table_name) do
+    case Map.get(state.tables, normalize(table_name)) do
+      nil -> {:error, :missing}
+      table -> {:ok, table.rows}
+    end
+  end
+
+  defp source_agent(source) do
+    :persistent_term.get({__MODULE__, source, :agent})
+  end
+
+  defp unique_module(kind) do
+    n = :erlang.unique_integer([:positive, :monotonic])
+    :"Elixir.CodingAdventures.MiniSqlite.#{kind}._#{n}"
+  end
+
+  defp normalize(name), do: String.downcase(name)
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/errors.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/errors.ex
@@ -1,0 +1,19 @@
+defmodule CodingAdventures.MiniSqlite.Errors do
+  @moduledoc "Exception types returned by the mini-sqlite facade."
+
+  defmodule ProgrammingError do
+    defexception [:message]
+  end
+
+  defmodule OperationalError do
+    defexception [:message]
+  end
+
+  defmodule IntegrityError do
+    defexception [:message]
+  end
+
+  defmodule NotSupportedError do
+    defexception [:message]
+  end
+end

--- a/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/sql.ex
+++ b/code/packages/elixir/mini_sqlite/lib/coding_adventures/mini_sqlite/sql.ex
@@ -1,0 +1,370 @@
+defmodule CodingAdventures.MiniSqlite.Sql do
+  @moduledoc false
+
+  alias CodingAdventures.MiniSqlite.Errors.ProgrammingError
+
+  @create_re ~r/^\s*CREATE\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*;?\s*$/is
+  @drop_re ~r/^\s*DROP\s+TABLE\s+(IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*;?\s*$/is
+  @insert_re ~r/^\s*INSERT\s+INTO\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*\(([^)]*)\))?\s+VALUES\s+(.*?)\s*;?\s*$/is
+  @delete_re ~r/^\s*DELETE\s+FROM\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s+WHERE\s+(.*?))?\s*;?\s*$/is
+  @update_re ~r/^\s*UPDATE\s+([A-Za-z_][A-Za-z0-9_]*)\s+SET\s+(.*?)\s*;?\s*$/is
+
+  def parse_create(sql) do
+    case Regex.run(@create_re, sql, capture: :all_but_first) do
+      [if_part, table, defs] ->
+        columns =
+          defs
+          |> split_top_level(",")
+          |> Enum.map(&identifier_at_start/1)
+          |> Enum.reject(&(&1 == nil or &1 == ""))
+
+        if columns == [] do
+          {:error, %ProgrammingError{message: "CREATE TABLE requires at least one column"}}
+        else
+          {:ok, %{table: table, columns: columns, if_not_exists: if_part != ""}}
+        end
+
+      _ ->
+        {:error, %ProgrammingError{message: "invalid CREATE TABLE statement"}}
+    end
+  end
+
+  def parse_drop(sql) do
+    case Regex.run(@drop_re, sql, capture: :all_but_first) do
+      [if_part, table] -> {:ok, %{table: table, if_exists: if_part != ""}}
+      _ -> {:error, %ProgrammingError{message: "invalid DROP TABLE statement"}}
+    end
+  end
+
+  def parse_insert(sql) do
+    case Regex.run(@insert_re, sql, capture: :all_but_first) do
+      [table, columns_sql, rows_sql] ->
+        with {:ok, columns} <- parse_columns(columns_sql),
+             {:ok, rows} <- parse_value_rows(rows_sql) do
+          {:ok, %{table: table, columns: columns, rows: rows}}
+        end
+
+      _ ->
+        {:error, %ProgrammingError{message: "invalid INSERT statement"}}
+    end
+  end
+
+  def parse_update(sql) do
+    case Regex.run(@update_re, String.trim(sql), capture: :all_but_first) do
+      [table, rest] ->
+        {assign_sql, where_sql} = split_top_level_keyword(rest, "WHERE")
+
+        assignments =
+          assign_sql
+          |> split_top_level(",")
+          |> Enum.map(&parse_assignment/1)
+
+        case Enum.find(assignments, &match?({:error, _}, &1)) do
+          {:error, error} ->
+            {:error, error}
+
+          nil ->
+            pairs = Enum.map(assignments, fn {:ok, pair} -> pair end)
+
+            if pairs == [] do
+              {:error, %ProgrammingError{message: "UPDATE requires at least one assignment"}}
+            else
+              {:ok, %{table: table, assignments: pairs, where_sql: where_sql}}
+            end
+        end
+
+      _ ->
+        {:error, %ProgrammingError{message: "invalid UPDATE statement"}}
+    end
+  end
+
+  def parse_delete(sql) do
+    case Regex.run(@delete_re, sql, capture: :all_but_first) do
+      [table, where_sql] -> {:ok, %{table: table, where_sql: String.trim(where_sql || "")}}
+      _ -> {:error, %ProgrammingError{message: "invalid DELETE statement"}}
+    end
+  end
+
+  defp parse_columns(""), do: {:ok, []}
+  defp parse_columns(nil), do: {:ok, []}
+
+  defp parse_columns(columns_sql) do
+    columns =
+      columns_sql
+      |> split_top_level(",")
+      |> Enum.map(&String.trim/1)
+
+    invalid = Enum.find(columns, &(identifier_at_start(&1) != &1))
+
+    if invalid do
+      {:error, %ProgrammingError{message: "invalid identifier: #{invalid}"}}
+    else
+      {:ok, columns}
+    end
+  end
+
+  defp parse_assignment(assignment) do
+    case split_top_level(assignment, "=") do
+      [column, value_sql] ->
+        column = String.trim(column)
+
+        if identifier_at_start(column) != column do
+          {:error, %ProgrammingError{message: "invalid identifier: #{column}"}}
+        else
+          with {:ok, value} <- parse_literal(value_sql) do
+            {:ok, {column, value}}
+          end
+        end
+
+      _ ->
+        {:error, %ProgrammingError{message: "invalid assignment: #{String.trim(assignment)}"}}
+    end
+  end
+
+  defp parse_value_rows(sql) do
+    do_parse_value_rows(String.trim(sql), [])
+  end
+
+  defp do_parse_value_rows("", []) do
+    {:error, %ProgrammingError{message: "INSERT requires at least one row"}}
+  end
+
+  defp do_parse_value_rows("", rows), do: {:ok, Enum.reverse(rows)}
+
+  defp do_parse_value_rows(sql, rows) do
+    if not String.starts_with?(sql, "(") do
+      {:error, %ProgrammingError{message: "INSERT VALUES rows must be parenthesized"}}
+    else
+      case find_matching_paren(sql, 0) do
+        nil ->
+          {:error, %ProgrammingError{message: "unterminated INSERT VALUES row"}}
+
+        close ->
+          inside = binary_part(sql, 1, close - 1)
+
+          with {:ok, row} <- parse_value_list(inside) do
+            rest = sql |> binary_part(close + 1, byte_size(sql) - close - 1) |> String.trim()
+
+            cond do
+              rest == "" ->
+                do_parse_value_rows(rest, [row | rows])
+
+              String.starts_with?(rest, ",") ->
+                next = rest |> binary_part(1, byte_size(rest) - 1) |> String.trim()
+                do_parse_value_rows(next, [row | rows])
+
+              true ->
+                {:error, %ProgrammingError{message: "invalid text after INSERT row"}}
+            end
+          end
+      end
+    end
+  end
+
+  defp parse_value_list(sql) do
+    values =
+      sql
+      |> split_top_level(",")
+      |> Enum.map(&parse_literal/1)
+
+    case Enum.find(values, &match?({:error, _}, &1)) do
+      {:error, error} -> {:error, error}
+      nil -> {:ok, Enum.map(values, fn {:ok, value} -> value end)}
+    end
+  end
+
+  defp parse_literal(text) do
+    value = String.trim(text)
+    upper = String.upcase(value)
+
+    cond do
+      upper == "NULL" ->
+        {:ok, nil}
+
+      upper == "TRUE" ->
+        {:ok, true}
+
+      upper == "FALSE" ->
+        {:ok, false}
+
+      String.starts_with?(value, "'") and String.ends_with?(value, "'") and byte_size(value) >= 2 ->
+        inner = binary_part(value, 1, byte_size(value) - 2)
+        {:ok, unescape_string(inner)}
+
+      String.contains?(value, ".") ->
+        case Float.parse(value) do
+          {number, ""} -> {:ok, number}
+          _ -> {:error, %ProgrammingError{message: "expected literal value, got: #{text}"}}
+        end
+
+      true ->
+        case Integer.parse(value) do
+          {number, ""} -> {:ok, number}
+          _ -> {:error, %ProgrammingError{message: "expected literal value, got: #{text}"}}
+        end
+    end
+  end
+
+  defp unescape_string(value) do
+    value
+    |> String.replace("\\n", "\n")
+    |> String.replace("\\t", "\t")
+    |> String.replace("\\'", "'")
+    |> String.replace("\\\\", "\\")
+  end
+
+  defp identifier_at_start(text) do
+    case Regex.run(~r/^\s*([A-Za-z_][A-Za-z0-9_]*)/, text) do
+      [_, identifier] -> identifier
+      _ -> nil
+    end
+  end
+
+  defp split_top_level(text, delimiter) do
+    {parts, current, _depth, _quote, _escaped} =
+      text
+      |> String.graphemes()
+      |> Enum.reduce({[], [], 0, nil, false}, fn ch, {parts, current, depth, quote, escaped} ->
+        cond do
+          quote && escaped ->
+            {parts, [ch | current], depth, quote, false}
+
+          quote && ch == "\\" ->
+            {parts, [ch | current], depth, quote, true}
+
+          quote && ch == quote ->
+            {parts, [ch | current], depth, nil, false}
+
+          quote ->
+            {parts, [ch | current], depth, quote, false}
+
+          ch in ["'", "\""] ->
+            {parts, [ch | current], depth, ch, false}
+
+          ch == "(" ->
+            {parts, [ch | current], depth + 1, nil, false}
+
+          ch == ")" ->
+            {parts, [ch | current], max(depth - 1, 0), nil, false}
+
+          depth == 0 and ch == delimiter ->
+            {[finish_part(current) | parts], [], depth, nil, false}
+
+          true ->
+            {parts, [ch | current], depth, nil, false}
+        end
+      end)
+
+    [finish_part(current) | parts]
+    |> Enum.reverse()
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp finish_part(chars) do
+    chars |> Enum.reverse() |> IO.iodata_to_binary() |> String.trim()
+  end
+
+  defp split_top_level_keyword(text, keyword) do
+    do_split_keyword(text, String.upcase(keyword), byte_size(keyword), 0, 0, nil, false)
+  end
+
+  defp do_split_keyword(text, _keyword, _keyword_len, pos, _depth, _quote, _escaped)
+       when pos >= byte_size(text) do
+    {String.trim(text), ""}
+  end
+
+  defp do_split_keyword(text, keyword, keyword_len, pos, depth, quote, escaped) do
+    ch = binary_part(text, pos, 1)
+
+    cond do
+      quote && escaped ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth, quote, false)
+
+      quote && ch == "\\" ->
+        do_split_keyword(
+          text,
+          keyword,
+          keyword_len,
+          min(pos + 2, byte_size(text)),
+          depth,
+          quote,
+          false
+        )
+
+      quote && ch == quote ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth, nil, false)
+
+      quote ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth, quote, false)
+
+      ch in ["'", "\""] ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth, ch, false)
+
+      ch == "(" ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth + 1, nil, false)
+
+      ch == ")" ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, max(depth - 1, 0), nil, false)
+
+      depth == 0 and keyword_at?(text, keyword, keyword_len, pos) ->
+        left = binary_part(text, 0, pos)
+        right = binary_part(text, pos + keyword_len, byte_size(text) - pos - keyword_len)
+        {String.trim(left), String.trim(right)}
+
+      true ->
+        do_split_keyword(text, keyword, keyword_len, pos + 1, depth, nil, false)
+    end
+  end
+
+  defp keyword_at?(text, keyword, keyword_len, pos) do
+    pos + keyword_len <= byte_size(text) and
+      text |> binary_part(pos, keyword_len) |> String.upcase() == keyword and
+      boundary?(text, pos - 1) and boundary?(text, pos + keyword_len)
+  end
+
+  defp boundary?(_text, index) when index < 0, do: true
+  defp boundary?(text, index) when index >= byte_size(text), do: true
+
+  defp boundary?(text, index) do
+    not Regex.match?(~r/[A-Za-z0-9_]/, binary_part(text, index, 1))
+  end
+
+  defp find_matching_paren(text, open_pos) do
+    do_find_paren(text, open_pos, 0, nil, false)
+  end
+
+  defp do_find_paren(text, pos, _depth, _quote, _escaped) when pos >= byte_size(text), do: nil
+
+  defp do_find_paren(text, pos, depth, quote, escaped) do
+    ch = binary_part(text, pos, 1)
+
+    cond do
+      quote && escaped ->
+        do_find_paren(text, pos + 1, depth, quote, false)
+
+      quote && ch == "\\" ->
+        do_find_paren(text, min(pos + 2, byte_size(text)), depth, quote, false)
+
+      quote && ch == quote ->
+        do_find_paren(text, pos + 1, depth, nil, false)
+
+      quote ->
+        do_find_paren(text, pos + 1, depth, quote, false)
+
+      ch in ["'", "\""] ->
+        do_find_paren(text, pos + 1, depth, ch, false)
+
+      ch == "(" ->
+        do_find_paren(text, pos + 1, depth + 1, nil, false)
+
+      ch == ")" and depth == 1 ->
+        pos
+
+      ch == ")" ->
+        do_find_paren(text, pos + 1, max(depth - 1, 0), nil, false)
+
+      true ->
+        do_find_paren(text, pos + 1, depth, nil, false)
+    end
+  end
+end

--- a/code/packages/elixir/mini_sqlite/mix.exs
+++ b/code/packages/elixir/mini_sqlite/mix.exs
@@ -1,0 +1,23 @@
+defmodule CodingAdventures.MiniSqlite.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_mini_sqlite,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_sql_execution_engine, path: "../sql_execution_engine"}
+    ]
+  end
+end

--- a/code/packages/elixir/mini_sqlite/required_capabilities.json
+++ b/code/packages/elixir/mini_sqlite/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/mini_sqlite",
+  "capabilities": [],
+  "justification": "Pure computation over in-memory tables. Level 0 does not access files, network, OS processes, or environment."
+}

--- a/code/packages/elixir/mini_sqlite/test/mini_sqlite_test.exs
+++ b/code/packages/elixir/mini_sqlite/test/mini_sqlite_test.exs
@@ -1,0 +1,145 @@
+defmodule CodingAdventures.MiniSqliteTest do
+  use ExUnit.Case, async: false
+
+  alias CodingAdventures.MiniSqlite
+  alias CodingAdventures.MiniSqlite.Cursor
+  alias CodingAdventures.MiniSqlite.Errors.{NotSupportedError, OperationalError, ProgrammingError}
+
+  defp connect! do
+    {:ok, conn} = MiniSqlite.connect(":memory:")
+    conn
+  end
+
+  defp execute!(conn, sql, params \\ []) do
+    case MiniSqlite.execute(conn, sql, params) do
+      {:ok, cursor} -> cursor
+      {:error, error} -> flunk("execute failed: #{Exception.message(error)}")
+    end
+  end
+
+  test "exposes DB-API style constants" do
+    assert MiniSqlite.apilevel() == "2.0"
+    assert MiniSqlite.threadsafety() == 1
+    assert MiniSqlite.paramstyle() == "qmark"
+  end
+
+  test "creates, inserts, and selects rows" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER, name TEXT, active BOOLEAN)")
+
+    {:ok, _cursor} =
+      MiniSqlite.executemany(conn, "INSERT INTO users VALUES (?, ?, ?)", [
+        [1, "Alice", true],
+        [2, "Bob", false],
+        [3, "Carol", true]
+      ])
+
+    cursor = execute!(conn, "SELECT name FROM users WHERE active = ? ORDER BY id ASC", [true])
+    assert cursor.description == [%{name: "name"}]
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == [["Alice"], ["Carol"]]
+  end
+
+  test "fetchone, fetchmany, and fetchall advance immutable cursors" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE nums (n INTEGER)")
+    {:ok, _cursor} = MiniSqlite.executemany(conn, "INSERT INTO nums VALUES (?)", [[1], [2], [3]])
+
+    cursor = execute!(conn, "SELECT n FROM nums ORDER BY n ASC")
+    {row, cursor} = Cursor.fetchone(cursor)
+    assert row == [1]
+    {rows, cursor} = Cursor.fetchmany(cursor, 1)
+    assert rows == [[2]]
+    {rows, cursor} = Cursor.fetchall(cursor)
+    assert rows == [[3]]
+    {row, _cursor} = Cursor.fetchone(cursor)
+    assert row == nil
+  end
+
+  test "updates rows using the delegated WHERE engine" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+
+    {:ok, _cursor} =
+      MiniSqlite.executemany(conn, "INSERT INTO users VALUES (?, ?)", [[1, "Alice"], [2, "Bob"]])
+
+    cursor = execute!(conn, "UPDATE users SET name = ? WHERE id = ?", ["Bobby", 2])
+    assert cursor.rowcount == 1
+
+    cursor = execute!(conn, "SELECT name FROM users ORDER BY id ASC")
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == [["Alice"], ["Bobby"]]
+  end
+
+  test "deletes rows using the delegated WHERE engine" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+
+    {:ok, _cursor} =
+      MiniSqlite.executemany(conn, "INSERT INTO users VALUES (?, ?)", [
+        [1, "Alice"],
+        [2, "Bob"],
+        [3, "Carol"]
+      ])
+
+    cursor = execute!(conn, "DELETE FROM users WHERE id IN (?, ?)", [1, 3])
+    assert cursor.rowcount == 2
+
+    cursor = execute!(conn, "SELECT id, name FROM users")
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == [[2, "Bob"]]
+  end
+
+  test "rollback restores the open transaction snapshot" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+    assert :ok = MiniSqlite.commit(conn)
+    execute!(conn, "INSERT INTO users VALUES (?, ?)", [1, "Alice"])
+    assert :ok = MiniSqlite.rollback(conn)
+
+    cursor = execute!(conn, "SELECT * FROM users")
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == []
+  end
+
+  test "commit keeps changes" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER, name TEXT)")
+    execute!(conn, "INSERT INTO users VALUES (?, ?)", [1, "Alice"])
+    assert :ok = MiniSqlite.commit(conn)
+    assert :ok = MiniSqlite.rollback(conn)
+
+    cursor = execute!(conn, "SELECT name FROM users")
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == [["Alice"]]
+  end
+
+  test "autocommit disables rollback snapshots" do
+    {:ok, conn} = MiniSqlite.connect(":memory:", autocommit: true)
+    execute!(conn, "CREATE TABLE users (id INTEGER)")
+    execute!(conn, "INSERT INTO users VALUES (?)", [1])
+    assert :ok = MiniSqlite.rollback(conn)
+
+    cursor = execute!(conn, "SELECT id FROM users")
+    {rows, _cursor} = Cursor.fetchall(cursor)
+    assert rows == [[1]]
+  end
+
+  test "drops tables" do
+    conn = connect!()
+    execute!(conn, "CREATE TABLE users (id INTEGER)")
+    execute!(conn, "DROP TABLE users")
+
+    assert {:error, %OperationalError{}} = MiniSqlite.execute(conn, "SELECT * FROM users")
+  end
+
+  test "wrong parameter counts are programming errors" do
+    conn = connect!()
+    assert {:error, %ProgrammingError{}} = MiniSqlite.execute(conn, "SELECT ? FROM t")
+    assert {:error, %ProgrammingError{}} = MiniSqlite.execute(conn, "SELECT 1 FROM t", [1])
+  end
+
+  test "rejects file-backed connections in Level 0" do
+    assert {:error, %NotSupportedError{}} = MiniSqlite.connect("app.db")
+  end
+end

--- a/code/packages/elixir/mini_sqlite/test/test_helper.exs
+++ b/code/packages/elixir/mini_sqlite/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/sql_execution_engine/lib/coding_adventures/sql_execution_engine/executor.ex
+++ b/code/packages/elixir/sql_execution_engine/lib/coding_adventures/sql_execution_engine/executor.ex
@@ -121,6 +121,10 @@ defmodule CodingAdventures.SqlExecutionEngine.Executor do
     execute_statement(inner, data_source)
   end
 
+  defp execute_statement(%ASTNode{rule_name: "query_stmt", children: [inner]}, data_source) do
+    execute_statement(inner, data_source)
+  end
+
   defp execute_statement(%ASTNode{rule_name: "select_stmt"} = node, data_source) do
     {:ok, execute_select(node, data_source)}
   end
@@ -561,10 +565,11 @@ defmodule CodingAdventures.SqlExecutionEngine.Executor do
   # Find the first ASTNode with matching rule_name; return {node, remaining}.
   # Uses a linear scan — the children list is small so this is fine.
   defp find_first_node(target_rule, children) do
-    idx = Enum.find_index(children, fn
-      %ASTNode{rule_name: r} -> r == target_rule
-      _ -> false
-    end)
+    idx =
+      Enum.find_index(children, fn
+        %ASTNode{rule_name: r} -> r == target_rule
+        _ -> false
+      end)
 
     node = Enum.at(children, idx)
     rest = Enum.drop(children, idx + 1)
@@ -573,10 +578,11 @@ defmodule CodingAdventures.SqlExecutionEngine.Executor do
 
   # Find the first Token with matching value; return {token, remaining}.
   defp find_token_by_value(target_value, children) do
-    idx = Enum.find_index(children, fn
-      %Token{value: v} -> v == target_value
-      _ -> false
-    end)
+    idx =
+      Enum.find_index(children, fn
+        %Token{value: v} -> v == target_value
+        _ -> false
+      end)
 
     token = Enum.at(children, idx)
     rest = Enum.drop(children, idx + 1)
@@ -585,10 +591,11 @@ defmodule CodingAdventures.SqlExecutionEngine.Executor do
 
   # Find an optional node; returns {nil, children} if absent.
   defp find_optional_node(target_rule, children) do
-    idx = Enum.find_index(children, fn
-      %ASTNode{rule_name: r} -> r == target_rule
-      _ -> false
-    end)
+    idx =
+      Enum.find_index(children, fn
+        %ASTNode{rule_name: r} -> r == target_rule
+        _ -> false
+      end)
 
     if idx do
       node = Enum.at(children, idx)

--- a/code/packages/elixir/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.ex
+++ b/code/packages/elixir/sql_execution_engine/lib/coding_adventures/sql_execution_engine/expression.ex
@@ -260,20 +260,40 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
         eval_between(lhs, low, high)
 
       # NOT BETWEEN — children: [lhs, Token("NOT"), Token("BETWEEN"), low, Token("AND"), high]
-      [lhs_node, %Token{value: "NOT"}, %Token{value: "BETWEEN"}, low_node, %Token{value: "AND"}, high_node] ->
+      [
+        lhs_node,
+        %Token{value: "NOT"},
+        %Token{value: "BETWEEN"},
+        low_node,
+        %Token{value: "AND"},
+        high_node
+      ] ->
         lhs = eval_expr(lhs_node, row_ctx)
         low = eval_expr(low_node, row_ctx)
         high = eval_expr(high_node, row_ctx)
         sql_not(eval_between(lhs, low, high))
 
       # IN (...) — children: [lhs, Token("IN"), Token("("), value_list_node, Token(")")]
-      [lhs_node, %Token{value: "IN"}, %Token{type: "LPAREN"}, value_list_node, %Token{type: "RPAREN"}] ->
+      [
+        lhs_node,
+        %Token{value: "IN"},
+        %Token{type: "LPAREN"},
+        value_list_node,
+        %Token{type: "RPAREN"}
+      ] ->
         lhs = eval_expr(lhs_node, row_ctx)
         values = eval_value_list(value_list_node, row_ctx)
         eval_in(lhs, values)
 
       # NOT IN (...) — children: [lhs, Token("NOT"), Token("IN"), Token("("), value_list_node, Token(")")]
-      [lhs_node, %Token{value: "NOT"}, %Token{value: "IN"}, %Token{type: "LPAREN"}, value_list_node, %Token{type: "RPAREN"}] ->
+      [
+        lhs_node,
+        %Token{value: "NOT"},
+        %Token{value: "IN"},
+        %Token{type: "LPAREN"},
+        value_list_node,
+        %Token{type: "RPAREN"}
+      ] ->
         lhs = eval_expr(lhs_node, row_ctx)
         values = eval_value_list(value_list_node, row_ctx)
         sql_not(eval_in(lhs, values))
@@ -413,7 +433,9 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
       agg_key = build_agg_key(uname, rest)
 
       case Map.fetch(row_ctx, agg_key) do
-        {:ok, value} -> value
+        {:ok, value} ->
+          value
+
         :error ->
           # Aggregate not yet computed (this eval is used for the raw row,
           # not the aggregate result). Return nil as a sentinel — the Aggregate
@@ -479,6 +501,7 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
   # We fold left: ((op1 OP op2) OP op3)
   defp eval_binary_op_chain([first | rest], op_value, row_ctx, combiner) do
     first_val = eval_expr(first, row_ctx)
+
     Enum.chunk_every(rest, 2)
     |> Enum.reduce(first_val, fn [%Token{value: ^op_value}, rhs_node], acc ->
       combiner.(acc, eval_expr(rhs_node, row_ctx))
@@ -488,6 +511,7 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
   # Evaluate arithmetic chains: [operand, Token(op), operand, ...]
   defp eval_arithmetic_chain([first | rest], row_ctx) do
     first_val = eval_expr(first, row_ctx)
+
     Enum.chunk_every(rest, 2)
     |> Enum.reduce(first_val, fn [op_token, rhs_node], acc ->
       rhs = eval_expr(rhs_node, row_ctx)
@@ -538,7 +562,7 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
       |> Enum.map(fn
         "%" -> ".*"
         "_" -> "."
-        c   -> Regex.escape(c)
+        c -> Regex.escape(c)
       end)
       |> Enum.join()
 
@@ -566,16 +590,21 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
     end
   end
 
-  # Evaluate a list of expressions from a value_list node.
-  defp eval_value_list(%ASTNode{rule_name: "value_list", children: children}, row_ctx) do
+  # Evaluate a list of expressions from a value_list-like node.
+  defp eval_value_list(%ASTNode{children: children}, row_ctx) do
     # children: [expr, Token(","), expr, Token(","), expr, ...]
     children
     |> Enum.reject(fn
       %Token{type: "COMMA"} -> true
       _ -> false
     end)
-    |> Enum.map(&eval_expr(&1, row_ctx))
+    |> Enum.flat_map(fn
+      %ASTNode{rule_name: "value_list"} = node -> eval_value_list(node, row_ctx)
+      node -> [eval_expr(node, row_ctx)]
+    end)
   end
+
+  defp eval_value_list(%Token{} = token, row_ctx), do: [eval_expr(token, row_ctx)]
 
   # Build the aggregate key string that the Aggregate module stores in row_ctx.
   #
@@ -601,13 +630,20 @@ defmodule CodingAdventures.SqlExecutionEngine.Expression do
 
     arg_str =
       case args do
-        [] -> ""
-        [%Token{type: "STAR"}] -> "*"
-        [%Token{value: v}] -> v
+        [] ->
+          ""
+
+        [%Token{type: "STAR"}] ->
+          "*"
+
+        [%Token{value: v}] ->
+          v
+
         [%ASTNode{} = node] ->
           # Single AST node argument (e.g., value_list wrapping an expression).
           # Collect all leaf tokens and join their values.
           collect_tokens_for_key(node)
+
         nodes ->
           # Multiple nodes — collect all leaf tokens.
           nodes


### PR DESCRIPTION
## Summary
- add an Elixir Level 0 `coding_adventures_mini_sqlite` package with Agent-backed in-memory connections, immutable cursor fetch helpers, qmark binding, and commit/rollback snapshots
- support basic create/drop/insert/update/delete and delegate SELECT and WHERE filtering through the Elixir SQL execution engine
- fix Elixir SQL execution dispatch for `query_stmt` wrappers and recursive `IN (...)` value lists used by the mini-sqlite facade

## Validation
- `mix format "lib/**/*.ex" "test/**/*.exs"` in `code/packages/elixir/mini_sqlite`
- `mix test` in `code/packages/elixir/sql_execution_engine`
- `mix test` in `code/packages/elixir/mini_sqlite`