### PR TITLE
Add GPU linear gradient ramp rendering

### DIFF
--- a/code/packages/rust/paint-vm-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-gpu-core/CHANGELOG.md
@@ -8,3 +8,5 @@
   groups, layers, images, text, and glyph runs.
 - Added diagnostics for degraded GPU-core gaps such as path arcs, gradients,
   filters, blend modes, dashed strokes, and exact fill rules.
+- Added linear gradient ramp textures with linear sampling metadata for GPU
+  backends that support texture sampling.

--- a/code/packages/rust/paint-vm-gpu-core/README.md
+++ b/code/packages/rust/paint-vm-gpu-core/README.md
@@ -8,6 +8,7 @@ Instead, it converts `paint-instructions::PaintScene` into a backend-neutral
 
 - Solid vector primitives become indexed triangle meshes.
 - Pixel images become texture-upload records plus textured quads.
+- Linear gradients become sampled ramp textures plus gradient UVs on meshes.
 - Rectangular clips become push/pop clip commands.
 - Text and glyph runs are preserved as explicit commands so backend-specific
   glyph atlas and shaping strategies can evolve without losing IR fidelity.
@@ -30,11 +31,11 @@ backend interprets the PaintScene geometry.
 | `PaintImage` | Texture upload plus textured quad |
 | `PaintText` | Preserved text command |
 | `PaintGlyphRun` | Preserved positioned glyph command |
-| `PaintGradient` | Referenced gradient fills degrade to first stop with diagnostics |
+| `PaintGradient` | Linear fills become ramp textures; radial fills degrade to first stop with diagnostics |
 
 ## Next Steps
 
 - Replace simple fan path filling with a robust tessellator.
 - Add stroke joins, caps, and dashed stroke expansion.
-- Add gradient uniforms/textures instead of first-stop fallback.
+- Add radial gradient textures instead of first-stop fallback.
 - Add glyph atlas planning once text shaping/font metrics are finalized.

--- a/code/packages/rust/paint-vm-gpu-core/src/lib.rs
+++ b/code/packages/rust/paint-vm-gpu-core/src/lib.rs
@@ -8,12 +8,13 @@
 use std::collections::HashMap;
 
 use paint_instructions::{
-    BlendMode, FillRule, ImageSrc, PaintClip, PaintEllipse, PaintGlyphRun, PaintGradient,
-    PaintGroup, PaintImage, PaintInstruction, PaintLayer, PaintLine, PaintPath, PaintRect,
-    PaintScene, PaintText, PathCommand, Transform2D, IDENTITY_TRANSFORM,
+    BlendMode, FillRule, GradientKind, GradientStop, ImageSrc, PaintClip, PaintEllipse,
+    PaintGlyphRun, PaintGradient, PaintGroup, PaintImage, PaintInstruction, PaintLayer, PaintLine,
+    PaintPath, PaintRect, PaintScene, PaintText, PathCommand, Transform2D, IDENTITY_TRANSFORM,
 };
 
 pub const VERSION: &str = "0.1.0";
