### PR TITLE
feat(mini-sqlite): numeric parameter binding (:N style) (v1.11.0)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [1.11.0] - 2026-04-29
+
+### Added
+
+**Numeric parameter binding (`:N` style)**
+
+`Cursor.execute` and `Connection.execute` now accept the third PEP 249
+positional paramstyle: numeric `:N` placeholders bound from a `Sequence`.
+This completes the trio (`?`, `:N`, `:name`) supported by the stdlib
+`sqlite3` module.
+
+```python
+conn.execute(
+    "SELECT * FROM employees WHERE dept = :1 OR dept = :2",
+    ("eng", "sales"),
+)
+```
+
+- **`binding.substitute`** — recognises `:` followed by digits as a
+  numeric placeholder.  `N` is 1-indexed: `:1` → `parameters[0]`,
+  `:2` → `parameters[1]`, etc.
+- **Mutual exclusion** — qmark, numeric, and named styles cannot be
+  mixed in a single statement.  The error message now lists all three:
+  `"cannot mix '?', ':N', and ':name' parameter styles in one statement"`.
+- **Error cases** — `:0` raises `ProgrammingError("1-indexed")`;
+  `:N` with `N > len(parameters)` raises `out of range`; `:N` with a
+  mapping raises `numeric` (must be a sequence).
+- **Repeated indices** — `:1` may appear multiple times, all binding to
+  the same value.  Trailing unused values in the sequence are silently
+  ignored (matching `sqlite3`).
+- **`paramstyle`** docstring extended to mention all three runtime
+  styles; the declared value remains `"qmark"`.
+
+### Tests added
+
+- `tests/test_binding.py::TestNumericParameters` — 13 unit tests:
+  single/multi binding, repeated index, extra-value tolerance,
+  out-of-range, zero-index, scanner safe inside literals/comments,
+  multi-digit index, paramstyle exclusivity (mixing, mapping rejection),
+  value type rendering.
+- `tests/test_cursor.py` — 3 end-to-end tests via `Connection.execute`:
+  numeric SELECT, numeric INSERT, repeated index.
+
 ## [1.10.0] - 2026-04-29
 
 ### Added

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/__init__.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/__init__.py
@@ -33,10 +33,11 @@ threadsafety = 1
 paramstyle = "qmark"
 """PEP 249: declared paramstyle is ``qmark`` (``?`` placeholders).
 
-The driver also accepts ``:name`` placeholders when *parameters* is a
-mapping — matching the stdlib ``sqlite3`` module's behaviour, which also
-declares ``qmark`` while accepting both styles at runtime.  See
-``binding.py`` for substitution rules.
+The driver also accepts the other two SQLite paramstyles at runtime:
+``:N`` (numeric, 1-indexed) when *parameters* is a sequence, and
+``:name`` (named) when *parameters* is a mapping.  This matches the
+stdlib ``sqlite3`` module, which likewise declares ``qmark`` while
+accepting all three styles.  See ``binding.py`` for substitution rules.
 """
 
 

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/binding.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/binding.py
@@ -1,18 +1,24 @@
 """
 Parameter binding — substitute placeholders into SQL source text.
 
-PEP 249 ``paramstyle``: this driver supports both ``"qmark"`` (``?``) and
-``"named"`` (``:name``) styles, matching the stdlib ``sqlite3`` module.
+PEP 249 ``paramstyle``: this driver supports all three positional /
+ordinal styles: ``"qmark"`` (``?``), ``"numeric"`` (``:N``), and
+``"named"`` (``:name``).  ``sqlite3`` itself accepts the same set.
 
-* ``qmark``: caller passes a ``Sequence``.  Each ``?`` consumes the next
+* ``qmark`` — caller passes a ``Sequence``.  Each ``?`` consumes the next
   positional parameter.  Arity must match exactly.
-* ``named``: caller passes a ``Mapping``.  Each ``:identifier`` is replaced
-  by ``parameters[identifier]``.  A missing key raises ``ProgrammingError``.
+* ``numeric`` — caller passes a ``Sequence``.  Each ``:N`` (1-indexed)
+  binds to ``parameters[N - 1]``.  ``N`` may be reused; out-of-range or
+  ``:0`` raises ``ProgrammingError``.
+* ``named`` — caller passes a ``Mapping``.  Each ``:identifier`` is
+  replaced by ``parameters[identifier]``.  Missing keys raise
+  ``ProgrammingError``.
 
-Mixing both styles in one statement is rejected — pick one paramstyle per
-statement.  Inside string literals (``'...'``, with backslash escapes) and
-comments (``--...\\n`` and ``/* ... */``) the scanner does *not* count
-placeholders — those aren't parameter markers.
+The three styles are mutually exclusive within a single statement —
+mixing them raises ``ProgrammingError``.  Inside string literals
+(``'...'``, with backslash escapes) and comments (``--...\\n`` and
+``/* ... */``) the scanner does *not* count placeholders — those aren't
+parameter markers.
 
 Type mapping — the output must parse as a valid SQL literal:
 
@@ -42,21 +48,23 @@ _IDENT_CONT = re.compile(r"[A-Za-z0-9_]")
 
 
 def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
-    """Return ``sql`` with each ``?`` or ``:name`` replaced by a SQL literal.
+    """Return ``sql`` with each placeholder replaced by a SQL literal.
 
     The paramstyle is decided from the type of *parameters*:
 
-    * ``Sequence`` (tuple, list, …) → qmark style.  Every ``?`` in the SQL
-      consumes one positional parameter; the count must match exactly.
-    * ``Mapping`` (dict, …) → named style.  Every ``:identifier`` is looked
-      up by key in *parameters*.  Missing keys raise ``ProgrammingError``.
-
-    Mixing ``?`` and ``:name`` markers in the same statement is rejected.
+    * ``Sequence`` (tuple, list, …) → qmark style (``?``) and/or numeric
+      style (``:N``, 1-indexed).  ``?`` consumes the next positional value;
+      ``:N`` looks up ``parameters[N - 1]``.  qmark and numeric cannot be
+      mixed in one statement.
+    * ``Mapping`` (dict, …) → named style (``:identifier``).
 
     Raises :class:`ProgrammingError` on any of:
       * arity mismatch (qmark)
+      * out-of-range index (numeric)
       * unknown key (named)
-      * mixed paramstyle in one statement
+      * mixed paramstyles in one statement (any pair of qmark/numeric/named)
+      * wrong container for a placeholder (mapping with ``?``/``:N``, or
+        sequence with ``:name``)
       * unsupported parameter type
     """
     is_mapping = isinstance(parameters, Mapping) and not isinstance(parameters, str | bytes)
