### PR TITLE
Recover one-dash markup declarations

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -89,6 +89,8 @@ documented in this file.
   an unrelated `eof-in-comment` diagnostic.
 - Malformed markup declarations such as `<!foo>` now report
   `incorrectly-opened-comment` while recovering as bogus comments.
+- One-dash markup declarations such as `<!->` and `<!-x>` now use
+  incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is
   preserved and malformed end-tag openers recover as bogus comments.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -38,7 +38,9 @@ comment recovery emits the recovered comment without adding an unrelated
 `eof-in-comment` diagnostic.
 Malformed markup declarations such as `<!foo>` also recover as bogus comments
 and report `incorrectly-opened-comment`, matching the tokenizer error shape the
-future parser will rely on for compatibility diagnostics.
+future parser will rely on for compatibility diagnostics. One-dash declaration
+openers such as `<!->` and `<!-x>` use that same bogus-comment recovery instead
+of being mistaken for normal empty-comment syntax.
 The tag-open states now only begin normal tags when the next character is an
 ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
 end-tag openers such as `</3>` recover as bogus comments with a tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4456,7 +4456,8 @@ from = "comment_start"
 matcher = { literal = ">" }
 to = "data"
 actions = [
-  "parse_error(abrupt-closing-of-empty-comment)",
+  "parse_error(incorrectly-opened-comment)",
+  "append_comment(-)",
   "emit_current_token",
 ]
 
@@ -4465,13 +4466,22 @@ from = "comment_start"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "append_comment(-)",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "comment_start"
 matcher = { anything = true }
 to = "bogus_comment"
-actions = ["append_comment(-)", "append_comment(current)"]
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "append_comment(-)",
+  "append_comment(current)",
+]
 
 [[transitions]]
 from = "comment_start_dash"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9428,7 +9428,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(abrupt-closing-of-empty-comment)".to_string(),
+                "parse_error(incorrectly-opened-comment)".to_string(),
+                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -9444,7 +9445,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(eof-in-comment)".to_string(),
+                "parse_error(incorrectly-opened-comment)".to_string(),
+                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -9461,6 +9463,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(incorrectly-opened-comment)".to_string(),
                 "append_comment(-)".to_string(),
                 "append_comment(current)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 55);
+    assert_eq!(html1.cases.len(), 56);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 53);
+    assert_eq!(file.tests.len(), 54);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 53);
+    assert_eq!(normalized.cases.len(), 54);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 53);
+    assert_eq!(suite.cases.len(), 54);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -609,6 +609,25 @@
       ]
     },
     {
+      "id": "one-dash-markup-declaration-bogus-comment",
+      "description": "Markup declarations with only one opening dash recover as bogus comments",
+      "input": "Before<!->Middle<!-x>After<!-",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=-)",
+        "Text(data=Middle)",
+        "Comment(data=-x)",
+        "Text(data=After)",
+        "Comment(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment",
+        "incorrectly-opened-comment",
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
       "id": "invalid-tag-open-text-recovery",
       "description": "A less-than sign before non-tag text remains text instead of starting a tag",
       "input": "Before < after",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -649,6 +649,25 @@
     },
     {
       "id": "html5lib-smoke-53",
+      "description": "one dash markup declaration recovers as bogus comment",
+      "input": "Before<!->Middle<!-x>After<!-",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=-)",
+        "Text(data=Middle)",
+        "Comment(data=-x)",
+        "Text(data=After)",
+        "Comment(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment",
+        "incorrectly-opened-comment",
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-54",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -565,6 +565,23 @@
       ]
     },
     {
+      "description": "one dash markup declaration recovers as bogus comment",
+      "input": "Before<!->Middle<!-x>After<!-",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", "-"],
+        ["Character", "Middle"],
+        ["Comment", "-x"],
+        ["Character", "After"],
+        ["Comment", "-"]
+      ],
+      "errors": [
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 9},
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 19},
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 29}
+      ]
+    },
+    {
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -405,6 +405,43 @@ fn default_html_lexer_reports_incorrectly_opened_markup_declaration() {
 }
 
 #[test]
+fn default_html_lexer_reports_one_dash_markup_declaration_as_incorrectly_opened() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<!->Middle<!-x>After<!-").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("-".to_string()),
+            Token::Text("Middle".to_string()),
+            Token::Comment("-x".to_string()),
+            Token::Text("After".to_string()),
+            Token::Comment("-".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "incorrectly-opened-comment")
+            .count(),
+        3
+    );
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "abrupt-closing-of-empty-comment"));
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-comment"));
+}
+
+#[test]
 fn default_html_lexer_recovers_invalid_tag_open_as_text() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Treat one-dash markup declarations like `<!->`, `<!-x>`, and `<!-` as incorrectly opened bogus comments.
- Keep valid `<!--...-->` and `<!-->` handling intact while avoiding empty-comment/eof-in-comment diagnostics on the one-dash path.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage, then regenerate static HTML1 source and normalized fixtures.

## Verification
- `python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`
- `cargo run` in `/tmp/html_numeric_codegen_tool`
- `cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests`
- `cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests`
- `git diff --check`