### PR TITLE
feat(prolog): adapt clpfd sum global

### DIFF
--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -199,6 +199,9 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return goal if ins_goal is None else ins_goal
     if goal.relation.arity == 2 and name in binary_fd_builtins:
         return binary_fd_builtins[name](args[0], args[1])
+    if goal.relation.arity == 3 and name == "sum":
+        sum_goal = _adapt_fd_sum(args[0], args[1], args[2])
+        return goal if sum_goal is None else sum_goal
 
     ternary_arithmetic_builtins: dict[
         str,
@@ -326,6 +329,16 @@ def _adapt_fd_equality(left: Term, right: Term) -> GoalExpr:
         return left_expression
 
     return fd_eqo(left, right)
+
+
+def _adapt_fd_sum(
+    terms_value: Term,
+    operator_value: Term,
+    result: Term,
+) -> GoalExpr | None:
+    if _atom_symbol_name(operator_value) != "#=":
+        return None
+    return fd_sumo(terms_value, result)
 
 
 def _adapt_fd_arithmetic_expression(expression: Term, result: Term) -> GoalExpr | None:
@@ -496,3 +509,11 @@ def _logic_list_items(term_value: Term) -> list[Term] | None:
             current = current.args[1]
             continue
         return None
+
+
+def _atom_symbol_name(term_value: Term) -> str | None:
+    if isinstance(term_value, Atom) and term_value.symbol.namespace is None:
+        return term_value.symbol.name
+    if isinstance(term_value, str):
+        return term_value
+    return None

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1026,6 +1026,25 @@ class TestPrologGoalAdapter:
             adapted,
         ) == [num(3), num(2), num(1)]
 
+    def test_adapt_prolog_goal_rewrites_clpfd_sum_global(self) -> None:
+        parsed = parse_swi_query(
+            "?- [X,Y,Z] ins 1..4, "
+            "sum([X,Y,Z], #=, 6), "
+            "X #< Y, "
+            "Y #< Z, "
+            "labeling([], [X,Y,Z]).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            (parsed.variables["X"], parsed.variables["Y"], parsed.variables["Z"]),
+            adapted,
+        ) == [
+            (num(1), num(2), num(3)),
+        ]
+
     def test_adapt_prolog_goal_rewrites_common_list_predicates(self) -> None:
         parsed = parse_swi_query(
             "?- member(Item, [tea, cake]), "

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -261,6 +261,23 @@ class TestPrologVMStress:
             {"X": num(1)},
         ]
 
+    def test_clpfd_sum_global_runs_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- [X,Y,Z] ins 1..4,
+               sum([X,Y,Z], #=, 6),
+               X #< Y,
+               Y #< Z,
+               labeling([], [X,Y,Z]).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"X": num(1), "Y": num(2), "Z": num(3)},
+        ]
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR34-prolog-clpfd-sum-global.md
+++ b/code/specs/PR34-prolog-clpfd-sum-global.md
@@ -1,0 +1,45 @@
+# PR34: Prolog CLP(FD) Sum Global
+
+## Goal
+
+Support the common Prolog CLP(FD) global constraint:
+
+```prolog
+sum(Vars, #=, Total)
+```
+
+This keeps the Prolog frontend aligned with the existing Logic VM
+`fd_sumo/2` primitive instead of requiring users to spell larger additions as
+nested infix `#=/2` expressions.
+
+## Scope
+
+- Parse SWI-style `sum(List, #=, Total)` through the existing callable syntax.
+- Adapt the parsed `sum/3` goal to the library `fd_sumo(List, Total)` relation.
+- Leave unsupported `sum/3` operators unchanged for ordinary predicate
+  resolution or future adapter support.
+- Verify the loader path and the compiled VM query path with an end-to-end
+  CLP(FD) example.
+
+## Example
+
+```prolog
+?- [X,Y,Z] ins 1..4,
+   sum([X,Y,Z], #=, 6),
+   X #< Y,
+   Y #< Z,
+   labeling([], [X,Y,Z]).
+```
+
+Expected answer:
+
+```prolog
+X = 1, Y = 2, Z = 3.
+```
+
+## Follow-Up Work
+
+- Add additional `sum/3` relation operators if the VM gains compatible
+  primitives for `#\=`, `#<`, `#=<`, `#>`, and `#>=`.
+- Add more CLP(FD) global constraints such as `scalar_product/4`,
+  `global_cardinality/2`, and `element/3`.


### PR DESCRIPTION
## Summary

- adapt Prolog CLP(FD) `sum(List, #=, Total)` goals to the existing Logic VM `fd_sumo/2` primitive
- add loader coverage for solving a `sum/3` CLP(FD) query through the Python library API
- add VM stress coverage plus PR34 spec documentation for the supported global constraint

## Verification

- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `go build -o /tmp/ca-build-tool-prolog-sum-global .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-sum-global -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-sum-global-build-plan.json`
