### PR TITLE
Add ALGOL standard real math runtime imports

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -89,6 +89,9 @@ All notable changes to this package will be documented in this file.
   existing integer/f64 IR operations.
 - Lowered standard real builtin function `sqrt` to integer-to-real promotion,
   a negative-domain runtime failure guard, and the `F64_SQRT` IR opcode.
+- Lowered standard real builtin functions `sin`, `cos`, `arctan`, `ln`, and
+  `exp` to integer-to-real promotion and the corresponding imported f64 math
+  IR opcodes, with nonpositive `ln` guarded by the runtime-failure path.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -35,9 +35,10 @@ expressions, and ALGOL-left-associative exponentiation when the exponent is an
 integer. Real bases with negative integer exponents are lowered through a
 reciprocal path; arbitrary real exponents remain outside this phase until the
 runtime has a real `pow` implementation instead of an approximation shortcut.
-Standard numeric functions `abs`, `sign`, `entier`, and `sqrt` lower directly
-to existing integer/f64 comparison, arithmetic, conversion, and square-root IR
-instructions.
+Standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
+`arctan`, `ln`, and `exp` lower to existing integer/f64 comparison,
+arithmetic, conversion, native square-root IR, and imported standard real-math
+IR instructions.
 
 Scalar by-name parameters lower through a one-word cell in the callee frame.
 Passing a scalar variable as a by-name actual gives the callee a storage pointer,

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -115,6 +115,18 @@ _BUILTIN_ABS_LABEL = "__algol_builtin_abs"
 _BUILTIN_ENTIER_LABEL = "__algol_builtin_entier"
 _BUILTIN_SIGN_LABEL = "__algol_builtin_sign"
 _BUILTIN_SQRT_LABEL = "__algol_builtin_sqrt"
+_BUILTIN_SIN_LABEL = "__algol_builtin_sin"
+_BUILTIN_COS_LABEL = "__algol_builtin_cos"
+_BUILTIN_ARCTAN_LABEL = "__algol_builtin_arctan"
+_BUILTIN_LN_LABEL = "__algol_builtin_ln"
+_BUILTIN_EXP_LABEL = "__algol_builtin_exp"
+_BUILTIN_REAL_MATH_OPS = {
+    _BUILTIN_SIN_LABEL: IrOp.F64_SIN,
+    _BUILTIN_COS_LABEL: IrOp.F64_COS,
+    _BUILTIN_ARCTAN_LABEL: IrOp.F64_ATAN,
+    _BUILTIN_LN_LABEL: IrOp.F64_LN,
+    _BUILTIN_EXP_LABEL: IrOp.F64_EXP,
+}
 _WRITE_SYSCALL = 1
 
 
@@ -2837,6 +2849,7 @@ class AlgolIrCompiler:
             _BUILTIN_ENTIER_LABEL,
             _BUILTIN_SIGN_LABEL,
             _BUILTIN_SQRT_LABEL,
+            *_BUILTIN_REAL_MATH_OPS,
         }:
             return self._compile_builtin_numeric(node, call, scope)
         if call.parameter_symbol_id is not None:
@@ -3384,6 +3397,9 @@ class AlgolIrCompiler:
             return self._emit_builtin_sign(value, actual_type)
         if call.label == _BUILTIN_SQRT_LABEL:
             return self._emit_builtin_sqrt(value, actual_type, scope)
+        math_op = _BUILTIN_REAL_MATH_OPS.get(call.label)
+        if math_op is not None:
+            return self._emit_builtin_real_math(value, actual_type, math_op, scope)
         raise CompileError(f"unknown builtin numeric function {call.name!r}")
 
     def _emit_builtin_abs(self, value: int, actual_type: str) -> int:
@@ -3572,6 +3588,40 @@ class AlgolIrCompiler:
 
         result = self._fresh_reg()
         self._emit(IrOp.F64_SQRT, IrRegister(result), IrRegister(value))
