### PR TITLE
Drop duplicate HTML attributes

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -95,6 +95,9 @@ documented in this file.
 - EOF after a malformed markup declaration opener such as `<!` now emits an
   empty bogus comment with `incorrectly-opened-comment` instead of preserving
   the opener as text.
+- Duplicate attributes now follow HTML recovery by keeping the first attribute,
+  dropping later attributes with the same interpreted name, and reporting
+  `duplicate-attribute`.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -25,6 +25,9 @@ the project, but the first real HTML authoring artifact that must keep HTML
 The default lexer already resolves the core named character references and the
 classic Latin-1 entity set, preserving entity-name case so legacy names such as
 `Agrave` and `agrave` remain distinct.
+Duplicate attributes recover with HTML semantics: the first attribute value is
+kept, later attributes with the same interpreted name are dropped, and a
+`duplicate-attribute` diagnostic is recorded.
 Comment tokenization includes the standard start-dash recovery cases for empty
 HTML comments such as `<!-->` and `<!--->`, while still preserving normal
 Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -2619,7 +2619,7 @@ to = "after_attribute_name"
 from = "attribute_name"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_name"
@@ -2630,7 +2630,7 @@ to = "before_attribute_value"
 from = "attribute_name"
 matcher = { literal = ">" }
 to = "data"
-actions = ["emit_current_token"]
+actions = ["commit_attribute_dedup", "emit_current_token"]
 
 [[transitions]]
 from = "attribute_name"
@@ -2639,6 +2639,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -2673,7 +2674,7 @@ to = "after_attribute_name"
 from = "after_attribute_name"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "after_attribute_name"
@@ -2684,7 +2685,7 @@ to = "before_attribute_value"
 from = "after_attribute_name"
 matcher = { literal = ">" }
 to = "data"
-actions = ["commit_attribute", "emit_current_token"]
+actions = ["commit_attribute_dedup", "emit_current_token"]
 
 [[transitions]]
 from = "after_attribute_name"
@@ -2693,7 +2694,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -2703,7 +2704,7 @@ from = "after_attribute_name"
 matcher = { anything = true }
 to = "attribute_name"
 actions = [
-  "commit_attribute",
+  "commit_attribute_dedup",
   "start_attribute",
   "append_attribute_name(current_lowercase)",
 ]
@@ -2744,7 +2745,7 @@ matcher = { literal = ">" }
 to = "data"
 actions = [
   "parse_error(missing-attribute-value)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
 ]
 
@@ -2755,7 +2756,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -2780,7 +2781,7 @@ actions = ["append_attribute_value(current)"]
 from = "attribute_value_double_quoted"
 matcher = { literal = "\"" }
 to = "after_attribute_value_quoted"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_double_quoted"
@@ -2789,7 +2790,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -2814,7 +2815,7 @@ actions = ["append_attribute_value(current)"]
 from = "attribute_value_single_quoted"
 matcher = { literal = "'" }
 to = "after_attribute_value_quoted"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_single_quoted"
@@ -2823,7 +2824,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -2848,37 +2849,37 @@ actions = ["append_attribute_value(current)"]
 from = "attribute_value_unquoted"
 matcher = { literal = " " }
 to = "before_attribute_name"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "\n" }
 to = "before_attribute_name"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "\t" }
 to = "before_attribute_name"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "\r" }
 to = "before_attribute_name"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
-actions = ["commit_attribute"]
+actions = ["commit_attribute_dedup"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = ">" }
 to = "data"
