### PR TITLE
spec(twig): CLR02 + BEAM02 — closure lowering specs (Phase 2 sister tracks)

### DIFF
--- a/code/specs/BEAM02-closure-lowering.md
+++ b/code/specs/BEAM02-closure-lowering.md
@@ -1,0 +1,194 @@
+# BEAM02 — Closure lowering for the BEAM backend
+
+## Why this spec exists
+
+This is the **BEAM-side companion** to
+[JVM02 Phase 2](JVM02-phase2-multi-class-closure-lowering.md)
+and [CLR02](CLR02-closure-lowering.md), implementing
+[TW03 Phase 2](TW03-lisp-primitives-and-gc.md) (closures across
+all backends).
+
+BEAM's strategy is **completely different** from JVM/CLR
+because BEAM has a first-class notion of "fun objects" baked
+into the file format and instruction set:
+
+- A new ``FunT`` chunk in the ``.beam`` file describes each
+  lifted lambda — atom, arity, list of free variables, etc.
+- A new ``make_fun2`` opcode at the closure-creation site
+  packages captured values into a fun handle.
+- A ``call_fun`` opcode at the apply site invokes it.
+
+No new classes, no JAR — just one extra chunk plus two new
+opcode types.  This is the **simplest** of the three backend
+strategies.
+
+## Acceptance criterion
+
+```python
+>>> from twig_beam_compiler import run_source
+>>> run_source(
+...   "(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)",
+...   module_name="adder",
+... ).stdout.strip()
+b'42'
+```
+
+The Twig program uses a closure capturing the free variable
+``n``.  Real ``erl`` runs it and prints ``42``.
+
+## Design
+
+### The FunT chunk
+
+ECMA-style BEAM file format reference §FunT.  One row per lifted
+lambda::
+
+    {function_atom_idx, arity, code_label, index, num_free, old_uniq}
+
+- ``function_atom_idx`` — atom-table index of the lifted
+  lambda's name (e.g. ``_lambda_0`` interned as an atom).
+- ``arity`` — the lambda's parameter count (does not include
+  captured free variables).
+- ``code_label`` — BEAM label number where the lambda body
+  starts (the lifted region's call-target label).
+- ``index`` — fun-table entry index, sequential from 0.
+- ``num_free`` — count of captured free variables.
+- ``old_uniq`` — a 32-bit hash of the function body for
+  versioning.  We can compute it as a CRC32 of the body bytes
+  or use a fixed value for v1 (Erlang accepts both).
+
+The ``beam-bytecode-encoder`` package needs a new
+``BEAMFun`` dataclass and an ``encode_funt(funs)`` helper.  The
+``FunT`` chunk goes after ``ExpT`` in the chunk order.
+
+### make_fun2 opcode
+
+BEAM opcode 103 (per ``beam-opcode-metadata`` catalog).  Single
+operand: an unsigned integer index into the FunT table.
+
+```
+make_fun2 fun_index
+```
+
+Pre-conditions: the captured values must be in the ``x0..xN-1``
+registers in declaration order.  ``make_fun2`` reads them,
+allocates a fun heap object, and stores the resulting fun
+reference in ``x0``.
+
+So the lowering of ``MAKE_CLOSURE`` becomes:
+
+```
+; First, move the captured values from their current
+; (y-register) IR slots into BEAM x-registers x0..xN-1
+move {y, capt0_reg}, {x, 0}
+move {y, capt1_reg}, {x, 1}
+...
+make_fun2 fun_index
+move {x, 0}, {y, dst_reg}    ; store fun ref into IR dst register
+```
+
+### call_fun opcode
+
+BEAM opcode 75 (per the catalog: arity 1).  Single operand: the
+arity of the call (number of args being passed, not counting
+the closure value itself).
+
+Pre-conditions:
+- The closure (fun) reference must be in ``x{arity}``.
+- The arguments must be in ``x0..x{arity-1}``.
+
+So the lowering of ``APPLY_CLOSURE`` becomes:
+
+```
+move {y, arg0_reg}, {x, 0}
+move {y, arg1_reg}, {x, 1}
+...
+move {y, closure_reg}, {x, arity}   ; closure goes in x{arity}
+call_fun arity
+move {x, 0}, {y, dst_reg}            ; result lands in x0
+```
+
+### Closure body emission
+
+The lifted lambda body is emitted as a regular BEAM function
+**but with extra implicit parameters for the captured
+variables**.  Inside the body, captured variables are accessed
+as ``x{arity..arity+num_free-1}`` (BEAM's calling convention
+for fun-internal access — the runtime restores the captures
+from the fun object into x-registers before invoking the body).
+
+The Twig frontend already tracks free vars per lambda (via
+``twig.free_vars``); the BEAM lowering reads that info and
+generates the right ``allocate K, arity+num_free`` at function
+entry plus the right ``move {x, captN}, {y, slot}`` shuffle.
+
+### Operand encoding
+
+The ``z`` extended-tag in BEAM compact-term encoding handles
+some operand types we haven't touched yet.  For ``make_fun2``
+the operand is just a ``u`` (small unsigned int) — no new
+encoding needed.
+
+For ``call_fun`` similarly: just a ``u`` for arity.
+
+## Implementation phases
+
+Same staging as JVM02 Phase 2 / CLR02:
+
+- **BEAM02 Phase 2a** — IR ops (already shipped via the
+  ``compiler-ir`` v0.4.0 release alongside the JVM02 spec).
+- **BEAM02 Phase 2b** — ``FunT`` chunk encoding in
+  ``beam-bytecode-encoder``: new ``BEAMFun`` dataclass,
+  ``encode_funt`` helper, ``FunT`` added to the standard chunk
+  order.
+- **BEAM02 Phase 2c** — ``MAKE_CLOSURE`` / ``APPLY_CLOSURE``
+  lowering in ``ir-to-beam``: new opcode constants for
+  ``make_fun2``/``call_fun``, register-shuffle logic at both
+  sites, FunT-row population.
+- **BEAM02 Phase 2d** — ``twig-beam-compiler`` accepts
+  ``Lambda`` + real-``erl`` closure test.
+
+## Risk register
+
+- **``old_uniq`` hash mismatch.**  BEAM's loader caches funs
+  across module reloads keyed on ``old_uniq``.  A hand-rolled
+  hash that collides with a real ``erlc`` output could cause
+  surprising behavior in mixed-source environments (test
+  harnesses that load both our modules and ``erlc``-produced
+  ones).  Mitigation: use a deterministic CRC32 of the body
+  bytes; document the choice.
+- **``allocate`` framing across ``call_fun``.**  BEAM funs may
+  themselves call other funs.  The y-register frame allocated
+  by the caller must be re-established after the call returns.
+  ``call_fun`` saves/restores the frame automatically (same
+  semantics as ``call``), so no special handling needed —
+  just keeping the same y-register convention works.
+- **``num_free`` parameter ordering.**  The convention
+  (captured free vars come AFTER explicit args in
+  ``x0..x{arity+num_free-1}``) is non-obvious.  Mitigation:
+  document inline; tests assert on exact register-shuffle
+  bytecode.
+
+## Cross-spec parity
+
+| Aspect | JVM02 | CLR02 | BEAM02 |
+|--------|-------|-------|--------|
+| Closure container | per-lambda class | per-lambda TypeDef | FunT chunk row |
+| Apply dispatch | ``invokeinterface Closure.apply`` | ``callvirt IClosure.Apply`` | ``call_fun`` opcode |
+| Capture storage | object fields | object fields | fun heap object slots |
+| Packaging | JAR (multi-class) | single ``.exe`` | single ``.beam`` |
+| Difficulty | High (JAR + multi-class plumbing) | Medium (multi-TypeDef in one file) | Low (one new chunk + two opcodes) |
+
+BEAM is the easiest of the three, JVM the hardest.  Suggested
+implementation order: **BEAM Phase 2 first** (smallest scope
+to validate the full flow) → CLR Phase 2 → JVM Phase 2.
+
+## Out of scope
+
+- **Tail calls into closures.**  BEAM has ``call_fun_last`` for
+  tail calls; we'll wire that as an optimisation later.  v1
+  uses plain ``call_fun``.
+- **Closures captured in lists / cons cells.**  Heap primitives
+  are TW03 Phase 3.
+- **First-class fun introspection** (``is_function/1``,
+  ``fun_info/2``) — out of scope.

--- a/code/specs/CLR02-closure-lowering.md
+++ b/code/specs/CLR02-closure-lowering.md
@@ -1,0 +1,190 @@
+# CLR02 — Closure lowering for the CLR backend
+
+## Why this spec exists
+
+This is the **CLR-side companion** to
+[JVM02 Phase 2](JVM02-phase2-multi-class-closure-lowering.md).
+Both implement [TW03 Phase 2](TW03-lisp-primitives-and-gc.md)
+(closures across all backends) but the lowering strategies differ
+significantly because PE/CLI's class model is more flexible than
+the JVM's.
+
+**Key advantage for CLR**: a single PE/CLI assembly natively
+supports **multiple ``TypeDef`` rows** in one ``.exe``.  No
+"JAR equivalent" needed — closure classes live alongside the
+program's main type in the same file.  That makes CLR
+implementation substantially simpler than JVM Phase 2.
+
+## Acceptance criterion
+
+```python
+>>> from twig_clr_compiler import run_source
+>>> run_source(
+...   "(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)",
+...   assembly_name="Adder",
+... ).returncode
+42
+```
+
+The Twig program uses a closure (``lambda``) capturing the free
+variable ``n`` from ``make-adder``'s scope.  Real ``dotnet``
+runs the produced ``.exe`` and exits with code 42.
+
+## Design
+
+### Closure as a CIL TypeDef
+
+Each ``MAKE_CLOSURE fn_label`` site causes us to emit one
+additional ``TypeDef`` row in the assembly's metadata:
+
+```
+TypeDef row for Closure_<fn_label>:
+  Flags         = 0x00100001  (public + auto-layout)
+  Name          = "Closure_<fn_label>"
+  Namespace     = "" (or the assembly namespace)
+  Extends       = TypeRef to System.Object
+  FieldList     = first field row for this type's fields
+  MethodList    = first method row for this type's methods
+```
+
+Fields: one ``int32`` instance field per captured variable
+(``capt0``, ``capt1``, ...).
+
+Methods:
+- ``ctor(int, int, ...)`` — constructor takes one int32 per
+  capture and stores them in the fields.  Standard CIL ctor
+  prologue: ``ldarg.0; call System.Object::.ctor()`` followed
+  by ``ldarg.0; ldarg.1; stfld capt0`` per capture.
+- ``Apply(int[])`` — the lifted lambda body.  Reads captured
+  values from instance fields (``ldarg.0; ldfld capt0``),
+  reads arguments from the array (``ldarg.1; ldc.i4 i; ldelem.i4``),
+  computes, returns ``int``.
+
+### Why an Apply method on each TypeDef instead of an interface?
+
+JVM02 uses a shared ``Closure`` interface to make
+``invokeinterface`` monomorphic.  CLR has the same option
+(emit an ``IClosure`` ``TypeDef`` with abstract Apply, then
+each closure ``Implements`` it), but it's not strictly
+necessary for v1 — we can dispatch via ``callvirt`` on a
+known-at-call-site closure type.
+
+For v2 we'd add an ``IClosure`` interface to support
+"first-class closure values" stored in heterogeneous
+collections.  v1 keeps it simple: each closure is a concrete
+type, and ``apply_closure`` IR-op lowering tracks the closure's
+type at compile time.
+
+Wait — that's actually a problem.  ``APPLY_CLOSURE`` operates
+on a closure value held in a register.  We don't always know
+the closure's type at the apply site (e.g. when the closure
+came from a function call).  So we DO need the interface.
+
+**Revised decision**: emit ``IClosure`` interface as the first
+extra TypeDef.  Every closure ``Implements`` it.  ``APPLY_CLOSURE``
+lowers to ``callvirt IClosure::Apply(int32[]) int32``.
+
+### MAKE_CLOSURE lowering
+
+```
+MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...
+```
+
+Lowers to:
+
+```
+ldloc capt0                  ; push captured value 0
+ldloc capt1                  ; push captured value 1
+...                          ; (one ldloc per capture)
+newobj instance void Closure_<fn_label>::.ctor(int32, int32, ...)
+                              ; allocate + invoke ctor
+stloc dst                    ; store the new reference
+```
+
+The IR register for ``dst`` needs to hold an object reference
+rather than an int.  Same problem JVM02 has — solved the same
+way: parallel ``object[]`` register pool alongside the existing
+``int32[]``.
+
+### APPLY_CLOSURE lowering
+
+```
+APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...
+```
+
+Lowers to:
+
+```
+ldloc closure_reg            ; push the closure reference
+ldc.i4 num_args              ; push args-array length
+newarr int32                 ; allocate int[num_args]
+dup                          ; (one dup per arg-store)
+ldc.i4 0                     ; index 0
+ldloc arg0                   ; value
+stelem.i4                    ; arr[0] = arg0
+... (repeat for each arg)
+callvirt instance int32 IClosure::Apply(int32[])
+stloc dst
+```
+
+### Cross-spec parity with JVM02
+
+Both backends use the same shape:
+- One root interface (``Closure`` on JVM, ``IClosure`` on CLR)
+- One subclass per ``MAKE_CLOSURE`` site, with captured fields
+  and an ``Apply`` method
+- ``APPLY_CLOSURE`` lowers to a virtual call on the interface
+
+The only structural difference: JVM packages everything in a
+JAR; CLR packages everything in one ``.exe`` (no archive
+container needed).
+
+### The Twig frontend (TW02.5 — same for both backends)
+
+``twig-clr-compiler`` extends to:
+1. Discover anonymous lambdas.
+2. Lift each to a synthetic top-level region (``_lambda_0``, ...).
+3. Run free-variable analysis (re-use ``twig.free_vars``).
+4. At the lambda site, emit ``MAKE_CLOSURE``.
+5. At apply-of-local sites, emit ``APPLY_CLOSURE``.
+
+## Implementation phases
+
+Same staging as JVM02 Phase 2:
+
+- **CLR02 Phase 2a** — IR ops (already shipped via the
+  ``compiler-ir`` v0.4.0 release).
+- **CLR02 Phase 2b** — ``IClosure`` interface + multi-TypeDef
+  emission in ``cli-assembly-writer``.  Easier than JVM Phase 2b
+  because PE/CLI natively supports multi-class.
+- **CLR02 Phase 2c** — ``MAKE_CLOSURE`` / ``APPLY_CLOSURE``
+  lowering in ``ir-to-cil-bytecode``.
+- **CLR02 Phase 2d** — ``twig-clr-compiler`` accepts ``Lambda``
+  + real-``dotnet`` factorial-closure test.
+
+## Risk register
+
+- **CLR class-name uniqueness across runs.**  Closure class
+  names are derived from IR labels (``_lambda_0``, ...).  Two
+  separate Twig programs in the same process would conflict if
+  the assembly were loaded into a shared AppDomain.  Acceptable
+  for v1 (each Twig run produces its own assembly with a
+  unique ``assembly_name``).
+- **Recursive ``IClosure.Apply`` and stack overflow.**  CLR has
+  no proper TCO either.  Document this; recommend top-level
+  ``define`` for deep recursion.
+- **``int32[]`` allocation per call.**  Same overhead as JVM02.
+  Future optimisation: specialise ``Apply0()`` / ``Apply1(int)``
+  / ``Apply2(int, int)`` etc. on ``IClosure`` and dispatch by
+  arity.
+
+## Out of scope
+
+- **Closure values in heterogeneous collections.**  TW03
+  Phase 3 (heap primitives) brings cons cells; only then will
+  closures need to live in ``object[]``-shaped data.  v1 only
+  flows them through registers.
+- **Tail-call elimination.**  CLR ``.tail`` prefix could be
+  emitted but most JITs ignore it.  Out of scope for v1.
+- **Closure introspection** (``procedure?``, etc.) — TW03
+  Phase 3 territory.


