### PR TITLE
Reconsume malformed markup declarations

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -89,6 +89,9 @@ documented in this file.
   an unrelated `eof-in-comment` diagnostic.
 - Malformed markup declarations such as `<!foo>` now report
   `incorrectly-opened-comment` while recovering as bogus comments.
+- Malformed markup declaration fallback now reconsumes the first non-matching
+  byte in bogus-comment state, so `<!>` emits an empty comment and returns to
+  data state.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -38,9 +38,12 @@ comment recovery emits the recovered comment without adding an unrelated
 `eof-in-comment` diagnostic.
 Malformed markup declarations such as `<!foo>` also recover as bogus comments
 and report `incorrectly-opened-comment`, matching the tokenizer error shape the
-future parser will rely on for compatibility diagnostics. One-dash declaration
-openers such as `<!->` and `<!-x>` use that same bogus-comment recovery instead
-of being mistaken for normal empty-comment syntax.
+future parser will rely on for compatibility diagnostics. That recovery
+reconsumes the first non-matching byte in bogus-comment state, so empty
+declarations such as `<!>` emit an empty comment and return to normal data
+lexing. One-dash declaration openers such as `<!->` and `<!-x>` use that same
+bogus-comment recovery instead of being mistaken for normal empty-comment
+syntax.
 The tag-open states now only begin normal tags when the next character is an
 ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
 end-tag openers such as `</3>` recover as bogus comments with a tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4280,10 +4280,10 @@ actions = [
 from = "markup_declaration_open"
 matcher = { anything = true }
 to = "bogus_comment"
+consume = false
 actions = [
   "parse_error(incorrectly-opened-comment)",
   "create_comment",
-  "append_comment(current)",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9106,9 +9106,8 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "parse_error(incorrectly-opened-comment)".to_string(),
                 "create_comment".to_string(),
-                "append_comment(current)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "cdata_open_bracket".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 56);
+    assert_eq!(html1.cases.len(), 57);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 54);
+    assert_eq!(file.tests.len(), 55);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 54);
+    assert_eq!(normalized.cases.len(), 55);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 54);
+    assert_eq!(suite.cases.len(), 55);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -609,6 +609,20 @@
       ]
     },
     {
+      "id": "empty-incorrectly-opened-markup-declaration",
+      "description": "Malformed empty declarations reconsume > in bogus comment recovery",
+      "input": "Before<!>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
       "id": "one-dash-markup-declaration-bogus-comment",
       "description": "Markup declarations with only one opening dash recover as bogus comments",
       "input": "Before<!->Middle<!-x>After<!-",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -649,6 +649,20 @@
     },
     {
       "id": "html5lib-smoke-53",
+      "description": "empty incorrectly opened markup declaration reconsumes delimiter",
+      "input": "Before<!>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=)",
+        "Text(data=After)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-54",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -667,7 +681,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -565,6 +565,18 @@
       ]
     },
     {
+      "description": "empty incorrectly opened markup declaration reconsumes delimiter",
+      "input": "Before<!>After",
+      "output": [
+        ["Character", "Before"],
+        ["Comment", ""],
+        ["Character", "After"]
+      ],
+      "errors": [
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 9}
+      ]
+    },
+    {
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -405,6 +405,28 @@ fn default_html_lexer_reports_incorrectly_opened_markup_declaration() {
 }
 
 #[test]
+fn default_html_lexer_reconsumes_empty_incorrectly_opened_markup_declaration() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before<!>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment(String::new()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "incorrectly-opened-comment"));
+}
+
+#[test]
 fn default_html_lexer_reports_one_dash_markup_declaration_as_incorrectly_opened() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Reconsume malformed markup declaration fallback in bogus-comment state so delimiters like > terminate correctly.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage for <!>.
- Regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- python3 normalize_html5lib_fixtures.py upstream-html5lib-smoke.test html5lib-smoke.json
- cargo run in /tmp/html_numeric_codegen_tool
- cargo fmt for html-lexer, state-machine-tokenizer, state-machine-markup-deserializer, state-machine-source-compiler
- cargo test for html_lexer_test, conformance_test, html1_authoring_test
- cargo test for state-machine-source-compiler, state-machine-tokenizer, state-machine-markup-deserializer focused suites
- cargo check for html-lexer and state-machine-tokenizer tests
- git diff --check