-actions = ["commit_attribute", "emit_current_token"]
+actions = ["commit_attribute_dedup", "emit_current_token"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
@@ -2887,7 +2888,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3018,7 +3019,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3059,7 +3060,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3100,7 +3101,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3151,7 +3152,7 @@ actions = [
   "append_numeric_character_reference_to_attribute_value",
   "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3191,7 +3192,7 @@ actions = [
   "append_numeric_character_reference_to_attribute_value",
   "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3243,7 +3244,7 @@ consume = false
 actions = [
   "recover_named_character_reference_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3290,7 +3291,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3325,7 +3326,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3358,7 +3359,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3393,7 +3394,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3428,7 +3429,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3461,7 +3462,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3496,7 +3497,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3529,7 +3530,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3564,7 +3565,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3597,7 +3598,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3632,7 +3633,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3667,7 +3668,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3702,7 +3703,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3735,7 +3736,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3770,7 +3771,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3805,7 +3806,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3840,7 +3841,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3873,7 +3874,7 @@ actions = [
   "append_named_character_reference_to_attribute_value",
   "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3919,7 +3920,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3954,7 +3955,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -3989,7 +3990,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -4022,7 +4023,7 @@ actions = [
   "append_named_character_reference_to_attribute_value",
   "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -4068,7 +4069,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -4103,7 +4104,7 @@ consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -4136,7 +4137,7 @@ actions = [
   "append_named_character_reference_to_attribute_value",
   "parse_error(missing-semicolon-after-character-reference)",
   "parse_error(eof-in-tag)",
-  "commit_attribute",
+  "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
 ]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -5927,7 +5927,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -5955,6 +5955,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -5971,6 +5972,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6054,7 +6056,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6082,7 +6084,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -6099,7 +6101,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6116,7 +6118,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "start_attribute".to_string(),
                 "append_attribute_name(current_lowercase)".to_string(),
             ],
@@ -6212,7 +6214,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(missing-attribute-value)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -6229,7 +6231,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6278,7 +6280,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6294,7 +6296,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6343,7 +6345,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6359,7 +6361,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6408,7 +6410,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6423,7 +6425,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6438,7 +6440,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6453,7 +6455,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6468,7 +6470,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
             ],
             consume: true,
         },
@@ -6483,7 +6485,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -6500,7 +6502,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6806,7 +6808,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6886,7 +6888,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -6966,7 +6968,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7063,7 +7065,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_numeric_character_reference_to_attribute_value".to_string(),
                 "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7131,7 +7133,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_numeric_character_reference_to_attribute_value".to_string(),
                 "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7229,7 +7231,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "recover_named_character_reference_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7324,7 +7326,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7389,7 +7391,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7441,7 +7443,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7506,7 +7508,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7571,7 +7573,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7623,7 +7625,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7688,7 +7690,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7740,7 +7742,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7805,7 +7807,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7857,7 +7859,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7922,7 +7924,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -7987,7 +7989,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8052,7 +8054,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8104,7 +8106,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8169,7 +8171,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8234,7 +8236,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8299,7 +8301,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8351,7 +8353,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_named_character_reference_to_attribute_value".to_string(),
                 "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8433,7 +8435,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8498,7 +8500,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8563,7 +8565,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8615,7 +8617,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_named_character_reference_to_attribute_value".to_string(),
                 "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8697,7 +8699,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8762,7 +8764,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -8814,7 +8816,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "append_named_character_reference_to_attribute_value".to_string(),
                 "parse_error(missing-semicolon-after-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute".to_string(),
