### PR TITLE
spec(twig): TW03 Phase 2 closure ops (compiler-ir) + JVM02 Phase 2 lowering spec

### DIFF
--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.4.0] — 2026-04-29
+
+### Added — TW03 Phase 2 closure ops
+
+- **``IrOp.MAKE_CLOSURE`` (25)** — construct a closure value
+  capturing free variables from the enclosing scope.  Operand
+  layout: ``MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...``
+- **``IrOp.APPLY_CLOSURE`` (26)** — invoke a closure value with
+  zero or more arguments.  Operand layout:
+  ``APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...``
+
+These ops are the **cross-backend interface** for TW03 Phase 2.
+Lowering strategies differ per backend:
+
+- JVM/CLR — closure becomes an object reference; per-lambda
+  class with captured fields + ``apply`` method.  See
+  ``code/specs/JVM02-phase2-multi-class-closure-lowering.md``.
+- BEAM — emit ``make_fun2`` referencing a ``FunT`` chunk row.
+- vm-core — delegate to the host-side ``make_closure`` /
+  ``apply_closure`` builtins (already implemented in TW00).
+
+Backends that don't yet support these ops should reject via
+their pre-flight validator with a clear "TW03 Phase 2: closures
+not yet implemented for this backend" message — never silently
+miscompile.
+
 ## [0.3.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -29,6 +29,7 @@ The opcodes are grouped by category:
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
+  Closures:     MAKE_CLOSURE, APPLY_CLOSURE   (TW03 Phase 2)
 
 Text Names
 ----------
@@ -257,6 +258,46 @@ class IrOp(IntEnum):
     # Useful for debugging IR output.
     #   COMMENT "load tape base address"
     COMMENT = 24
