### PR TITLE
Replace null characters in HTML lexer

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -101,6 +101,9 @@ documented in this file.
 - Unquoted attribute values now preserve unexpected characters such as `"`,
   `'`, `<`, `=`, and `` ` `` while reporting
   `unexpected-character-in-unquoted-attribute-value`.
+- NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
+  attribute values now recover with `unexpected-null-character` and append
+  U+FFFD.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -31,6 +31,10 @@ kept, later attributes with the same interpreted name are dropped, and a
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`.
+NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
+attribute values recover by reporting `unexpected-null-character` and appending
+U+FFFD, matching the replacement behavior the future parser will expect from
+the lexer/tokenizer boundary.
 Comment tokenization includes the standard start-dash recovery cases for empty
 HTML comments such as `<!-->` and `<!--->`, while still preserving normal
 Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -22,6 +22,7 @@ alphabet = [
   "\"",
   "'",
   "`",
+  "\u0000",
   " ",
   "\n",
   "\t",
@@ -621,6 +622,12 @@ actions = [
 
 [[transitions]]
 from = "data"
+matcher = { literal = "\u0000" }
+to = "data"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
+
+[[transitions]]
+from = "data"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -650,6 +657,12 @@ actions = [
 
 [[transitions]]
 from = "rcdata"
+matcher = { literal = "\u0000" }
+to = "rcdata"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
+
+[[transitions]]
+from = "rcdata"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -666,6 +679,12 @@ from = "rawtext"
 matcher = { literal = "<" }
 to = "rawtext_less_than_sign"
 actions = ["flush_text"]
+
+[[transitions]]
+from = "rawtext"
+matcher = { literal = "\u0000" }
+to = "rawtext"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "rawtext"
@@ -689,6 +708,12 @@ actions = ["flush_text", "emit(EOF)"]
 
 [[transitions]]
 from = "plaintext"
+matcher = { literal = "\u0000" }
+to = "plaintext"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
+
+[[transitions]]
+from = "plaintext"
 matcher = { anything = true }
 to = "plaintext"
 actions = ["append_text(current)"]
@@ -697,6 +722,12 @@ actions = ["append_text(current)"]
 from = "cdata_section"
 matcher = { literal = "]" }
 to = "cdata_section_bracket"
+
+[[transitions]]
+from = "cdata_section"
+matcher = { literal = "\u0000" }
+to = "cdata_section"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "cdata_section"
@@ -759,6 +790,12 @@ actions = ["append_text(]])"]
 from = "script_data"
 matcher = { literal = "<" }
 to = "script_data_less_than_sign"
+
+[[transitions]]
+from = "script_data"
+matcher = { literal = "\u0000" }
+to = "script_data"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "script_data"
@@ -2774,6 +2811,15 @@ actions = [
 
 [[transitions]]
 from = "before_attribute_value"
+matcher = { literal = "\u0000" }
+to = "attribute_value_unquoted"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_attribute_value_replacement",
+]
+
+[[transitions]]
+from = "before_attribute_value"
 matcher = { anything = true }
 to = "attribute_value_unquoted"
 actions = ["append_attribute_value(current)"]
@@ -2808,6 +2854,15 @@ actions = [
 
 [[transitions]]
 from = "attribute_value_double_quoted"
+matcher = { literal = "\u0000" }
+to = "attribute_value_double_quoted"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_attribute_value_replacement",
+]
+
+[[transitions]]
+from = "attribute_value_double_quoted"
 matcher = { anything = true }
 to = "attribute_value_double_quoted"
 actions = ["append_attribute_value(current)"]
@@ -2838,6 +2893,15 @@ actions = [
   "set_return_state(attribute_value_single_quoted)",
   "clear_temporary_buffer",
   "append_temporary_buffer(&)",
+]
+
+[[transitions]]
+from = "attribute_value_single_quoted"
+matcher = { literal = "\u0000" }
+to = "attribute_value_single_quoted"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_attribute_value_replacement",
 ]
 
 [[transitions]]
@@ -2902,6 +2966,15 @@ actions = [
   "set_return_state(attribute_value_unquoted)",
   "clear_temporary_buffer",
   "append_temporary_buffer(&)",
+]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "\u0000" }
+to = "attribute_value_unquoted"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_attribute_value_replacement",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -4,11 +4,7 @@
 //! Do not edit by hand.
 
 #[allow(unused_imports)]
-use state_machine::{
-    EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind,
-    MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition,
-    TokenDefinition, TransitionDefinition,
-};
+use state_machine::{EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition, TransitionDefinition};
 
 pub fn html1_lexer_definition() -> StateMachineDefinition {
     let mut definition = StateMachineDefinition::new("html1-lexer", MachineKind::Transducer);
@@ -18,6 +14,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
     definition.runtime_min = Some("state-machine-tokenizer/0.1".to_string());
     definition.done = Some("done".to_string());
     definition.alphabet = vec![
+        "\0".to_string(),
         "\t".to_string(),
         "\n".to_string(),
         "\r".to_string(),
@@ -79,7 +76,9 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
     definition.tokens = vec![
         TokenDefinition {
             name: "Text".to_string(),
-            fields: vec!["data".to_string()],
+            fields: vec![
+                "data".to_string(),
+            ],
         },
         TokenDefinition {
             name: "StartTag".to_string(),
@@ -91,11 +90,15 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         TokenDefinition {
             name: "EndTag".to_string(),
-            fields: vec!["name".to_string()],
+            fields: vec![
+                "name".to_string(),
+            ],
         },
         TokenDefinition {
             name: "Comment".to_string(),
-            fields: vec!["data".to_string()],
+            fields: vec![
+                "data".to_string(),
+            ],
         },
         TokenDefinition {
             name: "Doctype".to_string(),
@@ -1395,6 +1398,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "data".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "data".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -1458,6 +1477,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rcdata".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "rcdata".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -1498,6 +1533,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "flush_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "rawtext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
             ],
             consume: true,
         },
@@ -1551,6 +1602,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "plaintext".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "plaintext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "plaintext".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "plaintext".to_string(),
@@ -1574,6 +1641,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "cdata_section".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "cdata_section".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
             consume: true,
         },
         TransitionDefinition {
@@ -1723,6 +1806,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
             consume: true,
         },
         TransitionDefinition {
@@ -6258,6 +6357,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_attribute_value".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_value_unquoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_attribute_value_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_value".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_value_unquoted".to_string(),
@@ -6323,6 +6438,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_value_double_quoted".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_value_double_quoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_attribute_value_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_value_double_quoted".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_value_double_quoted".to_string(),
@@ -6382,6 +6513,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "set_return_state(attribute_value_single_quoted)".to_string(),
                 "clear_temporary_buffer".to_string(),
                 "append_temporary_buffer(&)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_value_single_quoted".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_value_single_quoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_attribute_value_replacement".to_string(),
             ],
             consume: true,
         },
@@ -6523,6 +6670,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "set_return_state(attribute_value_unquoted)".to_string(),
                 "clear_temporary_buffer".to_string(),
                 "append_temporary_buffer(&)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_value_unquoted".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_value_unquoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_attribute_value_replacement".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 60);
+    assert_eq!(html1.cases.len(), 61);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 58);
+    assert_eq!(file.tests.len(), 59);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 58);
+    assert_eq!(normalized.cases.len(), 59);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 58);
+    assert_eq!(suite.cases.len(), 59);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -61,6 +61,23 @@
       ]
     },
     {
+      "id": "null-character-replacement",
+      "description": "NULL characters in data and attribute values are replaced with U+FFFD",
+      "input": "A\u0000<a title=\"x\u0000y\" data=x\u0000y bare=\u0000>z",
+      "tokens": [
+        "Text(data=A\uFFFD)",
+        "StartTag(name=a, attributes=[title=x\uFFFDy, data=x\uFFFDy, bare=\uFFFD], self_closing=false)",
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ]
+    },
+    {
       "id": "mosaic-doctype-and-heading",
       "input": "<!DOCTYPE HTML><H1 class=test>Hello</H1>",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -296,6 +296,23 @@
     },
     {
       "id": "html5lib-smoke-24",
+      "description": "null characters are replaced in data and attributes",
+      "input": "A\u0000<a title=\"x\u0000y\" data=x\u0000y bare=\u0000>z",
+      "tokens": [
+        "Text(data=A\ufffd)",
+        "StartTag(name=a, attributes=[title=x\ufffdy, data=x\ufffdy, bare=\ufffd], self_closing=false)",
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-25",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -306,7 +323,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-25",
+      "id": "html5lib-smoke-26",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -319,7 +336,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -332,7 +349,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -342,7 +359,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -352,7 +369,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -364,7 +381,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -374,7 +391,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -384,7 +401,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -397,7 +414,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -407,7 +424,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -417,7 +434,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -430,7 +447,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -444,7 +461,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -458,7 +475,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -475,7 +492,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -485,7 +502,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -495,7 +512,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -505,7 +522,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -515,7 +532,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -527,7 +544,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -540,7 +557,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -553,7 +570,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -568,7 +585,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -581,7 +598,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-49",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -595,7 +612,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-50",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -608,7 +625,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-51",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -622,7 +639,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -636,7 +653,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -650,7 +667,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -663,7 +680,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -677,7 +694,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -691,7 +708,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -704,7 +721,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-58",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -723,7 +740,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-59",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -224,6 +224,21 @@
       ]
     },
     {
+      "description": "null characters are replaced in data and attributes",
+      "input": "A\u0000<a title=\"x\u0000y\" data=x\u0000y bare=\u0000>z",
+      "output": [
+        ["Character", "A\uFFFD"],
+        ["StartTag", "a", {"title": "x\uFFFDy", "data": "x\uFFFDy", "bare": "\uFFFD"}],
+        ["Character", "z"]
+      ],
+      "errors": [
+        {"code": "unexpected-null-character", "line": 1, "col": 2},
+        {"code": "unexpected-null-character", "line": 1, "col": 14},
+        {"code": "unexpected-null-character", "line": 1, "col": 24},
+        {"code": "unexpected-null-character", "line": 1, "col": 32}
+      ]
+    },
+    {
       "description": "plaintext state literalizes markup and character references",
       "initialStates": ["PLAINTEXT state"],
       "input": "hello <b>still text</b> &amp; literal",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -162,6 +162,51 @@ fn default_html_lexer_reports_unexpected_chars_in_unquoted_attribute_values() {
 }
 
 #[test]
+fn default_html_lexer_replaces_null_characters_in_text_and_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("A\0<a title=\"x\0y\" data=x\0y bare=\0>z")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("A\u{FFFD}".to_string()),
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "x\u{FFFD}y".to_string(),
+                    },
+                    Attribute {
+                        name: "data".to_string(),
+                        value: "x\u{FFFD}y".to_string(),
+                    },
+                    Attribute {
+                        name: "bare".to_string(),
+                        value: "\u{FFFD}".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Text("z".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        4
+    );
+}
+
+#[test]
 fn default_html_lexer_marks_missing_doctype_name_force_quirks() {
     let mut lexer = create_html_lexer().unwrap();
 
@@ -804,6 +849,38 @@ fn default_html_lexer_supports_seeded_rcdata_lt_references() {
         lexer.drain_tokens(),
         vec![Token::Text("Hello</title>".to_string()), Token::Eof]
     );
+}
+
+#[test]
+fn default_html_lexer_replaces_null_characters_in_text_submodes() {
+    for initial_state in [
+        "rcdata",
+        "rawtext",
+        "script_data",
+        "plaintext",
+        "cdata_section",
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+
+        lexer.push("a\0b").unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![Token::Text("a\u{FFFD}b".to_string()), Token::Eof],
+            "state {initial_state} should replace NULL characters"
+        );
+        assert_eq!(
+            lexer
+                .diagnostics()
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+                .count(),
+            1,
+            "state {initial_state} should report NULL recovery"
+        );
+    }
 }
 
 #[test]

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -679,6 +679,7 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         "flush_text"
         | "emit_current_as_text"
         | "append_text_replacement"
