### PR TITLE
Add ALGOL numeric builtins

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -85,6 +85,8 @@ All notable changes to this package will be documented in this file.
   dispatch rather than compile-time descriptor expansion.
 - Lowered `go to` statements through the same direct and designational goto
   paths as the compact `goto` spelling.
+- Lowered standard numeric builtin functions `abs`, `sign`, and `entier` using
+  existing integer/f64 IR operations.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -35,6 +35,8 @@ expressions, and ALGOL-left-associative exponentiation when the exponent is an
 integer. Real bases with negative integer exponents are lowered through a
 reciprocal path; arbitrary real exponents remain outside this phase until the
 runtime has a real `pow` implementation instead of an approximation shortcut.
+Standard numeric functions `abs`, `sign`, and `entier` lower directly to
+existing integer/f64 comparison, arithmetic, and conversion IR instructions.
 
 Scalar by-name parameters lower through a one-word cell in the callee frame.
 Passing a scalar variable as a by-name actual gives the callee a storage pointer,

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -111,6 +111,9 @@ _MAX_STRING_OUTPUT_BYTES = 4096
 _MAX_TOTAL_OUTPUT_BYTES = 8192
 _BUILTIN_PRINT_LABEL = "__algol_builtin_print"
 _BUILTIN_OUTPUT_LABEL = "__algol_builtin_output"
+_BUILTIN_ABS_LABEL = "__algol_builtin_abs"
+_BUILTIN_ENTIER_LABEL = "__algol_builtin_entier"
+_BUILTIN_SIGN_LABEL = "__algol_builtin_sign"
 _WRITE_SYSCALL = 1
 
 
@@ -2828,6 +2831,12 @@ class AlgolIrCompiler:
         call = self._require_procedure_call(name, role)
         if call.label in {_BUILTIN_PRINT_LABEL, _BUILTIN_OUTPUT_LABEL}:
             return self._compile_builtin_output(node, scope)
+        if call.label in {
+            _BUILTIN_ABS_LABEL,
+            _BUILTIN_ENTIER_LABEL,
+            _BUILTIN_SIGN_LABEL,
+        }:
+            return self._compile_builtin_numeric(node, call, scope)
         if call.parameter_symbol_id is not None:
             return self._compile_procedure_parameter_call(node, call, scope)
         procedure = self.procedures[call.procedure_id]
@@ -3352,6 +3361,184 @@ class AlgolIrCompiler:
         if saved_arg_reg is not None:
             self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
         return _ZERO_REG
