### PR TITLE
Replace null characters in HTML comments

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -106,6 +106,9 @@ documented in this file.
   U+FFFD.
 - NULL characters in tag names and attribute names now recover with
   `unexpected-null-character` and append U+FFFD.
+- NULL characters in comments and bogus comments now recover with
+  `unexpected-null-character` and append U+FFFD while preserving pending comment
+  dashes.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -38,6 +38,9 @@ the lexer/tokenizer boundary.
 Tag names and attribute names now use the same recovery shape, so a raw NULL in
 markup names becomes U+FFFD and records `unexpected-null-character` instead of
 leaking the raw code point into emitted tokens.
+Comments and bogus comments also replace raw NULL characters with U+FFFD while
+recording `unexpected-null-character`, including dash-sensitive comment end
+substates that must preserve their pending `-` or `--` text first.
 Comment tokenization includes the standard start-dash recovery cases for empty
 HTML comments such as `<!-->` and `<!--->`, while still preserving normal
 Mosaic-era `<!--note-->` comments. Nested-looking `<!--` sequences inside an

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -4639,6 +4639,17 @@ actions = [
 
 [[transitions]]
 from = "comment_start"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "parse_error(unexpected-null-character)",
+  "append_comment(-)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "comment_start"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = [
@@ -4670,6 +4681,12 @@ actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
 
 [[transitions]]
 from = "comment_start_dash"
+matcher = { literal = "\u0000" }
+to = "comment"
+actions = ["parse_error(unexpected-null-character)", "append_comment_replacement"]
+
+[[transitions]]
+from = "comment_start_dash"
 matcher = { anything = true }
 to = "comment"
 actions = ["append_comment(current)"]
@@ -4691,6 +4708,12 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "comment"
+matcher = { literal = "\u0000" }
+to = "comment"
+actions = ["parse_error(unexpected-null-character)", "append_comment_replacement"]
 
 [[transitions]]
 from = "comment"
@@ -4802,6 +4825,16 @@ actions = [
 
 [[transitions]]
 from = "comment_end_dash"
+matcher = { literal = "\u0000" }
+to = "comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_comment(-)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "comment_end_dash"
 matcher = { anything = true }
 to = "comment"
 actions = ["append_comment(-)", "append_comment(current)"]
@@ -4833,6 +4866,16 @@ actions = [
   "append_comment(--)",
   "emit_current_token",
   "emit(EOF)",
+]
+
+[[transitions]]
+from = "comment_end"
+matcher = { literal = "\u0000" }
+to = "comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_comment(--)",
+  "append_comment_replacement",
 ]
 
 [[transitions]]
@@ -4884,6 +4927,12 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["emit_current_token", "emit(EOF)"]
+
+[[transitions]]
+from = "bogus_comment"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = ["parse_error(unexpected-null-character)", "append_comment_replacement"]
 
 [[transitions]]
 from = "bogus_comment"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -9780,6 +9780,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "comment_start".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(incorrectly-opened-comment)".to_string(),
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment(-)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_start".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "bogus_comment".to_string(),
@@ -9843,6 +9861,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "comment_start_dash".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_start_dash".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "comment".to_string(),
@@ -9899,6 +9933,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "comment".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "comment".to_string(),
@@ -10137,6 +10187,23 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "comment_end_dash".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment(-)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "comment_end_dash".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "comment".to_string(),
@@ -10210,6 +10277,23 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "comment_end".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment(--)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "comment_end".to_string(),
@@ -10321,6 +10405,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "bogus_comment".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "bogus_comment".to_string(),

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 62);
+    assert_eq!(html1.cases.len(), 63);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 60);
+    assert_eq!(file.tests.len(), 61);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 60);
+    assert_eq!(normalized.cases.len(), 61);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 60);
+    assert_eq!(suite.cases.len(), 61);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -95,6 +95,30 @@
       ]
     },
     {
+      "id": "null-character-comment-replacement",
+      "description": "NULL characters in comments and bogus comments are replaced with U+FFFD",
+      "input": "<!--a\u0000b--><!--\u0000--><!--a-\u0000b--><!--a--\u0000b--><!foo\u0000><!-\u0000>",
+      "tokens": [
+        "Comment(data=a\uFFFDb)",
+        "Comment(data=\uFFFD)",
+        "Comment(data=a-\uFFFDb)",
+        "Comment(data=a--\uFFFDb)",
+        "Comment(data=foo\uFFFD)",
+        "Comment(data=-\uFFFD)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "incorrectly-opened-comment",
+        "unexpected-null-character",
+        "incorrectly-opened-comment",
+        "unexpected-null-character"
+      ]
+    },
+    {
       "id": "mosaic-doctype-and-heading",
       "input": "<!DOCTYPE HTML><H1 class=test>Hello</H1>",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -330,6 +330,30 @@
     },
     {
       "id": "html5lib-smoke-26",
+      "description": "null characters are replaced in comments and bogus comments",
+      "input": "<!--a\u0000b--><!--\u0000--><!--a-\u0000b--><!--a--\u0000b--><!foo\u0000><!-\u0000>",
+      "tokens": [
+        "Comment(data=a\ufffdb)",
+        "Comment(data=\ufffd)",
+        "Comment(data=a-\ufffdb)",
+        "Comment(data=a--\ufffdb)",
+        "Comment(data=foo\ufffd)",
+        "Comment(data=-\ufffd)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "incorrectly-opened-comment",
+        "unexpected-null-character",
+        "incorrectly-opened-comment",
+        "unexpected-null-character"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-27",
       "description": "plaintext state literalizes markup and character references",
       "input": "hello <b>still text</b> &amp; literal",
       "tokens": [
@@ -340,7 +364,7 @@
       "initial_state": "PLAINTEXT state"
     },
     {
-      "id": "html5lib-smoke-27",
+      "id": "html5lib-smoke-28",
       "description": "script data matching end tag emits end tag token",
       "input": "if (a < b) alert('&amp;');</script>",
       "tokens": [
@@ -353,7 +377,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-28",
+      "id": "html5lib-smoke-29",
       "description": "script data escaped matching end tag emits end tag token",
       "input": "if (a < b) </script>",
       "tokens": [
@@ -366,7 +390,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-29",
+      "id": "html5lib-smoke-30",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -376,7 +400,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-30",
+      "id": "html5lib-smoke-31",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -386,7 +410,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-31",
+      "id": "html5lib-smoke-32",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -398,7 +422,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-33",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -408,7 +432,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-34",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -418,7 +442,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-35",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -431,7 +455,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-36",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -441,7 +465,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-37",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -451,7 +475,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-38",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -464,7 +488,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-39",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -478,7 +502,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-40",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -492,7 +516,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-41",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -509,7 +533,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-42",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -519,7 +543,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-43",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -529,7 +553,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-44",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -539,7 +563,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-45",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -549,7 +573,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-46",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -561,7 +585,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-47",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -574,7 +598,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-48",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -587,7 +611,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-49",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -602,7 +626,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-50",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -615,7 +639,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-51",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -629,7 +653,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -642,7 +666,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -656,7 +680,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -670,7 +694,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -684,7 +708,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -697,7 +721,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -711,7 +735,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-58",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -725,7 +749,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-59",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -738,7 +762,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-60",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -757,7 +781,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-60",
+      "id": "html5lib-smoke-61",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -254,6 +254,28 @@
       ]
     },
     {
+      "description": "null characters are replaced in comments and bogus comments",
+      "input": "<!--a\u0000b--><!--\u0000--><!--a-\u0000b--><!--a--\u0000b--><!foo\u0000><!-\u0000>",
+      "output": [
+        ["Comment", "a\uFFFDb"],
+        ["Comment", "\uFFFD"],
+        ["Comment", "a-\uFFFDb"],
+        ["Comment", "a--\uFFFDb"],
+        ["Comment", "foo\uFFFD"],
+        ["Comment", "-\uFFFD"]
+      ],
+      "errors": [
+        {"code": "unexpected-null-character", "line": 1, "col": 6},
+        {"code": "unexpected-null-character", "line": 1, "col": 15},
+        {"code": "unexpected-null-character", "line": 1, "col": 25},
+        {"code": "unexpected-null-character", "line": 1, "col": 37},
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 44},
+        {"code": "unexpected-null-character", "line": 1, "col": 47},
+        {"code": "incorrectly-opened-comment", "line": 1, "col": 52},
+        {"code": "unexpected-null-character", "line": 1, "col": 52}
+      ]
+    },
+    {
       "description": "plaintext state literalizes markup and character references",
       "initialStates": ["PLAINTEXT state"],
       "input": "hello <b>still text</b> &amp; literal",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -817,6 +817,37 @@ fn default_html_lexer_preserves_bang_after_comment_end_when_not_closing() {
 }
 
 #[test]
+fn default_html_lexer_replaces_null_characters_in_comments() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<!--a\0b--><!--\0--><!--a-\0b--><!--a--\0b--><!foo\0><!-\0>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Comment("a\u{FFFD}b".to_string()),
+            Token::Comment("\u{FFFD}".to_string()),
+            Token::Comment("a-\u{FFFD}b".to_string()),
+            Token::Comment("a--\u{FFFD}b".to_string()),
+            Token::Comment("foo\u{FFFD}".to_string()),
+            Token::Comment("-\u{FFFD}".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        6
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_chunked_input_and_unicode_any_matcher() {
     let mut lexer = create_html_lexer().unwrap();
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -682,6 +682,7 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "append_attribute_value_replacement"
         | "append_tag_name_replacement"
         | "append_attribute_name_replacement"
+        | "append_comment_replacement"
         | "create_start_tag"
         | "create_end_tag"
         | "create_comment"

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -28,3 +28,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   invalid attribute-value code points with U+FFFD without host callbacks.
 - Added `append_tag_name_replacement` and `append_attribute_name_replacement`
   so lexer definitions can recover invalid name code points with U+FFFD.
+- Added `append_comment_replacement` so lexer definitions can recover invalid
+  comment data code points with U+FFFD.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -60,6 +60,7 @@ Comments and doctypes:
 - `append_comment(current)`
 - `append_comment(current_lowercase)`
 - `append_comment(literal)`
+- `append_comment_replacement`
 - `create_doctype`
 - `append_doctype_name(current)`
 - `append_doctype_name(current_lowercase)`

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -497,6 +497,9 @@ impl Tokenizer {
                     })?;
                     self.append_comment(action, ch, true)?;
                 }
+                "append_comment_replacement" => {
+                    self.append_comment(action, '\u{FFFD}', false)?;
+                }
                 "append_doctype_name(current)" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
                         action: action.clone(),

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -250,6 +250,37 @@ fn tokenizer_builds_comment_tokens_with_current_and_literal_actions() {
 }
 
 #[test]
+fn tokenizer_appends_replacement_character_to_comments() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "done"]),
+            set(&["!"]),
+            vec![EffectfulTransition::new(
+                "data",
+                EffectfulMatcher::Event("!".to_string()),
+                "done",
+            )
+            .with_effects(&[
+                "create_comment",
+                "append_comment(open)",
+                "append_comment_replacement",
+                "emit_current_token",
+            ])],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("!").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Comment("open\u{FFFD}".to_string())]
+    );
+}
+
+#[test]
 fn tokenizer_builds_doctypes_and_marks_force_quirks() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## Summary
- add a portable tokenizer action for U+FFFD replacement in comment data
- teach the HTML1 state machine to recover NULL characters in comments, dash-pending comment substates, and bogus comments
- add wrapper, tokenizer, Venture, and html5lib-style fixture coverage and regenerate static Rust source

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_replaces_null_characters_in_comments -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- cargo check --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- git diff --check
- git diff --check HEAD~1 HEAD