### PR TITLE
feat(beam): TW03 Phase 2 — closures via apply/3 on real Erlang/OTP 28

### DIFF
--- a/code/packages/python/beam-bytecode-encoder/CHANGELOG.md
+++ b/code/packages/python/beam-bytecode-encoder/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — beam-bytecode-encoder
 
+## 0.2.0 — 2026-04-29 — BEAM02 Phase 2b (FunT scaffolding)
+
+### Added — ``FunT`` chunk encoding
+
+- ``BEAMFun`` dataclass — one row of the ``FunT`` (function)
+  table.  Fields: ``function_atom_index``, ``arity``,
+  ``code_label``, ``index``, ``num_free``, ``old_uniq``.
+- ``BEAMModule.funs`` field — populates the ``FunT`` chunk;
+  the chunk is omitted when empty.
+- Validation rules for ``FunT`` rows: rejects out-of-range atom
+  indices, ``code_label`` exceeding ``label_count``, non-sequential
+  ``index`` values, negative ``num_free`` / ``arity``.
+- ``old_uniq`` values wider than 32 bits are silently truncated
+  to fit the ``u32`` field — useful when callers compute uniqs
+  from a wider hash without downcasting first.
+
+This is infrastructure for the ``make_fun2`` / ``make_fun3``
+closure-construction opcodes.  The ir-to-beam Phase 2 lowering
+ended up using a list-based closure representation +
+``erlang:apply/3`` instead (modern OTP rejects ``make_fun2`` and
+``make_fun3`` needs z-tagged extended-list operands), so the
+``FunT`` chunk is currently unused by Twig — but the encoder
+support stays for future work that wants real BEAM funs.
+
 ## 0.1.0 — 2026-04-29
 
 ### Added — BEAM01 Phase 2: pure encoder

--- a/code/packages/python/beam-bytecode-encoder/src/beam_bytecode_encoder/__init__.py
+++ b/code/packages/python/beam-bytecode-encoder/src/beam_bytecode_encoder/__init__.py
@@ -7,6 +7,7 @@ This is BEAM01 Phase 2.  See
 from beam_bytecode_encoder.encoder import (
     BEAMEncodeError,
     BEAMExport,
+    BEAMFun,
     BEAMImport,
     BEAMInstruction,
     BEAMModule,
@@ -19,6 +20,7 @@ from beam_bytecode_encoder.encoder import (
 __all__ = [
     "BEAMEncodeError",
     "BEAMExport",
+    "BEAMFun",
     "BEAMImport",
     "BEAMInstruction",
     "BEAMModule",

--- a/code/packages/python/beam-bytecode-encoder/src/beam_bytecode_encoder/encoder.py
+++ b/code/packages/python/beam-bytecode-encoder/src/beam_bytecode_encoder/encoder.py
@@ -135,6 +135,45 @@ class BEAMExport:
 
 
 @dataclass(frozen=True)
+class BEAMFun:
+    """One row of the ``FunT`` (fun) table — describes a closure /
+    lambda lifted from the source program.
+
+    BEAM has first-class fun objects; the ``FunT`` chunk plus the
+    ``make_fun2`` opcode together let us construct closure values
+    that capture free variables.  See
+    ``code/specs/BEAM02-closure-lowering.md`` for the lowering plan.
+
+    Fields:
+
+    * ``function_atom_index`` — 1-based atom-table index of the
+      lifted lambda's name (e.g. ``_lambda_0`` interned as an atom).
+    * ``arity`` — the lambda's parameter count, NOT counting
+      captured free variables.
+    * ``code_label`` — BEAM label number where the lambda body
+      starts.  Must match the label used by the ``make_fun2``
+      opcode at the construction site.
+    * ``index`` — fun-table entry index, sequential from 0.  Real
+      ``erlc`` mirrors this in the chunk's ``index`` column.
+    * ``num_free`` — count of captured free variables.  Determines
+      how many x-registers ``make_fun2`` reads at the construction
+      site.
+    * ``old_uniq`` — a 32-bit hash used by Erlang's loader to
+      version funs across module reloads.  Real ``erlc`` computes
+      a CRC32 of the function body; for first-emit modules a
+      stable derived value (e.g. CRC32 of the lambda's IR label
+      name) is acceptable and what we use.
+    """
+
+    function_atom_index: int
+    arity: int
+    code_label: int
+    index: int
+    num_free: int
+    old_uniq: int
+
+
+@dataclass(frozen=True)
 class BEAMModule:
     """Structural description of a BEAM module ready for encoding.
 
@@ -171,6 +210,7 @@ class BEAMModule:
     imports: tuple[BEAMImport, ...] = ()
     exports: tuple[BEAMExport, ...] = ()
     locals_: tuple[BEAMExport, ...] = ()
+    funs: tuple[BEAMFun, ...] = ()
     label_count: int = 0
     max_opcode: int = 0
     instruction_set_version: int = 0
@@ -348,6 +388,38 @@ def _encode_imports(imports: tuple[BEAMImport, ...]) -> bytes:
     return bytes(out)
 
 
+def _encode_funt(funs: tuple[BEAMFun, ...]) -> bytes:
+    """Encode the ``FunT`` chunk.
+
+    Layout::
+
+        <u32 BE>  count
+        for each row:
+          <u32 BE>  function_atom_index
+          <u32 BE>  arity
+          <u32 BE>  code_label
+          <u32 BE>  index
+          <u32 BE>  num_free
+          <u32 BE>  old_uniq
+
+    Each row is 24 bytes.  See ``BEAMFun`` for field semantics.
+    """
+    out = bytearray(struct.pack(">I", len(funs)))
+    for fun in funs:
+        out.extend(
+            struct.pack(
+                ">IIIIII",
+                fun.function_atom_index,
+                fun.arity,
+                fun.code_label,
+                fun.index,
+                fun.num_free,
+                fun.old_uniq & 0xFFFFFFFF,  # mask to 32 bits
+            )
+        )
+    return bytes(out)
+
+
 def _encode_exports(exports: tuple[BEAMExport, ...]) -> bytes:
     """Encode the ``ExpT`` or ``LocT`` chunk.
 
@@ -421,6 +493,12 @@ def encode_beam(module: BEAMModule) -> bytes:
     ]
     if module.locals_:
         chunks.append(("LocT", _encode_exports(module.locals_)))
+    if module.funs:
+        # ``FunT`` goes after ``LocT`` per the conventional chunk
+        # ordering ``erlc`` uses.  Order isn't strictly load-bearing
+        # (the BEAM loader looks chunks up by ID, not position) but
+        # matching ``erlc`` keeps disassembler output predictable.
+        chunks.append(("FunT", _encode_funt(module.funs)))
     chunks.extend(module.extra_chunks)
 
     body = bytearray(b"BEAM")
@@ -478,3 +556,37 @@ def _validate(module: BEAMModule) -> None:
                     f"label_count is {module.label_count}"
                 )
                 raise BEAMEncodeError(msg)
+
+    # FunT — same atom-index + label sanity, plus monotonic
+    # ``index`` field check (real ``erlc`` always emits index
+    # rows in 0..N-1 order; the loader doesn't enforce it but
+    # disassembler tooling tends to assume it).
+    for i, fun in enumerate(module.funs):
+        if fun.function_atom_index < 1 or fun.function_atom_index > n_atoms:
+            msg = (
+                f"FunT row references function_atom_index="
+                f"{fun.function_atom_index} but only {n_atoms} atoms "
+                "are declared"
+            )
+            raise BEAMEncodeError(msg)
+        if fun.code_label < 1:
+            msg = f"FunT row code_label must be >= 1, got {fun.code_label}"
+            raise BEAMEncodeError(msg)
+        if module.label_count and fun.code_label > module.label_count:
+            msg = (
+                f"FunT row references code_label {fun.code_label} but "
+                f"label_count is {module.label_count}"
+            )
+            raise BEAMEncodeError(msg)
+        if fun.index != i:
+            msg = (
+                f"FunT row {i} has index={fun.index}; convention is to "
+                "number rows sequentially from 0 in declaration order"
+            )
+            raise BEAMEncodeError(msg)
+        if fun.num_free < 0:
+            msg = f"FunT row num_free must be >= 0, got {fun.num_free}"
+            raise BEAMEncodeError(msg)
+        if fun.arity < 0:
+            msg = f"FunT row arity must be >= 0, got {fun.arity}"
+            raise BEAMEncodeError(msg)

--- a/code/packages/python/beam-bytecode-encoder/tests/test_encode_module.py
+++ b/code/packages/python/beam-bytecode-encoder/tests/test_encode_module.py
@@ -20,6 +20,7 @@ import pytest
 from beam_bytecode_encoder import (
     BEAMEncodeError,
     BEAMExport,
+    BEAMFun,
     BEAMImport,
     BEAMInstruction,
     BEAMModule,
@@ -257,3 +258,128 @@ class TestValidation:
                     label_count=1,
                 )
             )
