### PR TITLE
feat(beam): TW03 Phase 1 — define, recursion, if, comparison on real erl

### DIFF
--- a/code/packages/python/ir-to-beam/CHANGELOG.md
+++ b/code/packages/python/ir-to-beam/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog — ir-to-beam
 
+## 0.2.0 — 2026-04-29 — TW03 Phase 1 (BEAM)
+
+### Added — branching, comparison, and recursion
+
+- ``BRANCH_Z`` / ``BRANCH_NZ`` lowering via BEAM's ``is_ne_exact`` /
+  ``is_eq_exact`` (whose "fall through if condition holds, jump
+  otherwise" semantics flip to direct BRANCH semantics with
+  appropriate operand choice).
+- ``JUMP`` lowering to BEAM's ``jump`` opcode.
+- ``CMP_EQ`` / ``CMP_LT`` / ``CMP_GT`` lowering — each becomes a
+  5-instruction if-then-else pattern (``is_X`` + move 1 + jump +
+  label + move 0 + label).  ``CMP_GT`` uses ``is_lt`` with swapped
+  operands since BEAM has no ``is_gt``.
+- ``ADD_IMM`` lowering — single ``move`` for ``imm == 0`` (the
+  Twig MOV idiom), ``gc_bif2`` otherwise.
+- Internal LABEL handling: ``_split_callable_regions`` now
+  distinguishes callable regions (CALL targets + entry) from
+  internal labels (``_else_*``, ``_endif_*``); internal labels
+  stay in the body and emit ``label N`` opcodes.
+
+### Changed — y-register frame for recursion support
+
+- Function bodies now use BEAM **y-registers** (callee-saves stack)
+  for all IR registers, with **x-registers** used only at CALL
+  boundaries.  This is necessary for recursive functions because
+  BEAM x-registers are caller-saves (clobbered across calls).
+- Each function emits ``allocate K, arity`` at entry (K = max IR
+  register index used) and ``deallocate K`` before ``return``.
+- At function entry, args are copied from BEAM ``x0..x{arity-1}``
+  into the IR's param-slot registers ``y2..y{arity+1}``.
+- At each CALL site, args are copied from ``y{2+i}`` to ``x{i}``,
+  then ``call N, label``, then the result is copied from ``x0``
+  back into the IR's HALT-result register ``y1``.
+
+### Added tests
+
+- ``test_recursive_factorial_returns_120`` — hand-built IR
+  exercising ``allocate`` + ``call`` + ``deallocate`` +
+  ``BRANCH_Z`` + ``CMP_EQ`` + arithmetic across recursive call
+  boundaries.  Confirms ``fact(5) → 120`` on real ``erl``.
+- Tests for each new IR-op lowering.
+
+### Migration notes for existing callers
+
+The IR convention is now **r1 holds the function's return value**
+(matches twig-jvm-compiler / twig-clr-compiler).  Programs that
+used ``r0`` as the result must update.
+
 ## 0.1.0 — 2026-04-29
 
 ### Added — BEAM01 Phase 3: compiler-ir → BEAMModule lowering

--- a/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
+++ b/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
@@ -1,7 +1,9 @@
 """Lower a ``compiler-ir`` ``IrProgram`` into a ``BEAMModule``.
 
-This is BEAM01 Phase 3 — see
-``code/specs/BEAM01-twig-on-real-erl.md``.
+This is BEAM01 Phase 3 + TW03 Phase 1 (BEAM extension).  See
+``code/specs/BEAM01-twig-on-real-erl.md`` and
+``code/specs/TW03-lisp-primitives-and-gc.md`` for the broader
+plan.
 
 Pipeline
 ========
@@ -11,52 +13,70 @@ output of ``ir-optimizer`` or, for tests, of a hand-built
 program).  It produces a ``BEAMModule`` ready for
 ``beam_bytecode_encoder.encode_beam`` to serialize.
 
-Calling convention
-==================
+Calling convention (TW03 Phase 1)
+=================================
 
-BEAM is register-based with two register files:
+BEAM has two register files:
 
-* ``x`` registers — function arguments and scratch (caller-saves).
-  Args to a call go in ``x0..x{arity-1}``; the return value lives
-  in ``x0``.
-* ``y`` registers — stack-allocated locals (callee-saves).  Live
-  across calls; require an ``allocate``/``deallocate`` framing
-  pair.
+* ``x`` — caller-saves scratch.  Args to a call go in ``x0..xN-1``;
+  return value comes back in ``x0``.
+* ``y`` — stack-allocated locals (callee-saves).  Survive across
+  calls.  Require an ``allocate``/``deallocate`` framing pair.
 
-Our v1 lowering uses **only** ``x`` registers and emits no
-``allocate``/``deallocate`` instructions.  This is correct for the
-BEAM01 Phase 3 op set (``LABEL``, ``LOAD_IMM``, ``ADD``, ``SUB``,
-``MUL``, ``DIV``, ``CALL``, ``RET``) because none of them need
-values to survive a call boundary — argument registers are set
-right before the ``call`` and read right after on return.
+Recursive functions need to preserve state across calls, so we
+**use y-registers for everything in the function body** and only
+touch x-registers at call boundaries.  This sidesteps the
+"caller-saves" footgun that bit JVM01 — the BEAM stack frame
+naturally provides per-invocation isolation.
 
-When ``BRANCH``/``JUMP`` and tail-recursive ``call_only`` join the
-op set (v2), proper ``allocate`` framing becomes necessary.
+Concretely, **IR register ``rN`` lowers to BEAM ``yN``** in every
+body opcode (LOAD_IMM, ADD, BRANCH_Z, etc.).  At function entry
+we ``allocate K, 0`` enough y-registers for the program's max
+register index, then copy the args from ``x0..x{arity-1}`` into
+``y2..y{arity+1}`` to match the Twig calling convention (param
+``i`` at register ``_REG_PARAM_BASE + i = 2 + i``).
 
-Module shape
-============
+At a CALL site:
 
-For an ``IrProgram`` with N callable regions:
+1. Move each arg from its IR param slot ``y{2+i}`` into the BEAM
+   ``x{i}`` slot the callee expects.
+2. ``call N, label`` (where N = arity).
+3. Move the result back from ``x0`` into ``y1`` (the IR's
+   ``_REG_HALT_RESULT`` convention).
 
-```
-{label, 1}.
-{func_info, {atom, mod}, {atom, fn1}, arity}.
-{label, 2}.   <--- call-target label for fn1
-... fn1 body ...
-{return}.
-{label, 3}.
-{func_info, {atom, mod}, {atom, fn2}, arity}.
-{label, 4}.
-... fn2 body ...
-{return}.
-... module_info/0 + module_info/1 ...
-{int_code_end}.
-```
+At RET:
 
-Real ``erlc`` always inserts ``module_info/0`` and
-``module_info/1`` exports that delegate to
-``erlang:get_module_info/{1,2}`` — the BEAM loader rejects modules
-without those two exports.  We do the same.
+1. Move ``y1`` (the IR return-value register) into ``x0``.
+2. ``deallocate K``.
+3. ``return``.
+
+Why this matters: the JVM and CLR Twig frontends both put params
+in ``r2..rN+1`` and the return value in ``r1`` — same convention,
+shared IR.  ir-to-beam absorbs the BEAM-specific x↔y dance so
+the upstream compilers don't need a backend-aware register layout.
+
+Branch lowering (TW03 Phase 1 additions)
+========================================
+
+BEAM has no "set boolean register from comparison" opcode pattern;
+its comparison opcodes (is_lt, is_eq_exact, …) are conditional
+*jumps*: each takes a fail-label and falls through if the
+condition holds, jumping otherwise.  ``CMP_EQ dst, a, b`` lowers
+as a 5-instruction if-then-else::
+
+    is_eq_exact F, a, b
+    move {integer, 1}, dst
+    jump END
+  F:
+    move {integer, 0}, dst
+  END:
+
+with synthetic labels ``F`` and ``END`` allocated from the
+backend's ``fresh_label`` pool.
+
+``BRANCH_Z reg, target`` lowers to ``is_ne_exact target, reg, {integer,0}``
+— is_ne_exact's "fall through if NOT equal, jump if equal"
+semantics directly match BRANCH_Z's "jump when zero" condition.
 """
 
 from __future__ import annotations
@@ -90,30 +110,27 @@ _OP_LABEL: Final[int] = 1
 _OP_FUNC_INFO: Final[int] = 2
 _OP_INT_CODE_END: Final[int] = 3
 _OP_CALL: Final[int] = 4
-_OP_CALL_EXT_ONLY: Final[int] = 78  # tail-call to imported BIF
+_OP_ALLOCATE: Final[int] = 12
+_OP_DEALLOCATE: Final[int] = 18
 _OP_RETURN: Final[int] = 19
+_OP_IS_LT: Final[int] = 39           # is_lt fail src1 src2
+_OP_IS_EQ_EXACT: Final[int] = 43     # is_eq_exact fail src1 src2
+_OP_IS_NE_EXACT: Final[int] = 44     # is_ne_exact fail src1 src2
+_OP_JUMP: Final[int] = 61
 _OP_MOVE: Final[int] = 64
+_OP_CALL_EXT_ONLY: Final[int] = 78
 _OP_GC_BIF2: Final[int] = 125
 
 # Minimum ``max_opcode`` value the modern Erlang loader accepts.
-# The loader uses this field as a "what BEAM dialect was this
-# module compiled against" declaration, not as a real "highest
-# opcode used" value.  OTP 25 introduced opcode 178 (``call_fun2``)
-# and rejects anything that doesn't advertise at least that level
-# with the cryptic "compiled for an old version of the runtime
-# system" error.  We always declare 178 even though our v1 op set
-# tops out at 125; that's exactly what ``erlc`` does for modules
-# that don't actually use the OTP-25-specific opcodes.
+# Loader treats this as a "what BEAM dialect was this compiled
+# against" declaration, not the actual highest opcode used.
 _MIN_RUNTIME_MAX_OPCODE: Final[int] = 178
 
-# Erlang BIFs we may need.  Keys are ``(module_atom, fn_atom, arity)``,
-# values are display names — used for atom-table population only.
+# Erlang BIFs we may need.
 _BIF_PLUS: Final[tuple[str, str, int]] = ("erlang", "+", 2)
 _BIF_MINUS: Final[tuple[str, str, int]] = ("erlang", "-", 2)
 _BIF_MUL: Final[tuple[str, str, int]] = ("erlang", "*", 2)
 _BIF_DIV: Final[tuple[str, str, int]] = ("erlang", "div", 2)
