### PR TITLE
fix(mini-sqlite): split concatenated v1.9.0 CHANGELOG entries

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.9.0] - 2026-04-28
+## [1.10.0] - 2026-04-29
 
 ### Added
 
@@ -42,6 +42,11 @@ PRAGMA schema_version;           -- read: returns one row (schema_version,)
 - `tests/test_tier3_pragma.py::TestSchemaVersion` — 6 tests: default,
   description, CREATE TABLE bumps, DROP TABLE bumps, CREATE INDEX
   bumps, DML does not bump.
+
+## [1.9.0] - 2026-04-28
+
+### Added
+
 **Bytes (BLOB) parameter binding**
 
 `bytes`, `bytearray`, and `memoryview` parameters can now be bound to `?`


### PR DESCRIPTION
## Summary

PRs [#1678](https://github.com/adhithyan15/coding-adventures/pull/1678) (bytes BLOB binding) and [#1684](https://github.com/adhithyan15/coding-adventures/pull/1684) (PRAGMA user/schema_version) both landed claiming mini-sqlite v1.9.0. GitHub's auto-merge concatenated their CHANGELOG entries under a single v1.9.0 heading, producing a nonsensical history with two \`### Added\` sections and two \`### Tests added\` sections in one version.

Re-version the PRAGMA work as v1.10.0 (the natural next-version after v1.9.0), and split the entries into two distinct version sections:

- **v1.10.0** (today) — PRAGMA user_version + schema_version
- **v1.9.0** (yesterday) — bytes (BLOB) parameter binding

No code changes — pure CHANGELOG correction before the package is published.

## Test plan

- [x] CHANGELOG headers are now in monotonic descending order (1.10.0, 1.9.0, 1.8.0, …)
- [x] Each version has a single coherent \`### Added\` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)