+
+
+class TestFunT:
+    """``FunT`` chunk encoding for closures (BEAM02 Phase 2b)."""
+
+    def _module_with_fun(self, fun: BEAMFun) -> BEAMModule:
+        return BEAMModule(
+            name="m",
+            atoms=("m", "_lambda_0"),
+            instructions=(),
+            exports=(BEAMExport(1, 0, 1),),
+            funs=(fun,),
+            label_count=2,
+        )
+
+    def test_funt_chunk_emitted_when_funs_present(self) -> None:
+        module = self._module_with_fun(
+            BEAMFun(
+                function_atom_index=2,
+                arity=1,
+                code_label=2,
+                index=0,
+                num_free=1,
+                old_uniq=0xDEADBEEF,
+            )
+        )
+        chunks = _parse_chunks(encode_beam(module))
+        assert "FunT" in chunks
+
+    def test_funt_chunk_omitted_when_no_funs(self) -> None:
+        module = BEAMModule(
+            name="m",
+            atoms=("m",),
+            instructions=(),
+            exports=(BEAMExport(1, 0, 1),),
+            label_count=1,
+        )
+        chunks = _parse_chunks(encode_beam(module))
+        assert "FunT" not in chunks
+
+    def test_funt_row_layout(self) -> None:
+        module = self._module_with_fun(
+            BEAMFun(
+                function_atom_index=2,
+                arity=3,
+                code_label=2,
+                index=0,
+                num_free=2,
+                old_uniq=0x12345678,
+            )
+        )
+        chunks = _parse_chunks(encode_beam(module))
+        funt = chunks["FunT"]
+        # First 4 bytes: count.
+        assert struct.unpack(">I", funt[:4])[0] == 1
+        # Then 6 × u32 = 24 bytes per row.
+        row = struct.unpack(">IIIIII", funt[4:28])
+        assert row == (2, 3, 2, 0, 2, 0x12345678)
+
+    def test_funt_validation_rejects_bad_atom_index(self) -> None:
+        with pytest.raises(BEAMEncodeError, match="function_atom_index"):
+            encode_beam(
+                self._module_with_fun(
+                    BEAMFun(
+                        function_atom_index=99,  # out of bounds
+                        arity=1,
+                        code_label=2,
+                        index=0,
+                        num_free=0,
+                        old_uniq=0,
+                    )
+                )
+            )
+
+    def test_funt_validation_rejects_bad_label(self) -> None:
+        with pytest.raises(BEAMEncodeError, match="code_label"):
+            encode_beam(
+                self._module_with_fun(
+                    BEAMFun(
+                        function_atom_index=2,
+                        arity=1,
+                        code_label=99,  # exceeds label_count=2
+                        index=0,
+                        num_free=0,
+                        old_uniq=0,
+                    )
+                )
+            )
+
+    def test_funt_validation_rejects_non_sequential_index(self) -> None:
+        with pytest.raises(BEAMEncodeError, match="number rows sequentially"):
+            encode_beam(
+                self._module_with_fun(
+                    BEAMFun(
+                        function_atom_index=2,
+                        arity=1,
+                        code_label=2,
+                        index=5,  # should be 0 (first row)
+                        num_free=0,
+                        old_uniq=0,
+                    )
+                )
+            )
+
+    def test_funt_old_uniq_truncates_to_32_bits(self) -> None:
+        """A 64-bit ``old_uniq`` is silently truncated to 32 bits.
+
+        Useful when callers compute uniqs from a wider hash without
+        downcasting first.
+        """
+        module = self._module_with_fun(
+            BEAMFun(
+                function_atom_index=2,
+                arity=1,
+                code_label=2,
+                index=0,
+                num_free=0,
+                old_uniq=0x1_FFFFFFFF,  # > 32 bits
+            )
+        )
+        chunks = _parse_chunks(encode_beam(module))
+        funt = chunks["FunT"]
+        # Last u32 of the row is old_uniq.
+        old_uniq = struct.unpack(">I", funt[24:28])[0]
+        assert old_uniq == 0xFFFFFFFF

--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added — TW03 Phase 2 closure ops
 
-- **``IrOp.MAKE_CLOSURE`` (25)** — construct a closure value
+- **``IrOp.MAKE_CLOSURE`` (47)** — construct a closure value
   capturing free variables from the enclosing scope.  Operand
   layout: ``MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...``
-- **``IrOp.APPLY_CLOSURE`` (26)** — invoke a closure value with
+- **``IrOp.APPLY_CLOSURE`` (48)** — invoke a closure value with
   zero or more arguments.  Operand layout:
   ``APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...``
 

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -279,7 +279,7 @@ class IrOp(IntEnum):
     #               free-variable list maps to the captured registers.
     #   - vm-core:  delegate to the host-side ``make_closure`` builtin
     #               (already implemented in TW00).
-    MAKE_CLOSURE = 25
+    MAKE_CLOSURE = 47
 
     # Apply a closure value to zero or more arguments.
     #
@@ -297,7 +297,7 @@ class IrOp(IntEnum):
     #   - BEAM:     emit ``call_fun`` (or ``call_fun2``) on the closure
     #               handle.
     #   - vm-core:  delegate to the host-side ``apply_closure`` builtin.
-    APPLY_CLOSURE = 26
+    APPLY_CLOSURE = 48
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -99,8 +99,9 @@ class TestIrOp:
         assert IrOp.I32_TRUNC_FROM_F64 == 46
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 47 opcodes after adding f64-to-i32 truncation."""
-        assert len(IrOp) == 47
+        """There are exactly 49 opcodes after adding TW03 Phase 2 closure ops
+        (MAKE_CLOSURE = 47, APPLY_CLOSURE = 48) on top of the existing 47."""
+        assert len(IrOp) == 49
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1006,6 +1007,21 @@ class TestAllOpcodesPrintParse:
             IrOp.F64_CMP_GE:   [IrRegister(4), IrRegister(1), IrRegister(2)],
             IrOp.F64_FROM_I32: [IrRegister(2), IrRegister(1)],
             IrOp.I32_TRUNC_FROM_F64: [IrRegister(2), IrRegister(1)],
+            # MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1
+            IrOp.MAKE_CLOSURE: [
+                IrRegister(0),
+                IrLabel("_lambda_0"),
+                IrImmediate(2),
+                IrRegister(1),
+                IrRegister(2),
+            ],
+            # APPLY_CLOSURE dst, closure_reg, num_args, arg0
+            IrOp.APPLY_CLOSURE: [
+                IrRegister(0),
+                IrRegister(3),
+                IrImmediate(1),
+                IrRegister(4),
+            ],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/packages/python/ir-to-beam/CHANGELOG.md
+++ b/code/packages/python/ir-to-beam/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog — ir-to-beam
 
+## 0.3.0 — 2026-04-29 — TW03 Phase 2 (BEAM closures)
+
+### Added — ``MAKE_CLOSURE`` and ``APPLY_CLOSURE`` lowering
+
+- ``MAKE_CLOSURE dst, fn_label, num_captured, capt0, ..., captN-1``
+  lowers to a chain of ``put_list`` opcodes that build the closure
+  value as the cons cell ``[FnAtom | [capt0, capt1, ..., captN-1]]``
+  on the heap (preceded by a ``test_heap`` reservation).
+- ``APPLY_CLOSURE dst, closure, num_args, arg0, ..., argM-1``
+  lowers to: build args list, ``get_tl`` for captures,
+  ``erlang:'++'/2`` to glue them, ``get_hd`` for the function
+  atom, then ``erlang:apply/3`` for the dynamic dispatch.
+- ``BEAMBackendConfig.closure_free_var_counts`` — declares which
+  callable regions are lifted lambda bodies and how many captured
+  free variables each takes.  The backend widens
+  ``arity_overrides[name]`` to ``num_free + explicit`` so apply/3
+  can find the lifted lambda by its full arity.
+- Lifted lambdas are now exported (apply/3 needs to look them up
+  by atom name in the export table).
+
+### Why we don't use ``make_fun2`` / ``make_fun3``
+
+Real ``erlc`` emits ``make_fun3`` (opcode 171), which uses the
+z-tagged extended-list compact-term encoding our encoder doesn't
+yet support.  The older ``make_fun2`` (opcode 103) is rejected by
+Erlang/OTP 28 with "please re-compile with an OTP 28 compiler".
+Encoding closures as plain cons-cell lists + ``erlang:apply/3``
+side-steps both problems and uses only standard, well-supported
+opcodes.  The runtime cost is one ``apply`` indirection per
+invocation; the engineering benefit is a closure pipeline that
+loads cleanly under modern OTP.
+
+### Added tests
+
+- ``test_closure_make_adder_returns_42`` —
+  ``((make-adder 7) 35) → 42`` end-to-end on real ``erl``,
+  exercising MAKE_CLOSURE + APPLY_CLOSURE in the same module.
+
 ## 0.2.0 — 2026-04-29 — TW03 Phase 1 (BEAM)
 
 ### Added — branching, comparison, and recursion

--- a/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
+++ b/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
@@ -1,9 +1,39 @@
 """Lower a ``compiler-ir`` ``IrProgram`` into a ``BEAMModule``.
 
-This is BEAM01 Phase 3 + TW03 Phase 1 (BEAM extension).  See
-``code/specs/BEAM01-twig-on-real-erl.md`` and
+This is BEAM01 Phase 3 + TW03 Phase 1 + Phase 2 (BEAM closures).
+See ``code/specs/BEAM01-twig-on-real-erl.md`` and
 ``code/specs/TW03-lisp-primitives-and-gc.md`` for the broader
 plan.