-_BIF_GET_MODULE_INFO_1: Final[tuple[str, str, int]] = ("erlang", "get_module_info", 1)
-_BIF_GET_MODULE_INFO_2: Final[tuple[str, str, int]] = ("erlang", "get_module_info", 2)
 
 _ARITHMETIC_BIF: dict[IrOp, tuple[str, str, int]] = {
     IrOp.ADD: _BIF_PLUS,
@@ -121,6 +138,12 @@ _ARITHMETIC_BIF: dict[IrOp, tuple[str, str, int]] = {
     IrOp.MUL: _BIF_MUL,
     IrOp.DIV: _BIF_DIV,
 }
+
+# Twig calling-convention constants (shared with twig-jvm-compiler
+# and twig-clr-compiler — see those files for the rationale).
+# IR register N maps to BEAM y-register N in body code.
+_REG_HALT_RESULT: Final = 1
+_REG_PARAM_BASE: Final = 2
 
 
 class BEAMBackendError(ValueError):
@@ -132,29 +155,30 @@ class BEAMBackendConfig:
     """Knobs for the lowering.
 
     ``module_name`` is the Erlang module name (must be a valid
-    atom).  ``arity_overrides`` lets the caller declare the arity
-    of specific entry points; if not present, arity defaults to 0
-    for every region (matching how Twig top-level functions and
-    the synthesised ``_start`` look in IR before TW04 lands an
-    explicit arity per region).
+    atom).  ``arity_overrides`` declares the arity of specific
+    callable regions (function names) — required when the
+    function takes any arguments, since the IR itself doesn't
+    encode arity per region.  Defaults to 0 for any region not
+    listed.
+
+    ``y_register_count`` declares how many y-registers each
+    function body needs.  Auto-derived from the program's max IR
+    register index when ``None`` (the typical case).
     """
 
     module_name: str
     arity_overrides: dict[str, int] = field(default_factory=dict)
+    y_register_count: int | None = None
 
 
 # ---------------------------------------------------------------------------
-# Lowering driver
+# Atom + import tables
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class _AtomTable:
-    """Insertion-ordered atom table that maps to 1-based BEAM indices.
-
-    Atom 1 is the module name (BEAM mandates this).  Atoms 2+ are
-    inserted lazily as the lowering runs into them.
-    """
+    """Insertion-ordered atom table that maps to 1-based BEAM indices."""
 
     atoms: list[str]
     index_of: dict[str, int]
@@ -178,12 +202,7 @@ class _AtomTable:
 
 @dataclass
 class _ImportTable:
-    """Insertion-ordered ``ImpT`` row builder.
-
-    Each unique ``(module, function, arity)`` triple gets a 1-based
-    import index.  The ``BEAMImport`` row references atom-table
-    indices, so callers must make sure those atoms are added first.
-    """
+    """Insertion-ordered ``ImpT`` row builder."""
 
     rows: list[BEAMImport]
     index_of: dict[tuple[int, int, int], int]
@@ -236,22 +255,42 @@ class _Builder:
         self.instructions.append(BEAMInstruction(opcode=opcode, operands=operands))
 
 
+# ---------------------------------------------------------------------------
+# Region splitting and label discovery
+# ---------------------------------------------------------------------------
+
+
+def _discover_callable_names(program: IrProgram) -> set[str]:
+    """All region names that are CALL targets or the entry label.
+
+    Internal labels (``_else_0``, ``_endif_0``, etc.) are NOT
+    callable — they're targets of branches/jumps within a single
+    function, and they stay as ``label N`` opcodes inside that
+    function's body.
+    """
+    callable_names: set[str] = {program.entry_label}
+    for instr in program.instructions:
+        if instr.opcode is IrOp.CALL:
+            target = _operand_label(instr.operands[0], role="CALL target")
+            callable_names.add(target)
+    return callable_names
+
+
 def _split_callable_regions(
     program: IrProgram,
+    callable_names: set[str],
 ) -> list[tuple[str, list[IrInstruction]]]:
     """Group an IR instruction stream into ``(label_name, body)`` regions.
 
-    Each region begins at an ``IrOp.LABEL`` and ends at the
-    instruction before the next ``IrOp.LABEL`` (or end-of-stream).
-    The region's body excludes the leading LABEL itself.
+    A region starts at any LABEL whose name is in ``callable_names``.
+    Other LABELs (synthetic ``_else_*`` / ``_endif_*`` markers)
+    stay in the body for emission as ``label N`` opcodes.
     """
     regions: list[tuple[str, list[IrInstruction]]] = []
     current_name: str | None = None
     current_body: list[IrInstruction] = []
     for instr in program.instructions:
         if instr.opcode is IrOp.LABEL:
-            if current_name is not None:
-                regions.append((current_name, current_body))
             label_arg = instr.operands[0]
             if not isinstance(label_arg, IrLabel):
                 msg = (
@@ -259,8 +298,20 @@ def _split_callable_regions(
                     f"got {label_arg!r}"
                 )
                 raise BEAMBackendError(msg)
-            current_name = label_arg.name
-            current_body = []
+            if label_arg.name in callable_names:
+                if current_name is not None:
+                    regions.append((current_name, current_body))
+                current_name = label_arg.name
+                current_body = []
+                continue
+            # Internal label — keep it in the current body.
+            if current_name is None:
+                msg = (
+                    f"internal LABEL {label_arg.name!r} appears before any "
+                    "callable region — this is structurally invalid IR"
+                )
+                raise BEAMBackendError(msg)
+            current_body.append(instr)
         else:
             if current_name is None:
                 msg = (
@@ -274,6 +325,15 @@ def _split_callable_regions(
     return regions
 
 
+def _max_register_index(program: IrProgram) -> int:
+    highest = 1  # enough for at least ``_REG_HALT_RESULT``
+    for instr in program.instructions:
+        for op in instr.operands:
+            if isinstance(op, IrRegister) and op.index > highest:
+                highest = op.index
+    return highest
+
+
 def _operand_register(value: object, *, role: str) -> int:
     if not isinstance(value, IrRegister):
         msg = f"expected IR register for {role}, got {value!r}"
@@ -285,12 +345,6 @@ def _operand_register(value: object, *, role: str) -> int:
 
 
 def _operand_immediate(value: object, *, role: str) -> int:
-    """Pull an integer out of an IR immediate operand.
-
-    The compiler-ir module exposes immediates as either a bare
-    Python int or as a small ``IrImmediate`` dataclass — handle
-    both and reject everything else with a clear message.
-    """
     if isinstance(value, int):
         return value
     if hasattr(value, "value") and isinstance(value.value, int):
@@ -307,13 +361,36 @@ def _operand_label(value: object, *, role: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Per-instruction lowering
+# Per-instruction lowering — body code uses y-registers
 # ---------------------------------------------------------------------------
+
+
+def _y(reg_index: int) -> BEAMOperand:
+    """Map an IR register index to its BEAM y-register operand."""
+    return BEAMOperand(BEAMTag.Y, reg_index)
+
+
+def _x(idx: int) -> BEAMOperand:
+    return BEAMOperand(BEAMTag.X, idx)
+
+
+def _i(value: int) -> BEAMOperand:
+    return BEAMOperand(BEAMTag.I, value)
+
+
+def _u(value: int) -> BEAMOperand:
+    return BEAMOperand(BEAMTag.U, value)
+
+
+def _f(value: int) -> BEAMOperand:
+    return BEAMOperand(BEAMTag.F, value)
 
 
 def _emit_load_imm(builder: _Builder, instr: IrInstruction) -> None:
     if len(instr.operands) != 2:
-        raise BEAMBackendError(f"LOAD_IMM expects 2 operands, got {len(instr.operands)}")
+        raise BEAMBackendError(
+            f"LOAD_IMM expects 2 operands, got {len(instr.operands)}"
+        )
     dest = _operand_register(instr.operands[0], role="LOAD_IMM dest")
     value = _operand_immediate(instr.operands[1], role="LOAD_IMM value")
     if value < 0:
@@ -322,22 +399,11 @@ def _emit_load_imm(builder: _Builder, instr: IrInstruction) -> None:
             "by ir-to-beam — the BEAM compact-term encoder rejects negatives"
         )
         raise BEAMBackendError(msg)
-    builder.emit(
-        _OP_MOVE,
-        BEAMOperand(BEAMTag.I, value),
-        BEAMOperand(BEAMTag.X, dest),
-    )
+    builder.emit(_OP_MOVE, _i(value), _y(dest))
 
 
 def _emit_arithmetic(builder: _Builder, instr: IrInstruction) -> None:
-    """Lower ADD/SUB/MUL/DIV via ``gc_bif2``.
-
-    ``gc_bif2`` operands: fail-label, live-regs, bif-import-idx,
-    src1, src2, dest.  We pass fail-label = 0 (no failure handler;
-    integer arithmetic on integer operands cannot fail under BEAM
-    semantics) and live = 0 (we don't allocate any y-registers in
-    v1, so no live state to preserve across the BIF call).
-    """
+    """Lower ADD/SUB/MUL/DIV via ``gc_bif2`` over y-register sources."""
     if len(instr.operands) != 3:
         msg = (
             f"{instr.opcode.name} expects 3 operands "
@@ -355,13 +421,175 @@ def _emit_arithmetic(builder: _Builder, instr: IrInstruction) -> None:
 
     builder.emit(
         _OP_GC_BIF2,
-        BEAMOperand(BEAMTag.F, 0),                # fail label = 0 (no failure)
-        BEAMOperand(BEAMTag.U, 0),                # live regs = 0
-        BEAMOperand(BEAMTag.U, bif_import_idx - 1),  # BIF index is 0-based here
-        BEAMOperand(BEAMTag.X, lhs),
-        BEAMOperand(BEAMTag.X, rhs),
-        BEAMOperand(BEAMTag.X, dest),
+        _f(0),                              # fail label = 0
+        _u(0),                              # live x-regs = 0 (we use y for state)
+        _u(bif_import_idx - 1),             # BIF index (0-based here)
+        _y(lhs),
+        _y(rhs),
+        _y(dest),
     )
+
+
+def _emit_add_imm(builder: _Builder, instr: IrInstruction) -> None:
+    """Lower ADD_IMM dst, src, imm.
+
+    Used by Twig compilers as a "MOV" idiom (``ADD_IMM dst, src, 0``).
+    Lower to a single ``move`` when ``imm == 0``; otherwise lower
+    via ``gc_bif2 +/2`` with the immediate as the second operand.
+    """
+    if len(instr.operands) != 3:
+        msg = f"ADD_IMM expects 3 operands, got {len(instr.operands)}"
+        raise BEAMBackendError(msg)
+    dest = _operand_register(instr.operands[0], role="ADD_IMM dest")
+    src = _operand_register(instr.operands[1], role="ADD_IMM src")
+    imm = _operand_immediate(instr.operands[2], role="ADD_IMM imm")
+    if imm == 0:
+        # Pure move — no BIF needed.  Compact and avoids importing
+        # ``erlang:+/2`` for non-arithmetic uses.
+        if dest == src:
+            return  # no-op
+        builder.emit(_OP_MOVE, _y(src), _y(dest))
+        return
+
+    if imm < 0:
+        msg = (
+            f"ADD_IMM with negative immediate ({imm}) is not yet supported "
+            "by ir-to-beam"
+        )
+        raise BEAMBackendError(msg)
+
+    module_atom_idx = builder.atoms.add("erlang")
+    fn_atom_idx = builder.atoms.add("+")
+    bif_import_idx = builder.imports.add(module_atom_idx, fn_atom_idx, 2)
+
+    builder.emit(
+        _OP_GC_BIF2,
+        _f(0),
+        _u(0),
+        _u(bif_import_idx - 1),
+        _y(src),
+        _i(imm),
+        _y(dest),
+    )
+
+
+def _emit_jump(
+    builder: _Builder,
+    instr: IrInstruction,
+    label_for: dict[str, int],
+) -> None:
+    if len(instr.operands) != 1:
+        msg = f"JUMP expects 1 operand, got {len(instr.operands)}"
+        raise BEAMBackendError(msg)
+    target = _operand_label(instr.operands[0], role="JUMP target")
+    if target not in label_for:
+        msg = f"JUMP target {target!r} has no corresponding LABEL"
+        raise BEAMBackendError(msg)
+    builder.emit(_OP_JUMP, _f(label_for[target]))
+
+
+def _emit_branch(
+    builder: _Builder,
+    instr: IrInstruction,
+    label_for: dict[str, int],
+) -> None:
+    """Lower BRANCH_Z / BRANCH_NZ to is_ne_exact / is_eq_exact.
+
+    BEAM's ``is_X`` opcodes have "falls through if condition holds,
+    else jumps to fail-label" semantics.  We use is_ne_exact for
+    BRANCH_Z (jump when reg==0): is_ne_exact's fall-through-if-not-
+    equal flips to "jump when equal".  Symmetric for BRANCH_NZ.
+    """
+    if len(instr.operands) != 2:
+        msg = (
+            f"{instr.opcode.name} expects 2 operands "
+            f"(reg, target), got {len(instr.operands)}"
+        )
+        raise BEAMBackendError(msg)
+    reg = _operand_register(instr.operands[0], role=f"{instr.opcode.name} reg")
+    target = _operand_label(instr.operands[1], role=f"{instr.opcode.name} target")
+    if target not in label_for:
+        msg = f"{instr.opcode.name} target {target!r} has no corresponding LABEL"
+        raise BEAMBackendError(msg)
+
+    target_label = _f(label_for[target])
+    if instr.opcode is IrOp.BRANCH_Z:
+        # Jump when reg == 0.
+        builder.emit(_OP_IS_NE_EXACT, target_label, _y(reg), _i(0))
+    elif instr.opcode is IrOp.BRANCH_NZ:
+        # Jump when reg != 0.
+        builder.emit(_OP_IS_EQ_EXACT, target_label, _y(reg), _i(0))
+    else:  # pragma: no cover — caller dispatches by opcode
+        msg = f"unexpected branch opcode {instr.opcode.name}"
+        raise BEAMBackendError(msg)
+
+
+def _emit_cmp(
+    builder: _Builder,
+    instr: IrInstruction,
+) -> None:
+    """Lower CMP_EQ / CMP_LT / CMP_GT to is_X-then-set-bool pattern.
+
+    The pattern emits two synthetic labels (an "else" label and an
+    "end" label) and 5 instructions::
+
+        is_X false_label, src1, src2  ; falls through if comparison holds
+        move {integer, 1}, dst
+        jump end_label
+      false_label:
+        move {integer, 0}, dst
+      end_label:
+
+    For ``CMP_GT`` we swap the operands and use ``is_lt`` (BEAM
+    has no ``is_gt`` opcode).
+    """
+    if len(instr.operands) != 3:
+        msg = (
+            f"{instr.opcode.name} expects 3 operands "
+            f"(dest, lhs, rhs), got {len(instr.operands)}"
+        )
+        raise BEAMBackendError(msg)
+    dest = _operand_register(instr.operands[0], role=f"{instr.opcode.name} dest")
+    lhs = _operand_register(instr.operands[1], role=f"{instr.opcode.name} lhs")
+    rhs = _operand_register(instr.operands[2], role=f"{instr.opcode.name} rhs")
+
+    false_label = builder.fresh_label()
+    end_label = builder.fresh_label()
+
+    if instr.opcode is IrOp.CMP_EQ:
+        builder.emit(_OP_IS_EQ_EXACT, _f(false_label), _y(lhs), _y(rhs))
+    elif instr.opcode is IrOp.CMP_LT:
+        builder.emit(_OP_IS_LT, _f(false_label), _y(lhs), _y(rhs))
+    elif instr.opcode is IrOp.CMP_GT:
+        # BEAM has no is_gt — use is_lt with swapped operands.
+        builder.emit(_OP_IS_LT, _f(false_label), _y(rhs), _y(lhs))
+    else:  # pragma: no cover — caller dispatches by opcode
+        msg = f"unexpected compare opcode {instr.opcode.name}"
+        raise BEAMBackendError(msg)
+
+    # Fall-through path (condition true): set dest = 1, jump to end.
+    builder.emit(_OP_MOVE, _i(1), _y(dest))
+    builder.emit(_OP_JUMP, _f(end_label))
+
+    # False path: set dest = 0.
+    builder.emit(_OP_LABEL, _u(false_label))
+    builder.emit(_OP_MOVE, _i(0), _y(dest))
+
+    # Common continuation.
+    builder.emit(_OP_LABEL, _u(end_label))
+
+
+def _emit_label_in_body(
+    builder: _Builder,
+    instr: IrInstruction,
+    label_for: dict[str, int],
+) -> None:
+    """An internal LABEL appearing in the body emits a ``label N`` opcode."""
+    name = _operand_label(instr.operands[0], role="LABEL operand")
+    if name not in label_for:
+        msg = f"internal LABEL {name!r} has no allocated BEAM label number"
+        raise BEAMBackendError(msg)
+    builder.emit(_OP_LABEL, _u(label_for[name]))
 
 
 def _emit_call(
@@ -370,6 +598,14 @@ def _emit_call(
     label_for: dict[str, int],
     arity_for: dict[str, int],
 ) -> None:
+    """Lower CALL with the Twig calling convention.
+
+    Twig stages args in IR registers ``r2..r{arity+1}``.  BEAM
+    expects them in ``x0..x{arity-1}``.  We bridge by emitting one
+    ``move {y, 2+i}, {x, i}`` per arg before the ``call``, then
+    one ``move {x, 0}, {y, 1}`` after to copy the return value
+    back into the IR's ``_REG_HALT_RESULT`` slot.
+    """
     target = _operand_label(instr.operands[0], role="CALL target")
     if target not in label_for:
         msg = (
@@ -378,37 +614,57 @@ def _emit_call(
         )
         raise BEAMBackendError(msg)
     arity = arity_for.get(target, 0)
-    builder.emit(
-        _OP_CALL,
-        BEAMOperand(BEAMTag.U, arity),
-        BEAMOperand(BEAMTag.F, label_for[target]),
-    )
+
+    for i in range(arity):
+        # Move the staged arg from y{2+i} to x{i}.
+        builder.emit(_OP_MOVE, _y(_REG_PARAM_BASE + i), _x(i))
+
+    builder.emit(_OP_CALL, _u(arity), _f(label_for[target]))
+
+    # Copy the return value (BEAM x0) into the IR's HALT-result reg.
+    builder.emit(_OP_MOVE, _x(0), _y(_REG_HALT_RESULT))
 
 
-def _emit_return(builder: _Builder, instr: IrInstruction) -> None:
+def _emit_return(
+    builder: _Builder,
+    instr: IrInstruction,
+    *,
+    y_reg_count: int,
+) -> None:
+    """Lower RET as: copy y1 → x0; deallocate K; return."""
     if instr.operands:
         msg = f"RET takes no operands, got {len(instr.operands)}"
         raise BEAMBackendError(msg)
+    builder.emit(_OP_MOVE, _y(_REG_HALT_RESULT), _x(0))
+    builder.emit(_OP_DEALLOCATE, _u(y_reg_count))
     builder.emit(_OP_RETURN)
 
 
-_HANDLERS: dict[IrOp, str] = {
-    IrOp.LOAD_IMM: "_emit_load_imm",
-    IrOp.ADD: "_emit_arithmetic",
-    IrOp.SUB: "_emit_arithmetic",
-    IrOp.MUL: "_emit_arithmetic",
-    IrOp.DIV: "_emit_arithmetic",
-    IrOp.RET: "_emit_return",
-    IrOp.CALL: "_emit_call",
+_HANDLERS: Final[set[IrOp]] = {
+    IrOp.LOAD_IMM,
+    IrOp.ADD,
+    IrOp.SUB,
+    IrOp.MUL,
+    IrOp.DIV,
+    IrOp.ADD_IMM,
+    IrOp.RET,
+    IrOp.CALL,
+    IrOp.JUMP,
+    IrOp.BRANCH_Z,
+    IrOp.BRANCH_NZ,
+    IrOp.CMP_EQ,
+    IrOp.CMP_LT,
+    IrOp.CMP_GT,
+    IrOp.LABEL,  # internal labels in body
 }
 
 
 def _supported_op_summary() -> str:
-    return ", ".join(sorted(name for op in _HANDLERS for name in [op.name]))
+    return ", ".join(sorted(op.name for op in _HANDLERS))
 
 
 # ---------------------------------------------------------------------------
-# Module-info synthesis
+# Module-info synthesis — unchanged from the BEAM01 v1
 # ---------------------------------------------------------------------------
 
 
@@ -421,67 +677,32 @@ def _emit_module_info_pair(
     label_module_info_1: int,
     label_after_func_info_0: int,
 ) -> None:
-    """Emit ``module_info/0`` and ``module_info/1`` mirrors of
-    what ``erlc`` produces.
-
-    These functions exist for the runtime's introspection
-    (``M:module_info()`` and ``M:module_info(Key)``).  Their bodies
-    are simply tail-calls to ``erlang:get_module_info/{1,2}`` with
-    the module-name atom prepended.
-    """
-    # Atom indices for the BIF imports.
     erlang_atom_idx = builder.atoms.add("erlang")
     gmi_atom_idx = builder.atoms.add("get_module_info")
     gmi1_import = builder.imports.add(erlang_atom_idx, gmi_atom_idx, 1)
     gmi2_import = builder.imports.add(erlang_atom_idx, gmi_atom_idx, 2)
 
-    # module_info/0 — func_info, label, move atom into x0, tail-call to gmi/1.
     builder.emit(
         _OP_FUNC_INFO,
         BEAMOperand(BEAMTag.A, module_atom_idx),
         BEAMOperand(BEAMTag.A, module_info_atom_idx),
-        BEAMOperand(BEAMTag.U, 0),
+        _u(0),
     )
-    builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, label_module_info_0))
-    builder.emit(
-        _OP_MOVE,
-        BEAMOperand(BEAMTag.A, module_atom_idx),
-        BEAMOperand(BEAMTag.X, 0),
-    )
-    builder.emit(
-        _OP_CALL_EXT_ONLY,
-        BEAMOperand(BEAMTag.U, 1),
-        BEAMOperand(BEAMTag.U, gmi1_import - 1),
-    )
+    builder.emit(_OP_LABEL, _u(label_module_info_0))
+    builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, module_atom_idx), _x(0))
+    builder.emit(_OP_CALL_EXT_ONLY, _u(1), _u(gmi1_import - 1))
 
-    # module_info/1 — func_info, label, move-args, tail-call gmi/2.
-    builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, label_after_func_info_0))
+    builder.emit(_OP_LABEL, _u(label_after_func_info_0))
     builder.emit(
         _OP_FUNC_INFO,
         BEAMOperand(BEAMTag.A, module_atom_idx),
         BEAMOperand(BEAMTag.A, module_info_atom_idx),
-        BEAMOperand(BEAMTag.U, 1),
+        _u(1),
     )
-    builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, label_module_info_1))
-    builder.emit(
-        _OP_MOVE,
-        BEAMOperand(BEAMTag.X, 0),
-        BEAMOperand(BEAMTag.X, 1),
-    )
-    builder.emit(
-        _OP_MOVE,
-        BEAMOperand(BEAMTag.A, module_atom_idx),
-        BEAMOperand(BEAMTag.X, 0),
-    )
-    builder.emit(
-        _OP_CALL_EXT_ONLY,
-        BEAMOperand(BEAMTag.U, 2),
-        BEAMOperand(BEAMTag.U, gmi2_import - 1),
-    )
-    # No trailing label — ``erlc`` reference output ends
-    # ``module_info/1`` with the ``call_ext_only`` opcode and the
-    # caller (``lower_ir_to_beam``) appends ``int_code_end``
-    # directly after.
+    builder.emit(_OP_LABEL, _u(label_module_info_1))
+    builder.emit(_OP_MOVE, _x(0), _x(1))
+    builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, module_atom_idx), _x(0))
+    builder.emit(_OP_CALL_EXT_ONLY, _u(2), _u(gmi2_import - 1))
 
 
 # ---------------------------------------------------------------------------