+
+    # ── Closures (TW03 Phase 2 — cross-backend Lisp closure support) ─────
+    # Construct a closure value that captures values from the enclosing
+    # lexical scope.  The closure can later be invoked via APPLY_CLOSURE.
+    #
+    # Operand layout:
+    #   MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...
+    # where:
+    #   - ``dst``         — register receiving the resulting closure handle
+    #   - ``fn_label``    — IR label of the lifted lambda body (a top-level
+    #                       region just like a user-defined function)
+    #   - ``num_captured`` — IrImmediate count of captured values
+    #   - ``capt0..captN-1`` — registers holding the captured values
+    #
+    # Backend lowering strategies (see TW03 spec):
+    #   - JVM/CLR:  allocate a closure object whose fields hold the captures;
+    #               the resulting reference is the "closure handle".
+    #   - BEAM:     emit ``make_fun2`` referencing a FunT-table entry whose
+    #               free-variable list maps to the captured registers.
+    #   - vm-core:  delegate to the host-side ``make_closure`` builtin
+    #               (already implemented in TW00).
+    MAKE_CLOSURE = 25
+
+    # Apply a closure value to zero or more arguments.
+    #
+    # Operand layout:
+    #   APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...
+    # where:
+    #   - ``dst``         — register receiving the call's return value
+    #   - ``closure_reg`` — register holding the closure handle from
+    #                        a prior MAKE_CLOSURE
+    #   - ``num_args``    — IrImmediate count of arguments
+    #   - ``arg0..argN-1`` — registers holding the argument values
+    #
+    # Backend lowering strategies:
+    #   - JVM/CLR:  invoke the closure object's ``apply(int...)`` method.
+    #   - BEAM:     emit ``call_fun`` (or ``call_fun2``) on the closure
+    #               handle.
+    #   - vm-core:  delegate to the host-side ``apply_closure`` builtin.
+    APPLY_CLOSURE = 26
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/specs/JVM02-phase2-multi-class-closure-lowering.md
+++ b/code/specs/JVM02-phase2-multi-class-closure-lowering.md
@@ -1,0 +1,230 @@
+# JVM02 Phase 2 — multi-class closure lowering
+
+## Why this spec exists
+
+[JVM02](JVM02-jar-as-distribution-unit.md) Phase 1 shipped the
+JAR writer (``jvm-jar-writer``).  Phase 2 is the implementation
+that **uses** the JAR writer: extending ``ir-to-jvm-class-file``
+to emit multiple classes from one IR program — specifically, one
+class per closure plus the main program class.
+
+This is the JVM-side implementation of [TW03](TW03-lisp-primitives-and-gc.md)
+Phase 2 (closures across all backends).  Mirrors the user vision
+(quote): "if a JAR is a better abstraction instead of class, we
+should also reorient it towards that."
+
+This spec depends on the new IR ops ``MAKE_CLOSURE`` and
+``APPLY_CLOSURE`` (added to ``compiler-ir`` alongside this spec).
+Those ops are the cross-backend interface; lowering strategies
+differ per backend (see TW03 spec for the full table).
+
+## Acceptance criterion
+
+```python
+>>> from twig_jvm_compiler import run_source
+>>> run_source(
+...   "(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)",
+...   class_name="Adder",  # becomes the JAR's Main-Class
+... ).stdout.strip()
+b'*'   # (= 42 = 0x2a)
+```
+
+The Twig program uses a closure (``lambda``) that captures the
+free variable ``n`` from the enclosing ``make-adder`` scope.
+Real ``java`` runs the produced JAR and the answer comes out.
+
+## Design
+
+### The Closure base interface
+
+Every closure produced by Twig implements a shared interface
+emitted at the root of the JAR:
+
+```java
+package coding_adventures.twig.runtime;
+
+public interface Closure {
+    int apply(int[] args);
+}
+```
+
+Why ``int[] args`` and not varargs of ``int``?  Because the
+Twig calling convention (today) only handles integer registers,
+and ``int[] args`` lets us call any closure of any arity through
+a single JVM ``invokeinterface`` site without per-arity
+dispatch.  Adds one allocation per call but keeps the invoke
+site monomorphic, which matters for HotSpot inlining.
+
+### Per-lambda subclass
+
+Each ``MAKE_CLOSURE fn_label`` site causes us to emit a class:
+
+```java
+public class Closure_<fn_label> implements Closure {
+    private final int capt0;
+    private final int capt1;
+    // ... one final field per captured variable
+
+    public Closure_<fn_label>(int capt0, int capt1, /* ... */) {
+        this.capt0 = capt0;
+        this.capt1 = capt1;
+        // ...
+    }
+
+    @Override
+    public int apply(int[] args) {
+        // The lifted lambda body — uses ``capt*`` for captured
+        // free variables and ``args[i]`` for the lambda's own
+        // params.
+        return /* lowered IR body */;
+    }
+}
+```
+
+The class name uses a sanitised version of the IR ``fn_label``
+(replacing ``-`` with ``_``, etc.).  All closure classes go
+under the package ``coding_adventures.twig.<assembly>.``  to keep
+the JAR's class layout predictable.
+
+### MAKE_CLOSURE lowering
+
+```
+MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...
+```
+
+Lowers to:
+
+```
+new <ClosureClass>           ; allocate the closure object
+dup                          ; duplicate the reference for the constructor
+ldloc capt0                  ; push captured value 0
+ldloc capt1                  ; push captured value 1
+...                          ; (one ldloc per capture)
+invokespecial Closure_<fn_label>.<init>(I, I, ...)V
+                              ; constructor takes one int per capture
+astore dst                   ; store the new reference into dst
+```
+
+There's a wrinkle: today the JVM backend treats all IR
+registers as ``int``.  Closure values are object references,
+not ints.  We need to widen the in-class register pool to hold
+both ints and references.
+
+**Strategy**: introduce a parallel ``Object[]`` register file
+alongside the existing ``int[]``.  Each IR register has both
+slots.  Most operations use the int slot; ``MAKE_CLOSURE``
+writes the object slot; ``APPLY_CLOSURE`` reads the object slot.
+``ADD_IMM`` (used as MOV) copies both slots.
+
+Why parallel arrays instead of an `Object[]` everywhere?
+Boxing every int would explode allocation pressure and tank
+arithmetic-heavy programs.  Parallel arrays let us pay the
+boxing cost only at closure boundaries.
+
+### APPLY_CLOSURE lowering
+
+```
+APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...
+```
+
+Lowers to:
+
+```
+aload closure_reg            ; push the closure object reference
+ldc num_args                 ; push the args-array length
+newarray int                 ; allocate int[num_args]
+dup                          ; (one dup per arg-store, see below)
+ldc 0                        ; index 0
+iload arg0                   ; value
+iastore                      ; arr[0] = arg0
+... (repeat for each arg)
+invokeinterface Closure.apply([I)I
+istore dst                   ; the int return goes into dst
+```
+
+The ``int[]`` allocation per call is the cost we pay for the
+monomorphic invoke site.  Future optimisation: specialise apply
+to common arities (apply0, apply1, apply2) on the Closure
+interface and dispatch on `args.length`.
+
+### The Twig frontend (TW02.5 work)
+
+``twig-jvm-compiler`` extends to:
+
+1. Discover anonymous lambdas in the AST.
+2. Lift each to a synthetic top-level region (``_lambda_0``,
+   ``_lambda_1``, ...).
+3. Run free-variable analysis (already done in
+   [twig/free_vars.py](../packages/python/twig/src/twig/free_vars.py)
+   for the vm-core path) to find captured names.
+4. At the lambda-creation site, emit ``MAKE_CLOSURE``.
+5. At apply sites where the function position is a local (not a
+   top-level name), emit ``APPLY_CLOSURE``.
+
+The existing ``_compile_apply`` already dispatches on whether
+the function is a top-level name; the new branch handles
+"closure-valued local variable" by emitting ``APPLY_CLOSURE``.
+
+## Implementation phases
+
+This is a substantial change; suggested PR breakdown:
+
+1. **Phase 2a** (this spec) — add IR ops + scaffolding.
+   - Add ``MAKE_CLOSURE`` / ``APPLY_CLOSURE`` to compiler-ir
+     ✓ shipped alongside this spec.
+   - Backend stubs that raise ``NotImplementedError`` with a
+     clear message pointing at the relevant spec phase.
+   - This unblocks parallel work on JVM, CLR, BEAM.
+
+2. **Phase 2b** — the Closure base interface + multi-class
+   plumbing in ``ir-to-jvm-class-file``.
+   - Add ``JVMMultiClassArtifact`` data type.
+   - Emit ``Closure.class`` (interface) at JAR root.
+   - Allow the lowering API to return multiple class artifacts
+     instead of one.
+
+3. **Phase 2c** — ``MAKE_CLOSURE`` / ``APPLY_CLOSURE`` lowering
+   in ``ir-to-jvm-class-file``.
+   - Object register pool extension.
+   - Per-lambda ``Closure_*.class`` emission.
+   - Bytecode for both new ops.
+
+4. **Phase 2d** — ``twig-jvm-compiler`` accepts ``Lambda``.
+   - Lambda lifting.
+   - Free-var analysis (re-use ``twig.free_vars``).
+   - JAR packaging via ``jvm-jar-writer``.
+   - Real-``java`` test: ``((make-adder 7) 35) → 42``.
+
+## Risk register
+
+- **Object register pool overhead.**  Doubling the per-method
+  local-variable-table size hurts class-file footprint slightly.
+  Mitigation: only allocate the parallel ``Object[]`` slot if
+  the function actually uses ``MAKE_CLOSURE`` or
+  ``APPLY_CLOSURE``.  ``int``-only methods stay unchanged.
+- **JVM verifier strictness on ``invokespecial`` constructor
+  arity.**  Each closure class's constructor signature depends
+  on capture count; getting the descriptor wrong produces
+  ``VerifyError`` at load time.  Mitigation: unit tests assert
+  on the exact descriptor strings emitted.
+- **Cross-PR coordination.**  Phases 2b/2c/2d are sequenced;
+  each blocks the next.  Mitigation: open them as stacked
+  branches with explicit dependency notes.
+- **Sister-spec drift.**  CLR Phase 2 and BEAM Phase 2 will
+  use different lowering strategies (CLR does multi-class
+  natively, BEAM uses ``FunT`` + ``make_fun2``).  Each gets its
+  own implementation spec; this spec is **JVM-only**.
+
+## Out of scope
+
+- **Recursive closures inside their own lambda body.**  Today's
+  Twig has no ``letrec``; recursion only works through
+  top-level ``define``.  Closures that recursively reference
+  themselves (e.g. ``(define f (lambda (n) (if ... (f ...))))``)
+  need ``letrec`` or Y-combinator-style indirection, both of
+  which are out of scope for this phase.
+- **Tail-call elimination across ``apply``.**  JVM has no proper
+  TCO.  Closures that recurse via ``apply`` will blow the JVM
+  stack on deep recursion.  Acceptable for v1.
+- **Closure introspection** (``procedure?``, etc.) — TW03
+  Phase 3 territory.