+const GRADIENT_RAMP_WIDTH: u32 = 1024;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct GpuPaintPlan {
@@ -77,6 +78,13 @@ pub struct GpuImageUpload {
     pub width: u32,
     pub height: u32,
     pub data: Vec<u8>,
+    pub filter: GpuTextureFilter,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpuTextureFilter {
+    Nearest,
+    Linear,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -158,6 +166,7 @@ pub struct GpuBackendProfile {
     pub supports_indexed_meshes: bool,
     pub supports_scissor_clips: bool,
     pub supports_texture_sampling: bool,
+    pub supports_linear_gradients: bool,
     pub supports_glyph_atlas: bool,
     pub accepts_degraded_solid_gradients: bool,
 }
@@ -179,6 +188,7 @@ impl GpuBackendProfile {
             supports_indexed_meshes: true,
             supports_scissor_clips: true,
             supports_texture_sampling: false,
+            supports_linear_gradients: false,
             supports_glyph_atlas: false,
             accepts_degraded_solid_gradients: true,
         }
@@ -268,6 +278,44 @@ struct PlanBuilder {
     plan: GpuPaintPlan,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum PaintBrush {
+    Solid(GpuColor),
+    LinearGradient {
+        texture_id: usize,
+        start: GpuPoint,
+        end: GpuPoint,
+    },
+}
+
+impl PaintBrush {
+    fn vertex(self, position: GpuPoint) -> GpuVertex {
+        match self {
+            PaintBrush::Solid(color) => vertex(position, color),
+            PaintBrush::LinearGradient {
+                texture_id: _,
+                start,
+                end,
+            } => vertex_uv(
+                position,
+                [linear_gradient_t(position, start, end), 0.5],
+                GpuColor::white(),
+            ),
+        }
+    }
+
+    fn texture_id(self) -> Option<usize> {
+        match self {
+            PaintBrush::Solid(_) => None,
+            PaintBrush::LinearGradient { texture_id, .. } => Some(texture_id),
+        }
+    }
+
+    fn is_transparent(self) -> bool {
+        matches!(self, PaintBrush::Solid(color) if color.a == 0.0)
+    }
+}
+
 impl PlanBuilder {
     fn plan_instructions(
         &mut self,
@@ -302,14 +350,14 @@ impl PlanBuilder {
                 "rounded rectangles are currently lowered as sharp rectangles",
             );
         }
-        if let Some(color) = self.paint_color(rect.fill.as_deref(), opacity) {
+        if let Some(brush) = self.paint_brush(rect.fill.as_deref(), opacity, transform) {
             self.add_rect_mesh(
                 rect.x,
                 rect.y,
                 rect.width,
                 rect.height,
                 transform,
-                color,
+                brush,
                 "rect",
             );
         }
@@ -339,24 +387,18 @@ impl PlanBuilder {
     }
 
     fn plan_ellipse(&mut self, ellipse: &PaintEllipse, transform: Transform2D, opacity: f32) {
-        if let Some(color) = self.paint_color(ellipse.fill.as_deref(), opacity) {
+        if let Some(brush) = self.paint_brush(ellipse.fill.as_deref(), opacity, transform) {
             let mut vertices = Vec::with_capacity(self.options.ellipse_segments + 1);
-            vertices.push(vertex(
-                apply_transform(point(ellipse.cx, ellipse.cy), transform),
-                color,
-            ));
+            vertices.push(brush.vertex(apply_transform(point(ellipse.cx, ellipse.cy), transform)));
             for i in 0..self.options.ellipse_segments {
                 let t = i as f32 / self.options.ellipse_segments as f32 * std::f32::consts::TAU;
-                vertices.push(vertex(
-                    apply_transform(
-                        GpuPoint {
-                            x: ellipse.cx as f32 + ellipse.rx as f32 * t.cos(),
-                            y: ellipse.cy as f32 + ellipse.ry as f32 * t.sin(),
-                        },
-                        transform,
-                    ),
-                    color,
-                ));
+                vertices.push(brush.vertex(apply_transform(
+                    GpuPoint {
+                        x: ellipse.cx as f32 + ellipse.rx as f32 * t.cos(),
+                        y: ellipse.cy as f32 + ellipse.ry as f32 * t.sin(),
+                    },
+                    transform,
+                )));
             }
             let mut indices = Vec::with_capacity(self.options.ellipse_segments * 3);
             for i in 1..=self.options.ellipse_segments {
@@ -368,7 +410,7 @@ impl PlanBuilder {
                     i as u32 + 1
                 });
             }
-            self.add_mesh(vertices, indices, None, "ellipse.fill");
+            self.add_mesh(vertices, indices, brush.texture_id(), "ellipse.fill");
         }
 
         if let Some(color) = self.stroke_color(ellipse.stroke.as_deref(), opacity) {
@@ -424,20 +466,20 @@ impl PlanBuilder {
                 "evenodd path filling is not exact in the simple GPU tessellator",
             );
         }
-        if let Some(color) = self.paint_color(path.fill.as_deref(), opacity) {
+        if let Some(brush) = self.paint_brush(path.fill.as_deref(), opacity, transform) {
             for contour in &contours {
                 if contour.points.len() >= 3 {
                     let base = contour.points[0];
                     let mut vertices = Vec::with_capacity(contour.points.len());
-                    vertices.push(vertex(apply_transform(base, transform), color));
+                    vertices.push(brush.vertex(apply_transform(base, transform)));
                     for point in contour.points.iter().skip(1) {
-                        vertices.push(vertex(apply_transform(*point, transform), color));
+                        vertices.push(brush.vertex(apply_transform(*point, transform)));
                     }
                     let mut indices = Vec::new();
                     for i in 1..vertices.len().saturating_sub(1) {
                         indices.extend_from_slice(&[0, i as u32, i as u32 + 1]);
                     }
-                    self.add_mesh(vertices, indices, None, "path.fill");
+                    self.add_mesh(vertices, indices, brush.texture_id(), "path.fill");
                 }
             }
         }
@@ -567,6 +609,7 @@ impl PlanBuilder {
             width: pixels.width,
             height: pixels.height,
             data: pixels.data.clone(),
+            filter: GpuTextureFilter::Nearest,
         });
         let color = GpuColor {
             r: 1.0,
@@ -590,6 +633,86 @@ impl PlanBuilder {
         self.add_mesh(vertices, vec![0, 1, 2, 0, 2, 3], Some(texture_id), "image");
     }
 
+    fn paint_brush(
+        &mut self,
+        paint: Option<&str>,
+        opacity: f32,
+        transform: Transform2D,
+    ) -> Option<PaintBrush> {
+        let paint = paint?;
+        if paint.trim().eq_ignore_ascii_case("none") {
+            return None;
+        }
+        if let Some(id) = gradient_ref(paint) {
+            return self.gradient_brush(id, opacity, transform);
+        }
+        let color = parse_color_with_opacity(paint, opacity);
+        (color.a > 0.0).then_some(PaintBrush::Solid(color))
+    }
+
+    fn gradient_brush(
+        &mut self,
+        id: &str,
+        opacity: f32,
+        transform: Transform2D,
+    ) -> Option<PaintBrush> {
+        let Some(gradient) = self.gradients.get(id).cloned() else {
+            self.diagnostic(
+                GpuPlanSeverity::Unsupported,
+                "gradient",
+                format!("gradient reference '{id}' does not resolve to a PaintGradient"),
+            );
+            return None;
+        };
+        if gradient.stops.is_empty() {
+            self.diagnostic(
+                GpuPlanSeverity::Unsupported,
+                "gradient",
+                format!("gradient reference '{id}' has no usable PaintGradient stop"),
+            );
+            return None;
+        }
+        match gradient.kind {
+            GradientKind::Linear { x1, y1, x2, y2 } => {
+                let start = apply_transform(point(x1, y1), transform);
+                let end = apply_transform(point(x2, y2), transform);
+                if same_point(start, end) {
+                    self.diagnostic(
+                        GpuPlanSeverity::Degraded,
+                        "gradient.linear",
+                        "zero-length linear gradient is lowered to its first stop color",
+                    );
+                    return gradient.stops.first().map(|stop| {
+                        PaintBrush::Solid(parse_color_with_opacity(&stop.color, opacity))
+                    });
+                }
+                let texture_id = self.plan.images.len();
+                self.plan.images.push(GpuImageUpload {
+                    width: GRADIENT_RAMP_WIDTH,
+                    height: 1,
+                    data: build_gradient_ramp(&gradient.stops, opacity),
+                    filter: GpuTextureFilter::Linear,
+                });
+                Some(PaintBrush::LinearGradient {
+                    texture_id,
+                    start,
+                    end,
+                })
+            }
+            GradientKind::Radial { .. } => {
+                self.diagnostic(
+                    GpuPlanSeverity::Degraded,
+                    "gradient.radial",
+                    "radial gradients are currently lowered to their first stop color",
+                );
+                gradient
+                    .stops
+                    .first()
+                    .map(|stop| PaintBrush::Solid(parse_color_with_opacity(&stop.color, opacity)))
+            }
+        }
+    }
+
     fn paint_color(&mut self, paint: Option<&str>, opacity: f32) -> Option<GpuColor> {
         let paint = paint?;
         if paint.trim().eq_ignore_ascii_case("none") {
@@ -611,8 +734,8 @@ impl PlanBuilder {
             };
             self.diagnostic(
                 GpuPlanSeverity::Degraded,
-                "gradient",
-                "gradient fills are currently lowered to their first stop color",
+                "gradient.stroke",
+                "gradient strokes are currently lowered to their first stop color",
             );
             return Some(parse_color_with_opacity(&first_stop_color, opacity));
         }
@@ -635,10 +758,11 @@ impl PlanBuilder {
         color: GpuColor,
     ) {
         let w = stroke_width;
-        self.add_rect_mesh(x, y, width, w, transform, color, "rect.stroke");
-        self.add_rect_mesh(x, y + height - w, width, w, transform, color, "rect.stroke");
-        self.add_rect_mesh(x, y, w, height, transform, color, "rect.stroke");
-        self.add_rect_mesh(x + width - w, y, w, height, transform, color, "rect.stroke");
+        let brush = PaintBrush::Solid(color);
+        self.add_rect_mesh(x, y, width, w, transform, brush, "rect.stroke");
+        self.add_rect_mesh(x, y + height - w, width, w, transform, brush, "rect.stroke");
+        self.add_rect_mesh(x, y, w, height, transform, brush, "rect.stroke");
+        self.add_rect_mesh(x + width - w, y, w, height, transform, brush, "rect.stroke");
     }
 
     fn add_rect_mesh(
@@ -648,10 +772,10 @@ impl PlanBuilder {
         width: f64,
         height: f64,
         transform: Transform2D,
-        color: GpuColor,
+        brush: PaintBrush,
         label: &'static str,
     ) {
-        if width <= 0.0 || height <= 0.0 || color.a == 0.0 {
+        if width <= 0.0 || height <= 0.0 || brush.is_transparent() {
             return;
         }
         let p0 = apply_transform(point(x, y), transform);
@@ -660,13 +784,13 @@ impl PlanBuilder {
         let p3 = apply_transform(point(x, y + height), transform);
         self.add_mesh(
             vec![
-                vertex(p0, color),
-                vertex(p1, color),
-                vertex(p2, color),
-                vertex(p3, color),
+                brush.vertex(p0),
+                brush.vertex(p1),
+                brush.vertex(p2),
+                brush.vertex(p3),
             ],
             vec![0, 1, 2, 0, 2, 3],
-            None,
+            brush.texture_id(),
             label,
         );
     }
@@ -888,6 +1012,89 @@ fn gradient_ref(value: &str) -> Option<&str> {
         .and_then(|value| value.strip_suffix(')'))
 }
 
+fn build_gradient_ramp(stops: &[GradientStop], opacity: f32) -> Vec<u8> {
+    let mut stops: Vec<(f32, GpuColor)> = stops
+        .iter()
+        .map(|stop| {
+            (
+                stop.offset.clamp(0.0, 1.0) as f32,
+                parse_color_with_opacity(&stop.color, opacity),
+            )
+        })
+        .collect();
+    stops.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut data = Vec::with_capacity(GRADIENT_RAMP_WIDTH as usize * 4);
+    for i in 0..GRADIENT_RAMP_WIDTH {
+        let t = if GRADIENT_RAMP_WIDTH <= 1 {
+            0.0
+        } else {
+            i as f32 / (GRADIENT_RAMP_WIDTH - 1) as f32
+        };
+        let color = sample_gradient_stops(&stops, t);
+        data.extend_from_slice(&color_to_rgba8(color));
+    }
+    data
+}
+
+fn sample_gradient_stops(stops: &[(f32, GpuColor)], t: f32) -> GpuColor {
+    if stops.is_empty() {
+        return GpuColor::transparent();
+    }
+    if t <= stops[0].0 {
+        return stops[0].1;
+    }
+    for pair in stops.windows(2) {
+        let (left_offset, left_color) = pair[0];
+        let (right_offset, right_color) = pair[1];
+        if t <= right_offset {
+            let width = (right_offset - left_offset).max(f32::EPSILON);
+            return mix_color(left_color, right_color, (t - left_offset) / width);
+        }
+    }
+    stops
+        .last()
+        .map(|(_, color)| *color)
+        .unwrap_or_else(GpuColor::transparent)
+}
+
+fn mix_color(a: GpuColor, b: GpuColor, t: f32) -> GpuColor {
+    let t = t.clamp(0.0, 1.0);
+    GpuColor {
+        r: a.r + (b.r - a.r) * t,
+        g: a.g + (b.g - a.g) * t,
+        b: a.b + (b.b - a.b) * t,
+        a: a.a + (b.a - a.a) * t,
+    }
+}
+
+fn color_to_rgba8(color: GpuColor) -> [u8; 4] {
+    [
+        float_to_u8(color.r),
+        float_to_u8(color.g),
+        float_to_u8(color.b),
+        float_to_u8(color.a),
+    ]
+}
+
+fn float_to_u8(value: f32) -> u8 {
+    (value.clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+fn linear_gradient_t(position: GpuPoint, start: GpuPoint, end: GpuPoint) -> f32 {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let len2 = dx * dx + dy * dy;
+    if len2 <= f32::EPSILON {
+        return 0.0;
+    }
+    (((position.x - start.x) * dx + (position.y - start.y) * dy) / len2).clamp(0.0, 1.0)
+}
+
+fn same_point(a: GpuPoint, b: GpuPoint) -> bool {
+    (a.x - b.x).abs() <= f32::EPSILON && (a.y - b.y).abs() <= f32::EPSILON
+}
+
 fn parse_color_with_opacity(color: &str, opacity: f32) -> GpuColor {
     let mut parsed = parse_color(color);
     parsed.a *= opacity.clamp(0.0, 1.0);
@@ -963,6 +1170,15 @@ impl GpuColor {
             g: 0.0,
             b: 0.0,
             a: 0.0,
+        }
+    }
+
+    pub const fn white() -> Self {
+        Self {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
         }
     }
 }
@@ -1223,7 +1439,7 @@ mod tests {
     }
 
     #[test]
-    fn degrades_gradient_to_first_stop_with_diagnostic() {
+    fn lowers_linear_gradient_to_texture_ramp() {
         let mut scene = PaintScene::new(10.0, 10.0);
         scene
             .instructions
@@ -1237,6 +1453,55 @@ mod tests {
                     y1: 0.0,
                     x2: 10.0,
                     y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#fade)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let plan = plan_scene(&scene);
+        assert_eq!(plan.images.len(), 1);
+        assert_eq!(plan.images[0].filter, GpuTextureFilter::Linear);
+        assert_eq!(plan.meshes[0].texture_id, Some(0));
+        assert_eq!(plan.meshes[0].vertices[0].uv[0], 0.0);
+        assert_eq!(plan.meshes[0].vertices[1].uv[0], 1.0);
+        assert!(plan.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn degrades_radial_gradient_to_first_stop_with_diagnostic() {
+        let mut scene = PaintScene::new(10.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("fade".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 5.0,
+                    cy: 5.0,
+                    r: 5.0,
                 },
                 stops: vec![GradientStop {
                     offset: 0.0,
@@ -1258,11 +1523,12 @@ mod tests {
         }));
 
         let plan = plan_scene(&scene);
+        assert_eq!(plan.images.len(), 0);
         assert_eq!(plan.meshes[0].vertices[0].color.r, 1.0);
         assert!(plan
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.feature == "gradient"));
+            .any(|diagnostic| diagnostic.feature == "gradient.radial"));
     }
 
     #[test]

--- a/code/packages/rust/paint-vm-wgpu/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-wgpu/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Added a Tier 1 WGPU renderer for solid `paint-vm-gpu-core` meshes.
 - Added RGBA texture upload and nearest-neighbor sampling for
   `ImageSrc::Pixels`.
+- Added linear gradient rendering through shared ramp textures and linear
+  filtering.
 - Added offscreen `Rgba8Unorm` render target creation and CPU readback.
 - Added WGPU scissor-stack support for rectangular clips.
-- Declared text, glyphs, filters, and exact gradients as unsupported or degraded
-  so runtime selection remains honest.
+- Declared text, glyphs, filters, and radial gradients as unsupported or
+  degraded so runtime selection remains honest.

--- a/code/packages/rust/paint-vm-wgpu/README.md
+++ b/code/packages/rust/paint-vm-wgpu/README.md
@@ -11,8 +11,9 @@ offscreen `Rgba8Unorm` WGPU texture and reads the result back as a
 can share the same scene lowering and tessellation model.
 
 This crate is intentionally Tier 1: it validates the backend plumbing, command
-ordering, solid mesh rendering, rectangular clips, and readback path without
-pretending that text, image textures, gradients, or filters are already exact.
+ordering, solid mesh rendering, image textures, linear gradients, rectangular
+clips, and readback path without pretending that text, radial gradients, or
+filters are already exact.
 
 ## Where It Fits
 
@@ -35,7 +36,8 @@ Producer (barcode, Mermaid, layout, HTML)
 | Layer transform / opacity | Implemented by the shared GPU plan |
 | Offscreen readback | Implemented with padded row-copy handling |
 | Images | Implemented for `ImageSrc::Pixels` through RGBA texture upload/sampling |
-| Gradients | Degraded by `paint-vm-gpu-core` to first-stop solid fills |
+| Linear gradients | Implemented through shared ramp textures and gradient UVs |
+| Radial gradients | Degraded by `paint-vm-gpu-core` to first-stop solid fills |
 | Text / glyph runs | Not implemented until glyph atlas and shaping strategy lands |
 | Filters / blend modes | Not implemented |
 
@@ -47,12 +49,12 @@ let pixels = backend.render(&scene)?;
 ```
 
 Register `renderer()` with `paint-vm-runtime` when a portable GPU backend is
-acceptable. Exact text or image rendering should still select Direct2D, GDI,
-Cairo, Skia, or future GPU backends until WGPU grows those paths.
+acceptable. Exact text rendering should still select Direct2D, GDI, Cairo,
+Skia, or future GPU backends until WGPU grows a glyph atlas and shaping path.
 
 ## Next Steps
 
-- Add gradient uniforms or small ramp textures instead of first-stop fallback.
+- Add radial gradient textures instead of first-stop fallback.
 - Add glyph atlas planning once the shared text shaping and font metric pipeline
   is ready.
 - Reuse the same WGPU plumbing as a reference implementation for native

--- a/code/packages/rust/paint-vm-wgpu/src/lib.rs
+++ b/code/packages/rust/paint-vm-wgpu/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc;
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_gpu_core::{
     plan_scene, GpuApiFamily, GpuBackendProfile, GpuColor, GpuCommand, GpuImageUpload, GpuMesh,
-    GpuPaintPlan, GpuPlanSeverity, GpuReadbackStrategy, GpuRect, GpuRenderPath,
+    GpuPaintPlan, GpuPlanSeverity, GpuReadbackStrategy, GpuRect, GpuRenderPath, GpuTextureFilter,
 };
 use paint_vm_runtime::{
     PaintAcceleration, PaintBackendCapabilities, PaintBackendDescriptor, PaintBackendFamily,
@@ -49,7 +49,7 @@ pub fn descriptor() -> PaintBackendDescriptor {
             layer_opacity: SupportLevel::Supported,
             layer_filters: SupportLevel::Unsupported,
             layer_blend_modes: SupportLevel::Unsupported,
-            linear_gradient: SupportLevel::Degraded,
+            linear_gradient: SupportLevel::Supported,
             radial_gradient: SupportLevel::Degraded,
             antialiasing: SupportLevel::Unsupported,
             offscreen_pixels: SupportLevel::Supported,
@@ -67,6 +67,7 @@ pub fn profile() -> GpuBackendProfile {
         GpuReadbackStrategy::TextureCopyToBuffer,
     );
     profile.supports_texture_sampling = true;
+    profile.supports_linear_gradients = true;
     profile
 }
 
@@ -133,6 +134,7 @@ struct PreparedTexture {
     bind_group: wgpu::BindGroup,
     _texture: wgpu::Texture,
     _view: wgpu::TextureView,
+    _sampler: wgpu::Sampler,
 }
 
 fn render_scene(scene: &PaintScene) -> Result<PixelContainer, PaintRenderError> {
@@ -225,16 +227,6 @@ async fn render_plan(plan: GpuPaintPlan) -> Result<PixelContainer, PaintRenderEr
             resource: viewport_buffer.as_entire_binding(),
         }],
     });
-    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        label: Some("paint-vm-wgpu-nearest-sampler"),
-        address_mode_u: wgpu::AddressMode::ClampToEdge,
-        address_mode_v: wgpu::AddressMode::ClampToEdge,
-        address_mode_w: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Nearest,
-        min_filter: wgpu::FilterMode::Nearest,
-        mipmap_filter: wgpu::FilterMode::Nearest,
-        ..wgpu::SamplerDescriptor::default()
-    });
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("paint-vm-wgpu-pipeline-layout"),
         bind_group_layouts: &[&viewport_bind_group_layout, &texture_bind_group_layout],
@@ -287,13 +279,8 @@ async fn render_plan(plan: GpuPaintPlan) -> Result<PixelContainer, PaintRenderEr
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
     let prepared_meshes = prepare_meshes(&device, &plan.meshes);
-    let (white_texture, prepared_textures) = prepare_textures(
-        &device,
-        &queue,
-        &texture_bind_group_layout,
-        &sampler,
-        &plan.images,
-    );
+    let (white_texture, prepared_textures) =
+        prepare_textures(&device, &queue, &texture_bind_group_layout, &plan.images);
     let row_bytes = plan.width * 4;
     let padded_row_bytes = align_to(row_bytes, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
     let readback_size = padded_row_bytes as u64 * plan.height as u64;
@@ -491,18 +478,17 @@ fn prepare_textures(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     layout: &wgpu::BindGroupLayout,
-    sampler: &wgpu::Sampler,
     images: &[GpuImageUpload],
 ) -> (PreparedTexture, Vec<PreparedTexture>) {
     let white_texture = prepare_texture(
         device,
         queue,
         layout,
-        sampler,
         "paint-vm-wgpu-white-texture",
         1,
         1,
         &[255, 255, 255, 255],
+        GpuTextureFilter::Nearest,
     );
     let textures = images
         .iter()
@@ -512,11 +498,11 @@ fn prepare_textures(
                 device,
                 queue,
                 layout,
-                sampler,
                 texture_label(index),
                 image.width,
                 image.height,
                 &image.data,
+                image.filter,
             )
         })
         .collect();
@@ -527,11 +513,11 @@ fn prepare_texture(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     layout: &wgpu::BindGroupLayout,
-    sampler: &wgpu::Sampler,
     label: &'static str,
     width: u32,
     height: u32,
     data: &[u8],
+    filter: GpuTextureFilter,
 ) -> PreparedTexture {
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some(label),
@@ -567,6 +553,20 @@ fn prepare_texture(
         },
     );
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let filter_mode = match filter {
+        GpuTextureFilter::Nearest => wgpu::FilterMode::Nearest,
+        GpuTextureFilter::Linear => wgpu::FilterMode::Linear,
+    };
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some(label),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: filter_mode,
+        min_filter: filter_mode,
+        mipmap_filter: wgpu::FilterMode::Nearest,
+        ..wgpu::SamplerDescriptor::default()
+    });
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some(label),
         layout,
@@ -577,7 +577,7 @@ fn prepare_texture(
             },
             wgpu::BindGroupEntry {
                 binding: 1,
-                resource: wgpu::BindingResource::Sampler(sampler),
+                resource: wgpu::BindingResource::Sampler(&sampler),
             },
         ],
     });
@@ -585,6 +585,7 @@ fn prepare_texture(
         bind_group,
         _texture: texture,
         _view: view,
+        _sampler: sampler,
     }
 }
 
@@ -678,7 +679,8 @@ fn fs_main(input: VertexOut) -> @location(0) vec4<f32> {
 mod tests {
     use super::*;
     use paint_instructions::{
-        ImageSrc, PaintBase, PaintImage, PaintInstruction, PaintRect, PaintText,
+        GradientKind, GradientStop, ImageSrc, PaintBase, PaintGradient, PaintImage,
+        PaintInstruction, PaintRect, PaintText,
     };
     use paint_vm_runtime::{PaintBackendPreference, PaintBackendRegistry, PaintRenderOptions};
 
@@ -690,6 +692,10 @@ mod tests {
         assert_eq!(descriptor.tier, PaintBackendTier::Tier1Smoke);
         assert_eq!(descriptor.capabilities.rect, SupportLevel::Supported);
         assert_eq!(descriptor.capabilities.image, SupportLevel::Supported);
+        assert_eq!(
+            descriptor.capabilities.linear_gradient,
+            SupportLevel::Supported
+        );
     }
 
     #[test]
@@ -700,6 +706,7 @@ mod tests {
         assert_eq!(profile.render_path, GpuRenderPath::GraphicsPipeline);
         assert_eq!(profile.readback, GpuReadbackStrategy::TextureCopyToBuffer);
         assert!(profile.supports_texture_sampling);
+        assert!(profile.supports_linear_gradients);
     }
 
     #[test]
@@ -742,6 +749,62 @@ mod tests {
             height: 4.0,
             src: ImageSrc::Pixels(pixels),
             opacity: None,
+        }));
+
+        let selected = registry
+            .select(
+                &scene,
+                PaintRenderOptions {
+                    preference: PaintBackendPreference::Named("paint-vm-wgpu".to_string()),
+                    ..PaintRenderOptions::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(selected.descriptor().id, "paint-vm-wgpu");
+    }
+
+    #[test]
+    fn runtime_selects_wgpu_for_linear_gradient_scene() {
+        let backend = renderer();
+        let mut registry = PaintBackendRegistry::new();
+        registry.register(&backend);
+        let mut scene = PaintScene::new(8.0, 2.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("fade".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 8.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#000000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#ffffff".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 8.0,
+            height: 2.0,
+            fill: Some("url(#fade)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
         }));
 
         let selected = registry
@@ -811,6 +874,67 @@ mod tests {
         assert_eq!(pixels.pixel_at(2, 1), (0, 255, 0, 255));
         assert_eq!(pixels.pixel_at(1, 2), (0, 0, 255, 255));
         assert_eq!(pixels.pixel_at(2, 2), (255, 255, 0, 255));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn renders_linear_gradient_when_adapter_is_available() {
+        let mut scene = PaintScene::new(8.0, 2.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("fade".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 8.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#000000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#ffffff".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 8.0,
+            height: 2.0,
+            fill: Some("url(#fade)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let pixels = match render(&scene) {
+            Ok(pixels) => pixels,
+            Err(PaintRenderError::BackendUnavailable { .. }) => return,
+            Err(err) => panic!("unexpected WGPU render failure: {err:?}"),
+        };
+        let left = pixels.pixel_at(0, 0);
+        let right = pixels.pixel_at(7, 0);
+
+        assert!(
+            left.0 < 80,
+            "expected dark left gradient edge, got {left:?}"
+        );
+        assert!(
+            right.0 > 170,
+            "expected bright right gradient edge, got {right:?}"
+        );
+        assert!(right.0 > left.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Lowers linear Paint VM gradients into shared GPU ramp textures with gradient UVs instead of degrading to the first stop.
- Adds per-texture filtering metadata so decoded images stay nearest-neighbor while gradient ramps use linear filtering.
- Marks WGPU linear gradients as supported and verifies live Windows WGPU gradient readback; radial gradients still degrade with diagnostics.

## Verification
- `cargo test -p paint-vm-gpu-core -p paint-vm-wgpu -p paint-vm-opengl -p paint-vm-vulkan -p paint-vm-mesa -p paint-vm-opencl -- --nocapture` on Windows.
- `wsl -d Ubuntu bash -lc "cd /mnt/c/Users/adhit/Downloads/Codex/coding-adventures/.codex-worktrees/gpu-linear-gradient-plan/code/packages/rust && CARGO_TARGET_DIR=/tmp/codex-gpu-gradient-target ~/.cargo/bin/cargo test -p paint-vm-gpu-core -p paint-vm-wgpu -p paint-vm-opengl -p paint-vm-vulkan -p paint-vm-mesa -p paint-vm-opencl -- --nocapture"` on WSL/Linux.
- After final rebase: `cargo test -p paint-vm-gpu-core -p paint-vm-wgpu -- --nocapture`.