@@ -493,12 +714,7 @@ def lower_ir_to_beam(
     program: IrProgram,
     config: BEAMBackendConfig,
 ) -> BEAMModule:
-    """Lower ``program`` into a ``BEAMModule`` ready for encoding.
-
-    Raises ``BEAMBackendError`` for any structurally invalid IR or
-    any IR opcode that isn't yet supported in v1.  See
-    ``_HANDLERS`` for the supported set.
-    """
+    """Lower ``program`` into a ``BEAMModule`` ready for encoding."""
     if not config.module_name:
         raise BEAMBackendError("BEAMBackendConfig.module_name must not be empty")
 
@@ -509,54 +725,71 @@ def lower_ir_to_beam(
     module_atom_idx = 1  # by construction, atoms[0] == config.module_name
     module_info_atom_idx = builder.atoms.add("module_info")
 
-    regions = _split_callable_regions(program)
+    callable_names = _discover_callable_names(program)
+    regions = _split_callable_regions(program, callable_names)
     if not regions:
         raise BEAMBackendError(
             "IrProgram contains no callable regions; need at least one LABEL"
         )
 
-    # First pass: allocate one BEAM label per region's call entry,
-    # plus one preceding label for the func_info opcode.  Real
-    # ``erlc`` puts func_info BEFORE the call-target label so error
-    # tracebacks can find the function definition.
-    label_for: dict[str, int] = {}
+    # Pre-pass 1: y-register count for every function body.
+    # Simplest: one program-wide value (the highest IR register
+    # index used anywhere + 1).  Wasteful for small functions but
+    # correct.
+    y_reg_count = (
+        config.y_register_count
+        if config.y_register_count is not None
+        else _max_register_index(program) + 1
+    )
+
+    # Pre-pass 2: allocate a BEAM label number for every IR label.
+    # Callable regions get TWO each (one for the func_info opcode,
+    # one for the call target).  Internal labels get ONE each.
     func_info_label_for: dict[str, int] = {}
+    label_for: dict[str, int] = {}
     arity_for: dict[str, int] = {}
     for name, _body in regions:
         func_info_label_for[name] = builder.fresh_label()
         label_for[name] = builder.fresh_label()
         arity_for[name] = config.arity_overrides.get(name, 0)
 
-    # Second pass: emit each region's prologue + body.
+    # Internal labels — found inside region bodies.
+    for _name, body in regions:
+        for instr in body:
+            if instr.opcode is IrOp.LABEL:
+                internal_name = _operand_label(
+                    instr.operands[0], role="internal LABEL"
+                )
+                if internal_name not in label_for:
+                    label_for[internal_name] = builder.fresh_label()
+
+    # Pass 3: emit each region's prologue + body + epilogue.
     for name, body in regions:
         function_atom_idx = builder.atoms.add(name)
-        builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, func_info_label_for[name]))
+        builder.emit(_OP_LABEL, _u(func_info_label_for[name]))
         builder.emit(
             _OP_FUNC_INFO,
             BEAMOperand(BEAMTag.A, module_atom_idx),
             BEAMOperand(BEAMTag.A, function_atom_idx),
-            BEAMOperand(BEAMTag.U, arity_for[name]),
+            _u(arity_for[name]),
         )