+                "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 58);
+    assert_eq!(html1.cases.len(), 59);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 56);
+    assert_eq!(file.tests.len(), 57);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 56);
+    assert_eq!(normalized.cases.len(), 57);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 56);
+    assert_eq!(suite.cases.len(), 57);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -32,6 +32,18 @@
       ]
     },
     {
+      "id": "duplicate-attributes",
+      "description": "Duplicate attributes keep the first value and report duplicate-attribute",
+      "input": "<a href=one HREF=two title=ok>",
+      "tokens": [
+        "StartTag(name=a, attributes=[href=one, title=ok], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "duplicate-attribute"
+      ]
+    },
+    {
       "id": "mosaic-doctype-and-heading",
       "input": "<!DOCTYPE HTML><H1 class=test>Hello</H1>",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -267,6 +267,18 @@
     },
     {
       "id": "html5lib-smoke-22",
+      "description": "duplicate attributes keep first value",
+      "input": "<a href=one HREF=two title=ok>",
+      "tokens": [
+        "StartTag(name=a, attributes=[href=one, title=ok], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "duplicate-attribute"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-23",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -277,7 +289,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-23",
+      "id": "html5lib-smoke-24",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -290,7 +302,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-24",
+      "id": "html5lib-smoke-25",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -303,7 +315,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -313,7 +325,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -323,7 +335,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -335,7 +347,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -345,7 +357,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -355,7 +367,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -368,7 +380,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -378,7 +390,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -388,7 +400,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -401,7 +413,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -415,7 +427,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -429,7 +441,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -446,7 +458,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -456,7 +468,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -466,7 +478,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -476,7 +488,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -486,7 +498,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -498,7 +510,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -511,7 +523,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -524,7 +536,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -539,7 +551,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -552,7 +564,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -566,7 +578,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -579,7 +591,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-49",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -593,7 +605,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-50",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -607,7 +619,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-51",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -621,7 +633,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -634,7 +646,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -648,7 +660,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -662,7 +674,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -675,7 +687,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -694,7 +706,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -199,6 +199,16 @@
       ]
     },
     {
+      "description": "duplicate attributes keep first value",
+      "input": "<a href=one HREF=two title=ok>",
+      "output": [
+        ["StartTag", "a", {"href": "one", "title": "ok"}]
+      ],
+      "errors": [
+        {"code": "duplicate-attribute", "line": 1, "col": 21}
+      ]
+    },
+    {
       "description": "plaintext state literalizes markup and character references",
       "initialStates": ["PLAINTEXT state"],
       "input": "hello <b>still text</b> &amp; literal",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -68,6 +68,43 @@ fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
 }
 
 #[test]