@@ -65,6 +73,7 @@ def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
     n = len(sql)
     pos_idx = 0
     seen_qmark = False
+    seen_numeric = False
     seen_named = False
 
     while i < n:
@@ -107,9 +116,10 @@ def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
 
         # Qmark placeholder.
         if ch == "?":
-            if seen_named:
+            if seen_named or seen_numeric:
                 raise ProgrammingError(
-                    "cannot mix '?' and ':name' parameter styles in one statement"
+                    "cannot mix '?', ':N', and ':name' parameter styles "
+                    "in one statement"
                 )
             seen_qmark = True
             if is_mapping:
@@ -127,6 +137,41 @@ def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
             i += 1
             continue
 
+        # Numeric placeholder ``:N`` (1-indexed positional).  PEP 249 calls
+        # this the ``"numeric"`` paramstyle; ``sqlite3`` accepts it too.
+        # Disjoint from the named branch below — that branch requires the
+        # next char to be an identifier-start (letter or underscore), this
+        # one requires a digit.
+        if ch == ":" and i + 1 < n and sql[i + 1].isdigit():
+            j = i + 1
+            while j < n and sql[j].isdigit():
+                j += 1
+            number = int(sql[i + 1 : j])
+            if seen_qmark or seen_named:
+                raise ProgrammingError(
+                    "cannot mix '?', ':N', and ':name' parameter styles "
+                    "in one statement"
+                )
+            seen_numeric = True
+            if is_mapping:
+                raise ProgrammingError(
+                    f"SQL has numeric parameter ':{number}' but parameters "
+                    f"is a mapping; pass a sequence for numeric style"
+                )
+            if number < 1:
+                raise ProgrammingError(
+                    f"numeric parameter ':{number}' is invalid — "
+                    f"PEP 249 numeric placeholders are 1-indexed"
+                )
+            if number > len(parameters):
+                raise ProgrammingError(
+                    f"numeric parameter ':{number}' is out of range "
+                    f"(only {len(parameters)} parameters supplied)"
+                )
+            out.append(_to_sql_literal(parameters[number - 1]))
+            i = j
+            continue
+
         # Named placeholder ``:identifier``.  Only treat as a placeholder if
         # the next character looks like the start of an identifier.  This
         # avoids false positives in expressions like ``a::INT`` (Postgres-
@@ -140,11 +185,12 @@ def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
             while j < n and _IDENT_CONT.match(sql[j]):
                 j += 1
             name = sql[i + 1 : j]
-            seen_named = True
-            if seen_qmark:
+            if seen_qmark or seen_numeric:
                 raise ProgrammingError(
-                    "cannot mix '?' and ':name' parameter styles in one statement"
+                    "cannot mix '?', ':N', and ':name' parameter styles "
+                    "in one statement"
                 )
