### PR TITLE
feat(clr): CLR02 Phase 2c — closure lowering (structural)

### DIFF
--- a/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
+++ b/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
@@ -55,8 +55,13 @@ _TYPE_FLAGS_PUBLIC_INTERFACE = 0x000000A1
 # 0x0016 = Public(0x6) + Static(0x10).  Instance methods drop Static
 # and add HideBySig.  Constructors add SpecialName + RTSpecialName.
 _METHOD_FLAGS_PUBLIC_STATIC = 0x0016
-# Public + Virtual + HideBySig.
-_METHOD_FLAGS_PUBLIC_INSTANCE = 0x0086
+# Public + Virtual + HideBySig + NewSlot + Final.  Used for
+# concrete instance methods on closure classes that *implement*
+# an interface method.  ``NewSlot`` puts the method into its own
+# vtable slot (rather than trying to override a parent class
+# slot, which doesn't exist for closure ``Apply``); ``Final``
+# prevents further overriding (closures are leaf types).
+_METHOD_FLAGS_PUBLIC_INSTANCE = 0x01E6
 # Public + HideBySig + SpecialName + RTSpecialName.
 _METHOD_FLAGS_PUBLIC_CTOR = 0x1886
 # Public + Virtual + HideBySig + NewSlot + Abstract.
@@ -355,6 +360,25 @@ class CLIAssemblyWriter:
         for offset, t in enumerate(program.extra_types):
             typedef_row_for_name[_qualified_name(t.namespace, t.name)] = 3 + offset
 
+        # CLR02 Phase 2c: when any extra type extends ``System.Object``
+        # (i.e. a concrete closure class), the closure's .ctor body
+        # chains into ``Object::.ctor()``.  That requires a MemberRef
+        # row pointing at the existing System.Object TypeRef.  We
+        # always emit it at MemberRef row ``len(helper_specs) + 1``
+        # whenever the trigger fires, so the lowerer's deterministic
+        # token computation matches the actual emitted row.
+        needs_object_ctor_memberref = any(
+            (not t.is_interface) and t.extends == "System.Object"
+            for t in program.extra_types
+        )
+        ctor_string_index = strings.add(".ctor") if needs_object_ctor_memberref else 0
+        # ``HASTHIS | paramcount(0) | retType(void)`` per ECMA-335 §II.23.2.1
+        object_ctor_sig_index = (
+            blobs.add(bytes([_SIG_CALLCONV_HASTHIS, 0x00, 0x01]))
+            if needs_object_ctor_memberref
+            else 0
+        )
+
         helper_namespace, helper_name = _split_type_name(self.config.helper_type_name)
         helper_name_index = strings.add(helper_name)
         helper_namespace_index = strings.add(helper_namespace)
@@ -454,6 +478,9 @@ class CLIAssemblyWriter:
             typedef_row_for_name=typedef_row_for_name,
             field_name_indices=field_name_indices,
             field_sig_indices=field_sig_indices,
+            ctor_string_index=ctor_string_index,
+            object_ctor_sig_index=object_ctor_sig_index,
+            needs_object_ctor_memberref=needs_object_ctor_memberref,
             mvid_index=mvid_index,
             system_runtime_name_index=system_runtime_name_index,
             empty_string_index=empty_string_index,
@@ -499,6 +526,9 @@ class CLIAssemblyWriter:
         typedef_row_for_name: dict[str, int],
         field_name_indices: dict[int, int],
         field_sig_indices: dict[int, int],
+        ctor_string_index: int,
+        object_ctor_sig_index: int,
+        needs_object_ctor_memberref: bool,
         mvid_index: int,
         system_runtime_name_index: int,
         empty_string_index: int,
@@ -564,15 +594,14 @@ class CLIAssemblyWriter:
                 program=program,
                 typedef_row_for_name=typedef_row_for_name,
             ),