+
+    def _compile_builtin_numeric(
+        self,
+        node: ASTNode,
+        call: ResolvedProcedureCall,
+        scope: _FrameScope,
+    ) -> int:
+        actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
+        if len(actuals) != 1:
+            raise CompileError(f"builtin {call.name} expects exactly 1 argument")
+        actual = actuals[0]
+        actual_type = self._expr_type(actual)
+        value = self._compile_expr(actual, scope)
+        if call.label == _BUILTIN_ABS_LABEL:
+            return self._emit_builtin_abs(value, actual_type)
+        if call.label == _BUILTIN_ENTIER_LABEL:
+            return self._emit_builtin_entier(value, actual_type)
+        if call.label == _BUILTIN_SIGN_LABEL:
+            return self._emit_builtin_sign(value, actual_type)
+        raise CompileError(f"unknown builtin numeric function {call.name!r}")
+
+    def _emit_builtin_abs(self, value: int, actual_type: str) -> int:
+        index = self.if_count
+        self.if_count += 1
+        nonnegative_label = f"builtin_abs_{index}_nonnegative"
+        end_label = f"builtin_abs_{index}_end"
+        result = self._fresh_reg()
+        negative = self._fresh_reg()
+        if actual_type == _REAL_TYPE:
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(negative),
+                IrRegister(value),
+                IrRegister(self._const_f64_reg(0.0)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(negative), IrLabel(nonnegative_label))
+            self._emit(
+                IrOp.F64_SUB,
+                IrRegister(result),
+                IrRegister(self._const_f64_reg(0.0)),
+                IrRegister(value),
+            )
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(nonnegative_label)
+            self._copy_scalar_reg(type_name=_REAL_TYPE, dst=result, src=value)
+            self._label(end_label)
+            return result
+
+        if actual_type != _INTEGER_TYPE:
+            raise CompileError(f"builtin abs does not support {actual_type}")
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(negative),
+            IrRegister(value),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(negative), IrLabel(nonnegative_label))
+        self._emit(
+            IrOp.SUB,
+            IrRegister(result),
+            IrRegister(_ZERO_REG),
+            IrRegister(value),
+        )
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(nonnegative_label)
+        self._copy_reg(dst=result, src=value)
+        self._label(end_label)
+        return result
+
+    def _emit_builtin_entier(self, value: int, actual_type: str) -> int:
+        if actual_type == _INTEGER_TYPE:
+            result = self._fresh_reg()
+            self._copy_reg(dst=result, src=value)
+            return result
+        if actual_type != _REAL_TYPE:
+            raise CompileError(f"builtin entier does not support {actual_type}")
+
+        index = self.if_count
+        self.if_count += 1
+        maybe_adjust_label = f"builtin_entier_{index}_maybe_adjust"
+        end_label = f"builtin_entier_{index}_end"
+        result = self._fresh_reg()
+        self._emit(IrOp.I32_TRUNC_FROM_F64, IrRegister(result), IrRegister(value))
+        negative = self._fresh_reg()
+        self._emit(
+            IrOp.F64_CMP_LT,
+            IrRegister(negative),
+            IrRegister(value),
+            IrRegister(self._const_f64_reg(0.0)),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(negative), IrLabel(maybe_adjust_label))
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(maybe_adjust_label)
+        truncated_as_real = self._fresh_reg()
+        exact = self._fresh_reg()
+        self._emit(
+            IrOp.F64_FROM_I32,
+            IrRegister(truncated_as_real),
+            IrRegister(result),
+        )
+        self._emit(
+            IrOp.F64_CMP_EQ,
+            IrRegister(exact),
+            IrRegister(truncated_as_real),
+            IrRegister(value),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(exact), IrLabel(end_label))
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(result),
+            IrRegister(result),
+            IrImmediate(-1),
+        )
+        self._label(end_label)
+        return result
+
+    def _emit_builtin_sign(self, value: int, actual_type: str) -> int:
+        index = self.if_count
+        self.if_count += 1
+        nonnegative_label = f"builtin_sign_{index}_nonnegative"
+        zero_label = f"builtin_sign_{index}_zero"
+        end_label = f"builtin_sign_{index}_end"
+        result = self._fresh_reg()
+        negative = self._fresh_reg()
+        positive = self._fresh_reg()
+        if actual_type == _REAL_TYPE:
+            zero = self._const_f64_reg(0.0)
+            self._emit(
+                IrOp.F64_CMP_LT,
+                IrRegister(negative),
+                IrRegister(value),
+                IrRegister(zero),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(negative), IrLabel(nonnegative_label))
+            self._emit(
+                IrOp.LOAD_IMM,
+                IrRegister(result),
+                IrImmediate(-1),
+            )
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(nonnegative_label)
+            self._emit(
+                IrOp.F64_CMP_GT,
+                IrRegister(positive),
+                IrRegister(value),
+                IrRegister(zero),
+            )
+        elif actual_type == _INTEGER_TYPE:
+            self._emit(
+                IrOp.CMP_LT,
+                IrRegister(negative),
+                IrRegister(value),
+                IrRegister(_ZERO_REG),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(negative), IrLabel(nonnegative_label))
+            self._emit(
+                IrOp.LOAD_IMM,
+                IrRegister(result),
+                IrImmediate(-1),
+            )
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(nonnegative_label)
+            self._emit(
+                IrOp.CMP_GT,
+                IrRegister(positive),
+                IrRegister(value),
+                IrRegister(_ZERO_REG),
+            )
+        else:
+            raise CompileError(f"builtin sign does not support {actual_type}")
+
+        self._emit(IrOp.BRANCH_Z, IrRegister(positive), IrLabel(zero_label))
+        self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(1))
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(zero_label)
+        self._copy_reg(dst=result, src=_ZERO_REG)
+        self._label(end_label)
+        return result
 
     def _emit_output_chars(self, text: str, scope: _FrameScope) -> None:
         for char in text:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -583,6 +583,21 @@ class TestAlgolIrCompiler:
         assert IrOp.MUL in opcodes
         assert opcodes.count(IrOp.SUB) >= 2
 