-        builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, label_for[name]))
+        builder.emit(_OP_LABEL, _u(label_for[name]))
+
+        # Function entry: allocate y-register frame + copy args
+        # from x-registers into the Twig param slots.
+        builder.emit(_OP_ALLOCATE, _u(y_reg_count), _u(arity_for[name]))
+        for i in range(arity_for[name]):
+            builder.emit(_OP_MOVE, _x(i), _y(_REG_PARAM_BASE + i))
+
+        # Body.
         for instr in body:
-            handler_name = _HANDLERS.get(instr.opcode)
-            if handler_name is None:
-                msg = (
-                    f"unsupported IR op {instr.opcode.name} for BEAM v1 — "
-                    f"supported ops: {_supported_op_summary()}"
-                )
-                raise BEAMBackendError(msg)
-            if handler_name == "_emit_load_imm":
-                _emit_load_imm(builder, instr)
-            elif handler_name == "_emit_arithmetic":
-                _emit_arithmetic(builder, instr)
-            elif handler_name == "_emit_call":
-                _emit_call(builder, instr, label_for, arity_for)
-            elif handler_name == "_emit_return":
-                _emit_return(builder, instr)
-            else:  # pragma: no cover — _HANDLERS entries are exhaustive
-                msg = f"internal: missing handler dispatch for {handler_name}"
-                raise BEAMBackendError(msg)
+            _emit_body_instruction(
+                builder,
+                instr,
+                label_for=label_for,
+                arity_for=arity_for,
+                y_reg_count=y_reg_count,
+            )
 
         # Each user region is exported (Twig has no module-private
         # functions in v1).
@@ -568,17 +801,13 @@ def lower_ir_to_beam(
             )
         )
 
-    # Synthesise module_info/0 and module_info/1 after the user
-    # functions, before the final int_code_end.
+    # Synthesise module_info/0 and module_info/1.
     label_func_info_mi_0 = builder.fresh_label()
     label_mi_0 = builder.fresh_label()
     label_func_info_mi_1 = builder.fresh_label()
     label_mi_1 = builder.fresh_label()
 
-    # Re-shape: the func_info-label/main-label pairs come BEFORE the
-    # func_info opcode for each module_info function.  Using the
-    # label numbers we just minted, emit the prologue + tail-calls.
-    builder.emit(_OP_LABEL, BEAMOperand(BEAMTag.U, label_func_info_mi_0))
+    builder.emit(_OP_LABEL, _u(label_func_info_mi_0))
     _emit_module_info_pair(
         builder,
         module_atom_idx=module_atom_idx,
@@ -603,15 +832,9 @@ def lower_ir_to_beam(
         )
     )
 
-    # Terminator.
     builder.emit(_OP_INT_CODE_END)
 
-    # Empty Attr / CInf BERT terms — real ``erlc`` always emits
-    # these chunks, and Erlang OTP's loader probes for them on
-    # some load paths.  An empty proplist in the External Term
-    # Format is two bytes: ``83`` (version 131) + ``6a`` (NIL).
     _BERT_EMPTY_LIST: bytes = b"\x83\x6a"