### PR DESCRIPTION
## Summary

Companion specs to [JVM02 Phase 2 (#1750)](https://github.com/adhithyan15/coding-adventures/pull/1750). All three implement [TW03 Phase 2](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/TW03-lisp-primitives-and-gc.md) (closures across all backends) but use very different lowering strategies — one per runtime.

## Cross-spec parity

| Aspect | JVM02 | CLR02 | BEAM02 |
|--------|-------|-------|--------|
| Closure container | per-lambda class | per-lambda TypeDef | FunT chunk row |
| Apply dispatch | `invokeinterface Closure.apply` | `callvirt IClosure.Apply` | `call_fun` opcode |
| Capture storage | object fields | object fields | fun heap-object slots |
| Packaging | JAR (multi-class) | single `.exe` | single `.beam` |
| **Difficulty** | **High** | **Medium** | **Low** |

## Suggested implementation order

**BEAM first** — smallest new-code surface (one chunk type + two opcodes), exercises the full IR-op flow end-to-end. Then CLR (medium — multi-TypeDef in one file). Then JVM (hardest — JAR + multi-class plumbing).

## Acceptance criterion (each backend)

```
(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)
→ 42
```

…on real `java -jar`, real `dotnet`, and real `erl` respectively.

## What this PR ships

**Spec-only** — two new design docs under `code/specs/`. No code changes; the `compiler-ir` IR ops they reference (`MAKE_CLOSURE`, `APPLY_CLOSURE`) ship in PR #1750.

## Test plan

- [x] Both specs reviewed against the existing backend code paths
- [x] `build-tool -validate-build-files` — clean
- [ ] Implementation lands in subsequent PRs, phase by phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)