+            seen_named = True
             if not is_mapping:
                 raise ProgrammingError(
                     f"SQL has named parameter ':{name}' but parameters is not "
@@ -167,8 +213,16 @@ def substitute(sql: str, parameters: Sequence[Any] | Mapping[str, Any]) -> str:
             f"too many parameters supplied: SQL has {pos_idx} placeholders, "
             f"got {len(parameters)}"
         )
-    # For an empty SQL with a non-empty sequence, also flag.
-    if not seen_qmark and not seen_named and not is_mapping and len(parameters) > 0:
+    # For an empty SQL with a non-empty sequence, also flag.  ``seen_numeric``
+    # statements are exempt — numeric style does not consume sequentially,
+    # so "extra" trailing values are allowed (matching sqlite3 semantics).
+    if (
+        not seen_qmark
+        and not seen_named
+        and not seen_numeric
+        and not is_mapping
+        and len(parameters) > 0
+    ):
         raise ProgrammingError(
             f"too many parameters supplied: SQL has 0 placeholders, "
             f"got {len(parameters)}"

--- a/code/packages/python/mini-sqlite/tests/test_binding.py
+++ b/code/packages/python/mini-sqlite/tests/test_binding.py
@@ -181,12 +181,10 @@ class TestNamedParameters:
         out = substitute("SELECT :col1, :col2", {"col1": 1, "col2": 2})
         assert out == "SELECT 1, 2"
 
-    def test_leading_digit_after_colon_is_not_named(self):
-        """``:1`` is *numeric* style — not supported here, must not consume."""
-        # We expect substitute to leave ``:1`` untouched (then parser will
-        # decide how to handle it).  The mapping has no key '1' anyway.
-        out = substitute("SELECT :1", {})
-        assert out == "SELECT :1"
+    def test_leading_digit_with_mapping_raises(self):
+        """``:1`` is numeric style — using it with a Mapping raises."""
+        with pytest.raises(mini_sqlite.ProgrammingError, match="numeric"):
+            substitute("SELECT :1", {})
 
     def test_qmark_with_mapping_raises(self):
         with pytest.raises(mini_sqlite.ProgrammingError, match="mapping"):
@@ -212,3 +210,89 @@ class TestNamedParameters:
 
     def test_empty_mapping_with_no_placeholders(self):
         assert substitute("SELECT 1", {}) == "SELECT 1"
+
+
+# ---------------------------------------------------------------------------
+# Numeric parameter style (``:N``, 1-indexed)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericParameters:
+    """``:N`` placeholders bound from a Sequence by 1-indexed position."""
+
+    def test_single_numeric_param(self):
+        assert substitute("SELECT :1", (42,)) == "SELECT 42"
+
+    def test_multiple_distinct_numeric_params(self):
+        out = substitute(
+            "SELECT :1, :2, :3", (1, 2.5, "hi"),
+        )
+        assert out == "SELECT 1, 2.5, 'hi'"
+
+    def test_same_numeric_param_used_twice(self):
+        """A numeric placeholder may appear more than once."""
+        out = substitute(
+            "SELECT * FROM t WHERE x = :1 OR y = :1", (7,),
+        )
+        assert out == "SELECT * FROM t WHERE x = 7 OR y = 7"
+
+    def test_extra_sequence_values_are_allowed(self):
+        """Numeric style does not require all values to be referenced.
+
+        Matches sqlite3 semantics: extra trailing values in the sequence
+        are silently ignored when only some indices are used.
+        """
+        out = substitute("SELECT :1", (5, 99, 100))
+        assert out == "SELECT 5"
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(mini_sqlite.ProgrammingError, match="out of range"):
+            substitute("SELECT :3", (1, 2))
+
+    def test_zero_index_raises(self):
+        """Numeric style is 1-indexed; ``:0`` is invalid."""
+        with pytest.raises(mini_sqlite.ProgrammingError, match="1-indexed"):
+            substitute("SELECT :0", (1,))
+
+    def test_numeric_inside_string_literal_is_ignored(self):
+        out = substitute(
+            "SELECT ':1 is not bound' WHERE y = :1", (5,),
+        )
+        assert out == "SELECT ':1 is not bound' WHERE y = 5"
+
+    def test_numeric_inside_line_comment_is_ignored(self):
+        out = substitute(
+            "SELECT 1 -- :2\nWHERE x = :1", (9,),
+        )
+        assert out == "SELECT 1 -- :2\nWHERE x = 9"
+
+    def test_numeric_inside_block_comment_is_ignored(self):
+        out = substitute(
+            "SELECT /* :2 */ :1", (9,),
+        )
+        assert out == "SELECT /* :2 */ 9"
+
+    def test_multi_digit_index(self):
+        out = substitute("SELECT :12", tuple(range(20)))
+        assert out == "SELECT 11"  # 1-indexed → parameters[11]
+
+    def test_numeric_with_mapping_raises(self):
+        with pytest.raises(mini_sqlite.ProgrammingError, match="numeric"):
+            substitute("SELECT :1", {"1": "a"})
+
+    def test_numeric_mixed_with_qmark_raises(self):
+        with pytest.raises(mini_sqlite.ProgrammingError, match="mix"):
+            substitute("SELECT ?, :1", (1, 2))
+
+    def test_numeric_mixed_with_named_raises(self):
+        # ``:n`` (named) must come first so the mixing check fires before
+        # the wrong-container check.
+        with pytest.raises(mini_sqlite.ProgrammingError, match="mix"):
+            substitute("SELECT :n, :1", {"n": 5})
+
+    def test_numeric_value_types(self):
+        out = substitute(
+            "VALUES (:1, :2, :3, :4, :5)",
+            (None, 7, 1.5, "ok", True),
+        )
+        assert out == "VALUES (NULL, 7, 1.5, 'ok', 1)"

--- a/code/packages/python/mini-sqlite/tests/test_cursor.py
+++ b/code/packages/python/mini-sqlite/tests/test_cursor.py
@@ -183,3 +183,34 @@ def test_bytes_param_round_trip():
     conn.commit()
     rows = conn.execute("SELECT id, data FROM blobs ORDER BY id").fetchall()
     assert rows == [(1, b"\xde\xad\xbe\xef"), (2, b"")]
+
+
+def test_parameterised_select_with_numeric_params():
+    """End-to-end: ``:N`` placeholders bound from a sequence (PEP 249 numeric)."""
+    conn = _seeded()
+    cur = conn.execute(
+        "SELECT name FROM employees WHERE dept = :1 OR dept = :2",
+        ("eng", "sales"),
+    )
+    names = sorted(row[0] for row in cur)
+    assert names == ["Alice", "Bob", "Carol"]
+
+
+def test_parameterised_insert_with_numeric_params():
+    conn = _seeded()
+    conn.execute(
+        "INSERT INTO employees (id, name, dept) VALUES (:1, :2, :3)",
+        (99, "Dan", "ops"),
+    )
+    cur = conn.execute("SELECT name FROM employees WHERE id = :1", (99,))
+    assert cur.fetchone() == ("Dan",)
+
+
+def test_numeric_param_reused_in_same_statement():
+    conn = _seeded()
+    cur = conn.execute(
+        "SELECT name FROM employees WHERE dept = :1 OR name = :1",
+        ("eng",),
+    )
+    names = sorted(row[0] for row in cur)
+    assert names == ["Alice", "Bob"]


### PR DESCRIPTION
## Summary

- `Cursor.execute` and `Connection.execute` now accept the third PEP 249 positional paramstyle: numeric `:N` placeholders bound from a `Sequence` (1-indexed)
- Completes the trio (`?`, `:N`, `:name`) supported by stdlib `sqlite3`
- Mutual exclusion: any pair of styles in one statement raises `ProgrammingError(\"cannot mix '?', ':N', and ':name' parameter styles in one statement\")`
- 13 new unit tests + 3 end-to-end tests; 617 mini-sqlite tests pass; ruff clean
- Security review passed in one round (thorough SQL-injection analysis, no findings)

```python
conn.execute(
    \"SELECT * FROM employees WHERE dept = :1 OR dept = :2\",
    (\"eng\", \"sales\"),
)
```

## Implementation note

The new branch sits between the qmark and named branches in `binding.substitute`. It's disjoint from the named branch by lookahead: numeric requires a digit after `:`, named requires a letter/underscore. Postgres-style casts (`a::INT`) and stray colons fall through to the literal-char append unchanged.

`:0` raises `ProgrammingError(\"1-indexed\")`. `:N` with `N > len(parameters)` raises `out of range`. `:N` with a mapping raises `numeric`. Repeated indices are allowed; trailing unused values are silently ignored (matches sqlite3).

## Test plan

- [x] All 617 mini-sqlite tests pass
- [x] `ruff check src/ tests/` — clean
- [x] Security review passed (no findings, deep SQL-injection analysis: int() DoS, range validation, scanner-safety inside literals/comments, mixing detection across all 3 styles, value rendering reuses hardened `_to_sql_literal`)
- [x] Tested: single/multi binding, repeated index, extra-value tolerance, out-of-range, zero-index, scanner safe inside literals/comments, multi-digit index, paramstyle exclusivity, value type rendering, end-to-end via Connection.execute (SELECT, INSERT, repeated index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)