-
     return BEAMModule(
         name=config.module_name,
         atoms=builder.atoms.as_tuple(),
@@ -619,13 +842,57 @@ def lower_ir_to_beam(
         imports=builder.imports.as_tuple(),
         exports=tuple(builder.exports),
         locals_=(),
-        label_count=builder.next_label,  # 1 past the last allocated
-        # See ``_MIN_RUNTIME_MAX_OPCODE`` — must be >= 178 for OTP
-        # 25+ runtimes, which is the minimum modern Erlang we
-        # support.
+        label_count=builder.next_label,
         max_opcode=_MIN_RUNTIME_MAX_OPCODE,
         extra_chunks=(
             ("Attr", _BERT_EMPTY_LIST),
             ("CInf", _BERT_EMPTY_LIST),
         ),
     )
+
+
+def _emit_body_instruction(
+    builder: _Builder,
+    instr: IrInstruction,
+    *,
+    label_for: dict[str, int],
+    arity_for: dict[str, int],
+    y_reg_count: int,
+) -> None:
+    op = instr.opcode
+    if op not in _HANDLERS:
+        msg = (
+            f"unsupported IR op {op.name} for BEAM TW03 Phase 1 — "
+            f"supported ops: {_supported_op_summary()}"
+        )
+        raise BEAMBackendError(msg)
+
+    if op is IrOp.LABEL:
+        _emit_label_in_body(builder, instr, label_for)
+        return
+    if op is IrOp.LOAD_IMM:
+        _emit_load_imm(builder, instr)
+        return
+    if op in (IrOp.ADD, IrOp.SUB, IrOp.MUL, IrOp.DIV):
+        _emit_arithmetic(builder, instr)
+        return
+    if op is IrOp.ADD_IMM:
+        _emit_add_imm(builder, instr)
+        return
+    if op is IrOp.JUMP:
+        _emit_jump(builder, instr, label_for)
+        return
+    if op in (IrOp.BRANCH_Z, IrOp.BRANCH_NZ):
+        _emit_branch(builder, instr, label_for)
+        return
+    if op in (IrOp.CMP_EQ, IrOp.CMP_LT, IrOp.CMP_GT):
+        _emit_cmp(builder, instr)
+        return
+    if op is IrOp.CALL:
+        _emit_call(builder, instr, label_for, arity_for)
+        return
+    if op is IrOp.RET:
+        _emit_return(builder, instr, y_reg_count=y_reg_count)
+        return
+    msg = f"internal: missing handler dispatch for {op.name}"
+    raise BEAMBackendError(msg)

--- a/code/packages/python/ir-to-beam/tests/test_lower_basic.py
+++ b/code/packages/python/ir-to-beam/tests/test_lower_basic.py
@@ -40,33 +40,37 @@ def _imm(v: int) -> IrImmediate:
 
 
 def _build_identity_program() -> IrProgram:
-    """``identity()`` returns the constant 42.  Smallest non-trivial
-    end-to-end IR program we can lower."""
+    """``identity()`` returns the constant 42.
+
+    TW03 Phase 1 convention: the result lands in ``r1``
+    (``_REG_HALT_RESULT``) before ``RET`` because ir-to-beam's
+    RET lowering reads y1 → x0 → return.
+    """
     gen = IDGenerator()
     program = IrProgram(entry_label="identity")
     program.add_instruction(
         IrInstruction(IrOp.LABEL, [_label("identity")], id=-1)
     )
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(0), _imm(42)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(42)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
     return program
 
 
 def _build_add_program() -> IrProgram:
-    """``add() -> 17 + 25`` (= 42)."""
+    """``add() -> 17 + 25`` (= 42).  Result in r1."""
     gen = IDGenerator()
     program = IrProgram(entry_label="add")
     program.add_instruction(IrInstruction(IrOp.LABEL, [_label("add")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(0), _imm(17)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(17)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(25)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(3), _imm(25)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.ADD, [_reg(0), _reg(0), _reg(1)], id=gen.next())
+        IrInstruction(IrOp.ADD, [_reg(1), _reg(2), _reg(3)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
     return program
@@ -171,11 +175,11 @@ class TestErrors:
         program.add_instruction(
             IrInstruction(IrOp.LABEL, [_label("boom")], id=-1)
         )
-        # JUMP isn't supported in v1.
+        # SYSCALL isn't supported in TW03 Phase 1.
         program.add_instruction(
-            IrInstruction(IrOp.JUMP, [_label("boom")], id=gen.next())
+            IrInstruction(IrOp.SYSCALL, [_imm(1), _reg(1)], id=gen.next())
         )
-        with pytest.raises(BEAMBackendError, match="unsupported IR op JUMP"):
+        with pytest.raises(BEAMBackendError, match="unsupported IR op SYSCALL"):
             lower_ir_to_beam(program, BEAMBackendConfig(module_name="boom"))
 
     def test_load_imm_negative_rejected(self) -> None:
@@ -229,10 +233,82 @@ class TestOpcodeChoices:
         assert len(gc_bif2_instructions) == 1
         ops = gc_bif2_instructions[0].operands
         # gc_bif2 has 6 operands: fail-label, live, bif-idx, src1, src2, dest.
+        # TW03 Phase 1 — sources/dest are y-registers (callee-saves
+        # state survives recursive calls).
         assert len(ops) == 6
         assert ops[0].tag == BEAMTag.F
         assert ops[1].tag == BEAMTag.U
         assert ops[2].tag == BEAMTag.U
-        assert ops[3].tag == BEAMTag.X
-        assert ops[4].tag == BEAMTag.X
-        assert ops[5].tag == BEAMTag.X
+        assert ops[3].tag == BEAMTag.Y
+        assert ops[4].tag == BEAMTag.Y
+        assert ops[5].tag == BEAMTag.Y
+
+    def test_branch_lowering_uses_is_ne_exact(self) -> None:
+        """``BRANCH_Z r, label`` lowers to ``is_ne_exact label, {y,r}, {integer,0}``."""
+        from compiler_ir import IDGenerator
+        gen = IDGenerator()
+        program = IrProgram(entry_label="b")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("b")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(0)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.BRANCH_Z, [_reg(1), _label("end")], id=gen.next()
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("end")], id=-1))
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        m = lower_ir_to_beam(program, BEAMBackendConfig(module_name="b"))
+        used = {ins.opcode for ins in m.instructions}
+        assert 44 in used  # is_ne_exact
+
+    def test_cmp_eq_lowers_to_5_instructions(self) -> None:
+        """``CMP_EQ`` becomes is_eq_exact + move 1 + jump + label + move 0 + label."""
+        from compiler_ir import IDGenerator
+        gen = IDGenerator()
+        program = IrProgram(entry_label="c")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("c")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(1)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(3), _imm(2)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.CMP_EQ, [_reg(1), _reg(2), _reg(3)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        m = lower_ir_to_beam(program, BEAMBackendConfig(module_name="c"))
+        used = {ins.opcode for ins in m.instructions}
+        assert 43 in used  # is_eq_exact
+        assert 61 in used  # jump
+
+    def test_recursive_function_emits_allocate_call_deallocate(self) -> None:
+        """Recursive ``fact`` IR uses CALL — backend emits allocate / call / deallocate."""
+        from compiler_ir import IDGenerator
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+        # fact(n)
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("fact")], id=-1))
+        # Body: just CALL itself (artificial — no termination, but enough
+        # to exercise allocate + call + deallocate emission).
+        program.add_instruction(IrInstruction(IrOp.CALL, [_label("fact")], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        # main
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        m = lower_ir_to_beam(
+            program,
+            BEAMBackendConfig(
+                module_name="rec",
+                arity_overrides={"fact": 1},
+            ),
+        )
+        used = {ins.opcode for ins in m.instructions}
+        assert 12 in used   # allocate
+        assert 18 in used   # deallocate
+        assert 4 in used    # call

--- a/code/packages/python/ir-to-beam/tests/test_real_erl.py
+++ b/code/packages/python/ir-to-beam/tests/test_real_erl.py
@@ -89,12 +89,16 @@ def _drop_and_run(
 
 @requires_erl
 def test_identity_returns_42(tmp_path: Path) -> None:
-    """``identity()`` returns the constant 42."""
+    """``identity()`` returns the constant 42.
+
+    TW03 Phase 1 convention: the result lands in ``r1``
+    (``_REG_HALT_RESULT``) before ``RET``.
+    """
     gen = IDGenerator()
     program = IrProgram(entry_label="identity")
     program.add_instruction(IrInstruction(IrOp.LABEL, [_label("identity")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(0), _imm(42)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(42)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
 
@@ -115,13 +119,13 @@ def test_add_returns_42(tmp_path: Path) -> None:
     program = IrProgram(entry_label="add")
     program.add_instruction(IrInstruction(IrOp.LABEL, [_label("add")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(0), _imm(17)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(17)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(25)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(3), _imm(25)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.ADD, [_reg(0), _reg(0), _reg(1)], id=gen.next())
+        IrInstruction(IrOp.ADD, [_reg(1), _reg(2), _reg(3)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
 
@@ -142,13 +146,13 @@ def test_multiplication_returns_42(tmp_path: Path) -> None:
     program = IrProgram(entry_label="mul")
     program.add_instruction(IrInstruction(IrOp.LABEL, [_label("mul")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(0), _imm(6)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(6)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(7)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [_reg(3), _imm(7)], id=gen.next())
     )
     program.add_instruction(
-        IrInstruction(IrOp.MUL, [_reg(0), _reg(0), _reg(1)], id=gen.next())
+        IrInstruction(IrOp.MUL, [_reg(1), _reg(2), _reg(3)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
 
@@ -157,3 +161,100 @@ def test_multiplication_returns_42(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "42"
+
+
+@requires_erl
+def test_recursive_factorial_returns_120(tmp_path: Path) -> None:
+    """The headline TW03 Phase 1 BEAM test: ``fact(5) → 120`` on real ``erl``.
+
+    Hand-built IR mirroring what twig-beam-compiler will eventually
+    emit, exercising:
+    - allocate / deallocate y-register frame
+    - x-register arg passing at CALL sites
+    - BRANCH_Z + JUMP for the if/else of the base case
+    - CMP_EQ + arithmetic across recursive call boundary
+    """
+    gen = IDGenerator()
+    program = IrProgram(entry_label="main")
+
+    # fact(n):
+    #   if n == 0 -> return 1
+    #   else      -> return n * fact(n - 1)
+    program.add_instruction(IrInstruction(IrOp.LABEL, [_label("fact")], id=-1))
+    # r2 = arg n (placed by entry-shuffle).  Compare with 0 → r10.
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(11), _imm(0)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.CMP_EQ, [_reg(10), _reg(2), _reg(11)], id=gen.next()
+        )
+    )
+    # if (r10 == 0): jump to else_label  (BRANCH_Z r10 → jump if zero)
+    program.add_instruction(
+        IrInstruction(
+            IrOp.BRANCH_Z, [_reg(10), _label("_else")], id=gen.next()
+        )
+    )
+    # then-branch: r1 = 1; jump end
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(1)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.JUMP, [_label("_end")], id=gen.next())
+    )
+    # else-branch: compute n * fact(n-1)
+    program.add_instruction(IrInstruction(IrOp.LABEL, [_label("_else")], id=-1))
+    # r12 = n - 1
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(13), _imm(1)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.SUB, [_reg(12), _reg(2), _reg(13)], id=gen.next())
+    )
+    # Stage arg in r2 for the recursive call (Twig calling convention).
+    program.add_instruction(
+        IrInstruction(IrOp.ADD_IMM, [_reg(14), _reg(2), _imm(0)], id=gen.next())
+    )  # save n
+    program.add_instruction(
+        IrInstruction(IrOp.ADD_IMM, [_reg(2), _reg(12), _imm(0)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.CALL, [_label("fact")], id=gen.next()))
+    # Result of fact(n-1) is in r1.  r1 = saved_n * r1.
+    program.add_instruction(
+        IrInstruction(IrOp.MUL, [_reg(1), _reg(14), _reg(1)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.LABEL, [_label("_end")], id=-1))
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # main(): r2 = 5; call fact; result lands in r1.
+    program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(5)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.CALL, [_label("fact")], id=gen.next()))
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    config = BEAMBackendConfig(
+        module_name="rec_fact",
+        arity_overrides={"fact": 1, "main": 0},
+    )
+    beam = encode_beam(lower_ir_to_beam(program, config))
+    (tmp_path / "rec_fact.beam").write_bytes(beam)
+    eval_expr = textwrap.dedent("""
+        {module, _} = code:load_file(rec_fact),
+        Result = rec_fact:main(),
+        io:format("~p~n", [Result]),
+        init:stop().
+    """).strip()
+    result = subprocess.run(
+        ["erl", "-noshell", "-pa", str(tmp_path), "-eval", eval_expr],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "120", (
+        f"factorial result mismatch — stdout={result.stdout!r}, "
+        f"stderr={result.stderr!r}"
+    )

--- a/code/packages/python/twig-beam-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-beam-compiler/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog — twig-beam-compiler
 
+## 0.2.0 — 2026-04-29 — TW03 Phase 1 (BEAM)
+
+Closes the language-surface gap on the BEAM backend so Twig
+source has the same expressive power on real ``erl`` as it does
+on real ``java`` (since JVM01) and real ``dotnet`` (since the
+Phase 1 CLR PR).
+
+### Added — full TW03 Phase 1 surface
+
+- Top-level ``define`` for both functions and value constants
+- Function calls (incl. multi-arg, nested, value-returning)
+- Recursion (incl. mutual recursion)
+- ``if`` / ``else``
+- Comparison: ``=``, ``<``, ``>``
+
+### Changed — register convention to match JVM/CLR
+
+- Result lives in ``r1`` (was implicit before)
+- Function params arrive in ``r2..r{arity+1}``
+- Holding registers start at ``r10``
+
+### Test additions (51 tests total, 88% coverage)
+
+- 6 arithmetic + ``let``
+- 4 ``if`` / comparison
+- 4 ``define`` + multi-arg + nested calls + value-define inlining
+- **2 recursion**: ``(fact 5) → 120`` and ``(evenp 4) → 1`` mutual
+  recursion
+- All confirmed passing on local Erlang/OTP
+
+### Out of scope (TW03 Phase 2+)
+
+- Closures (lambdas)
+- Heap primitives (``cons`` / ``car`` / ``cdr`` / symbols / quote)
+- Explicit I/O via ``erlang:put_chars/1`` (today the result
+  channel is the function return value printed by ``-eval``)
+
 ## 0.1.0 — 2026-04-29
 
 ### Added — BEAM01 Phase 4: Twig source → real `erl` execution

--- a/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
+++ b/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
@@ -7,31 +7,48 @@ Pipeline
     Twig source
         ↓ parse + extract     (twig package)
     typed AST
-        ↓ Compiler.compile()  (this module)
+        ↓ Compiler.compile()  (this module — Twig → compiler-IR)
     IrProgram
         ↓ ir-optimizer
     IrProgram (optimised)
-        ↓ lower_ir_to_beam
+        ↓ lower_ir_to_beam    (ir-to-beam)
     BEAMModule
-        ↓ encode_beam
+        ↓ encode_beam         (beam-bytecode-encoder)
     .beam bytes
         ↓ erl -noshell -eval ...
-    program output
+    program output (printed by io:format)
 
-Why this is intentionally narrow
-================================
+TW03 Phase 1 surface (this version)
+===================================
 
-The v1 surface is *just* what ``ir-to-beam`` Phase 3 supports plus
-the boilerplate to wrap an expression as a ``main/0`` function.
-That means: integer literals, binary arithmetic (+, -, *, /),
-single-binding ``let``, and a ``begin`` for sequencing.  Top-level
-``define`` and ``if`` need branch lowering in ``ir-to-beam`` (a
-follow-up PR).
+Mirrors the twig-jvm-compiler / twig-clr-compiler frontends so
+all three real-runtime Twig tracks share IR shape:
 
-The contract: ``main/0`` returns the value of the program's last
-top-level expression.  Real ``erl`` then prints that value via
-``-eval 'io:format("~p~n", [<module>:main()])'``, which the
-``run_source`` helper does for us.
+- Integer literals (positive)
+- Binary arithmetic: ``+``, ``-``, ``*``, ``/``
+- Comparison: ``=``, ``<``, ``>``
+- ``let`` (single + multi binding), ``begin``, ``if``
+- Top-level ``define`` for both functions and value constants
+- Function calls (incl. nested) and **recursion**
+
+The contract: ``run_source`` invokes
+``erl -noshell -eval 'io:format("~p~n", [<module>:main()])'``,
+printing the value of the program's final top-level expression
+to stdout.  ``BeamRunResult.stdout`` carries that printed value.
+
+Register convention (shared with JVM/CLR compilers)
+===================================================
+
+* ``register 0`` — scratch.
+* ``register 1`` — function return value / HALT result.
+* ``registers 2..N`` — function parameter slots
+  (param ``i`` → register ``_REG_PARAM_BASE + i = 2 + i``).
+* ``registers 10..`` — compiler-allocated holding registers for
+  intermediate values.  Using a high base keeps them clear of
+  the param window so nested calls don't clobber.
+
+ir-to-beam translates this convention to the BEAM x/y register
+files (see that package's docs).
 """
 
 from __future__ import annotations
@@ -65,11 +82,14 @@ from twig import (
 from twig.ast_nodes import (
     Apply,
     Begin,
+    BoolLit,
     Define,
     Expr,
+    If,
     IntLit,
     Lambda,
     Let,
+    NilLit,
     Program,
     SymLit,
     VarRef,
@@ -120,54 +140,35 @@ class BeamPackageError(TwigError):
 
 
 # ---------------------------------------------------------------------------
-# Builtins recognised in v1
+# Builtins
 # ---------------------------------------------------------------------------
 
 
-# Map a Twig builtin name to the ``IrOp`` for its single-instruction
-# emission.  Only binary numeric ops are in v1.
 _BINARY_OPS: dict[str, IrOp] = {
     "+": IrOp.ADD,
     "-": IrOp.SUB,
     "*": IrOp.MUL,
     "/": IrOp.DIV,
+    "=": IrOp.CMP_EQ,
+    "<": IrOp.CMP_LT,
+    ">": IrOp.CMP_GT,
 }
 
-# Twig builtins we don't yet support on BEAM.  Everything else
-# falls through to the generic "unsupported" error.
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {
-        # Comparison/logic — needs branching.
-        "=",
-        "<",
-        ">",
-        # Cons/list/symbol — heap-side machinery, not yet wired.
-        "cons",
-        "car",
-        "cdr",
-        "null?",
-        "pair?",
-        "number?",
-        "symbol?",
-        "print",
-    }
+    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
 )
 
 
-# Register convention.  We use only x-registers (compiler-IR
-# ``IrRegister`` indices map directly to BEAM's ``x{i}``).  Reg 0
-# is the ``main/0`` return value (matching BEAM's "x0 holds the
-# return" convention).
-_REG_RETURN: int = 0
-_REG_HOLDING_BASE: int = 1
+# Register convention — see module docstring.
+_REG_HALT_RESULT: Final = 1
+_REG_PARAM_BASE: Final = 2
+_REG_HOLDING_BASE: Final = 10
 
-# A safe Erlang atom name — strict allowlist (lowercase ASCII
-# start, alnum + underscore tail, length 1..64).  We use this to
-# block code-injection through ``module_name``: ``run_source``
-# interpolates ``module_name`` into the ``erl -eval`` Erlang source
-# string, so an unvalidated value lets a caller execute arbitrary
-# Erlang (e.g. ``os:cmd("...")``).  The same allowlist also
-# protects the on-disk ``.beam`` filename from path traversal.
+
+# Strict allowlist for ``module_name``.  Used as the on-disk
+# ``.beam`` filename AND interpolated into the ``erl -eval``
+# Erlang source string in ``run_source`` — so untrusted values
+# would let a caller execute arbitrary Erlang.
 _SAFE_MODULE_NAME_RE: Final = re.compile(r"^[a-z][a-zA-Z0-9_]{0,63}$")
 
 
@@ -190,12 +191,7 @@ def _validate_module_name(name: str) -> None:
 
 @dataclass
 class _FnCtx:
-    """Mutable state during compilation of one IR region.
-
-    ``locals_`` maps Twig names introduced by ``let`` bindings to
-    the IR register that holds the bound value.  ``next_holding``
-    is the next intermediate-value register to allocate.
-    """
+    """Mutable state during compilation of one IR region."""
 
     locals_: dict[str, IrRegister]
     next_holding: int = _REG_HOLDING_BASE
@@ -207,49 +203,106 @@ class _FnCtx:
 
 
 class _Compiler:
-    """Walk the typed Twig AST and emit a single ``IrProgram`` whose
-    sole region is ``main``.
-
-    v1 only handles top-level expressions (no ``define``).  The
-    last top-level expression's value lands in ``x0`` (the BEAM
-    return-value register) and the region closes with ``RET``.
+    """Walk the typed Twig AST → ``IrProgram`` with one region per
+    top-level function plus a synthesised ``main`` for top-level
+    expressions.  Mirrors twig-jvm-compiler / twig-clr-compiler.
     """
 
     def __init__(self) -> None:
         self._program = IrProgram(entry_label="main")
         self._gen = IDGenerator()
+        self._value_consts: dict[str, int] = {}
+        self._fn_params: dict[str, list[str]] = {}
+        # Program-wide label counter.  Per-region counters would
+        # produce duplicate ``_else_0`` etc. across functions, and
+        # the BEAM backend rejects duplicate label names just like
+        # the CIL backend does.
+        self._next_label_id = 0
 
     # ------------------------------------------------------------------
 
     def compile(self, program: Program) -> IrProgram:
-        # v1 forbids top-level ``define`` (function or value).
-        # When we add ``define`` support we'll either inline value
-        # defines like the JVM compiler does, or emit them as
-        # additional BEAM functions.
+        top_level_exprs: list[Expr] = []
+        function_defs: list[tuple[str, Lambda]] = []
         for form in program.forms:
             if isinstance(form, Define):
-                raise TwigCompileError(
-                    "(define ...) is not yet supported by the BEAM backend "
-                    "v1 — only top-level expressions.  See BEAM01 Phase 4 "
-                    "for the planned roadmap."
-                )
+                self._classify_define(form)
+                if isinstance(form.expr, Lambda):
+                    function_defs.append((form.name, form.expr))
+            else:
+                top_level_exprs.append(form)
 
+        for name, lam in function_defs:
+            self._emit_function(name, lam)
+
+        self._emit_main(top_level_exprs)
+        return self._program
+
+    # ------------------------------------------------------------------
+
+    def _classify_define(self, form: Define) -> None:
+        if isinstance(form.expr, Lambda):
+            self._fn_params[form.name] = list(form.expr.params)
+            return
+
+        if isinstance(form.expr, IntLit):
+            self._value_consts[form.name] = int(form.expr.value)
+            return
+        if isinstance(form.expr, BoolLit):
+            self._value_consts[form.name] = 1 if form.expr.value else 0
+            return
+
+        raise TwigCompileError(
+            f"(define {form.name} ...) — v1 only supports literal "
+            "RHS for value defines.  Use a top-level function for "
+            "computed values."
+        )
+
+    # ------------------------------------------------------------------
+    # Function emission
+    # ------------------------------------------------------------------
+
+    def _emit_function(self, name: str, lam: Lambda) -> None:
+        self._emit(IrOp.LABEL, IrLabel(name=name), id=-1)
+
+        # Copy each parameter out of its arrival register
+        # (``_REG_PARAM_BASE + i``) into a fresh body-local
+        # holding register.  Mirrors the JVM01 paired fix +
+        # twig-clr-compiler convention.  ir-to-beam handles the
+        # x→y register dance internally (see its docstring), so
+        # this front-end stays IR-shaped identically across all
+        # three Twig backends.
+        ctx = _FnCtx(locals_={})
+        for i, param in enumerate(lam.params):
+            arrival = IrRegister(index=_REG_PARAM_BASE + i)
+            body_local = self._fresh_holding(ctx)
+            self._emit_move(body_local, arrival)
+            ctx.locals_[param] = body_local
+
+        last: IrRegister | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            raise TwigCompileError(f"function {name!r} has empty body")
+
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.RET)
+
+    def _emit_main(self, exprs: list[Expr]) -> None:
         self._emit(IrOp.LABEL, IrLabel(name="main"), id=-1)
         ctx = _FnCtx(locals_={})
 
         last: IrRegister | None = None
-        for expr in program.forms:
+        for expr in exprs:
             last = self._compile_expr(expr, ctx)
 
         if last is None:
-            # Empty program → return 0.
             zero = self._fresh_holding(ctx)
             self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
             last = zero
 
-        self._emit_move(IrRegister(_REG_RETURN), last)
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
         self._emit(IrOp.RET)
-        return self._program
 
     # ------------------------------------------------------------------
     # Expression compilation
@@ -261,13 +314,31 @@ class _Compiler:
             self._emit(IrOp.LOAD_IMM, reg, IrImmediate(int(expr.value)))
             return reg
 
+        if isinstance(expr, BoolLit):
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(1 if expr.value else 0))
+            return reg
+
+        if isinstance(expr, NilLit):
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(0))
+            return reg
+
         if isinstance(expr, VarRef):
-            try:
+            if expr.name in ctx.locals_:
                 return ctx.locals_[expr.name]
-            except KeyError as exc:
-                raise TwigCompileError(
-                    f"unbound name: {expr.name!r}"
-                ) from exc
+            if expr.name in self._value_consts:
+                reg = self._fresh_holding(ctx)
+                self._emit(
+                    IrOp.LOAD_IMM,
+                    reg,
+                    IrImmediate(self._value_consts[expr.name]),
+                )
+                return reg
+            raise TwigCompileError(f"unbound name: {expr.name!r}")
+
+        if isinstance(expr, If):
+            return self._compile_if(expr, ctx)
 
         if isinstance(expr, Let):
             return self._compile_let(expr, ctx)
@@ -280,42 +351,61 @@ class _Compiler:
 
         if isinstance(expr, Lambda):
             raise TwigCompileError(
-                "lambdas are not yet supported by the BEAM backend "
-                "v1 — see BEAM01 Phase 4+ for closures."
+                "anonymous lambdas are not yet supported by the BEAM "
+                "backend — see TW03 Phase 2 for closures."
             )
 
         if isinstance(expr, SymLit):
             raise TwigCompileError(
                 "quoted symbols are not yet supported by the BEAM "
-                "backend v1 — atoms-as-values needs heap support."
+                "backend — see TW03 Phase 3."
             )
 
         msg = f"unsupported Twig form for BEAM v1: {type(expr).__name__}"
         raise TwigCompileError(msg)
 
-    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
-        # v1: single-binding ``let`` only — no shadowing concerns.
-        if len(expr.bindings) != 1:
-            raise TwigCompileError(
-                "(let ((name expr) ...) body) with multiple bindings "
-                "is not yet supported — v1 only handles a single binding"
-            )
-        name, value_expr = expr.bindings[0]
-        bound_reg = self._compile_expr(value_expr, ctx)
+    def _compile_if(self, expr: If, ctx: _FnCtx) -> IrRegister:
+        cond = self._compile_expr(expr.cond, ctx)
+        else_label = self._fresh_label("else")
+        end_label = self._fresh_label("endif")
+        result = self._fresh_holding(ctx)
 
-        # Save and restore the binding so the let scope is correct.
-        previous = ctx.locals_.get(name)
-        ctx.locals_[name] = bound_reg
-        try:
-            last = self._compile_expr(expr.body[0], ctx)
-            for body_expr in expr.body[1:]:
-                last = self._compile_expr(body_expr, ctx)
-            return last
-        finally:
-            if previous is None:
+        self._emit(IrOp.BRANCH_Z, cond, IrLabel(else_label))
+
+        then_v = self._compile_expr(expr.then_branch, ctx)
+        self._emit_move(result, then_v)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+
+        self._emit(IrOp.LABEL, IrLabel(else_label), id=-1)
+        else_v = self._compile_expr(expr.else_branch, ctx)
+        self._emit_move(result, else_v)
+
+        self._emit(IrOp.LABEL, IrLabel(end_label), id=-1)
+        return result
+
+    def _compile_let(self, expr: Let, ctx: _FnCtx) -> IrRegister:
+        binding_regs: list[tuple[str, IrRegister]] = []
+        for name, rhs in expr.bindings:
+            v = self._compile_expr(rhs, ctx)
+            binding_regs.append((name, v))
+
+        saved: dict[str, IrRegister | None] = {}
+        for name, reg in binding_regs:
+            saved[name] = ctx.locals_.get(name)
+            ctx.locals_[name] = reg
+
+        last: IrRegister | None = None
+        for e in expr.body:
+            last = self._compile_expr(e, ctx)
+        assert last is not None
+
+        for name, prior in saved.items():
+            if prior is None:
                 del ctx.locals_[name]
             else:
-                ctx.locals_[name] = previous
+                ctx.locals_[name] = prior
+
+        return last
 
     def _compile_begin(self, expr: Begin, ctx: _FnCtx) -> IrRegister:
         last: IrRegister | None = None
@@ -330,65 +420,85 @@ class _Compiler:
     def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
         if not isinstance(expr.fn, VarRef):
             raise TwigCompileError(
-                "v1 only supports calls to named builtins (no first-class "
-                "function values yet)"
+                "v1 only supports direct calls of top-level names"
             )
         name = expr.fn.name
+
         if name in _V1_REJECTED_BUILTINS:
             raise TwigCompileError(
                 f"builtin {name!r} is not yet supported by the BEAM "
-                "backend v1 — needs branching / heap / I/O support"
+                "backend — see TW03 Phase 3 for heap primitives."
             )
-        if name not in _BINARY_OPS:
-            raise TwigCompileError(
-                f"unknown builtin: {name!r}"
-            )
-        if len(expr.args) != 2:
-            raise TwigCompileError(
-                f"{name!r} expects exactly 2 arguments, got {len(expr.args)}"
-            )
-        lhs = self._compile_expr(expr.args[0], ctx)
-        rhs = self._compile_expr(expr.args[1], ctx)
-        result = self._fresh_holding(ctx)
-        self._emit(_BINARY_OPS[name], result, lhs, rhs)
-        return result
+
+        if name in _BINARY_OPS:
+            if len(expr.args) != 2:
+                raise TwigCompileError(
+                    f"{name!r} expects 2 arguments, got {len(expr.args)}"
+                )
+            left = self._compile_expr(expr.args[0], ctx)
+            right = self._compile_expr(expr.args[1], ctx)
+            dest = self._fresh_holding(ctx)
+            self._emit(_BINARY_OPS[name], dest, left, right)
+            return dest
+
+        if name in self._fn_params:
+            params = self._fn_params[name]
+            if len(expr.args) != len(params):
+                raise TwigCompileError(
+                    f"function {name!r} takes {len(params)} arguments, "
+                    f"got {len(expr.args)}"
+                )
+
+            arg_regs: list[IrRegister] = [
+                self._compile_expr(a, ctx) for a in expr.args
+            ]
+
+            for i, src in enumerate(arg_regs):
+                self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+
+            self._emit(IrOp.CALL, IrLabel(name))
+
+            dest = self._fresh_holding(ctx)
+            self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+            return dest
+
+        raise TwigCompileError(
+            f"unknown function {name!r}.  v1 supports binary builtins "
+            "(+, -, *, /, =, <, >) and top-level (define (f ...) ...)."
+        )
 
     # ------------------------------------------------------------------
-    # Low-level emit helpers
+    # IR-emission helpers
     # ------------------------------------------------------------------
 
-    def _emit(self, op: IrOp, *operands: object, id: int | None = None) -> None:
+    def _emit(
+        self,
+        opcode: IrOp,
+        *operands: object,
+        id: int | None = None,
+    ) -> None:
         self._program.add_instruction(
             IrInstruction(
-                op,
-                list(operands),
+                opcode=opcode,
+                operands=list(operands),
                 id=self._gen.next() if id is None else id,
             )
         )
 
     def _emit_move(self, dst: IrRegister, src: IrRegister) -> None:
-        # Lower a "move" as an ADD_IMM 0 — the IR has no MOVE op
-        # but ADD_IMM with immediate 0 is the canonical idiom in
-        # the existing twig-jvm-compiler.  Here we go even simpler:
-        # if dst == src already, no instruction needed.
-        if dst.index == src.index:
+        if dst == src:
             return
-        # We don't have ADD_IMM in our ir-to-beam v1 op set, so use
-        # a load-and-add-zero pattern:
-        zero = self._fresh_holding_for_move()
-        self._emit(IrOp.LOAD_IMM, zero, IrImmediate(0))
-        self._emit(IrOp.ADD, dst, src, zero)
+        self._emit(IrOp.ADD_IMM, dst, src, IrImmediate(0))
 
     def _fresh_holding(self, ctx: _FnCtx) -> IrRegister:
-        reg = IrRegister(index=ctx.next_holding)
+        idx = ctx.next_holding
         ctx.next_holding += 1
-        return reg
+        return IrRegister(index=idx)
 
-    def _fresh_holding_for_move(self) -> IrRegister:
-        # Use a high-numbered scratch register the rest of the
-        # compiler doesn't allocate from.  Picking 1000 is arbitrary
-        # but well above anything the tests will exercise.
-        return IrRegister(index=1000)
+    def _fresh_label(self, prefix: str) -> str:
+        idx = self._next_label_id
+        self._next_label_id += 1
+        return f"_{prefix}_{idx}"
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +507,7 @@ class _Compiler:
 
 
 def compile_to_ir(source: str) -> IrProgram:
-    """Compile Twig source into an unoptimised ``IrProgram``."""
+    """Compile Twig source into an unoptimised :class:`IrProgram`."""
     ast = parse_twig(source)
     program = extract_program(ast)
     return _Compiler().compile(program)
@@ -418,7 +528,8 @@ def compile_source(
         raise BeamPackageError("parse", str(exc), exc) from exc
 
     try:
-        raw_ir = _Compiler().compile(twig_program)
+        compiler = _Compiler()
+        raw_ir = compiler.compile(twig_program)
     except TwigCompileError:
         raise
     except Exception as exc:  # pragma: no cover
@@ -431,10 +542,21 @@ def compile_source(
         optimization = OptimizationResult(program=raw_ir)
         optimized_ir = raw_ir
 
+    # Build arity overrides for every top-level function the
+    # compiler discovered.  ``ir-to-beam`` needs these to emit
+    # the right ``call N, label`` arity at each call site and to
+    # declare the right parameter count per function.
+    arity_overrides = {
+        name: len(params) for name, params in compiler._fn_params.items()  # noqa: SLF001
+    }
+
     try:
         beam_module = lower_ir_to_beam(
             optimized_ir,
-            BEAMBackendConfig(module_name=module_name),
+            BEAMBackendConfig(
+                module_name=module_name,
+                arity_overrides=arity_overrides,
+            ),
         )
         beam_bytes = encode_beam(beam_module)
     except Exception as exc:
@@ -477,8 +599,8 @@ def run_source(
     """Compile and execute on the **real** ``erl`` runtime.
 
     Drops the ``.beam`` to a fresh temp dir and uses ``erl -eval``
-    to call ``<module>:main()`` and ``io:format`` its return value
-    to stdout, then ``init:stop()``.
+    to call ``<module>:main()`` and ``io:format`` its return
+    value to stdout, then ``init:stop()``.
     """
     compilation = compile_source(
         source, module_name=module_name, optimize=optimize

--- a/code/packages/python/twig-beam-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_compile.py
@@ -1,24 +1,22 @@
-"""Compile-time tests — no ``erl`` required.
-
-Verifies the Twig → IR lowering produces sensible IR and rejects
-out-of-scope forms with clear error messages.
-"""
+"""Compile-time tests for twig-beam-compiler (TW03 Phase 1)."""
 
 from __future__ import annotations
 
 import pytest
-from compiler_ir import IrOp
+from compiler_ir import IrLabel, IrOp
 from twig.errors import TwigCompileError
 
-from twig_beam_compiler import compile_source, compile_to_ir
+from twig_beam_compiler import (
+    BeamPackageError,
+    compile_source,
+    compile_to_ir,
+)
 
 
 class TestSupportedSurface:
     def test_int_literal_compiles(self) -> None:
         ir = compile_to_ir("42")
         ops = [ins.opcode for ins in ir.instructions]
-        # Expect: LABEL, LOAD_IMM (the literal), maybe an ADD for
-        # the move, RET.
         assert IrOp.LABEL in ops
         assert IrOp.LOAD_IMM in ops
         assert IrOp.RET in ops
@@ -28,38 +26,117 @@ class TestSupportedSurface:
         ops = [ins.opcode for ins in ir.instructions]
         assert IrOp.ADD in ops
 
-    def test_subtraction_emits_sub(self) -> None:
-        ir = compile_to_ir("(- 10 3)")
-        ops = [ins.opcode for ins in ir.instructions]
-        assert IrOp.SUB in ops
+    @pytest.mark.parametrize(
+        ("src", "op"),
+        [
+            ("(+ 1 2)", IrOp.ADD),
+            ("(- 10 3)", IrOp.SUB),
+            ("(* 6 7)", IrOp.MUL),
+            ("(/ 10 2)", IrOp.DIV),
+        ],
+    )
+    def test_arithmetic_ops(self, src: str, op: IrOp) -> None:
+        ir = compile_to_ir(src)
+        assert op in [ins.opcode for ins in ir.instructions]
 
-    def test_multiplication_emits_mul(self) -> None:
-        ir = compile_to_ir("(* 6 7)")
-        ops = [ins.opcode for ins in ir.instructions]
-        assert IrOp.MUL in ops
+    @pytest.mark.parametrize(
+        ("src", "op"),
+        [
+            ("(= 1 1)", IrOp.CMP_EQ),
+            ("(< 1 2)", IrOp.CMP_LT),
+            ("(> 2 1)", IrOp.CMP_GT),
+        ],
+    )
+    def test_comparison_ops(self, src: str, op: IrOp) -> None:
+        ir = compile_to_ir(src)
+        assert op in [ins.opcode for ins in ir.instructions]
 
     def test_let_compiles(self) -> None:
         ir = compile_to_ir("(let ((x 5)) (* x x))")
+        assert IrOp.MUL in [ins.opcode for ins in ir.instructions]
+
+    def test_if_emits_branch(self) -> None:
+        ir = compile_to_ir("(if (= 1 1) 100 200)")
         ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.BRANCH_Z in ops
+        assert IrOp.JUMP in ops
+        assert IrOp.CMP_EQ in ops
+
+    def test_define_function_emits_call(self) -> None:
+        ir = compile_to_ir("(define (square x) (* x x)) (square 7)")
+        ops = [ins.opcode for ins in ir.instructions]
+        assert IrOp.CALL in ops
+        # Two callable LABELs: square and main.
+        region_labels = [
+            ins.operands[0].name
+            for ins in ir.instructions
+            if ins.opcode is IrOp.LABEL
+            and isinstance(ins.operands[0], IrLabel)
+            and not ins.operands[0].name.startswith("_")
+        ]
+        assert "square" in region_labels
+        assert "main" in region_labels
+
+    def test_recursive_function_compiles(self) -> None:
+        ir = compile_to_ir(
+            "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))"
+            "(fact 5)"
+        )
+        ops = [ins.opcode for ins in ir.instructions]
+        assert ops.count(IrOp.CALL) >= 2
+        assert IrOp.BRANCH_Z in ops
         assert IrOp.MUL in ops
+        assert IrOp.SUB in ops
+
+    def test_value_define_inlined(self) -> None:
+        ir = compile_to_ir("(define x 42) x")
+        region_labels = [
+            ins.operands[0].name
+            for ins in ir.instructions
+            if ins.opcode is IrOp.LABEL
+            and isinstance(ins.operands[0], IrLabel)
+            and not ins.operands[0].name.startswith("_")
+        ]
+        # Value defines fold to compile-time constants — only main.
+        assert region_labels == ["main"]
 
 
 class TestRejectedSurface:
-    def test_define_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(define x 1)")
-
     def test_lambda_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="not yet supported"):
             compile_to_ir("(lambda (x) x)")
 
-    def test_comparison_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(= 1 1)")
-
     def test_unbound_name_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="unbound name"):
             compile_to_ir("foo")
+
+    def test_unknown_function_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="unknown function"):
+            compile_to_ir("(weirdop 1 2)")
+
+    def test_arity_mismatch_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="expects 2 arguments"):
+            compile_to_ir("(+ 1 2 3)")
+
+    def test_function_arity_mismatch_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="takes 1 arguments"):
+            compile_to_ir("(define (id x) x) (id 1 2)")
+
+    def test_cons_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(cons 1 2)")
+
+    def test_print_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="not yet supported"):
+            compile_to_ir("(print 42)")
+
+    def test_quoted_symbol_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="quoted symbols"):
+            compile_to_ir("'foo")
+
+    def test_non_literal_value_define_rejected(self) -> None:
+        with pytest.raises(TwigCompileError, match="literal RHS"):
+            compile_to_ir("(define x (+ 1 2))")
 
 
 class TestCompileSourceShape:
@@ -67,7 +144,6 @@ class TestCompileSourceShape:
         result = compile_source("(+ 1 2)")
         assert result.beam_bytes[:4] == b"FOR1"
         assert b"BEAM" in result.beam_bytes[:16]
-        assert result.module_name == "twig_main"
 
     def test_custom_module_name(self) -> None:
         result = compile_source("(+ 1 2)", module_name="adder")
@@ -79,48 +155,11 @@ class TestCompileSourceShape:
 
     def test_empty_program_returns_zero(self) -> None:
         result = compile_source("")
-        # Should still produce a valid .beam (main/0 returns 0).
         assert result.beam_bytes[:4] == b"FOR1"
-
-    def test_begin_compiles(self) -> None:
-        result = compile_source("(begin 1 2 3)")
-        assert result.beam_bytes[:4] == b"FOR1"
-
-
-class TestRejectedSurfaceMore:
-    def test_unknown_builtin_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="unknown builtin"):
-            compile_to_ir("(weirdop 1 2)")
-
-    def test_arity_mismatch_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="expects exactly 2"):
-            compile_to_ir("(+ 1 2 3)")
-
-    def test_multi_binding_let_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="multiple bindings"):
-            compile_to_ir("(let ((x 1) (y 2)) (+ x y))")
-
-    def test_quoted_symbol_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="quoted symbols"):
-            compile_to_ir("'foo")
-
-    def test_call_of_non_var_rejected(self) -> None:
-        # An apply where the function position is itself a call —
-        # not a VarRef, so v1 rejects.
-        with pytest.raises(TwigCompileError, match="named builtins"):
-            compile_to_ir("((+ 1 1) 2 3)")
 
 
 class TestModuleNameSecurity:
