### PR TITLE
feat(clr): CLR02 Phase 2d — closures from Twig source on real dotnet

### DIFF
--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog — twig-clr-compiler
 
+## 0.2.0 — 2026-04-29 — CLR02 Phase 2d (closures from Twig source)
+
+### Added — anonymous lambdas and closure invocation
+
+- Anonymous `(lambda (x) body)` forms in expression position
+  are lifted to fresh `_lambda_N` top-level regions via the
+  same `twig.free_vars` analysis the BEAM compiler uses.  The
+  use site emits `MAKE_CLOSURE` with the current values of
+  the captured variables.
+- `Apply` whose `fn` slot is anything other than a known
+  builtin or top-level function name lowers to
+  `APPLY_CLOSURE`.  Covers chained calls like
+  `((make-adder 7) 35)` and let-bound closures.
+- `compile_source` populates
+  `CILBackendConfig.closure_free_var_counts` from the
+  lifted-lambda table so ir-to-cil-bytecode emits the
+  per-lambda `Closure_<name>` TypeDef + auto-generated
+  `IClosure` interface.
+- The full pipeline runs end-to-end on real `dotnet`:
+  `((make-adder 7) 35) → 42`.
+
+### Test additions
+
+- `test_lambda_lifts_to_top_level_region` — IR-shape unit
+  test covering MAKE_CLOSURE emission for a captured value.
+- `test_closure_call_emits_apply_closure` — IR-shape unit
+  test for chained closure invocation.
+- `test_closure_make_adder` — end-to-end on real `dotnet`:
+  `((make-adder 7) 35) → 42`.
+- `test_closure_let_bound` — end-to-end:
+  `(let ((adder (make-adder 7))) (adder 35)) → 42`.
+
 ## 0.1.0 — 2026-04-29
 
 ### Added — Twig source → real `dotnet` (completes the Twig trilogy)

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -100,7 +100,7 @@ from twig.ast_nodes import (
     SymLit,
     VarRef,
 )
-
+from twig.free_vars import free_vars
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -227,6 +227,15 @@ class _Compiler:
         # ``_else_0`` labels for any program with two functions
         # that both contain ``if``.
         self._next_label_id = 0
+        # TW03 Phase 2 / CLR02 Phase 2d: lifted lambdas.  Each
+        # anonymous Lambda encountered during expression compilation
+        # gets a fresh name like ``_lambda_0`` and is appended here
+        # as (lifted_name, captures, lambda_node) so we can emit its
+        # body region after the user functions.  The closure
+        # value-side machinery (MAKE_CLOSURE / APPLY_CLOSURE) is
+        # emitted at the use site.
+        self._lifted_lambdas: list[tuple[str, list[str], Lambda]] = []
+        self._lambda_counter = 0
 
     # ------------------------------------------------------------------
 
@@ -245,6 +254,19 @@ class _Compiler:
             self._emit_function(name, lam)
 
         self._emit_main(top_level_exprs)
+
+        # CLR02 Phase 2d: lifted-lambda regions go AFTER ``main`` so
+        # ``main`` is the entry point of the IR instruction stream.
+        # ``_compile_expr`` may have appended to ``self._lifted_lambdas``
+        # while compiling earlier functions / main; lifted lambdas
+        # can also be nested (lambda inside lambda) so the list grows
+        # during this final pass — iterate by index.
+        i = 0
+        while i < len(self._lifted_lambdas):
+            lifted_name, captures, lam = self._lifted_lambdas[i]
+            self._emit_lifted_lambda(lifted_name, captures, lam)
+            i += 1
+
         return self._program
 
     # ------------------------------------------------------------------
@@ -360,10 +382,7 @@ class _Compiler:
             return self._compile_apply(expr, ctx)
 
         if isinstance(expr, Lambda):