+
+Closure representation (Phase 2)
+================================
+
+Real ``erlc`` emits ``make_fun3`` (opcode 171, OTP 24+) which
+needs the z-tagged extended-list operand encoding our encoder
+doesn't yet support, and modern Erlang/OTP 28 refuses to load
+modules using the older ``make_fun2`` (103) — so we sidestep
+both by representing closures as plain cons cells:
+
+    Closure value = ``[FnAtom | CapturesList]``
+
+where ``FnAtom`` is the lifted lambda's name (an exported
+function in the same module) and ``CapturesList`` is the list
+of captured free-variable values in declaration order.
+
+* ``MAKE_CLOSURE`` lowers to a cascade of ``put_list`` opcodes
+  that consume captures in reverse, then prepends the function
+  atom.
+* ``APPLY_CLOSURE`` lowers to: build the explicit args list,
+  extract captures with ``get_tl``, concatenate with
+  ``erlang:'++'/2``, extract the function atom with ``get_hd``,
+  and dispatch via ``erlang:apply/3``.
+
+Lifted lambdas are exported with arity ``num_free + explicit``
+so ``apply/3`` can find them by name.  The lambda body sees
+``y2..y{1+num_free}`` as captures and
+``y{2+num_free}..y{1+num_free+explicit}`` as explicit args —
+captures-first matches the order we stage them in the apply
+arglist.
 
 Pipeline
 ========
@@ -100,7 +130,6 @@ from compiler_ir import (
     IrRegister,
 )
 
-
 # ---------------------------------------------------------------------------
 # BEAM opcodes we emit (subset of the full table)
 # ---------------------------------------------------------------------------
@@ -110,7 +139,9 @@ _OP_LABEL: Final[int] = 1
 _OP_FUNC_INFO: Final[int] = 2
 _OP_INT_CODE_END: Final[int] = 3
 _OP_CALL: Final[int] = 4
+_OP_CALL_EXT: Final[int] = 7         # call_ext arity import_idx  (preserves frame)
 _OP_ALLOCATE: Final[int] = 12
+_OP_TEST_HEAP: Final[int] = 16       # test_heap heap_need live  (heap reservation)
 _OP_DEALLOCATE: Final[int] = 18
 _OP_RETURN: Final[int] = 19
 _OP_IS_LT: Final[int] = 39           # is_lt fail src1 src2
@@ -118,8 +149,11 @@ _OP_IS_EQ_EXACT: Final[int] = 43     # is_eq_exact fail src1 src2
 _OP_IS_NE_EXACT: Final[int] = 44     # is_ne_exact fail src1 src2
 _OP_JUMP: Final[int] = 61
 _OP_MOVE: Final[int] = 64
+_OP_PUT_LIST: Final[int] = 69        # put_list head tail dst  (build cons cell)
 _OP_CALL_EXT_ONLY: Final[int] = 78
 _OP_GC_BIF2: Final[int] = 125
+_OP_GET_HD: Final[int] = 162         # get_hd src dst  (head of cons cell)
+_OP_GET_TL: Final[int] = 163         # get_tl src dst  (tail of cons cell)
 
 # Minimum ``max_opcode`` value the modern Erlang loader accepts.
 # Loader treats this as a "what BEAM dialect was this compiled
@@ -164,11 +198,29 @@ class BEAMBackendConfig:
     ``y_register_count`` declares how many y-registers each
     function body needs.  Auto-derived from the program's max IR
     register index when ``None`` (the typical case).
+
+    ``closure_free_var_counts`` declares the **lifted lambda**
+    regions: maps region-name → number of captured free
+    variables.  Presence in this dict marks a region as a
+    closure body; absence means a regular function.  For
+    closure regions, ``arity_overrides[name]`` declares the
+    EXPLICIT argument count (the ``(lambda (X) ...)``-level
+    arity, NOT counting captures).  The lifted lambda's full
+    arity (as seen in ``func_info`` / exports / apply) is
+    ``num_free + explicit``.
+
+    Closure body register layout (captures-first matches the
+    arg order ``apply/3`` produces):
+
+      - ``y2..y{1+num_free}``                          — captured free variables
+      - ``y{2+num_free}..y{1+num_free+explicit}``      — explicit args
+      - ``y{2+num_free+explicit}..``                   — body holding registers
     """
 
     module_name: str
     arity_overrides: dict[str, int] = field(default_factory=dict)
     y_register_count: int | None = None
+    closure_free_var_counts: dict[str, int] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -261,17 +313,30 @@ class _Builder:
 
 
 def _discover_callable_names(program: IrProgram) -> set[str]:
-    """All region names that are CALL targets or the entry label.
+    """All region names that are CALL or MAKE_CLOSURE targets,
+    plus the entry label.
 
     Internal labels (``_else_0``, ``_endif_0``, etc.) are NOT
     callable — they're targets of branches/jumps within a single
     function, and they stay as ``label N`` opcodes inside that
     function's body.
+
+    ``MAKE_CLOSURE``'s ``fn_label`` operand also produces a
+    callable region (the lifted lambda body).  We treat it as
+    callable so it gets a func_info + label-target pair like
+    regular functions, even though it's invoked indirectly via
+    ``call_fun`` rather than ``call``.
     """
     callable_names: set[str] = {program.entry_label}
     for instr in program.instructions:
         if instr.opcode is IrOp.CALL:
             target = _operand_label(instr.operands[0], role="CALL target")
+            callable_names.add(target)
+        elif instr.opcode is IrOp.MAKE_CLOSURE:
+            # MAKE_CLOSURE dst, fn_label, num_captured, capt0, ...
+            target = _operand_label(
+                instr.operands[1], role="MAKE_CLOSURE fn_label"
+            )
             callable_names.add(target)
     return callable_names
 