-            _MEMBER_REF_TABLE: [
-                struct.pack(
-                    "<HHH",
-                    (1 << 3) | 1,
-                    helper_name_indices[spec.helper],
-                    helper_sig_indices[spec.helper],
-                )
-                for spec in program.helper_specs
-            ],
+            _MEMBER_REF_TABLE: _build_memberref_rows(
+                program=program,
+                helper_name_indices=helper_name_indices,
+                helper_sig_indices=helper_sig_indices,
+                ctor_string_index=ctor_string_index,
+                object_ctor_sig_index=object_ctor_sig_index,
+                needs_object_ctor_memberref=needs_object_ctor_memberref,
+            ),
             _STANDALONE_SIG_TABLE: [
                 struct.pack("<H", local_sig_indices[layout.local_sig_token])
                 for layout in method_layouts
@@ -839,6 +868,52 @@ def _build_interfaceimpl_rows(
             )
         for iface_coded in sorted(encoded):
             rows.append(struct.pack("<HH", class_row, iface_coded))
+    return rows
+
+
+def _build_memberref_rows(
+    *,
+    program: CILProgramArtifact,
+    helper_name_indices: dict[CILHelper, int],
+    helper_sig_indices: dict[CILHelper, int],
+    ctor_string_index: int,
+    object_ctor_sig_index: int,
+    needs_object_ctor_memberref: bool,
+) -> list[bytes]:
+    """Emit the MemberRef table.
+
+    Helper rows go first (so their token positions stay stable for
+    CLR01 callers).  When any closure type is present (CLR02
+    Phase 2c), one additional row is appended for
+    ``[System.Runtime]System.Object::.ctor()`` so closure ctors can
+    chain into it via a deterministic ``0x0A...`` token.
+
+    Layout per row: ``Class(MemberRefParent), Name(StringIdx),
+    Signature(BlobIdx)`` = 6 bytes with narrow heaps.
+
+    ``MemberRefParent`` tag bits (low 3): TypeRef = 1.  Helper rows
+    point at TypeRef row 1 (the helper's TypeRef) → ``(1 << 3) | 1
+    = 9``.  System.Object::.ctor points at TypeRef row 2 →
+    ``(2 << 3) | 1 = 17``.
+    """
+    rows: list[bytes] = [
+        struct.pack(
+            "<HHH",
+            (1 << 3) | 1,
+            helper_name_indices[spec.helper],
+            helper_sig_indices[spec.helper],
+        )
+        for spec in program.helper_specs
+    ]
+    if needs_object_ctor_memberref:
+        rows.append(
+            struct.pack(
+                "<HHH",
+                (2 << 3) | 1,
+                ctor_string_index,
+                object_ctor_sig_index,
+            )
+        )
     return rows
 
 

--- a/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
+++ b/code/packages/python/cli-assembly-writer/tests/test_real_dotnet.py
@@ -371,6 +371,144 @@ def test_concrete_class_with_field_and_interfaceimpl_loads(
     )
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# CLR02 Phase 2c — closures end-to-end through the full pipeline
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.xfail(
+    reason=(
+        "CLR02 Phase 2c lowering is structural only — closure refs are "
+        "managed pointers but the existing CLR backend uses int32-uniform "
+        "locals/args, so storing a closure ref into a local typed as "
+        "int32 either truncates the pointer or trips the GC.  The next "
+        "phase (typed register pool, parallel object-slot tracking) "
+        "wires the runtime end-to-end.  Test stays in the file so the "
+        "shape stays right; it'll flip to passing when the typed pool "
+        "lands."
+    ),
+    strict=True,
+)
+@_skip_if_no_dotnet
+def test_make_adder_closure_returns_42_on_real_dotnet(tmp_path: Path) -> None:
+    """The headline CLR02 Phase 2c test:
+    ``((make-adder 7) 35) → 42`` end-to-end on real ``dotnet``.
+
+    Hand-built IR mirroring what twig-clr-compiler will eventually
+    emit for ``(define (make-adder n) (lambda (x) (+ x n)))
+    ((make-adder 7) 35)``.  Exercises the full Phase 2c pipeline:
+
+    * MAKE_CLOSURE → ``newobj Closure_lambda::.ctor(int32)``.
+    * APPLY_CLOSURE → ``callvirt int32 IClosure::Apply(int32)``.
+    * Auto-emitted IClosure interface + per-lambda Closure_lambda
+      TypeDef with one int32 instance field, a ctor, and an Apply
+      method whose body reads the captured ``n`` from the field.
+    * MemberRef to ``System.Object::.ctor`` so the closure ctor can
+      chain into the base class.
+    """
+    from compiler_ir import (
+        IDGenerator,
+        IrImmediate,
+        IrInstruction,
+        IrLabel,
+        IrOp,
+        IrProgram,
+        IrRegister,
+    )
+    from ir_to_cil_bytecode import CILBackendConfig, lower_ir_to_cil_bytecode
+
+    def lbl(name: str) -> IrLabel:
+        return IrLabel(name=name)
+
+    def reg(i: int) -> IrRegister:
+        return IrRegister(index=i)
+
+    def imm(v: int) -> IrImmediate:
+        return IrImmediate(value=v)
+
+    gen = IDGenerator()
+    program = IrProgram(entry_label="Main")
+
+    # _lambda_0(N, X) — captures-first layout: r2 = N (capture),
+    # r3 = X (explicit arg).  Body: r1 = r2 + r3.
+    program.add_instruction(IrInstruction(IrOp.LABEL, [lbl("_lambda_0")], id=-1))
+    program.add_instruction(
+        IrInstruction(IrOp.ADD, [reg(1), reg(2), reg(3)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # make_adder(n): returns MAKE_CLOSURE(_lambda_0, [n]).
+    program.add_instruction(IrInstruction(IrOp.LABEL, [lbl("make_adder")], id=-1))
+    program.add_instruction(
+        IrInstruction(
+            IrOp.MAKE_CLOSURE,
+            [reg(1), lbl("_lambda_0"), imm(1), reg(2)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    # Main(): closure = make_adder(7); return APPLY_CLOSURE(closure, [35]).
+    program.add_instruction(IrInstruction(IrOp.LABEL, [lbl("Main")], id=-1))
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [reg(2), imm(7)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.CALL, [lbl("make_adder")], id=gen.next())
+    )
+    # Stash the closure ref in a holding reg so the arg-staging move
+    # for APPLY_CLOSURE doesn't clobber it.
+    program.add_instruction(
+        IrInstruction(IrOp.ADD_IMM, [reg(10), reg(1), imm(0)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(IrOp.LOAD_IMM, [reg(11), imm(35)], id=gen.next())
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.APPLY_CLOSURE,
+            [reg(1), reg(10), imm(1), reg(11)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    cil_program = lower_ir_to_cil_bytecode(
+        program,
+        CILBackendConfig(
+            call_register_count=None,
+            closure_free_var_counts={"_lambda_0": 1},
+        ),
+    )
+    artifact = write_cli_assembly(
+        cil_program,
+        CLIAssemblyConfig(
+            assembly_name="ClosureAdder",
+            module_name="ClosureAdder.exe",
+            type_name="ClosureAdder",
+        ),
+    )
+
+    asm_path = tmp_path / "ClosureAdder.exe"
+    cfg_path = tmp_path / "ClosureAdder.runtimeconfig.json"
+    asm_path.write_bytes(artifact.assembly_bytes)
+    cfg_path.write_text(_runtimeconfig_for_net9())
+
+    result = subprocess.run(
+        ["dotnet", str(asm_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 42, (
+        f"closure pipeline broke at runtime.\n"
+        f"  exit code: {result.returncode}\n"
+        f"  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+
+
 def test_writer_produces_nonempty_output() -> None:
     """Pure unit test — the writer produces some PE bytes for a
     minimal return-42 program.  Pre-CLR01 this test was where we

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -279,6 +279,8 @@ class IrOp(IntEnum):
     #               free-variable list maps to the captured registers.
     #   - vm-core:  delegate to the host-side ``make_closure`` builtin
     #               (already implemented in TW00).
+    #
+    # Note: numbered 47 (NOT 25) because 25/26 collide with MUL/DIV.
     MAKE_CLOSURE = 47
 
     # Apply a closure value to zero or more arguments.

--- a/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 0.5.0 — 2026-04-29 — CLR02 Phase 2c lowering (structural)
+
+### Added — `MAKE_CLOSURE` and `APPLY_CLOSURE` lowering
+
+- New handlers in `_emit_instruction`:
+  - **`MAKE_CLOSURE`** → `ldloc capt0; ...; ldloc captN-1;
+    newobj Closure_<fn>::.ctor(int32, ...); stloc dst`.
+  - **`APPLY_CLOSURE`** → `ldloc closure; ldloc arg0;
+    callvirt int32 IClosure::Apply(int32); stloc dst`.
+- `CILBackendConfig.closure_free_var_counts` declares which IR
+  regions are lifted-lambda bodies; the backend lowers those
+  regions as `Apply` methods on auto-generated
+  `Closure_<name>` TypeDefs (captures-first prologue copies
+  fields and the explicit arg into IR register slots).
+- Closure regions are no longer included in
+  `CILProgramArtifact.methods` (the main user TypeDef's method
+  list); instead they land on their own TypeDefs via
+  `extra_types`.
+- `_discover_callable_regions` now finds `MAKE_CLOSURE`'s
+  `fn_label` operand as a callable region (the lambda body is
+  invoked indirectly via `callvirt` rather than directly via
+  `CALL`).
+- `SequentialCILTokenProvider` gains five closure-aware
+  methods (`iclosure_apply_token`, `closure_ctor_token`,
+  `closure_apply_token`, `closure_field_token`,
+  `system_object_ctor_token`), all returning deterministic
+  tokens that match the row layout the writer emits.
+
+### Auto-generated TypeArtifacts
+
+For any program with at least one closure region, the lowerer
+emits:
+
+1. `CodingAdventures.IClosure` — abstract interface with one
+   abstract instance method `Apply(int32) → int32`.
+2. One `CodingAdventures.Closure_<name>` per lifted lambda —
+   concrete class extending `System.Object`, implementing
+   `IClosure`, with one `int32` field per capture, a `.ctor`
+   that chains into `System.Object::.ctor()` and stores
+   captures into fields, and an `Apply` instance method whose
+   body is the lambda's lowered IR with a captures-from-fields
+   prologue.
+
+### v1 limitations
+
+- **Arity-1 closures only** for `APPLY_CLOSURE`.  Multi-arity
+  needs `int[]` parameter typing on `IClosure::Apply` plus
+  `newarr int32` machinery (which needs a `System.Int32`
+  TypeRef the writer doesn't yet emit).
+- **Runtime end-to-end is not yet wired.**  Closure references
+  are managed pointers but the existing CLR backend uses an
+  int32-uniform local/parameter convention, so a closure ref
+  stored into an `int32` local truncates the pointer.  The
+  full `((make-adder 7) 35) → 42` pipeline lives as
+  an `xfail(strict=True)` real-`dotnet` test in
+  `cli-assembly-writer` so the structural shape stays right —
+  it'll flip to passing when the typed-register pool work
+  lands (planned next phase).
+
+### Added — opcode renumbering (compiler-ir 0.5.0)
+
+`MAKE_CLOSURE` moved from opcode 25 → 47 and `APPLY_CLOSURE`
+from 26 → 48.  The original numbering collided with `MUL` /
+`DIV` (added in compiler-ir 0.2.0); the IR enum's old values
+silently shadowed them, causing the lowering dispatcher to
+treat closure ops as arithmetic.  This change matches what
+ir-to-beam already adopted in its TW03 Phase 2 PR.
+
 ## 0.4.0 — 2026-04-29 — CLR02 Phase 2b dataclasses
 
 ### Added — closure-shape input to the writer

--- a/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
@@ -9,7 +9,7 @@ placeholder tokens that are useful for tests and for composing later stages.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Protocol
 
@@ -47,12 +47,30 @@ class CILHelperSpec:
 
 @dataclass(frozen=True)
 class CILBackendConfig:
-    """Configuration for compiler IR to CIL bytecode lowering."""
+    """Configuration for compiler IR to CIL bytecode lowering.
+
+    ``closure_free_var_counts`` declares which IR regions are
+    lifted-lambda bodies (TW03 Phase 2 / CLR02 Phase 2c).  Each
+    entry maps a region's name to its number of captured free
+    variables.  Regions in this map are lowered as the ``Apply``
+    method on an auto-generated ``Closure_<name>`` TypeDef, with
+    a prologue that copies captures from instance fields and
+    arguments from the caller-passed ``int[]`` into the IR's
+    expected register slots.
+
+    The lambda body itself sees a captures-first IR register
+    layout (matches what twig-clr-compiler produces and what
+    BEAM Phase 2 already uses):
+
+      * ``r2..r{1+num_free}``                             — captures
+      * ``r{2+num_free}..r{1+num_free+explicit_arity}``   — explicit args
+    """
 
     syscall_arg_reg: int = 4
     max_static_data_bytes: int = _MAX_STATIC_DATA_BYTES
     method_max_stack: int = 16
     call_register_count: int | None = 0
+    closure_free_var_counts: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -167,21 +185,97 @@ class CILTokenProvider(Protocol):
     def helper_token(self, helper: CILHelper) -> int:
         """Return the MemberRef or MethodDef token for a runtime helper."""
 
+    # ── CLR02 Phase 2c — closure metadata tokens ────────────────────────
+    #
+    # All four return MethodDef / Field tokens (0x06xxxxxx / 0x04xxxxxx)
+    # for CLR02 Phase 2c closure lowering.  Implementations compute
+    # them deterministically from the closure ordering in the program.
+    # The ``cli-assembly-writer`` honours the same ordering so the
+    # tokens line up with the actual emitted rows.
+
+    def iclosure_apply_token(self) -> int:
+        """Return the MethodDef token for ``IClosure::Apply(int32) → int32``."""
+
+    def closure_ctor_token(self, closure_name: str) -> int:
+        """Return the MethodDef token for ``Closure_<closure_name>::.ctor``."""
+
+    def closure_apply_token(self, closure_name: str) -> int:
+        """Return the MethodDef token for ``Closure_<closure_name>::Apply``."""
+
+    def closure_field_token(self, closure_name: str, capture_index: int) -> int:
+        """Return the Field token for the ``capture_index``-th field
+        on ``Closure_<closure_name>``."""
+
+    def system_object_ctor_token(self) -> int:
+        """Return the MemberRef token for ``[System.Runtime]System.Object::.ctor()``."""
+
 
 class SequentialCILTokenProvider:
     """Deterministic token provider for standalone bytecode lowering.
 
-    Method tokens start at ``0x06000001`` in emitted callable order. Helper
-    tokens start at ``0x0A000001`` in ``CILHelper`` enum order.
+    Method tokens start at ``0x06000001`` in emitted callable order.
+    Helper tokens start at ``0x0A000001`` in ``CILHelper`` enum order.
+
+    For CLR02 Phase 2c, closure-related tokens follow a deterministic
+    layout that ``cli-assembly-writer`` mirrors:
+
+    * After the M main-method MethodDef rows comes one row for
+      ``IClosure::Apply`` (the abstract interface method) — token
+      ``0x06000001 + M``.
+    * Then for each closure k (0-indexed in declaration order),
+      two rows: ``.ctor`` at ``0x06000001 + M + 1 + 2k`` and
+      ``Apply`` at ``0x06000001 + M + 2 + 2k``.
+    * Field tokens (``0x04xxxxxx``) walk the closures in
+      declaration order, with one row per capture in declaration
+      order.
+    * The ``System.Object::.ctor`` MemberRef is emitted by the
+      writer at row ``len(helper_specs) + 1`` whenever any
+      closure type is present, giving a deterministic
+      ``0x0A000000 | (len(helper_specs) + 1)`` token.
     """
 
-    def __init__(self, method_names: tuple[str, ...]) -> None:
+    def __init__(
+        self,
+        method_names: tuple[str, ...],
+        *,
+        closure_names: tuple[str, ...] = (),
+        closure_free_var_counts: dict[str, int] | None = None,
+    ) -> None:
         self._method_tokens = {
             name: 0x06000001 + index for index, name in enumerate(method_names)
         }
         self._helper_tokens = {
             helper: 0x0A000001 + index for index, helper in enumerate(CILHelper)
         }
+
+        # Closure-method tokens.  Layout described in the class
+        # docstring: IClosure::Apply, then per-closure (ctor, Apply)
+        # pairs in ``closure_names`` order.
+        self._closure_names = closure_names
+        self._free_counts = closure_free_var_counts or {}
+        m = len(method_names)
+        self._iclosure_apply = 0x06000001 + m if closure_names else 0
+        self._closure_ctors: dict[str, int] = {}
+        self._closure_applies: dict[str, int] = {}
+        for k, name in enumerate(closure_names):
+            self._closure_ctors[name] = 0x06000001 + m + 1 + 2 * k
+            self._closure_applies[name] = 0x06000001 + m + 2 + 2 * k
+
+        # Field tokens.  One per capture, walking closures in
+        # declaration order.
+        self._closure_fields: dict[tuple[str, int], int] = {}
+        field_row = 0
+        for name in closure_names:
+            for i in range(self._free_counts.get(name, 0)):
+                field_row += 1
+                self._closure_fields[(name, i)] = 0x04000000 | field_row
+
+        # System.Object::.ctor MemberRef — present iff any closure
+        # is present (because closures are the only thing that needs
+        # to chain into the base ctor).  Row = helper count + 1.
+        self._object_ctor = (
+            0x0A000000 | (len(CILHelper) + 1) if closure_names else 0
+        )
 
     def method_token(self, method_name: str) -> int:
         """Return the deterministic MethodDef token for ``method_name``."""
@@ -199,6 +293,42 @@ class SequentialCILTokenProvider:
             msg = f"Unknown CIL helper token target: {helper}"
             raise CILBackendError(msg) from exc
 
+    def iclosure_apply_token(self) -> int:
+        if not self._iclosure_apply:
+            msg = "no closure regions registered with this token provider"
+            raise CILBackendError(msg)
+        return self._iclosure_apply
+
+    def closure_ctor_token(self, closure_name: str) -> int:
+        try:
+            return self._closure_ctors[closure_name]
+        except KeyError as exc:
+            msg = f"unknown closure region: {closure_name!r}"
+            raise CILBackendError(msg) from exc
+
+    def closure_apply_token(self, closure_name: str) -> int:
+        try:
+            return self._closure_applies[closure_name]
+        except KeyError as exc:
+            msg = f"unknown closure region: {closure_name!r}"
+            raise CILBackendError(msg) from exc
+
+    def closure_field_token(self, closure_name: str, capture_index: int) -> int:
+        try:
+            return self._closure_fields[(closure_name, capture_index)]
+        except KeyError as exc:
+            msg = (
+                f"unknown closure field: {closure_name!r} capture "
+                f"{capture_index}"
+            )
+            raise CILBackendError(msg) from exc
+
+    def system_object_ctor_token(self) -> int:
+        if not self._object_ctor:
+            msg = "no closure regions registered with this token provider"
+            raise CILBackendError(msg)
+        return self._object_ctor
+
 
 @dataclass(frozen=True)
 class _CallableRegion:
@@ -210,13 +340,23 @@ class _CallableRegion:
 
 @dataclass(frozen=True)
 class CILLoweringPlan:
-    """Validated lowering plan shared by composable pipeline stages."""
+    """Validated lowering plan shared by composable pipeline stages.
+
+    ``closure_names`` is the ordered tuple of region names that
+    are lifted-lambda bodies (CLR02 Phase 2c).  ``main_region_names``
+    contains the remaining regions — the methods that go on the
+    user's main TypeDef.  ``closure_free_var_counts`` repeats the
+    config knob so the lower stage doesn't need the config.
+    """
 
     regions: tuple[_CallableRegion, ...]
     data_offsets: dict[str, int]
     data_size: int
     local_count: int
     token_provider: CILTokenProvider
+    closure_names: tuple[str, ...] = ()
+    main_region_names: tuple[str, ...] = ()
+    closure_free_var_counts: dict[str, int] = field(default_factory=dict)
 
 
 AnalyzeProgramStage = Callable[[IrProgram, CILBackendConfig], CILLoweringPlan]
@@ -246,17 +386,27 @@ class CILLoweringPipeline:
         """Lower ``program`` to CIL method artifacts."""
         resolved_config = config or CILBackendConfig()
         plan = self._analyze_program(program, resolved_config)
-        methods = tuple(
-            self._lower_region(program, resolved_config, plan, region)
-            for region in plan.regions
-        )
+        # Main-type methods first (existing path); closures go into
+        # extra_types (CLR02 Phase 2c).
+        main_methods: list[CILMethodArtifact] = []
+        closure_apply_methods: dict[str, CILMethodArtifact] = {}
+        for region in plan.regions:
+            artifact = self._lower_region(program, resolved_config, plan, region)
+            if region.name in plan.closure_free_var_counts:
+                closure_apply_methods[region.name] = artifact
+            else:
+                main_methods.append(artifact)
+
+        extra_types = _build_closure_extra_types(plan, closure_apply_methods)
+
         return CILProgramArtifact(
             entry_label=program.entry_label,
-            methods=methods,
+            methods=tuple(main_methods),
             data_offsets=dict(plan.data_offsets),
             data_size=plan.data_size,
             helper_specs=HELPER_SPECS,
             token_provider=plan.token_provider,
+            extra_types=extra_types,
         )
 
 
@@ -323,6 +473,9 @@ _CLR_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     IrOp.BRANCH_NZ,
     IrOp.CALL,
     IrOp.SYSCALL,
+    # CLR02 Phase 2c — closures.
+    IrOp.MAKE_CLOSURE,
+    IrOp.APPLY_CLOSURE,
 })
 
 
@@ -462,8 +615,28 @@ def _analyze_program(
     regions = tuple(_discover_callable_regions(program, label_positions))
     data_offsets, data_size = _assign_data_offsets(program, config)
     local_count = max(_max_register_index(program) + 1, config.syscall_arg_reg + 1, 2)
+
+    # Split regions into "main" and "closure" buckets.  Closure
+    # regions become Apply methods on auto-generated Closure_<name>
+    # TypeDefs (CLR02 Phase 2c).  Main regions become methods on
+    # the user's main TypeDef (the existing CLR01 path).
+    closure_set = set(config.closure_free_var_counts)
+    unknown_closures = closure_set - {r.name for r in regions}
+    if unknown_closures:
+        msg = (
+            "closure_free_var_counts references regions that don't "
+            f"exist in the IR: {sorted(unknown_closures)}"
+        )
+        raise CILBackendError(msg)
+    main_region_names = tuple(r.name for r in regions if r.name not in closure_set)
+    # Closure ordering follows IR-region order so token assignment
+    # is deterministic.
+    closure_names = tuple(r.name for r in regions if r.name in closure_set)
+
     provider = token_provider or SequentialCILTokenProvider(
-        tuple(region.name for region in regions)
+        main_region_names,
+        closure_names=closure_names,
+        closure_free_var_counts=dict(config.closure_free_var_counts),
     )
     return CILLoweringPlan(
         regions=regions,
@@ -471,6 +644,9 @@ def _analyze_program(
         data_size=data_size,
         local_count=local_count,
         token_provider=provider,
+        closure_names=closure_names,
+        main_region_names=main_region_names,
+        closure_free_var_counts=dict(config.closure_free_var_counts),
     )
 
 
@@ -510,6 +686,15 @@ def _discover_callable_regions(
     for instruction in program.instructions:
         if instruction.opcode == IrOp.CALL:
             target = _as_label(instruction.operands[0], "CALL target")
+            callable_names.add(target.name)
+        elif instruction.opcode == IrOp.MAKE_CLOSURE:
+            # MAKE_CLOSURE dst, fn_label, num_captured, capt0, ...
+            # The lambda body is a callable region too, even though
+            # it's invoked indirectly via callvirt at the apply site
+            # rather than directly via CALL.
+            target = _as_label(
+                instruction.operands[1], "MAKE_CLOSURE fn_label",
+            )
             callable_names.add(target.name)
 
     if program.entry_label not in label_positions:
@@ -607,6 +792,9 @@ def _lower_region(
     plan: CILLoweringPlan,
     region: _CallableRegion,
 ) -> CILMethodArtifact:
+    if region.name in plan.closure_free_var_counts:
+        return _lower_closure_region(_program, config, plan, region)
+
     builder = CILBytecodeBuilder()
     call_register_count = _call_register_count(config, plan)
 
@@ -629,6 +817,156 @@ def _lower_region(
                 call_register_count if region.name != _program.entry_label else 0
             )
         ),
+    )
+
+
+# CLR02 Phase 2c — closure body lowering.
+#
+# A closure's lifted lambda becomes ``Apply(int32) → int32`` on a
+# per-lambda ``Closure_<name>`` TypeDef.  The instance method gets:
+#
+#   * Param 0 = ``this`` (the closure object)
+#   * Param 1 = the single explicit argument (v1 supports arity-1 only)
+#
+# The IR body uses the captures-first register convention shared with
+# the BEAM backend:
+#
+#   r2..r{1+num_free}                           — captures
+#   r{2+num_free}                               — explicit arg (arity-1)
+#
+# The Apply method's prologue copies captures from instance fields
+# and the explicit arg from ldarg.1 into those slots so the rest of
+# the IR body's lowering works unmodified.
+_CLR_CLOSURE_EXPLICIT_ARITY: int = 1
+_REG_PARAM_BASE: int = 2
+
+
+def _lower_closure_region(
+    _program: IrProgram,
+    config: CILBackendConfig,
+    plan: CILLoweringPlan,
+    region: _CallableRegion,
+) -> CILMethodArtifact:
+    builder = CILBytecodeBuilder()
+    num_free = plan.closure_free_var_counts[region.name]
+
+    # Prologue: captures from this.fieldI → r{2..1+num_free}
+    for i in range(num_free):
+        field_token = plan.token_provider.closure_field_token(region.name, i)
+        builder.emit_ldarg(0)  # this
+        builder.emit_token_instruction(0x7B, field_token)  # ldfld
+        builder.emit_stloc(_REG_PARAM_BASE + i)
+
+    # The single explicit arg (param 1) → r{2+num_free}.
+    builder.emit_ldarg(1)
+    builder.emit_stloc(_REG_PARAM_BASE + num_free)
+
+    for instruction in region.instructions:
+        _emit_instruction(builder, instruction, config, plan)
+
+    # Apply has fixed name on every closure type (overrides the
+    # IClosure interface's abstract method); the IR's region name
+    # (e.g. ``_lambda_0``) becomes the TypeDef name instead.
+    return CILMethodArtifact(
+        name="Apply",
+        body=builder.assemble(),
+        max_stack=max(config.method_max_stack, 2),
+        local_types=tuple("int32" for _ in range(plan.local_count)),
+        return_type="int32",
+        parameter_types=("int32",),
+        is_instance=True,
+    )
+
+
+def _build_closure_extra_types(
+    plan: CILLoweringPlan,
+    closure_apply_methods: dict[str, CILMethodArtifact],
+) -> tuple[CILTypeArtifact, ...]:
+    """Build the IClosure interface + one Closure_<name> TypeDef per
+    closure region.  Returns them in declaration order so the writer
+    assigns matching MethodDef row indices.
+    """
+    if not plan.closure_names:
+        return ()
+
+    iclosure = CILTypeArtifact(
+        name="IClosure",
+        namespace="CodingAdventures",
+        is_interface=True,
+        extends=None,
+        methods=(
+            CILMethodArtifact(
+                name="Apply",
+                body=b"",
+                max_stack=0,
+                local_types=(),
+                return_type="int32",
+                parameter_types=("int32",),
+                is_instance=True,
+                is_abstract=True,
+            ),
+        ),
+    )
+    extras: list[CILTypeArtifact] = [iclosure]
+
+    object_ctor_token = plan.token_provider.system_object_ctor_token()
+
+    for closure_name in plan.closure_names:
+        num_free = plan.closure_free_var_counts[closure_name]
+        # Fields: capt0, capt1, ...
+        fields = tuple(
+            CILFieldArtifact(name=f"capt{i}", type="int32")
+            for i in range(num_free)
+        )
+        ctor = _build_closure_ctor(
+            num_free, object_ctor_token,
+            field_token=lambda i, _name=closure_name: (
+                plan.token_provider.closure_field_token(_name, i)
+            ),
+        )
+        extras.append(
+            CILTypeArtifact(
+                name=f"Closure_{closure_name}",
+                namespace="CodingAdventures",
+                extends="System.Object",
+                implements=("CodingAdventures.IClosure",),
+                fields=fields,
+                methods=(ctor, closure_apply_methods[closure_name]),
+            )
+        )
+
+    return tuple(extras)
+
+
+def _build_closure_ctor(
+    num_free: int,
+    object_ctor_token: int,
+    *,
+    field_token: Callable[[int], int],
+) -> CILMethodArtifact:
+    """Synthesise a ``.ctor(int32, ..., int32)`` body that chains
+    into ``System.Object::.ctor()`` then stores each capture
+    parameter into its instance field.
+    """
+    builder = CILBytecodeBuilder()
+    # Chain into base ctor: ldarg.0; call instance void Object::.ctor()
+    builder.emit_ldarg(0)
+    builder.emit_call(object_ctor_token)
+    # For each capture i: ldarg.0; ldarg.{1+i}; stfld capt_i
+    for i in range(num_free):
+        builder.emit_ldarg(0)
+        builder.emit_ldarg(1 + i)
+        builder.emit_token_instruction(0x7D, field_token(i))  # stfld
+    builder.emit_ret()
+    return CILMethodArtifact(
+        name=".ctor",
+        body=builder.assemble(),
+        max_stack=2,
+        local_types=(),
+        return_type="void",
+        parameter_types=tuple("int32" for _ in range(num_free)),
+        is_instance=True,
+        is_special_name=True,
     )
 
 
@@ -787,6 +1125,92 @@ def _emit_instruction(
     if instruction.opcode in (IrOp.RET, IrOp.HALT):
         builder.emit_ldloc(1)
         builder.emit_ret()
+        return
+
+    if instruction.opcode == IrOp.MAKE_CLOSURE:
+        # MAKE_CLOSURE dst, fn_label, num_captured, capt0, ..., captN-1
+        # → ldloc capt0; ...; ldloc captN-1; newobj Closure_<fn>::.ctor(...);
+        #   stloc dst
+        if len(instruction.operands) < 3:
+            msg = (
+                f"MAKE_CLOSURE expects at least 3 operands "
+                f"(dst, fn_label, num_captured, capt...), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "MAKE_CLOSURE dst")
+        fn_label = _as_label(instruction.operands[1], "MAKE_CLOSURE fn_label")
+        num_captured = _as_immediate(
+            instruction.operands[2], "MAKE_CLOSURE num_captured"
+        ).value
+        if num_captured != plan.closure_free_var_counts.get(fn_label.name):
+            msg = (
+                f"MAKE_CLOSURE for {fn_label.name!r}: num_captured="
+                f"{num_captured} but config.closure_free_var_counts says "
+                f"{plan.closure_free_var_counts.get(fn_label.name)}"
+            )
+            raise CILBackendError(msg)
+        if len(instruction.operands) != 3 + num_captured:
+            msg = (
+                f"MAKE_CLOSURE for {fn_label.name!r}: num_captured="
+                f"{num_captured} but {len(instruction.operands) - 3} "
+                "capture operands provided"
+            )
+            raise CILBackendError(msg)
+
+        for i in range(num_captured):
+            capt_reg = _as_register(
+                instruction.operands[3 + i],
+                f"MAKE_CLOSURE capture {i}",
+            )
+            builder.emit_ldloc(capt_reg.index)
+        # newobj instance void Closure_<fn>::.ctor(int32, ...)
+        builder.emit_token_instruction(
+            0x73, plan.token_provider.closure_ctor_token(fn_label.name),
+        )
+        builder.emit_stloc(dst.index)
+        return
+
+    if instruction.opcode == IrOp.APPLY_CLOSURE:
+        # APPLY_CLOSURE dst, closure_reg, num_args, arg0
+        # → ldloc closure; ldloc arg0;
+        #   callvirt instance int32 IClosure::Apply(int32);
+        #   stloc dst
+        # v1 supports exactly arity-1.
+        if len(instruction.operands) < 3:
+            msg = (
+                f"APPLY_CLOSURE expects at least 3 operands "
+                f"(dst, closure, num_args, args...), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "APPLY_CLOSURE dst")
+        closure_reg = _as_register(
+            instruction.operands[1], "APPLY_CLOSURE closure_reg"
+        )
+        num_args = _as_immediate(
+            instruction.operands[2], "APPLY_CLOSURE num_args"
+        ).value
+        if num_args != _CLR_CLOSURE_EXPLICIT_ARITY:
+            msg = (
+                f"APPLY_CLOSURE: V1 CLR backend only supports "
+                f"arity-{_CLR_CLOSURE_EXPLICIT_ARITY} closures, got "
+                f"num_args={num_args}.  Multi-arity closures land in a "
+                "later phase."
+            )
+            raise CILBackendError(msg)
+        if len(instruction.operands) != 3 + num_args:
+            msg = (
+                f"APPLY_CLOSURE: num_args={num_args} but "
+                f"{len(instruction.operands) - 3} arg operands provided"
+            )
+            raise CILBackendError(msg)
+        arg_reg = _as_register(instruction.operands[3], "APPLY_CLOSURE arg 0")
+
+        builder.emit_ldloc(closure_reg.index)
+        builder.emit_ldloc(arg_reg.index)
+        builder.emit_callvirt(plan.token_provider.iclosure_apply_token())
+        builder.emit_stloc(dst.index)
         return
 
     if instruction.opcode == IrOp.SYSCALL:

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
@@ -765,3 +765,244 @@ def _program(*instructions: IrInstruction) -> IrProgram:
     for instruction in instructions:
         program.add_instruction(instruction)
     return program
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# CLR02 Phase 2c — closure lowering (structural)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClosureLoweringStructure:
+    """Tests for MAKE_CLOSURE / APPLY_CLOSURE lowering shape.
+
+    These verify the auto-generated TypeArtifacts and bytecode
+    layout — *not* runtime semantics, which require typed-register
+    work landing in a follow-up phase (managed-pointer locals can't
+    fit in the current int32-uniform register convention; see the
+    xfail real-dotnet test in cli-assembly-writer).
+    """
+
+    def _build_make_adder_program(self) -> IrProgram:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [IrLabel("_lambda_0")])
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.ADD,
+                [IrRegister(1), IrRegister(2), IrRegister(3)],
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [IrLabel("make_adder")])
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [
+                    IrRegister(1),
+                    IrLabel("_lambda_0"),
+                    IrImmediate(1),
+                    IrRegister(2),
+                ],
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(7)])
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.CALL, [IrLabel("make_adder")])
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.APPLY_CLOSURE,
+                [
+                    IrRegister(1),
+                    IrRegister(1),
+                    IrImmediate(1),
+                    IrRegister(2),
+                ],
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        return program
+
+    def _config(self) -> CILBackendConfig:
+        return CILBackendConfig(
+            call_register_count=None,
+            closure_free_var_counts={"_lambda_0": 1},
+        )
+
+    def test_iclosure_interface_emitted_when_any_closure_present(self) -> None:
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        names = {(t.namespace, t.name) for t in artifact.extra_types}
+        assert ("CodingAdventures", "IClosure") in names
+        assert ("CodingAdventures", "Closure__lambda_0") in names
+
+    def test_no_extra_types_when_no_closures(self) -> None:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(42)])
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        artifact = lower_ir_to_cil_bytecode(program)
+        assert artifact.extra_types == ()
+
+    def test_iclosure_apply_is_abstract(self) -> None:
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        iclosure = next(
+            t for t in artifact.extra_types if t.name == "IClosure"
+        )
+        assert iclosure.is_interface is True
+        assert iclosure.extends is None
+        assert len(iclosure.methods) == 1
+        apply = iclosure.methods[0]
+        assert apply.name == "Apply"
+        assert apply.is_abstract is True
+        assert apply.is_instance is True
+        assert apply.return_type == "int32"
+        assert apply.parameter_types == ("int32",)
+
+    def test_closure_class_has_field_per_capture(self) -> None:
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        closure = next(
+            t for t in artifact.extra_types if t.name == "Closure__lambda_0"
+        )
+        assert len(closure.fields) == 1
+        assert closure.fields[0].name == "capt0"
+        assert closure.fields[0].type == "int32"
+        assert closure.implements == ("CodingAdventures.IClosure",)
+
+    def test_closure_class_has_ctor_and_apply(self) -> None:
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        closure = next(
+            t for t in artifact.extra_types if t.name == "Closure__lambda_0"
+        )
+        method_names = {m.name for m in closure.methods}
+        assert method_names == {".ctor", "Apply"}
+        ctor = next(m for m in closure.methods if m.name == ".ctor")
+        assert ctor.is_special_name is True
+        assert ctor.is_instance is True
+        assert ctor.return_type == "void"
+        assert ctor.parameter_types == ("int32",)
+        apply = next(m for m in closure.methods if m.name == "Apply")
+        assert apply.is_instance is True
+        assert apply.is_abstract is False
+        assert apply.return_type == "int32"
+        assert apply.parameter_types == ("int32",)
+
+    def test_lambda_region_omitted_from_main_methods(self) -> None:
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        names = {m.name for m in artifact.methods}
+        assert "_lambda_0" not in names
+        assert "Main" in names
+        assert "make_adder" in names
+
+    def test_make_closure_emits_newobj_token(self) -> None:
+        from cil_bytecode_builder import CILOpcode
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        make_adder = next(m for m in artifact.methods if m.name == "make_adder")
+        # newobj opcode = 0x73; appears at least once.
+        assert 0x73 in make_adder.body, "MAKE_CLOSURE should emit newobj"
+        # No callvirt — that's APPLY_CLOSURE's opcode.
+        assert int(CILOpcode.CALLVIRT) not in make_adder.body
+
+    def test_apply_closure_emits_callvirt(self) -> None:
+        from cil_bytecode_builder import CILOpcode
+        artifact = lower_ir_to_cil_bytecode(
+            self._build_make_adder_program(), self._config()
+        )
+        main = next(m for m in artifact.methods if m.name == "Main")
+        assert int(CILOpcode.CALLVIRT) in main.body, (
+            "APPLY_CLOSURE should emit callvirt"
+        )
+
+    def test_closure_arity_other_than_one_rejected(self) -> None:
+        """V1 supports arity-1 closures only; arity-2 should error."""
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [IrLabel("_lambda_0")])
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [
+                    IrRegister(1),
+                    IrLabel("_lambda_0"),
+                    IrImmediate(0),
+                ],
+            )
+        )
+        program.add_instruction(
+            IrInstruction(
+                IrOp.APPLY_CLOSURE,
+                [
+                    IrRegister(1),
+                    IrRegister(1),
+                    IrImmediate(2),  # arity 2
+                    IrRegister(2),
+                    IrRegister(3),
+                ],
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        with pytest.raises(CILBackendError, match=r"arity-1"):
+            lower_ir_to_cil_bytecode(
+                program,
+                CILBackendConfig(closure_free_var_counts={"_lambda_0": 0}),
+            )
+
+    def test_closure_free_var_counts_unknown_region_rejected(self) -> None:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        with pytest.raises(CILBackendError, match=r"don't exist"):
+            lower_ir_to_cil_bytecode(
+                program,
+                CILBackendConfig(closure_free_var_counts={"_ghost": 1}),
+            )
+
+    def test_make_closure_capture_count_mismatch_rejected(self) -> None:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(
+            IrInstruction(IrOp.LABEL, [IrLabel("_lambda_0")])
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        program.add_instruction(
+            IrInstruction(
+                IrOp.MAKE_CLOSURE,
+                [
+                    IrRegister(1),
+                    IrLabel("_lambda_0"),
+                    IrImmediate(2),
+                    IrRegister(2),
+                ],
+            )
+        )
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        with pytest.raises(CILBackendError, match=r"num_captured=2"):
+            lower_ir_to_cil_bytecode(
+                program,
+                CILBackendConfig(closure_free_var_counts={"_lambda_0": 2}),
+            )

--- a/code/specs/CLR02-closure-lowering.md
+++ b/code/specs/CLR02-closure-lowering.md
@@ -164,9 +164,30 @@ Same staging as JVM02 Phase 2:
   prove that an ``IClosure`` interface and a concrete closure-
   shape class with a field round-trip and load.
 - **CLR02 Phase 2c** — ``MAKE_CLOSURE`` / ``APPLY_CLOSURE``
-  lowering in ``ir-to-cil-bytecode``.  Pending.
+  lowering in ``ir-to-cil-bytecode``.  **Shipped (structural).**
+  The backend emits ``newobj`` / ``callvirt`` against
+  auto-generated ``IClosure`` + ``Closure_<name>`` TypeDefs,
+  with deterministic token assignment that matches the
+  writer's row layout.  Captures-first prologue copies
+  ``ldfld`` results into IR register slots.  V1 limitation:
+  arity-1 closures only (multi-arity needs ``int[]`` array
+  handling).  V1 limitation: end-to-end runtime semantics
+  blocked on a typed-register pool — closure refs are managed
+  pointers but the existing CLR backend uses an int32-uniform
+  local/parameter convention, so a closure ref stored into an
+  int32 local truncates the pointer.  The full ``((make-adder
+  7) 35) → 42`` test is committed as ``xfail(strict=True)`` so
+  it'll flip to passing the moment the typed pool lands.
+- **CLR02 Phase 2c.5** (added during 2c implementation) —
+  typed register pool: parallel ``object[]`` slots for
+  closure-flow registers, with a per-method analysis to
+  classify each register as int or object based on
+  MAKE_CLOSURE / CALL-of-closure-returning-method / ADD_IMM
+  copies.  Required to make Phase 2c semantics work end-to-end
+  on real ``dotnet``.  Pending.
 - **CLR02 Phase 2d** — ``twig-clr-compiler`` accepts ``Lambda``
-  + real-``dotnet`` factorial-closure test.  Pending.
+  + real-``dotnet`` factorial-closure test.  Pending — gated
+  on Phase 2c.5.
 
 ## Risk register
 


### PR DESCRIPTION
## Summary

Builds on the now-merged Phase 2b multi-TypeDef metadata in `cli-assembly-writer` (#1762). Adds the IR-to-CIL lowering for `MAKE_CLOSURE` / `APPLY_CLOSURE` and auto-generates the supporting `IClosure` interface + per-lambda `Closure_<name>` TypeDefs.

- `MAKE_CLOSURE` lowers to `newobj Closure_<fn>::.ctor(int32, ..., int32); stloc dst`.
- `APPLY_CLOSURE` lowers to `callvirt int32 IClosure::Apply(int32); stloc dst`.
- Lifted lambda bodies become the `Apply` instance method on their `Closure_<name>` TypeDef, with a captures-from-fields prologue that copies `ldfld` results into IR register slots.
- `cli-assembly-writer` auto-emits the `[System.Runtime]System.Object::.ctor()` MemberRef when any closure type is present, at a deterministic position the lowerer's token provider can reference. `_METHOD_FLAGS_PUBLIC_INSTANCE` widened from `0x86` to `0x1E6` (adds `NewSlot` + `Final`) so the closure's `Apply` is recognized by the runtime as implementing the interface contract.
- `compiler-ir`: `MAKE_CLOSURE` 25→47 and `APPLY_CLOSURE` 26→48 to fix a silent collision with `MUL`/`DIV` (matches what `ir-to-beam` already adopted).

## V1 limitations (documented in CHANGELOG + spec)

- **Arity-1 closures only** for `APPLY_CLOSURE`. Multi-arity needs `int[]` parameter typing on `IClosure::Apply`, which needs a `System.Int32` TypeRef the writer doesn't yet emit.
- **Runtime end-to-end is not yet wired.** Closure refs are managed pointers but the existing CLR backend uses an int32-uniform local/parameter convention; storing a closure ref into an int32 local truncates the pointer. The full `((make-adder 7) 35) → 42` test ships as `xfail(strict=True)` so the structural shape stays right and it'll auto-flip to passing the moment the typed-register pool work lands (CLR02 Phase 2c.5, added to the spec).

## Test plan

- [x] 11 new structural unit tests for closure lowering (auto-emission, TypeDef shape, MethodDef ordering, opcode emission, validation paths)
- [x] All 14 cli-assembly-writer tests pass (1 xfail end-to-end)
- [x] All 58 ir-to-cil-bytecode tests pass at 93% coverage
- [x] All 114 compiler-ir tests pass (opcode count + roundtrip fixtures updated)
- [x] All 50 twig-clr-compiler tests pass — no regressions
- [x] Security review passed (one round)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)