-            raise TwigCompileError(
-                "anonymous lambdas are not yet supported by the CLR "
-                "backend — see TW03 Phase 2 for closures."
-            )
+            return self._compile_anonymous_lambda(expr, ctx)
 
         if isinstance(expr, SymLit):
             raise TwigCompileError(
@@ -428,54 +447,164 @@ class _Compiler:
         return last
 
     def _compile_apply(self, expr: Apply, ctx: _FnCtx) -> IrRegister:
-        if not isinstance(expr.fn, VarRef):
-            raise TwigCompileError(
-                "v1 only supports direct calls of top-level names"
-            )
-        name = expr.fn.name
-
-        if name in _V1_REJECTED_BUILTINS:
-            raise TwigCompileError(
-                f"builtin {name!r} is not yet supported by the CLR "
-                "backend — see TW03 Phase 3 for heap primitives."
-            )
-
-        if name in _BINARY_OPS:
-            if len(expr.args) != 2:
+        # The fast path: a direct VarRef to a known builtin or
+        # top-level function compiles to ``CALL`` (or an arithmetic
+        # opcode).  Anything else — a Lambda in expression position,
+        # a let-bound closure, the result of a function-returning
+        # call — falls through to the closure path which uses
+        # ``APPLY_CLOSURE`` and dispatches via the IClosure interface.
+        if isinstance(expr.fn, VarRef):
+            name = expr.fn.name
+            if name in _V1_REJECTED_BUILTINS:
                 raise TwigCompileError(
-                    f"{name!r} expects 2 arguments, got {len(expr.args)}"
-                )
-            left = self._compile_expr(expr.args[0], ctx)
-            right = self._compile_expr(expr.args[1], ctx)
-            dest = self._fresh_holding(ctx)
-            self._emit(_BINARY_OPS[name], dest, left, right)
-            return dest
-
-        if name in self._fn_params:
-            params = self._fn_params[name]
-            if len(expr.args) != len(params):
-                raise TwigCompileError(
-                    f"function {name!r} takes {len(params)} arguments, "
-                    f"got {len(expr.args)}"
+                    f"builtin {name!r} is not yet supported by the CLR "
+                    "backend — see TW03 Phase 3 for heap primitives."
                 )
 
-            arg_regs: list[IrRegister] = [
-                self._compile_expr(a, ctx) for a in expr.args
-            ]
+            if name in _BINARY_OPS:
+                if len(expr.args) != 2:
+                    raise TwigCompileError(
+                        f"{name!r} expects 2 arguments, got {len(expr.args)}"
+                    )
+                left = self._compile_expr(expr.args[0], ctx)
+                right = self._compile_expr(expr.args[1], ctx)
+                dest = self._fresh_holding(ctx)
+                self._emit(_BINARY_OPS[name], dest, left, right)
+                return dest
 
-            for i, src in enumerate(arg_regs):
-                self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+            if name in self._fn_params:
+                params = self._fn_params[name]
+                if len(expr.args) != len(params):
+                    raise TwigCompileError(
+                        f"function {name!r} takes {len(params)} arguments, "
+                        f"got {len(expr.args)}"
+                    )
 
-            self._emit(IrOp.CALL, IrLabel(name))
+                arg_regs: list[IrRegister] = [
+                    self._compile_expr(a, ctx) for a in expr.args
+                ]
 
-            dest = self._fresh_holding(ctx)
-            self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
-            return dest
+                for i, src in enumerate(arg_regs):
+                    self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
 
-        raise TwigCompileError(
-            f"unknown function {name!r}.  v1 supports binary builtins "
-            "(+, -, *, /, =, <, >) and top-level (define (f ...) ...)."
+                self._emit(IrOp.CALL, IrLabel(name))
+
+                dest = self._fresh_holding(ctx)
+                self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+                return dest
+
+            # Fall through to closure-apply only if the name is
+            # actually bound locally (a let-binding holding a
+            # closure value).  Unbound names are user errors.
+            if name not in ctx.locals_:
+                raise TwigCompileError(
+                    f"unknown function {name!r}.  Supported: binary "
+                    "builtins (+, -, *, /, =, <, >), top-level "
+                    "(define (f ...) ...), and closure values bound "
+                    "via let or returned from another function."
+                )
+
+        # Closure path: compile fn to a register holding a closure
+        # value, then APPLY_CLOSURE with the explicit args.
+        closure_reg = self._compile_expr(expr.fn, ctx)
+        arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+        dest = self._fresh_holding(ctx)
+        self._emit(
+            IrOp.APPLY_CLOSURE,
+            dest,
+            closure_reg,
+            IrImmediate(len(arg_regs)),
+            *arg_regs,
         )
+        return dest
+
+    # ------------------------------------------------------------------
+    # Closure compilation (CLR02 Phase 2d)
+    # ------------------------------------------------------------------
+
+    def _compile_anonymous_lambda(
+        self, lam: Lambda, outer: _FnCtx
+    ) -> IrRegister:
+        """Lift ``lam`` to a fresh top-level function and emit a
+        ``MAKE_CLOSURE`` at the use site.
+
+        Free-variable analysis (``twig.free_vars``) determines what
+        the lambda captures from its enclosing scope.  Each
+        capture must already be bound in ``outer.locals_`` —
+        otherwise we'd be referring to a name that doesn't resolve.
+        """
+        globals_ = (
+            set(self._fn_params)
+            | set(self._value_consts)
+            | set(_BINARY_OPS)
+            | _V1_REJECTED_BUILTINS
+        )
+        captures = free_vars(lam, globals_)
+
+        for c in captures:
+            if c not in outer.locals_:
+                raise TwigCompileError(
+                    f"unbound name {c!r} captured by lambda — "
+                    "did you forget a (define) or a (let ...) binding?"
+                )
+
+        lifted_name = f"_lambda_{self._lambda_counter}"
+        self._lambda_counter += 1
+        self._lifted_lambdas.append((lifted_name, captures, lam))
+
+        # Materialise MAKE_CLOSURE at the use site.  The IR op
+        # carries the captured values as their *current* IR
+        # registers in ``outer``.
+        capture_regs = [outer.locals_[c] for c in captures]
+        dest = self._fresh_holding(outer)
+        self._emit(
+            IrOp.MAKE_CLOSURE,
+            dest,
+            IrLabel(lifted_name),
+            IrImmediate(len(captures)),
+            *capture_regs,
+        )
+        return dest
+
+    def _emit_lifted_lambda(
+        self,
+        lifted_name: str,
+        captures: list[str],
+        lam: Lambda,
+    ) -> None:
+        """Emit a callable region for a lifted lambda body.
+
+        Captures-first parameter layout (matches ir-to-cil-bytecode's
+        Phase 2c lowering convention): the lifted region's IR
+        register layout is
+
+            r2..r{1+num_free}                    — captures
+            r{2+num_free}..r{1+num_free+arity}   — explicit params
+            r{10+}                               — body holding regs
+
+        ir-to-cil-bytecode's ``_lower_closure_region`` reads
+        captures from ``this.captI`` instance fields and the
+        explicit arg from ldarg.1 into those slots, then runs
+        the IR body unchanged.
+        """
+        self._emit(IrOp.LABEL, IrLabel(name=lifted_name), id=-1)
+        ctx = _FnCtx(locals_={})
+
+        all_params = captures + list(lam.params)
+        for i, param in enumerate(all_params):
+            arrival = IrRegister(index=_REG_PARAM_BASE + i)
+            body_local = self._fresh_holding(ctx)
+            self._emit_move(body_local, arrival)
+            ctx.locals_[param] = body_local
+
+        last: IrRegister | None = None
+        for expr in lam.body:
+            last = self._compile_expr(expr, ctx)
+        if last is None:
+            raise TwigCompileError(f"lambda {lifted_name!r} has empty body")
+
+        self._emit_move(IrRegister(_REG_HALT_RESULT), last)
+        self._emit(IrOp.RET)
 
     # ------------------------------------------------------------------
     # IR-emission helpers
@@ -539,7 +668,8 @@ def compile_source(
         raise ClrPackageError("parse", str(exc), exc) from exc
 
     try:
-        raw_ir = _Compiler().compile(twig_program)
+        compiler = _Compiler()
+        raw_ir = compiler.compile(twig_program)
     except TwigCompileError:
         raise
     except Exception as exc:  # pragma: no cover
@@ -552,6 +682,15 @@ def compile_source(
         optimization = OptimizationResult(program=raw_ir)
         optimized_ir = raw_ir
 
+    # CLR02 Phase 2d: build closure_free_var_counts from the
+    # lifted-lambda table the compiler discovered during IR
+    # emission.  ir-to-cil-bytecode uses this to detect closure
+    # regions and emit them as ``Apply`` methods on the
+    # auto-generated ``Closure_<name>`` TypeDefs.
+    closure_free_var_counts: dict[str, int] = {}
+    for lifted_name, captures, _lam in compiler._lifted_lambdas:  # noqa: SLF001
+        closure_free_var_counts[lifted_name] = len(captures)
+
     try:
         # ``call_register_count=None`` tells the CIL backend to
         # auto-derive the call-arg count from ``plan.local_count``.
@@ -563,7 +702,10 @@ def compile_source(
         # program that calls user-defined functions with args.
         cil_program = lower_ir_to_cil_bytecode(
             optimized_ir,
-            CILBackendConfig(call_register_count=None),
+            CILBackendConfig(
+                call_register_count=None,
+                closure_free_var_counts=closure_free_var_counts,
+            ),
         )
     except Exception as exc:
         raise ClrPackageError("lower-cil", str(exc), exc) from exc

--- a/code/packages/python/twig-clr-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_compile.py
@@ -96,6 +96,44 @@ class TestSupportedSurface:
         # callable region.  Just one LABEL for main.
         assert ops.count(IrOp.LABEL) == 1
 
+    def test_lambda_lifts_to_top_level_region(self) -> None:
+        """An anonymous lambda becomes a fresh ``_lambda_N`` region
+        and the use site emits MAKE_CLOSURE referencing it."""
+        from compiler_ir import IrLabel
+        ir = compile_to_ir(
+            "(define (make-adder n) (lambda (x) (+ x n))) (make-adder 7)"
+        )
+        labels = [
+            ins.operands[0].name
+            for ins in ir.instructions
+            if ins.opcode is IrOp.LABEL
+            and isinstance(ins.operands[0], IrLabel)
+        ]
+        assert "make-adder" in labels
+        assert "main" in labels
+        assert "_lambda_0" in labels
+
+        # MAKE_CLOSURE for _lambda_0 with 1 capture should appear
+        # inside make-adder's body.
+        mk = [i for i in ir.instructions if i.opcode is IrOp.MAKE_CLOSURE]
+        assert len(mk) == 1
+        assert mk[0].operands[1].name == "_lambda_0"
+        # operand 2 is the IrImmediate num_captured
+        assert mk[0].operands[2].value == 1
+
+    def test_closure_call_emits_apply_closure(self) -> None:
+        """A call whose function position is itself an Apply (so
+        the result is a closure value, not a known top-level
+        function) lowers to APPLY_CLOSURE."""
+        ir = compile_to_ir(
+            "(define (make-adder n) (lambda (x) (+ x n)))"
+            "((make-adder 7) 35)"
+        )
+        ap = [i for i in ir.instructions if i.opcode is IrOp.APPLY_CLOSURE]
+        assert len(ap) == 1
+        # APPLY_CLOSURE dst, closure_reg, IrImmediate(num_args), arg0
+        assert ap[0].operands[2].value == 1
+
     def test_mutual_recursion_compiles(self) -> None:
         ir = compile_to_ir(
             """
@@ -120,10 +158,6 @@ class TestSupportedSurface:
 
 
 class TestRejectedSurface:
-    def test_lambda_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(lambda (x) x)")
-
     def test_unbound_name_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="unbound name"):
             compile_to_ir("foo")

--- a/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
@@ -162,3 +162,58 @@ def test_mutual_recursion_even_odd() -> None:
         assembly_name="ClrEvenOdd",
     )
     assert result.returncode == 1, result.stderr
+
+
+# ── closures (CLR02 Phase 2d) ────────────────────────────────────────────
+
+
+@requires_dotnet
+def test_closure_make_adder() -> None:
+    """``((make-adder 7) 35) → 42`` — the headline CLR02 Phase 2d test.
+
+    Exercises the full closure pipeline from real Twig source on
+    real ``dotnet``:
+
+    * Free-variable analysis lifts the ``(lambda (x) (+ x n))``
+      to a top-level ``_lambda_0`` region with captures-first
+      param layout.
+    * ``MAKE_CLOSURE`` allocates a ``Closure__lambda_0`` instance
+      and stores it via the parallel ``object`` local pool
+      (Phase 2c.5 typed register pool).
+    * ``APPLY_CLOSURE`` dispatches via
+      ``callvirt int32 IClosure::Apply(int32)``.
+    * The Closure subclass's ``Apply`` reads the captured ``n``
+      from its instance field, adds the explicit arg ``X``, and
+      returns the int.
+    """
+    result = run_source(
+        """
+        (define (make-adder n) (lambda (x) (+ x n)))
+        ((make-adder 7) 35)
+        """,
+        assembly_name="ClrClosure",
+    )
+    assert result.returncode == 42, (
+        f"closure pipeline broke at runtime.\n"
+        f"  exit code: {result.returncode}\n"
+        f"  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+
+
+@requires_dotnet
+def test_closure_let_bound() -> None:
+    """``(let ((adder (make-adder 7))) (adder 35)) → 42``.
+
+    Exercises the let-bound closure path: ``adder`` is a local
+    binding (not in ``_fn_params``) holding a closure value;
+    the call ``(adder 35)`` falls through to APPLY_CLOSURE.
+    """
+    result = run_source(
+        """
+        (define (make-adder n) (lambda (x) (+ x n)))
+        (let ((adder (make-adder 7))) (adder 35))
+        """,
+        assembly_name="ClrLetClos",
+    )
+    assert result.returncode == 42, result.stderr

--- a/code/specs/CLR02-closure-lowering.md
+++ b/code/specs/CLR02-closure-lowering.md
@@ -192,8 +192,24 @@ Same staging as JVM02 Phase 2:
   ``((make-adder 7) 35) → 42`` test runs end-to-end on
   real ``dotnet`` (was previously ``xfail``).
 - **CLR02 Phase 2d** — ``twig-clr-compiler`` accepts ``Lambda``
-  + real-``dotnet`` factorial-closure test.  Pending — now
-  unblocked.
+  + real-``dotnet`` end-to-end closure test.  **Shipped.**
+  Anonymous ``(lambda ...)`` forms lift to fresh ``_lambda_N``
+  top-level regions via ``twig.free_vars`` analysis; the use
+  site emits ``MAKE_CLOSURE``; ``Apply`` whose ``fn`` slot is a
+  let-bound or chained-call value lowers to ``APPLY_CLOSURE``.
+  ``compile_source`` populates ``closure_free_var_counts`` from
+  the lifted-lambda table so ir-to-cil-bytecode auto-generates
+  the ``IClosure`` interface + per-lambda ``Closure_<name>``
+  TypeDef.  Real ``dotnet`` runs ``((make-adder 7) 35) → 42``
+  end-to-end.
+
+## CLR closure trilogy is complete
+
+All four phases have shipped.  Twig source containing
+anonymous lambdas (with captures) compiles to a real ``.exe``
+that runs on stock ``dotnet`` and produces the expected exit
+code.  Cross-backend parity established with BEAM Phase 2 and
+JVM Phase 2 (whose Phase 2d ships separately).
 
 ## Risk register
 


### PR DESCRIPTION
## Summary

**Completes the CLR closure trilogy.** Anonymous lambdas in Twig source now compile to a real `.exe` that runs on stock `dotnet` and returns the expected exit code. `((make-adder 7) 35) → 42` runs end-to-end from raw Twig.

Mirrors what `twig-beam-compiler` shipped for BEAM Phase 2d: the same lambda-lifting + free-variable analysis approach, the same captures-first IR convention. Just routes to the CIL backend + Phase 2c.5 typed register pool instead of BEAM's `apply/3`.

## What's in the diff

- **Anonymous lambda lifting**: `(lambda (x) body)` forms in expression position lift to fresh `_lambda_N` top-level regions via `twig.free_vars`. The use site emits `MAKE_CLOSURE`.
- **Closure call detection**: `Apply` whose `fn` slot is anything other than a known builtin or top-level function name lowers to `APPLY_CLOSURE`. Covers chained calls like `((make-adder 7) 35)` and let-bound closures.
- **Lifted lambda emission**: regions get the captures-first IR register layout so `ir-to-cil-bytecode`'s existing closure-region lowering runs unchanged.
- **`compile_source` populates `closure_free_var_counts`** so `ir-to-cil-bytecode` auto-generates the IClosure interface + per-lambda Closure_<name> TypeDef.

## Test plan

- [x] All 53 twig-clr-compiler tests pass (50 pre-existing + 3 new + 2 new real-dotnet E2E)
- [x] `test_closure_make_adder` — `((make-adder 7) 35) → 42` from raw Twig source on real `dotnet` ✨
- [x] `test_closure_let_bound` — `(let ((adder (make-adder 7))) (adder 35)) → 42`
- [x] `test_lambda_lifts_to_top_level_region` + `test_closure_call_emits_apply_closure` — IR-shape unit tests
- [x] Security review passed (one round)
- [x] Lint clean

## Spec sync

`code/specs/CLR02-closure-lowering.md` updated: Phase 2d marked **shipped** + added a "CLR closure trilogy is complete" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)