-    """Defends against Erlang code-injection via ``module_name``.
-
-    ``run_source`` interpolates ``module_name`` into an ``erl
-    -eval`` Erlang source string.  Without an allowlist a caller
-    could pass e.g. ``module_name="ok, os:cmd(...), m"`` and get
-    arbitrary command execution.  ``compile_source`` validates
-    upfront and rejects anything that isn't a strict atom-like
-    identifier.
-    """
+    """Defends against Erlang code-injection via ``module_name``."""
 
     def test_legal_name_accepted(self) -> None:
         result = compile_source("(+ 1 2)", module_name="answer42")
@@ -129,18 +168,15 @@ class TestModuleNameSecurity:
     @pytest.mark.parametrize(
         "bad",
         [
-            "ok, os:cmd(\"id\"), m",   # full Erlang injection
-            "../etc_passwd",            # path-traversal style
-            "Module",                   # uppercase start (Erlang variable)
-            "1main",                    # digit start
-            "foo bar",                  # space
-            "",                          # empty
-            "a" * 65,                   # too long
+            "ok, os:cmd(\"id\"), m",
+            "../etc_passwd",
+            "Module",
+            "1main",
+            "foo bar",
+            "",
+            "a" * 65,
         ],
     )
     def test_unsafe_names_rejected(self, bad: str) -> None:
-        # BeamPackageError is the wrapper around module-name violations.
-        from twig_beam_compiler import BeamPackageError
-
         with pytest.raises(BeamPackageError, match="module_name must match"):
             compile_source("(+ 1 2)", module_name=bad)

--- a/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
@@ -1,13 +1,15 @@
 """End-to-end Twig source → real ``erl`` execution tests.
 
-These tests require ``erl`` on PATH and skip cleanly if it's not.
-They are the headline proof that BEAM01 Phases 2-4 work together:
-Twig source goes in, byte output comes out of real Erlang/OTP.
+Headline TW03 Phase 1 BEAM proof: ``define``, ``if``,
+comparison, recursion all work on real Erlang/OTP — completing
+parity with JVM01's factorial test on real ``java`` and the
+twig-clr-compiler factorial test on real ``dotnet``.
 """
 
 from __future__ import annotations
 
 import pytest
+
 from twig_beam_compiler import erl_available, run_source
 
 requires_erl = pytest.mark.skipif(
@@ -16,22 +18,19 @@ requires_erl = pytest.mark.skipif(
 )
 
 
+# ── Arithmetic ─────────────────────────────────────────────────────────────
+
+
 @requires_erl
 def test_addition() -> None:
-    """``(+ 1 2)`` → ``main/0`` returns 3 from real erl."""
+    """``(+ 1 2)`` → 3."""
     result = run_source("(+ 1 2)", module_name="bm_add")
-    assert result.returncode == 0, (
-        f"erl rejected the module:\n  stdout: {result.stdout!r}\n"
-        f"  stderr: {result.stderr!r}"
-    )
-    # ``erl -eval 'io:format("~p~n", [Result])'`` prints the integer
-    # followed by a newline.
+    assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"3"
 
 
 @requires_erl
 def test_multiplication() -> None:
-    """``(* 6 7)`` → 42."""
     result = run_source("(* 6 7)", module_name="bm_mul")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"42"
@@ -39,7 +38,6 @@ def test_multiplication() -> None:
 
 @requires_erl
 def test_subtraction() -> None:
-    """``(- 10 3)`` → 7."""
     result = run_source("(- 10 3)", module_name="bm_sub")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"7"
@@ -47,8 +45,7 @@ def test_subtraction() -> None:
 
 @requires_erl
 def test_division() -> None:
-    """``(/ 10 2)`` → 5.  BEAM lowering uses ``erlang:div/2`` which
-    is integer division, so 10/2 = 5."""
+    """``(/ 10 2)`` → 5.  BEAM lowers ``/`` to ``erlang:div/2`` (integer division)."""
     result = run_source("(/ 10 2)", module_name="bm_div")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"5"
@@ -56,7 +53,6 @@ def test_division() -> None:
 
 @requires_erl
 def test_let_binding() -> None:
-    """``(let ((x 5)) (* x x))`` → 25."""
     result = run_source("(let ((x 5)) (* x x))", module_name="bm_let")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"25"
@@ -64,9 +60,133 @@ def test_let_binding() -> None:
 
 @requires_erl
 def test_nested_arithmetic() -> None:
-    """``(+ (* 6 7) (* 2 3))`` → 48."""
-    result = run_source(
-        "(+ (* 6 7) (* 2 3))", module_name="bm_nested"
-    )
+    result = run_source("(+ (* 6 7) (* 2 3))", module_name="bm_nested")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"48"
+
+
+# ── if / comparison ────────────────────────────────────────────────────────
+
+
+@requires_erl
+def test_if_taken_branch() -> None:
+    result = run_source("(if (= 1 1) 100 200)", module_name="bm_if_t")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"100"
+
+
+@requires_erl
+def test_if_not_taken_branch() -> None:
+    result = run_source("(if (= 1 2) 100 200)", module_name="bm_if_f")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"200"
+
+
+@requires_erl
+def test_comparison_lt() -> None:
+    result = run_source("(if (< 3 5) 1 0)", module_name="bm_lt")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"1"
+
+
+@requires_erl
+def test_comparison_gt() -> None:
+    result = run_source("(if (> 3 5) 1 0)", module_name="bm_gt")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"0"
+
+
+# ── define + function calls ────────────────────────────────────────────────
+
+
+@requires_erl
+def test_top_level_function() -> None:
+    """``(define (square x) (* x x)) (square 7) → 49``."""
+    result = run_source(
+        "(define (square x) (* x x)) (square 7)",
+        module_name="bm_square",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"49"
+
+
+@requires_erl
+def test_two_param_function() -> None:
+    result = run_source(
+        "(define (add3 a b) (+ a (+ b 3))) (add3 10 20)",
+        module_name="bm_add3",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"33"
+
+
+@requires_erl
+def test_top_level_value_define_inlined() -> None:
+    result = run_source("(define x 42) x", module_name="bm_val")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"42"
+
+
+@requires_erl
+def test_nested_function_calls() -> None:
+    result = run_source(
+        """
+        (define (inc x) (+ x 1))
+        (define (dbl x) (* x 2))
+        (inc (dbl 5))
+        """,
+        module_name="bm_nested_fn",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"11"
+
+
+# ── recursion ──────────────────────────────────────────────────────────────
+
+
+@requires_erl
+def test_recursion_factorial() -> None:
+    """``(fact 5) → 120`` — the headline TW03 Phase 1 BEAM test.
+
+    Proves recursion works on real ``erl``, completing parity
+    with JVM01's ``test_recursion_factorial`` on real ``java``
+    and twig-clr-compiler's same-named test on real ``dotnet``.
+    """
+    result = run_source(
+        """
+        (define (fact n)
+          (if (= n 0) 1 (* n (fact (- n 1)))))
+        (fact 5)
+        """,
+        module_name="bm_fact",
+    )
+    assert result.returncode == 0, (
+        f"erl rejected the module:\n  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+    assert result.stdout.strip() == b"120"
+
+
+@requires_erl
+def test_mutual_recursion_even_odd() -> None:
+    """``(even? 4) → 1``.
+
+    Mutual recursion needs both functions to call each other,
+    so this exercises CALL across two regions that each push
+    args via the Twig calling convention.
+
+    Note: BEAM atoms can't contain ``?`` so we use ``even_q`` /
+    ``odd_q`` here (the Twig source uses standard names; the
+    *Twig* compiler doesn't sanitise them so we work around
+    by avoiding ``?`` in this test).
+    """
+    result = run_source(
+        """
+        (define (evenp n) (if (= n 0) 1 (oddp (- n 1))))
+        (define (oddp n) (if (= n 0) 0 (evenp (- n 1))))
+        (evenp 4)
+        """,
+        module_name="bm_evenodd",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"1"


### PR DESCRIPTION
## Summary

Closes the language-surface gap on the **BEAM backend** so Twig source has the same expressive power on real `erl` as on real `java` (since JVM01) and real `dotnet` (since the twig-clr-compiler Phase 1 PR).

**Headline test**:

```python
>>> from twig_beam_compiler import run_source
>>> run_source(
...   "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) (fact 5)",
...   module_name="bm_fact",
... ).stdout.strip()
b'120'
```

This matches JVM01's `test_recursion_factorial` on real `java` and twig-clr-compiler's same-named test on real `dotnet` — **byte-for-byte parity across the JVM, CLR, and BEAM Twig real-runtime tracks**.

## What ships

**ir-to-beam (0.2.0)**
- Adds `BRANCH_Z` / `BRANCH_NZ` / `JUMP` / `CMP_EQ` / `CMP_LT` / `CMP_GT` / `ADD_IMM` lowerings.
- Internal LABEL handling (`_else_*` / `_endif_*` stay in body as `label N` opcodes; only CALL targets become regions).
- **Switches body code to BEAM y-registers** with `allocate K, arity` / `deallocate K` frames. Necessary because BEAM x-registers are caller-saves (clobbered across calls) — using y-registers sidesteps the JVM01-style "preserve state across recursive call" problem at the architectural level rather than via manual snapshots.

**twig-beam-compiler (0.2.0)**
- Frontend extended to mirror twig-jvm-compiler / twig-clr-compiler: top-level `define`, function calls, recursion, mutual recursion, `if`, comparison, value-define inlining.

## Test coverage

**142 tests pass across all 7 BEAM packages** (was 87 before):

| Package | Before | After | Highlights |
|---------|-------:|------:|------------|
| ir-to-beam | 15 | 19 | + BRANCH/CMP lowering, recursive factorial real-`erl` test |
| twig-beam-compiler | 25 | 51 | + 13 compile-time, +8 real-`erl` (incl. `(fact 5) → 120`, `(evenp 4) → 1` mutual recursion) |
| (5 other BEAM packages) | unchanged | unchanged | still all green |

## Test plan

- [x] All 142 BEAM-related tests pass locally
- [x] `build-tool -validate-build-files` — clean
- [x] `/security-review` — passed
- [ ] CI confirmation across runners

## What's next (TW03)

- **Phase 2** — closures across all backends (JVM02 implementation + parallel CLR/BEAM work)
- **Phase 3** — heap primitives (`cons`, `car`, `cdr`, symbols, `quote`)
- **Phase 4** — GC

🤖 Generated with [Claude Code](https://claude.com/claude-code)