+        return result
+
+    def _emit_builtin_real_math(
+        self,
+        value: int,
+        actual_type: str,
+        opcode: IrOp,
+        scope: _FrameScope,
+    ) -> int:
+        if actual_type == _INTEGER_TYPE:
+            real_value = self._fresh_reg()
+            self._emit(
+                IrOp.F64_FROM_I32,
+                IrRegister(real_value),
+                IrRegister(value),
+            )
+            value = real_value
+        elif actual_type != _REAL_TYPE:
+            raise CompileError(
+                f"builtin {opcode.name.lower()} does not support {actual_type}"
+            )
+
+        if opcode == IrOp.F64_LN:
+            nonpositive = self._fresh_reg()
+            self._emit(
+                IrOp.F64_CMP_LE,
+                IrRegister(nonpositive),
+                IrRegister(value),
+                IrRegister(self._const_f64_reg(0.0)),
+            )
+            self._emit_runtime_failure_guard(nonpositive, scope)
+
+        result = self._fresh_reg()
+        self._emit(opcode, IrRegister(result), IrRegister(value))
         return result
 
     def _emit_output_chars(self, text: str, scope: _FrameScope) -> None:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -587,7 +587,9 @@ class TestAlgolIrCompiler:
         result = compile_algol(
             parse_algol(
                 "begin integer result; real x; "
-                "x := -2.5; result := abs(0 - 3) + sign(x) + entier(sqrt(9)) "
+                "x := -2.5; "
+                "x := sin(sqrt(9)) + cos(0) + arctan(1) + ln(exp(1)); "
+                "result := abs(0 - 3) + sign(x) + entier(x) "
                 "end"
             )
         )
@@ -598,6 +600,11 @@ class TestAlgolIrCompiler:
         assert IrOp.I32_TRUNC_FROM_F64 in opcodes
         assert IrOp.F64_FROM_I32 in opcodes
         assert IrOp.F64_SQRT in opcodes
+        assert IrOp.F64_SIN in opcodes
+        assert IrOp.F64_COS in opcodes
+        assert IrOp.F64_ATAN in opcodes
+        assert IrOp.F64_LN in opcodes
+        assert IrOp.F64_EXP in opcodes
 
     def test_integer_division_emits_runtime_failure_guard(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -63,6 +63,9 @@ All notable changes to this package will be documented in this file.
   integer/real argument checking and read-only by-name analysis.
 - Accepted standard real builtin function `sqrt`, returning `real` for integer
   or real arguments while preserving read-only by-name analysis.
+- Accepted standard real builtin functions `sin`, `cos`, `arctan`, `ln`, and
+  `exp`, returning `real` for integer or real arguments while preserving
+  read-only by-name analysis.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -18,8 +18,8 @@ expressions, tolerant trailing/repeated semicolons from the parser, and
 left-associative exponentiation for numeric bases with integer exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
 types are still rejected before IR lowering. Standard numeric functions
-`abs`, `sign`, `entier`, and `sqrt` are resolved as read-only builtins with
-integer/real argument validation.
+`abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`, `arctan`, `ln`, and `exp` are
+resolved as read-only builtins with integer/real argument validation.
 
 The checker also builds the first ALGOL 60 full-runtime semantic model. Each
 source block receives a stable block id, lexical depth, static-parent id, and a

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -24,7 +24,16 @@ STATIC = "static"
 PARAMETER_STORAGE = "parameter"
 MAX_ARRAY_DIMENSIONS = 4
 _OUTPUT_BUILTINS = {"print", "output"}
-_FIXED_RETURN_NUMERIC_BUILTINS = {"entier": INTEGER, "sign": INTEGER, "sqrt": REAL}
+_FIXED_RETURN_NUMERIC_BUILTINS = {
+    "entier": INTEGER,
+    "sign": INTEGER,
+    "sqrt": REAL,
+    "sin": REAL,
+    "cos": REAL,
+    "arctan": REAL,
+    "ln": REAL,
+    "exp": REAL,
+}
 _NUMERIC_BUILTINS = {"abs"} | set(_FIXED_RETURN_NUMERIC_BUILTINS)
 _READ_ONLY_BUILTINS = _OUTPUT_BUILTINS | _NUMERIC_BUILTINS
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -370,6 +370,7 @@ class TestAlgolTypeChecker:
         ast = parse_algol(
             "begin integer result; real x, root; "
             "root := sqrt(9); "
+            "root := sin(root) + cos(0) + arctan(1) + ln(exp(1)); "
             "result := abs(0 - 3) + sign(x) + entier(root) "
             "end"
         )
@@ -385,6 +386,11 @@ class TestAlgolTypeChecker:
         assert calls["sign"] == "integer"
         assert calls["entier"] == "integer"
         assert calls["sqrt"] == "real"
+        assert calls["sin"] == "real"
+        assert calls["cos"] == "real"
+        assert calls["arctan"] == "real"
+        assert calls["ln"] == "real"
+        assert calls["exp"] == "real"
 
     def test_rejects_boolean_actual_for_numeric_builtin_function(self) -> None:
         ast = parse_algol("begin integer result; result := abs(false) end")

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -83,6 +83,12 @@ All notable changes to this package will be documented in this file.
 - Executed standard real builtin function `sqrt` through the full parser,
   type-checker, IR, and WASM pipeline with negative-domain failure returning
   `0`.
+- Executed standard real builtin functions `sin`, `cos`, `arctan`, `ln`, and
+  `exp` through the full parser, type-checker, IR, and WASM pipeline using the
+  `compiler_math` host import ABI, with nonpositive `ln` arguments returning
+  `0` through the ALGOL runtime failure path.
+- Added a standard-real-math golden fixture covering imported real math and
+  output in one end-to-end program.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,7 +21,9 @@ the current lane already supports a substantial ALGOL 60 surface:
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer exponents
-- standard numeric functions `abs`, `sign`, `entier`, and `sqrt`
+- standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
+  `arctan`, `ln`, and `exp`; non-native real math is imported through the
+  runtime's `compiler_math` host ABI
 - value and by-name parameters, including Jensen-style expression thunks,
   typed whole-array formals with copy or aliasing semantics, and formal
   procedure calls that forward scalar, whole-array, label, switch, or
@@ -57,6 +59,13 @@ with_array = compile_source(
     "a[2] := 9; result := a[2] end"
 )
 assert WasmRuntime().load_and_run(with_array.binary, "_start", []) == [9]
+
+with_math = compile_source(
+    "begin integer result; real x; "
+    "x := sin(0) + cos(0) + arctan(1) + ln(exp(1)); "
+    "result := entier(x * 100) end"
+)
+assert WasmRuntime(host=WasiHost()).load_and_run(with_math.binary, "_start", []) == [278]
 
 showcase = compile_source(
     "begin own integer counter; integer array a[1:3]; real average; "

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/standard-real-math.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/standard-real-math.alg
@@ -1,0 +1,10 @@
+begin
+  integer result;
+  real metric;
+  string msg;
+
+  msg := 'MATH';
+  metric := sin(0) + cos(0) + arctan(1) + ln(exp(1));
+  result := entier(metric * 100);
+  print(msg); output(' '); print(result);
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -205,6 +205,28 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
 
+    def test_standard_real_math_builtins_execute_through_host_imports(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := sin(0) + cos(0) + arctan(1) + ln(exp(1)); "
+            "result := entier(x * 100) "
+            "end"
+        )
+        assert WasmRuntime(host=WasiHost()).load_and_run(
+            result.binary, "_start", []
+        ) == [278]
+
+    def test_ln_nonpositive_argument_returns_zero_through_runtime_failure(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := ln(0); "
+            "result := 7 "
+            "end"
+        )
+        assert WasmRuntime(host=WasiHost()).load_and_run(
+            result.binary, "_start", []
+        ) == [0]
+
     def test_builtin_print_string_literal_writes_stdout(self) -> None:
         result = compile_source("begin integer result; print('Hi'); result := 7 end")
         captured: list[str] = []

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -26,6 +26,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="jensens-device", result=[30], stdout=""),
     GoldenFixture(name="control-flow", result=[7], stdout="FLOW 7"),
     GoldenFixture(name="convergence", result=[39], stdout="CONVERGE 39"),
+    GoldenFixture(name="standard-real-math", result=[278], stdout="MATH 278"),
 )
 
 