@@ -640,6 +705,181 @@ def _emit_return(
     builder.emit(_OP_RETURN)
 
 
+def _emit_make_closure(
+    builder: _Builder,
+    instr: IrInstruction,
+    fn_atom_for: dict[str, int],
+) -> None:
+    """Lower MAKE_CLOSURE.
+
+    Operand layout (per ``compiler-ir`` docs)::
+
+        MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1, ...
+
+    Closure value: ``[FnAtom | CapturesList]`` (a single cons
+    cell whose head is the function atom and whose tail is the
+    captures list, in declaration order).
+
+    BEAM emission::
+
+        ; Reserve heap for num_captured + 1 cons cells (2 words each).
+        test_heap (2 * (num_captured + 1)) 0
+
+        ; Build the captures list bottom-up: start with [] in x0,
+        ; then prepend each capture starting from the LAST one so
+        ; that the final list reads capt0, capt1, ..., captN-1.
+        move {atom, 0}, {x, 0}                 ; x0 = []  ('nil' encoded as atom 0)
+        put_list {y, captN-1}, {x, 0}, {x, 0}  ; x0 = [captN-1]
+        ...
+        put_list {y, capt0},   {x, 0}, {x, 0}  ; x0 = [capt0, ..., captN-1]
+
+        ; Cons the function atom on the front and store in dst.
+        put_list {atom, FnAtom}, {x, 0}, {y, dst}
+    """
+    if len(instr.operands) < 3:
+        msg = (
+            f"MAKE_CLOSURE expects at least 3 operands "
+            f"(dst, fn_label, num_captured, capt...), got {len(instr.operands)}"
+        )
+        raise BEAMBackendError(msg)
+    dst = _operand_register(instr.operands[0], role="MAKE_CLOSURE dst")
+    fn_label = _operand_label(instr.operands[1], role="MAKE_CLOSURE fn_label")
+    num_captured = _operand_immediate(
+        instr.operands[2], role="MAKE_CLOSURE num_captured"
+    )
+
+    if fn_label not in fn_atom_for:
+        msg = (
+            f"MAKE_CLOSURE references {fn_label!r} but no closure region "
+            "with that name was declared in "
+            "BEAMBackendConfig.closure_free_var_counts"
+        )
+        raise BEAMBackendError(msg)
+    if len(instr.operands) != 3 + num_captured:
+        msg = (
+            f"MAKE_CLOSURE for {fn_label!r}: num_captured={num_captured} "
+            f"but {len(instr.operands) - 3} capture operands provided"
+        )
+        raise BEAMBackendError(msg)
+
+    fn_atom_idx = fn_atom_for[fn_label]
+    cons_count = num_captured + 1
+    builder.emit(_OP_TEST_HEAP, _u(2 * cons_count), _u(0))
+
+    # x0 = []  (nil = atom index 0).
+    builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, 0), _x(0))
+
+    # Cons captures in reverse so the list reads capt0..captN-1.
+    for i in range(num_captured - 1, -1, -1):
+        capt_reg = _operand_register(
+            instr.operands[3 + i], role=f"MAKE_CLOSURE capture {i}"
+        )
+        builder.emit(_OP_PUT_LIST, _y(capt_reg), _x(0), _x(0))
+
+    # Final cons: prepend the function atom, store directly in dst.
+    builder.emit(
+        _OP_PUT_LIST,
+        BEAMOperand(BEAMTag.A, fn_atom_idx),
+        _x(0),
+        _y(dst),
+    )
+
+
+def _emit_apply_closure(
+    builder: _Builder,
+    instr: IrInstruction,
+    *,
+    module_atom_idx: int,
+    pp_import_idx: int,
+    apply_import_idx: int,
+) -> None:
+    """Lower APPLY_CLOSURE.
+
+    Operand layout::
+
+        APPLY_CLOSURE dst, closure_reg, num_args, arg0, arg1, ...
+
+    Closure value (per MAKE_CLOSURE): ``[FnAtom | CapturesList]``.
+    To invoke we need to call ``apply(ThisModule, FnAtom,
+    CapturesList ++ [arg0, ..., argM-1])``.
+
+    BEAM emission::
+
+        ; -- Heap reservation for the num_args explicit args list --
+        test_heap (2 * num_args) 0       ; only emitted if num_args > 0
+
+        ; -- Build the explicit args list directly into x1 --
+        move {atom, 0}, {x, 1}
+        put_list {y, argM-1}, {x, 1}, {x, 1}
+        ...
+        put_list {y, arg0},   {x, 1}, {x, 1}     ; x1 = [arg0, ..., argM-1]
+
+        ; -- Captures list into x0 --
+        get_tl {y, closure}, {x, 0}              ; x0 = CapturesList
+
+        ; -- erlang:'++'/2 to glue them: x0 = Captures ++ Args --
+        call_ext 2, pp_import_idx-1
+
+        ; -- Stage apply(M, F, FullArgs); use dst as scratch --
+        get_hd {y, closure}, {x, 1}              ; x1 = FnAtom
+        move {x, 0}, {y, dst}                    ; stash combined list
+        move {atom, ThisModule}, {x, 0}          ; x0 = module atom
+        move {y, dst}, {x, 2}                    ; x2 = full args list
+
+        ; -- erlang:apply/3 --
+        call_ext 3, apply_import_idx-1
+        move {x, 0}, {y, dst}                    ; result lands in dst
+
+    The "extract head AFTER ++ but BEFORE overwriting dst" order
+    matters in case ``dst`` aliases ``closure_reg``: once we write
+    the combined list into y{dst}, the closure pointer there is
+    gone, so we must read its head first.
+    """
+    if len(instr.operands) < 3:
+        msg = (
+            f"APPLY_CLOSURE expects at least 3 operands "
+            f"(dst, closure_reg, num_args, args...), got {len(instr.operands)}"
+        )
+        raise BEAMBackendError(msg)
+    dst = _operand_register(instr.operands[0], role="APPLY_CLOSURE dst")
+    closure_reg = _operand_register(
+        instr.operands[1], role="APPLY_CLOSURE closure_reg"
+    )
+    num_args = _operand_immediate(
+        instr.operands[2], role="APPLY_CLOSURE num_args"
+    )
+
+    if len(instr.operands) != 3 + num_args:
+        msg = (
+            f"APPLY_CLOSURE: num_args={num_args} but "
+            f"{len(instr.operands) - 3} arg operands provided"
+        )
+        raise BEAMBackendError(msg)
+
+    if num_args > 0:
+        builder.emit(_OP_TEST_HEAP, _u(2 * num_args), _u(0))
+
+    # Build args list in x1.
+    builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, 0), _x(1))
+    for i in range(num_args - 1, -1, -1):
+        arg_reg = _operand_register(
+            instr.operands[3 + i], role=f"APPLY_CLOSURE arg {i}"
+        )
+        builder.emit(_OP_PUT_LIST, _y(arg_reg), _x(1), _x(1))
+
+    # Captures list into x0, then call ++.
+    builder.emit(_OP_GET_TL, _y(closure_reg), _x(0))
+    builder.emit(_OP_CALL_EXT, _u(2), _u(pp_import_idx - 1))
+
+    # Prepare apply/3 args.  Order matters in case dst == closure_reg.
+    builder.emit(_OP_GET_HD, _y(closure_reg), _x(1))
+    builder.emit(_OP_MOVE, _x(0), _y(dst))
+    builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, module_atom_idx), _x(0))
+    builder.emit(_OP_MOVE, _y(dst), _x(2))
+    builder.emit(_OP_CALL_EXT, _u(3), _u(apply_import_idx - 1))
+    builder.emit(_OP_MOVE, _x(0), _y(dst))
+
+
 _HANDLERS: Final[set[IrOp]] = {
     IrOp.LOAD_IMM,
     IrOp.ADD,
@@ -655,7 +895,9 @@ _HANDLERS: Final[set[IrOp]] = {
     IrOp.CMP_EQ,
     IrOp.CMP_LT,
     IrOp.CMP_GT,
-    IrOp.LABEL,  # internal labels in body
+    IrOp.LABEL,           # internal labels in body
+    IrOp.MAKE_CLOSURE,    # BEAM02 Phase 2 — closure construction
+    IrOp.APPLY_CLOSURE,   # BEAM02 Phase 2 — closure invocation
 }
 
 
@@ -763,7 +1005,41 @@ def lower_ir_to_beam(
                 if internal_name not in label_for:
                     label_for[internal_name] = builder.fresh_label()
 
-    # Pass 3: emit each region's prologue + body + epilogue.
+    # Pre-pass 3: register lambda atoms.  Each closure region
+    # gets its name interned as an atom so MAKE_CLOSURE can
+    # cons-prepend it onto the captures list.  We also bump
+    # arity_for to its FULL value (explicit + num_free) — apply/3
+    # will call the lifted lambda with that many args, so the
+    # exported function's arity must match.  The IR's
+    # ``arity_overrides`` declares the EXPLICIT arity (e.g. 1 for
+    # ``(lambda (x) ...)``) and we widen here.
+    fn_atom_for: dict[str, int] = {}
+    for name, num_free in config.closure_free_var_counts.items():
+        if name not in label_for:
+            msg = (
+                f"closure_free_var_counts references {name!r} but no "
+                "callable region with that label exists in the IR"
+            )
+            raise BEAMBackendError(msg)
+        fn_atom_for[name] = builder.atoms.add(name)
+        arity_for[name] = arity_for[name] + num_free
+
+    # Imports used by APPLY_CLOSURE — declared up front so the
+    # import-table indices are stable regardless of code order.
+    needs_apply = any(
+        instr.opcode is IrOp.APPLY_CLOSURE for instr in program.instructions
+    )
+    if needs_apply:
+        erlang_atom_idx = builder.atoms.add("erlang")
+        pp_atom_idx = builder.atoms.add("++")
+        apply_atom_idx = builder.atoms.add("apply")
+        pp_import_idx = builder.imports.add(erlang_atom_idx, pp_atom_idx, 2)
+        apply_import_idx = builder.imports.add(erlang_atom_idx, apply_atom_idx, 3)
+    else:
+        pp_import_idx = 0
+        apply_import_idx = 0
+
+    # Pass 4: emit each region's prologue + body + epilogue.
     for name, body in regions:
         function_atom_idx = builder.atoms.add(name)
         builder.emit(_OP_LABEL, _u(func_info_label_for[name]))
@@ -778,21 +1054,31 @@ def lower_ir_to_beam(
         # Function entry: allocate y-register frame + copy args
         # from x-registers into the Twig param slots.
         builder.emit(_OP_ALLOCATE, _u(y_reg_count), _u(arity_for[name]))
-        for i in range(arity_for[name]):
+        arity = arity_for[name]
+        for i in range(arity):
             builder.emit(_OP_MOVE, _x(i), _y(_REG_PARAM_BASE + i))
 
-        # Body.
+        # Body.  Lifted lambdas need no special entry shuffle:
+        # arity_for[name] already includes captures, so the loop
+        # above copied ALL of x0..x{full_arity-1} into the
+        # captures-then-explicit slots in one pass, matching the
+        # apply-time arglist order ``[Caps... | Args...]``.
         for instr in body:
             _emit_body_instruction(
                 builder,
                 instr,
                 label_for=label_for,
                 arity_for=arity_for,
+                fn_atom_for=fn_atom_for,
+                module_atom_idx=module_atom_idx,
+                pp_import_idx=pp_import_idx,
+                apply_import_idx=apply_import_idx,
                 y_reg_count=y_reg_count,
             )
 
-        # Each user region is exported (Twig has no module-private
-        # functions in v1).
+        # Lifted lambdas MUST be exported because ``apply/3``
+        # looks up the function by atom name in the module's
+        # export table.  Regular user functions are also exported.
         builder.exports.append(
             BEAMExport(
                 function_atom_index=function_atom_idx,
@@ -842,6 +1128,7 @@ def lower_ir_to_beam(
         imports=builder.imports.as_tuple(),
         exports=tuple(builder.exports),
         locals_=(),
+        funs=(),
         label_count=builder.next_label,
         max_opcode=_MIN_RUNTIME_MAX_OPCODE,
         extra_chunks=(
@@ -857,12 +1144,16 @@ def _emit_body_instruction(
     *,
     label_for: dict[str, int],
     arity_for: dict[str, int],
+    fn_atom_for: dict[str, int],
+    module_atom_idx: int,
+    pp_import_idx: int,
+    apply_import_idx: int,
     y_reg_count: int,
 ) -> None:
     op = instr.opcode
     if op not in _HANDLERS:
         msg = (
-            f"unsupported IR op {op.name} for BEAM TW03 Phase 1 — "
+            f"unsupported IR op {op.name} for BEAM — "
             f"supported ops: {_supported_op_summary()}"
         )
         raise BEAMBackendError(msg)
@@ -893,6 +1184,18 @@ def _emit_body_instruction(
         return
     if op is IrOp.RET:
         _emit_return(builder, instr, y_reg_count=y_reg_count)
+        return
+    if op is IrOp.MAKE_CLOSURE:
+        _emit_make_closure(builder, instr, fn_atom_for)
+        return
+    if op is IrOp.APPLY_CLOSURE:
+        _emit_apply_closure(
+            builder,
+            instr,
+            module_atom_idx=module_atom_idx,
+            pp_import_idx=pp_import_idx,
+            apply_import_idx=apply_import_idx,
+        )
         return
     msg = f"internal: missing handler dispatch for {op.name}"
     raise BEAMBackendError(msg)

--- a/code/packages/python/ir-to-beam/tests/test_lower_basic.py
+++ b/code/packages/python/ir-to-beam/tests/test_lower_basic.py
@@ -312,3 +312,239 @@ class TestOpcodeChoices:
         assert 12 in used   # allocate
         assert 18 in used   # deallocate
         assert 4 in used    # call
+
+
+# ---------------------------------------------------------------------------
+# TW03 Phase 2 — closure lowering shape
+# ---------------------------------------------------------------------------
+
+
+class TestClosureLowering:
+    """Structural tests for MAKE_CLOSURE / APPLY_CLOSURE lowering.
+
+    These assert on the emitted BEAMModule (atoms / instructions /
+    exports / imports) rather than running anything against ``erl``,
+    so they cover the closure code paths in CI environments without
+    Erlang installed.  The end-to-end ``((make-adder 7) 35) → 42``
+    test against real ``erl`` lives in ``test_real_erl.py``.
+    """
+
+    def _build_closure_program(self) -> IrProgram:
+        """The hand-built closure_adder fixture used throughout —
+        ``make_adder(N) = lambda(X) -> X + N``, called as
+        ``main() = (make_adder(7))(35)``.
+        """
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+
+        # _lambda_0(N, X) — captures-first layout: y2=N, y3=X.
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [_label("_lambda_0")], id=-1)
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.ADD, [_reg(1), _reg(2), _reg(3)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        # make_adder(n) -> closure capturing n.
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [_label("make_adder")], id=-1)
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [_reg(1), _label("_lambda_0"), _imm(1), _reg(2)],
+                id=gen.next(),
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        # main(): call make_adder(7), then APPLY_CLOSURE with 35.
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(7)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.CALL, [_label("make_adder")], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.ADD_IMM, [_reg(10), _reg(1), _imm(0)], id=gen.next()
+            )
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(11), _imm(35)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.APPLY_CLOSURE,
+                [_reg(1), _reg(10), _imm(1), _reg(11)],
+                id=gen.next(),
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        return program
+
+    def _config(self) -> BEAMBackendConfig:
+        # Lambda's explicit arity is 1 (X); the backend widens to 2
+        # internally because num_free=1 (N).
+        return BEAMBackendConfig(
+            module_name="closure_adder",
+            arity_overrides={"_lambda_0": 1, "make_adder": 1, "main": 0},
+            closure_free_var_counts={"_lambda_0": 1},
+        )
+
+    def test_apply_imports_pp_and_apply_3_bifs(self) -> None:
+        """``erlang:'++'/2`` and ``erlang:apply/3`` get wired into the
+        ImpT table when APPLY_CLOSURE appears anywhere in the IR."""
+        m = lower_ir_to_beam(self._build_closure_program(), self._config())
+        triples = {
+            (m.atoms[imp.module_atom_index - 1], m.atoms[imp.function_atom_index - 1], imp.arity)
+            for imp in m.imports
+        }
+        assert ("erlang", "++", 2) in triples
+        assert ("erlang", "apply", 3) in triples
+
+    def test_lifted_lambda_is_exported_with_full_arity(self) -> None:
+        """The lifted ``_lambda_0`` is exported (apply/3 looks it up
+        by atom name), and its arity equals ``num_free + explicit``
+        — for ``(lambda (x) ...)`` capturing 1 var, that's 2."""
+        m = lower_ir_to_beam(self._build_closure_program(), self._config())
+        exports = {
+            (m.atoms[ex.function_atom_index - 1], ex.arity) for ex in m.exports
+        }
+        assert ("_lambda_0", 2) in exports
+
+    def test_make_closure_emits_put_list_chain(self) -> None:
+        """MAKE_CLOSURE lowers to a chain of ``put_list`` opcodes
+        (69) preceded by a ``test_heap`` (16); no ``make_fun*``
+        opcode appears."""
+        m = lower_ir_to_beam(self._build_closure_program(), self._config())
+        opcodes = [ins.opcode for ins in m.instructions]
+        assert 16 in opcodes  # test_heap
+        assert 69 in opcodes  # put_list
+        assert 103 not in opcodes  # NO make_fun2
+        assert 171 not in opcodes  # NO make_fun3
+
+    def test_apply_closure_emits_get_hd_get_tl_call_ext(self) -> None:
+        """APPLY_CLOSURE lowers using ``get_hd`` (162), ``get_tl``
+        (163), and ``call_ext`` (7) for the apply/3 dispatch."""
+        m = lower_ir_to_beam(self._build_closure_program(), self._config())
+        opcodes = [ins.opcode for ins in m.instructions]
+        assert 162 in opcodes  # get_hd
+        assert 163 in opcodes  # get_tl
+        assert 7 in opcodes    # call_ext
+
+    def test_no_make_fun_nor_call_fun(self) -> None:
+        """Sanity: even though the Phase 2b FunT scaffolding exists,
+        the Phase 2c lowering deliberately avoids ``make_fun*`` and
+        ``call_fun`` because OTP 28 rejects the former and the
+        latter only pairs with funs."""
+        m = lower_ir_to_beam(self._build_closure_program(), self._config())
+        opcodes = {ins.opcode for ins in m.instructions}
+        assert 75 not in opcodes   # call_fun
+        assert 76 not in opcodes   # make_fun
+        assert 103 not in opcodes  # make_fun2
+        assert 171 not in opcodes  # make_fun3
+        # And no FunT chunk gets emitted — funs tuple is empty.
+        assert m.funs == ()
+
+    def test_make_closure_with_zero_captures(self) -> None:
+        """MAKE_CLOSURE with num_captured=0 (a function value with
+        no captures) still emits a 1-element list ``[FnAtom]``."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [_label("_lambda_0")], id=-1)
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [_reg(1), _imm(7)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [_reg(1), _label("_lambda_0"), _imm(0)],
+                id=gen.next(),
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+        m = lower_ir_to_beam(
+            program,
+            BEAMBackendConfig(
+                module_name="zero_caps",
+                arity_overrides={"_lambda_0": 0, "main": 0},
+                closure_free_var_counts={"_lambda_0": 0},
+            ),
+        )
+        opcodes = [ins.opcode for ins in m.instructions]
+        assert 69 in opcodes  # put_list — still needed for the [Fn] cons
+        assert 16 in opcodes  # test_heap reservation
+
+    def test_make_closure_unknown_lambda_rejected(self) -> None:
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [_reg(1), _label("nope"), _imm(0)],
+                id=gen.next(),
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        with pytest.raises(BEAMBackendError, match="no closure region"):
+            lower_ir_to_beam(
+                program,
+                BEAMBackendConfig(
+                    module_name="bad",
+                    arity_overrides={"main": 0},
+                    # Note: closure_free_var_counts left empty so the
+                    # MAKE_CLOSURE target ``nope`` is unknown.
+                ),
+            )
+
+    def test_make_closure_capture_count_mismatch_rejected(self) -> None:
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [_label("_lambda_0")], id=-1)
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        # Says num_captured=2 but only 1 capture operand provided.
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [_reg(1), _label("_lambda_0"), _imm(2), _reg(2)],
+                id=gen.next(),
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        with pytest.raises(BEAMBackendError, match="capture operands"):
+            lower_ir_to_beam(
+                program,
+                BEAMBackendConfig(
+                    module_name="bad",
+                    arity_overrides={"_lambda_0": 0, "main": 0},
+                    closure_free_var_counts={"_lambda_0": 2},
+                ),
+            )
+
+    def test_closure_free_var_counts_unknown_region_rejected(self) -> None:
+        gen = IDGenerator()
+        program = IrProgram(entry_label="main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+        program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+        with pytest.raises(BEAMBackendError, match="no\\s+callable region"):
+            lower_ir_to_beam(
+                program,
+                BEAMBackendConfig(
+                    module_name="bad",
+                    arity_overrides={"main": 0},
+                    closure_free_var_counts={"_ghost_lambda": 1},
+                ),
+            )

--- a/code/packages/python/ir-to-beam/tests/test_real_erl.py
+++ b/code/packages/python/ir-to-beam/tests/test_real_erl.py
@@ -258,3 +258,101 @@ def test_recursive_factorial_returns_120(tmp_path: Path) -> None:
         f"factorial result mismatch — stdout={result.stdout!r}, "
         f"stderr={result.stderr!r}"
     )
+
+
+@requires_erl
+def test_closure_make_adder_returns_42(tmp_path: Path) -> None:
+    """The headline BEAM02 Phase 2 test: ``((make-adder 7) 35) → 42``.
+
+    Hand-built IR mirroring what twig-beam-compiler will emit for
+    ``(define (make-adder n) (lambda (x) (+ x n))) ((make-adder 7) 35)``,
+    exercising the full closure pipeline end-to-end on real ``erl``:
+
+    - ``MAKE_CLOSURE`` lowering → cons-cell ``[FnAtom | Caps]``
+    - ``APPLY_CLOSURE`` lowering → ``erlang:'++'/2`` + ``erlang:apply/3``
+    - Captures-first register layout in the lifted lambda body
+    """
+    gen = IDGenerator()
+    program = IrProgram(entry_label="main")
+
+    # _lambda_0(N, X) — exported with full arity 2 (1 capture + 1 explicit).
+    # Captures-first layout: y2 = N (captured), y3 = X (explicit).
+    # Body: r1 = N + X.
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [_label("_lambda_0")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.ADD, [_reg(1), _reg(2), _reg(3)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # make_adder(n).  Body: r1 = MAKE_CLOSURE(_lambda_0, [n]).
+    # Layout: y2 = arg n, y10 = closure ref.
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [_label("make_adder")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.MAKE_CLOSURE,
+            [_reg(1), _label("_lambda_0"), _imm(1), _reg(2)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # main().  Body: r1 = APPLY_CLOSURE(make_adder(7), [35]).
+    program.add_instruction(IrInstruction(IrOp.LABEL, [_label("main")], id=-1))
+    # call make_adder(7) — stage arg in r2
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(2), _imm(7)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.CALL, [_label("make_adder")], id=gen.next())
+    )
+    # The closure ref is in r1 after CALL.  Save it in r10 so the
+    # arg-staging dance (r2 = 35) doesn't clobber it.
+    program.add_instruction(
+        IrInstruction(IrOp.ADD_IMM, [_reg(10), _reg(1), _imm(0)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [_reg(11), _imm(35)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.APPLY_CLOSURE,
+            [_reg(1), _reg(10), _imm(1), _reg(11)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # arity_overrides for _lambda_0 declares the EXPLICIT arity (1 — the
+    # ``(lambda (x) ...)`` parameter). The backend widens it to 2 (1
+    # capture + 1 explicit) for func_info / exports / apply.
+    config = BEAMBackendConfig(
+        module_name="closure_adder",
+        arity_overrides={"_lambda_0": 1, "make_adder": 1, "main": 0},
+        closure_free_var_counts={"_lambda_0": 1},
+    )
+    beam = encode_beam(lower_ir_to_beam(program, config))
+    (tmp_path / "closure_adder.beam").write_bytes(beam)
+    eval_expr = textwrap.dedent("""
+        {module, _} = code:load_file(closure_adder),
+        Result = closure_adder:main(),
+        io:format("~p~n", [Result]),
+        init:stop().
+    """).strip()
+    result = subprocess.run(
+        ["erl", "-noshell", "-pa", str(tmp_path), "-eval", eval_expr],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, (
+        f"erl rejected the closure module:\n  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+    assert result.stdout.strip() == "42", (
+        f"closure result mismatch — stdout={result.stdout!r}, "
+        f"stderr={result.stderr!r}"
+    )

--- a/code/packages/python/twig-beam-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-beam-compiler/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — twig-beam-compiler
 
+## 0.3.0 — 2026-04-29 — TW03 Phase 2 (BEAM closures)
+
+### Added — anonymous lambdas and closure invocation
+
+- Anonymous ``(lambda (x) body)`` forms in expression position
+  are lifted to fresh ``_lambda_N`` top-level regions.  Free-
+  variable analysis (via ``twig.free_vars``) determines what
+  each lifted lambda captures; the use site emits
+  ``MAKE_CLOSURE`` with the current values of those captures.
+- ``Apply`` whose ``fn`` slot is anything other than a known
+  builtin or top-level function name lowers to
+  ``APPLY_CLOSURE``.  This covers calls of let-bound closures,
+  closures returned from other functions, and chained calls
+  like ``((make-adder 7) 35)``.
+- ``BEAMBackendConfig.closure_free_var_counts`` is populated
+  from the lifted-lambda table so ir-to-beam knows the
+  captures-first parameter layout for each lifted region.
+
+### Test additions (54 tests total, 89.56% coverage)
+
+- ``test_lambda_lifts_to_top_level_region`` — IR-shape unit
+  test covering MAKE_CLOSURE emission for a captured value.
+- ``test_closure_call_emits_apply_closure`` — IR-shape unit
+  test for chained closure invocation.
+- ``test_closure_make_adder`` — end-to-end on real ``erl``:
+  ``((make-adder 7) 35) → 42``.
+- ``test_closure_let_bound`` — end-to-end:
+  ``(let ((adder (make-adder 7))) (adder 35)) → 42``.
+
 ## 0.2.0 — 2026-04-29 — TW03 Phase 1 (BEAM)
 
 Closes the language-surface gap on the BEAM backend so Twig
@@ -30,9 +59,8 @@ Phase 1 CLR PR).
   recursion
 - All confirmed passing on local Erlang/OTP
 
-### Out of scope (TW03 Phase 2+)
+### Out of scope at the time (closures landed in 0.3.0; the rest still pending)
 
-- Closures (lambdas)
 - Heap primitives (``cons`` / ``car`` / ``cdr`` / symbols / quote)
 - Explicit I/O via ``erlang:put_chars/1`` (today the result
   channel is the function return value printed by ``-eval``)

--- a/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
+++ b/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
@@ -94,7 +94,7 @@ from twig.ast_nodes import (
     SymLit,
     VarRef,
 )
-
+from twig.free_vars import free_vars
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -218,6 +218,15 @@ class _Compiler:
         # the BEAM backend rejects duplicate label names just like
         # the CIL backend does.
         self._next_label_id = 0
+        # TW03 Phase 2: lifted lambdas.  Each anonymous Lambda
+        # encountered during expression compilation gets a fresh
+        # name like ``_lambda_0`` and is appended here as
+        # (lifted_name, captures, lambda_node) so we can emit its
+        # body region after the user functions.  The closure
+        # value-side machinery (MAKE_CLOSURE / APPLY_CLOSURE) is
+        # emitted at the use site.
+        self._lifted_lambdas: list[tuple[str, list[str], Lambda]] = []
+        self._lambda_counter = 0
 
     # ------------------------------------------------------------------
 
@@ -236,6 +245,20 @@ class _Compiler:
             self._emit_function(name, lam)
 
         self._emit_main(top_level_exprs)
+
+        # Lifted-lambda regions go AFTER ``main`` so ``main`` is
+        # unambiguously the program's entry point in the IR
+        # instruction stream.  ``_compile_expr`` may have appended
+        # to ``self._lifted_lambdas`` while compiling earlier
+        # functions / main; lifted lambdas can also be nested
+        # (lambda inside lambda) so the list grows during this
+        # final pass — iterate by index.
+        i = 0
+        while i < len(self._lifted_lambdas):
+            lifted_name, captures, lam = self._lifted_lambdas[i]
+            self._emit_lifted_lambda(lifted_name, captures, lam)
+            i += 1
+
         return self._program
 
     # ------------------------------------------------------------------
@@ -350,10 +373,7 @@ class _Compiler:
             return self._compile_apply(expr, ctx)
 
         if isinstance(expr, Lambda):
-            raise TwigCompileError(
-                "anonymous lambdas are not yet supported by the BEAM "
-                "backend — see TW03 Phase 2 for closures."
-            )
+            return self._compile_anonymous_lambda(expr, ctx)
 
         if isinstance(expr, SymLit):
             raise TwigCompileError(
@@ -418,54 +438,159 @@ class _Compiler:
         return last
 
     def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
-        if not isinstance(expr.fn, VarRef):
-            raise TwigCompileError(
-                "v1 only supports direct calls of top-level names"
-            )
-        name = expr.fn.name
-
-        if name in _V1_REJECTED_BUILTINS:
-            raise TwigCompileError(
-                f"builtin {name!r} is not yet supported by the BEAM "
-                "backend — see TW03 Phase 3 for heap primitives."
-            )
-
-        if name in _BINARY_OPS:
-            if len(expr.args) != 2:
+        # The fast path: a direct VarRef to a known builtin or
+        # top-level function compiles to ``CALL`` (or an arithmetic
+        # opcode).  Anything else — a Lambda in expression position,
+        # a let-bound closure, the result of a function-returning
+        # call — falls through to the closure path which uses
+        # ``APPLY_CLOSURE`` and dispatches via ``erlang:apply/3``.
+        if isinstance(expr.fn, VarRef):
+            name = expr.fn.name
+            if name in _V1_REJECTED_BUILTINS:
                 raise TwigCompileError(
-                    f"{name!r} expects 2 arguments, got {len(expr.args)}"
+                    f"builtin {name!r} is not yet supported by the BEAM "
+                    "backend — see TW03 Phase 3 for heap primitives."
                 )
-            left = self._compile_expr(expr.args[0], ctx)
-            right = self._compile_expr(expr.args[1], ctx)
-            dest = self._fresh_holding(ctx)
-            self._emit(_BINARY_OPS[name], dest, left, right)
-            return dest
+            if name in _BINARY_OPS:
+                if len(expr.args) != 2:
+                    raise TwigCompileError(
+                        f"{name!r} expects 2 arguments, got {len(expr.args)}"
+                    )
+                left = self._compile_expr(expr.args[0], ctx)
+                right = self._compile_expr(expr.args[1], ctx)
+                dest = self._fresh_holding(ctx)
+                self._emit(_BINARY_OPS[name], dest, left, right)
+                return dest
 
-        if name in self._fn_params:
-            params = self._fn_params[name]
-            if len(expr.args) != len(params):
+            if name in self._fn_params:
+                params = self._fn_params[name]
+                if len(expr.args) != len(params):
+                    raise TwigCompileError(
+                        f"function {name!r} takes {len(params)} arguments, "
+                        f"got {len(expr.args)}"
+                    )
+
+                arg_regs: list[IrRegister] = [
+                    self._compile_expr(a, ctx) for a in expr.args
+                ]
+
+                for i, src in enumerate(arg_regs):
+                    self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+
+                self._emit(IrOp.CALL, IrLabel(name))
+
+                dest = self._fresh_holding(ctx)
+                self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+                return dest
+
+            # Fall through to closure-apply only if the name is
+            # actually bound locally (a let-binding holding a
+            # closure value).  Unbound names are user errors.
+            if name not in ctx.locals_:
                 raise TwigCompileError(
-                    f"function {name!r} takes {len(params)} arguments, "
-                    f"got {len(expr.args)}"
+                    f"unknown function {name!r}.  Supported: binary "
+                    "builtins (+, -, *, /, =, <, >), top-level "
+                    "(define (f ...) ...), and closure values bound "
+                    "via let or returned from another function."
                 )
 
-            arg_regs: list[IrRegister] = [
-                self._compile_expr(a, ctx) for a in expr.args
-            ]
-
-            for i, src in enumerate(arg_regs):
-                self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
-
-            self._emit(IrOp.CALL, IrLabel(name))
-
-            dest = self._fresh_holding(ctx)
-            self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
-            return dest
-
-        raise TwigCompileError(
-            f"unknown function {name!r}.  v1 supports binary builtins "
-            "(+, -, *, /, =, <, >) and top-level (define (f ...) ...)."
+        # Closure path: compile fn to a register holding a closure
+        # value, then APPLY_CLOSURE with the explicit args.
+        closure_reg = self._compile_expr(expr.fn, ctx)
+        arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+        dest = self._fresh_holding(ctx)
+        self._emit(
+            IrOp.APPLY_CLOSURE,
+            dest,
+            closure_reg,
+            IrImmediate(len(arg_regs)),
+            *arg_regs,
         )
+        return dest
+
+    # ------------------------------------------------------------------
+    # Closure compilation (TW03 Phase 2)
+    # ------------------------------------------------------------------
+
+    def _compile_anonymous_lambda(
+        self, lam: Lambda, outer: _FnCtx
+    ) -> IrRegister:
+        """Lift ``lam`` to a fresh top-level function and emit a
+        ``MAKE_CLOSURE`` at the use site.
+
+        Free-variable analysis (``twig.free_vars``) determines what
+        the lambda captures from its enclosing scope.  Each
+        capture must already be bound in ``outer.locals_`` —
+        otherwise we'd be referring to a name that doesn't resolve.
+        """
+        globals_ = (
+            set(self._fn_params)
+            | set(self._value_consts)
+            | set(_BINARY_OPS)
+            | _V1_REJECTED_BUILTINS
+        )
+        captures = free_vars(lam, globals_)
+
+        for c in captures:
+            if c not in outer.locals_:
+                raise TwigCompileError(
+                    f"unbound name {c!r} captured by lambda — "
+                    "did you forget a (define) or a (let ...) binding?"
+                )
+
+        lifted_name = f"_lambda_{self._lambda_counter}"
+        self._lambda_counter += 1
+        self._lifted_lambdas.append((lifted_name, captures, lam))
+
+        # Materialise MAKE_CLOSURE at the use site.  The IR op
+        # carries the captured values as their *current* IR
+        # registers in ``outer``.
+        capture_regs = [outer.locals_[c] for c in captures]
+        dest = self._fresh_holding(outer)
+        self._emit(
+            IrOp.MAKE_CLOSURE,
+            dest,
+            IrLabel(lifted_name),
+            IrImmediate(len(captures)),
+            *capture_regs,
+        )
+        return dest
+
+    def _emit_lifted_lambda(
+        self,
+        lifted_name: str,
+        captures: list[str],
+        lam: Lambda,
+    ) -> None:
+        """Emit a callable region for a lifted lambda body.
+
+        Captures-first parameter layout (matching the
+        ``[Caps... | Args...]`` arglist that ir-to-beam stages
+        when calling via apply/3): the lifted function's IR
+        register layout is
+
+            r2..r{1+num_free}                    — captures
+            r{2+num_free}..r{1+num_free+arity}   — explicit params
+            r{10+}                               — body holding regs
+        """
+        self._emit(IrOp.LABEL, IrLabel(name=lifted_name), id=-1)
+        ctx = _FnCtx(locals_={})
+
+        all_params = captures + list(lam.params)
+        for i, param in enumerate(all_params):
+            arrival = IrRegister(index=_REG_PARAM_BASE + i)
+            body_local = self._fresh_holding(ctx)
+            self._emit_move(body_local, arrival)
+            ctx.locals_[param] = body_local
+
+        last: IrRegister | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            raise TwigCompileError(f"lambda {lifted_name!r} has empty body")
+
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.RET)
 
     # ------------------------------------------------------------------
     # IR-emission helpers
@@ -545,10 +670,18 @@ def compile_source(
     # Build arity overrides for every top-level function the
     # compiler discovered.  ``ir-to-beam`` needs these to emit
     # the right ``call N, label`` arity at each call site and to
-    # declare the right parameter count per function.
+    # declare the right parameter count per function.  For
+    # lifted lambdas, ``arity_overrides`` carries the EXPLICIT
+    # arity (the ``(lambda (x) ...)``-level count) — the BEAM
+    # backend widens this internally to ``num_free + explicit``
+    # using ``closure_free_var_counts``.
     arity_overrides = {
         name: len(params) for name, params in compiler._fn_params.items()  # noqa: SLF001
     }
+    closure_free_var_counts: dict[str, int] = {}
+    for lifted_name, captures, lam in compiler._lifted_lambdas:  # noqa: SLF001
+        arity_overrides[lifted_name] = len(lam.params)
+        closure_free_var_counts[lifted_name] = len(captures)
 
     try:
         beam_module = lower_ir_to_beam(
@@ -556,6 +689,7 @@ def compile_source(
             BEAMBackendConfig(
                 module_name=module_name,
                 arity_overrides=arity_overrides,
+                closure_free_var_counts=closure_free_var_counts,
             ),
         )
         beam_bytes = encode_beam(beam_module)

--- a/code/packages/python/twig-beam-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_compile.py
@@ -100,12 +100,45 @@ class TestSupportedSurface:
         # Value defines fold to compile-time constants — only main.
         assert region_labels == ["main"]
 
+    def test_lambda_lifts_to_top_level_region(self) -> None:
+        """An anonymous lambda becomes a fresh ``_lambda_N`` region
+        and the use site emits MAKE_CLOSURE referencing it."""
+        ir = compile_to_ir(
+            "(define (make-adder n) (lambda (x) (+ x n))) (make-adder 7)"
+        )
+        labels = [
+            ins.operands[0].name
+            for ins in ir.instructions
+            if ins.opcode is IrOp.LABEL
+            and isinstance(ins.operands[0], IrLabel)
+        ]
+        assert "make-adder" in labels
+        assert "main" in labels
+        assert "_lambda_0" in labels
+
+        # MAKE_CLOSURE for _lambda_0 with 1 capture should appear
+        # inside make-adder's body.
+        mk = [i for i in ir.instructions if i.opcode is IrOp.MAKE_CLOSURE]
+        assert len(mk) == 1
+        assert mk[0].operands[1].name == "_lambda_0"
+        # operand 2 is the IrImmediate num_captured
+        assert mk[0].operands[2].value == 1
+
+    def test_closure_call_emits_apply_closure(self) -> None:
+        """A call whose function position is itself an Apply (so
+        the result is a closure value, not a known top-level
+        function) lowers to APPLY_CLOSURE."""
+        ir = compile_to_ir(
+            "(define (make-adder n) (lambda (x) (+ x n)))"
+            "((make-adder 7) 35)"
+        )
+        ap = [i for i in ir.instructions if i.opcode is IrOp.APPLY_CLOSURE]
+        assert len(ap) == 1
+        # APPLY_CLOSURE dst, closure_reg, IrImmediate(num_args), arg0
+        assert ap[0].operands[2].value == 1
+
 
 class TestRejectedSurface:
-    def test_lambda_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(lambda (x) x)")
-
     def test_unbound_name_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="unbound name"):
             compile_to_ir("foo")

--- a/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
@@ -190,3 +190,53 @@ def test_mutual_recursion_even_odd() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"1"
+
+
+# ── closures (TW03 Phase 2) ────────────────────────────────────────────────
+
+
+@requires_erl
+def test_closure_make_adder() -> None:
+    """``((make-adder 7) 35) → 42`` — the headline TW03 Phase 2 test.
+
+    Exercises the full closure pipeline end-to-end on real ``erl``:
+
+    * Free-variable analysis lifts the ``(lambda (x) (+ x n))``
+      to a top-level ``_lambda_0/2`` that takes ``n`` (captured)
+      then ``x`` (explicit).
+    * ``MAKE_CLOSURE`` builds a ``[FnAtom | [n]]`` cons cell.
+    * The outer call ``((make-adder 7) ...)`` uses
+      ``APPLY_CLOSURE`` because the function position is itself
+      an ``Apply`` (not a known top-level name).
+    """
+    result = run_source(
+        """
+        (define (make-adder n) (lambda (x) (+ x n)))
+        ((make-adder 7) 35)
+        """,
+        module_name="bm_closure",
+    )
+    assert result.returncode == 0, (
+        f"erl rejected the module:\n  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+    assert result.stdout.strip() == b"42"
+
+
+@requires_erl
+def test_closure_let_bound() -> None:
+    """``(let ((adder (make-adder 7))) (adder 35)) → 42``.
+
+    Exercises the let-bound closure path: ``adder`` is a local
+    binding (not in ``_fn_params``) holding a closure value; the
+    call ``(adder 35)`` drops through to the APPLY_CLOSURE branch.
+    """
+    result = run_source(
+        """
+        (define (make-adder n) (lambda (x) (+ x n)))
+        (let ((adder (make-adder 7))) (adder 35))
+        """,
+        module_name="bm_letclos",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"42"

--- a/code/specs/BEAM02-closure-lowering.md
+++ b/code/specs/BEAM02-closure-lowering.md
@@ -1,5 +1,29 @@
 # BEAM02 — Closure lowering for the BEAM backend
 
+> **Implementation note (2026-04-29).**  This spec was written
+> assuming we'd lower to ``make_fun2`` (opcode 103).  When we
+> tried, real Erlang/OTP 28 rejected the resulting modules with
+> "please re-compile this module with an Erlang/OTP 28
+> compiler" — OTP 28 deprecated ``make_fun2`` in favour of
+> ``make_fun3`` (opcode 171, OTP 24+).  ``make_fun3`` uses
+> z-tagged extended-list operands which our compact-term
+> encoder doesn't yet support.
+>
+> **What shipped instead** ([PR #1759](https://github.com/adhithyan15/coding-adventures/pull/1759)):
+> closures encoded as the cons cell ``[FnAtom | CapturesList]``,
+> dispatched via ``erlang:apply/3`` after splicing
+> ``Captures ++ Args`` with ``erlang:'++'/2``.  Lifted lambdas
+> are exported with full arity ``num_free + explicit`` so
+> apply/3 can find them by name.  Uses only standard,
+> well-supported opcodes (``put_list``, ``get_hd``, ``get_tl``,
+> ``call_ext``).  The ``FunT`` chunk encoder is implemented
+> (Phase 2b) but currently unused by Twig — it's there for
+> future work that grows z-tag operand support and wants real
+> BEAM funs.
+>
+> The original ``make_fun2`` design below is preserved as
+> historical context.
+
 ## Why this spec exists
 
 This is the **BEAM-side companion** to
@@ -8,9 +32,7 @@ and [CLR02](CLR02-closure-lowering.md), implementing
 [TW03 Phase 2](TW03-lisp-primitives-and-gc.md) (closures across
 all backends).
 
-BEAM's strategy is **completely different** from JVM/CLR
-because BEAM has a first-class notion of "fun objects" baked
-into the file format and instruction set:
+The original strategy (see implementation note above):
 
 - A new ``FunT`` chunk in the ``.beam`` file describes each
   lifted lambda — atom, arity, list of free variables, etc.
@@ -19,8 +41,10 @@ into the file format and instruction set:
 - A ``call_fun`` opcode at the apply site invokes it.
 
 No new classes, no JAR — just one extra chunk plus two new
-opcode types.  This is the **simplest** of the three backend
-strategies.
+opcode types.  This was meant to be the **simplest** of the
+three backend strategies; in practice the OTP-28 rejection of
+``make_fun2`` made the apply-based fallback (described in the
+implementation note) simpler still.
 
 ## Acceptance criterion
 
@@ -133,20 +157,24 @@ For ``call_fun`` similarly: just a ``u`` for arity.
 
 ## Implementation phases
 
-Same staging as JVM02 Phase 2 / CLR02:
+Same staging as JVM02 Phase 2 / CLR02 — but Phase 2c pivoted
+mid-flight (see implementation note at the top of this file):
 
-- **BEAM02 Phase 2a** — IR ops (already shipped via the
+- **BEAM02 Phase 2a** — IR ops (shipped via the
   ``compiler-ir`` v0.4.0 release alongside the JVM02 spec).
 - **BEAM02 Phase 2b** — ``FunT`` chunk encoding in
-  ``beam-bytecode-encoder``: new ``BEAMFun`` dataclass,
+  ``beam-bytecode-encoder``: ``BEAMFun`` dataclass,
   ``encode_funt`` helper, ``FunT`` added to the standard chunk
-  order.
+  order.  **Shipped, but currently unused by Twig.**
 - **BEAM02 Phase 2c** — ``MAKE_CLOSURE`` / ``APPLY_CLOSURE``
-  lowering in ``ir-to-beam``: new opcode constants for
-  ``make_fun2``/``call_fun``, register-shuffle logic at both
-  sites, FunT-row population.
-- **BEAM02 Phase 2d** — ``twig-beam-compiler`` accepts
-  ``Lambda`` + real-``erl`` closure test.
+  lowering in ``ir-to-beam``.  **Shipped using the apply-based
+  encoding** (cons cell ``[FnAtom | Caps]`` + ``erlang:apply/3``)
+  because OTP 28 rejects ``make_fun2`` and ``make_fun3``
+  requires z-tagged operand encoding.
+- **BEAM02 Phase 2d** — ``twig-beam-compiler`` lifts anonymous
+  lambdas (via ``twig.free_vars``), emits ``MAKE_CLOSURE`` at
+  the use site, and lowers non-static call sites to
+  ``APPLY_CLOSURE``.  **Shipped.**
 
 ## Risk register
 
@@ -169,19 +197,21 @@ Same staging as JVM02 Phase 2 / CLR02:
   document inline; tests assert on exact register-shuffle
   bytecode.
 
-## Cross-spec parity
+## Cross-spec parity (as shipped, not as originally designed)
 
-| Aspect | JVM02 | CLR02 | BEAM02 |
-|--------|-------|-------|--------|
-| Closure container | per-lambda class | per-lambda TypeDef | FunT chunk row |
-| Apply dispatch | ``invokeinterface Closure.apply`` | ``callvirt IClosure.Apply`` | ``call_fun`` opcode |
-| Capture storage | object fields | object fields | fun heap object slots |
+| Aspect | JVM02 | CLR02 | BEAM02 (as shipped) |
+|--------|-------|-------|---------------------|
+| Closure container | per-lambda class | per-lambda TypeDef | cons cell ``[FnAtom \| Caps]`` |
+| Apply dispatch | ``invokeinterface Closure.apply`` | ``callvirt IClosure.Apply`` | ``erlang:apply/3`` BIF |
+| Capture storage | object fields | object fields | tail of cons cell |
 | Packaging | JAR (multi-class) | single ``.exe`` | single ``.beam`` |
-| Difficulty | High (JAR + multi-class plumbing) | Medium (multi-TypeDef in one file) | Low (one new chunk + two opcodes) |
+| Difficulty | High (JAR + multi-class plumbing) | Medium (multi-TypeDef in one file) | Low (uses only standard list/apply opcodes) |
 
-BEAM is the easiest of the three, JVM the hardest.  Suggested
-implementation order: **BEAM Phase 2 first** (smallest scope
-to validate the full flow) → CLR Phase 2 → JVM Phase 2.
+BEAM ended up being the easiest of the three (no new file
+format work, no class layout, just cons cells and a BIF
+call).  Suggested implementation order remains: **BEAM
+Phase 2 first** (validates the full flow) → CLR Phase 2 →
+JVM Phase 2.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- Lands closure support across the entire BEAM stack so `((make-adder 7) 35) → 42` runs on real `erl` (Erlang/OTP 28).
- Anonymous `(lambda (x) body)` forms in Twig source now lift to top-level functions; free-variable analysis computes captures and the use site emits `MAKE_CLOSURE`. Calls of let-bound or chained closure values lower to `APPLY_CLOSURE`.
- Closure encoding is **list-based + `erlang:apply/3`** instead of `make_fun*`. Real `erlc` emits `make_fun3` (opcode 171) which uses z-tagged extended-list operands our encoder doesn't yet support; OTP 28 refuses to load `make_fun2`. Encoding closures as `[FnAtom | CapturesList]` cons cells and dispatching via apply uses only standard, well-supported opcodes (`put_list`, `get_hd`, `get_tl`, `call_ext`).
- `beam-bytecode-encoder` gains FunT chunk scaffolding (Phase 2b) — currently unused by Twig but kept for future work that wants real BEAM funs once z-tag support lands.
- `compiler-ir` gains `MAKE_CLOSURE` (47) and `APPLY_CLOSURE` (48) — cross-backend opcodes; JVM/CLR lowering still pending.

## What's in the diff

- `code/packages/python/beam-bytecode-encoder/` — `BEAMFun` dataclass, FunT chunk emission, validation, 7 new tests.
- `code/packages/python/compiler-ir/` — two new opcodes + tests.
- `code/packages/python/ir-to-beam/` — MAKE_CLOSURE/APPLY_CLOSURE lowering, captures-first register layout, `closure_free_var_counts` config knob, end-to-end real-`erl` closure test.
- `code/packages/python/twig-beam-compiler/` — anonymous lambda lifting, free-var analysis wiring, APPLY_CLOSURE generation for non-static call sites, two new real-`erl` Twig source tests.

## Test plan

- [x] All 250 tests pass across the four impacted packages
  - compiler-ir: 114 passed, 95% coverage
  - beam-bytecode-encoder: 62 passed, 92% coverage
  - ir-to-beam: 20 passed, 85% coverage
  - twig-beam-compiler: 54 passed, 90% coverage
- [x] `((make-adder 7) 35) → 42` confirmed on real Erlang/OTP 28 via `test_closure_make_adder`
- [x] `(let ((adder (make-adder 7))) (adder 35)) → 42` confirmed via `test_closure_let_bound`
- [x] No regressions in the recursion / arithmetic / `if` test suites
- [x] Security review passed (one round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)