+fn default_html_lexer_reports_and_drops_duplicate_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<a href=one HREF=two title=ok>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "href".to_string(),
+                        value: "one".to_string(),
+                    },
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "ok".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "duplicate-attribute")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn default_html_lexer_marks_missing_doctype_name_force_quirks() {
     let mut lexer = create_html_lexer().unwrap();
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -685,6 +685,7 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "create_doctype"
         | "start_attribute"
         | "commit_attribute"
+        | "commit_attribute_dedup"
         | "mark_self_closing"
         | "mark_force_quirks"
         | "set_doctype_public_identifier_empty"

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -21,3 +21,6 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   that need declarative branch decisions after scanning a keyword.
 - Expanded the built-in HTML named-character-reference table through the
   classic Latin-1 entity set used by early web content.
+- Added `commit_attribute_dedup` for lexer definitions that need HTML-style
+  duplicate attribute recovery while keeping plain `commit_attribute`
+  available for definitions that preserve duplicates.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -47,6 +47,7 @@ Tag tokens:
 - `append_attribute_value(current)`
 - `append_attribute_value(literal)`
 - `commit_attribute`
+- `commit_attribute_dedup`
 - `mark_self_closing`
 - `emit_current_token`
 
@@ -98,6 +99,12 @@ Diagnostics and stream control:
 
 It also enforces a per-input step limit so malformed reconsume-style machines
 cannot spin forever on one code point.
+
+`commit_attribute_dedup` commits the current attribute only when the current
+start tag does not already have an attribute with the same interpreted name. If
+there is already a matching attribute, the runtime drops the current attribute
+and records a `duplicate-attribute` diagnostic. Definitions that want to keep
+duplicates can continue using plain `commit_attribute`.
 
 The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state` and `Tokenizer::set_last_start_tag` so wrapper

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -474,6 +474,7 @@ impl Tokenizer {
                     self.append_attribute_value(action, ch)?;
                 }
                 "commit_attribute" => self.commit_attribute(action)?,
+                "commit_attribute_dedup" => self.commit_attribute_dedup(action, position, state)?,
                 "mark_self_closing" => self.mark_self_closing(action)?,
                 "append_comment(current)" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
@@ -794,6 +795,47 @@ impl Tokenizer {
                 actual: other.kind_name(),
             }),
         }
+    }
+
+    fn commit_attribute_dedup(
+        &mut self,
+        action: &str,
+        position: SourcePosition,
+        state: &str,
+    ) -> Result<()> {
+        let attribute = self.current_attribute.take().ok_or_else(|| {
+            TokenizerError::MissingCurrentAttribute {
+                action: action.to_string(),
+            }
+        })?;
+        let duplicate = match self.current_token_mut(action)? {
+            CurrentToken::StartTag { attributes, .. } => {
+                if attributes
+                    .iter()
+                    .any(|existing| existing.name == attribute.name)
+                {
+                    true
+                } else {
+                    attributes.push(attribute);
+                    false
+                }
+            }
+            other => {
+                return Err(TokenizerError::InvalidCurrentToken {
+                    action: action.to_string(),
+                    expected: "start-tag",
+                    actual: other.kind_name(),
+                })
+            }
+        };
+        if duplicate {
+            self.diagnostics.push(Diagnostic {
+                code: "duplicate-attribute".to_string(),
+                position,
+                state: state.to_string(),
+            });
+        }
+        Ok(())
     }
 
     fn mark_self_closing(&mut self, action: &str) -> Result<()> {

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -140,6 +140,64 @@ fn tokenizer_builds_start_tag_attributes_and_self_closing_markers() {
 }
 
 #[test]
+fn tokenizer_can_drop_duplicate_attributes_when_requested() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "tag_open", "attr", "done"]),
+            set(&["<", "A", "H", "1", "2", ">", " "]),
+            vec![
+                EffectfulTransition::new(
+                    "data",
+                    EffectfulMatcher::Event("<".to_string()),
+                    "tag_open",
+                ),
+                EffectfulTransition::new(
+                    "tag_open",
+                    EffectfulMatcher::Event("A".to_string()),
+                    "attr",
+                )
+                .with_effects(&["create_start_tag", "append_tag_name(current_lowercase)"]),
+                EffectfulTransition::new("attr", EffectfulMatcher::Event("H".to_string()), "attr")
+                    .with_effects(&[
+                        "start_attribute",
+                        "append_attribute_name(href)",
+                        "append_attribute_value(1)",
+                        "commit_attribute_dedup",
+                    ]),
+                EffectfulTransition::new("attr", EffectfulMatcher::Event("1".to_string()), "attr")
+                    .with_effects(&[
+                        "start_attribute",
+                        "append_attribute_name(href)",
+                        "append_attribute_value(2)",
+                        "commit_attribute_dedup",
+                    ]),
+                EffectfulTransition::new("attr", EffectfulMatcher::Event(">".to_string()), "done")
+                    .with_effects(&["emit_current_token"]),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("<AH1>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::StartTag {
+            name: "a".to_string(),
+            attributes: vec![Attribute {
+                name: "href".to_string(),
+                value: "1".to_string(),
+            }],
+            self_closing: false,
+        }]
+    );
+    assert_eq!(tokenizer.diagnostics().len(), 1);
+    assert_eq!(tokenizer.diagnostics()[0].code, "duplicate-attribute");
+}
+
+#[test]
 fn tokenizer_builds_comment_tokens_with_current_and_literal_actions() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## Summary
- Add an opt-in commit_attribute_dedup tokenizer action and allow it through TOML deserialization.
- Wire the HTML1 lexer attribute commits through dedup recovery so duplicate attributes keep the first value and report duplicate-attribute.
- Add wrapper, Venture fixture, and html5lib-style smoke coverage, then regenerate the static HTML1 Rust machine and normalized smoke fixtures.

## Verification
- python3 normalize_html5lib_fixtures.py upstream-html5lib-smoke.test html5lib-smoke.json
- cargo run in /tmp/html_numeric_codegen_tool
- cargo fmt for html-lexer, state-machine-tokenizer, state-machine-markup-deserializer, state-machine-source-compiler
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- git diff --check