--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`IrOp.F64_SQRT` (49)** — unary 64-bit floating square root
   (`dst = sqrt(src)`) for frontends that need standard real math builtins.
+- **`IrOp.F64_SIN` (50)**, **`IrOp.F64_COS` (51)**,
+  **`IrOp.F64_ATAN` (52)**, **`IrOp.F64_LN` (53)**, and
+  **`IrOp.F64_EXP` (54)** — unary 64-bit floating standard math operations
+  for frontends with real numeric libraries.
 
 ## [0.4.0] — 2026-04-29
 

--- a/code/packages/python/compiler-ir/README.md
+++ b/code/packages/python/compiler-ir/README.md
@@ -7,8 +7,9 @@ General-purpose intermediate representation (IR) type library for the AOT compil
 This package provides the IR data structures used by the AOT native compiler pipeline:
 
 - **Opcodes** (`IrOp`) — stable integer opcodes covering constants, memory,
-  arithmetic, bitwise logic, 64-bit floating operations including `F64_SQRT`,
-  comparison, control flow, system calls, and meta instructions
+  arithmetic, bitwise logic, 64-bit floating operations including standard
+  unary real math, comparison, control flow, system calls, and meta
+  instructions
 - **Operand types** — `IrRegister` (v0, v1, ...), `IrImmediate` (literal integers), `IrLabel` (named jump targets)
 - **Instruction** (`IrInstruction`) — opcode + operands + unique ID for source mapping
 - **Data declarations** (`IrDataDecl`) — named static memory regions

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -25,7 +25,8 @@ The opcodes are grouped by category:
   Bitwise:      OR, OR_IMM, XOR, XOR_IMM, NOT
   Comparison:   CMP_EQ, CMP_NE, CMP_LT, CMP_GT
   Floating:     LOAD_F64_IMM, LOAD_F64, STORE_F64, F64_ADD, ..., F64_FROM_I32,