### PR DESCRIPTION
## Summary

**Scaffolding PR for TW03 Phase 2 (closures).** Ships two pieces that unblock parallel closure-implementation work across JVM/CLR/BEAM:

1. **New IR ops** in `compiler-ir` (the cross-backend interface):
   - `MAKE_CLOSURE` (25) — construct a closure capturing free variables
   - `APPLY_CLOSURE` (26) — invoke a closure with zero or more arguments

2. **JVM02 Phase 2 implementation spec** — detailed multi-class lowering plan covering the shared `Closure` interface, per-lambda subclass with captured fields, JAR packaging, frontend lambda lifting, and a 4-step phased implementation breakdown (2a → 2d).

## Why ship as scaffolding

These ops + spec **don't change any existing behavior** — no backend uses them yet — but they capture the cross-backend contract so JVM/CLR/BEAM closure implementations can proceed in parallel rather than as one big cross-cutting change.

## Acceptance criterion (the eventual JVM02 Phase 2 implementation)

```python
>>> from twig_jvm_compiler import run_source
>>> run_source(
...   "(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)",
...   class_name="Adder",
... ).stdout.strip()
b'*'   # = 42 = 0x2a
```

This PR doesn't ship that yet — it ships the IR ops + design that the implementation PRs will use.

## Test plan

- [x] All 114 `compiler-ir` tests pass with the new opcodes
- [x] `build-tool -validate-build-files` — clean
- [x] Per the user's earlier preference, JAR-based multi-class is the chosen JVM lowering strategy (vs single-class table dispatch)

## Phase 2 PR breakdown

This PR is **Phase 2a**. Subsequent PRs:
- Phase 2b — `Closure` interface + multi-class plumbing in `ir-to-jvm-class-file`
- Phase 2c — `MAKE_CLOSURE` / `APPLY_CLOSURE` lowering in `ir-to-jvm-class-file`
- Phase 2d — `twig-jvm-compiler` accepts `Lambda`, packages as JAR, real-`java` factorial-style closure test

Plus parallel CLR Phase 2 and BEAM Phase 2 PRs (separate spec each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)