### PR TITLE
[codex] Add neural matrix backend plan

### DIFF
--- a/code/packages/typescript/matrix/tsconfig.json
+++ b/code/packages/typescript/matrix/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/code/packages/typescript/neural-graph-vm/BUILD
+++ b/code/packages/typescript/neural-graph-vm/BUILD
@@ -1,4 +1,5 @@
-cd ../multi-directed-graph && npm install --silent
-cd ../neural-network && npm install --silent
+(cd ../matrix && npm ci --quiet && npm run build --silent)
+(cd ../multi-directed-graph && npm ci --quiet)
+(cd ../neural-network && npm ci --quiet)
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/neural-graph-vm/BUILD_windows
+++ b/code/packages/typescript/neural-graph-vm/BUILD_windows
@@ -1,4 +1,5 @@
-cd ../multi-directed-graph && npm install --silent
-cd ../neural-network && npm install --silent
+(cd ../matrix && npm ci --quiet && npm run build --silent)
+(cd ../multi-directed-graph && npm ci --quiet)
+(cd ../neural-network && npm ci --quiet)
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/neural-graph-vm/CHANGELOG.md
+++ b/code/packages/typescript/neural-graph-vm/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - Added scalar `constant` node compilation through `LOAD_CONST`.
 - Added `runNeuralBytecodeForwardWithTrace` for instruction-level VM traces.
 - Added XOR bytecode coverage through the neural-network helper graph.
+- Added NN01 matrix plan lowering and a swappable `MatrixBackend` interface.
+- Added `TypeScriptMatrixBackend` as the reference CPU adapter for the existing
+  `matrix` package.
 
 ## [0.1.0] - 2026-04-29
 

--- a/code/packages/typescript/neural-graph-vm/README.md
+++ b/code/packages/typescript/neural-graph-vm/README.md
@@ -10,9 +10,11 @@ lower from.
 ```typescript
 import { createNeuralNetwork } from "@coding-adventures/neural-network";
 import {
+  compileBytecodeToMatrixPlan,
   compileNeuralNetworkToBytecode,
   runNeuralBytecodeForward,
   runNeuralBytecodeForwardWithTrace,
+  runNeuralMatrixForward,
 } from "@coding-adventures/neural-graph-vm";
 
 const network = createNeuralNetwork("tiny-model")
@@ -30,6 +32,13 @@ const outputs = runNeuralBytecodeForward(bytecode, { x0: 4, x1: 8 });
 
 const trace = runNeuralBytecodeForwardWithTrace(bytecode, { x0: 4, x1: 8 });
 trace.instructions[0].sourceNode; // "x0"
+
+const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+const batch = runNeuralMatrixForward(matrixPlan, {
+  x0: [4, 8],
+  x1: [8, 16],
+});
+// batch.outputs is { prediction: [7, 14] }
 ```
 
 Supported v0 graph ops:
@@ -43,12 +52,19 @@ Supported v0 graph ops:
 | `output` | Stores a named scalar output. |
 
 The interpreter is intentionally scalar and small. Its job is correctness,
-debuggability, and portability before optimized matrix lowering exists.
+debuggability, and portability.
 
 `runNeuralBytecodeForwardWithTrace` returns each instruction's value reads,
 value write, output write, and source graph node/edge metadata. Visualizers can
 use that to show how graph edges become bytecode operations without making the
 graph data structure own runtime behavior.
+
+`compileBytecodeToMatrixPlan` lowers scalar forward bytecode into a backend-
+neutral matrix plan. `runNeuralMatrixForward` executes that plan through a
+`MatrixBackend` interface, with `TypeScriptMatrixBackend` adapting the existing
+`matrix` package as the reference CPU implementation. Future GPU or WASM
+backends can implement the same interface without changing graph or bytecode
+compiler code.
 
 `MultiDirectedGraph` remains generic and domain-neutral. The
 `@coding-adventures/neural-network` package is the neural primitive layer on top:

--- a/code/packages/typescript/neural-graph-vm/package-lock.json
+++ b/code/packages/typescript/neural-graph-vm/package-lock.json
@@ -10,12 +10,22 @@
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph",
-        "@coding-adventures/neural-network": "file:../neural-network"
+        "@coding-adventures/neural-network": "file:../neural-network",
+        "matrix": "file:../matrix"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "../matrix": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.0.0"
       }
     },
     "../multi-directed-graph": {
@@ -1727,6 +1737,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/matrix": {
+      "resolved": "../matrix",
+      "link": true
     },
     "node_modules/minimatch": {
       "version": "10.2.5",

--- a/code/packages/typescript/neural-graph-vm/package.json
+++ b/code/packages/typescript/neural-graph-vm/package.json
@@ -13,7 +13,8 @@
   "author": "Adhithya Rajasekaran",
   "dependencies": {
     "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph",
-    "@coding-adventures/neural-network": "file:../neural-network"
+    "@coding-adventures/neural-network": "file:../neural-network",
+    "matrix": "file:../matrix"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/code/packages/typescript/neural-graph-vm/src/index.ts
+++ b/code/packages/typescript/neural-graph-vm/src/index.ts
@@ -1,5 +1,6 @@
 export {
   NeuralGraphCompileError,
+  applyNeuralActivation,
   compileNeuralNetworkToBytecode,
   compileNeuralGraphToBytecode,
   runNeuralBytecodeForward,
@@ -14,3 +15,18 @@ export {
   type NeuralBytecodeValueRead,
   type NeuralBytecodeValueWrite,
 } from "./neural-graph-vm.js";
+
+export {
+  TypeScriptMatrixBackend,
+  compileBytecodeToMatrixPlan,
+  runNeuralMatrixForward,
+  runNeuralMatrixForwardScalars,
+  type MatrixBackend,
+  type NeuralMatrixForwardResult,
+  type NeuralMatrixInputValue,
+  type NeuralMatrixInputs,
+  type NeuralMatrixPlan,
+  type NeuralMatrixPlanInstruction,
+  type NeuralMatrixPlanOpcode,
+  type NeuralMatrixPlanTerm,
+} from "./matrix-plan.js";

--- a/code/packages/typescript/neural-graph-vm/src/matrix-plan.ts
+++ b/code/packages/typescript/neural-graph-vm/src/matrix-plan.ts
@@ -1,0 +1,454 @@
+import { Matrix } from "matrix";
+
+import {
+  applyNeuralActivation,
+  type NeuralBytecodeInstruction,
+  type NeuralBytecodeModule,
+} from "./neural-graph-vm.js";
+
+export type NeuralMatrixPlanOpcode =
+  | "LOAD_INPUT_MATRIX"
+  | "LOAD_CONST_MATRIX"
+  | "WEIGHTED_SUM_MATRIX"
+  | "ACTIVATE_MATRIX"
+  | "STORE_OUTPUT_MATRIX";
+
+export interface NeuralMatrixPlanTerm {
+  readonly sourceValue: string;
+  readonly sourceNode?: string;
+  readonly edgeId: string;
+  readonly weight: number;
+}
+
+export interface NeuralMatrixPlanInstruction {
+  readonly op: NeuralMatrixPlanOpcode;
+  readonly dst?: string;
+  readonly inputName?: string;
+  readonly outputName?: string;
+  readonly value?: number;
+  readonly terms?: readonly NeuralMatrixPlanTerm[];
+  readonly input?: string;
+  readonly activation?: string;
+  readonly sourceNode?: string;
+  readonly sourceEdge?: string;
+  readonly sourceInstructionIndexes: readonly number[];
+}
+
+export interface NeuralMatrixPlan {
+  readonly magic: "CANM";
+  readonly version: 0;
+  readonly sourceBytecodeVersion: 0;
+  readonly instructions: readonly NeuralMatrixPlanInstruction[];
+}
+
+export type NeuralMatrixInputValue = number | readonly number[];
+export type NeuralMatrixInputs = Record<string, NeuralMatrixInputValue>;
+
+export interface NeuralMatrixForwardResult {
+  readonly outputs: Record<string, number[]>;
+  readonly values: Record<string, number[]>;
+}
+
+export interface MatrixBackend<M> {
+  fromRows(rows: readonly (readonly number[])[]): M;
+  toRows(matrix: M): number[][];
+  column(values: readonly number[]): M;
+  constant(value: number, rows: number, cols?: number): M;
+  add(left: M, right: M): M;
+  scale(matrix: M, scalar: number): M;
+  dot(left: M, right: M): M;
+  map(matrix: M, fn: (value: number) => number): M;
+  toColumn(matrix: M): number[];
+}
+
+export class TypeScriptMatrixBackend implements MatrixBackend<Matrix> {
+  fromRows(rows: readonly (readonly number[])[]): Matrix {
+    return new Matrix(cloneRows(rows));
+  }
+
+  toRows(matrix: Matrix): number[][] {
+    return cloneRows(matrix.data);
+  }
+
+  column(values: readonly number[]): Matrix {
+    return new Matrix(values.map((value) => [value]));
+  }
+
+  constant(value: number, rows: number, cols = 1): Matrix {
+    return new Matrix(
+      Array.from({ length: rows }, () => Array(cols).fill(value))
+    );
+  }
+
+  add(left: Matrix, right: Matrix): Matrix {
+    return left.add(right);
+  }
+
+  scale(matrix: Matrix, scalar: number): Matrix {
+    return matrix.scale(scalar);
+  }
+
+  dot(left: Matrix, right: Matrix): Matrix {
+    return left.dot(right);
+  }
+
+  map(matrix: Matrix, fn: (value: number) => number): Matrix {
+    return matrix.map(fn);
+  }
+
+  toColumn(matrix: Matrix): number[] {
+    if (matrix.cols !== 1) {
+      throw new Error(
+        `Expected a single-column matrix, got ${matrix.cols} columns`
+      );
+    }
+    return matrix.data.map((row) => row[0]);
+  }
+}
+
+export function compileBytecodeToMatrixPlan(
+  module: NeuralBytecodeModule
+): NeuralMatrixPlan {
+  const forward = module.functions.find((fn) => fn.kind === "forward");
+  if (forward === undefined) {
+    throw new Error("Neural bytecode module has no forward function");
+  }
+
+  const edgeWeights = new Map(
+    module.graph.edges.map((edge) => [edge.id, edge.weight])
+  );
+  const valueSources = new Map<string, ValueSource>();
+  const edgeWeightValues = new Map<string, EdgeWeightValue>();
+  const termValues = new Map<string, NeuralMatrixPlanTerm>();
+  const instructions: NeuralMatrixPlanInstruction[] = [];
+
+  for (const [index, instruction] of forward.instructions.entries()) {
+    switch (instruction.op) {
+      case "LOAD_INPUT": {
+        const dst = requireDst(instruction);
+        valueSources.set(dst, {
+          valueId: dst,
+          sourceNode: instruction.sourceNode,
+        });
+        instructions.push({
+          op: "LOAD_INPUT_MATRIX",
+          dst,
+          inputName: instruction.inputName,
+          sourceNode: instruction.sourceNode,
+          sourceInstructionIndexes: [index],
+        });
+        break;
+      }
+      case "LOAD_CONST": {
+        const dst = requireDst(instruction);
+        valueSources.set(dst, {
+          valueId: dst,
+          sourceNode: instruction.sourceNode,
+        });
+        instructions.push({
+          op: "LOAD_CONST_MATRIX",
+          dst,
+          value: instruction.value ?? 0,
+          sourceNode: instruction.sourceNode,
+          sourceInstructionIndexes: [index],
+        });
+        break;
+      }
+      case "LOAD_EDGE_WEIGHT": {
+        const dst = requireDst(instruction);
+        const edgeId = requireEdgeId(instruction);
+        edgeWeightValues.set(dst, {
+          valueId: dst,
+          edgeId,
+          weight: edgeWeights.get(edgeId) ?? 1,
+        });
+        break;
+      }
+      case "MUL": {
+        const dst = requireDst(instruction);
+        const term = lowerWeightedTerm(
+          instruction,
+          valueSources,
+          edgeWeightValues
+        );
+        termValues.set(dst, term);
+        break;
+      }
+      case "ADD": {
+        const dst = requireDst(instruction);
+        const terms = (instruction.inputs ?? []).map((valueId) => {
+          const term = termValues.get(valueId);
+          if (term === undefined) {
+            throw new Error(`Cannot lower ADD input ${valueId} to a matrix term`);
+          }
+          return term;
+        });
+        valueSources.set(dst, {
+          valueId: dst,
+          sourceNode: instruction.sourceNode,
+        });
+        instructions.push({
+          op: "WEIGHTED_SUM_MATRIX",
+          dst,
+          terms,
+          sourceNode: instruction.sourceNode,
+          sourceInstructionIndexes: [index],
+        });
+        break;
+      }
+      case "ACTIVATE": {
+        const dst = requireDst(instruction);
+        requireValueSource(instruction.input, valueSources);
+        valueSources.set(dst, {
+          valueId: dst,
+          sourceNode: instruction.sourceNode,
+        });
+        instructions.push({
+          op: "ACTIVATE_MATRIX",
+          dst,
+          input: instruction.input,
+          activation: instruction.activation ?? "relu",
+          sourceNode: instruction.sourceNode,
+          sourceInstructionIndexes: [index],
+        });
+        break;
+      }
+      case "STORE_OUTPUT": {
+        requireValueSource(instruction.input, valueSources);
+        instructions.push({
+          op: "STORE_OUTPUT_MATRIX",
+          outputName: instruction.outputName ?? "output",
+          input: instruction.input,
+          sourceNode: instruction.sourceNode,
+          sourceInstructionIndexes: [index],
+        });
+        break;
+      }
+    }
+  }
+
+  return {
+    magic: "CANM",
+    version: 0,
+    sourceBytecodeVersion: module.version,
+    instructions,
+  };
+}
+
+export function runNeuralMatrixForward(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs
+): NeuralMatrixForwardResult;
+export function runNeuralMatrixForward<M>(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs,
+  backend: MatrixBackend<M>
+): NeuralMatrixForwardResult;
+export function runNeuralMatrixForward<M>(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs,
+  backend: MatrixBackend<M> = new TypeScriptMatrixBackend() as MatrixBackend<M>
+): NeuralMatrixForwardResult {
+  const batchSize = inferBatchSize(inputs);
+  const values = new Map<string, M>();
+  const outputs: Record<string, number[]> = {};
+
+  for (const instruction of plan.instructions) {
+    switch (instruction.op) {
+      case "LOAD_INPUT_MATRIX": {
+        const dst = requirePlanDst(instruction);
+        const inputName = instruction.inputName ?? instruction.sourceNode ?? dst;
+        values.set(
+          dst,
+          backend.column(readInputColumn(inputs, inputName, batchSize))
+        );
+        break;
+      }
+      case "LOAD_CONST_MATRIX": {
+        const dst = requirePlanDst(instruction);
+        values.set(dst, backend.constant(instruction.value ?? 0, batchSize));
+        break;
+      }
+      case "WEIGHTED_SUM_MATRIX": {
+        const dst = requirePlanDst(instruction);
+        const terms = instruction.terms ?? [];
+        let result: M | undefined;
+        for (const term of terms) {
+          const weighted = backend.scale(
+            readMatrixValue(values, term.sourceValue),
+            term.weight
+          );
+          result = result === undefined ? weighted : backend.add(result, weighted);
+        }
+        values.set(dst, result ?? backend.constant(0, batchSize));
+        break;
+      }
+      case "ACTIVATE_MATRIX": {
+        const dst = requirePlanDst(instruction);
+        values.set(
+          dst,
+          backend.map(
+            readMatrixValue(values, instruction.input),
+            (value) => applyNeuralActivation(value, instruction.activation ?? "relu")
+          )
+        );
+        break;
+      }
+      case "STORE_OUTPUT_MATRIX": {
+        const outputName = instruction.outputName ?? "output";
+        outputs[outputName] = backend.toColumn(
+          readMatrixValue(values, instruction.input)
+        );
+        break;
+      }
+    }
+  }
+
+  return {
+    outputs,
+    values: Object.fromEntries(
+      [...values.entries()].map(([valueId, matrix]) => [
+        valueId,
+        backend.toColumn(matrix),
+      ])
+    ),
+  };
+}
+
+export function runNeuralMatrixForwardScalars(
+  plan: NeuralMatrixPlan,
+  inputs: Record<string, number>,
+  backend?: MatrixBackend<unknown>
+): Record<string, number> {
+  const result = backend === undefined
+    ? runNeuralMatrixForward(plan, inputs)
+    : runNeuralMatrixForward(plan, inputs, backend);
+
+  return Object.fromEntries(
+    Object.entries(result.outputs).map(([outputName, values]) => [
+      outputName,
+      values[0] ?? 0,
+    ])
+  );
+}
+
+interface ValueSource {
+  readonly valueId: string;
+  readonly sourceNode?: string;
+}
+
+interface EdgeWeightValue {
+  readonly valueId: string;
+  readonly edgeId: string;
+  readonly weight: number;
+}
+
+function lowerWeightedTerm(
+  instruction: NeuralBytecodeInstruction,
+  valueSources: ReadonlyMap<string, ValueSource>,
+  edgeWeightValues: ReadonlyMap<string, EdgeWeightValue>
+): NeuralMatrixPlanTerm {
+  const leftValue = valueSources.get(instruction.left ?? "");
+  const rightValue = valueSources.get(instruction.right ?? "");
+  const leftWeight = edgeWeightValues.get(instruction.left ?? "");
+  const rightWeight = edgeWeightValues.get(instruction.right ?? "");
+
+  if (leftValue !== undefined && rightWeight !== undefined) {
+    return {
+      sourceValue: leftValue.valueId,
+      sourceNode: leftValue.sourceNode,
+      edgeId: rightWeight.edgeId,
+      weight: rightWeight.weight,
+    };
+  }
+  if (rightValue !== undefined && leftWeight !== undefined) {
+    return {
+      sourceValue: rightValue.valueId,
+      sourceNode: rightValue.sourceNode,
+      edgeId: leftWeight.edgeId,
+      weight: leftWeight.weight,
+    };
+  }
+
+  throw new Error(
+    `Cannot lower MUL ${instruction.dst ?? "<unknown>"} to a weighted matrix term`
+  );
+}
+
+function inferBatchSize(inputs: NeuralMatrixInputs): number {
+  let batchSize = 1;
+  for (const value of Object.values(inputs)) {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        throw new Error("Batched inputs must contain at least one value");
+      }
+      if (batchSize !== 1 && value.length !== batchSize) {
+        throw new Error("All batched inputs must have the same length");
+      }
+      batchSize = value.length;
+    }
+  }
+  return batchSize;
+}
+
+function readInputColumn(
+  inputs: NeuralMatrixInputs,
+  inputName: string,
+  batchSize: number
+): number[] {
+  if (!(inputName in inputs)) {
+    throw new Error(`Missing input: ${inputName}`);
+  }
+  const value = inputs[inputName];
+  if (Array.isArray(value)) {
+    if (value.length !== batchSize) {
+      throw new Error("All batched inputs must have the same length");
+    }
+    return [...value];
+  }
+  return Array(batchSize).fill(value);
+}
+
+function requireDst(instruction: NeuralBytecodeInstruction): string {
+  if (instruction.dst === undefined) {
+    throw new Error(`Instruction ${instruction.op} is missing dst`);
+  }
+  return instruction.dst;
+}
+
+function requireEdgeId(instruction: NeuralBytecodeInstruction): string {
+  if (instruction.edgeId === undefined) {
+    throw new Error("LOAD_EDGE_WEIGHT is missing edgeId");
+  }
+  return instruction.edgeId;
+}
+
+function requireValueSource(
+  valueId: string | undefined,
+  values: ReadonlyMap<string, ValueSource>
+): void {
+  if (valueId === undefined || !values.has(valueId)) {
+    throw new Error(`Cannot lower missing value: ${valueId ?? "<undefined>"}`);
+  }
+}
+
+function requirePlanDst(instruction: NeuralMatrixPlanInstruction): string {
+  if (instruction.dst === undefined) {
+    throw new Error(`Matrix plan instruction ${instruction.op} is missing dst`);
+  }
+  return instruction.dst;
+}
+
+function readMatrixValue<M>(
+  values: ReadonlyMap<string, M>,
+  valueId: string | undefined
+): M {
+  if (valueId === undefined || !values.has(valueId)) {
+    throw new Error(`Missing matrix value: ${valueId ?? "<undefined>"}`);
+  }
+  return values.get(valueId)!;
+}
+
+function cloneRows(rows: readonly (readonly number[])[]): number[][] {
+  return rows.map((row) => [...row]);
+}

--- a/code/packages/typescript/neural-graph-vm/src/neural-graph-vm.ts
+++ b/code/packages/typescript/neural-graph-vm/src/neural-graph-vm.ts
@@ -306,7 +306,7 @@ function executeNeuralBytecodeForward(
         requireDst(instruction);
         writeValue(
           instruction.dst,
-          applyScalarActivation(
+          applyNeuralActivation(
             read(instruction.input),
             instruction.activation ?? "relu"
           )
@@ -410,7 +410,7 @@ function readValue(values: Map<string, number>, valueId: string | undefined): nu
   return values.get(valueId)!;
 }
 
-function applyScalarActivation(value: number, activation: string): number {
+export function applyNeuralActivation(value: number, activation: string): number {
   switch (activation) {
     case "relu":
       return Math.max(0, value);

--- a/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
+++ b/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
@@ -12,10 +12,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   NeuralGraphCompileError,
+  compileBytecodeToMatrixPlan,
   compileNeuralGraphToBytecode,
   compileNeuralNetworkToBytecode,
   runNeuralBytecodeForward,
   runNeuralBytecodeForwardWithTrace,
+  runNeuralMatrixForward,
+  runNeuralMatrixForwardScalars,
+  type MatrixBackend,
 } from "../src/index.js";
 
 function makeTinyWeightedSumGraph(): NeuralGraph {
@@ -85,6 +89,103 @@ describe("neural graph vm", () => {
     const outputs = runNeuralBytecodeForward(bytecode, { x0: 4, x1: 8 });
 
     expect(outputs).toEqual({ prediction: 6 });
+  });
+
+  it("lowers forward bytecode into a matrix plan", () => {
+    const bytecode = compileNeuralGraphToBytecode(makeTinyWeightedSumGraph());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+
+    expect(plan.magic).toBe("CANM");
+    expect(plan.instructions.map((insn) => insn.op)).toEqual([
+      "LOAD_CONST_MATRIX",
+      "LOAD_INPUT_MATRIX",
+      "LOAD_INPUT_MATRIX",
+      "WEIGHTED_SUM_MATRIX",
+      "ACTIVATE_MATRIX",
+      "STORE_OUTPUT_MATRIX",
+    ]);
+    expect(plan.instructions[3].terms?.map((term) => term.edgeId)).toEqual([
+      "bias_to_sum",
+      "w0",
+      "w1",
+    ]);
+  });
+
+  it("runs lowered matrix plans through the default matrix backend", () => {
+    const bytecode = compileNeuralGraphToBytecode(makeTinyWeightedSumGraph());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const outputs = runNeuralMatrixForwardScalars(plan, { x0: 4, x1: 8 });
+
+    expect(outputs).toEqual({ prediction: 6 });
+  });
+
+  it("runs matrix plans across a small batch", () => {
+    const bytecode = compileNeuralNetworkToBytecode(createXorNetwork());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = runNeuralMatrixForward(plan, {
+      x0: [0, 0, 1, 1],
+      x1: [0, 1, 0, 1],
+    });
+    const predictions = result.outputs.prediction;
+
+    expect(predictions[0]).toBeLessThan(0.01);
+    expect(predictions[1]).toBeGreaterThan(0.99);
+    expect(predictions[2]).toBeGreaterThan(0.99);
+    expect(predictions[3]).toBeLessThan(0.01);
+  });
+
+  it("runs matrix plans against a swappable backend interface", () => {
+    const calls: string[] = [];
+    const backend: MatrixBackend<number[]> = {
+      fromRows(rows) {
+        calls.push("fromRows");
+        return rows.map((row) => row[0] ?? 0);
+      },
+      toRows(matrix) {
+        calls.push("toRows");
+        return matrix.map((value) => [value]);
+      },
+      column(values) {
+        calls.push("column");
+        return [...values];
+      },
+      constant(value, rows) {
+        calls.push("constant");
+        return Array(rows).fill(value);
+      },
+      add(left, right) {
+        calls.push("add");
+        return left.map((value, index) => value + right[index]);
+      },
+      scale(matrix, scalar) {
+        calls.push("scale");
+        return matrix.map((value) => value * scalar);
+      },
+      dot() {
+        calls.push("dot");
+        throw new Error("dot is not used by this v0 plan");
+      },
+      map(matrix, fn) {
+        calls.push("map");
+        return matrix.map(fn);
+      },
+      toColumn(matrix) {
+        calls.push("toColumn");
+        return [...matrix];
+      },
+    };
+    const bytecode = compileNeuralGraphToBytecode(makeTinyWeightedSumGraph());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = runNeuralMatrixForward(
+      plan,
+      { x0: [4, 8], x1: [8, 16] },
+      backend
+    );
+
+    expect(result.outputs).toEqual({ prediction: [6, 13] });
+    expect(calls).toContain("scale");
+    expect(calls).toContain("add");
+    expect(calls).toContain("map");
   });
 
   it("supports negative weighted sums through relu", () => {

--- a/code/specs/NN01-matrix-backend.md
+++ b/code/specs/NN01-matrix-backend.md
@@ -1,0 +1,119 @@
+# NN01: Matrix Backend Interface and Bytecode Lowering
+
+Status: draft
+
+## Purpose
+
+NN01 describes the first optimized execution path for Neural Graph VM bytecode:
+lowering scalar forward bytecode into matrix-oriented operations that can run on
+different backends.
+
+The important boundary is this:
+
+- The graph describes structure.
+- NN00 bytecode describes portable execution.
+- NN01 matrix plans describe vectorized execution.
+- A backend performs the actual matrix work.
+
+The VM must not be hard-wired to one matrix implementation. The current
+TypeScript matrix package is the reference CPU backend, but future backends
+should be able to target WebGPU, native GPU libraries, browser SIMD, WASM, or
+hardware simulators without changing neural-network graph authoring code.
+
+## Layering
+
+```text
+neural-network graph primitives
+  -> NN00 bytecode compiler
+    -> scalar reference interpreter
+    -> NN01 matrix plan compiler
+      -> MatrixBackend interface
+        -> TypeScript Matrix CPU backend
+        -> WebGPU backend
+        -> native/WASM backend
+        -> accelerator simulator backend
+```
+
+The scalar interpreter remains the correctness reference. Matrix lowering is an
+execution optimization, not the source of truth.
+
+## Backend Contract
+
+Backends implement a small shape-preserving matrix API. The VM owns neural
+semantics; the backend owns storage, kernels, device placement, and transfer
+costs.
+
+```text
+MatrixBackend<M>
+  from_rows(rows) -> M
+  to_rows(matrix) -> number[][]
+  column(values) -> M
+  constant(value, rows, cols = 1) -> M
+  add(left, right) -> M
+  scale(matrix, scalar) -> M
+  dot(left, right) -> M
+  map(matrix, fn) -> M
+  to_column(matrix) -> number[]
+```
+
+`M` is deliberately opaque. A CPU backend can use a simple `number[][]`, the
+current TypeScript `Matrix`, or a packed typed array. A GPU backend can use a
+device buffer handle. The VM should only pass values back to the backend
+interface.
+
+## Matrix Plan
+
+A matrix plan is a backend-neutral lowering of NN00 forward bytecode. It groups
+the scalar op stream into higher-level vector operations while preserving source
+metadata for visualization and debugging.
+
+Initial v0 matrix plan opcodes:
+
+| Opcode | Meaning |
+| --- | --- |
+| `LOAD_INPUT_MATRIX` | Load one runtime input as a column matrix. Scalars broadcast to the current batch size. |
+| `LOAD_CONST_MATRIX` | Load a scalar constant as a repeated column matrix. |
+| `WEIGHTED_SUM_MATRIX` | Compute `sum(source_matrix * edge_weight)` for a graph node. |
+| `ACTIVATE_MATRIX` | Apply an elementwise activation. |
+| `STORE_OUTPUT_MATRIX` | Copy a column matrix into a named output. |
+
+The compiler must retain the `sourceNode` and `sourceEdge` relationships already
+present in NN00 bytecode. A visualizer should be able to show both the original
+graph edge and the matrix operation it became.
+
+## Batch Semantics
+
+The first matrix runner treats each runtime input as a column:
+
+```text
+scalar input:      x = 4       -> [[4]]
+batched input:     x = [4, 8]  -> [[4], [8]]
+constant/bias:     b = 1       -> [[1], [1]]
+```
+
+All array inputs in a single run must have the same length. Scalar inputs are
+broadcast to that length. This lets the same compiled plan run one sample or a
+small batch without changing the graph.
+
+## Backend Swapping Rules
+
+The VM runtime may depend on the backend interface, not on a concrete matrix
+class. Concrete adapters are leaf code:
+
+- `TypeScriptMatrixBackend` adapts the existing `matrix` package.
+- A future `WebGpuMatrixBackend` can keep values on the GPU.
+- A future `ComputeUnitMatrixBackend` can run against the compute-unit simulator.
+
+Backends may fuse work internally, but the visible contract must preserve the
+same outputs as the scalar interpreter for the same bytecode and inputs.
+
+## Non-Goals for v0
+
+- Training and backpropagation lowering.
+- Automatic dense-layer fusion.
+- Device scheduling.
+- Graph-language parsing.
+- Hidden layer architecture search.
+
+Those can build on the same contract later. v0 only proves that bytecode can
+lower to swappable matrix operations for forward inference.


### PR DESCRIPTION
## Summary
- add NN01 spec for bytecode-to-matrix lowering and swappable matrix backends
- add MatrixBackend interface, TypeScriptMatrixBackend adapter, matrix plan compiler, and batched forward runner
- make the matrix package buildable and update neural-graph-vm BUILD prerequisites

## Tests
- npm test (code/packages/typescript/neural-graph-vm)
- npm run build (code/packages/typescript/neural-graph-vm)
- npm run test:coverage (code/packages/typescript/neural-graph-vm)
- npm test (code/packages/typescript/matrix)
- npm run build (code/packages/typescript/matrix)
- bash BUILD (code/packages/typescript/neural-graph-vm)
- git diff --check HEAD~1..HEAD