-                I32_TRUNC_FROM_F64, F64_SQRT
+                I32_TRUNC_FROM_F64, F64_SQRT, F64_SIN, F64_COS, F64_ATAN,
+                F64_LN, F64_EXP
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
@@ -305,6 +306,24 @@ class IrOp(IntEnum):
     # Appended after the closure opcodes to preserve stable opcode values.
     #   F64_SQRT v1, v2  →  v1 = sqrt(v2)
     F64_SQRT = 49
+
+    # Compute standard unary real functions for frontends that need a
+    # language-level math runtime. WASM core has no native sine/cosine/etc.,
+    # so WASM backends may lower these to typed host imports.
+    #   F64_SIN v1, v2    →  v1 = sin(v2)
+    F64_SIN = 50
+
+    #   F64_COS v1, v2    →  v1 = cos(v2)
+    F64_COS = 51
+
+    #   F64_ATAN v1, v2   →  v1 = arctan(v2)
+    F64_ATAN = 52
+
+    #   F64_LN v1, v2     →  v1 = ln(v2)
+    F64_LN = 53
+
+    #   F64_EXP v1, v2    →  v1 = exp(v2)
+    F64_EXP = 54
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -100,10 +100,15 @@ class TestIrOp:
         assert IrOp.MAKE_CLOSURE == 47
         assert IrOp.APPLY_CLOSURE == 48
         assert IrOp.F64_SQRT == 49
