### PR TITLE
Replace null characters in HTML names

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -104,6 +104,8 @@ documented in this file.
 - NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
   attribute values now recover with `unexpected-null-character` and append
   U+FFFD.
+- NULL characters in tag names and attribute names now recover with
+  `unexpected-null-character` and append U+FFFD.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -35,6 +35,9 @@ NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
 attribute values recover by reporting `unexpected-null-character` and appending
 U+FFFD, matching the replacement behavior the future parser will expect from
 the lexer/tokenizer boundary.
+Tag names and attribute names now use the same recovery shape, so a raw NULL in
+markup names becomes U+FFFD and records `unexpected-null-character` instead of
+leaking the raw code point into emitted tokens.
 Comment tokenization includes the standard start-dash recovery cases for empty
 HTML comments such as `<!-->` and `<!--->`, while still preserving normal
 Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -2485,6 +2485,16 @@ actions = [
 
 [[transitions]]
 from = "tag_open"
+matcher = { literal = "\u0000" }
+to = "data"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_text(<)",
+  "append_text_replacement",
+]
+
+[[transitions]]
+from = "tag_open"
 matcher = { anything = true }
 to = "data"
 consume = false
@@ -2571,6 +2581,12 @@ actions = [
 
 [[transitions]]
 from = "tag_name"
+matcher = { literal = "\u0000" }
+to = "tag_name"
+actions = ["parse_error(unexpected-null-character)", "append_tag_name_replacement"]
+
+[[transitions]]
+from = "tag_name"
 matcher = { anything = true }
 to = "tag_name"
 actions = ["append_tag_name(current_lowercase)"]
@@ -2625,6 +2641,16 @@ actions = [
   "parse_error(eof-in-tag)",
   "emit_current_token",
   "emit(EOF)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "\u0000" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "start_attribute",
+  "append_attribute_name_replacement",
 ]
 
 [[transitions]]
@@ -2684,6 +2710,15 @@ actions = [
 
 [[transitions]]
 from = "attribute_name"
+matcher = { literal = "\u0000" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_attribute_name_replacement",
+]
+
+[[transitions]]
+from = "attribute_name"
 matcher = { anything = true }
 to = "attribute_name"
 actions = ["append_attribute_name(current_lowercase)"]
@@ -2735,6 +2770,17 @@ actions = [
   "commit_attribute_dedup",
   "emit_current_token",
   "emit(EOF)",
+]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\u0000" }
+to = "attribute_name"
+actions = [
+  "commit_attribute_dedup",
+  "parse_error(unexpected-null-character)",
+  "start_attribute",
+  "append_attribute_name_replacement",
 ]
 
 [[transitions]]
@@ -6249,6 +6295,12 @@ actions = [
   "emit_current_token",
   "emit(EOF)",
 ]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = "\u0000" }
+to = "end_tag_name"
+actions = ["parse_error(unexpected-null-character)", "append_tag_name_replacement"]
 
 [[transitions]]
 from = "end_tag_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -4,7 +4,11 @@
 //! Do not edit by hand.
 
 #[allow(unused_imports)]
-use state_machine::{EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition, TransitionDefinition};
+use state_machine::{
+    EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind,
+    MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition,
+    TokenDefinition, TransitionDefinition,
+};
 
 pub fn html1_lexer_definition() -> StateMachineDefinition {
     let mut definition = StateMachineDefinition::new("html1-lexer", MachineKind::Transducer);
@@ -76,9 +80,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
     definition.tokens = vec![
         TokenDefinition {
             name: "Text".to_string(),
-            fields: vec![
-                "data".to_string(),
-            ],
+            fields: vec!["data".to_string()],
         },
         TokenDefinition {
             name: "StartTag".to_string(),
@@ -90,15 +92,11 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         TokenDefinition {
             name: "EndTag".to_string(),
-            fields: vec![
-                "name".to_string(),
-            ],
+            fields: vec!["name".to_string()],
         },
         TokenDefinition {
             name: "Comment".to_string(),
-            fields: vec![
-                "data".to_string(),
-            ],
+            fields: vec!["data".to_string()],
         },
         TokenDefinition {
             name: "Doctype".to_string(),
@@ -5628,6 +5626,23 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "tag_open".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text(<)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_open".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "data".to_string(),
@@ -5822,6 +5837,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_tag_name_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "tag_name".to_string(),
@@ -5951,6 +5982,23 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_attribute_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_name".to_string(),
@@ -6081,6 +6129,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_attribute_name_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_name".to_string(),
@@ -6206,6 +6270,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "after_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "commit_attribute_dedup".to_string(),
+                "parse_error(unexpected-null-character)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "after_attribute_name".to_string(),
@@ -13072,6 +13154,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_tag_name_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "end_tag_name".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 61);
+    assert_eq!(html1.cases.len(), 62);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 59);
+    assert_eq!(file.tests.len(), 60);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 59);
+    assert_eq!(normalized.cases.len(), 60);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 59);
+    assert_eq!(suite.cases.len(), 60);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -78,6 +78,23 @@
       ]
     },
     {
+      "id": "null-character-name-replacement",
+      "description": "NULL characters in tag and attribute names are replaced with U+FFFD",
+      "input": "<x\u0000 \u0000=v a\u0000b=1 first \u0000second=2></x\u0000>",
+      "tokens": [
+        "StartTag(name=x\uFFFD, attributes=[\uFFFD=v, a\uFFFDb=1, first=, \uFFFDsecond=2], self_closing=false)",
+        "EndTag(name=x\uFFFD)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ]
+    },
+    {
       "id": "mosaic-doctype-and-heading",
       "input": "<!DOCTYPE HTML><H1 class=test>Hello</H1>",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -313,6 +313,23 @@
     },
     {
       "id": "html5lib-smoke-25",
+      "description": "null characters are replaced in tag and attribute names",
+      "input": "<x\u0000 \u0000=v a\u0000b=1 first \u0000second=2></x\u0000>",
+      "tokens": [
+        "StartTag(name=x\ufffd, attributes=[\ufffd=v, a\ufffdb=1, first=, \ufffdsecond=2], self_closing=false)",
+        "EndTag(name=x\ufffd)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-26",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -323,7 +340,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-26",
+      "id": "html5lib-smoke-27",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -336,7 +353,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -349,7 +366,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -359,7 +376,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -369,7 +386,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -381,7 +398,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -391,7 +408,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -401,7 +418,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -414,7 +431,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -424,7 +441,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -434,7 +451,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -447,7 +464,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -461,7 +478,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -475,7 +492,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -492,7 +509,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -502,7 +519,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -512,7 +529,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -522,7 +539,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -532,7 +549,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -544,7 +561,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -557,7 +574,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -570,7 +587,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -585,7 +602,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-49",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -598,7 +615,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-50",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -612,7 +629,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-51",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -625,7 +642,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -639,7 +656,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -653,7 +670,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -667,7 +684,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -680,7 +697,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -694,7 +711,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -708,7 +725,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-58",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -721,7 +738,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-59",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -740,7 +757,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-60",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -239,6 +239,21 @@
       ]
     },
     {
+      "description": "null characters are replaced in tag and attribute names",
+      "input": "<x\u0000 \u0000=v a\u0000b=1 first \u0000second=2></x\u0000>",
+      "output": [
+        ["StartTag", "x\uFFFD", {"\uFFFD": "v", "a\uFFFDb": "1", "first": "", "\uFFFDsecond": "2"}],
+        ["EndTag", "x\uFFFD"]
+      ],
+      "errors": [
+        {"code": "unexpected-null-character", "line": 1, "col": 3},
+        {"code": "unexpected-null-character", "line": 1, "col": 5},
+        {"code": "unexpected-null-character", "line": 1, "col": 10},
+        {"code": "unexpected-null-character", "line": 1, "col": 21},
+        {"code": "unexpected-null-character", "line": 1, "col": 34}
+      ]
+    },
+    {
       "description": "plaintext state literalizes markup and character references",
       "initialStates": ["PLAINTEXT state"],
       "input": "hello <b>still text</b> &amp; literal",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -207,6 +207,56 @@ fn default_html_lexer_replaces_null_characters_in_text_and_attributes() {
 }
 
 #[test]
+fn default_html_lexer_replaces_null_characters_in_tag_and_attribute_names() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<x\0 \0=v a\0b=1 first \0second=2></x\0>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "x\u{FFFD}".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "\u{FFFD}".to_string(),
+                        value: "v".to_string(),
+                    },
+                    Attribute {
+                        name: "a\u{FFFD}b".to_string(),
+                        value: "1".to_string(),
+                    },
+                    Attribute {
+                        name: "first".to_string(),
+                        value: String::new(),
+                    },
+                    Attribute {
+                        name: "\u{FFFD}second".to_string(),
+                        value: "2".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "x\u{FFFD}".to_string(),
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        5
+    );
+}
+
+#[test]
 fn default_html_lexer_marks_missing_doctype_name_force_quirks() {
     let mut lexer = create_html_lexer().unwrap();
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -680,6 +680,8 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "emit_current_as_text"
         | "append_text_replacement"
         | "append_attribute_value_replacement"
+        | "append_tag_name_replacement"
+        | "append_attribute_name_replacement"
         | "create_start_tag"
         | "create_end_tag"
         | "create_comment"

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -26,3 +26,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   available for definitions that preserve duplicates.
 - Added `append_attribute_value_replacement` so lexer definitions can recover
   invalid attribute-value code points with U+FFFD without host callbacks.
+- Added `append_tag_name_replacement` and `append_attribute_name_replacement`
+  so lexer definitions can recover invalid name code points with U+FFFD.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -40,10 +40,12 @@ Tag tokens:
 - `create_end_tag`
 - `append_tag_name(current)`
 - `append_tag_name(current_lowercase)`
+- `append_tag_name_replacement`
 - `start_attribute`
 - `append_attribute_name(current)`
 - `append_attribute_name(current_lowercase)`
 - `append_attribute_name(literal)`
+- `append_attribute_name_replacement`
 - `append_attribute_value(current)`
 - `append_attribute_value(literal)`
 - `append_attribute_value_replacement`

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -452,6 +452,9 @@ impl Tokenizer {
                     })?;
                     self.append_tag_name(action, ch, true)?;
                 }