+    def test_compiles_standard_numeric_builtin_functions(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real x; "
+                "x := -2.5; result := abs(0 - 3) + sign(x) + entier(x) "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.CMP_LT in opcodes
+        assert IrOp.F64_CMP_LT in opcodes
+        assert IrOp.I32_TRUNC_FROM_F64 in opcodes
+        assert IrOp.F64_FROM_I32 in opcodes
+
     def test_integer_division_emits_runtime_failure_guard(self) -> None:
         result = compile_algol(
             parse_algol("begin integer result, divisor; result := 10 div divisor end")

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -59,6 +59,8 @@ All notable changes to this package will be documented in this file.
   designational dispatch can lower through the WASM pipeline.
 - Accepted `go to` as an alternate spelling for direct and designational
   `goto` statements.
+- Accepted standard numeric builtin functions `abs`, `sign`, and `entier` with
+  integer/real argument checking and read-only by-name analysis.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -17,7 +17,9 @@ The expression checker also accepts chained assignments, ALGOL conditional
 expressions, tolerant trailing/repeated semicolons from the parser, and
 left-associative exponentiation for numeric bases with integer exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
-types are still rejected before IR lowering.
+types are still rejected before IR lowering. Standard numeric functions
+`abs`, `sign`, and `entier` are resolved as read-only builtins with integer/real
+argument validation.
 
 The checker also builds the first ALGOL 60 full-runtime semantic model. Each
 source block receives a stable block id, lexical depth, static-parent id, and a
@@ -28,8 +30,9 @@ Procedure declarations receive semantic descriptors with generated function
 labels, parameter slots, value-vs-name parameter modes, conservative by-name
 write metadata, result slots for typed procedures, and resolved call sites
 carrying the static-link delta needed by code generation. Builtin output calls
-are treated as read-only by the write analysis, so formals that are only
-printed can still accept expression actuals.
+and standard numeric functions are treated as read-only by the write analysis,
+so formals that are only printed or inspected can still accept expression
+actuals.
 Bare no-argument typed procedure names used in expressions are resolved as
 procedure calls, matching ALGOL's omitted-parentheses call syntax, while
 procedure result variables inside their own bodies still resolve as storage.

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -23,7 +23,9 @@ SWITCH = "switch"
 STATIC = "static"
 PARAMETER_STORAGE = "parameter"
 MAX_ARRAY_DIMENSIONS = 4
-_READ_ONLY_BUILTINS = {"print", "output"}
+_OUTPUT_BUILTINS = {"print", "output"}
+_NUMERIC_BUILTINS = {"abs", "entier", "sign"}
+_READ_ONLY_BUILTINS = _OUTPUT_BUILTINS | _NUMERIC_BUILTINS
 
 
 @dataclass(frozen=True)
@@ -1902,6 +1904,36 @@ class AlgolTypeChecker:
                 f"procedure {name_token.value!r} expects "
                 f"{len(descriptor.parameters)} argument(s), got {len(arguments)}",
             )
+        if descriptor.procedure_id == -1:
+            return_type = self._check_builtin_procedure_call(
+                name_token,
+                arguments,
+                scope,
+                role=role,
+            )
+            if role == "expression" and return_type is None:
+                self._error(
+                    name_token,
+                    f"procedure {name_token.value!r} does not return a value",
+                )
+            call = ResolvedProcedureCall(
+                token_id=id(name_token),
+                name=name_token.value,
+                role=role,
+                procedure_id=descriptor.procedure_id,
+                label=descriptor.label,
+                use_block_id=scope.block_id,
+                declaration_block_id=declaring_scope.block_id,
+                lexical_depth_delta=lexical_depth_delta,
+                argument_count=len(arguments),
+                return_type=return_type,
+                line=name_token.line,
+                column=name_token.column,
+                parameter_symbol_id=descriptor.parameter_symbol_id,
+            )
+            self.resolved_procedure_calls.append(call)
+            return call
+
         for argument, parameter in zip(arguments, descriptor.parameters, strict=False):
             if parameter.kind == ARRAY:
                 self._check_array_parameter_actual(argument, scope, parameter)
@@ -1916,19 +1948,6 @@ class AlgolTypeChecker:
                 self._check_procedure_parameter_actual(argument, scope, parameter)
                 continue
             actual_type = self._infer_expr(argument, scope)
-            if descriptor.procedure_id == -1:
-                if actual_type != ERROR and actual_type not in {
-                    INTEGER,
-                    BOOLEAN,
-                    REAL,
-                    STRING,
-                }:
-                    self._error(
-                        argument,
-                        f"builtin procedure {name_token.value!r} expects integer, "
-                        f"boolean, real, or string, got {actual_type}",
-                    )
-                continue
             if actual_type != ERROR and not self._parameter_accepts_type(
                 parameter.mode,
                 parameter.type_name,
@@ -1986,6 +2005,43 @@ class AlgolTypeChecker:
         )
         self.resolved_procedure_calls.append(call)
         return call
+
+    def _check_builtin_procedure_call(
+        self,
+        name_token: Token,
+        arguments: list[ASTNode],
+        scope: Scope,
+        *,
+        role: str,
+    ) -> str | None:
+        if not arguments:
+            return None
+        actual_type = self._infer_expr(arguments[0], scope)
+        if name_token.value in _OUTPUT_BUILTINS:
+            if actual_type != ERROR and actual_type not in {
+                INTEGER,
+                BOOLEAN,
+                REAL,
+                STRING,
+            }:
+                self._error(
+                    arguments[0],
+                    f"builtin procedure {name_token.value!r} expects integer, "
+                    f"boolean, real, or string, got {actual_type}",
+                )
+            return None
+        if actual_type != ERROR and not _is_numeric_type(actual_type):
+            self._error(
+                arguments[0],
+                f"builtin function {name_token.value!r} expects integer or real, "
+                f"got {actual_type}",
+            )
+            return ERROR
+        if name_token.value == "abs":
+            return actual_type
+        if name_token.value in {"entier", "sign"}:
+            return INTEGER
+        return ERROR
 
     def _resolved_bare_procedure_expression(
         self,
@@ -2590,8 +2646,9 @@ class AlgolTypeChecker:
         token: Token,
         scope: Scope,
     ) -> tuple[ProcedureDescriptor, Scope, int] | None:
-        if token.value not in {"print", "output"}:
+        if token.value not in _READ_ONLY_BUILTINS:
             return None
+        return_type = INTEGER if token.value in _NUMERIC_BUILTINS else None
         descriptor = ProcedureDescriptor(
             procedure_id=-1,
             name=token.value,
@@ -2599,7 +2656,7 @@ class AlgolTypeChecker:
             declaring_block_id=scope.block_id,
             body_block_id=scope.block_id,
             body_node_id=-1,
-            return_type=None,
+            return_type=return_type,
             parameters=(
                 ProcedureParameter(
                     name="value",

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -366,6 +366,33 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
         assert result.ok
 
+    def test_accepts_standard_numeric_builtin_functions(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; "
+            "result := abs(0 - 3) + sign(x) + entier(2.5) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        calls = {
+            call.name: call.return_type
+            for call in result.semantic.procedure_calls
+        }
+        assert calls["abs"] == "integer"
+        assert calls["sign"] == "integer"
+        assert calls["entier"] == "integer"
+
+    def test_rejects_boolean_actual_for_numeric_builtin_function(self) -> None:
+        ast = parse_algol("begin integer result; result := abs(false) end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "builtin function 'abs' expects integer or real" in (
+            result.diagnostics[0].message
+        )
+
     def test_rejects_real_exponent_for_exponentiation(self) -> None:
         ast = parse_algol("begin real result; result := 2.0 ** 3.5 end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -78,6 +78,8 @@ All notable changes to this package will be documented in this file.
   descriptor lookup through the switch-eval helper at runtime.
 - Executed the report-style `go to` spelling through the full parser,
   type-checker, IR, and WASM pipeline.
+- Executed standard numeric builtin functions `abs`, `sign`, and `entier`
+  through the full parser, type-checker, IR, and WASM pipeline.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,6 +21,7 @@ the current lane already supports a substantial ALGOL 60 surface:
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer exponents
+- standard numeric functions `abs`, `sign`, and `entier`
 - value and by-name parameters, including Jensen-style expression thunks,
   typed whole-array formals with copy or aliasing semantics, and formal
   procedure calls that forward scalar, whole-array, label, switch, or

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -168,6 +168,25 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [3]
 
+    def test_standard_numeric_builtin_functions_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; real x, y; "
+            "x := 0.0 - 2.5; y := abs(x); "
+            "if y > 2.4 then result := 10 else result := 0; "
+            "result := result + abs(0 - 7) + sign(x) + sign(0) + sign(5) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [17]
+
+    def test_entier_floors_positive_and_negative_reals(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 0.0 - 2.1; "
+            "result := entier(2.9) * 10 + entier(x) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [17]
+
     def test_builtin_print_string_literal_writes_stdout(self) -> None:
         result = compile_source("begin integer result; print('Hi'); result := 7 end")
         captured: list[str] = []


### PR DESCRIPTION
## Summary
- adds standard ALGOL numeric builtins `abs`, `sign`, and `entier` to semantic resolution as read-only builtin functions
- lowers the builtins directly to existing integer/f64 IR operations, including real `abs`, integer/real `sign`, and floor-style `entier`
- adds type-checker, IR, and WASM coverage plus docs/changelog updates

## Tests
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check origin/main`

## Security
- Diff scan for process/network/file-write/secret patterns: no findings.