+        assert IrOp.F64_SIN == 50
+        assert IrOp.F64_COS == 51
+        assert IrOp.F64_ATAN == 52
+        assert IrOp.F64_LN == 53
+        assert IrOp.F64_EXP == 54
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 50 opcodes after adding f64 sqrt."""
-        assert len(IrOp) == 50
+        """There are exactly 55 opcodes after adding f64 standard math."""
+        assert len(IrOp) == 55
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1010,6 +1015,11 @@ class TestAllOpcodesPrintParse:
             IrOp.F64_FROM_I32: [IrRegister(2), IrRegister(1)],
             IrOp.I32_TRUNC_FROM_F64: [IrRegister(2), IrRegister(1)],
             IrOp.F64_SQRT:     [IrRegister(2), IrRegister(1)],
+            IrOp.F64_SIN:      [IrRegister(2), IrRegister(1)],
+            IrOp.F64_COS:      [IrRegister(2), IrRegister(1)],
+            IrOp.F64_ATAN:     [IrRegister(2), IrRegister(1)],
+            IrOp.F64_LN:       [IrRegister(2), IrRegister(1)],
+            IrOp.F64_EXP:      [IrRegister(2), IrRegister(1)],
             # MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1
             IrOp.MAKE_CLOSURE: [
                 IrRegister(0),

--- a/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
@@ -37,6 +37,9 @@ round-trip, export check.
 
 - Lowered `IrOp.F64_SQRT` to the native WASM `f64.sqrt` instruction and
   inferred its destination register as `f64`.
+- Lowered `IrOp.F64_SIN`, `IrOp.F64_COS`, `IrOp.F64_ATAN`, `IrOp.F64_LN`,
+  and `IrOp.F64_EXP` through typed `compiler_math` host imports and inferred
+  their destination registers as `f64`.
 - **Oct 8-bit arithmetic e2e tests** (`tests/test_oct_8bit_e2e.py`):
   7 end-to-end tests confirming the WASM backend correctly compiles and
   executes 8-bit integer arithmetic IR — the same IR that the Oct compiler

--- a/code/packages/python/ir-to-wasm-compiler/README.md
+++ b/code/packages/python/ir-to-wasm-compiler/README.md
@@ -30,4 +30,6 @@ Generated functions return `i32` values through virtual register `v1` and
 `f64` values through virtual register `v31`. Calls mirror the same convention:
 integer results are copied into `v1`, while real results are copied into `v31`.
 The f64 lowering path includes arithmetic, comparisons, integer conversion,
-truncation, and unary square root via WASM `f64.sqrt`.
+truncation, unary square root via WASM `f64.sqrt`, and standard unary real
+math through typed `compiler_math` imports (`f64_sin`, `f64_cos`, `f64_atan`,
+`f64_ln`, `f64_exp`).

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -42,10 +42,20 @@ _SYSCALL_READ = 2
 _SYSCALL_EXIT = 10
 
 _WASI_MODULE = "wasi_snapshot_preview1"
+_COMPILER_MATH_MODULE = "compiler_math"
 _WASI_IOVEC_OFFSET = 0
 _WASI_COUNT_OFFSET = 8
 _WASI_BYTE_OFFSET = 12
 _WASI_SCRATCH_SIZE = 16
+
+_F64_UNARY_MATH_IMPORT_NAMES: dict[IrOp, str] = {
+    IrOp.F64_SIN: "f64_sin",
+    IrOp.F64_COS: "f64_cos",
+    IrOp.F64_ATAN: "f64_atan",
+    IrOp.F64_LN: "f64_ln",
+    IrOp.F64_EXP: "f64_exp",
+}
+_F64_UNARY_MATH_OPS = frozenset(_F64_UNARY_MATH_IMPORT_NAMES)
 
 _MEMORY_OPS = frozenset(
     {
@@ -153,6 +163,11 @@ _WASM_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     IrOp.F64_MUL,
     IrOp.F64_DIV,
     IrOp.F64_SQRT,
+    IrOp.F64_SIN,
+    IrOp.F64_COS,
+    IrOp.F64_ATAN,
+    IrOp.F64_LN,
+    IrOp.F64_EXP,
     IrOp.F64_CMP_EQ,
     IrOp.F64_CMP_NE,
     IrOp.F64_CMP_LT,
@@ -296,19 +311,22 @@ class _FunctionIR:
 
 
 @dataclass(frozen=True)
-class _WasiImport:
-    syscall_number: int
+class _FunctionImport:
+    module_name: str
     name: str
     func_type: FuncType
+    syscall_number: int | None = None
+    math_opcode: IrOp | None = None
 
     @property
     def type_key(self) -> str:
-        return f"wasi::{self.name}"
+        return f"{self.module_name}::{self.name}"
 
 
 @dataclass(frozen=True)
-class _WasiContext:
-    function_indices: dict[int, int]
+class _ImportContext:
+    syscall_function_indices: dict[int, int]
+    math_function_indices: dict[IrOp, int]
     scratch_base: int | None
 
 
@@ -335,7 +353,7 @@ class IrToWasmCompiler:
                 signatures[signature.label] = signature
 
         functions = self._split_functions(program, signatures)
-        imports = self._collect_wasi_imports(program)
+        imports = self._collect_function_imports(program)
         type_indices, types = self._build_type_table(functions, imports)
         data_offsets = self._layout_data(program.data)
         scratch_base = None
@@ -346,7 +364,7 @@ class IrToWasmCompiler:
         module.types.extend(types)
         module.imports.extend(
             Import(
-                module_name=_WASI_MODULE,
+                module_name=imp.module_name,
                 name=imp.name,
                 kind=ExternalKind.FUNCTION,
                 type_info=type_indices[imp.type_key],
@@ -383,8 +401,17 @@ class IrToWasmCompiler:
             _DispatchLoopLowerer if strategy == "dispatch_loop" else _FunctionLowerer
         )
 
-        wasi_context = _WasiContext(
-            function_indices={imp.syscall_number: index for index, imp in enumerate(imports)},
+        import_context = _ImportContext(
+            syscall_function_indices={
+                imp.syscall_number: index
+                for index, imp in enumerate(imports)
+                if imp.syscall_number is not None
+            },
+            math_function_indices={
+                imp.math_opcode: index
+                for index, imp in enumerate(imports)
+                if imp.math_opcode is not None
+            },
             scratch_base=scratch_base,
         )
         for function in functions:
@@ -394,7 +421,7 @@ class IrToWasmCompiler:
                     signatures=signatures,
                     function_indices=function_indices,
                     data_offsets=data_offsets,
-                    wasi_context=wasi_context,
+                    import_context=import_context,
                 ).lower()
             )
             if function.signature.export_name is not None:
@@ -411,7 +438,7 @@ class IrToWasmCompiler:
     def _build_type_table(
         self,
         functions: list[_FunctionIR],
-        imports: list[_WasiImport],
+        imports: list[_FunctionImport],
     ) -> tuple[dict[str, int], list[FuncType]]:
         type_indices: dict[FuncType, int] = {}
         function_types: list[FuncType] = []
@@ -457,15 +484,20 @@ class IrToWasmCompiler:
                 return True
         return False
 
-    def _collect_wasi_imports(self, program: IrProgram) -> list[_WasiImport]:
+    def _collect_function_imports(self, program: IrProgram) -> list[_FunctionImport]:
         required_syscalls: set[int] = set()
+        required_math_ops: set[IrOp] = set()
         for instruction in program.instructions:
-            if instruction.opcode != IrOp.SYSCALL or not instruction.operands:
-                continue
-            required_syscalls.add(_expect_immediate(instruction.operands[0], "SYSCALL number").value)
+            if instruction.opcode == IrOp.SYSCALL and instruction.operands:
+                required_syscalls.add(
+                    _expect_immediate(instruction.operands[0], "SYSCALL number").value
+                )
+            elif instruction.opcode in _F64_UNARY_MATH_OPS:
+                required_math_ops.add(instruction.opcode)
 
         ordered_imports = (
-            _WasiImport(
+            _FunctionImport(
+                module_name=_WASI_MODULE,
                 syscall_number=_SYSCALL_WRITE,
                 name="fd_write",
                 func_type=FuncType(
@@ -473,7 +505,8 @@ class IrToWasmCompiler:
                     results=(ValueType.I32,),
                 ),
             ),
-            _WasiImport(
+            _FunctionImport(
+                module_name=_WASI_MODULE,
                 syscall_number=_SYSCALL_READ,
                 name="fd_read",
                 func_type=FuncType(
@@ -481,7 +514,8 @@ class IrToWasmCompiler:
                     results=(ValueType.I32,),
                 ),
             ),
-            _WasiImport(
+            _FunctionImport(
+                module_name=_WASI_MODULE,
                 syscall_number=_SYSCALL_EXIT,
                 name="proc_exit",
                 func_type=FuncType(
@@ -494,9 +528,25 @@ class IrToWasmCompiler:
         supported_syscalls = {imp.syscall_number for imp in ordered_imports}
         unsupported = sorted(required_syscalls - supported_syscalls)
         if unsupported:
-            raise WasmLoweringError(f"unsupported SYSCALL number(s): {', '.join(map(str, unsupported))}")
+            unsupported_text = ", ".join(map(str, unsupported))
+            raise WasmLoweringError(
+                f"unsupported SYSCALL number(s): {unsupported_text}"
+            )
 
-        return [imp for imp in ordered_imports if imp.syscall_number in required_syscalls]
+        imports = [
+            imp for imp in ordered_imports if imp.syscall_number in required_syscalls
+        ]
+        math_type = FuncType(params=(ValueType.F64,), results=(ValueType.F64,))
+        imports.extend(
+            _FunctionImport(
+                module_name=_COMPILER_MATH_MODULE,
+                name=_F64_UNARY_MATH_IMPORT_NAMES[opcode],
+                func_type=math_type,
+                math_opcode=opcode,
+            )
+            for opcode in sorted(required_math_ops, key=int)
+        )
+        return imports
 
     def _split_functions(
         self,
@@ -544,13 +594,13 @@ class _FunctionLowerer:
         signatures: dict[str, FunctionSignature],
         function_indices: dict[str, int],
         data_offsets: dict[str, int],
-        wasi_context: _WasiContext,
+        import_context: _ImportContext,
     ) -> None:
         self.function = function
         self.signatures = signatures
         self.function_indices = function_indices
         self.data_offsets = data_offsets
-        self.wasi_context = wasi_context
+        self.import_context = import_context
         self.param_count = function.signature.param_count
         self._register_types = function.register_types
         self._bytes = bytearray()
@@ -814,6 +864,14 @@ class _FunctionLowerer:
                 self._emit_local_get(src.index)
                 self._emit_opcode("f64.sqrt")
                 self._emit_local_set(dst.index)
+            case (
+                IrOp.F64_SIN
+                | IrOp.F64_COS
+                | IrOp.F64_ATAN
+                | IrOp.F64_LN
+                | IrOp.F64_EXP
+            ):
+                self._emit_f64_unary_math_call(instruction)
             case IrOp.CMP_EQ:
                 self._emit_binary_numeric("i32.eq", instruction)
             case IrOp.CMP_NE:
@@ -993,16 +1051,38 @@ class _FunctionLowerer:
         self._emit_memarg(2, 0)
 
     def _emit_wasi_call(self, syscall_number: int) -> None:
-        function_index = self.wasi_context.function_indices.get(syscall_number)
+        function_index = self.import_context.syscall_function_indices.get(
+            syscall_number
+        )
         if function_index is None:
             raise WasmLoweringError(f"missing WASI import for SYSCALL {syscall_number}")
         self._emit_opcode("call")
         self._emit_u32(function_index)
 
+    def _emit_f64_unary_math_call(self, instruction: IrInstruction) -> None:
+        dst = _expect_register(
+            instruction.operands[0], f"{instruction.opcode.name} dst"
+        )
+        src = _expect_register(
+            instruction.operands[1], f"{instruction.opcode.name} src"
+        )
+        function_index = self.import_context.math_function_indices.get(
+            instruction.opcode
+        )
+        if function_index is None:
+            name = _F64_UNARY_MATH_IMPORT_NAMES[instruction.opcode]
+            raise WasmLoweringError(
+                f"missing compiler math import for {name}"
+            )
+        self._emit_local_get(src.index)
+        self._emit_opcode("call")
+        self._emit_u32(function_index)
+        self._emit_local_set(dst.index)
+
     def _require_wasi_scratch(self) -> int:
-        if self.wasi_context.scratch_base is None:
+        if self.import_context.scratch_base is None:
             raise WasmLoweringError("SYSCALL lowering requires WASM scratch memory")
-        return self.wasi_context.scratch_base
+        return self.import_context.scratch_base
 
     def _emit_binary_numeric(self, wasm_op: str, instruction: IrInstruction) -> None:
         dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")
@@ -1491,6 +1571,11 @@ def _infer_register_types(
                 | IrOp.F64_MUL
                 | IrOp.F64_DIV
                 | IrOp.F64_SQRT
+                | IrOp.F64_SIN
+                | IrOp.F64_COS
+                | IrOp.F64_ATAN
+                | IrOp.F64_LN
+                | IrOp.F64_EXP
                 | IrOp.F64_FROM_I32
             ):
                 dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -373,6 +373,52 @@ def test_compile_f64_sqrt() -> None:
     assert _runtime_result(module, "sqrt_real", [0.25]) == [0.5]
 
 
+@pytest.mark.parametrize(
+    ("opcode", "import_name", "arg", "expected"),
+    [
+        (IrOp.F64_SIN, "f64_sin", 0.0, 0.0),
+        (IrOp.F64_COS, "f64_cos", 0.0, 1.0),
+        (IrOp.F64_ATAN, "f64_atan", 1.0, 0.7853981633974483),
+        (IrOp.F64_LN, "f64_ln", 2.718281828459045, 1.0),
+        (IrOp.F64_EXP, "f64_exp", 1.0, 2.718281828459045),
+    ],
+)
+def test_compile_f64_unary_math_imports(
+    opcode: IrOp,
+    import_name: str,
+    arg: float,
+    expected: float,
+) -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_real_math")
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [IrLabel("_fn_real_math")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(opcode, [IrRegister(31), IrRegister(2)], id=gen.next())
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_real_math",
+                param_count=1,
+                export_name="real_math",
+                param_types=(ValueType.F64,),
+                result_types=(ValueType.F64,),
+            )
+        ],
+    )
+
+    assert [(imp.module_name, imp.name) for imp in module.imports] == [
+        ("compiler_math", import_name)
+    ]
+    result = _runtime_result(module, "real_math", [arg], host=WasiHost())
+    assert result == pytest.approx([expected])
+
+
 def test_compile_function_call_and_run_it() -> None:
     gen = IDGenerator()
     program = IrProgram(entry_label="_start")

--- a/code/packages/python/wasm-runtime/CHANGELOG.md
+++ b/code/packages/python/wasm-runtime/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this package will be documented in this file.
 - **`WasiConfig` dataclass** — collects all `WasiHost` options in one place: `args`, `env`, `stdout`, `stderr`, `clock`, `random`
 - All new classes exported from `wasm_runtime.__init__`
 - 32 new tests in `tests/test_wasi_tier3.py` covering happy paths, edge cases, no-memory guards, and the `clock_time_get` EINVAL path
+- **`compiler_math` host imports** — `WasiHost` now resolves `f64_sin`,
+  `f64_cos`, `f64_atan`, `f64_ln`, and `f64_exp` for generic compiler
+  pipeline modules that need non-core WASM real math.
 
 ### Changed
 

--- a/code/packages/python/wasm-runtime/README.md
+++ b/code/packages/python/wasm-runtime/README.md
@@ -84,6 +84,13 @@ class FakeClock(WasiClock):
 host = WasiHost(WasiConfig(clock=FakeClock()))
 ```
 
+### Compiler math imports
+
+`WasiHost` also resolves the generic compiler pipeline's `compiler_math`
+imports for standard unary f64 math: `f64_sin`, `f64_cos`, `f64_atan`,
+`f64_ln`, and `f64_exp`. These imports are intentionally separate from WASI
+so generated modules declare the non-core WASM math surface they need.
+
 ## WASI functions implemented
 
 | Function            | Tier | Description                                      |

--- a/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
+++ b/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
@@ -25,6 +25,12 @@ can talk to the outside world through imported WASI functions.
   - random_get      — fill a buffer with cryptographically random bytes
   - sched_yield     — cooperative scheduler hint (no-op in single-thread)
 
+Compiler math imports
+─────────────────────
+The generic compiler pipeline may also import unary f64 math helpers from
+``compiler_math``. These are intentionally separate from WASI so generated
+modules have a small, explicit ABI for non-core WASM math operations.
+
 Design: pluggable clock and random
 ───────────────────────────────────
 Clock and random number generation are injected through abstract base
@@ -46,6 +52,7 @@ WASI uses numeric errno codes (same idea as POSIX):
 
 from __future__ import annotations
 
+import math
 import secrets
 import time
 from abc import ABC, abstractmethod
@@ -53,7 +60,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from wasm_execution import LinearMemory, WasmValue, i32
+from wasm_execution import LinearMemory, WasmValue, f64, i32
 from wasm_types import FuncType, ValueType
 
 # ---------------------------------------------------------------------------
@@ -63,6 +70,15 @@ ESUCCESS = 0    # no error
 EBADF = 8       # bad file descriptor
 EINVAL = 28     # invalid argument  (e.g. unknown clock id)
 ENOSYS = 52     # function not (yet) implemented
+
+_COMPILER_MATH_MODULE = "compiler_math"
+_COMPILER_MATH_UNARY_F64: dict[str, Callable[[float], float]] = {
+    "f64_sin": math.sin,
+    "f64_cos": math.cos,
+    "f64_atan": math.atan,
+    "f64_ln": math.log,
+    "f64_exp": math.exp,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -291,7 +307,9 @@ class WasiHost:
     # ------------------------------------------------------------------
 
     def resolve_function(self, module_name: str, name: str) -> Any | None:  # noqa: ANN401
-        """Return a _HostFunc for the named WASI function, or None."""
+        """Return a _HostFunc for a supported import, or None."""
+        if module_name == _COMPILER_MATH_MODULE:
+            return self._make_compiler_math(name)
         if module_name != "wasi_snapshot_preview1":
             return None
 
@@ -315,6 +333,19 @@ class WasiHost:
         # Everything else returns ENOSYS so the module can link but will
         # get an explicit "not implemented" error if called at runtime.
         return self._make_stub(name)
+
+    def _make_compiler_math(self, name: str) -> _HostFunc | None:
+        fn = _COMPILER_MATH_UNARY_F64.get(name)
+        if fn is None:
+            return None
+
+        def unary_f64_impl(args: list[WasmValue]) -> list[WasmValue]:
+            return [f64(fn(float(args[0].value)))]
+
+        return _HostFunc(
+            FuncType(params=(ValueType.F64,), results=(ValueType.F64,)),
+            unary_f64_impl,
+        )
 
     def resolve_global(self, _module_name: str, _name: str) -> Any | None:  # noqa: ANN401
         return None


### PR DESCRIPTION
## Summary
- adds IR opcodes for standard unary f64 math: `sin`, `cos`, `arctan`, `ln`, and `exp`
- lowers those ops to typed `compiler_math` WASM imports and teaches `WasiHost` to resolve them with Python's math library
- wires ALGOL builtins through type checking, IR lowering, runtime-domain guarding for nonpositive `ln`, WASM execution tests, docs, and a new golden fixture

## Tests
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/compiler-ir/tests/test_compiler_ir.py code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/wasm-runtime/tests -q --no-cov`
- `PYTHONPATH="$(find code/packages/python -path '*/src' -type d | paste -sd: -)" python3.12 -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py -q --no-cov`
- `python3.12 -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py`
- `git diff --check origin/main`

## Security
- Diff scan for process/network/file-write/eval/secret patterns: no new findings. The only hit was existing `import secrets` context in `wasm_runtime.wasi_host`.
- Note: broad Ruff over `compiler-ir` / `ir-to-wasm-compiler` still reports pre-existing lint debt outside this slice, so the clean lint gate is scoped to the ALGOL packages plus the touched runtime host file.