+                "append_tag_name_replacement" => {
+                    self.append_tag_name(action, '\u{FFFD}', false)?;
+                }
                 "start_attribute" => {
                     self.current_attribute = Some(Attribute {
                         name: String::new(),
@@ -469,6 +472,9 @@ impl Tokenizer {
                         action: action.clone(),
                     })?;
                     self.append_attribute_name(action, ch, true)?;
+                }
+                "append_attribute_name_replacement" => {
+                    self.append_attribute_name(action, '\u{FFFD}', false)?;
                 }
                 "append_attribute_value(current)" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -451,6 +451,49 @@ fn tokenizer_appends_replacement_character_to_attribute_value() {
 }
 
 #[test]
+fn tokenizer_appends_replacement_character_to_tag_and_attribute_names() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "done"]),
+            set(&["A"]),
+            vec![EffectfulTransition::new(
+                "data",
+                EffectfulMatcher::Event("A".to_string()),
+                "done",
+            )
+            .with_effects(&[
+                "create_start_tag",
+                "append_tag_name(current_lowercase)",
+                "append_tag_name_replacement",
+                "start_attribute",
+                "append_attribute_name_replacement",
+                "append_attribute_name(title)",
+                "append_attribute_value(ok)",
+                "commit_attribute",
+                "emit_current_token",
+            ])],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("A").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::StartTag {
+            name: "a\u{FFFD}".to_string(),
+            attributes: vec![Attribute {
+                name: "\u{FFFD}title".to_string(),
+                value: "ok".to_string(),
+            }],
+            self_closing: false,
+        }]
+    );
+}
+
+#[test]
 fn tokenizer_decodes_numeric_character_references_from_temporary_buffer() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## Summary
- add portable tokenizer actions for U+FFFD replacement in tag and attribute names
- teach the HTML1 state machine to recover NULL characters in start/end tag names and attribute-name states
- add wrapper, tokenizer, Venture, and html5lib-style fixtures and regenerate static Rust source

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_replaces_null_characters_in_tag_and_attribute_names -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- git diff --check HEAD~1 HEAD