+        | "append_attribute_value_replacement"
         | "create_start_tag"
         | "create_end_tag"
         | "create_comment"

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -24,3 +24,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 - Added `commit_attribute_dedup` for lexer definitions that need HTML-style
   duplicate attribute recovery while keeping plain `commit_attribute`
   available for definitions that preserve duplicates.
+- Added `append_attribute_value_replacement` so lexer definitions can recover
+  invalid attribute-value code points with U+FFFD without host callbacks.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -46,6 +46,7 @@ Tag tokens:
 - `append_attribute_name(literal)`
 - `append_attribute_value(current)`
 - `append_attribute_value(literal)`
+- `append_attribute_value_replacement`
 - `commit_attribute`
 - `commit_attribute_dedup`
 - `mark_self_closing`

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -400,6 +400,9 @@ impl Tokenizer {
                     }
                 })?),
                 "append_text_replacement" => self.text_buffer.push('\u{FFFD}'),
+                "append_attribute_value_replacement" => {
+                    self.attribute_mut(action)?.value.push('\u{FFFD}');
+                }
                 "flush_text" => self.flush_text(),
                 "emit_current_as_text" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -410,6 +410,47 @@ fn tokenizer_appends_temporary_buffer_to_attribute_value() {
 }
 
 #[test]
+fn tokenizer_appends_replacement_character_to_attribute_value() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "done"]),
+            set(&["A"]),
+            vec![EffectfulTransition::new(
+                "data",
+                EffectfulMatcher::Event("A".to_string()),
+                "done",
+            )
+            .with_effects(&[
+                "create_start_tag",
+                "append_tag_name(current_lowercase)",
+                "start_attribute",
+                "append_attribute_name(title)",
+                "append_attribute_value_replacement",
+                "commit_attribute",
+                "emit_current_token",
+            ])],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("A").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::StartTag {
+            name: "a".to_string(),
+            attributes: vec![Attribute {
+                name: "title".to_string(),
+                value: "\u{FFFD}".to_string(),
+            }],
+            self_closing: false,
+        }]
+    );
+}
+
+#[test]
 fn tokenizer_decodes_numeric_character_references_from_temporary_buffer() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## Summary
- add portable tokenizer support for appending U+FFFD to attribute values
- teach the HTML1 authored state machine to recover NULL characters in text submodes and attribute values
- add wrapper, tokenizer, Venture, and html5lib-style fixture coverage and regenerate static Rust source

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- git diff --check